### PR TITLE
Remove the `Reactor::run` method

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -33,7 +33,7 @@ use futures::future::Executor;
 use futures::stream::{self, Stream};
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::io;
 use tokio_io::AsyncRead;
 
@@ -41,9 +41,8 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse().unwrap();
 
-    // Create the event loop and TCP listener we'll accept connections on.
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    // Create the TCP listener we'll accept connections on.
+    let handle = Handle::default();
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);
 
@@ -135,5 +134,5 @@ fn main() {
     });
 
     // execute server
-    core.run(srv).unwrap();
+    srv.wait().unwrap();
 }

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -32,7 +32,7 @@ use futures::{Future, Stream, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
 use flate2::write::GzEncoder;
 
@@ -41,8 +41,7 @@ fn main() {
     // reactor.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
     let socket = TcpListener::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", addr);
 
@@ -64,7 +63,7 @@ fn main() {
         Ok(())
     });
 
-    core.run(server).unwrap();
+    server.wait().unwrap();
 }
 
 /// The main workhorse of this example. This'll compress all data read from

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -28,7 +28,7 @@ use std::thread;
 use futures::sync::mpsc;
 use futures::{Sink, Future, Stream};
 use futures_cpupool::CpuPool;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 fn main() {
     // Determine if we're going to run in TCP or UDP mode
@@ -47,9 +47,7 @@ fn main() {
     });
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    // Create the event loop and initiate the connection to the remote server
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
 
     let pool = CpuPool::new(1);
 
@@ -76,9 +74,9 @@ fn main() {
     // loop. In this case, though, we know it's ok as the event loop isn't
     // otherwise running anything useful.
     let mut out = io::stdout();
-    core.run(stdout.for_each(|chunk| {
+    stdout.for_each(|chunk| {
         out.write_all(&chunk)
-    })).unwrap();
+    }).wait().unwrap();
 }
 
 mod tcp {

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -20,7 +20,7 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll};
 use tokio::net::UdpSocket;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 struct Server {
     socket: UdpSocket,
@@ -54,18 +54,15 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    // Create the event loop that will drive this server, and also bind the
-    // socket we'll be listening to.
-    let mut l = Reactor::new().unwrap();
-    let handle = l.handle();
+    let handle = Handle::default();
     let socket = UdpSocket::bind(&addr, &handle).unwrap();
     println!("Listening on: {}", socket.local_addr().unwrap());
 
     // Next we'll create a future to spawn (the one we defined above) and then
-    // we'll run the event loop by running the future.
-    l.run(Server {
+    // we'll block our current thread waiting on the result of the future
+    Server {
         socket: socket,
         buf: vec![0; 1024],
         to_send: None,
-    }).unwrap();
+    }.wait().unwrap();
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -32,7 +32,7 @@ use futures_cpupool::CpuPool;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 fn main() {
     // Allow passing an address to listen on as the first argument of this
@@ -41,17 +41,7 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    // First up we'll create the event loop that's going to drive this server.
-    // This is done by creating an instance of the `Reactor` type, tokio-core's
-    // event loop. Most functions in tokio-core return an `io::Result`, and
-    // `Reactor::new` is no exception. For this example, though, we're mostly just
-    // ignoring errors, so we unwrap the return value.
-    //
-    // After the event loop is created we acquire a handle to it through the
-    // `handle` method. With this handle we'll then later be able to create I/O
-    // objects.
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
 
     // Next up we create a TCP listener which will listen for incoming
     // connections. This TCP listener is bound to the address we determined
@@ -125,13 +115,8 @@ fn main() {
         Ok(())
     });
 
-    // And finally now that we've define what our server is, we run it! We
-    // didn't actually do much I/O up to this point and this `Reactor::run` method
-    // is responsible for driving the entire server to completion.
-    //
-    // The `run` method will return the result of the future that it's running,
-    // but in our case the `done` future won't ever finish because a TCP
-    // listener is never done accepting clients. That basically just means that
-    // we're going to be running the server until it's killed (e.g. ctrl-c).
-    core.run(done).unwrap();
+    // And finally now that we've define what our server is, we run it! Here we
+    // just need to execute the future we've created and wait for it to complete
+    // using the standard methods in the `futures` crate.
+    done.wait().unwrap();
 }

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -19,17 +19,17 @@ extern crate tokio_io;
 use std::env;
 use std::net::SocketAddr;
 
-use futures::stream::Stream;
-use tokio::reactor::Reactor;
+use futures::prelude::*;
 use tokio::net::TcpListener;
+use tokio::reactor::Handle;
 
 fn main() {
     env_logger::init().unwrap();
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let mut core = Reactor::new().unwrap();
-    let listener = TcpListener::bind(&addr, &core.handle()).unwrap();
+    let handle = Handle::default();
+    let listener = TcpListener::bind(&addr, &handle).unwrap();
 
     let addr = listener.local_addr().unwrap();
     println!("Listening for connections on {}", addr);
@@ -42,5 +42,5 @@ fn main() {
         Ok(())
     });
 
-    core.run(server).unwrap();
+    server.wait().unwrap();
 }

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -31,7 +31,7 @@ use futures::{Future, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::{copy, shutdown};
 
@@ -42,14 +42,12 @@ fn main() {
     let server_addr = env::args().nth(2).unwrap_or("127.0.0.1:8080".to_string());
     let server_addr = server_addr.parse::<SocketAddr>().unwrap();
 
-    // Create the event loop that will drive this server.
-    let mut l = Reactor::new().unwrap();
-    let handle = l.handle();
+    let handle = Handle::default();
 
     let pool = CpuPool::new(1);
 
     // Create a TCP listener which will listen for incoming connections.
-    let socket = TcpListener::bind(&listen_addr, &l.handle()).unwrap();
+    let socket = TcpListener::bind(&listen_addr, &handle).unwrap();
     println!("Listening on: {}", listen_addr);
     println!("Proxying to: {}", server_addr);
 
@@ -97,7 +95,7 @@ fn main() {
 
         Ok(())
     });
-    l.run(done).unwrap();
+    done.wait().unwrap();
 }
 
 // This is a custom type used to have a custom implementation of the

--- a/examples/tinydb.rs
+++ b/examples/tinydb.rs
@@ -54,7 +54,7 @@ use futures::prelude::*;
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::AsyncRead;
 use tokio_io::io::{lines, write_all};
 
@@ -80,12 +80,11 @@ enum Response {
 }
 
 fn main() {
-    // Parse the address we're going to run this server on, create a `Reactor`, and
-    // set up our TCP listener to accept connections.
+    // Parse the address we're going to run this server on
+    // and set up our TCP listener to accept connections.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
     let listener = TcpListener::bind(&addr, &handle).expect("failed to bind");
     println!("Listening on: {}", addr);
 
@@ -163,7 +162,7 @@ fn main() {
         Ok(())
     });
 
-    core.run(done).unwrap();
+    done.wait().unwrap();
 }
 
 impl Request {

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -31,15 +31,15 @@ use std::net::{self, SocketAddr};
 use std::thread;
 
 use bytes::BytesMut;
-use futures::future;
 use futures::future::Executor;
+use futures::future;
 use futures::sync::mpsc;
 use futures::{Stream, Future, Sink};
 use futures_cpupool::CpuPool;
-use http::{Request, Response, StatusCode};
 use http::header::HeaderValue;
+use http::{Request, Response, StatusCode};
 use tokio::net::TcpStream;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::codec::{Encoder, Decoder};
 use tokio_io::{AsyncRead};
 
@@ -70,8 +70,7 @@ fn main() {
 }
 
 fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
 
     let pool = CpuPool::new(1);
 
@@ -92,7 +91,7 @@ fn worker(rx: mpsc::UnboundedReceiver<net::TcpStream>) {
         })).unwrap();
         Ok(())
     });
-    core.run(done).unwrap();
+    done.wait().unwrap();
 }
 
 /// "Server logic" is implemented in this function.

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -18,7 +18,7 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{UdpSocket, UdpCodec};
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 pub struct LineCodec;
 
@@ -39,8 +39,7 @@ impl UdpCodec for LineCodec {
 fn main() {
     drop(env_logger::init());
 
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
+    let handle = Handle::default();
 
     let pool = CpuPool::new(1);
 
@@ -79,5 +78,5 @@ fn main() {
 
     // Spawn the sender of pongs and then wait for our pinger to finish.
     pool.execute(b.then(|_| Ok(()))).unwrap();
-    drop(core.run(a));
+    drop(a.wait());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,18 +43,16 @@
 //! extern crate tokio;
 //! extern crate tokio_io;
 //!
-//! use futures::{Future, Stream};
+//! use futures::prelude::*;
 //! use futures::future::Executor;
 //! use futures_cpupool::CpuPool;
 //! use tokio_io::AsyncRead;
 //! use tokio_io::io::copy;
 //! use tokio::net::TcpListener;
-//! use tokio::reactor::Reactor;
+//! use tokio::reactor::Handle;
 //!
 //! fn main() {
-//!     // Create the event loop that will drive this server.
-//!     let mut core = Reactor::new().unwrap();
-//!     let handle = core.handle();
+//!     let handle = Handle::default();
 //!
 //!     let pool = CpuPool::new_num_cpus();
 //!
@@ -86,8 +84,8 @@
 //!         Ok(())
 //!     });
 //!
-//!     // Spin up the server on the event loop.
-//!     core.run(server).unwrap();
+//!     // Spin up the server on this thread
+//!     server.wait().unwrap();
 //! }
 //! ```
 

--- a/tests/buffered.rs
+++ b/tests/buffered.rs
@@ -11,7 +11,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,8 +25,8 @@ fn echo_server() {
     const N: usize = 1024;
     drop(env_logger::init());
 
-    let mut l = t!(Reactor::new());
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
+    let handle = Handle::default();
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
     let addr = t!(srv.local_addr());
 
     let msg = "foo bar baz";
@@ -56,7 +56,7 @@ fn echo_server() {
         copy(a, b)
     });
 
-    let (amt, _, _) = t!(l.run(copied));
+    let (amt, _, _) = t!(copied.wait());
     let (expected, t2) = t.join().unwrap();
     let actual = t2.join().unwrap();
 

--- a/tests/chain.rs
+++ b/tests/chain.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,8 +21,8 @@ macro_rules! t {
 
 #[test]
 fn chain_clients() {
-    let mut l = t!(Reactor::new());
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
+    let handle = Handle::default();
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {
@@ -44,7 +44,7 @@ fn chain_clients() {
         read_to_end(a.chain(b).chain(c), Vec::new())
     });
 
-    let (_, data) = t!(l.run(copied));
+    let (_, data) = t!(copied.wait());
     t.join().unwrap();
 
     assert_eq!(data, b"foo bar baz");

--- a/tests/echo.rs
+++ b/tests/echo.rs
@@ -10,7 +10,7 @@ use std::thread;
 use futures::Future;
 use futures::stream::Stream;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 
@@ -25,8 +25,8 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let mut l = t!(Reactor::new());
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
+    let handle = Handle::default();
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
     let addr = t!(srv.local_addr());
 
     let msg = "foo bar baz";
@@ -46,7 +46,7 @@ fn echo_server() {
     let halves = client.map(|s| s.0.split());
     let copied = halves.and_then(|(a, b)| copy(a, b));
 
-    let (amt, _, _) = t!(l.run(copied));
+    let (amt, _, _) = t!(copied.wait());
     t.join().unwrap();
 
     assert_eq!(amt, msg.len() as u64 * 1024);

--- a/tests/limit.rs
+++ b/tests/limit.rs
@@ -10,7 +10,7 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,8 +21,8 @@ macro_rules! t {
 
 #[test]
 fn limit() {
-    let mut l = t!(Reactor::new());
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
+    let handle = Handle::default();
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {
@@ -38,7 +38,7 @@ fn limit() {
         read_to_end(a.take(4), Vec::new())
     });
 
-    let (_, data) = t!(l.run(copied));
+    let (_, data) = t!(copied.wait());
     t.join().unwrap();
 
     assert_eq!(data, b"foo ");

--- a/tests/line-frames.rs
+++ b/tests/line-frames.rs
@@ -13,7 +13,7 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 use tokio_io::codec::{Encoder, Decoder};
 use tokio_io::io::{write_all, read};
 use tokio_io::AsyncRead;
@@ -55,10 +55,8 @@ impl Encoder for LineCodec {
 fn echo() {
     drop(env_logger::init());
 
-    let mut core = Reactor::new().unwrap();
-    let handle = core.handle();
-
     let pool = CpuPool::new(1);
+    let handle = Handle::default();
 
     let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
     let addr = listener.local_addr().unwrap();
@@ -69,24 +67,23 @@ fn echo() {
         Ok(())
     });
 
-    let handle = core.handle();
     pool.execute(srv.map_err(|e| panic!("srv error: {}", e))).unwrap();
 
     let client = TcpStream::connect(&addr, &handle);
-    let client = core.run(client).unwrap();
-    let (client, _) = core.run(write_all(client, b"a\n")).unwrap();
-    let (client, buf, amt) = core.run(read(client, vec![0; 1024])).unwrap();
+    let client = client.wait().unwrap();
+    let (client, _) = write_all(client, b"a\n").wait().unwrap();
+    let (client, buf, amt) = read(client, vec![0; 1024]).wait().unwrap();
     assert_eq!(amt, 2);
     assert_eq!(&buf[..2], b"a\n");
 
-    let (client, _) = core.run(write_all(client, b"\n")).unwrap();
-    let (client, buf, amt) = core.run(read(client, buf)).unwrap();
+    let (client, _) = write_all(client, b"\n").wait().unwrap();
+    let (client, buf, amt) = read(client, buf).wait().unwrap();
     assert_eq!(amt, 1);
     assert_eq!(&buf[..1], b"\n");
 
-    let (client, _) = core.run(write_all(client, b"b")).unwrap();
+    let (client, _) = write_all(client, b"b").wait().unwrap();
     client.shutdown(Shutdown::Write).unwrap();
-    let (_client, buf, amt) = core.run(read(client, buf)).unwrap();
+    let (_client, buf, amt) = read(client, buf).wait().unwrap();
     assert_eq!(amt, 1);
     assert_eq!(&buf[..1], b"b");
 }

--- a/tests/stream-buffered.rs
+++ b/tests/stream-buffered.rs
@@ -12,7 +12,7 @@ use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio_io::AsyncRead;
 use tokio::net::TcpListener;
-use tokio::reactor::Reactor;
+use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,8 +25,8 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let mut l = t!(Reactor::new());
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &l.handle()));
+    let handle = Handle::default();
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {
@@ -50,7 +50,7 @@ fn echo_server() {
                     .take(2)
                     .collect();
 
-    t!(l.run(future));
+    t!(future.wait());
 
     t.join().unwrap();
 }


### PR DESCRIPTION
This commit removes the `Reactor::run` method which has previously been used to
execute futures and turn the reactor at the same time. The tests/examples made
heavy usage of this method but they have now all temporarily moved to `wait()`
until the futures dependency is upgraded. In the meantime this'll allow us to
further trim down the `Reactor` APIs to their final state.

This PR is based on https://github.com/tokio-rs/tokio/pull/57, only the last commit needs to be reviewed.