### PR TITLE
Remove uses of futures_cpupool

### DIFF
--- a/tokio-threadpool/benches/basic.rs
+++ b/tokio-threadpool/benches/basic.rs
@@ -87,7 +87,7 @@ mod threadpool {
 // benchmark quickly but results in poor runtime characteristics for a thread
 // pool.
 //
-// See alexcrichton/futures-rs#617
+// See rust-lang-nursery/futures-rs#617
 //
 mod cpupool {
     use futures::{task, Async};


### PR DESCRIPTION
`tests/line-frames.rs` used `futures-cpupool`, but now Tokio has its own thread pool!  I just replaced the uses of `futures-cpupool` with those of `tokio-threadpool`.

related: #211 