### PR TITLE
Update the required Mio point release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ appveyor = { repository = "carllerche/tokio" }
 [dependencies]
 bytes = "0.4"
 log = "0.4"
-mio = "0.6.12"
+mio = "0.6.13"
 slab = "0.4"
 iovec = "0.1"
 tokio-io = "0.1"


### PR DESCRIPTION
Tokio depends on the latest Mio point release, so update Cargo.toml to
reflect this.