### PR TITLE
Switch TCP/UDP fns to poll_ -> Poll<...> style

### DIFF
--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -10,9 +10,9 @@
 //!
 //! Each line you type in to the `nc` terminal should be echo'd back to you!
 
+#[macro_use]
 extern crate futures;
 extern crate tokio;
-#[macro_use]
 extern crate tokio_io;
 
 use std::{env, io};
@@ -37,14 +37,14 @@ impl Future for Server {
             // If so then we try to send it back to the original source, waiting
             // until it's writable and we're able to do so.
             if let Some((size, peer)) = self.to_send {
-                let amt = try_nb!(self.socket.send_to(&self.buf[..size], &peer));
+                let amt = try_ready!(self.socket.poll_send_to(&self.buf[..size], &peer));
                 println!("Echoed {}/{} bytes to {}", amt, size, peer);
                 self.to_send = None;
             }
 
             // If we're here then `to_send` is `None`, so we take a look for the
             // next message we're going to echo back.
-            self.to_send = Some(try_nb!(self.socket.recv_from(&mut self.buf)));
+            self.to_send = Some(try_ready!(self.socket.poll_recv_from(&mut self.buf)));
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,6 @@ extern crate futures;
 extern crate iovec;
 extern crate mio;
 extern crate slab;
-#[macro_use]
 extern crate tokio_io;
 extern crate tokio_executor;
 extern crate tokio_reactor;

--- a/src/net/udp/frame.rs
+++ b/src/net/udp/frame.rs
@@ -44,7 +44,7 @@ impl<C: Decoder> Stream for UdpFramed<C> {
 
         let (n, addr) = unsafe {
             // Read into the buffer without having to initialize the memory.
-            let (n, addr) = try_nb!(self.socket.recv_from(self.rd.bytes_mut()));
+            let (n, addr) = try_ready!(self.socket.poll_recv_from(self.rd.bytes_mut()));
             self.rd.advance_mut(n);
             (n, addr)
         };
@@ -87,7 +87,7 @@ impl<C: Encoder> Sink for UdpFramed<C> {
         }
 
         trace!("flushing frame; length={}", self.wr.len());
-        let n = try_nb!(self.socket.send_to(&self.wr, &self.out_addr));
+        let n = try_ready!(self.socket.poll_send_to(&self.wr, &self.out_addr));
         trace!("written {}", n);
 
         let wrote_all = n == self.wr.len();

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 extern crate futures;
 extern crate tokio;
 #[macro_use]


### PR DESCRIPTION
Tokio is moving away from using `WouldBlock`, instead favoring
`Async::NotReady`.

This patch updates the TCP and UDP types, deprecating any function that
returns `WouldBlock` and adding a poll_ prefixed equivalent.