### PR TITLE
Make Handle `Send + Sync`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ appveyor = { repository = "alexcrichton/tokio" }
 bytes = "0.4"
 log = "0.3"
 mio = "0.6.10"
-scoped-tls = "0.1.0"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,7 @@
 #![doc(html_root_url = "https://docs.rs/tokio-core/0.1")]
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![allow(unused_macros)]
 
 extern crate bytes;
 #[macro_use]
@@ -95,9 +96,6 @@ extern crate mio;
 extern crate slab;
 #[macro_use]
 extern crate tokio_io;
-
-#[macro_use]
-extern crate scoped_tls;
 
 #[macro_use]
 extern crate log;

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -7,15 +7,14 @@
 use std::cell::RefCell;
 use std::fmt;
 use std::io::{self, ErrorKind};
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
+use std::sync::{Arc, Weak, RwLock};
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT, Ordering};
 use std::time::{Instant, Duration};
 
 use futures::{Future, Async};
 use futures::executor::{self, Spawn, Notify};
 use futures::sync::mpsc;
-use futures::task::Task;
+use futures::task::{AtomicTask};
 use mio;
 use mio::event::Evented;
 use slab::Slab;
@@ -37,12 +36,12 @@ scoped_thread_local!(static CURRENT_LOOP: Core);
 // TODO: expand this
 pub struct Core {
     events: mio::Events,
-    tx: mpsc::UnboundedSender<Message>,
+    _tx: mpsc::UnboundedSender<Message>,
     rx: RefCell<Spawn<mpsc::UnboundedReceiver<Message>>>,
     _rx_registration: mio::Registration,
     rx_readiness: Arc<MySetReadiness>,
 
-    inner: Rc<RefCell<Inner>>,
+    inner: Arc<Inner>,
 
     // Used for determining when the future passed to `run` is ready. Once the
     // registration is passed to `io` above we never touch it again, just keep
@@ -56,7 +55,7 @@ struct Inner {
     io: mio::Poll,
 
     // Dispatch slabs for I/O and futures events
-    io_dispatch: Slab<ScheduledIo>,
+    io_dispatch: RwLock<Slab<ScheduledIo>>,
 }
 
 /// An unique ID for a Core
@@ -76,7 +75,7 @@ pub struct CoreId(usize);
 #[derive(Clone)]
 pub struct Remote {
     id: usize,
-    tx: mpsc::UnboundedSender<Message>,
+    inner: Weak<Inner>,
 }
 
 /// A non-sendable handle to an event loop, useful for manufacturing instances
@@ -84,13 +83,12 @@ pub struct Remote {
 #[derive(Clone)]
 pub struct Handle {
     remote: Remote,
-    inner: Weak<RefCell<Inner>>,
 }
 
 struct ScheduledIo {
-    readiness: Arc<AtomicUsize>,
-    reader: Option<Task>,
-    writer: Option<Task>,
+    readiness: AtomicUsize,
+    reader: AtomicTask,
+    writer: AtomicTask,
 }
 
 enum Direction {
@@ -99,14 +97,18 @@ enum Direction {
 }
 
 enum Message {
-    DropSource(usize),
-    Schedule(usize, Task, Direction),
-    Run(Box<FnBox>),
 }
 
 const TOKEN_MESSAGES: mio::Token = mio::Token(0);
 const TOKEN_FUTURE: mio::Token = mio::Token(1);
 const TOKEN_START: usize = 2;
+
+fn _assert_kinds() {
+    fn _assert<T: Send + Sync>() {}
+
+    _assert::<Handle>();
+    _assert::<Remote>();
+}
 
 impl Core {
     /// Creates a new event loop, returning any error that happened during the
@@ -129,7 +131,7 @@ impl Core {
 
         Ok(Core {
             events: mio::Events::with_capacity(1024),
-            tx: tx,
+            _tx: tx,
             rx: RefCell::new(executor::spawn(rx)),
             _rx_registration: channel_pair.0,
             rx_readiness: rx_readiness,
@@ -137,11 +139,11 @@ impl Core {
             _future_registration: future_pair.0,
             future_readiness: Arc::new(MySetReadiness(future_pair.1)),
 
-            inner: Rc::new(RefCell::new(Inner {
+            inner: Arc::new(Inner {
                 id: NEXT_LOOP_ID.fetch_add(1, Ordering::Relaxed),
                 io: io,
-                io_dispatch: Slab::with_capacity(1),
-            })),
+                io_dispatch: RwLock::new(Slab::with_capacity(1)),
+            }),
         })
     }
 
@@ -152,18 +154,16 @@ impl Core {
     /// This handle is typically passed into functions that create I/O objects
     /// to bind them to this event loop.
     pub fn handle(&self) -> Handle {
-        Handle {
-            remote: self.remote(),
-            inner: Rc::downgrade(&self.inner),
-        }
+        let remote = self.remote();
+        Handle { remote }
     }
 
     /// Generates a remote handle to this event loop which can be used to spawn
     /// tasks from other threads into this event loop.
     pub fn remote(&self) -> Remote {
         Remote {
-            id: self.inner.borrow().id,
-            tx: self.tx.clone(),
+            id: self.inner.id,
+            inner: Arc::downgrade(&self.inner),
         }
     }
 
@@ -221,7 +221,7 @@ impl Core {
 
         // Block waiting for an event to happen, peeling out how many events
         // happened.
-        let amt = match self.inner.borrow_mut().io.poll(&mut self.events, max_wait) {
+        let amt = match self.inner.io.poll(&mut self.events, max_wait) {
             Ok(a) => a,
             Err(ref e) if e.kind() == ErrorKind::Interrupted => return false,
             Err(e) => panic!("error in poll: {}", e),
@@ -258,35 +258,15 @@ impl Core {
     }
 
     fn dispatch_io(&mut self, token: usize, ready: mio::Ready) {
-        let mut reader = None;
-        let mut writer = None;
-        let mut inner = self.inner.borrow_mut();
-        if let Some(io) = inner.io_dispatch.get_mut(token) {
+        if let Some(io) = self.inner.io_dispatch.read().unwrap().get(token) {
             io.readiness.fetch_or(ready2usize(ready), Ordering::Relaxed);
             if ready.is_writable() {
-                writer = io.writer.take();
+                io.writer.notify();
             }
             if !(ready & (!mio::Ready::writable())).is_empty() {
-                reader = io.reader.take();
+                io.reader.notify();
             }
         }
-        drop(inner);
-        // TODO: don't notify the same task twice
-        if let Some(reader) = reader {
-            self.notify_handle(reader);
-        }
-        if let Some(writer) = writer {
-            self.notify_handle(writer);
-        }
-    }
-
-    /// Method used to notify a task handle.
-    ///
-    /// Note that this should be used instead of `handle.notify()` to ensure
-    /// that the `CURRENT_LOOP` variable is set appropriately.
-    fn notify_handle(&self, handle: Task) {
-        debug!("notifying a task handle");
-        CURRENT_LOOP.set(&self, || handle.notify());
     }
 
     fn consume_queue(&self) {
@@ -304,20 +284,12 @@ impl Core {
 
     fn notify(&self, msg: Message) {
         match msg {
-            Message::DropSource(tok) => self.inner.borrow_mut().drop_source(tok),
-            Message::Schedule(tok, wake, dir) => {
-                let task = self.inner.borrow_mut().schedule(tok, wake, dir);
-                if let Some(task) = task {
-                    self.notify_handle(task);
-                }
-            }
-            Message::Run(r) => r.call_box(self),
         }
     }
 
     /// Get the ID of this loop
     pub fn id(&self) -> CoreId {
-        CoreId(self.inner.borrow().id)
+        CoreId(self.inner.id)
     }
 }
 
@@ -330,111 +302,79 @@ impl fmt::Debug for Core {
 }
 
 impl Inner {
-    fn add_source(&mut self, source: &Evented)
-                  -> io::Result<(Arc<AtomicUsize>, usize)> {
-        debug!("adding a new I/O source");
-        let sched = ScheduledIo {
-            readiness: Arc::new(AtomicUsize::new(0)),
-            reader: None,
-            writer: None,
-        };
-        if self.io_dispatch.len() == self.io_dispatch.capacity() {
-            let amt = self.io_dispatch.len();
-            self.io_dispatch.reserve_exact(amt);
-        }
-        let entry = self.io_dispatch.vacant_entry();
-        let key = entry.key();
+    /// Register an I/O resource with the reactor.
+    ///
+    /// The registration token is returned.
+    fn add_source(&self, source: &Evented)
+        -> io::Result<usize>
+    {
+        // Acquire a write lock
+        let key = self.io_dispatch.write().unwrap()
+            .insert(ScheduledIo {
+                readiness: AtomicUsize::new(0),
+                reader: AtomicTask::new(),
+                writer: AtomicTask::new(),
+            });
+
         try!(self.io.register(source,
                               mio::Token(TOKEN_START + key),
                               mio::Ready::readable() |
                                 mio::Ready::writable() |
                                 platform::all(),
                               mio::PollOpt::edge()));
-        let sched = entry.insert(sched);
-        Ok((sched.readiness.clone(), key))
+
+        Ok(key)
     }
 
-    fn deregister_source(&mut self, source: &Evented) -> io::Result<()> {
+    fn deregister_source(&self, source: &Evented) -> io::Result<()> {
         self.io.deregister(source)
     }
 
-    fn drop_source(&mut self, token: usize) {
+    fn drop_source(&self, token: usize) {
         debug!("dropping I/O source: {}", token);
-        self.io_dispatch.remove(token);
+        self.io_dispatch.write().unwrap().remove(token);
     }
 
-    fn schedule(&mut self, token: usize, wake: Task, dir: Direction)
-                -> Option<Task> {
+    /// Registers interest in the I/O resource associated with `token`.
+    fn schedule(&self, token: usize, dir: Direction) {
         debug!("scheduling direction for: {}", token);
-        let sched = self.io_dispatch.get_mut(token).unwrap();
-        let (slot, ready) = match dir {
-            Direction::Read => (&mut sched.reader, !mio::Ready::writable()),
-            Direction::Write => (&mut sched.writer, mio::Ready::writable()),
+        let io_dispatch = self.io_dispatch.read().unwrap();
+        let sched = io_dispatch.get(token).unwrap();
+
+        let (task, ready) = match dir {
+            Direction::Read => (&sched.reader, !mio::Ready::writable()),
+            Direction::Write => (&sched.writer, mio::Ready::writable()),
         };
+
+        task.register();
+
         if sched.readiness.load(Ordering::SeqCst) & ready2usize(ready) != 0 {
-            debug!("cancelling block");
-            *slot = None;
-            Some(wake)
-        } else {
-            debug!("blocking");
-            *slot = Some(wake);
-            None
+            task.notify();
         }
     }
 }
 
 impl Remote {
-    fn send(&self, msg: Message) {
-        self.with_loop(|lp| {
-            match lp {
-                Some(lp) => {
-                    // We want to make sure that all messages are received in
-                    // order, so we need to consume pending messages before
-                    // delivering this message to the core. The actually
-                    // `consume_queue` function, however, can be somewhat slow
-                    // right now where receiving on a channel will acquire a
-                    // lock and block the current task.
-                    //
-                    // To speed this up check the message queue's readiness as a
-                    // sort of preflight check to see if we've actually got any
-                    // messages. This should just involve some atomics and if it
-                    // comes back false then we know for sure there are no
-                    // pending messages, so we can immediately deliver our
-                    // message.
-                    if lp.rx_readiness.0.readiness().is_readable() {
-                        lp.consume_queue();
-                    }
-                    lp.notify(msg);
-                }
-                None => {
-                    match self.tx.unbounded_send(msg) {
-                        Ok(()) => {}
-
-                        // TODO: this error should punt upwards and we should
-                        //       notify the caller that the message wasn't
-                        //       received. This is tokio-core#17
-                        Err(e) => drop(e),
-                    }
-                }
-            }
-        })
+    /// Return the ID of the represented Core
+    pub fn id(&self) -> CoreId {
+        CoreId(self.id)
     }
 
-    fn with_loop<F, R>(&self, f: F) -> R
-        where F: FnOnce(Option<&Core>) -> R
-    {
-        if CURRENT_LOOP.is_set() {
-            CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
-                if same {
-                    f(Some(lp))
-                } else {
-                    f(None)
-                }
-            })
-        } else {
-            f(None)
-        }
+    /// Attempts to "promote" this remote to a handle, if possible.
+    ///
+    /// This function is intended for structures which typically work through a
+    /// `Remote` but want to optimize runtime when the remote doesn't actually
+    /// leave the thread of the original reactor. This will attempt to return a
+    /// handle if the `Remote` is on the same thread as the event loop and the
+    /// event loop is running.
+    ///
+    /// If this `Remote` has moved to a different thread or if the event loop is
+    /// running, then `None` may be returned. If you need to guarantee access to
+    /// a `Handle`, then you can call this function and fall back to using
+    /// `spawn` above if it returns `None`.
+    pub fn handle(&self) -> Option<Handle> {
+        let remote = self.clone();
+        Some(Handle { remote } )
     }
 
     /// Spawns a new future into the event loop this remote is associated with.
@@ -454,41 +394,8 @@ impl Remote {
     pub(crate) fn run<F>(&self, f: F)
         where F: FnOnce(&Handle) + Send + 'static,
     {
-        self.send(Message::Run(Box::new(|lp: &Core| {
-            f(&lp.handle());
-        })));
-    }
-
-    /// Return the ID of the represented Core
-    pub fn id(&self) -> CoreId {
-        CoreId(self.id)
-    }
-
-    /// Attempts to "promote" this remote to a handle, if possible.
-    ///
-    /// This function is intended for structures which typically work through a
-    /// `Remote` but want to optimize runtime when the remote doesn't actually
-    /// leave the thread of the original reactor. This will attempt to return a
-    /// handle if the `Remote` is on the same thread as the event loop and the
-    /// event loop is running.
-    ///
-    /// If this `Remote` has moved to a different thread or if the event loop is
-    /// running, then `None` may be returned. If you need to guarantee access to
-    /// a `Handle`, then you can call this function and fall back to using
-    /// `spawn` above if it returns `None`.
-    pub fn handle(&self) -> Option<Handle> {
-        if CURRENT_LOOP.is_set() {
-            CURRENT_LOOP.with(|lp| {
-                let same = lp.inner.borrow().id == self.id;
-                if same {
-                    Some(lp.handle())
-                } else {
-                    None
-                }
-            })
-        } else {
-            None
-        }
+        let handle = self.handle().unwrap();
+        f(&handle);
     }
 }
 


### PR DESCRIPTION
This is an initial implementation making `Handle: Send + Sync`. It uses
a `RwLock` to coordinate access to the underlying state storage. An
implementation without the lock is left to later.

This pass also leaves a lot of dead code that can be removed in later
commits.

This is inspired by #34