### PR TITLE
Add debug logs for how long dispatch takes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "alexcrichton/tokio" }
 
 [dependencies]
 bytes = "0.4"
-log = "0.3"
+log = "0.4"
 mio = "0.6.11"
 slab = "0.4"
 iovec = "0.1"


### PR DESCRIPTION
I've often found this to be quite useful when debugging why event loops are
stuck or some other bug looks to be in play.