### PR TITLE
Explicitly deregister I/O resources on drop

### DIFF
--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -559,6 +559,11 @@ impl Inner {
         Ok(key)
     }
 
+    /// Deregisters an I/O resource from the reactor.
+    fn deregister_source(&self, source: &Evented) -> io::Result<()> {
+        self.io.deregister(source)
+    }
+
     fn drop_source(&self, token: usize) {
         debug!("dropping I/O source: {}", token);
         self.io_dispatch.write().unwrap().remove(token);


### PR DESCRIPTION
Mio will be requiring `deregister` to be called explicitly in order to
guarantee that Poll releases any state associated with the I/O resource.
See carllerche/mio#753.

This patch adds an explicit `deregister` function to `Registration` and
updates `PollEvented` to call this function on drop.

`Registration::deregister` is also called on `PollEvented::into_inner`.

Closes #168