### PR TITLE
Remove executor from reactor.

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -18,18 +18,20 @@
 //! messages.
 
 extern crate futures;
+extern crate futures_cpupool;
 extern crate tokio;
 extern crate tokio_io;
 
 use std::collections::HashMap;
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::iter;
 use std::env;
 use std::io::{Error, ErrorKind, BufReader};
+use std::sync::{Arc, Mutex};
 
 use futures::Future;
+use futures::future::Executor;
 use futures::stream::{self, Stream};
+use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
 use tokio::reactor::Core;
 use tokio_io::io;
@@ -45,9 +47,10 @@ fn main() {
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);
 
-    // This is a single-threaded server, so we can just use Rc and RefCell to
-    // store the map of all connections we know about.
-    let connections = Rc::new(RefCell::new(HashMap::new()));
+    // This is currently a multi threaded server.
+    //
+    // Once the same thread executor lands, transition to single threaded.
+    let connections = Arc::new(Mutex::new(HashMap::new()));
 
     let srv = socket.incoming().for_each(move |(stream, addr)| {
         println!("New Connection: {}", addr);
@@ -57,7 +60,7 @@ fn main() {
         // send us messages. Then register our address with the stream to send
         // data to us.
         let (tx, rx) = futures::sync::mpsc::unbounded();
-        connections.borrow_mut().insert(addr, tx);
+        connections.lock().unwrap().insert(addr, tx);
 
         // Define here what we do for the actual I/O. That is, read a bunch of
         // lines from the socket and dispatch them while we also write any lines
@@ -88,7 +91,7 @@ fn main() {
             let connections = connections_inner.clone();
             line.map(move |(reader, message)| {
                 println!("{}: {:?}", addr, message);
-                let mut conns = connections.borrow_mut();
+                let mut conns = connections.lock().unwrap();
                 if let Ok(msg) = message {
                     // For each open connection except the sender, send the
                     // string via the channel.
@@ -114,17 +117,19 @@ fn main() {
             amt.map_err(|_| ())
         });
 
+        let pool = CpuPool::new(1);
+
         // Now that we've got futures representing each half of the socket, we
         // use the `select` combinator to wait for either half to be done to
         // tear down the other. Then we spawn off the result.
         let connections = connections.clone();
         let socket_reader = socket_reader.map_err(|_| ());
         let connection = socket_reader.map(|_| ()).select(socket_writer.map(|_| ()));
-        handle.spawn(connection.then(move |_| {
-            connections.borrow_mut().remove(&addr);
+        pool.execute(connection.then(move |_| {
+            connections.lock().unwrap().remove(&addr);
             println!("Connection {} closed.", addr);
             Ok(())
-        }));
+        })).unwrap();
 
         Ok(())
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,10 +32,13 @@
 //!
 //! ```no_run
 //! extern crate futures;
+//! extern crate futures_cpupool;
 //! extern crate tokio;
 //! extern crate tokio_io;
 //!
 //! use futures::{Future, Stream};
+//! use futures::future::Executor;
+//! use futures_cpupool::CpuPool;
 //! use tokio_io::AsyncRead;
 //! use tokio_io::io::copy;
 //! use tokio::net::TcpListener;
@@ -45,6 +48,8 @@
 //!     // Create the event loop that will drive this server
 //!     let mut core = Core::new().unwrap();
 //!     let handle = core.handle();
+//!
+//!     let pool = CpuPool::new_num_cpus();
 //!
 //!     // Bind the server's socket
 //!     let addr = "127.0.0.1:12345".parse().unwrap();
@@ -68,7 +73,7 @@
 //!         });
 //!
 //!         // Spawn the future as a concurrent task
-//!         handle.spawn(handle_conn);
+//!         pool.execute(handle_conn).unwrap();
 //!
 //!         Ok(())
 //!     });

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -93,13 +93,12 @@ impl TcpListener {
                     // eventually.
                     let (tx, rx) = oneshot::channel();
                     let remote = self.io.remote().clone();
-                    remote.spawn(move |handle| {
+                    remote.run(move |handle| {
                         let res = PollEvented::new(sock, handle)
                             .map(move |io| {
                                 (TcpStream { io: io }, addr)
                             });
                         drop(tx.send(res));
-                        Ok(())
                     });
                     self.pending_accept = Some(rx);
                     // continue to polling the `rx` at the beginning of the loop


### PR DESCRIPTION
In accordance with tokio-rs/tokio-rfcs#3, the executor functionality of
Tokio is being removed and will be relocated into futures-rs as a
"current thread" executor.

This PR removes task execution from the code base. As a temporary
mesure, all examples and tests are switched to using CpuPool.

Depends on #19.