### PR TITLE
Support current_thread::spawn from task drop

### DIFF
--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -529,22 +529,9 @@ impl<'a, P: Park> Entered<'a, P> {
 
     /// Returns `true` if any futures were processed
     fn tick(&mut self) -> bool {
-        let num_futures = &mut self.executor.num_futures;
-        let enter = &mut *self.enter;
-
-        // work the scheduler
-        self.executor.scheduler.tick(|scheduler, scheduled| {
-            let mut borrow = Borrow {
-                scheduler,
-                num_futures,
-            };
-
-            // A future completed, decrement the future count
-            if borrow.enter(enter, || scheduled.tick()) {
-                debug_assert!(*borrow.num_futures > 0);
-                *borrow.num_futures -= 1;
-            }
-        })
+        self.executor.scheduler.tick(
+            &mut *self.enter,
+            &mut self.executor.num_futures)
     }
 }
 


### PR DESCRIPTION
Currently, the thread-local tracking the current thread executor is not
set when a task is dropped. This means that one cannot spawn a new
future from within the drop implementation of another future.

This patch adds support for this by setting the thread-local before
releasing a task.

This implementation is a bit messy. It probably could be cleaned up, but
this is being put off in favor of trying a more comprehensive
reorganization once the current thread executor is feature complete.