### PR TITLE
Disable future 0.2 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,11 @@ script:
         cargo check --tests --all --target $TARGET
     else
         cargo test --all
-        cargo test --features unstable-futures
-        cargo test --manifest-path tokio-threadpool/Cargo.toml --features unstable-futures
-        cargo test --manifest-path tokio-reactor/Cargo.toml --features unstable-futures
+        # Disable these tests for now as they are buggy
+        #
+        # cargo test --features unstable-futures
+        # cargo test --manifest-path tokio-threadpool/Cargo.toml --features unstable-futures
+        # cargo test --manifest-path tokio-reactor/Cargo.toml --features unstable-futures
     fi
 
 before_deploy:


### PR DESCRIPTION
Disable unstable-futures tests as they tend to hang (most likely due to #254).

Relates to #251 