### PR TITLE
Update send_dgram function signature.

### DIFF
--- a/src/net/udp/mod.rs
+++ b/src/net/udp/mod.rs
@@ -184,10 +184,10 @@ impl UdpSocket {
     /// The `buf` parameter here only requires the `AsRef<[u8]>` trait, which
     /// should be broadly applicable to accepting data which can be converted
     /// to a slice.
-    pub fn send_dgram<T>(self, buf: T, addr: SocketAddr) -> SendDgram<T>
+    pub fn send_dgram<T>(self, buf: T, addr: &SocketAddr) -> SendDgram<T>
         where T: AsRef<[u8]>,
     {
-        SendDgram::new(self, buf, addr)
+        SendDgram::new(self, buf, *addr)
     }
 
     /// Receives data from the socket. On success, returns the number of bytes

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -170,7 +170,7 @@ fn send_dgrams() {
     let b_addr = t!(b.local_addr());
 
     {
-        let send = a.send_dgram(&b"4321"[..], b_addr);
+        let send = a.send_dgram(&b"4321"[..], &b_addr);
         let recv = b.recv_dgram(&mut buf[..]);
         let (sendt, received) = t!(send.join(recv).wait());
         assert_eq!(received.2, 4);
@@ -180,7 +180,7 @@ fn send_dgrams() {
     }
 
     {
-        let send = a.send_dgram(&b""[..], b_addr);
+        let send = a.send_dgram(&b""[..], &b_addr);
         let recv = b.recv_dgram(&mut buf[..]);
         let received = t!(send.join(recv).wait()).1;
         assert_eq!(received.2, 0);


### PR DESCRIPTION
All other fns take `&SocketAddr`.