### PR TITLE
Remove `NEXT_LOOP_ID` 

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -82,26 +82,9 @@ impl TcpListener {
                     return Err(e)
                 },
                 Ok((sock, addr)) => {
-                    // Fast path if we haven't left the event loop
-                    if let Some(handle) = self.io.remote().handle() {
-                        let io = try!(PollEvented::new(sock, &handle));
-                        return Ok((TcpStream { io: io }, addr))
-                    }
-
-                    // If we're off the event loop then send the socket back
-                    // over there to get registered and then we'll get it back
-                    // eventually.
-                    let (tx, rx) = oneshot::channel();
-                    let remote = self.io.remote().clone();
-                    remote.run(move |handle| {
-                        let res = PollEvented::new(sock, handle)
-                            .map(move |io| {
-                                (TcpStream { io: io }, addr)
-                            });
-                        drop(tx.send(res));
-                    });
-                    self.pending_accept = Some(rx);
-                    // continue to polling the `rx` at the beginning of the loop
+                    let handle = self.io.handle();
+                    let io = try!(PollEvented::new(sock, &handle));
+                    return Ok((TcpStream { io: io }, addr))
                 }
             }
         }

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -3,12 +3,12 @@ use std::io;
 
 use mio::event::Evented;
 
-use reactor::{Remote, Handle, Direction};
+use reactor::{Handle, Direction};
 
 /// A token that identifies an active I/O resource.
 pub struct IoToken {
     token: usize,
-    handle: Remote,
+    handle: Handle,
 }
 
 impl IoToken {
@@ -29,10 +29,10 @@ impl IoToken {
     /// associated with has gone away, or if there is an error communicating
     /// with the event loop.
     pub fn new(source: &Evented, handle: &Handle) -> io::Result<IoToken> {
-        match handle.remote.inner.upgrade() {
+        match handle.inner.upgrade() {
             Some(inner) => {
                 let token = try!(inner.add_source(source));
-                let handle = handle.remote().clone();
+                let handle = handle.clone();
 
                 Ok(IoToken { token, handle })
             }
@@ -40,8 +40,8 @@ impl IoToken {
         }
     }
 
-    /// Returns a reference to the remote handle.
-    pub fn remote(&self) -> &Remote {
+    /// Returns a reference to this I/O token's event loop's handle.
+    pub fn handle(&self) -> &Handle {
         &self.handle
     }
 

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -15,7 +15,7 @@ use mio::event::Evented;
 use mio::Ready;
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use reactor::{Handle, Remote};
+use reactor::Handle;
 use reactor::io_token::IoToken;
 
 /// A concrete implementation of a stream of readiness notifications for I/O
@@ -103,7 +103,7 @@ impl<E: Evented> PollEvented<E> {
     /// method is called, and will likely return an error if this `PollEvented`
     /// was created on a separate event loop from the `handle` specified.
     pub fn deregister(self, handle: &Handle) -> io::Result<()> {
-        let inner = match handle.remote.inner.upgrade() {
+        let inner = match handle.inner.upgrade() {
             Some(inner) => inner,
             None => return Ok(()),
         };
@@ -251,8 +251,8 @@ impl<E> PollEvented<E> {
 
     /// Returns a reference to the event loop handle that this readiness stream
     /// is associated with.
-    pub fn remote(&self) -> &Remote {
-        self.token.remote()
+    pub fn handle(&self) -> &Handle {
+        self.token.handle()
     }
 
     /// Returns a shared reference to the underlying I/O object this readiness


### PR DESCRIPTION
This is no longer needed now that the public-facing `CoreId` has been removed

This PR is based on https://github.com/tokio-rs/tokio/pull/50, only the last commit needs to be reviewed.