### PR TITLE
Fix condition for updating the current date buffer

### DIFF
--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -274,7 +274,7 @@ mod date {
             LAST.with(|cache| {
                 let mut cache = cache.borrow_mut();
                 let now = time::get_time();
-                if now > cache.next_update {
+                if now >= cache.next_update {
                     cache.update(now);
                 }
                 f.write_str(cache.buffer())


### PR DESCRIPTION
For example, the original code uses the old cache in the following case.

```
first time:
now         = Sun, 07 Sep 2014 00:17:29 GMT
next_update = Sun, 07 Sep 2014 00:17:30 GMT
cache       = Sun, 07 Sep 2014 00:17:29 GMT
```

```
next time:
now         = Sun, 07 Sep 2014 00:17:30 GMT
next_update = Sun, 07 Sep 2014 00:17:30 GMT
cache       = Sun, 07 Sep 2014 00:17:29 GMT <- wrong!
    should be Sun, 07 Sep 2014 00:17:30 GMT 
```

I sent a pull request for rapidoid too.
https://github.com/rapidoid/rapidoid/pull/159