### PR TITLE
Add `io` facade and update `reactor` docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ travis-ci = { repository = "tokio-rs/tokio" }
 appveyor = { repository = "carllerche/tokio" }
 
 [dependencies]
-tokio-io = "0.1"
+tokio-io = { version = "0.1", path = "tokio-io" }
 tokio-executor = { version = "0.1", path = "tokio-executor" }
 tokio-threadpool = { version = "0.1", path = "tokio-threadpool" }
 bytes = "0.4"
@@ -55,3 +55,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
+
+[patch.crates-io]
+tokio-io = { path = "tokio-io" }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,51 @@ an asynchronous application.
 [reactor]: https://docs.rs/tokio/0.1.1/tokio/reactor/index.html
 [scheduler]: https://tokio-rs.github.io/tokio/tokio/runtime/index.html
 
+## Example
+
+A basic TCP echo server with Tokio:
+
+```rust
+extern crate tokio;
+
+use tokio::prelude::*;
+use tokio::io::copy;
+use tokio::net::TcpListener;
+
+fn main() {
+    // Bind the server's socket.
+    let addr = "127.0.0.1:12345".parse().unwrap();
+    let listener = TcpListener::bind(&addr)
+        .expect("unable to bind TCP listener");
+
+    // Pull out a stream of sockets for incoming connections
+    let server = listener.incoming()
+        .map_err(|e| eprintln!("accept failed = {:?}", e))
+        .for_each(|sock| {
+            // Split up the reading and writing parts of the
+            // socket.
+            let (reader, writer) = sock.split();
+
+            // A future that echos the data and returns how
+            // many bytes were copied...
+            let bytes_copied = copy(reader, writer);
+
+            // ... after which we'll print what happened.
+            let handle_conn = bytes_copied.map(|amt| {
+                println!("wrote {:?} bytes", amt)
+            }).map_err(|err| {
+                eprintln!("IO error {:?}", err)
+            });
+
+            // Spawn the future as a concurrent task.
+            tokio::spawn(handle_conn)
+        });
+
+    // Start the Tokio runtime
+    tokio::run(server);
+}
+```
+
 # License
 
 This project is licensed under either of

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -1,20 +1,139 @@
-//! The core reactor driving all I/O.
+//! Event loop that drives I/O resources.
 //!
-//! This module contains the [`Reactor`] reactor type which is the event loop for
-//! all I/O happening in `tokio`. This core reactor (or event loop) is used to
-//! drive I/O resources.
+//! This module contains [`Reactor`], which is the event loop that drives all
+//! Tokio I/O resources. It is the reactor's job to receive events from the
+//! operating system ([epoll], [kqueue], [IOCP], etc...) and forward them to
+//! waiting tasks. It is the bridge between operating system and the futures
+//! model.
 //!
-//! The [`Handle`] struct, created by [`handle`][handle_method], is a reference
-//! to the event loop and can be used when constructing I/O objects.
+//! # Overview
 //!
-//! Lastly [`PollEvented`] can be used to construct I/O objects that interact
-//! with the event loop, e.g. [`TcpStream`] in the net module.
+//! When using Tokio, all operations are asynchronous and represented by
+//! futures. These futures, representing the application logic, are scheduled by
+//! an executor (see [runtime model] for more details). Executors wait for
+//! notifications before scheduling the future for execution time, i.e., nothing
+//! happens until an event is received indicating that the task can make
+//! progress.
+//!
+//! The reactor receives events from the operating system and notifies the
+//! executor.
+//!
+//! Let's start with a basic example, establishing a TCP connection.
+//!
+//! ```rust
+//! # extern crate tokio;
+//! # fn dox() {
+//! use tokio::prelude::*;
+//! use tokio::net::TcpStream;
+//!
+//! let addr = "93.184.216.34:9243".parse().unwrap();
+//!
+//! let connect_future = TcpStream::connect(&addr);
+//!
+//! let task = connect_future
+//!     .and_then(|socket| {
+//!         println!("successfully connected");
+//!         Ok(())
+//!     })
+//!     .map_err(|e| println!("failed to connect; err={:?}", e));
+//!
+//! tokio::run(task);
+//! # }
+//! # fn main() {}
+//! ```
+//!
+//! Establishing a TCP connection usually cannot be completed immediately.
+//! [`TcpStream::connect`] does not block the current thread. Instead, it
+//! returns a [future][connect-future] that resolves once the TCP connection has
+//! been established. The connect future itself has no way of knowing when the
+//! TCP connection has been established.
+//!
+//! Before returning the future, [`TcpStream::connect`] registers the socket
+//! with a reactor. This registration process, handled by [`Registration`], is
+//! what links the [`TcpStream`] with the [`Reactor`] instance. At this point,
+//! the reactor starts listening for connection events from the operating system
+//! for that socket.
+//!
+//! Once the connect future is passed to [`tokio::run`], it is spawned onto a
+//! thread pool. The thread pool waits until it is notified that the connection
+//! has completed.
+//!
+//! When the TCP connection is established, the reactor receives an event from
+//! the operating system. It then notifies the thread pool, telling it that the
+//! connect future can complete. At this point, the thread pool will schedule
+//! the task to run on one of its worker threads. This results in the `and_then`
+//! closure to get executed.
+//!
+//! ## Lazy registration
+//!
+//! Notice how the snippet above does not explicitly reference a reactor. When
+//! [`TcpStream::connect`] is called, it registers the socket with a reactor,
+//! but no reactor is specified. This works because the registration process
+//! mentioned above is actually lazy. It doesn't *actually* happen in the
+//! [`connect`] function. Instead, the registration is established the first
+//! time that the task is polled (again, see [runtime model]).
+//!
+//! A reactor instance is automatically made available when using the Tokio
+//! [runtime], which is done using [`tokio::run`]. The Tokio runtime's executor
+//! sets a thread-local variable referencing the associated [`Reactor`] instance
+//! and [`Handle::current`] (used by [`Registration`]) returns the reference.
+//!
+//! ## Implementation
+//!
+//! The reactor implementation uses [`mio`] to interface with the operating
+//! system's event queue. A call to [`Reactor::poll`] results in in a single
+//! call to [`Poll::poll`] which in turn results in a single call to the
+//! operating system's selector.
+//!
+//! The reactor maintains state for each registered I/O resource. This tracks
+//! the executor task to notify when events are provided by the operating
+//! system's selector. This state is stored in a `Sync` data structure and
+//! referenced by [`Registration`]. When the [`Registration`] instance is
+//! dropped, this state is cleaned up. Because the state is stored in a `Sync`
+//! data structure, the [`Registration`] instance is able to be moved to other
+//! threads.
+//!
+//! By default, a runtime's default reactor runs on a background thread. This
+//! ensures that application code cannot significantly impact the reactor's
+//! responsiveness.
+//!
+//! ## Integrating with the reactor
+//!
+//! Tokio comes with a number of I/O resources, like TCP and UDP sockets, that
+//! automatically integrate with the reactor. However, library authors or
+//! applications may wish to implement their own resources that are also backed
+//! by the reactor.
+//!
+//! There are a couple of ways to do this.
+//!
+//! If the custom I/O resource implements [`mio::Evented`] and implements
+//! [`std::Read`] and / or [`std::Write`], then [`PollEvented2`] is the most
+//! suited.
+//!
+//! Otherwise, [`Registration`] can be used directly. This provides the lowest
+//! level primitive needed for integrating with the reactor: a stream of
+//! readiness events.
 //!
 //! [`Reactor`]: struct.Reactor.html
-//! [`Handle`]: struct.Handle.html
-//! [handle_method]: struct.Reactor.html#method.handle
-//! [`PollEvented`]: struct.PollEvented.html
+//! [`Registration`]: struct.Registration.html
+//! [runtime model]: https://tokio.rs/docs/getting-started/runtime-model/
+//! [epoll]: http://man7.org/linux/man-pages/man7/epoll.7.html
+//! [kqueue]: https://www.freebsd.org/cgi/man.cgi?query=kqueue&sektion=2
+//! [IOCP]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa365198(v=vs.85).aspx
+//! [`TcpStream::connect`]: ../net/struct.TcpStream.html#method.connect
+//! [`connect`]: ../net/struct.TcpStream.html#method.connect
+//! [connect-future]: ../net/struct.ConnectFuture.html
+//! [`tokio::run`]: ../runtime/fn.run.html
 //! [`TcpStream`]: ../net/struct.TcpStream.html
+//! [runtime]: ../runtime
+//! [`Handle::current`]: struct.Handle.html#method.current
+//! [`mio`]: https://github.com/carllerche/mio
+//! [`Reactor::poll`]: struct.Reactor.html#method.poll
+//! [`Poll::poll`]: https://docs.rs/mio/0.6/mio/struct.Poll.html#method.poll
+//! [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
+//! [`PollEvented2`]: struct.PollEvented2.html
+//! [`std::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+//! [`std::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 
 use tokio_executor::Enter;
 use tokio_executor::park::{Park, Unpark};
@@ -65,11 +184,11 @@ pub struct Reactor {
     _wakeup_registration: mio::Registration,
 }
 
-/// A handle to an event loop.
+/// A reference to a reactor.
 ///
 /// A `Handle` is used for associating I/O objects with an event loop
 /// explicitly. Typically though you won't end up using a `Handle` that often
-/// and will instead use an implicitly configured handle for your thread.
+/// and will instead use the default reactor for the execution context.
 #[derive(Clone)]
 pub struct Handle {
     inner: Weak<Inner>,

--- a/tokio-io/src/async_read.rs
+++ b/tokio-io/src/async_read.rs
@@ -6,23 +6,25 @@ use {framed, split, AsyncWrite};
 use codec::{Decoder, Encoder, Framed};
 use split::{ReadHalf, WriteHalf};
 
-/// A trait for readable objects which operated in an asynchronous and
-/// futures-aware fashion.
+/// Read bytes asynchronously.
 ///
-/// This trait inherits from `io::Read` and indicates as a marker that an I/O
-/// object is **nonblocking**, meaning that it will return an error instead of
-/// blocking when bytes are unavailable, but the stream hasn't reached EOF.
-/// Specifically this means that the `read` function for types that implement
-/// this trait can have a few return values:
+/// This trait inherits from `std::io::Read` and indicates that an I/O object is
+/// **non-blocking**. All non-blocking I/O objects must return an error when
+/// bytes are unavailable instead of blocking the current thread.
+///
+/// Specifically, this means that the `read` function will return one of the
+/// following:
 ///
 /// * `Ok(n)` means that `n` bytes of data was immediately read and placed into
 ///   the output buffer, where `n` == 0 implies that EOF has been reached.
+///
 /// * `Err(e) if e.kind() == ErrorKind::WouldBlock` means that no data was read
 ///   into the buffer provided. The I/O object is not currently readable but may
 ///   become readable in the future. Most importantly, **the current future's
 ///   task is scheduled to get unparked when the object is readable**. This
 ///   means that like `Future::poll` you'll receive a notification when the I/O
 ///   object is readable again.
+///
 /// * `Err(e)` for other errors are standard I/O errors coming from the
 ///   underlying object.
 ///

--- a/tokio-io/src/async_write.rs
+++ b/tokio-io/src/async_write.rs
@@ -5,22 +5,24 @@ use futures::{Async, Poll};
 
 use AsyncRead;
 
-/// A trait for writable objects which operated in an asynchronous and
-/// futures-aware fashion.
+/// Writes bytes asynchronously.
 ///
-/// This trait inherits from `io::Write` and indicates that an I/O object is
-/// **nonblocking**, meaning that it will return an error instead of blocking
-/// when bytes cannot currently be written, but hasn't closed. Specifically
-/// this means that the `write` function for types that implement this trait
-/// can have a few return values:
+/// The trait inherits from `std::io::Write` and indicates that an I/O object is
+/// **nonblocking**. All non-blocking I/O objects must return an error when
+/// bytes cannot be written instead of blocking the current thread.
+///
+/// Specifically, this means that the `write` function will return one of the
+/// following:
 ///
 /// * `Ok(n)` means that `n` bytes of data was immediately written .
+///
 /// * `Err(e) if e.kind() == ErrorKind::WouldBlock` means that no data was
 ///   written from the buffer provided. The I/O object is not currently
 ///   writable but may become writable in the future. Most importantly, **the
 ///   current future's task is scheduled to get unparked when the object is
 ///   readable**. This means that like `Future::poll` you'll receive a
 ///   notification when the I/O object is writable again.
+///
 /// * `Err(e)` for other errors are standard I/O errors coming from the
 ///   underlying object.
 ///


### PR DESCRIPTION
This patch updates the documentation for a number of APIs. It also
introduces a prelude module and an io facade module, re-exporting types
from tokio-io.