### PR TITLE
Specify version of log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ exclude       = [
 ]
 
 [dependencies]
-log = "*"
+log = "0.3.6"
 mio = { git = "https://github.com/carllerche/mio", branch = "dev" }
 slab = { git = "https://github.com/carllerche/slab" }
 futures = "0.1.0"


### PR DESCRIPTION
Even though most of the other dependencies are for in-dev crates/dev branches, there is no need to be unspecific about the version of the log. Also, I despise wildcard dependencies and consider them one of the few solid pieces of evidence that Satan exits (and hates SemVer). Just my opinion though. 😄 