### PR TITLE
Update to futures 0.2.0-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,13 @@ matrix:
 
 script:
   - |
+    set -e
     if [[ "$TRAVIS_RUST_VERSION" == nightly ]]
     then
         cargo build --benches --all
     fi
   - |
+    set -e
     if [[ "$TARGET" ]]
     then
         rustup target add $TARGET

--- a/futures2/Cargo.toml
+++ b/futures2/Cargo.toml
@@ -8,4 +8,4 @@ repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 
 [dependencies]
-futures = "0.2.0-alpha"
+futures = "=0.2.0-beta"

--- a/tests/echo2.rs
+++ b/tests/echo2.rs
@@ -42,7 +42,7 @@ fn echo_server() {
     });
 
     let clients = srv.incoming();
-    let client = clients.into_future().map(|e| e.0.unwrap()).map_err(|e| e.0);
+    let client = clients.next().map(|e| e.0.unwrap()).map_err(|e| e.0);
     let halves = client.map(|s| s.split());
     let copied = halves.and_then(|(a, b)| a.copy_into(b));
 

--- a/tests/global2.rs
+++ b/tests/global2.rs
@@ -34,7 +34,7 @@ fn hammer() {
             let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));
             let addr = t!(srv.local_addr());
             let mine = TcpStream::connect(&addr);
-            let theirs = srv.incoming().into_future()
+            let theirs = srv.incoming().next()
                 .map(|(s, _)| s.unwrap())
                 .map_err(|(s, _)| s);
             let (mine, theirs) = t!(block_on(mine.join(theirs)));

--- a/tests/tcp2.rs
+++ b/tests/tcp2.rs
@@ -48,7 +48,7 @@ fn accept() {
     let client = srv.incoming().map(move |t| {
         tx.send(()).unwrap();
         t
-    }).into_future().map_err(|e| e.0);
+    }).next().map_err(|e| e.0);
     assert!(rx.try_recv().is_err());
     let t = thread::spawn(move || {
         net::TcpStream::connect(&addr).unwrap()
@@ -76,7 +76,7 @@ fn accept2() {
     let client = srv.incoming().map(move |t| {
         tx.send(()).unwrap();
         t
-    }).into_future().map_err(|e| e.0);
+    }).next().map_err(|e| e.0);
     assert!(rx.try_recv().is_err());
 
     let (mine, _remaining) = t!(block_on(client));


### PR DESCRIPTION
Fixes test breakage, and also *locks* the version to `beta` so that this kind of breakage won't happen again.