### PR TITLE
Update Cargo.toml to use local tokio-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ travis-ci = { repository = "tokio-rs/tokio" }
 appveyor = { repository = "carllerche/tokio" }
 
 [dependencies]
-tokio-io = "0.1"
+tokio-io = { version = "0.1", path = "tokio-io" }
 tokio-executor = { version = "0.1", path = "tokio-executor" }
 tokio-threadpool = { version = "0.1", path = "tokio-threadpool" }
 bytes = "0.4"


### PR DESCRIPTION
Error:

```
error[E0277]: the trait bound `flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>: tokio_io::AsyncWrite` is not satisfied
  --> examples/compress.rs:93:19
   |
93 |     let process = io::copy(read, write).and_then(|(amt, _read, write)| {
   |                   ^^^^^^^^ the trait `tokio_io::AsyncWrite` is not implemented for `flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>`
   |
   = note: required by `tokio_io::io::copy`

error[E0599]: no method named `and_then` found for type `tokio_io::io::Copy<tokio_io::io::ReadHalf<tokio::net::TcpStream>, flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>>` in the current scope
  --> examples/compress.rs:93:41
   |
93 |     let process = io::copy(read, write).and_then(|(amt, _read, write)| {
   |                                         ^^^^^^^^
   |
   = note: the method `and_then` exists but the following trait bounds were not satisfied:
           `tokio_io::io::Copy<tokio_io::io::ReadHalf<tokio::net::TcpStream>, flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>> : futures::Future`
           `&mut tokio_io::io::Copy<tokio_io::io::ReadHalf<tokio::net::TcpStream>, flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>> : futures::Future`
           `&mut tokio_io::io::Copy<tokio_io::io::ReadHalf<tokio::net::TcpStream>, flate2::write::GzEncoder<Count<tokio_io::io::WriteHalf<tokio::net::TcpStream>>>> : futures::Stream`

error: aborting due to 2 previous errors

error: Could not compile `tokio`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Why is it a problem? Seems like the trait should have been implemented for GzEncoder https://github.com/alexcrichton/flate2-rs/blob/master/src/gz/write.rs#L160