### PR TITLE
Get the codec back from the Framed

### DIFF
--- a/tokio-io/src/framed.rs
+++ b/tokio-io/src/framed.rs
@@ -43,16 +43,17 @@ impl<T, U> Framed<T, U> {
     /// things like gzip or TLS, which require both read and write access to the
     /// underlying object.
     ///
-    /// This objects takes a stream and a readbuffer and a writebuffer. These field
-    /// can be obtained from an existing `Framed` with the `into_parts` method.
+    /// This objects takes a stream, a codec, a readbuffer and a writebuffer.
+    /// These field can be obtained from an existing `Framed` with the
+    /// `into_parts` method.
     ///
     /// If you want to work more directly with the streams and sink, consider
     /// calling `split` on the `Framed` returned by this method, which will
     /// break them into separate objects, allowing them to interact more easily.
-    pub fn from_parts(parts: FramedParts<T>, codec: U) -> Framed<T, U>
+    pub fn from_parts(parts: FramedParts<T, U>) -> Framed<T, U>
     {
         Framed {
-            inner: framed_read2_with_buffer(framed_write2_with_buffer(Fuse(parts.inner, codec), parts.writebuf), parts.readbuf),
+            inner: framed_read2_with_buffer(framed_write2_with_buffer(Fuse(parts.inner, parts.codec), parts.writebuf), parts.readbuf),
         }
     }
 
@@ -91,26 +92,10 @@ impl<T, U> Framed<T, U> {
     /// Note that care should be taken to not tamper with the underlying stream
     /// of data coming in as it may corrupt the stream of frames otherwise
     /// being worked with.
-    pub fn into_parts(self) -> FramedParts<T> {
-        let (inner, readbuf) = self.inner.into_parts();
-	    let (inner, writebuf) = inner.into_parts();
-        FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }
-    }
-
-    /// Consumes the `Frame`, returning its underlying I/O stream and the buffer
-    /// with unprocessed data, and also the current codec state.
-    ///
-    /// Note that care should be taken to not tamper with the underlying stream
-    /// of data coming in as it may corrupt the stream of frames otherwise
-    /// being worked with.
-    ///
-    /// Note that this function will be removed once the codec has been
-    /// integrated into `FramedParts` in a new version (see
-    /// [#53](https://github.com/tokio-rs/tokio-io/pull/53)).
-    pub fn into_parts_and_codec(self) -> (FramedParts<T>, U) {
+    pub fn into_parts(self) -> FramedParts<T, U> {
         let (inner, readbuf) = self.inner.into_parts();
         let (inner, writebuf) = inner.into_parts();
-        (FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }, inner.1)
+        FramedParts { inner: inner.0, codec: inner.1, readbuf: readbuf, writebuf: writebuf }
     }
 }
 
@@ -215,13 +200,16 @@ impl<T, U: Encoder> Encoder for Fuse<T, U> {
 }
 
 /// `FramedParts` contains an export of the data of a Framed transport.
-/// It can be used to construct a new `Framed` with a different codec.
-/// It contains all current buffers and the inner transport.
+/// It can be used to construct a new `Framed` with a different codec,
+/// or with a different inner transport.
+/// It contains all current buffers, codec and the inner transport.
 #[derive(Debug)]
-pub struct FramedParts<T>
+pub struct FramedParts<T, U>
 {
     /// The inner transport used to read bytes to and write bytes to
     pub inner: T,
+    /// The inner codec with its state.
+    pub codec: U,
     /// The buffer with read but unprocessed data.
     pub readbuf: BytesMut,
     /// A buffer with unprocessed data which are not written yet.

--- a/tokio-io/tests/framed.rs
+++ b/tokio-io/tests/framed.rs
@@ -53,10 +53,11 @@ impl AsyncRead for DontReadIntoThis {}
 fn can_read_from_existing_buf() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0, 0, 0, 42].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
 
     let num = framed
         .into_future()
@@ -73,10 +74,11 @@ fn can_read_from_existing_buf() {
 fn external_buf_grows_to_init() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0, 0, 0, 42].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
     let FramedParts { readbuf, .. } = framed.into_parts();
 
     assert_eq!(readbuf.capacity(), INITIAL_CAPACITY);
@@ -86,10 +88,11 @@ fn external_buf_grows_to_init() {
 fn external_buf_does_not_shrink() {
     let parts = FramedParts {
         inner: DontReadIntoThis,
+        codec: U32Codec,
         readbuf: vec![0; INITIAL_CAPACITY * 2].into(),
         writebuf: BytesMut::with_capacity(0),
     };
-    let framed = Framed::from_parts(parts, U32Codec);
+    let framed = Framed::from_parts(parts);
     let FramedParts { readbuf, .. } = framed.into_parts();
 
     assert_eq!(readbuf.capacity(), INITIAL_CAPACITY * 2);


### PR DESCRIPTION
Moved from https://github.com/tokio-rs/tokio-io/pull/53

And remove `Framed::into_parts_and_codec`