### PR TITLE
Add AsyncRead::poll_read, AsyncWrite::poll_write.

### DIFF
--- a/tokio-io/src/framed_write.rs
+++ b/tokio-io/src/framed_write.rs
@@ -184,7 +184,7 @@ impl<T> Sink for FramedWrite2<T>
         while !self.buffer.is_empty() {
             trace!("writing; remaining={}", self.buffer.len());
 
-            let n = try_nb!(self.inner.write(&self.buffer));
+            let n = try_ready!(self.inner.poll_write(&self.buffer));
 
             if n == 0 {
                 return Err(io::Error::new(io::ErrorKind::WriteZero, "failed to
@@ -197,7 +197,7 @@ impl<T> Sink for FramedWrite2<T>
         }
 
         // Try flushing the underlying IO
-        try_nb!(self.inner.flush());
+        try_ready!(self.inner.poll_flush());
 
         trace!("framed transport flushed");
         return Ok(Async::Ready(()));

--- a/tokio-io/src/io/copy.rs
+++ b/tokio-io/src/io/copy.rs
@@ -60,7 +60,7 @@ impl<R, W> Future for Copy<R, W>
             // continue.
             if self.pos == self.cap && !self.read_done {
                 let reader = self.reader.as_mut().unwrap();
-                let n = try_nb!(reader.read(&mut self.buf));
+                let n = try_ready!(reader.poll_read(&mut self.buf));
                 if n == 0 {
                     self.read_done = true;
                 } else {
@@ -72,7 +72,7 @@ impl<R, W> Future for Copy<R, W>
             // If our buffer has some data, let's write it out!
             while self.pos < self.cap {
                 let writer = self.writer.as_mut().unwrap();
-                let i = try_nb!(writer.write(&self.buf[self.pos..self.cap]));
+                let i = try_ready!(writer.poll_write(&self.buf[self.pos..self.cap]));
                 if i == 0 {
                     return Err(io::Error::new(io::ErrorKind::WriteZero,
                                               "write zero byte into writer"));
@@ -86,7 +86,7 @@ impl<R, W> Future for Copy<R, W>
             // data and finish the transfer.
             // done with the entire transfer.
             if self.pos == self.cap && self.read_done {
-                try_nb!(self.writer.as_mut().unwrap().flush());
+                try_ready!(self.writer.as_mut().unwrap().poll_flush());
                 let reader = self.reader.take().unwrap();
                 let writer = self.writer.take().unwrap();
                 return Ok((self.amt, reader, writer).into())

--- a/tokio-io/src/io/flush.rs
+++ b/tokio-io/src/io/flush.rs
@@ -37,7 +37,7 @@ impl<A> Future for Flush<A>
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<A, io::Error> {
-        try_nb!(self.a.as_mut().unwrap().flush());
+        try_ready!(self.a.as_mut().unwrap().poll_flush());
         Ok(Async::Ready(self.a.take().unwrap()))
     }
 }

--- a/tokio-io/src/io/read.rs
+++ b/tokio-io/src/io/read.rs
@@ -44,7 +44,7 @@ impl<R, T> Future for Read<R, T>
 
     fn poll(&mut self) -> Poll<(R, T, usize), io::Error> {
         let nread = match self.state {
-            State::Pending { ref mut rd, ref mut buf } => try_nb!(rd.read(&mut buf.as_mut()[..])),
+            State::Pending { ref mut rd, ref mut buf } => try_ready!(rd.poll_read(&mut buf.as_mut()[..])),
             State::Empty => panic!("poll a Read after it's done"),
         };
 

--- a/tokio-io/src/io/read_exact.rs
+++ b/tokio-io/src/io/read_exact.rs
@@ -65,7 +65,7 @@ impl<A, T> Future for ReadExact<A, T>
             State::Reading { ref mut a, ref mut buf, ref mut pos } => {
                 let buf = buf.as_mut();
                 while *pos < buf.len() {
-                    let n = try_nb!(a.read(&mut buf[*pos..]));
+                    let n = try_ready!(a.poll_read(&mut buf[*pos..]));
                     *pos += n;
                     if n == 0 {
                         return Err(eof())

--- a/tokio-io/src/io/write_all.rs
+++ b/tokio-io/src/io/write_all.rs
@@ -68,7 +68,7 @@ impl<A, T> Future for WriteAll<A, T>
             State::Writing { ref mut a, ref buf, ref mut pos } => {
                 let buf = buf.as_ref();
                 while *pos < buf.len() {
-                    let n = try_nb!(a.write(&buf[*pos..]));
+                    let n = try_ready!(a.poll_write(&buf[*pos..]));
                     *pos += n;
                     if n == 0 {
                         return Err(zero_write())

--- a/tokio-io/src/length_delimited.rs
+++ b/tokio-io/src/length_delimited.rs
@@ -511,7 +511,7 @@ impl<T: AsyncWrite, B: IntoBuf> Sink for FramedWrite<T, B> {
         try_ready!(self.do_write());
 
         // Try flushing the underlying IO
-        try_nb!(self.inner.flush());
+        try_ready!(self.inner.poll_flush());
 
         return Ok(Async::Ready(()));
     }


### PR DESCRIPTION
This removes the need for the `try_nb` macro as well as bring the traits
closer in line with the planed 0.2 iteration.