### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -433,16 +433,6 @@ mod platform {
     use mio::Ready;
     use mio::unix::UnixReady;
 
-    #[cfg(target_os = "dragonfly")]
-    pub fn all() -> Ready {
-        *UnixReady::hup() | UnixReady::aio()
-    }
-
-    #[cfg(target_os = "freebsd")]
-    pub fn all() -> Ready {
-        *UnixReady::hup() | UnixReady::aio() | UnixReady::lio()
-    }
-
     const HUP: usize = 1 << 2;
     const ERROR: usize = 1 << 3;
     const AIO: usize = 1 << 4;

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -435,12 +435,12 @@ mod platform {
 
     #[cfg(target_os = "dragonfly")]
     pub fn all() -> Ready {
-        hup() | UnixReady::aio()
+        *UnixReady::hup() | UnixReady::aio()
     }
 
     #[cfg(target_os = "freebsd")]
     pub fn all() -> Ready {
-        hup() | UnixReady::aio() | UnixReady::lio()
+        *UnixReady::hup() | UnixReady::aio() | UnixReady::lio()
     }
 
     const HUP: usize = 1 << 2;


### PR DESCRIPTION
This PR allows tokio (4d514b7eb3a3bb6173b6f2c66dda7851e79739b4) to compile on FreeBSD again. Prior to this change the following error was encountered:

```
error[E0425]: cannot find function `hup` in this scope
   --> src/reactor/poll_evented.rs:443:9
    |
443 |         hup() | UnixReady::aio() | UnixReady::lio()
    |         ^^^ not found in this scope
```

This is  on FreeBSD 11.1-RELEASE-p6, rustc 1.24.0.

I had a hard time working out where this `hup` function was supposed to be coming from. I came up with the following changes, which compile and the test suite passes. I fully admit I haven't studied the code enough to really know what is supposed to be happening though. Additionally I haven't tested the DragonflyBSD change but assume it's also in the same camp. Further review appreciated.
