### PR TITLE
Expand travis support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ rust:
   - beta
   - nightly
 before_script:
-  # OS X doesn't come with Python by default.
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install python fi
+  # OS X doesn't come with Python or pip by default.
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew brew install python ; fi
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ rust:
   - beta
   - nightly
 before_script:
+  # OS X doesn't come with Python by default.
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then brew install python fi
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cargo --version
   - rustc --version
   - cargo build --verbose
-  - cargo test --verbose
+  - RUST_LOG=tokio=trace cargo test --verbose
   - cargo doc --no-deps
 after_success:
   - travis-cargo --only nightly doc-upload --branch new-crate

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ rust:
   - nightly
 before_script:
   # OS X doesn't come with Python or pip by default.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew brew install python ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python ; fi
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ rust:
   - beta
   - nightly
 before_script:
-  # OS X doesn't come with Python or pip by default.
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python ; fi
-  - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
+  # On OS X pip2 need to be call for pip with support for python 2.
+  - export PIP_CMD=pip
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then PIP_CMD=pip2 ; fi
+  - $PIP_CMD install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
 script:
   - cargo --version
   - rustc --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,26 @@
----
-language: rust
 sudo: false
-
+cache: cargo
+os:
+  - linux
+  - osx
+language: rust
 rust:
   - stable
   - beta
   - nightly
-
 before_script:
   - pip install 'travis-cargo<0.2' --user && export PATH=$HOME/.local/bin:$PATH
-
 script:
-  - cargo build
-  - cargo test
+  - cargo --version
+  - rustc --version
+  - cargo build --verbose
+  - cargo test --verbose
   - cargo doc --no-deps
-
 after_success:
   - travis-cargo --only nightly doc-upload --branch new-crate
-
 env:
   global:
     - secure: iwlN1zfUCp/5BAAheqIRSFIqiM9zSwfIGcVDw/V7jHveqXyNzmCs7H58/cd90WLqonqpPX0t5GF66oTjms4v0DFjgXr/k4358qeSZaV082V3baNrVpCDHeCQV0SvKsfiYxDDJGSUL1WIUP+tqqDm4+ksZQP3LnwZojkABjWz5CBNt4kX+Wz5ZbYqtQoxyuZba5UyPY2CXJtubvCVPGMJULuUpklYxXZ4dWM2olzGgVJ8rE8udhSZ4ER4JgxB0KUx3/5TwHHzgyPEsWR4bKN6JzBjIczQofXUcUXXdoZBs23H/VhCpzKcn3/oJ8btVYPzwtdj5FmVB1aVR/gjPo2bSGi/sofq+LwL/1HJXkM+kjl8m2dLLcDBKqNYNERtVA1++LhkMWAFRgGYe8v8Ryxjiue1NF5LgAIA/fjK0uI1DELTzTf/TKrM+AtPDNTvhOft4/YD+hoImjwk6nv6PBb2TiTYnc79Qf4AZ65tv1qtsAUPuw4plLaccHQAO4ldYVXn4u9c+iisJwvovs6jo06bF3U3qtdI5gXsrI9+T25TrXvYb+IREo0MHzYEM0KlPFnscEArzC3eajuSd36ARFP3lDc+gp2RPs89iJjowms0eRyepp7Cu6XO3Cd2pfAX8AqvnmttZf4Nm51ONeiBPXPXItUkJm49MCpMJywU1IZcWZg=
-
 notifications:
   email:
     on_success: never
-
-os:
-  - linux


### PR DESCRIPTION
Start testing on OS X.
Print the version of cargo and rustc at the start of the testing,
useful for testing with nightly.
Add cargo to the cache.
Enable the verbose flag while building and testing.