### PR TITLE
fix(cargo): Bump dependencies so that Tokio compiles with minimal versions

### DIFF
--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -17,6 +17,6 @@ Core I/O primitives for asynchronous I/O in Rust.
 categories = ["asynchronous"]
 
 [dependencies]
-bytes = "0.4"
+bytes = "0.4.1"
 futures = "0.1.18"
 log = "0.4"

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.1.19"
 crossbeam-deque = "0.3"
 num_cpus = "1.2"
 rand = "0.4"
-log = "0.3"
+log = "0.4"
 
 # Futures 0.2 integration
 futures2 = { version = "0.1", path = "../futures2", optional = true }


### PR DESCRIPTION
I'm working on minimal version installer for cargo, turns out some dependencies are out of date:

```
cargo build -Z minimal-versions
   Compiling libc v0.1.0
error: expected identifier, found `"std"`
  --> /home/klausi/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.1.0/rust/src/liblibc/lib.rs:76:46
   |
76 | #[cfg(feature = "cargo-build")] extern crate "std" as core;
   |                                              ^^^^^ expected identifier

error: aborting due to previous error

error: Could not compile `libc`.

   Compiling bytes v0.4.0                                                       
error[E0432]: unresolved import `bytes::buf::Chain`
 --> tokio-io/src/length_delimited.rs:4:5
  |
4 | use bytes::buf::Chain;
  |     ^^^^^^^^^^^^^^^^^ no `Chain` in `buf`
```

Updating log to 0.4 as in the other tokio crates here and updating bytes to fix the type errors.