### PR TITLE
Fix bug with CurrentThread::turn

### DIFF
--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -466,6 +466,11 @@ impl<'a, P: Park> Entered<'a, P> {
     pub fn turn(&mut self, duration: Option<Duration>)
         -> Result<Turn, TurnError>
     {
+        if self.executor.is_idle() {
+            // Nothing to do
+            return Ok(Turn(()));
+        }
+
         if !self.tick() {
             let res = match duration {
                 Some(duration) => self.executor.park.park_timeout(duration),

--- a/src/executor/current_thread/scheduler.rs
+++ b/src/executor/current_thread/scheduler.rs
@@ -168,9 +168,12 @@ where U: Unpark,
     }
 
     pub fn schedule(&mut self, item: Box<Future<Item = (), Error = ()>>) {
+        // Get the current scheduler tick
+        let tick_num = self.inner.tick_num.load(SeqCst);
+
         let node = Arc::new(Node {
             item: UnsafeCell::new(Some(Task::new(item))),
-            notified_at: AtomicUsize::new(0),
+            notified_at: AtomicUsize::new(tick_num),
             next_all: UnsafeCell::new(ptr::null_mut()),
             prev_all: UnsafeCell::new(ptr::null_mut()),
             next_readiness: AtomicPtr::new(ptr::null_mut()),


### PR DESCRIPTION
CurrentThread::turn uses a turn count strategy to allow `turn` to not
run infinitely. Currently, there is a bug where spawned tasks will not
get executed in calls to `turn`.

This patch fixes the bug by correctly setting the turn count for newly
spawned tasks.