### PR TITLE
length_delimited: add a native_endian builder method

### DIFF
--- a/tokio-io/src/length_delimited.rs
+++ b/tokio-io/src/length_delimited.rs
@@ -649,6 +649,32 @@ impl Builder {
         self
     }
 
+    /// Read the length field as a native endian integer
+    ///
+    /// The default setting is big endian.
+    ///
+    /// This configuration option applies to both encoding and decoding.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tokio_io::AsyncRead;
+    /// use tokio_io::codec::length_delimited::Builder;
+    ///
+    /// # fn bind_read<T: AsyncRead>(io: T) {
+    /// Builder::new()
+    ///     .native_endian()
+    ///     .new_read(io);
+    /// # }
+    /// ```
+    pub fn native_endian(&mut self) -> &mut Self {
+        if cfg!(target_endian = "big") {
+            self.big_endian()
+        } else {
+            self.little_endian()
+        }
+    }
+
     /// Sets the max frame length
     ///
     /// This configuration option applies to both encoding and decoding. The

--- a/tokio-io/tests/length_delimited.rs
+++ b/tokio-io/tests/length_delimited.rs
@@ -49,6 +49,23 @@ fn read_single_frame_one_packet_little_endian() {
 }
 
 #[test]
+fn read_single_frame_one_packet_native_endian() {
+    let data = if cfg!(target_endian = "big") {
+        b"\x00\x00\x00\x09abcdefghi"
+    } else {
+        b"\x09\x00\x00\x00abcdefghi"
+    };
+    let mut io = Builder::new()
+        .native_endian()
+        .new_read(mock! {
+            Ok(data[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
 fn read_single_multi_frame_one_packet() {
     let mut data: Vec<u8> = vec![];
     data.extend_from_slice(b"\x00\x00\x00\x09abcdefghi");


### PR DESCRIPTION
This method is useful when reading from a operating system service.