### PR TITLE
Fix benches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
   - |
     if [[ "$TRAVIS_RUST_VERSION" == nightly ]]
     then
-        cargo build --benches
+        cargo build --benches --all
     fi
   - cargo test --all
 

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -1,10 +1,10 @@
 #![feature(test)]
+#![deny(warnings)]
 
 extern crate test;
+#[macro_use]
 extern crate futures;
 extern crate tokio;
-#[macro_use]
-extern crate tokio_io;
 
 use std::io;
 use std::net::SocketAddr;
@@ -40,10 +40,10 @@ impl Future for EchoServer {
     fn poll(&mut self) -> Poll<(), io::Error> {
         loop {
             if let Some(&(size, peer)) = self.to_send.as_ref() {
-                try_nb!(self.socket.send_to(&self.buf[..size], &peer));
+                try_ready!(self.socket.poll_send_to(&self.buf[..size], &peer));
                 self.to_send = None;
             }
-            self.to_send = Some(try_nb!(self.socket.recv_from(&mut self.buf)));
+            self.to_send = Some(try_ready!(self.socket.poll_recv_from(&mut self.buf)));
         }
     }
 }

--- a/benches/mio-ops.rs
+++ b/benches/mio-ops.rs
@@ -1,6 +1,7 @@
 // Measure cost of different operations
 // to get a sense of performance tradeoffs
 #![feature(test)]
+#![deny(warnings)]
 
 extern crate test;
 extern crate mio;

--- a/benches/tcp.rs
+++ b/benches/tcp.rs
@@ -1,4 +1,5 @@
 #![feature(test)]
+#![deny(warnings)]
 
 extern crate futures;
 extern crate tokio;


### PR DESCRIPTION
Some of the benchhmarks were broken and/or using deprecated APIs. This
patch updates the benches and requires them all to compile without
warnings in order to pass CI.