### PR TITLE
Start adding a global event loop 

### DIFF
--- a/src/reactor/global.rs
+++ b/src/reactor/global.rs
@@ -1,0 +1,43 @@
+use std::io;
+use std::thread;
+
+use reactor::{Reactor, Handle};
+
+pub struct HelperThread {
+    thread: Option<thread::JoinHandle<()>>,
+    reactor: Handle,
+}
+
+impl HelperThread {
+    pub fn new() -> io::Result<HelperThread> {
+        let reactor = Reactor::new()?;
+        let reactor_handle = reactor.handle().clone();
+        let thread = thread::Builder::new().spawn(move || run(reactor))?;
+
+        Ok(HelperThread {
+            thread: Some(thread),
+            reactor: reactor_handle,
+        })
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.reactor
+    }
+
+    pub fn forget(mut self) {
+        drop(self.thread.take());
+    }
+}
+
+impl Drop for HelperThread {
+    fn drop(&mut self) {
+        // TODO: kill the reactor thread and wait for it to exit, needs
+        //       `Handle::wakeup` to be implemented in a future PR
+    }
+}
+
+fn run(mut reactor: Reactor) {
+    loop {
+        reactor.turn(None);
+    }
+}

--- a/src/reactor/io_token.rs
+++ b/src/reactor/io_token.rs
@@ -29,7 +29,7 @@ impl IoToken {
     /// associated with has gone away, or if there is an error communicating
     /// with the event loop.
     pub fn new(source: &Evented, handle: &Handle) -> io::Result<IoToken> {
-        match handle.inner.upgrade() {
+        match handle.inner() {
             Some(inner) => {
                 let token = try!(inner.add_source(source));
                 let handle = handle.clone();
@@ -61,7 +61,7 @@ impl IoToken {
     /// >           rather the `ReadinessStream` type should be used instead.
     // TODO: this should really return a proper newtype/enum, not a usize
     pub fn take_readiness(&self) -> usize {
-        let inner = match self.handle.inner.upgrade() {
+        let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return 0,
         };
@@ -93,7 +93,7 @@ impl IoToken {
     /// This function will also panic if there is not a currently running future
     /// task.
     pub fn schedule_read(&self) -> io::Result<()> {
-        let inner = match self.handle.inner.upgrade() {
+        let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
@@ -126,7 +126,7 @@ impl IoToken {
     /// This function will also panic if there is not a currently running future
     /// task.
     pub fn schedule_write(&self) -> io::Result<()> {
-        let inner = match self.handle.inner.upgrade() {
+        let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
@@ -158,7 +158,7 @@ impl IoToken {
     /// with has gone away, or if there is an error communicating with the event
     /// loop.
     pub fn drop_source(&self) {
-        let inner = match self.handle.inner.upgrade() {
+        let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return,
         };

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -281,7 +281,7 @@ impl<E> PollEvented<E> {
     pub fn deregister(&self) -> io::Result<()>
         where E: Evented,
     {
-        let inner = match self.handle().inner.upgrade() {
+        let inner = match self.handle().inner() {
             Some(inner) => inner,
             None => return Ok(()),
         };

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,0 +1,37 @@
+extern crate futures;
+extern crate tokio;
+
+use std::thread;
+
+use futures::prelude::*;
+use tokio::net::{TcpStream, TcpListener};
+use tokio::reactor::Handle;
+
+macro_rules! t {
+    ($e:expr) => (match $e {
+        Ok(e) => e,
+        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+    })
+}
+
+#[test]
+fn hammer() {
+    let threads = (0..10).map(|_| {
+        thread::spawn(|| {
+            let handle = Handle::default();
+            let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle));
+            let addr = t!(srv.local_addr());
+            let mine = TcpStream::connect(&addr, &handle);
+            let theirs = srv.incoming().into_future()
+                .map(|(s, _)| s.unwrap().0)
+                .map_err(|(s, _)| s);
+            let (mine, theirs) = t!(mine.join(theirs).wait());
+
+            assert_eq!(t!(mine.local_addr()), t!(theirs.peer_addr()));
+            assert_eq!(t!(theirs.local_addr()), t!(mine.peer_addr()));
+        })
+    }).collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+}


### PR DESCRIPTION
This commit starts to add support for a global event loop by adding a
`Handle::default` method and implementing it. Currently the support is quite
rudimentary and doesn't support features such as shutdown, overriding the return
value of `Handle::default`, etc. Those will come as future commits.

This PR is based on https://github.com/tokio-rs/tokio/pull/56, only the last commit needs to be reviewed.