### PR TITLE
Remove `Handle` argument from I/O constructors 

### DIFF
--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -33,7 +33,6 @@ use futures::future::Executor;
 use futures::stream::{self, Stream};
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 use tokio_io::io;
 use tokio_io::AsyncRead;
 
@@ -42,8 +41,7 @@ fn main() {
     let addr = addr.parse().unwrap();
 
     // Create the TCP listener we'll accept connections on.
-    let handle = Handle::default();
-    let socket = TcpListener::bind(&addr, &handle).unwrap();
+    let socket = TcpListener::bind(&addr).unwrap();
     println!("Listening on: {}", addr);
 
     // This is currently a multi threaded server.

--- a/examples/compress.rs
+++ b/examples/compress.rs
@@ -32,7 +32,6 @@ use futures::{Future, Stream, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
 use flate2::write::GzEncoder;
 
@@ -41,8 +40,7 @@ fn main() {
     // reactor.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let handle = Handle::default();
-    let socket = TcpListener::bind(&addr, &handle).unwrap();
+    let socket = TcpListener::bind(&addr).unwrap();
     println!("Listening on: {}", addr);
 
     // This is where we're going to offload our computationally heavy work

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -28,7 +28,6 @@ use std::thread;
 use futures::sync::mpsc;
 use futures::{Sink, Future, Stream};
 use futures_cpupool::CpuPool;
-use tokio::reactor::Handle;
 
 fn main() {
     // Determine if we're going to run in TCP or UDP mode
@@ -47,8 +46,6 @@ fn main() {
     });
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let handle = Handle::default();
-
     let pool = CpuPool::new(1);
 
     // Right now Tokio doesn't support a handle to stdin running on the event
@@ -63,9 +60,9 @@ fn main() {
     // our UDP connection to get a stream of bytes we're going to emit to
     // stdout.
     let stdout = if tcp {
-        tcp::connect(&addr, &handle, &pool, Box::new(stdin_rx))
+        tcp::connect(&addr, &pool, Box::new(stdin_rx))
     } else {
-        udp::connect(&addr, &handle, &pool, Box::new(stdin_rx))
+        udp::connect(&addr, &pool, Box::new(stdin_rx))
     };
 
     // And now with our stream of bytes to write to stdout, we execute that in
@@ -88,17 +85,15 @@ mod tcp {
     use futures::future::Executor;
     use futures_cpupool::CpuPool;
     use tokio::net::TcpStream;
-    use tokio::reactor::Handle;
     use tokio_io::AsyncRead;
     use tokio_io::codec::{Encoder, Decoder};
 
     pub fn connect(addr: &SocketAddr,
-                   handle: &Handle,
                    pool: &CpuPool,
                    stdin: Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>)
         -> Box<Stream<Item = BytesMut, Error = io::Error>>
     {
-        let tcp = TcpStream::connect(addr, handle);
+        let tcp = TcpStream::connect(addr);
         let pool = pool.clone();
 
         // After the TCP connection has been established, we set up our client
@@ -175,10 +170,8 @@ mod udp {
     use futures::future::Executor;
     use futures_cpupool::CpuPool;
     use tokio::net::{UdpCodec, UdpSocket};
-    use tokio::reactor::Handle;
 
     pub fn connect(&addr: &SocketAddr,
-                   handle: &Handle,
                    pool: &CpuPool,
                    stdin: Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>)
         -> Box<Stream<Item = BytesMut, Error = io::Error>>
@@ -190,7 +183,7 @@ mod udp {
         } else {
             "[::]:0".parse().unwrap()
         };
-        let udp = UdpSocket::bind(&addr_to_bind, handle)
+        let udp = UdpSocket::bind(&addr_to_bind)
             .expect("failed to bind socket");
 
         // Like above with TCP we use an instance of `UdpCodec` to transform

--- a/examples/echo-threads.rs
+++ b/examples/echo-threads.rs
@@ -30,7 +30,6 @@ use futures_cpupool::CpuPool;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 use tokio::net::{TcpStream, TcpListener};
-use tokio::reactor::Handle;
 
 fn main() {
     // First argument, the address to bind
@@ -41,8 +40,7 @@ fn main() {
     let num_threads = env::args().nth(2).and_then(|s| s.parse().ok())
         .unwrap_or(num_cpus::get());
 
-    let handle = Handle::default();
-    let listener = TcpListener::bind(&addr, &handle).expect("failed to bind");
+    let listener = TcpListener::bind(&addr).expect("failed to bind");
     println!("Listening on: {}", addr);
 
     // Spin up our worker threads, creating a channel routing to each worker

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -20,7 +20,6 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll};
 use tokio::net::UdpSocket;
-use tokio::reactor::Handle;
 
 struct Server {
     socket: UdpSocket,
@@ -54,8 +53,7 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let handle = Handle::default();
-    let socket = UdpSocket::bind(&addr, &handle).unwrap();
+    let socket = UdpSocket::bind(&addr).unwrap();
     println!("Listening on: {}", socket.local_addr().unwrap());
 
     // Next we'll create a future to spawn (the one we defined above) and then

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -32,7 +32,6 @@ use futures_cpupool::CpuPool;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 fn main() {
     // Allow passing an address to listen on as the first argument of this
@@ -41,14 +40,12 @@ fn main() {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let handle = Handle::default();
-
     // Next up we create a TCP listener which will listen for incoming
     // connections. This TCP listener is bound to the address we determined
     // above and must be associated with an event loop, so we pass in a handle
     // to our event loop. After the socket's created we inform that we're ready
     // to go and start accepting connections.
-    let socket = TcpListener::bind(&addr, &handle).unwrap();
+    let socket = TcpListener::bind(&addr).unwrap();
     println!("Listening on: {}", addr);
 
     // A CpuPool allows futures to be executed concurrently.

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -21,15 +21,13 @@ use std::net::SocketAddr;
 
 use futures::prelude::*;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 fn main() {
     env_logger::init().unwrap();
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
 
-    let handle = Handle::default();
-    let listener = TcpListener::bind(&addr, &handle).unwrap();
+    let listener = TcpListener::bind(&addr).unwrap();
 
     let addr = listener.local_addr().unwrap();
     println!("Listening for connections on {}", addr);

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -31,7 +31,6 @@ use futures::{Future, Poll};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Handle;
 use tokio_io::{AsyncRead, AsyncWrite};
 use tokio_io::io::{copy, shutdown};
 
@@ -42,17 +41,15 @@ fn main() {
     let server_addr = env::args().nth(2).unwrap_or("127.0.0.1:8080".to_string());
     let server_addr = server_addr.parse::<SocketAddr>().unwrap();
 
-    let handle = Handle::default();
-
     let pool = CpuPool::new(1);
 
     // Create a TCP listener which will listen for incoming connections.
-    let socket = TcpListener::bind(&listen_addr, &handle).unwrap();
+    let socket = TcpListener::bind(&listen_addr).unwrap();
     println!("Listening on: {}", listen_addr);
     println!("Proxying to: {}", server_addr);
 
     let done = socket.incoming().for_each(move |(client, client_addr)| {
-        let server = TcpStream::connect(&server_addr, &handle);
+        let server = TcpStream::connect(&server_addr);
         let amounts = server.and_then(move |server| {
             // Create separate read/write handles for the TCP clients that we're
             // proxying data between. Note that typically you'd use

--- a/examples/sink.rs
+++ b/examples/sink.rs
@@ -31,7 +31,6 @@ use futures::stream::{self, Stream};
 use futures_cpupool::CpuPool;
 use tokio_io::IoFuture;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Handle;
 
 fn main() {
     env_logger::init().unwrap();
@@ -40,8 +39,7 @@ fn main() {
 
     let pool = CpuPool::new(1);
 
-    let handle = Handle::default();
-    let socket = TcpListener::bind(&addr, &handle).unwrap();
+    let socket = TcpListener::bind(&addr).unwrap();
     println!("Listening on: {}", addr);
     let server = socket.incoming().for_each(|(socket, addr)| {
         println!("got a socket: {}", addr);

--- a/examples/tinydb.rs
+++ b/examples/tinydb.rs
@@ -54,7 +54,6 @@ use futures::prelude::*;
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 use tokio_io::AsyncRead;
 use tokio_io::io::{lines, write_all};
 
@@ -84,8 +83,7 @@ fn main() {
     // and set up our TCP listener to accept connections.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>().unwrap();
-    let handle = Handle::default();
-    let listener = TcpListener::bind(&addr, &handle).expect("failed to bind");
+    let listener = TcpListener::bind(&addr).expect("failed to bind");
     println!("Listening on: {}", addr);
 
     // Create a CpuPool to execute tasks

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -18,7 +18,6 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{UdpSocket, UdpCodec};
-use tokio::reactor::Handle;
 
 pub struct LineCodec;
 
@@ -39,15 +38,13 @@ impl UdpCodec for LineCodec {
 fn main() {
     drop(env_logger::init());
 
-    let handle = Handle::default();
-
     let pool = CpuPool::new(1);
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
     // Bind both our sockets and then figure out what ports we got.
-    let a = UdpSocket::bind(&addr, &handle).unwrap();
-    let b = UdpSocket::bind(&addr, &handle).unwrap();
+    let a = UdpSocket::bind(&addr).unwrap();
+    let b = UdpSocket::bind(&addr).unwrap();
     let b_addr = b.local_addr().unwrap();
 
     // We're parsing each socket with the `LineCodec` defined above, and then we

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,16 +49,13 @@
 //! use tokio_io::AsyncRead;
 //! use tokio_io::io::copy;
 //! use tokio::net::TcpListener;
-//! use tokio::reactor::Handle;
 //!
 //! fn main() {
-//!     let handle = Handle::default();
-//!
 //!     let pool = CpuPool::new_num_cpus();
 //!
 //!     // Bind the server's socket.
 //!     let addr = "127.0.0.1:12345".parse().unwrap();
-//!     let listener = TcpListener::bind(&addr, &handle)
+//!     let listener = TcpListener::bind(&addr)
 //!         .expect("unable to bind TCP listener");
 //!
 //!     // Pull out a stream of sockets for incoming connections

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -34,9 +34,9 @@ impl TcpListener {
     ///
     /// The TCP listener will bind to the provided `addr` address, if available.
     /// If the result is `Ok`, the socket has successfully bound.
-    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<TcpListener> {
+    pub fn bind(addr: &SocketAddr) -> io::Result<TcpListener> {
         let l = try!(mio::net::TcpListener::bind(addr));
-        TcpListener::new(l, handle)
+        TcpListener::new(l, &Handle::default())
     }
 
     /// Attempt to accept a connection and create a new connected `TcpStream` if
@@ -247,9 +247,9 @@ impl TcpStream {
     /// the `addr` provided. The returned future will be resolved once the
     /// stream has successfully connected, or it wil return an error if one
     /// occurs.
-    pub fn connect(addr: &SocketAddr, handle: &Handle) -> TcpStreamNew {
+    pub fn connect(addr: &SocketAddr) -> TcpStreamNew {
         let inner = match mio::net::TcpStream::connect(addr) {
-            Ok(tcp) => TcpStream::new(tcp, handle),
+            Ok(tcp) => TcpStream::new(tcp, &Handle::default()),
             Err(e) => TcpStreamNewState::Error(e),
         };
         TcpStreamNew { inner: inner }

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -18,9 +18,9 @@ pub use self::frame::{UdpFramed, UdpCodec};
 impl UdpSocket {
     /// This function will create a new UDP socket and attempt to bind it to
     /// the `addr` provided.
-    pub fn bind(addr: &SocketAddr, handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
         let udp = try!(mio::net::UdpSocket::bind(addr));
-        UdpSocket::new(udp, handle)
+        UdpSocket::new(udp, &Handle::default())
     }
 
     fn new(socket: mio::net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {

--- a/tests/buffered.rs
+++ b/tests/buffered.rs
@@ -11,7 +11,6 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,8 +24,7 @@ fn echo_server() {
     const N: usize = 1024;
     drop(env_logger::init());
 
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let msg = "foo bar baz";

--- a/tests/chain.rs
+++ b/tests/chain.rs
@@ -10,7 +10,6 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,8 +20,7 @@ macro_rules! t {
 
 #[test]
 fn chain_clients() {
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -2,6 +2,7 @@ extern crate tokio;
 extern crate futures;
 
 use std::thread;
+use std::net;
 
 use futures::future;
 use futures::prelude::*;
@@ -13,7 +14,9 @@ use tokio::reactor::Reactor;
 fn tcp_doesnt_block() {
     let core = Reactor::new().unwrap();
     let handle = core.handle();
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::from_std(listener, &addr, &handle).unwrap();
     drop(core);
     assert!(listener.incoming().wait().next().unwrap().is_err());
 }
@@ -22,7 +25,9 @@ fn tcp_doesnt_block() {
 fn drop_wakes() {
     let core = Reactor::new().unwrap();
     let handle = core.handle();
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let listener = TcpListener::from_std(listener, &addr, &handle).unwrap();
     let (tx, rx) = oneshot::channel::<()>();
     let t = thread::spawn(move || {
         let incoming = listener.incoming();

--- a/tests/echo.rs
+++ b/tests/echo.rs
@@ -10,7 +10,6 @@ use std::thread;
 use futures::Future;
 use futures::stream::Stream;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 use tokio_io::AsyncRead;
 use tokio_io::io::copy;
 
@@ -25,8 +24,7 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let msg = "foo bar baz";

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -5,7 +5,6 @@ use std::thread;
 
 use futures::prelude::*;
 use tokio::net::{TcpStream, TcpListener};
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -18,10 +17,9 @@ macro_rules! t {
 fn hammer() {
     let threads = (0..10).map(|_| {
         thread::spawn(|| {
-            let handle = Handle::default();
-            let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle));
+            let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));
             let addr = t!(srv.local_addr());
-            let mine = TcpStream::connect(&addr, &handle);
+            let mine = TcpStream::connect(&addr);
             let theirs = srv.incoming().into_future()
                 .map(|(s, _)| s.unwrap().0)
                 .map_err(|(s, _)| s);

--- a/tests/limit.rs
+++ b/tests/limit.rs
@@ -10,7 +10,6 @@ use futures::Future;
 use futures::stream::Stream;
 use tokio_io::io::read_to_end;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -21,8 +20,7 @@ macro_rules! t {
 
 #[test]
 fn limit() {
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {

--- a/tests/line-frames.rs
+++ b/tests/line-frames.rs
@@ -13,7 +13,6 @@ use futures::{Future, Stream, Sink};
 use futures::future::Executor;
 use futures_cpupool::CpuPool;
 use tokio::net::{TcpListener, TcpStream};
-use tokio::reactor::Handle;
 use tokio_io::codec::{Encoder, Decoder};
 use tokio_io::io::{write_all, read};
 use tokio_io::AsyncRead;
@@ -56,9 +55,8 @@ fn echo() {
     drop(env_logger::init());
 
     let pool = CpuPool::new(1);
-    let handle = Handle::default();
 
-    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap(), &handle).unwrap();
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
     let addr = listener.local_addr().unwrap();
     let pool_inner = pool.clone();
     let srv = listener.incoming().for_each(move |(socket, _)| {
@@ -69,7 +67,7 @@ fn echo() {
 
     pool.execute(srv.map_err(|e| panic!("srv error: {}", e))).unwrap();
 
-    let client = TcpStream::connect(&addr, &handle);
+    let client = TcpStream::connect(&addr);
     let client = client.wait().unwrap();
     let (client, _) = write_all(client, b"a\n").wait().unwrap();
     let (client, buf, amt) = read(client, vec![0; 1024]).wait().unwrap();

--- a/tests/stream-buffered.rs
+++ b/tests/stream-buffered.rs
@@ -12,7 +12,6 @@ use futures::stream::Stream;
 use tokio_io::io::copy;
 use tokio_io::AsyncRead;
 use tokio::net::TcpListener;
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -25,8 +24,7 @@ macro_rules! t {
 fn echo_server() {
     drop(env_logger::init());
 
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -8,7 +8,6 @@ use std::thread;
 
 use futures::Future;
 use futures::stream::Stream;
-use tokio::reactor::Handle;
 use tokio::net::{TcpListener, TcpStream};
 
 macro_rules! t {
@@ -21,14 +20,13 @@ macro_rules! t {
 #[test]
 fn connect() {
     drop(env_logger::init());
-    let handle = Handle::default();
     let srv = t!(net::TcpListener::bind("127.0.0.1:0"));
     let addr = t!(srv.local_addr());
     let t = thread::spawn(move || {
         t!(srv.accept()).0
     });
 
-    let stream = TcpStream::connect(&addr, &handle);
+    let stream = TcpStream::connect(&addr);
     let mine = t!(stream.wait());
     let theirs = t.join().unwrap();
 
@@ -39,8 +37,7 @@ fn connect() {
 #[test]
 fn accept() {
     drop(env_logger::init());
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let (tx, rx) = channel();
@@ -64,8 +61,7 @@ fn accept() {
 #[test]
 fn accept2() {
     drop(env_logger::init());
-    let handle = Handle::default();
-    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
     let t = thread::spawn(move || {

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -8,7 +8,6 @@ use std::net::SocketAddr;
 
 use futures::{Future, Poll, Stream, Sink};
 use tokio::net::{UdpSocket, UdpCodec};
-use tokio::reactor::Handle;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -18,9 +17,8 @@ macro_rules! t {
 }
 
 fn send_messages<S: SendFn + Clone, R: RecvFn + Clone>(send: S, recv: R) {
-    let handle = Handle::default();
-    let mut a = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into(), &handle));
-    let mut b = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into(), &handle));
+    let mut a = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into()));
+    let mut b = t!(UdpSocket::bind(&([127, 0, 0, 1], 0).into()));
     let a_addr = t!(a.local_addr());
     let b_addr = t!(b.local_addr());
 
@@ -166,9 +164,8 @@ impl<R: RecvFn> Future for RecvMessage<R> {
 
 #[test]
 fn send_dgrams() {
-    let handle = Handle::default();
-    let mut a = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &handle));
-    let mut b = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let mut a = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let mut b = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
     let mut buf = [0u8; 50];
     let b_addr = t!(b.local_addr());
 
@@ -216,9 +213,8 @@ impl UdpCodec for Codec {
 
 #[test]
 fn send_framed() {
-    let handle = Handle::default();
-    let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &handle));
-    let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse()), &handle));
+    let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
     let a_addr = t!(a_soc.local_addr());
     let b_addr = t!(b_soc.local_addr());
 


### PR DESCRIPTION
This commit removes the `Handle` argument from the following constructors

* `TcpListener::bind`
* `TcpStream::connect`
* `UdpSocket::bind`

The `Handle` argument remains on the various `*_std` constructors as they're
more low-level, but this otherwise is intended to set forth a precedent of by
default not taking `Handle` arguments and instead relying on the global
`Handle::default` return value when necesary.

This PR is based on https://github.com/tokio-rs/tokio/pull/60, only the last commit needs to be reviewed.