### PR TITLE
Fix race condition related bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ matrix:
 
 script:
   - |
+    set -e
     if [[ "$TRAVIS_RUST_VERSION" == nightly ]]
     then
         cargo build --benches --all
     fi
   - |
+    set -e
     if [[ "$TARGET" ]]
     then
         rustup target add $TARGET

--- a/tokio-reactor/src/background.rs
+++ b/tokio-reactor/src/background.rs
@@ -137,7 +137,7 @@ impl Future for Shutdown {
 
     fn poll(&mut self) -> Poll<(), ()> {
         let task = Task::Futures1(task::current());
-        self.inner.shared.shutdown_task.register(task);
+        self.inner.shared.shutdown_task.register_task(task);
 
         if !self.inner.is_shutdown() {
             return Ok(Async::NotReady);

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -42,8 +42,8 @@ extern crate tokio_io;
 #[cfg(feature = "unstable-futures")]
 extern crate futures2;
 
-pub(crate) mod background;
 mod atomic_task;
+pub(crate) mod background;
 mod poll_evented;
 mod registration;
 
@@ -588,7 +588,7 @@ impl Inner {
             Direction::Write => (&sched.writer, mio::Ready::writable()),
         };
 
-        task.register(t);
+        task.register_task(t);
 
         if sched.readiness.load(SeqCst) & ready.as_usize() != 0 {
             task.notify();

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -120,6 +120,9 @@ struct Inner {
     /// The underlying system event queue.
     io: mio::Poll,
 
+    /// ABA guard counter
+    next_aba_guard: AtomicUsize,
+
     /// Dispatch slabs for I/O and futures events
     io_dispatch: RwLock<Slab<ScheduledIo>>,
 
@@ -128,6 +131,7 @@ struct Inner {
 }
 
 struct ScheduledIo {
+    aba_guard: usize,
     readiness: AtomicUsize,
     reader: AtomicTask,
     writer: AtomicTask,
@@ -145,11 +149,11 @@ static HANDLE_FALLBACK: AtomicUsize = ATOMIC_USIZE_INIT;
 /// Tracks the reactor for the current execution context.
 thread_local!(static CURRENT_REACTOR: RefCell<Option<Handle>> = RefCell::new(None));
 
-const TOKEN_WAKEUP: mio::Token = mio::Token(0);
-const TOKEN_START: usize = 1;
+const TOKEN_SHIFT: usize = 22;
 
 // Kind of arbitrary, but this reserves some token space for later usage.
-const MAX_SOURCES: usize = usize::MAX >> 4;
+const MAX_SOURCES: usize = (1 << TOKEN_SHIFT) - 1;
+const TOKEN_WAKEUP: mio::Token = mio::Token(MAX_SOURCES);
 
 fn _assert_kinds() {
     fn _assert<T: Send + Sync>() {}
@@ -221,6 +225,7 @@ impl Reactor {
             _wakeup_registration: wakeup_pair.0,
             inner: Arc::new(Inner {
                 io: io,
+                next_aba_guard: AtomicUsize::new(0),
                 io_dispatch: RwLock::new(Slab::with_capacity(1)),
                 wakeup: wakeup_pair.1,
             }),
@@ -358,10 +363,16 @@ impl Reactor {
     }
 
     fn dispatch(&self, token: mio::Token, ready: mio::Ready) {
-        let token = usize::from(token) - TOKEN_START;
+        let aba_guard = token.0 & !MAX_SOURCES;
+        let token = token.0 & MAX_SOURCES;
+
         let io_dispatch = self.inner.io_dispatch.read().unwrap();
 
         if let Some(io) = io_dispatch.get(token) {
+            if aba_guard != io.aba_guard {
+                return;
+            }
+
             io.readiness.fetch_or(ready.as_usize(), Relaxed);
 
             if ready.is_writable() || platform::is_hup(&ready) {
@@ -545,6 +556,9 @@ impl Inner {
     fn add_source(&self, source: &Evented)
         -> io::Result<usize>
     {
+        // Get an ABA guard value
+        let aba_guard = self.next_aba_guard.fetch_add(1 << TOKEN_SHIFT, Relaxed);
+
         let mut io_dispatch = self.io_dispatch.write().unwrap();
 
         if io_dispatch.len() == MAX_SOURCES {
@@ -554,13 +568,14 @@ impl Inner {
 
         // Acquire a write lock
         let key = io_dispatch.insert(ScheduledIo {
+            aba_guard,
             readiness: AtomicUsize::new(0),
             reader: AtomicTask::new(),
             writer: AtomicTask::new(),
         });
 
         try!(self.io.register(source,
-                              mio::Token(TOKEN_START + key),
+                              mio::Token(aba_guard | key),
                               mio::Ready::all(),
                               mio::PollOpt::edge()));
 

--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -647,9 +647,9 @@ impl<E: Evented + fmt::Debug> fmt::Debug for PollEvented<E> {
 
 impl<E: Evented> Drop for PollEvented<E> {
     fn drop(&mut self) {
-        if let Some(io) = self.io.as_ref() {
+        if let Some(io) = self.io.take() {
             // Ignore errors
-            let _ = self.inner.registration.deregister(io);
+            let _ = self.inner.registration.deregister(&io);
         }
     }
 }

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -411,7 +411,7 @@ impl Registration {
 
                     if actual != state {
                         // Back out of the node boxing
-                        let mut n = unsafe { Box::from_raw(node_ptr) };
+                        let n = unsafe { Box::from_raw(node_ptr) };
 
                         // Save this for next loop
                         node = Some(n);

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -6,7 +6,7 @@ use mio::{self, Evented};
 #[cfg(feature = "unstable-futures")]
 use futures2;
 
-use std::{io, mem, usize};
+use std::{io, ptr, usize};
 use std::cell::UnsafeCell;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
@@ -68,7 +68,7 @@ struct Inner {
 struct Node {
     direction: Direction,
     task: Task,
-    next: Option<Box<Node>>,
+    next: *mut Node,
 }
 
 /// Initial state. The handle is not set and the registration is idle.
@@ -197,40 +197,35 @@ impl Registration {
                     // are pending readiness notifications.
                     let actual = self.state.swap(READY, SeqCst);
 
-                    // Consume the stack of nodes.
-                    let ptr = actual & !LIFECYCLE_MASK;
+                    // Consume the stack of nodes
 
-                    if ptr != 0 {
-                        let mut read = false;
-                        let mut write = false;
-                        let mut curr = unsafe { Box::from_raw(ptr as *mut Node) };
+                    let mut read = false;
+                    let mut write = false;
+                    let mut ptr = (actual & !LIFECYCLE_MASK) as *mut Node;
 
-                        let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
+                    let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
 
-                        loop {
-                            let node = *curr;
-                            let Node {
-                                direction,
-                                task,
-                                next,
-                            } = node;
+                    while !ptr.is_null() {
+                        let node = unsafe { Box::from_raw(ptr) };
+                        let node = *node;
+                        let Node {
+                            direction,
+                            task,
+                            next,
+                        } = node;
 
-                            let flag = match direction {
-                                Direction::Read => &mut read,
-                                Direction::Write => &mut write,
-                            };
+                        let flag = match direction {
+                            Direction::Read => &mut read,
+                            Direction::Write => &mut write,
+                        };
 
-                            if !*flag {
-                                *flag = true;
+                        if !*flag {
+                            *flag = true;
 
-                                inner.register(direction, task);
-                            }
-
-                            match next {
-                                Some(next) => curr = next,
-                                None => break,
-                            }
+                            inner.register(direction, task);
                         }
+
+                        ptr = next;
                     }
 
                     return res.map(|_| true);
@@ -388,41 +383,35 @@ impl Registration {
                     let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
                     return inner.poll_ready(direction, notify, task);
                 }
-                _ => {
+                LOCKED => {
                     if !notify {
                         // Skip the notification tracking junk.
                         return Ok(None);
                     }
 
-                    let ptr = state & !LIFECYCLE_MASK;
+                    let next_ptr = (state & !LIFECYCLE_MASK) as *mut Node;
+
+                    let task = task();
 
                     // Get the node
                     let mut n = node.take().unwrap_or_else(|| {
                         Box::new(Node {
                             direction,
-                            task: task(),
-                            next: None,
+                            task: task,
+                            next: ptr::null_mut(),
                         })
                     });
 
-                    n.next = if ptr == 0 {
-                        None
-                    } else {
-                        // Great care must be taken of the CAS fails
-                        Some(unsafe { Box::from_raw(ptr as *mut Node) })
-                    };
+                    n.next = next_ptr;
 
-                    let ptr = Box::into_raw(n);
-                    let next = ptr as usize | (state & LIFECYCLE_MASK);
+                    let node_ptr = Box::into_raw(n);
+                    let next = node_ptr as usize | (state & LIFECYCLE_MASK);
 
                     let actual = self.state.compare_and_swap(state, next, SeqCst);
 
                     if actual != state {
                         // Back out of the node boxing
-                        let mut n = unsafe { Box::from_raw(ptr) };
-
-                        // We don't really own this
-                        mem::forget(n.next.take());
+                        let mut n = unsafe { Box::from_raw(node_ptr) };
 
                         // Save this for next loop
                         node = Some(n);
@@ -433,6 +422,7 @@ impl Registration {
 
                     return Ok(None);
                 }
+                _ => unreachable!(),
             }
         }
     }
@@ -532,10 +522,11 @@ impl Inner {
             sched.readiness.fetch_and(!mask_no_hup, SeqCst));
 
         if ready.is_empty() && notify {
+            let task = task();
             // Update the task info
             match direction {
-                Direction::Read => sched.reader.register(task()),
-                Direction::Write => sched.writer.register(task()),
+                Direction::Read => sched.reader.register_task(task),
+                Direction::Write => sched.writer.register_task(task),
             }
 
             // Try again

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -936,9 +936,10 @@ impl Future for Shutdown {
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
+        use futures::task;
         trace!("Shutdown::poll");
 
-        self.inner().shutdown_task.task1.register();
+        self.inner().shutdown_task.task1.register_task(task::current());
 
         if 0 != self.inner().num_workers.load(Acquire) {
             return Ok(Async::NotReady);

--- a/tokio-threadpool/src/task.rs
+++ b/tokio-threadpool/src/task.rs
@@ -222,13 +222,13 @@ impl Task {
             let actual = self.inner().state.compare_and_swap(
                 Idle.into(),
                 Scheduled.into(),
-                Relaxed).into();
+                AcqRel).into();
 
             match actual {
                 Idle => return true,
                 Running => {
                     let actual = self.inner().state.compare_and_swap(
-                        Running.into(), Notified.into(), Relaxed).into();
+                        Running.into(), Notified.into(), AcqRel).into();
 
                     match actual {
                         Idle => continue,

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -186,7 +186,7 @@ fn force_shutdown_drops_futures() {
         let a = num_inc.clone();
         let b = num_dec.clone();
 
-        let mut pool = Builder::new()
+        let pool = Builder::new()
             .around_worker(move |w, _| {
                 a.fetch_add(1, Relaxed);
                 w.run();
@@ -547,4 +547,104 @@ fn panic_in_task() {
     spawn_pool(&mut tx, Boom);
 
     await_shutdown(pool.shutdown_on_idle());
+}
+
+#[test]
+#[cfg(not(feature = "unstable-futures"))]
+fn hammer() {
+    use futures::future;
+    use futures::sync::{oneshot, mpsc};
+
+    const N: usize = 1000;
+    const ITER: usize = 20;
+
+    struct Counted<T> {
+        cnt: Arc<AtomicUsize>,
+        inner: T,
+    }
+
+    impl<T: Future> Future for Counted<T> {
+        type Item = T::Item;
+        type Error = T::Error;
+
+        fn poll(&mut self) -> Poll<T::Item, T::Error> {
+            self.inner.poll()
+        }
+    }
+
+    impl<T> Drop for Counted<T> {
+        fn drop(&mut self) {
+            self.cnt.fetch_add(1, Relaxed);
+        }
+    }
+
+    for i in 0.. ITER {
+        println!("~~~ ITER {} ~~~", i);
+
+        let pool = Builder::new()
+            // .pool_size(30)
+            .build();
+
+        let cnt = Arc::new(AtomicUsize::new(0));
+
+        let (listen_tx, listen_rx) = mpsc::unbounded::<oneshot::Sender<oneshot::Sender<()>>>();
+        let mut listen_tx = listen_tx.wait();
+
+        pool.spawn({
+            let c1 = cnt.clone();
+            let c2 = cnt.clone();
+            let pool = pool.sender().clone();
+            let task = listen_rx
+                .map_err(|e| panic!("accept error = {:?}", e))
+                .for_each(move |tx| {
+                    let task = future::lazy(|| {
+                        let (tx2, rx2) = oneshot::channel();
+
+                        tx.send(tx2).unwrap();
+                        rx2
+                    })
+                    .map_err(|e| panic!("e={:?}", e))
+                    .and_then(|_| {
+                        Ok(())
+                    });
+
+                    pool.spawn(Counted {
+                        inner: task,
+                        cnt: c1.clone(),
+                    }).unwrap();
+
+                    Ok(())
+                });
+
+            Counted {
+                inner: task,
+                cnt: c2,
+            }
+        });
+
+        for _ in 0..N {
+            let cnt = cnt.clone();
+            let (tx, rx) = oneshot::channel();
+            listen_tx.send(tx).unwrap();
+
+            pool.spawn({
+                let task = rx
+                    .map_err(|e| panic!("rx err={:?}", e))
+                    .and_then(|tx| {
+                        tx.send(()).unwrap();
+                        Ok(())
+                    });
+
+                Counted {
+                    inner: task,
+                    cnt,
+                }
+            });
+        }
+
+        drop(listen_tx);
+
+        pool.shutdown_on_idle().wait().unwrap();
+        assert_eq!(N * 2 + 1, cnt.load(Relaxed));
+    }
 }


### PR DESCRIPTION
This PR fixes some race conditions.

* The copied implementation of `AtomicTask` is fixed (see #881).
* Spurious notifications caused by reusing a token do not happen anymore.

The spurious notifications issue because on OS X `write` cannot be called until kqueue returns a notification.