### PR TITLE
Bump tokio to v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.1.2 (March 09, 2018)
+
+* Introduce Tokio Runtime (#141)
+* Provide `CurrentThread` for more flexible usage of current thread executor (#141).
+* Add Lio for platforms that support it (#142).
+* I/O resources now lazily bind to the reactor (#160).
+* Extract Reactor to dedicated crate (#169)
+* Add facade to sub crates and add prelude (#166).
+* Switch TCP/UDP fns to poll_ -> Poll<...> style (#175)
+
 # 0.1.1 (February 09, 2018)
 
 * Doc fixes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
@@ -34,16 +34,16 @@ travis-ci = { repository = "tokio-rs/tokio" }
 appveyor = { repository = "carllerche/tokio" }
 
 [dependencies]
-tokio-io = { version = "0.1", path = "tokio-io" }
-tokio-executor = { version = "0.1", path = "tokio-executor" }
-tokio-reactor = { version = "0.1", path = "tokio-reactor" }
-tokio-threadpool = { version = "0.1", path = "tokio-threadpool" }
+tokio-io = { version = "0.1.6", path = "tokio-io" }
+tokio-executor = { version = "0.1.0", path = "tokio-executor" }
+tokio-reactor = { version = "0.1.0", path = "tokio-reactor" }
+tokio-threadpool = { version = "0.1.0", path = "tokio-threadpool" }
 bytes = "0.4"
 log = "0.4"
 mio = "0.6.14"
 slab = "0.4"
 iovec = "0.1"
-futures = "0.1.16"
+futures = "0.1.18"
 
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@
 //! }
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.2")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (March 09, 2018)
+
+* Initial release

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -13,4 +13,4 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-futures = "0.1"
+futures = "0.1.18"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -31,7 +31,7 @@
 //! [`Park`]: park/index.html
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.0")]
 
 extern crate futures;
 

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.6 (March 09, 2018)
+
+* Add native endian builder fn to length_delimited (#144)
+* Add AsyncRead::poll_read, AsyncWrite::poll_write (#170)
+
 # 0.1.5 (February 07, 2018)
 
 * Fix bug in `BytesCodec` and `LinesCodec`.

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -1,6 +1,11 @@
 [package]
 name = "tokio-io"
-version = "0.1.5"
+
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag.
+version = "0.1.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/tokio-rs/tokio-io"
@@ -13,5 +18,5 @@ categories = ["asynchronous"]
 
 [dependencies]
 bytes = "0.4"
-futures = "0.1.11"
+futures = "0.1.18"
 log = "0.4"

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -7,7 +7,7 @@
 //! [low level details]: https://tokio.rs/docs/going-deeper-tokio/core-low-level/
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.6")]
 
 #[macro_use]
 extern crate log;

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (March 09, 2018)
+
+* Initial release

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -22,5 +22,5 @@ futures = "0.1.18"
 log = "0.4.1"
 mio = "0.6.13"
 slab = "0.4.0"
-tokio-executor = { version = "0.1", path = "../tokio-executor" }
-tokio-io = { version = "0.1", path = "../tokio-io" }
+tokio-executor = { version = "0.1.0", path = "../tokio-executor" }
+tokio-io = { version = "0.1.6", path = "../tokio-io" }

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (March 09, 2018)
+
+* Initial release

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1", path = "../tokio-executor" }
-futures = "0.1"
+tokio-executor = { version = "0.1.0", path = "../tokio-executor" }
+futures = "0.1.18"
 crossbeam-deque = "0.3"
 num_cpus = "1.2"
 rand = "0.3"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,5 +1,6 @@
 //! A work-stealing based thread pool for executing futures.
 
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.0")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate tokio_executor;


### PR DESCRIPTION
This also bumps tokio-io to v0.1.6 and prepares for the initial release
of tokio-executor, tokio-reactor, and tokio-threadpool.