### PR TITLE
Simultaneous futures compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
         cargo check --tests --all --target $TARGET
     else
         cargo test --all
+        cargo test --features unstable-futures
+        cargo test --manifest-path tokio-threadpool/Cargo.toml --features unstable-futures
+        cargo test --manifest-path tokio-reactor/Cargo.toml --features unstable-futures
     fi
 
 deploy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ mio = "0.6.14"
 slab = "0.4"
 iovec = "0.1"
 futures = "0.1.18"
+futures2 = { version = "0.1", path = "futures2", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
@@ -63,5 +64,5 @@ time = "0.1"
 tokio-io = { path = "tokio-io" }
 
 [features]
-futures-0-2 = ["tokio-reactor/futures-0-2"]
-default = []
+futures-0-2 = ["futures2", "tokio-reactor/futures-0-2", "tokio-threadpool/futures-0-2"]
+default = ["futures-0-2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,5 +64,5 @@ time = "0.1"
 tokio-io = { path = "tokio-io" }
 
 [features]
-futures-0-2 = ["futures2", "tokio-reactor/futures-0-2", "tokio-threadpool/futures-0-2"]
-default = ["futures-0-2"]
+unstable-futures = ["futures2", "tokio-reactor/unstable-futures", "tokio-threadpool/unstable-futures"]
+default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,5 +64,10 @@ time = "0.1"
 tokio-io = { path = "tokio-io" }
 
 [features]
-unstable-futures = ["futures2", "tokio-reactor/unstable-futures", "tokio-threadpool/unstable-futures"]
+unstable-futures = [
+    "futures2",
+    "tokio-reactor/unstable-futures",
+    "tokio-threadpool/unstable-futures",
+    "tokio-executor/unstable-futures"
+]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
   "tokio-io",
   "tokio-reactor",
   "tokio-threadpool",
+  "futures2",
 ]
 
 [badges]
@@ -60,3 +61,7 @@ time = "0.1"
 
 [patch.crates-io]
 tokio-io = { path = "tokio-io" }
+
+[features]
+futures-0-2 = ["tokio-reactor/futures-0-2"]
+default = []

--- a/futures2/Cargo.toml
+++ b/futures2/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "futures2"
+
+version = "0.1.0"
+authors = ["Aaron Turon <aturon@mozilla.com>"]
+license = "MIT/Apache-2.0"
+repository = "https://github.com/tokio-rs/tokio"
+homepage = "https://tokio.rs"
+
+[dependencies]
+futures = "0.2.0-alpha"

--- a/futures2/src/lib.rs
+++ b/futures2/src/lib.rs
@@ -1,0 +1,2 @@
+extern crate futures;
+pub use futures::*;

--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -119,6 +119,9 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+#[cfg(feature = "unstable-futures")]
+use futures2;
+
 /// Executes tasks on the current thread
 pub struct CurrentThread<P: Park = ParkThread> {
     /// Execute futures and receive unpark notifications.
@@ -386,6 +389,13 @@ impl tokio_executor::Executor for CurrentThread {
         self.borrow().spawn_local(future);
         Ok(())
     }
+
+    #[cfg(feature = "unstable-futures")]
+    fn spawn2(&mut self, _future: Box<futures2::Future<Item = (), Error = futures2::Never> + Send>)
+        -> Result<(), futures2::executor::SpawnError>
+    {
+        panic!("Futures 0.2 integration is not available for current_thread");
+    }
 }
 
 impl<P: Park> fmt::Debug for CurrentThread<P> {
@@ -589,6 +599,13 @@ impl tokio_executor::Executor for TaskExecutor {
         -> Result<(), SpawnError>
     {
         self.spawn_local(future)
+    }
+
+    #[cfg(feature = "unstable-futures")]
+    fn spawn2(&mut self, _future: Box<futures2::Future<Item = (), Error = futures2::Never> + Send>)
+        -> Result<(), futures2::executor::SpawnError>
+    {
+        panic!("Futures 0.2 integration is not available for current_thread");
     }
 
     fn status(&self) -> Result<(), SpawnError> {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -49,7 +49,7 @@
 //! [`Executor`]: #
 //! [`spawn`]: #
 
-
+#[cfg(not(feature = "unstable-futures"))]
 pub mod current_thread;
 
 pub mod thread_pool {

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -49,7 +49,6 @@
 //! [`Executor`]: #
 //! [`spawn`]: #
 
-#[cfg(not(feature = "unstable-futures"))]
 pub mod current_thread;
 
 pub mod thread_pool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,3 +190,19 @@ pub mod prelude {
         task,
     };
 }
+
+#[cfg(feature = "unstable-futures")]
+fn lift_async<T>(old: futures::Async<T>) -> futures2::Async<T> {
+    match old {
+        futures::Async::Ready(x) => futures2::Async::Ready(x),
+        futures::Async::NotReady => futures2::Async::Pending,
+    }
+}
+
+#[cfg(feature = "unstable-futures")]
+fn lower_async<T>(new: futures2::Async<T>) -> futures::Async<T> {
+    match new {
+        futures2::Async::Ready(x) => futures::Async::Ready(x),
+        futures2::Async::Pending => futures::Async::NotReady,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ extern crate tokio_threadpool;
 #[macro_use]
 extern crate log;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 extern crate futures2;
 
 pub mod executor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,9 @@ extern crate tokio_threadpool;
 #[macro_use]
 extern crate log;
 
+#[cfg(feature = "futures-0-2")]
+extern crate futures2;
+
 pub mod executor;
 pub mod net;
 pub mod reactor;

--- a/src/net/tcp/incoming.rs
+++ b/src/net/tcp/incoming.rs
@@ -5,6 +5,9 @@ use std::io;
 use futures::stream::Stream;
 use futures::{Poll, Async};
 
+#[cfg(feature = "unstable-futures")]
+use futures2;
+
 /// Stream returned by the `TcpListener::incoming` function representing the
 /// stream of sockets received from a listener.
 #[must_use = "streams do nothing unless polled"]
@@ -26,5 +29,17 @@ impl Stream for Incoming {
     fn poll(&mut self) -> Poll<Option<Self::Item>, io::Error> {
         let (socket, _) = try_ready!(self.inner.poll_accept());
         Ok(Async::Ready(Some(socket)))
+    }
+}
+
+#[cfg(feature = "unstable-futures")]
+impl futures2::Stream for Incoming {
+    type Item = TcpStream;
+    type Error = io::Error;
+
+    fn poll_next(&mut self, cx: &mut futures2::task::Context)
+        -> futures2::Poll<Option<Self::Item>, io::Error>
+    {
+        Ok(self.inner.poll_accept2(cx)?.map(|(sock, _)| Some(sock)))
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -112,7 +112,7 @@ use futures::future::{self, Future};
 
 use std::{fmt, io};
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 use futures2;
 
 /// Handle to the Tokio runtime.
@@ -213,7 +213,7 @@ where F: Future<Item = (), Error = ()> + Send + 'static,
 /// Start the Tokio runtime using the supplied future to bootstrap execution.
 ///
 /// Identical to `run` but works with futures 0.2-style futures.
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 pub fn run2<F>(future: F)
     where F: futures2::Future<Item = (), Error = futures2::Never> + Send + 'static,
 {
@@ -309,7 +309,7 @@ impl Runtime {
     /// Spawn a futures 0.2-style future onto the Tokio runtime.
     ///
     /// Otherwise identical to `spawn`
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     pub fn spawn2<F>(&mut self, future: F) -> &mut Self
         where F: futures2::Future<Item = (), Error = futures2::Never> + Send + 'static,
     {
@@ -454,10 +454,10 @@ impl ::executor::Executor for TaskExecutor {
     }
 }
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 type Task2 = Box<futures2::Future<Item = (), Error = futures2::Never> + Send>;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 impl futures2::executor::Executor for TaskExecutor {
     fn spawn(&mut self, f: Task2) -> Result<(), futures2::executor::SpawnError> {
         futures2::executor::Executor::spawn(&mut self.inner, f)

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -112,6 +112,9 @@ use futures::future::{self, Future};
 
 use std::{fmt, io};
 
+#[cfg(feature = "futures-0-2")]
+use futures2;
+
 /// Handle to the Tokio runtime.
 ///
 /// The Tokio runtime includes a reactor as well as an executor for running
@@ -153,6 +156,8 @@ struct Inner {
 // ===== impl Runtime =====
 
 /// Start the Tokio runtime using the supplied future to bootstrap execution.
+///
+/// To do so with a futures 0.2-style future, use `run2`
 ///
 /// This function is used to bootstrap the execution of a Tokio application. It
 /// does the following:
@@ -205,6 +210,18 @@ where F: Future<Item = (), Error = ()> + Send + 'static,
     runtime.shutdown_on_idle().wait().unwrap();
 }
 
+/// Start the Tokio runtime using the supplied future to bootstrap execution.
+///
+/// Identical to `run` but works with futures 0.2-style futures.
+#[cfg(feature = "futures-0-2")]
+pub fn run2<F>(future: F)
+    where F: futures2::Future<Item = (), Error = futures2::Never> + Send + 'static,
+{
+    let mut runtime = Runtime::new().unwrap();
+    runtime.spawn2(future);
+    runtime.shutdown_on_idle().wait().unwrap();
+}
+
 impl Runtime {
     /// Create a new runtime instance with default configuration values.
     ///
@@ -247,6 +264,8 @@ impl Runtime {
 
     /// Spawn a future onto the Tokio runtime.
     ///
+    /// Use `spawn2` to spawn a futures 0.2-style future.
+    ///
     /// This spawns the given future onto the runtime's executor, usually a
     /// thread pool. The thread pool is then responsible for polling the future
     /// until it completes.
@@ -284,6 +303,19 @@ impl Runtime {
     where F: Future<Item = (), Error = ()> + Send + 'static,
     {
         self.inner_mut().pool.sender().spawn(future).unwrap();
+        self
+    }
+
+    /// Spawn a futures 0.2-style future onto the Tokio runtime.
+    ///
+    /// Otherwise identical to `spawn`
+    #[cfg(feature = "futures-0-2")]
+    pub fn spawn2<F>(&mut self, future: F) -> &mut Self
+        where F: futures2::Future<Item = (), Error = futures2::Never> + Send + 'static,
+    {
+        futures2::executor::Executor::spawn(
+            self.inner_mut().pool.sender_mut(), Box::new(future)
+        ).unwrap();
         self
     }
 
@@ -421,6 +453,21 @@ impl ::executor::Executor for TaskExecutor {
         self.inner.spawn(future)
     }
 }
+
+#[cfg(feature = "futures-0-2")]
+type Task2 = Box<futures2::Future<Item = (), Error = futures2::Never> + Send>;
+
+#[cfg(feature = "futures-0-2")]
+impl futures2::executor::Executor for TaskExecutor {
+    fn spawn(&mut self, f: Task2) -> Result<(), futures2::executor::SpawnError> {
+        futures2::executor::Executor::spawn(&mut self.inner, f)
+    }
+
+    fn status(&self) -> Result<(), futures2::executor::SpawnError> {
+        futures2::executor::Executor::status(&self.inner)
+    }
+}
+
 
 // ===== impl Shutdown =====
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -157,8 +157,6 @@ struct Inner {
 
 /// Start the Tokio runtime using the supplied future to bootstrap execution.
 ///
-/// To do so with a futures 0.2-style future, use `run2`
-///
 /// This function is used to bootstrap the execution of a Tokio application. It
 /// does the following:
 ///
@@ -263,8 +261,6 @@ impl Runtime {
     }
 
     /// Spawn a future onto the Tokio runtime.
-    ///
-    /// Use `spawn2` to spawn a futures 0.2-style future.
     ///
     /// This spawns the given future onto the runtime's executor, usually a
     /// thread pool. The thread pool is then responsible for polling the future

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -448,6 +448,13 @@ impl ::executor::Executor for TaskExecutor {
     {
         self.inner.spawn(future)
     }
+
+    #[cfg(feature = "unstable-futures")]
+    fn spawn2(&mut self, future: Box<futures2::Future<Item = (), Error = futures2::Never> + Send>)
+        -> Result<(), futures2::executor::SpawnError>
+    {
+        self.inner.spawn2(future)
+    }
 }
 
 #[cfg(feature = "unstable-futures")]

--- a/tests/current_thread.rs
+++ b/tests/current_thread.rs
@@ -1,3 +1,5 @@
+#![cfg(not(feature = "unstable-futures"))]
+
 extern crate tokio;
 extern crate tokio_executor;
 extern crate futures;

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -14,3 +14,8 @@ categories = ["concurrency", "asynchronous"]
 
 [dependencies]
 futures = "0.1.18"
+futures2 = { version = "0.1", path = "../futures2", optional = true }
+
+[features]
+unstable-futures = ["futures2"]
+default = []

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -2,6 +2,9 @@ use std::prelude::v1::*;
 use std::cell::Cell;
 use std::fmt;
 
+#[cfg(feature = "unstable-futures")]
+use futures2;
+
 thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
 
 /// Represents an executor context.
@@ -10,6 +13,9 @@ thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
 pub struct Enter {
     on_exit: Vec<Box<Callback>>,
     permanent: bool,
+
+    #[cfg(feature = "unstable-futures")]
+    _enter2: futures2::executor::Enter,
 }
 
 /// An error returned by `enter` if an execution scope has already been
@@ -40,6 +46,9 @@ pub fn enter() -> Result<Enter, EnterError> {
             Ok(Enter {
                 on_exit: Vec::new(),
                 permanent: false,
+
+                #[cfg(feature = "unstable-futures")]
+                _enter2: futures2::executor::enter().unwrap(),
             })
         }
     })

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -35,6 +35,9 @@
 
 extern crate futures;
 
+#[cfg(feature = "unstable-futures")]
+extern crate futures2;
+
 mod enter;
 mod global;
 pub mod park;

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -45,6 +45,9 @@ pub mod park;
 pub use enter::{enter, Enter, EnterError};
 pub use global::{spawn, with_default, DefaultExecutor};
 
+#[cfg(feature = "unstable-futures")]
+pub use global::spawn2;
+
 use futures::Future;
 
 /// A value that executes futures.
@@ -132,7 +135,12 @@ pub trait Executor {
     /// # fn main() {}
     /// ```
     fn spawn(&mut self, future: Box<Future<Item = (), Error = ()> + Send>)
-        -> Result<(), SpawnError>;
+             -> Result<(), SpawnError>;
+
+    /// Like `spawn`, but compatible with futures 0.2
+    #[cfg(feature = "unstable-futures")]
+    fn spawn2(&mut self, future: Box<futures2::Future<Item = (), Error = futures2::Never> + Send>)
+             -> Result<(), futures2::executor::SpawnError>;
 
     /// Provides a best effort **hint** to whether or not `spawn` will succeed.
     ///

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -20,3 +20,8 @@ categories = ["asynchronous"]
 bytes = "0.4"
 futures = "0.1.18"
 log = "0.4"
+futures2 = { version = "0.1", path = "../futures2", optional = true }
+
+[features]
+unstable-futures = ["futures2"]
+default = []

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -24,3 +24,8 @@ mio = "0.6.14"
 slab = "0.4.0"
 tokio-executor = { version = "0.1.0", path = "../tokio-executor" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
+futures2 = { version = "0.1", path = "../futures2", optional = true }
+
+[features]
+futures-0-2 = ["futures2"]
+default = []

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -27,5 +27,5 @@ tokio-io = { version = "0.1.6", path = "../tokio-io" }
 futures2 = { version = "0.1", path = "../futures2", optional = true }
 
 [features]
-futures-0-2 = ["futures2"]
-default = ["futures-0-2"]
+unstable-futures = ["futures2"]
+default = []

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -28,4 +28,4 @@ futures2 = { version = "0.1", path = "../futures2", optional = true }
 
 [features]
 futures-0-2 = ["futures2"]
-default = []
+default = ["futures-0-2"]

--- a/tokio-reactor/src/background.rs
+++ b/tokio-reactor/src/background.rs
@@ -1,7 +1,7 @@
-use {Reactor, Handle};
+use {Reactor, Handle, Task};
 use atomic_task::AtomicTask;
 
-use futures::{Future, Async, Poll};
+use futures::{Future, Async, Poll, task};
 
 use std::io;
 use std::thread;
@@ -136,7 +136,8 @@ impl Future for Shutdown {
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
-        self.inner.shared.shutdown_task.register();
+        let task = Task::Futures1(task::current());
+        self.inner.shared.shutdown_task.register(task);
 
         if !self.inner.is_shutdown() {
             return Ok(Async::NotReady);

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -658,3 +658,19 @@ mod platform {
         false
     }
 }
+
+#[cfg(feature = "unstable-futures")]
+fn lift_async<T>(old: futures::Async<T>) -> futures2::Async<T> {
+    match old {
+        futures::Async::Ready(x) => futures2::Async::Ready(x),
+        futures::Async::NotReady => futures2::Async::Pending,
+    }
+}
+
+#[cfg(feature = "unstable-futures")]
+fn lower_async<T>(new: futures2::Async<T>) -> futures::Async<T> {
+    match new {
+        futures2::Async::Ready(x) => futures::Async::Ready(x),
+        futures2::Async::Pending => futures::Async::NotReady,
+    }
+}

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -39,6 +39,9 @@ extern crate slab;
 extern crate tokio_executor;
 extern crate tokio_io;
 
+#[cfg(feature = "futures-0-2")]
+extern crate futures2;
+
 pub(crate) mod background;
 mod atomic_task;
 mod poll_evented;
@@ -69,7 +72,6 @@ use std::time::{Duration, Instant};
 use log::Level;
 use mio::event::Evented;
 use slab::Slab;
-use futures::task::Task;
 
 /// The core reactor, or event loop.
 ///
@@ -153,6 +155,14 @@ fn _assert_kinds() {
     fn _assert<T: Send + Sync>() {}
 
     _assert::<Handle>();
+}
+
+/// A wakeup handle for a task, which may be either a futures 0.1 or 0.2 task
+#[derive(Debug, Clone)]
+pub(crate) enum Task {
+    Futures1(futures::task::Task),
+    #[cfg(feature = "futures-0-2")]
+    Futures2(futures2::task::Waker),
 }
 
 // ===== impl Reactor =====
@@ -578,7 +588,7 @@ impl Inner {
             Direction::Write => (&sched.writer, mio::Ready::writable()),
         };
 
-        task.register_task(t);
+        task.register(t);
 
         if sched.readiness.load(SeqCst) & ready.as_usize() != 0 {
             task.notify();
@@ -607,6 +617,17 @@ impl Direction {
                 mio::Ready::all() - mio::Ready::writable()
             }
             Direction::Write => mio::Ready::writable() | platform::hup(),
+        }
+    }
+}
+
+impl Task {
+    fn notify(&self) {
+        match *self {
+            Task::Futures1(ref task) => task.notify(),
+
+            #[cfg(feature = "futures-0-2")]
+            Task::Futures2(ref waker) => waker.wake(),
         }
     }
 }

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -39,7 +39,7 @@ extern crate slab;
 extern crate tokio_executor;
 extern crate tokio_io;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 extern crate futures2;
 
 pub(crate) mod background;
@@ -161,7 +161,7 @@ fn _assert_kinds() {
 #[derive(Debug, Clone)]
 pub(crate) enum Task {
     Futures1(futures::task::Task),
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     Futures2(futures2::task::Waker),
 }
 
@@ -626,7 +626,7 @@ impl Task {
         match *self {
             Task::Futures1(ref task) => task.notify(),
 
-            #[cfg(feature = "futures-0-2")]
+            #[cfg(feature = "unstable-futures")]
             Task::Futures2(ref waker) => waker.wake(),
         }
     }

--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -5,6 +5,9 @@ use mio;
 use mio::event::Evented;
 use tokio_io::{AsyncRead, AsyncWrite};
 
+#[cfg(feature = "unstable-futures")]
+use futures2;
+
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::sync::atomic::AtomicUsize;
@@ -99,7 +102,7 @@ struct Inner {
 // ===== impl PollEvented =====
 
 macro_rules! poll_ready {
-    ($me:expr, $mask:expr, $cache:ident, $poll:ident, $take:ident) => {{
+    ($me:expr, $mask:expr, $cache:ident, $take:ident, $poll:expr) => {{
         $me.register()?;
 
         // Load cached & encoded readiness.
@@ -114,7 +117,7 @@ macro_rules! poll_ready {
             // stream. This happens in a loop to ensure that the stream gets
             // drained.
             loop {
-                let ready = try_ready!($me.inner.registration.$poll());
+                let ready = try_ready!($poll);
                 cached |= ready.as_usize();
 
                 // Update the cache store
@@ -210,7 +213,22 @@ where E: Evented
     /// * called from outside of a task context.
     pub fn poll_read_ready(&self, mask: mio::Ready) -> Poll<mio::Ready, io::Error> {
         assert!(!mask.is_writable(), "cannot poll for write readiness");
-        poll_ready!(self, mask, read_readiness, poll_read_ready, take_read_ready)
+        poll_ready!(
+            self, mask, read_readiness, take_read_ready,
+            self.inner.registration.poll_read_ready()
+        )
+    }
+
+    /// Like `poll_read_ready` but compatible with futures 0.2.
+    pub fn poll_read_ready2(&self, cx: &mut futures2::task::Context, mask: mio::Ready)
+        -> futures2::Poll<mio::Ready, io::Error>
+    {
+        assert!(!mask.is_writable(), "cannot poll for write readiness");
+        let mut res = || poll_ready!(
+            self, mask, read_readiness, take_read_ready,
+            self.inner.registration.poll_read_ready2(cx).map(::lower_async)
+        );
+        res().map(::lift_async)
     }
 
     /// Clears the I/O resource's read readiness state and registers the current
@@ -243,6 +261,25 @@ where E: Evented
         Ok(())
     }
 
+    /// Like `clear_read_ready` but compatible with futures 0.2.
+    #[cfg(feature = "unstable-futures")]
+    pub fn clear_read_ready2(&self, cx: &mut futures2::task::Context, ready: mio::Ready)
+        -> io::Result<()>
+    {
+        // Cannot clear write readiness
+        assert!(!ready.is_writable(), "cannot clear write readiness");
+        assert!(!::platform::is_hup(&ready), "cannot clear HUP readiness");
+
+        self.inner.read_readiness.fetch_and(!ready.as_usize(), Relaxed);
+
+        if self.poll_read_ready2(cx, ready)?.is_ready() {
+            // Notify the current task
+            cx.waker().wake()
+        }
+
+        Ok(())
+    }
+
     /// Check the I/O resource's write readiness state.
     ///
     /// This always checks for writable readiness and also checks for HUP
@@ -263,12 +300,29 @@ where E: Evented
     /// * `ready` contains bits besides `writable` and `hup`.
     /// * called from outside of a task context.
     pub fn poll_write_ready(&self) -> Poll<mio::Ready, io::Error> {
-        poll_ready!(self,
-                    mio::Ready::writable(),
-                    write_readiness,
-                    poll_write_ready,
-                    take_write_ready)
+        poll_ready!(
+            self,
+            mio::Ready::writable(),
+            write_readiness,
+            take_write_ready,
+            self.inner.registration.poll_write_ready()
+        )
     }
+
+    /// Like `poll_write_ready` but compatible with futures 0.2.
+    pub fn poll_write_ready2(&self, cx: &mut futures2::task::Context)
+        -> futures2::Poll<mio::Ready, io::Error>
+    {
+        let mut res = || poll_ready!(
+            self,
+            mio::Ready::writable(),
+            write_readiness,
+            take_write_ready,
+            self.inner.registration.poll_write_ready2(cx).map(::lower_async)
+        );
+        res().map(::lift_async)
+    }
+
 
     /// Resets the I/O resource's write readiness state and registers the current
     /// task to be notified once a write readiness event is received.
@@ -290,6 +344,20 @@ where E: Evented
         if self.poll_write_ready()?.is_ready() {
             // Notify the current task
             task::current().notify();
+        }
+
+        Ok(())
+    }
+
+    /// Like `clear_write_ready`, but compatible with futures 0.2.
+    pub fn clear_write_ready2(&self, cx: &mut futures2::task::Context) -> io::Result<()> {
+        let ready = mio::Ready::writable();
+
+        self.inner.read_readiness.fetch_and(!ready.as_usize(), Relaxed);
+
+        if self.poll_write_ready2(cx)?.is_ready() {
+            // Notify the current task
+            cx.waker().wake()
         }
 
         Ok(())
@@ -319,6 +387,28 @@ where E: Evented + Read,
         }
 
         return r
+    }
+}
+
+#[cfg(feature = "unstable-futures")]
+impl<E> futures2::io::AsyncRead for PollEvented<E>
+    where E: Evented, E: Read,
+{
+    fn poll_read(&mut self, cx: &mut futures2::task::Context, buf: &mut [u8])
+                 -> futures2::Poll<usize, io::Error>
+    {
+        if let futures2::Async::Pending = self.poll_read_ready2(cx, mio::Ready::readable())? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_mut().read(buf) {
+            Ok(n) => Ok(futures2::Async::Ready(n)),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_read_ready2(cx, mio::Ready::readable())?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -354,6 +444,48 @@ where E: Evented + Write,
     }
 }
 
+#[cfg(feature = "unstable-futures")]
+impl<E> futures2::io::AsyncWrite for PollEvented<E>
+    where E: Evented, E: Write,
+{
+    fn poll_write(&mut self, cx: &mut futures2::task::Context, buf: &[u8])
+                  -> futures2::Poll<usize, io::Error>
+    {
+        if let futures2::Async::Pending = self.poll_write_ready2(cx)? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_mut().write(buf) {
+            Ok(n) => Ok(futures2::Async::Ready(n)),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_write_ready2(cx)?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_flush(&mut self, cx: &mut futures2::task::Context) -> futures2::Poll<(), io::Error> {
+        if let futures2::Async::Pending = self.poll_write_ready2(cx)? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_mut().flush() {
+            Ok(_) => Ok(futures2::Async::Ready(())),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_write_ready2(cx)?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut futures2::task::Context) -> futures2::Poll<(), io::Error> {
+        futures2::io::AsyncWrite::poll_flush(self, cx)
+    }
+}
+
+
 impl<E> AsyncRead for PollEvented<E>
 where E: Evented + Read,
 {
@@ -384,6 +516,28 @@ where E: Evented, &'a E: Read,
         }
 
         return r
+    }
+}
+
+#[cfg(feature = "unstable-futures")]
+impl<'a, E> futures2::io::AsyncRead for &'a PollEvented<E>
+    where E: Evented, &'a E: Read,
+{
+    fn poll_read(&mut self, cx: &mut futures2::task::Context, buf: &mut [u8])
+                 -> futures2::Poll<usize, io::Error>
+    {
+        if let futures2::Async::Pending = self.poll_read_ready2(cx, mio::Ready::readable())? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_ref().read(buf) {
+            Ok(n) => Ok(futures2::Async::Ready(n)),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_read_ready2(cx, mio::Ready::readable())?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
     }
 }
 
@@ -419,6 +573,47 @@ where E: Evented, &'a E: Write,
     }
 }
 
+#[cfg(feature = "unstable-futures")]
+impl<'a, E> futures2::io::AsyncWrite for &'a PollEvented<E>
+    where E: Evented, &'a E: Write,
+{
+    fn poll_write(&mut self, cx: &mut futures2::task::Context, buf: &[u8])
+                  -> futures2::Poll<usize, io::Error>
+    {
+        if let futures2::Async::Pending = self.poll_write_ready2(cx)? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_ref().write(buf) {
+            Ok(n) => Ok(futures2::Async::Ready(n)),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_write_ready2(cx)?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_flush(&mut self, cx: &mut futures2::task::Context) -> futures2::Poll<(), io::Error> {
+        if let futures2::Async::Pending = self.poll_write_ready2(cx)? {
+            return Ok(futures2::Async::Pending);
+        }
+
+        match self.get_ref().flush() {
+            Ok(_) => Ok(futures2::Async::Ready(())),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                self.clear_write_ready2(cx)?;
+                Ok(futures2::Async::Pending)
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn poll_close(&mut self, cx: &mut futures2::task::Context) -> futures2::Poll<(), io::Error> {
+        futures2::io::AsyncWrite::poll_flush(self, cx)
+    }
+}
+
 impl<'a, E> AsyncRead for &'a PollEvented<E>
 where E: Evented, &'a E: Read,
 {
@@ -438,7 +633,6 @@ fn is_wouldblock<T>(r: &io::Result<T>) -> bool {
         Err(ref e) => e.kind() == io::ErrorKind::WouldBlock,
     }
 }
-
 
 impl<E: Evented + fmt::Debug> fmt::Debug for PollEvented<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -220,6 +220,7 @@ where E: Evented
     }
 
     /// Like `poll_read_ready` but compatible with futures 0.2.
+    #[cfg(feature = "unstable-futures")]
     pub fn poll_read_ready2(&self, cx: &mut futures2::task::Context, mask: mio::Ready)
         -> futures2::Poll<mio::Ready, io::Error>
     {
@@ -310,6 +311,7 @@ where E: Evented
     }
 
     /// Like `poll_write_ready` but compatible with futures 0.2.
+    #[cfg(feature = "unstable-futures")]
     pub fn poll_write_ready2(&self, cx: &mut futures2::task::Context)
         -> futures2::Poll<mio::Ready, io::Error>
     {
@@ -350,6 +352,7 @@ where E: Evented
     }
 
     /// Like `clear_write_ready`, but compatible with futures 0.2.
+    #[cfg(feature = "unstable-futures")]
     pub fn clear_write_ready2(&self, cx: &mut futures2::task::Context) -> io::Result<()> {
         let ready = mio::Ready::writable();
 

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -1,8 +1,10 @@
-use {Handle, Direction};
+use {Handle, Direction, Task};
 
-use futures::{Async, Poll};
-use futures::task::{self, Task};
+use futures::{Async, Poll, task};
 use mio::{self, Evented};
+
+#[cfg(feature = "futures-0-2")]
+use futures2;
 
 use std::{io, mem, usize};
 use std::cell::UnsafeCell;
@@ -271,10 +273,23 @@ impl Registration {
     ///
     /// This function will panic if called from outside of a task context.
     pub fn poll_read_ready(&self) -> Poll<mio::Ready, io::Error> {
-        self.poll_ready(Direction::Read, true)
+        self.poll_ready(Direction::Read, true, || Task::Futures1(task::current()))
             .map(|v| match v {
                 Some(v) => Async::Ready(v),
                 _ => Async::NotReady,
+            })
+    }
+
+    /// Like `poll_ready_ready`, but compatible with futures 0.2
+    #[cfg(feature = "futures-0-2")]
+    pub fn poll_read_ready2(&self, cx: &mut futures2::task::Context)
+        -> futures2::Poll<mio::Ready, io::Error>
+    {
+        use futures2::Async as Async2;
+        self.poll_ready(Direction::Read, true, || Task::Futures2(cx.waker()))
+            .map(|v| match v {
+                Some(v) => Async2::Ready(v),
+                _ => Async2::Pending,
             })
     }
 
@@ -286,7 +301,7 @@ impl Registration {
     ///
     /// [`poll_read_ready`]: #method.poll_read_ready
     pub fn take_read_ready(&self) -> io::Result<Option<mio::Ready>> {
-        self.poll_ready(Direction::Read, false)
+        self.poll_ready(Direction::Read, false, || panic!())
 
     }
 
@@ -323,10 +338,23 @@ impl Registration {
     ///
     /// This function will panic if called from outside of a task context.
     pub fn poll_write_ready(&self) -> Poll<mio::Ready, io::Error> {
-        self.poll_ready(Direction::Write, true)
+        self.poll_ready(Direction::Write, true, || Task::Futures1(task::current()))
             .map(|v| match v {
                 Some(v) => Async::Ready(v),
                 _ => Async::NotReady,
+            })
+    }
+
+    /// Like `poll_write_ready`, but compatible with futures 0.2
+    #[cfg(feature = "futures-0-2")]
+    pub fn poll_write_ready2(&self, cx: &mut futures2::task::Context)
+                            -> futures2::Poll<mio::Ready, io::Error>
+    {
+        use futures2::Async as Async2;
+        self.poll_ready(Direction::Write, true, || Task::Futures2(cx.waker()))
+            .map(|v| match v {
+                Some(v) => Async2::Ready(v),
+                _ => Async2::Pending,
             })
     }
 
@@ -338,11 +366,12 @@ impl Registration {
     ///
     /// [`poll_write_ready`]: #method.poll_write_ready
     pub fn take_write_ready(&self) -> io::Result<Option<mio::Ready>> {
-        self.poll_ready(Direction::Write, false)
+        self.poll_ready(Direction::Write, false, || panic!())
     }
 
-    fn poll_ready(&self, direction: Direction, notify: bool)
+    fn poll_ready<F>(&self, direction: Direction, notify: bool, task: F)
         -> io::Result<Option<mio::Ready>>
+        where F: Fn() -> Task
     {
         let mut state = self.state.load(SeqCst);
 
@@ -357,7 +386,7 @@ impl Registration {
                 }
                 READY => {
                     let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
-                    return inner.poll_ready(direction, notify);
+                    return inner.poll_ready(direction, notify, task);
                 }
                 _ => {
                     if !notify {
@@ -371,7 +400,7 @@ impl Registration {
                     let mut n = node.take().unwrap_or_else(|| {
                         Box::new(Node {
                             direction,
-                            task: task::current(),
+                            task: task(),
                             next: None,
                         })
                     });
@@ -472,8 +501,9 @@ impl Inner {
         inner.deregister_source(io)
     }
 
-    fn poll_ready(&self, direction: Direction, notify: bool)
+    fn poll_ready<F>(&self, direction: Direction, notify: bool, task: F)
         -> io::Result<Option<mio::Ready>>
+        where F: FnOnce() -> Task
     {
         if self.token == ERROR {
             return Err(io::Error::new(io::ErrorKind::Other, "failed to associate with reactor"));
@@ -504,8 +534,8 @@ impl Inner {
         if ready.is_empty() && notify {
             // Update the task info
             match direction {
-                Direction::Read => sched.reader.register(),
-                Direction::Write => sched.writer.register(),
+                Direction::Read => sched.reader.register(task()),
+                Direction::Write => sched.writer.register(task()),
             }
 
             // Try again

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -286,7 +286,7 @@ impl Registration {
         -> futures2::Poll<mio::Ready, io::Error>
     {
         use futures2::Async as Async2;
-        self.poll_ready(Direction::Read, true, || Task::Futures2(cx.waker()))
+        self.poll_ready(Direction::Read, true, || Task::Futures2(cx.waker().clone()))
             .map(|v| match v {
                 Some(v) => Async2::Ready(v),
                 _ => Async2::Pending,
@@ -351,7 +351,7 @@ impl Registration {
                             -> futures2::Poll<mio::Ready, io::Error>
     {
         use futures2::Async as Async2;
-        self.poll_ready(Direction::Write, true, || Task::Futures2(cx.waker()))
+        self.poll_ready(Direction::Write, true, || Task::Futures2(cx.waker().clone()))
             .map(|v| match v {
                 Some(v) => Async2::Ready(v),
                 _ => Async2::Pending,

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -366,7 +366,7 @@ impl Registration {
     ///
     /// [`poll_write_ready`]: #method.poll_write_ready
     pub fn take_write_ready(&self) -> io::Result<Option<mio::Ready>> {
-        self.poll_ready(Direction::Write, false, || panic!())
+        self.poll_ready(Direction::Write, false, || unreachable!())
     }
 
     fn poll_ready<F>(&self, direction: Direction, notify: bool, task: F)

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -3,7 +3,7 @@ use {Handle, Direction, Task};
 use futures::{Async, Poll, task};
 use mio::{self, Evented};
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 use futures2;
 
 use std::{io, mem, usize};
@@ -281,7 +281,7 @@ impl Registration {
     }
 
     /// Like `poll_ready_ready`, but compatible with futures 0.2
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     pub fn poll_read_ready2(&self, cx: &mut futures2::task::Context)
         -> futures2::Poll<mio::Ready, io::Error>
     {
@@ -346,7 +346,7 @@ impl Registration {
     }
 
     /// Like `poll_write_ready`, but compatible with futures 0.2
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     pub fn poll_write_ready2(&self, cx: &mut futures2::task::Context)
                             -> futures2::Poll<mio::Ready, io::Error>
     {

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -27,5 +27,5 @@ env_logger = "0.4"
 futures-cpupool = "0.1.7"
 
 [features]
-unstable-futures = ["futures2"]
+unstable-futures = ["futures2", "tokio-executor/unstable-futures"]
 default = []

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -19,8 +19,13 @@ crossbeam-deque = "0.3"
 num_cpus = "1.2"
 rand = "0.4"
 log = "0.3"
+futures2 = { version = "0.1", path = "../futures2", optional = true }
 
 [dev-dependencies]
 tokio-timer = "0.1"
 env_logger = "0.4"
 futures-cpupool = "0.1.7"
+
+[features]
+futures-0-2 = ["futures2"]
+default = ["futures-0-2"]

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -27,5 +27,5 @@ env_logger = "0.4"
 futures-cpupool = "0.1.7"
 
 [features]
-futures-0-2 = ["futures2"]
-default = ["futures-0-2"]
+unstable-futures = ["futures2"]
+default = []

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -850,7 +850,12 @@ impl futures2::executor::Executor for Sender {
         // execution.
 
         // Create a new task for the future
-        let task = Task::new2(f, |_| panic!());
+        let task = Task::new2(f, |id| Arc::new(Futures2Wake {
+            id,
+            notifier: Arc::new(Notifier {
+                inner: Arc::downgrade(&self.inner),
+            })
+        }).into());
 
         self.inner.submit(task, &self.inner);
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1360,9 +1360,6 @@ impl Worker {
                 // Enter an execution context
                 let mut enter = tokio_executor::enter().unwrap();
 
-                #[cfg(feature = "unstable-futures")]
-                let _enter2 = futures2::executor::enter();
-
                 tokio_executor::with_default(&mut sender, &mut enter, |enter| {
                     if let Some(ref callback) = wref.inner.config.around_worker {
                         callback.call(wref, enter);

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -12,7 +12,7 @@ extern crate rand;
 #[macro_use]
 extern crate log;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 extern crate futures2;
 
 mod task;
@@ -183,7 +183,7 @@ struct Notifier {
     inner: Weak<Inner>,
 }
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 struct Futures2Wake {
     notifier: Arc<Notifier>,
     id: usize,
@@ -836,10 +836,10 @@ where T: Future<Item = (), Error = ()> + Send + 'static,
     }
 }
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 type Task2 = Box<futures2::Future<Item = (), Error = futures2::Never> + Send>;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 impl futures2::executor::Executor for Sender {
     fn spawn(&mut self, f: Task2) -> Result<(), futures2::executor::SpawnError> {
         self.prepare_for_spawn()
@@ -1310,7 +1310,7 @@ impl Notify for Notifier {
     }
 }
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 impl futures2::task::Wake for Futures2Wake {
     fn wake(arc_self: &Arc<Futures2Wake>) {
         arc_self.notifier.notify(arc_self.id)
@@ -1360,7 +1360,7 @@ impl Worker {
                 // Enter an execution context
                 let mut enter = tokio_executor::enter().unwrap();
 
-                #[cfg(feature = "futures-0-2")]
+                #[cfg(feature = "unstable-futures")]
                 let _enter2 = futures2::executor::enter();
 
                 tokio_executor::with_default(&mut sender, &mut enter, |enter| {

--- a/tokio-threadpool/src/task.rs
+++ b/tokio-threadpool/src/task.rs
@@ -495,6 +495,7 @@ impl From<State> for usize {
 // ===== impl TaskFuture =====
 
 impl TaskFuture {
+    #[allow(unused_variables)]
     fn poll(&mut self, unpark: &Arc<Notifier>, id: usize, exec: &mut Sender) -> futures::Poll<(), ()> {
         match *self {
             TaskFuture::Futures1(ref mut fut) => fut.poll_future_notify(unpark, id),

--- a/tokio-threadpool/src/task.rs
+++ b/tokio-threadpool/src/task.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize, AtomicPtr};
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Release, Relaxed};
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 use futures2;
 
 pub(crate) struct Task {
@@ -39,13 +39,13 @@ pub(crate) enum Run {
 
 type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
 
-#[cfg(feature = "futures-0-2")]
+#[cfg(feature = "unstable-futures")]
 type BoxFuture2 = Box<futures2::Future<Item = (), Error = futures2::Never> + Send>;
 
 enum TaskFuture {
     Futures1(Spawn<BoxFuture>),
 
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     Futures2 {
         tls: futures2::task::LocalMap,
         waker: futures2::task::Waker,
@@ -100,7 +100,7 @@ impl Task {
     }
 
     /// Create a new task handle for a futures 0.2 future
-    #[cfg(feature = "futures-0-2")]
+    #[cfg(feature = "unstable-futures")]
     pub fn new2<F>(fut: BoxFuture2, make_waker: F) -> Task
         where F: FnOnce(usize) -> futures2::task::Waker
     {
@@ -499,7 +499,7 @@ impl TaskFuture {
         match *self {
             TaskFuture::Futures1(ref mut fut) => fut.poll_future_notify(unpark, id),
 
-            #[cfg(feature = "futures-0-2")]
+            #[cfg(feature = "unstable-futures")]
             TaskFuture::Futures2 { ref mut fut, ref waker, ref mut tls } => {
                 let mut cx = futures2::task::Context::new(tls, waker, exec);
                 match fut.poll(&mut cx).unwrap() {

--- a/tokio-threadpool/src/task.rs
+++ b/tokio-threadpool/src/task.rs
@@ -1,6 +1,6 @@
-use Notifier;
+use {Notifier, Sender};
 
-use futures::{future, Future, Async};
+use futures::{self, future, Future, Async};
 use futures::executor::{self, Spawn};
 
 use std::{fmt, mem, panic, ptr};
@@ -8,6 +8,9 @@ use std::cell::Cell;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize, AtomicPtr};
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Release, Relaxed};
+
+#[cfg(feature = "futures-0-2")]
+use futures2;
 
 pub(crate) struct Task {
     ptr: *mut Inner,
@@ -34,6 +37,22 @@ pub(crate) enum Run {
     Complete,
 }
 
+type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
+
+#[cfg(feature = "futures-0-2")]
+type BoxFuture2 = Box<futures2::Future<Item = (), Error = futures2::Never> + Send>;
+
+enum TaskFuture {
+    Futures1(Spawn<BoxFuture>),
+
+    #[cfg(feature = "futures-0-2")]
+    Futures2 {
+        tls: futures2::task::LocalMap,
+        waker: futures2::task::Waker,
+        fut: BoxFuture2,
+    }
+}
+
 struct Inner {
     // Next pointer in the queue that submits tasks to a worker.
     next: AtomicPtr<Inner>,
@@ -47,7 +66,7 @@ struct Inner {
     // Store the future at the head of the struct
     //
     // The future is dropped immediately when it transitions to Complete
-    future: Option<Spawn<BoxFuture>>,
+    future: Option<TaskFuture>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -64,19 +83,37 @@ enum State {
     Complete,
 }
 
-type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
-
 // ===== impl Task =====
 
 impl Task {
     /// Create a new task handle
     pub fn new(future: BoxFuture) -> Task {
+        let task_fut = TaskFuture::Futures1(executor::spawn(future));
         let inner = Box::new(Inner {
             next: AtomicPtr::new(ptr::null_mut()),
             state: AtomicUsize::new(State::new().into()),
             ref_count: AtomicUsize::new(1),
-            future: Some(executor::spawn(future)),
+            future: Some(task_fut),
         });
+
+        Task { ptr: Box::into_raw(inner) }
+    }
+
+    /// Create a new task handle for a futures 0.2 future
+    #[cfg(feature = "futures-0-2")]
+    pub fn new2<F>(fut: BoxFuture2, make_waker: F) -> Task
+        where F: FnOnce(usize) -> futures2::task::Waker
+    {
+        let mut inner = Box::new(Inner {
+            next: AtomicPtr::new(ptr::null_mut()),
+            state: AtomicUsize::new(State::new().into()),
+            ref_count: AtomicUsize::new(1),
+            future: None,
+        });
+
+        let waker = make_waker((&*inner) as *const _ as usize);
+        let tls = futures2::task::LocalMap::new();
+        inner.future = Some(TaskFuture::Futures2 { waker, tls, fut });
 
         Task { ptr: Box::into_raw(inner) }
     }
@@ -93,7 +130,7 @@ impl Task {
 
     /// Execute the task returning `Run::Schedule` if the task needs to be
     /// scheduled again.
-    pub fn run(&self, unpark: &Arc<Notifier>) -> Run {
+    pub fn run(&self, unpark: &Arc<Notifier>, exec: &mut Sender) -> Run {
         use self::State::*;
 
         // Transition task to running state. At this point, the task must be
@@ -132,7 +169,7 @@ impl Task {
             let mut g = Guard(fut, true);
 
             let ret = g.0.as_mut().unwrap()
-                .poll_future_notify(unpark, self.ptr as usize);
+                .poll(unpark, self.ptr as usize, exec);
 
 
             g.1 = false;
@@ -302,7 +339,7 @@ impl Inner {
             next: AtomicPtr::new(ptr::null_mut()),
             state: AtomicUsize::new(State::stub().into()),
             ref_count: AtomicUsize::new(0),
-            future: Some(executor::spawn(Box::new(future::empty()))),
+            future: Some(TaskFuture::Futures1(executor::spawn(Box::new(future::empty())))),
         }
     }
 
@@ -451,6 +488,25 @@ impl From<State> for usize {
             Notified => 2,
             Scheduled => 3,
             Complete => 4,
+        }
+    }
+}
+
+// ===== impl TaskFuture =====
+
+impl TaskFuture {
+    fn poll(&mut self, unpark: &Arc<Notifier>, id: usize, exec: &mut Sender) -> futures::Poll<(), ()> {
+        match *self {
+            TaskFuture::Futures1(ref mut fut) => fut.poll_future_notify(unpark, id),
+
+            #[cfg(feature = "futures-0-2")]
+            TaskFuture::Futures2 { ref mut fut, ref waker, ref mut tls } => {
+                let mut cx = futures2::task::Context::new(tls, waker, exec);
+                match fut.poll(&mut cx).unwrap() {
+                    futures2::Async::Pending => Ok(Async::NotReady),
+                    futures2::Async::Ready(x) => Ok(Async::Ready(x)),
+                }
+            }
         }
     }
 }

--- a/tokio-threadpool/src/task.rs
+++ b/tokio-threadpool/src/task.rs
@@ -155,7 +155,7 @@ impl Task {
         // `thread::panicking() -> true`. To do this, the future is dropped from
         // within the catch_unwind block.
         let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            struct Guard<'a>(&'a mut Option<Spawn<BoxFuture>>, bool);
+            struct Guard<'a>(&'a mut Option<TaskFuture>, bool);
 
             impl<'a> Drop for Guard<'a> {
                 fn drop(&mut self) {

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -3,9 +3,20 @@ extern crate tokio_executor;
 extern crate futures;
 extern crate env_logger;
 
+#[cfg(feature = "unstable-futures")]
+extern crate futures2;
+
 use tokio_threadpool::*;
-use futures::{Poll, Sink, Stream, Async};
-use futures::future::{Future, lazy};
+
+#[cfg(not(feature = "unstable-futures"))]
+use futures::{Poll, Sink, Stream, Async, Future};
+#[cfg(not(feature = "unstable-futures"))]
+use futures::future::lazy;
+
+#[cfg(feature = "unstable-futures")]
+use futures2::prelude::*;
+#[cfg(feature = "unstable-futures")]
+use futures2::future::lazy;
 
 use std::cell::Cell;
 use std::sync::{mpsc, Arc};
@@ -14,6 +25,57 @@ use std::sync::atomic::Ordering::Relaxed;
 use std::time::Duration;
 
 thread_local!(static FOO: Cell<u32> = Cell::new(0));
+
+#[cfg(not(feature = "unstable-futures"))]
+fn spawn_pool<F>(pool: &mut Sender, f: F)
+    where F: Future<Item = (), Error = ()> + Send + 'static
+{
+    pool.spawn(f).unwrap()
+}
+#[cfg(feature = "unstable-futures")]
+fn spawn_pool<F>(pool: &mut Sender, f: F)
+    where F: Future<Item = (), Error = ()> + Send + 'static
+{
+    futures2::executor::Executor::spawn(
+        pool,
+        Box::new(f.map_err(|_| panic!()))
+    ).unwrap()
+}
+
+#[cfg(not(feature = "unstable-futures"))]
+fn spawn_default<F>(f: F)
+    where F: Future<Item = (), Error = ()> + Send + 'static
+{
+    tokio_executor::spawn(f)
+}
+#[cfg(feature = "unstable-futures")]
+fn spawn_default<F>(f: F)
+    where F: Future<Item = (), Error = ()> + Send + 'static
+{
+    tokio_executor::spawn2(Box::new(f.map_err(|_| panic!())))
+}
+
+fn ignore_results<F: Future + Send + 'static>(f: F) -> Box<Future<Item = (), Error = ()> + Send> {
+    Box::new(f.map(|_| ()).map_err(|_| ()))
+}
+
+#[cfg(feature = "unstable-futures")]
+fn await_shutdown(shutdown: Shutdown) {
+    futures::Future::wait(shutdown).unwrap()
+}
+#[cfg(not(feature = "unstable-futures"))]
+fn await_shutdown(shutdown: Shutdown) {
+    shutdown.wait().unwrap()
+}
+
+#[cfg(not(feature = "unstable-futures"))]
+fn block_on<F: Future>(f: F) -> Result<F::Item, F::Error> {
+    f.wait()
+}
+#[cfg(feature = "unstable-futures")]
+fn block_on<F: Future>(f: F) -> Result<F::Item, F::Error> {
+    futures2::executor::block_on(f)
+}
 
 #[test]
 fn natural_shutdown_simple_futures() {
@@ -33,29 +95,29 @@ fn natural_shutdown_simple_futures() {
                     NUM_DEC.fetch_add(1, Relaxed);
                 })
                 .build();
-            let tx = pool.sender().clone();
+            let mut tx = pool.sender().clone();
 
             let a = {
                 let (t, rx) = mpsc::channel();
-                tx.spawn(lazy(move || {
+                spawn_pool(&mut tx, lazy(move || {
                     // Makes sure this runs on a worker thread
                     FOO.with(|f| assert_eq!(f.get(), 0));
 
                     t.send("one").unwrap();
                     Ok(())
-                })).unwrap();
+                }));
                 rx
             };
 
             let b = {
                 let (t, rx) = mpsc::channel();
-                tx.spawn(lazy(move || {
+                spawn_pool(&mut tx, lazy(move || {
                     // Makes sure this runs on a worker thread
                     FOO.with(|f| assert_eq!(f.get(), 0));
 
                     t.send("two").unwrap();
                     Ok(())
-                })).unwrap();
+                }));
                 rx
             };
 
@@ -65,7 +127,7 @@ fn natural_shutdown_simple_futures() {
             assert_eq!("two", b.recv().unwrap());
 
             // Wait for the pool to shutdown
-            pool.shutdown().wait().unwrap();
+            await_shutdown(pool.shutdown());
 
             // Assert that at least one thread started
             let num_inc = NUM_INC.load(Relaxed);
@@ -89,12 +151,23 @@ fn force_shutdown_drops_futures() {
 
         struct Never(Arc<AtomicUsize>);
 
+        #[cfg(not(feature = "unstable-futures"))]
         impl Future for Never {
             type Item = ();
             type Error = ();
 
             fn poll(&mut self) -> Poll<(), ()> {
                 Ok(Async::NotReady)
+            }
+        }
+
+        #[cfg(feature = "unstable-futures")]
+        impl Future for Never {
+            type Item = ();
+            type Error = ();
+
+            fn poll(&mut self, _: &mut futures2::task::Context) -> Poll<(), ()> {
+                Ok(Async::Pending)
             }
         }
 
@@ -116,10 +189,10 @@ fn force_shutdown_drops_futures() {
             .build();
         let mut tx = pool.sender().clone();
 
-        tx.spawn(Never(num_drop.clone())).unwrap();
+        spawn_pool(&mut tx, Never(num_drop.clone()));
 
         // Wait for the pool to shutdown
-        pool.shutdown_now().wait().unwrap();
+        await_shutdown(pool.shutdown_now());
 
         // Assert that only a single thread was spawned.
         let a = num_inc.load(Relaxed);
@@ -146,12 +219,23 @@ fn drop_threadpool_drops_futures() {
 
         struct Never(Arc<AtomicUsize>);
 
+        #[cfg(not(feature = "unstable-futures"))]
         impl Future for Never {
             type Item = ();
             type Error = ();
 
             fn poll(&mut self) -> Poll<(), ()> {
                 Ok(Async::NotReady)
+            }
+        }
+
+        #[cfg(feature = "unstable-futures")]
+        impl Future for Never {
+            type Item = ();
+            type Error = ();
+
+            fn poll(&mut self, _: &mut futures2::task::Context) -> Poll<(), ()> {
+                Ok(Async::Pending)
             }
         }
 
@@ -173,7 +257,7 @@ fn drop_threadpool_drops_futures() {
             .build();
         let mut tx = pool.sender().clone();
 
-        tx.spawn(Never(num_drop.clone())).unwrap();
+        spawn_pool(&mut tx, Never(num_drop.clone()));
 
         // Wait for the pool to shutdown
         drop(pool);
@@ -211,13 +295,13 @@ fn thread_shutdown_timeout() {
             let _ = t.lock().unwrap().send(());
         })
         .build();
-    let tx = pool.sender().clone();
+    let mut tx = pool.sender().clone();
 
     let t = complete_tx.clone();
-    tx.spawn(lazy(move || {
+    spawn_pool(&mut tx, lazy(move || {
         t.send(()).unwrap();
         Ok(())
-    })).unwrap();
+    }));
 
     // The future completes
     complete_rx.recv().unwrap();
@@ -226,14 +310,14 @@ fn thread_shutdown_timeout() {
     shutdown_rx.recv().unwrap();
 
     // Futures can still be run
-    tx.spawn(lazy(move || {
+    spawn_pool(&mut tx, lazy(move || {
         complete_tx.send(()).unwrap();
         Ok(())
-    })).unwrap();
+    }));
 
     complete_rx.recv().unwrap();
 
-    pool.shutdown().wait().unwrap();
+    await_shutdown(pool.shutdown());
 }
 
 #[test]
@@ -249,14 +333,14 @@ fn many_oneshot_futures() {
 
         for _ in 0..NUM {
             let cnt = cnt.clone();
-            tx.spawn(lazy(move || {
+            spawn_pool(&mut tx, lazy(move || {
                 cnt.fetch_add(1, Relaxed);
                 Ok(())
-            })).unwrap();
+            }));
         }
 
         // Wait for the pool to shutdown
-        pool.shutdown().wait().unwrap();
+        await_shutdown(pool.shutdown());
 
         let num = cnt.load(Relaxed);
         assert_eq!(num, NUM);
@@ -265,7 +349,11 @@ fn many_oneshot_futures() {
 
 #[test]
 fn many_multishot_futures() {
+    #[cfg(not(feature = "unstable-futures"))]
     use futures::sync::mpsc;
+
+    #[cfg(feature = "unstable-futures")]
+    use futures2::channel::mpsc;
 
     const CHAIN: usize = 200;
     const CYCLES: usize = 5;
@@ -290,11 +378,11 @@ fn many_multishot_futures() {
                     .map_err(|e| panic!("{:?}", e));
 
                 // Forward all the messages
-                pool_tx.spawn(next_tx
+                spawn_pool(&mut pool_tx, next_tx
                     .send_all(rx)
                     .map(|_| ())
                     .map_err(|e| panic!("{:?}", e))
-                ).unwrap();
+                );
 
                 chain_rx = next_rx;
             }
@@ -304,7 +392,7 @@ fn many_multishot_futures() {
             let cycle_tx = start_tx.clone();
             let mut rem = CYCLES;
 
-            pool_tx.spawn(chain_rx.take(CYCLES as u64).for_each(move |msg| {
+            let task = chain_rx.take(CYCLES as u64).for_each(move |msg| {
                 rem -= 1;
                 let send = if rem == 0 {
                     final_tx.clone().send(msg)
@@ -316,75 +404,99 @@ fn many_multishot_futures() {
                     res.unwrap();
                     Ok(())
                 })
-            })).unwrap();
+            });
+            spawn_pool(&mut pool_tx, ignore_results(task));
 
             start_txs.push(start_tx);
             final_rxs.push(final_rx);
         }
 
         for start_tx in start_txs {
-            start_tx.send("ping").wait().unwrap();
+            block_on(start_tx.send("ping")).unwrap();
         }
 
         for final_rx in final_rxs {
-            final_rx.wait().next().unwrap().unwrap();
+            block_on(final_rx.into_future()).unwrap();
         }
 
         // Shutdown the pool
-        pool.shutdown().wait().unwrap();
+        await_shutdown(pool.shutdown());
     }
 }
 
 #[test]
 fn global_executor_is_configured() {
     let pool = ThreadPool::new();
-    let tx = pool.sender().clone();
+    let mut tx = pool.sender().clone();
 
     let (signal_tx, signal_rx) = mpsc::channel();
 
-    tx.spawn(lazy(move || {
-        tokio_executor::spawn(lazy(move || {
+    spawn_pool(&mut tx, lazy(move || {
+        spawn_default(lazy(move || {
             signal_tx.send(()).unwrap();
             Ok(())
         }));
 
         Ok(())
-    })).unwrap();
+    }));
 
     signal_rx.recv().unwrap();
 
-    pool.shutdown().wait().unwrap();
+    await_shutdown(pool.shutdown());
 }
 
 #[test]
 fn new_threadpool_is_idle() {
     let pool = ThreadPool::new();
-    pool.shutdown_on_idle().wait().unwrap();
+    await_shutdown(pool.shutdown_on_idle());
 }
 
 #[test]
 fn busy_threadpool_is_not_idle() {
+    #[cfg(not(feature = "unstable-futures"))]
     use futures::sync::oneshot;
 
+    #[cfg(feature = "unstable-futures")]
+    use futures2::channel::oneshot;
+
     let pool = ThreadPool::new();
-    let tx = pool.sender().clone();
+    let mut tx = pool.sender().clone();
 
     let (term_tx, term_rx) = oneshot::channel();
 
-    tx.spawn(term_rx.then(|_| {
+    spawn_pool(&mut tx, term_rx.then(|_| {
         Ok(())
-    })).unwrap();
+    }));
 
     let mut idle = pool.shutdown_on_idle();
 
-    futures::lazy(|| {
-        assert!(idle.poll().unwrap().is_not_ready());
-        Ok::<_, ()>(())
-    }).wait().unwrap();
+    struct IdleFut<'a>(&'a mut Shutdown);
+
+    #[cfg(not(feature = "unstable-futures"))]
+    impl<'a> Future for IdleFut<'a> {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self) -> Poll<(), ()> {
+            assert!(self.0.poll().unwrap().is_not_ready());
+            Ok(Async::Ready(()))
+        }
+    }
+
+    #[cfg(feature = "unstable-futures")]
+    impl<'a> Future for IdleFut<'a> {
+        type Item = ();
+        type Error = ();
+        fn poll(&mut self, cx: &mut futures2::task::Context) -> Poll<(), ()> {
+            assert!(self.0.poll(cx).unwrap().is_pending());
+            Ok(Async::Ready(()))
+        }
+    }
+
+    block_on(IdleFut(&mut idle)).unwrap();
 
     term_tx.send(()).unwrap();
 
-    idle.wait().unwrap();
+    await_shutdown(idle);
 }
 
 #[test]


### PR DESCRIPTION
I realized that, at least for the reactor (but I think throughout), it's possible to just simultaneously support both versions of the futures crate.

Here is a proof of concept showing how this is done for the reactor. Note that the `futures2` crate here is a hack until an actual release candidate is published to crates.io. This compiles for me locally.