### PR TITLE
Remove poll_read and poll_write from TCP/UDP types.

### DIFF
--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -131,16 +131,6 @@ impl TcpListener {
         Ok(TcpListener { io: io })
     }
 
-    /// Test whether this socket is ready to be read or not.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_read(&self) -> Async<()> {
-        self.io.poll_read()
-    }
-
     /// Returns the local address that this listener is bound to.
     ///
     /// This can be useful, for example, when binding to port 0 to figure out
@@ -306,32 +296,6 @@ impl TcpStream {
             Err(e) => TcpStreamNewState::Error(e),
         };
         TcpStreamNew { inner: inner }
-    }
-
-    /// Test whether this stream is ready to be read or not.
-    ///
-    /// If the stream is *not* readable then the current task is scheduled to
-    /// get a notification when the stream does become readable.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_read(&self) -> Async<()> {
-        self.io.poll_read()
-    }
-
-    /// Test whether this stream is ready to be written or not.
-    ///
-    /// If the stream is *not* writable then the current task is scheduled to
-    /// get a notification when the stream does become writable.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_write(&self) -> Async<()> {
-        self.io.poll_write()
     }
 
     /// Returns the local address that this stream is bound to.
@@ -554,7 +518,7 @@ impl<'a> AsyncRead for &'a TcpStream {
     }
 
     fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
-        if let Async::NotReady = <TcpStream>::poll_read(self) {
+        if let Async::NotReady = self.io.poll_read() {
             return Ok(Async::NotReady)
         }
         let r = unsafe {
@@ -607,7 +571,7 @@ impl<'a> AsyncWrite for &'a TcpStream {
     }
 
     fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
-        if let Async::NotReady = <TcpStream>::poll_write(self) {
+        if let Async::NotReady = self.io.poll_write() {
             return Ok(Async::NotReady)
         }
         let r = {

--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -122,32 +122,6 @@ impl UdpSocket {
         }
     }
 
-    /// Test whether this socket is ready to be read or not.
-    ///
-    /// If the socket is *not* readable then the current task is scheduled to
-    /// get a notification when the socket does become readable.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_read(&self) -> Async<()> {
-        self.io.poll_read()
-    }
-
-    /// Test whether this socket is ready to be written to or not.
-    ///
-    /// If the socket is *not* writable then the current task is scheduled to
-    /// get a notification when the socket does become writable.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if called outside the context of a future's
-    /// task.
-    pub fn poll_write(&self) -> Async<()> {
-        self.io.poll_write()
-    }
-
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
     ///


### PR DESCRIPTION
Fix for #75.