### PR TITLE
fix: struct shoutdown ignore Async::NotReady

### DIFF
--- a/tokio-io/src/shutdown.rs
+++ b/tokio-io/src/shutdown.rs
@@ -38,7 +38,7 @@ impl<A> Future for Shutdown<A>
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<A, io::Error> {
-        try_nb!(self.a.as_mut().unwrap().shutdown());
+        try_ready!(self.a.as_mut().unwrap().shutdown());
         Ok(Async::Ready(self.a.take().unwrap()))
     }
 }


### PR DESCRIPTION
fix issue https://github.com/tokio-rs/tokio/issues/100