### PR TITLE
Improve `poll_read_ready` implementation

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -93,12 +93,12 @@ impl TcpListener {
     ///
     /// This function will panic if called from outside of a task context.
     pub fn poll_accept_std(&mut self) -> Poll<(net::TcpStream, SocketAddr), io::Error> {
-        try_ready!(self.io.poll_read_ready());
+        try_ready!(self.io.poll_read_ready(mio::Ready::readable()));
 
         match self.io.get_ref().accept_std() {
             Ok(pair) => Ok(pair.into()),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read()?;
+                self.io.clear_read_ready(mio::Ready::readable())?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -114,6 +114,11 @@ impl TcpStream {
         ConnectFuture { inner: inner }
     }
 
+    /// TODO: Dox
+    pub fn poll_read_ready(&self, mask: mio::Ready) -> Poll<mio::Ready, io::Error> {
+        self.io.poll_read_ready(mask)
+    }
+
     /// Returns the local address that this stream is bound to.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().local_addr()
@@ -152,12 +157,12 @@ impl TcpStream {
     ///
     /// This function will panic if called from outside of a task context.
     pub fn poll_peek(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
-        try_ready!(self.io.poll_read_ready());
+        try_ready!(self.io.poll_read_ready(mio::Ready::readable()));
 
         match self.io.get_ref().peek(buf) {
             Ok(ret) => Ok(ret.into()),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read()?;
+                self.io.clear_read_ready(mio::Ready::readable())?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),
@@ -357,7 +362,7 @@ impl<'a> AsyncRead for &'a TcpStream {
     }
 
     fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, io::Error> {
-        if let Async::NotReady = self.io.poll_read_ready()? {
+        if let Async::NotReady = self.io.poll_read_ready(mio::Ready::readable())? {
             return Ok(Async::NotReady)
         }
 
@@ -397,7 +402,7 @@ impl<'a> AsyncRead for &'a TcpStream {
                 Ok(Async::Ready(n))
             }
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read()?;
+                self.io.clear_read_ready(mio::Ready::readable())?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),

--- a/src/net/udp/socket.rs
+++ b/src/net/udp/socket.rs
@@ -128,12 +128,12 @@ impl UdpSocket {
     ///
     /// This function will panic if called from outside of a task context.
     pub fn poll_recv(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
-        try_ready!(self.io.poll_read_ready());
+        try_ready!(self.io.poll_read_ready(mio::Ready::readable()));
 
         match self.io.get_ref().recv(buf) {
             Ok(n) => Ok(n.into()),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read()?;
+                self.io.clear_read_ready(mio::Ready::readable())?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),
@@ -216,12 +216,12 @@ impl UdpSocket {
     /// This function will panic if called outside the context of a future's
     /// task.
     pub fn poll_recv_from(&mut self, buf: &mut [u8]) -> Poll<(usize, SocketAddr), io::Error> {
-        try_ready!(self.io.poll_read_ready());
+        try_ready!(self.io.poll_read_ready(mio::Ready::readable()));
 
         match self.io.get_ref().recv_from(buf) {
             Ok(n) => Ok(n.into()),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.need_read()?;
+                self.io.clear_read_ready(mio::Ready::readable())?;
                 Ok(Async::NotReady)
             }
             Err(e) => Err(e),

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -352,7 +352,7 @@ impl Reactor {
         let io_dispatch = self.inner.io_dispatch.read().unwrap();
 
         if let Some(io) = io_dispatch.get(token) {
-            io.readiness.fetch_or(ready2usize(ready), Relaxed);
+            io.readiness.fetch_or(ready.as_usize(), Relaxed);
 
             if ready.is_writable() {
                 io.writer.notify();
@@ -551,9 +551,7 @@ impl Inner {
 
         try!(self.io.register(source,
                               mio::Token(TOKEN_START + key),
-                              mio::Ready::readable() |
-                                mio::Ready::writable() |
-                                platform::all(),
+                              mio::Ready::all(),
                               mio::PollOpt::edge()));
 
         Ok(key)
@@ -582,7 +580,7 @@ impl Inner {
 
         task.register_task(t);
 
-        if sched.readiness.load(SeqCst) & ready2usize(ready) != 0 {
+        if sched.readiness.load(SeqCst) & ready.as_usize() != 0 {
             task.notify();
         }
     }
@@ -602,53 +600,15 @@ impl Drop for Inner {
 }
 
 impl Direction {
-    fn ready(&self) -> mio::Ready {
+    fn mask(&self) -> mio::Ready {
         match *self {
-            Direction::Read => read_ready(),
-            Direction::Write => write_ready(),
+            Direction::Read => {
+                // Everything except writable is signaled through read.
+                mio::Ready::all() - mio::Ready::writable()
+            }
+            Direction::Write => mio::Ready::writable() | platform::hup(),
         }
     }
-
-    fn mask(&self) -> usize {
-        ready2usize(self.ready())
-    }
-}
-
-// ===== misc =====
-
-const READ: usize = 1 << 0;
-const WRITE: usize = 1 << 1;
-
-fn read_ready() -> mio::Ready {
-    mio::Ready::readable() | platform::hup()
-}
-
-fn write_ready() -> mio::Ready {
-    mio::Ready::writable()
-}
-
-// === legacy
-
-fn ready2usize(ready: mio::Ready) -> usize {
-    let mut bits = 0;
-    if ready.is_readable() {
-        bits |= READ;
-    }
-    if ready.is_writable() {
-        bits |= WRITE;
-    }
-    bits | platform::ready2usize(ready)
-}
-
-fn usize2ready(bits: usize) -> mio::Ready {
-    let mut ready = mio::Ready::empty();
-    if bits & READ != 0 {
-        ready.insert(mio::Ready::readable());
-    }
-    if bits & WRITE != 0 {
-        ready.insert(mio::Ready::writable());
-    }
-    ready | platform::usize2ready(bits)
 }
 
 #[cfg(all(unix, not(target_os = "fuchsia")))]
@@ -656,105 +616,12 @@ mod platform {
     use mio::Ready;
     use mio::unix::UnixReady;
 
-    #[cfg(target_os = "dragonfly")]
-    pub fn all() -> Ready {
-        hup() | UnixReady::aio()
-    }
-
-    #[cfg(target_os = "freebsd")]
-    pub fn all() -> Ready {
-        hup() | UnixReady::aio() | UnixReady::lio()
-    }
-
-    #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd")))]
-    pub fn all() -> Ready {
-        hup()
-    }
-
     pub fn hup() -> Ready {
         UnixReady::hup().into()
     }
 
-    const HUP: usize = 1 << 2;
-    const ERROR: usize = 1 << 3;
-    const AIO: usize = 1 << 4;
-    const LIO: usize = 1 << 5;
-
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
-    fn is_aio(ready: &Ready) -> bool {
-        UnixReady::from(*ready).is_aio()
-    }
-
-    #[cfg(not(any(target_os = "dragonfly", target_os = "freebsd")))]
-    fn is_aio(_ready: &Ready) -> bool {
-        false
-    }
-
-    #[cfg(target_os = "freebsd")]
-    fn is_lio(ready: &Ready) -> bool {
-        UnixReady::from(*ready).is_lio()
-    }
-
-    #[cfg(not(target_os = "freebsd"))]
-    fn is_lio(_ready: &Ready) -> bool {
-        false
-    }
-
-    pub fn ready2usize(ready: Ready) -> usize {
-        let ready = UnixReady::from(ready);
-        let mut bits = 0;
-        if is_aio(&ready) {
-            bits |= AIO;
-        }
-        if is_lio(&ready) {
-            bits |= LIO;
-        }
-        if ready.is_error() {
-            bits |= ERROR;
-        }
-        if ready.is_hup() {
-            bits |= HUP;
-        }
-        bits
-    }
-
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios",
-              target_os = "macos"))]
-    fn usize2ready_aio(ready: &mut UnixReady) {
-        ready.insert(UnixReady::aio());
-    }
-
-    #[cfg(not(any(target_os = "dragonfly",
-        target_os = "freebsd", target_os = "ios", target_os = "macos")))]
-    fn usize2ready_aio(_ready: &mut UnixReady) {
-        // aio not available here → empty
-    }
-
-    #[cfg(target_os = "freebsd")]
-    fn usize2ready_lio(ready: &mut UnixReady) {
-        ready.insert(UnixReady::lio());
-    }
-
-    #[cfg(not(target_os = "freebsd"))]
-    fn usize2ready_lio(_ready: &mut UnixReady) {
-        // lio not available here → empty
-    }
-
-    pub fn usize2ready(bits: usize) -> Ready {
-        let mut ready = UnixReady::from(Ready::empty());
-        if bits & AIO != 0 {
-            usize2ready_aio(&mut ready);
-        }
-        if bits & LIO != 0 {
-            usize2ready_lio(&mut ready);
-        }
-        if bits & HUP != 0 {
-            ready.insert(UnixReady::hup());
-        }
-        if bits & ERROR != 0 {
-            ready.insert(UnixReady::error());
-        }
-        ready.into()
+    pub fn is_hup(ready: &Ready) -> bool {
+        UnixReady::from(*ready).is_hup()
     }
 }
 
@@ -762,20 +629,11 @@ mod platform {
 mod platform {
     use mio::Ready;
 
-    pub fn all() -> Ready {
-        // No platform-specific Readinesses for Windows
-        Ready::empty()
-    }
-
     pub fn hup() -> Ready {
         Ready::empty()
     }
 
-    pub fn ready2usize(_r: Ready) -> usize {
-        0
-    }
-
-    pub fn usize2ready(_r: usize) -> Ready {
-        Ready::empty()
+    pub fn is_hup(ready: &Ready) -> bool {
+        false
     }
 }

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -480,7 +480,7 @@ impl Inner {
             None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
 
-        let mask = direction.mask();
+        let mask = direction.mask().as_usize();
 
         let io_dispatch = inner.io_dispatch.read().unwrap();
         let sched = &io_dispatch[self.token];
@@ -501,7 +501,7 @@ impl Inner {
         if ready == 0 {
             Ok(None)
         } else {
-            Ok(Some(super::usize2ready(ready)))
+            Ok(Some(mio::Ready::from_usize(ready)))
         }
     }
 }


### PR DESCRIPTION
**Work in progress**

This patch updates `poll_read_ready` to take a `mask` argument, enabling
the caller to specify the desired readiness. `need_read` is renamed to
`clear_read_ready` and also takes a mask.

This enables a caller to listen for HUP events without requiring reading
from the I/O resource.

### Remaining

* [ ] Update write direction
* [ ] HUP is part of both directions.
* [ ] Tests