### PR TITLE
Remove &addr arg from TcpListener::from_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
+
+[patch.crates-io]
+mio = { git = "https://github.com/carllerche/mio" }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -119,9 +119,8 @@ impl TcpListener {
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
     pub fn from_std(listener: net::TcpListener,
-                    addr: &SocketAddr,
                     handle: &Handle) -> io::Result<TcpListener> {
-        let l = mio::net::TcpListener::from_listener(listener, addr)?;
+        let l = mio::net::TcpListener::from_std(listener)?;
         TcpListener::new(l, handle)
     }
 

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -15,8 +15,7 @@ fn tcp_doesnt_block() {
     let core = Reactor::new().unwrap();
     let handle = core.handle();
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let listener = TcpListener::from_std(listener, &addr, &handle).unwrap();
+    let listener = TcpListener::from_std(listener, &handle).unwrap();
     drop(core);
     assert!(listener.incoming().wait().next().unwrap().is_err());
 }
@@ -26,8 +25,7 @@ fn drop_wakes() {
     let core = Reactor::new().unwrap();
     let handle = core.handle();
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap();
-    let listener = TcpListener::from_std(listener, &addr, &handle).unwrap();
+    let listener = TcpListener::from_std(listener, &handle).unwrap();
     let (tx, rx) = oneshot::channel::<()>();
     let t = thread::spawn(move || {
         let incoming = listener.incoming();


### PR DESCRIPTION
This has been deprecated in mio.