### PR TITLE
Tweak the `PollEvented::deregister` signature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/tokio" }
 [dependencies]
 bytes = "0.4"
 log = "0.3"
-mio = "0.6.10"
+mio = "0.6.11"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -79,7 +79,7 @@ fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
         // using the `TcpStream::from_stream` API. After that the socket is not
         // a `tokio::net::TcpStream` meaning it's in nonblocking mode and
         // ready to be used with Tokio
-        let socket = TcpStream::from_stream(socket, &handle)
+        let socket = TcpStream::from_std(socket, &handle)
             .expect("failed to associate TCP stream");
         let addr = socket.peer_addr().expect("failed to get remote address");
 

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -81,7 +81,7 @@ fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
         // request/response types instead of bytes. Here we'll just use our
         // framing defined below and then use the `send_all` helper to send the
         // responses back on the socket after we've processed them
-        let socket = future::result(TcpStream::from_stream(socket, &handle));
+        let socket = future::result(TcpStream::from_std(socket, &handle));
         let req = socket.and_then(|socket| {
             let (tx, rx) = socket.framed(Http).split();
             tx.send_all(rx.and_then(respond))

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -64,7 +64,7 @@ impl TcpListener {
         match self.io.get_ref().accept() {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             },
@@ -576,7 +576,7 @@ impl<'a> AsyncRead for &'a TcpStream {
                 Ok(Async::Ready(n))
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read();
+                self.io.need_read()?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),
@@ -614,7 +614,7 @@ impl<'a> AsyncWrite for &'a TcpStream {
                 Ok(Async::Ready(n))
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_write();
+                self.io.need_write()?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -103,10 +103,10 @@ impl TcpListener {
     ///   will only be for the same IP version as `addr` specified. That is, if
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
-    pub fn from_listener(listener: net::TcpListener,
-                         addr: &SocketAddr,
-                         handle: &Handle) -> io::Result<TcpListener> {
-        let l = try!(mio::net::TcpListener::from_listener(listener, addr));
+    pub fn from_std(listener: net::TcpListener,
+                    addr: &SocketAddr,
+                    handle: &Handle) -> io::Result<TcpListener> {
+        let l = mio::net::TcpListener::from_listener(listener, addr)?;
         TcpListener::new(l, handle)
     }
 
@@ -252,9 +252,10 @@ impl TcpStream {
     /// to a TCP stream ready to be used with the provided event loop handle.
     /// The stream returned is associated with the event loop and ready to
     /// perform I/O.
-    pub fn from_stream(stream: net::TcpStream, handle: &Handle)
-                       -> io::Result<TcpStream> {
-        let inner = try!(mio::net::TcpStream::from_stream(stream));
+    pub fn from_std(stream: net::TcpStream, handle: &Handle)
+        -> io::Result<TcpStream>
+    {
+        let inner = mio::net::TcpStream::from_stream(stream)?;
         Ok(TcpStream {
             io: try!(PollEvented::new(inner, handle)),
         })
@@ -278,10 +279,11 @@ impl TcpStream {
     ///   loop. Note that on Windows you must `bind` a socket before it can be
     ///   connected, so if a custom `TcpBuilder` is used it should be bound
     ///   (perhaps to `INADDR_ANY`) before this method is called.
-    pub fn connect_stream(stream: net::TcpStream,
-                          addr: &SocketAddr,
-                          handle: &Handle)
-                          -> Box<Future<Item=TcpStream, Error=io::Error> + Send> {
+    pub fn connect_std(stream: net::TcpStream,
+                       addr: &SocketAddr,
+                       handle: &Handle)
+        -> Box<Future<Item=TcpStream, Error=io::Error> + Send>
+    {
         let state = match mio::net::TcpStream::connect_stream(stream, addr) {
             Ok(tcp) => TcpStream::new(tcp, handle),
             Err(e) => TcpStreamNewState::Error(e),

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -82,26 +82,9 @@ impl TcpListener {
                     return Err(e)
                 },
                 Ok((sock, addr)) => {
-                    // Fast path if we haven't left the event loop
-                    if let Some(handle) = self.io.remote().handle() {
-                        let io = try!(PollEvented::new(sock, &handle));
-                        return Ok((TcpStream { io: io }, addr))
-                    }
-
-                    // If we're off the event loop then send the socket back
-                    // over there to get registered and then we'll get it back
-                    // eventually.
-                    let (tx, rx) = oneshot::channel();
-                    let remote = self.io.remote().clone();
-                    remote.run(move |handle| {
-                        let res = PollEvented::new(sock, handle)
-                            .map(move |io| {
-                                (TcpStream { io: io }, addr)
-                            });
-                        drop(tx.send(res));
-                    });
-                    self.pending_accept = Some(rx);
-                    // continue to polling the `rx` at the beginning of the loop
+                    let handle = self.io.handle();
+                    let io = try!(PollEvented::new(sock, &handle));
+                    return Ok((TcpStream { io: io }, addr))
                 }
             }
         }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -93,7 +93,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_write();
+                    self.io.need_write()?;
                 }
                 Err(e)
             }
@@ -115,7 +115,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             }
@@ -163,7 +163,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_write();
+                    self.io.need_write()?;
                 }
                 Err(e)
             }
@@ -205,7 +205,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -37,8 +37,8 @@ impl UdpSocket {
     /// This can be used in conjunction with net2's `UdpBuilder` interface to
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
-    pub fn from_socket(socket: net::UdpSocket,
-                       handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn from_std(socket: net::UdpSocket,
+                    handle: &Handle) -> io::Result<UdpSocket> {
         let udp = try!(mio::net::UdpSocket::from_socket(socket));
         UdpSocket::new(udp, handle)
     }

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -3,12 +3,12 @@ use std::io;
 
 use mio::event::Evented;
 
-use reactor::{Remote, Handle, Direction};
+use reactor::{Handle, Direction};
 
 /// A token that identifies an active I/O resource.
 pub struct IoToken {
     token: usize,
-    handle: Remote,
+    handle: Handle,
 }
 
 impl IoToken {
@@ -29,10 +29,10 @@ impl IoToken {
     /// associated with has gone away, or if there is an error communicating
     /// with the event loop.
     pub fn new(source: &Evented, handle: &Handle) -> io::Result<IoToken> {
-        match handle.remote.inner.upgrade() {
+        match handle.inner.upgrade() {
             Some(inner) => {
                 let token = try!(inner.add_source(source));
-                let handle = handle.remote().clone();
+                let handle = handle.clone();
 
                 Ok(IoToken { token, handle })
             }
@@ -40,8 +40,8 @@ impl IoToken {
         }
     }
 
-    /// Returns a reference to the remote handle.
-    pub fn remote(&self) -> &Remote {
+    /// Returns a reference to this I/O token's event loop's handle.
+    pub fn handle(&self) -> &Handle {
         &self.handle
     }
 

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -92,13 +92,14 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_read(&self) {
+    pub fn schedule_read(&self) -> io::Result<()> {
         let inner = match self.handle.inner.upgrade() {
             Some(inner) => inner,
-            None => return,
+            None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
 
         inner.schedule(self.token, Direction::Read);
+        Ok(())
     }
 
     /// Schedule the current future task to receive a notification when the
@@ -124,13 +125,14 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_write(&self) {
+    pub fn schedule_write(&self) -> io::Result<()> {
         let inner = match self.handle.inner.upgrade() {
             Some(inner) => inner,
-            None => return,
+            None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
 
         inner.schedule(self.token, Direction::Write);
+        Ok(())
     }
 
     /// Unregister all information associated with a token on an event loop,

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -15,7 +15,7 @@ use mio::event::Evented;
 use mio::Ready;
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use reactor::{Handle, Remote};
+use reactor::Handle;
 use reactor::io_token::IoToken;
 
 /// A concrete implementation of a stream of readiness notifications for I/O
@@ -103,7 +103,7 @@ impl<E: Evented> PollEvented<E> {
     /// method is called, and will likely return an error if this `PollEvented`
     /// was created on a separate event loop from the `handle` specified.
     pub fn deregister(self, handle: &Handle) -> io::Result<()> {
-        let inner = match handle.remote.inner.upgrade() {
+        let inner = match handle.inner.upgrade() {
             Some(inner) => inner,
             None => return Ok(()),
         };
@@ -251,8 +251,8 @@ impl<E> PollEvented<E> {
 
     /// Returns a reference to the event loop handle that this readiness stream
     /// is associated with.
-    pub fn remote(&self) -> &Remote {
-        self.token.remote()
+    pub fn handle(&self) -> &Handle {
+        self.token.handle()
     }
 
     /// Returns a shared reference to the underlying I/O object this readiness

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -1,0 +1,39 @@
+extern crate tokio;
+extern crate futures;
+
+use std::thread;
+
+use futures::future;
+use futures::prelude::*;
+use futures::sync::oneshot;
+use tokio::net::TcpListener;
+use tokio::reactor::Core;
+
+#[test]
+fn tcp_doesnt_block() {
+    let core = Core::new().unwrap();
+    let handle = core.handle();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    drop(core);
+    assert!(listener.incoming().wait().next().unwrap().is_err());
+}
+
+#[test]
+fn drop_wakes() {
+    let core = Core::new().unwrap();
+    let handle = core.handle();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    let (tx, rx) = oneshot::channel::<()>();
+    let t = thread::spawn(move || {
+        let incoming = listener.incoming();
+        let new_socket = incoming.into_future().map_err(|_| ());
+        let drop_tx = future::lazy(|| {
+            drop(tx);
+            future::ok(())
+        });
+        assert!(new_socket.join(drop_tx).wait().is_err());
+    });
+    drop(rx.wait());
+    drop(core);
+    t.join().unwrap();
+}


### PR DESCRIPTION
This commit changes the `PollEvented::deregister` signature from

    fn deregister(self, handle: &Handle) -> io::Result<()>

to

    fn deregister(&self) -> io::Result<()>

Now that the handles are `Send` and `Sync` there's no longer any need to pass it
in (it's already stored in the `PollEvented` itself). Additionally this switches
to `&self` instead of `self` to allow reclamation of the internal resources if
necessary.

This PR is based on https://github.com/tokio-rs/tokio/pull/54, only the last commit needs to be reviewed.