### PR TITLE
Replace coco with crossbeam

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1", path = "../tokio-executor" }
 futures = "0.1"
-coco = "0.3"
+crossbeam-deque = "0.3"
 num_cpus = "1.2"
 rand = "0.3"
 log = "0.3"


### PR DESCRIPTION
Since [coco is deprecated](https://github.com/stjepang/coco), I'd like to propose to switch to [crossbeam-deque](https://github.com/crossbeam-rs/crossbeam-deque) for the underlying work-stealing deque.

The performance is slightly degraded in a benchmark I did on a Linux machine w/ 4 cores, but I think the numbers look generally fine:

```
 name                                control ns/iter  variable ns/iter  diff ns/iter  diff %  speedup
 connect_churn::multi_threads        212,195,085      215,857,713          3,662,628   1.73%   x 0.98
 connect_churn::one_thread           11,274,537       11,393,499             118,962   1.06%   x 0.99
 connect_churn::two_threads          217,590,666      214,175,311         -3,415,355  -1.57%   x 1.02
 futures_channel_latency             6,247            6,266                       19   0.30%   x 1.00
 mio_poll                            288              288                          0   0.00%   x 1.00
 mio_register_deregister             876              885                          9   1.03%   x 0.99
 mio_reregister                      282              285                          3   1.06%   x 0.99
 transfer::big_chunks::one_thread    5,307,456        5,289,317              -18,139  -0.34%   x 1.00
 transfer::small_chunks::one_thread  98,694,777       99,180,576             485,799   0.49%   x 1.00
 udp_echo_latency                    16,219           16,545                     326   2.01%   x 0.98
```