### PR TITLE
Add constraint Encoder + Decoder for UdpFramed::new

### DIFF
--- a/tokio-udp/src/frame.rs
+++ b/tokio-udp/src/frame.rs
@@ -111,7 +111,7 @@ impl<C: Encoder> Sink for UdpFramed<C> {
 const INITIAL_RD_CAPACITY: usize = 64 * 1024;
 const INITIAL_WR_CAPACITY: usize = 8 * 1024;
 
-impl<C> UdpFramed<C> {
+impl<C: Encoder + Decoder> UdpFramed<C> {
     /// Create a new `UdpFramed` backed by the given socket and codec.
     ///
     /// See struct level documentation for more details.


### PR DESCRIPTION
To make compile errors more intelligible. I removed `impl Encoder for ByteCodec` in `tests/udp.rs` for example. Compare errors:

with constraint:
```
error[E0277]: the trait bound `ByteCodec: tokio_io::codec::Encoder` is not satisfied
   --> tests/udp.rs:219:17
    |
219 |         let a = UdpFramed::new(a_soc, ByteCodec);
    |                 ^^^^^^^^^^^^^^ the trait `tokio_io::codec::Encoder` is not implemented for `ByteCodec`
    |
    = note: required by `<tokio::net::UdpFramed<C>>::new`
```

without constraint:
```
    error[E0599]: no method named `send` found for type `tokio::net::UdpFramed<ByteCodec>` in the current scope
       --> tests/udp.rs:224:22
        |
    224 |         let send = a.send((msg.clone(), b_addr));
        |                      ^^^^
        |
        = note: the method `send` exists but the following trait bounds were not satisfied:
                `tokio::net::UdpFramed<ByteCodec> : futures::Sink`
                `&mut tokio::net::UdpFramed<ByteCodec> : futures::Sink`
        = help: items from traits can only be used if the trait is implemented and in scope
        = note: the following trait defines an item `send`, perhaps you need to implement it:
                candidate #1: `SendFn`
```