### PR TITLE
Blanket rename `Core` to `Reactor` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ appveyor = { repository = "alexcrichton/tokio" }
 [dependencies]
 bytes = "0.4"
 log = "0.3"
-mio = "0.6.10"
+mio = "0.6.11"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -16,7 +16,7 @@ use futures::sync::mpsc;
 use futures::{Future, Poll, Sink, Stream};
 use test::Bencher;
 use tokio::net::UdpSocket;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 /// UDP echo server
 struct EchoServer {
@@ -59,7 +59,7 @@ fn udp_echo_latency(b: &mut Bencher) {
     let (tx, rx) = oneshot::channel();
 
     let child = thread::spawn(move || {
-        let mut l = Core::new().unwrap();
+        let mut l = Reactor::new().unwrap();
         let handle = l.handle();
 
         let socket = tokio::net::UdpSocket::bind(&any_addr, &handle).unwrap();

--- a/benches/tcp.rs
+++ b/benches/tcp.rs
@@ -10,7 +10,7 @@ pub extern crate test;
 
 mod prelude {
     pub use futures::*;
-    pub use tokio::reactor::Core;
+    pub use tokio::reactor::Reactor;
     pub use tokio::net::{TcpListener, TcpStream};
     pub use tokio_io::io::read_to_end;
 
@@ -29,7 +29,7 @@ mod connect_churn {
     #[bench]
     fn one_thread(b: &mut Bencher) {
         let addr = "127.0.0.1:0".parse().unwrap();
-        let mut core = Core::new().unwrap();
+        let mut core = Reactor::new().unwrap();
         let handle = core.handle();
         let listener = TcpListener::bind(&addr, &handle).unwrap();
         let addr = listener.local_addr().unwrap();
@@ -63,7 +63,7 @@ mod connect_churn {
         // Spawn reactor thread
         thread::spawn(move || {
             // Create the core
-            let mut core = Core::new().unwrap();
+            let mut core = Reactor::new().unwrap();
 
             // Reactor handles
             let handle = core.handle();
@@ -209,7 +209,7 @@ mod transfer {
 
     fn one_thread(b: &mut Bencher, read_size: usize, write_size: usize) {
         let addr = "127.0.0.1:0".parse().unwrap();
-        let mut core = Core::new().unwrap();
+        let mut core = Reactor::new().unwrap();
         let handle = core.handle();
         let listener = TcpListener::bind(&addr, &handle).unwrap();
         let addr = listener.local_addr().unwrap();
@@ -255,7 +255,7 @@ mod transfer {
         // Spawn reactor thread
         thread::spawn(move || {
             // Create the core
-            let mut core = Core::new().unwrap();
+            let mut core = Reactor::new().unwrap();
 
             // Reactor handles
             let handle = core.handle();

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -33,7 +33,7 @@ use futures::future::Executor;
 use futures::stream::{self, Stream};
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::io;
 use tokio_io::AsyncRead;
 
@@ -42,7 +42,7 @@ fn main() {
     let addr = addr.parse().unwrap();
 
     // Create the event loop and TCP listener we'll accept connections on.
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -32,7 +32,7 @@ use futures::{Future, Stream, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::{AsyncRead, AsyncWrite};
 use flate2::write::GzEncoder;
 
@@ -41,7 +41,7 @@ fn main() {
     // reactor.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -28,7 +28,7 @@ use std::thread;
 use futures::sync::mpsc;
 use futures::{Sink, Future, Stream};
 use futures_cpupool::CpuPool;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 fn main() {
     // Determine if we're going to run in TCP or UDP mode
@@ -48,7 +48,7 @@ fn main() {
     let addr = addr.parse::<SocketAddr>().unwrap();
 
     // Create the event loop and initiate the connection to the remote server
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     let pool = CpuPool::new(1);

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -79,7 +79,7 @@ fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
         // using the `TcpStream::from_stream` API. After that the socket is not
         // a `tokio::net::TcpStream` meaning it's in nonblocking mode and
         // ready to be used with Tokio
-        let socket = TcpStream::from_stream(socket, &handle)
+        let socket = TcpStream::from_std(socket, &handle)
             .expect("failed to associate TCP stream");
         let addr = socket.peer_addr().expect("failed to get remote address");
 

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -31,7 +31,7 @@ use futures_cpupool::CpuPool;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 use tokio::net::TcpStream;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 fn main() {
     // First argument, the address to bind
@@ -69,7 +69,7 @@ fn main() {
 }
 
 fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     let pool = CpuPool::new(1);

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -20,7 +20,7 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll};
 use tokio::net::UdpSocket;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 struct Server {
     socket: UdpSocket,
@@ -56,7 +56,7 @@ fn main() {
 
     // Create the event loop that will drive this server, and also bind the
     // socket we'll be listening to.
-    let mut l = Core::new().unwrap();
+    let mut l = Reactor::new().unwrap();
     let handle = l.handle();
     let socket = UdpSocket::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", socket.local_addr().unwrap());

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -32,7 +32,7 @@ use futures_cpupool::CpuPool;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 fn main() {
     // Allow passing an address to listen on as the first argument of this
@@ -42,15 +42,15 @@ fn main() {
     let addr = addr.parse::<SocketAddr>().unwrap();
 
     // First up we'll create the event loop that's going to drive this server.
-    // This is done by creating an instance of the `Core` type, tokio-core's
+    // This is done by creating an instance of the `Reactor` type, tokio-core's
     // event loop. Most functions in tokio-core return an `io::Result`, and
-    // `Core::new` is no exception. For this example, though, we're mostly just
+    // `Reactor::new` is no exception. For this example, though, we're mostly just
     // ignoring errors, so we unwrap the return value.
     //
     // After the event loop is created we acquire a handle to it through the
     // `handle` method. With this handle we'll then later be able to create I/O
     // objects.
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     // Next up we create a TCP listener which will listen for incoming
@@ -126,7 +126,7 @@ fn main() {
     });
 
     // And finally now that we've define what our server is, we run it! We
-    // didn't actually do much I/O up to this point and this `Core::run` method
+    // didn't actually do much I/O up to this point and this `Reactor::run` method
     // is responsible for driving the entire server to completion.
     //
     // The `run` method will return the result of the future that it's running,

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -20,7 +20,7 @@ use std::env;
 use std::net::SocketAddr;
 
 use futures::stream::Stream;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio::net::TcpListener;
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let listener = TcpListener::bind(&addr, &core.handle()).unwrap();
 
     let addr = listener.local_addr().unwrap();

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -31,7 +31,7 @@ use futures::{Future, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::{copy, shutdown};
 
@@ -43,7 +43,7 @@ fn main() {
     let server_addr = server_addr.parse::<SocketAddr>().unwrap();
 
     // Create the event loop that will drive this server.
-    let mut l = Core::new().unwrap();
+    let mut l = Reactor::new().unwrap();
     let handle = l.handle();
 
     let pool = CpuPool::new(1);

--- a/examples/sink.rs
+++ b/examples/sink.rs
@@ -31,7 +31,7 @@ use futures::stream::{self, Stream};
 use futures_cpupool::CpuPool;
 use tokio_io::IoFuture;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 fn main() {
     env_logger::init().unwrap();
@@ -40,7 +40,7 @@ fn main() {
 
     let pool = CpuPool::new(1);
 
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);

--- a/examples/tinydb.rs
+++ b/examples/tinydb.rs
@@ -54,7 +54,7 @@ use futures::prelude::*;
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::AsyncRead;
 use tokio_io::io::{lines, write_all};
 
@@ -80,11 +80,11 @@ enum Response {
 }
 
 fn main() {
-    // Parse the address we're going to run this server on, create a `Core`, and
+    // Parse the address we're going to run this server on, create a `Reactor`, and
     // set up our TCP listener to accept connections.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
     let listener = TcpListener::bind(&addr, &handle).expect("failed to bind");
     println!("Listening on: {}", addr);

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -39,7 +39,7 @@ use futures_cpupool::CpuPool;
 use http::{Request, Response, StatusCode};
 use http::header::HeaderValue;
 use tokio::net::TcpStream;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::codec::{Encoder, Decoder};
 use tokio_io::{AsyncRead};
 
@@ -70,7 +70,7 @@ fn main() {
 }
 
 fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     let pool = CpuPool::new(1);

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -81,7 +81,7 @@ fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
         // request/response types instead of bytes. Here we'll just use our
         // framing defined below and then use the `send_all` helper to send the
         // responses back on the socket after we've processed them
-        let socket = future::result(TcpStream::from_stream(socket, &handle));
+        let socket = future::result(TcpStream::from_std(socket, &handle));
         let req = socket.and_then(|socket| {
             let (tx, rx) = socket.framed(Http).split();
             tx.send_all(rx.and_then(respond))

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -18,7 +18,7 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{UdpSocket, UdpCodec};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 pub struct LineCodec;
 
@@ -39,7 +39,7 @@ impl UdpCodec for LineCodec {
 fn main() {
     drop(env_logger::init());
 
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     let pool = CpuPool::new(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,11 @@
 //! use tokio_io::AsyncRead;
 //! use tokio_io::io::copy;
 //! use tokio::net::TcpListener;
-//! use tokio::reactor::Core;
+//! use tokio::reactor::Reactor;
 //!
 //! fn main() {
 //!     // Create the event loop that will drive this server.
-//!     let mut core = Core::new().unwrap();
+//!     let mut core = Reactor::new().unwrap();
 //!     let handle = core.handle();
 //!
 //!     let pool = CpuPool::new_num_cpus();

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -64,7 +64,7 @@ impl TcpListener {
         match self.io.get_ref().accept() {
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             },
@@ -576,7 +576,7 @@ impl<'a> AsyncRead for &'a TcpStream {
                 Ok(Async::Ready(n))
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read();
+                self.io.need_read()?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),
@@ -614,7 +614,7 @@ impl<'a> AsyncWrite for &'a TcpStream {
                 Ok(Async::Ready(n))
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_write();
+                self.io.need_write()?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -103,10 +103,10 @@ impl TcpListener {
     ///   will only be for the same IP version as `addr` specified. That is, if
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
-    pub fn from_listener(listener: net::TcpListener,
-                         addr: &SocketAddr,
-                         handle: &Handle) -> io::Result<TcpListener> {
-        let l = try!(mio::net::TcpListener::from_listener(listener, addr));
+    pub fn from_std(listener: net::TcpListener,
+                    addr: &SocketAddr,
+                    handle: &Handle) -> io::Result<TcpListener> {
+        let l = mio::net::TcpListener::from_listener(listener, addr)?;
         TcpListener::new(l, handle)
     }
 
@@ -252,9 +252,10 @@ impl TcpStream {
     /// to a TCP stream ready to be used with the provided event loop handle.
     /// The stream returned is associated with the event loop and ready to
     /// perform I/O.
-    pub fn from_stream(stream: net::TcpStream, handle: &Handle)
-                       -> io::Result<TcpStream> {
-        let inner = try!(mio::net::TcpStream::from_stream(stream));
+    pub fn from_std(stream: net::TcpStream, handle: &Handle)
+        -> io::Result<TcpStream>
+    {
+        let inner = mio::net::TcpStream::from_stream(stream)?;
         Ok(TcpStream {
             io: try!(PollEvented::new(inner, handle)),
         })
@@ -278,10 +279,11 @@ impl TcpStream {
     ///   loop. Note that on Windows you must `bind` a socket before it can be
     ///   connected, so if a custom `TcpBuilder` is used it should be bound
     ///   (perhaps to `INADDR_ANY`) before this method is called.
-    pub fn connect_stream(stream: net::TcpStream,
-                          addr: &SocketAddr,
-                          handle: &Handle)
-                          -> Box<Future<Item=TcpStream, Error=io::Error> + Send> {
+    pub fn connect_std(stream: net::TcpStream,
+                       addr: &SocketAddr,
+                       handle: &Handle)
+        -> Box<Future<Item=TcpStream, Error=io::Error> + Send>
+    {
         let state = match mio::net::TcpStream::connect_stream(stream, addr) {
             Ok(tcp) => TcpStream::new(tcp, handle),
             Err(e) => TcpStreamNewState::Error(e),

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -82,26 +82,9 @@ impl TcpListener {
                     return Err(e)
                 },
                 Ok((sock, addr)) => {
-                    // Fast path if we haven't left the event loop
-                    if let Some(handle) = self.io.remote().handle() {
-                        let io = try!(PollEvented::new(sock, &handle));
-                        return Ok((TcpStream { io: io }, addr))
-                    }
-
-                    // If we're off the event loop then send the socket back
-                    // over there to get registered and then we'll get it back
-                    // eventually.
-                    let (tx, rx) = oneshot::channel();
-                    let remote = self.io.remote().clone();
-                    remote.run(move |handle| {
-                        let res = PollEvented::new(sock, handle)
-                            .map(move |io| {
-                                (TcpStream { io: io }, addr)
-                            });
-                        drop(tx.send(res));
-                    });
-                    self.pending_accept = Some(rx);
-                    // continue to polling the `rx` at the beginning of the loop
+                    let handle = self.io.handle();
+                    let io = try!(PollEvented::new(sock, &handle));
+                    return Ok((TcpStream { io: io }, addr))
                 }
             }
         }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -93,7 +93,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_write();
+                    self.io.need_write()?;
                 }
                 Err(e)
             }
@@ -115,7 +115,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             }
@@ -163,7 +163,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_write();
+                    self.io.need_write()?;
                 }
                 Err(e)
             }
@@ -205,7 +205,7 @@ impl UdpSocket {
             Ok(n) => Ok(n),
             Err(e) => {
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.need_read();
+                    self.io.need_read()?;
                 }
                 Err(e)
             }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -37,8 +37,8 @@ impl UdpSocket {
     /// This can be used in conjunction with net2's `UdpBuilder` interface to
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
-    pub fn from_socket(socket: net::UdpSocket,
-                       handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn from_std(socket: net::UdpSocket,
+                    handle: &Handle) -> io::Result<UdpSocket> {
         let udp = try!(mio::net::UdpSocket::from_socket(socket));
         UdpSocket::new(udp, handle)
     }

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -3,12 +3,12 @@ use std::io;
 
 use mio::event::Evented;
 
-use reactor::{Remote, Handle, Direction};
+use reactor::{Handle, Direction};
 
 /// A token that identifies an active I/O resource.
 pub struct IoToken {
     token: usize,
-    handle: Remote,
+    handle: Handle,
 }
 
 impl IoToken {
@@ -29,10 +29,10 @@ impl IoToken {
     /// associated with has gone away, or if there is an error communicating
     /// with the event loop.
     pub fn new(source: &Evented, handle: &Handle) -> io::Result<IoToken> {
-        match handle.remote.inner.upgrade() {
+        match handle.inner.upgrade() {
             Some(inner) => {
                 let token = try!(inner.add_source(source));
-                let handle = handle.remote().clone();
+                let handle = handle.clone();
 
                 Ok(IoToken { token, handle })
             }
@@ -40,8 +40,8 @@ impl IoToken {
         }
     }
 
-    /// Returns a reference to the remote handle.
-    pub fn remote(&self) -> &Remote {
+    /// Returns a reference to this I/O token's event loop's handle.
+    pub fn handle(&self) -> &Handle {
         &self.handle
     }
 

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -92,13 +92,14 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_read(&self) {
+    pub fn schedule_read(&self) -> io::Result<()> {
         let inner = match self.handle.inner.upgrade() {
             Some(inner) => inner,
-            None => return,
+            None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
 
         inner.schedule(self.token, Direction::Read);
+        Ok(())
     }
 
     /// Schedule the current future task to receive a notification when the
@@ -124,13 +125,14 @@ impl IoToken {
     ///
     /// This function will also panic if there is not a currently running future
     /// task.
-    pub fn schedule_write(&self) {
+    pub fn schedule_write(&self) -> io::Result<()> {
         let inner = match self.handle.inner.upgrade() {
             Some(inner) => inner,
-            None => return,
+            None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
 
         inner.schedule(self.token, Direction::Write);
+        Ok(())
     }
 
     /// Unregister all information associated with a token on an event loop,

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -1,6 +1,6 @@
 //! The core reactor driving all I/O.
 //!
-//! This module contains the [`Core`] reactor type which is the event loop for
+//! This module contains the [`Reactor`] reactor type which is the event loop for
 //! all I/O happening in `tokio`. This core reactor (or event loop) is used to
 //! drive I/O resources.
 //!
@@ -12,11 +12,11 @@
 //! Lastly [`PollEvented`] can be used to construct I/O objects that interact
 //! with the event loop, e.g. [`TcpStream`] in the net module.
 //!
-//! [`Core`]: struct.Core.html
+//! [`Reactor`]: struct.Reactor.html
 //! [`Handle`]: struct.Handle.html
 //! [`Remote`]: struct.Remote.html
-//! [handle_method]: struct.Core.html#method.handle
-//! [remote_method]: struct.Core.html#method.remote
+//! [handle_method]: struct.Reactor.html#method.handle
+//! [remote_method]: struct.Reactor.html#method.remote
 //! [`PollEvented`]: struct.PollEvented.html
 //! [`TcpStream`]: ../net/struct.TcpStream.html
 
@@ -44,7 +44,7 @@ pub use self::poll_evented::PollEvented;
 /// all other I/O events and notifications happening. Each event loop can have
 /// multiple handles pointing to it, each of which can then be used to create
 /// various I/O objects to interact with the event loop in interesting ways.
-pub struct Core {
+pub struct Reactor {
     /// Reuse the `mio::Events` value across calls to poll.
     events: mio::Events,
 
@@ -96,10 +96,10 @@ fn _assert_kinds() {
     _assert::<Handle>();
 }
 
-impl Core {
+impl Reactor {
     /// Creates a new event loop, returning any error that happened during the
     /// creation.
-    pub fn new() -> io::Result<Core> {
+    pub fn new() -> io::Result<Reactor> {
         // Create the I/O poller
         let io = try!(mio::Poll::new());
 
@@ -111,7 +111,7 @@ impl Core {
                          mio::Ready::readable(),
                          mio::PollOpt::level()));
 
-        Ok(Core {
+        Ok(Reactor {
             events: mio::Events::with_capacity(1024),
             _future_registration: future_pair.0,
             future_readiness: Arc::new(MySetReadiness(future_pair.1)),
@@ -225,9 +225,9 @@ impl Core {
     }
 }
 
-impl fmt::Debug for Core {
+impl fmt::Debug for Reactor {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Core")
+        write!(f, "Reactor")
     }
 }
 

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -198,7 +198,7 @@ impl<E> PollEvented<E> {
     ///
     /// # Errors
     ///
-    /// This function will return an error if the `Core` that this `PollEvented`
+    /// This function will return an error if the `Reactor` that this `PollEvented`
     /// is associated with has gone away (been destroyed). The error means that
     /// the ambient futures task could not be scheduled to receive a
     /// notification and typically means that the error should be propagated
@@ -232,7 +232,7 @@ impl<E> PollEvented<E> {
     ///
     /// # Errors
     ///
-    /// This function will return an error if the `Core` that this `PollEvented`
+    /// This function will return an error if the `Reactor` that this `PollEvented`
     /// is associated with has gone away (been destroyed). The error means that
     /// the ambient futures task could not be scheduled to receive a
     /// notification and typically means that the error should be propagated

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -15,7 +15,7 @@ use mio::event::Evented;
 use mio::Ready;
 use tokio_io::{AsyncRead, AsyncWrite};
 
-use reactor::{Handle, Remote};
+use reactor::Handle;
 use reactor::io_token::IoToken;
 
 /// A concrete implementation of a stream of readiness notifications for I/O
@@ -103,7 +103,7 @@ impl<E: Evented> PollEvented<E> {
     /// method is called, and will likely return an error if this `PollEvented`
     /// was created on a separate event loop from the `handle` specified.
     pub fn deregister(self, handle: &Handle) -> io::Result<()> {
-        let inner = match handle.remote.inner.upgrade() {
+        let inner = match handle.inner.upgrade() {
             Some(inner) => inner,
             None => return Ok(()),
         };
@@ -251,8 +251,8 @@ impl<E> PollEvented<E> {
 
     /// Returns a reference to the event loop handle that this readiness stream
     /// is associated with.
-    pub fn remote(&self) -> &Remote {
-        self.token.remote()
+    pub fn handle(&self) -> &Handle {
+        self.token.handle()
     }
 
     /// Returns a shared reference to the underlying I/O object this readiness

--- a/tests/buffered.rs
+++ b/tests/buffered.rs
@@ -11,7 +11,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,7 +25,7 @@ fn echo_server() {
     const N: usize = 1024;
     drop(env_logger::init());
 
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/chain.rs
+++ b/tests/chain.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,7 +21,7 @@ macro_rules! t {
 
 #[test]
 fn chain_clients() {
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -7,11 +7,11 @@ use futures::future;
 use futures::prelude::*;
 use futures::sync::oneshot;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 #[test]
 fn tcp_doesnt_block() {
-    let core = Core::new().unwrap();
+    let core = Reactor::new().unwrap();
     let handle = core.handle();
     let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
     drop(core);
@@ -20,7 +20,7 @@ fn tcp_doesnt_block() {
 
 #[test]
 fn drop_wakes() {
-    let core = Core::new().unwrap();
+    let core = Reactor::new().unwrap();
     let handle = core.handle();
     let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
     let (tx, rx) = oneshot::channel::<()>();

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -1,0 +1,39 @@
+extern crate tokio;
+extern crate futures;
+
+use std::thread;
+
+use futures::future;
+use futures::prelude::*;
+use futures::sync::oneshot;
+use tokio::net::TcpListener;
+use tokio::reactor::Core;
+
+#[test]
+fn tcp_doesnt_block() {
+    let core = Core::new().unwrap();
+    let handle = core.handle();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    drop(core);
+    assert!(listener.incoming().wait().next().unwrap().is_err());
+}
+
+#[test]
+fn drop_wakes() {
+    let core = Core::new().unwrap();
+    let handle = core.handle();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    let (tx, rx) = oneshot::channel::<()>();
+    let t = thread::spawn(move || {
+        let incoming = listener.incoming();
+        let new_socket = incoming.into_future().map_err(|_| ());
+        let drop_tx = future::lazy(|| {
+            drop(tx);
+            future::ok(())
+        });
+        assert!(new_socket.join(drop_tx).wait().is_err());
+    });
+    drop(rx.wait());
+    drop(core);
+    t.join().unwrap();
+}

--- a/tests/echo.rs
+++ b/tests/echo.rs
@@ -10,7 +10,7 @@ use std::thread;
 use futures::Future;
 use futures::stream::Stream;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 
@@ -25,7 +25,7 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/limit.rs
+++ b/tests/limit.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,7 +21,7 @@ macro_rules! t {
 
 #[test]
 fn limit() {
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/line-frames.rs
+++ b/tests/line-frames.rs
@@ -13,7 +13,7 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio_io::codec::{Encoder, Decoder};
 use tokio_io::io::{write_all, read};
 use tokio_io::AsyncRead;
@@ -55,7 +55,7 @@ impl Encoder for LineCodec {
 fn echo() {
     drop(env_logger::init());
 
-    let mut core = Core::new().unwrap();
+    let mut core = Reactor::new().unwrap();
     let handle = core.handle();
 
     let pool = CpuPool::new(1);

--- a/tests/pipe-hup.rs
+++ b/tests/pipe-hup.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use mio::unix::{UnixReady, EventedFd};
 use mio::{PollOpt, Ready, Token};
 use mio::event::Evented;
-use tokio::reactor::{Core, PollEvented};
+use tokio::reactor::{Reactor, PollEvented};
 use tokio_io::io::read_to_end;
 
 macro_rules! t {
@@ -64,7 +64,7 @@ impl Evented for MyFile {
 fn hup() {
     drop(env_logger::init());
 
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     unsafe {
         let mut pipes = [0; 2];
         assert!(libc::pipe(pipes.as_mut_ptr()) != -1,

--- a/tests/stream-buffered.rs
+++ b/tests/stream-buffered.rs
@@ -12,7 +12,7 @@ use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio_io::AsyncRead;
 use tokio::net::TcpListener;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,7 +25,7 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -8,7 +8,7 @@ use std::thread;
 
 use futures::Future;
 use futures::stream::Stream;
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 use tokio::net::{TcpListener, TcpStream};
 
 macro_rules! t {
@@ -21,7 +21,7 @@ macro_rules! t {
 #[test]
 fn connect() {
     drop(env_logger::init());
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(net::TcpListener::bind("127.0.0.1:0"));
     let addr = t!(srv.local_addr());
     let t = thread::spawn(move || {
@@ -39,7 +39,7 @@ fn connect() {
 #[test]
 fn accept() {
     drop(env_logger::init());
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 
@@ -64,7 +64,7 @@ fn accept() {
 #[test]
 fn accept2() {
     drop(env_logger::init());
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let addr = t!(srv.local_addr());
 

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -8,7 +8,7 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll, Stream, Sink};
 use tokio::net::{UdpSocket, UdpCodec};
-use tokio::reactor::Core;
+use tokio::reactor::Reactor;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -18,7 +18,7 @@ macro_rules! t {
 }
 
 fn send_messages<S: SendFn + Clone, R: RecvFn + Clone>(send: S, recv: R) {
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let mut a = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into(), &l.handle()));
     let mut b = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into(), &l.handle()));
     let a_addr = t!(a.local_addr());
@@ -166,7 +166,7 @@ impl<R: RecvFn> Future for RecvMessage<R> {
 
 #[test]
 fn send_dgrams() {
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let mut a = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let mut b = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let mut buf = [0u8; 50];
@@ -216,7 +216,7 @@ impl UdpCodec for Codec {
 
 #[test]
 fn send_framed() {
-    let mut l = t!(Core::new());
+    let mut l = t!(Reactor::new());
     let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
     let a_addr = t!(a_soc.local_addr());


### PR DESCRIPTION
This commit uses a script to rename `Core` to `Reactor` all at once, notably:

    find . -name '*.rs' | xargs sed -i 's/\bCore\b/Reactor/g'

This PR is based on https://github.com/tokio-rs/tokio/pull/55, only the last commit needs to be reviewed.