### PR TITLE
fix unstable-futures feature flag propagation

### DIFF
--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -29,5 +29,8 @@ tokio-io = { version = "0.1.6", path = "../tokio-io" }
 futures2 = { version = "0.1", path = "../futures2", optional = true }
 
 [features]
-unstable-futures = ["futures2"]
+unstable-futures = [
+  "futures2",
+  "tokio-executor/unstable-futures",
+]
 default = []

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -31,5 +31,8 @@ futures2 = { version = "0.1", path = "../futures2", optional = true }
 env_logger = { version = "0.4", default-features = false }
 
 [features]
-unstable-futures = ["futures2"]
+unstable-futures = [
+  "futures2",
+  "tokio-reactor/unstable-futures",
+]
 default = []

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -29,5 +29,8 @@ env_logger = "0.4"
 futures-cpupool = "0.1.7"
 
 [features]
-unstable-futures = ["futures2", "tokio-executor/unstable-futures"]
+unstable-futures = [
+  "futures2",
+  "tokio-executor/unstable-futures",
+]
 default = []

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -31,5 +31,8 @@ futures2 = { version = "0.1", path = "../futures2", optional = true }
 env_logger = { version = "0.4", default-features = false }
 
 [features]
-unstable-futures = ["futures2"]
+unstable-futures = [
+  "futures2",
+  "tokio-reactor/unstable-futures",
+]
 default = []


### PR DESCRIPTION
As mentioned in #251, this fixes the flag propagation for the `unstable-futures` feature.