### PR TITLE
Allow customizing the threadpool's parker

### DIFF
--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 (unreleased)
+
+* Implement `Unpark` for `Box<Unpark>`.
+
 # 0.1.1 (March 22, 2018)
 
 * Optionally support futures 0.2.

--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -127,6 +127,12 @@ pub trait Unpark: Sync + Send + 'static {
     fn unpark(&self);
 }
 
+impl Unpark for Box<Unpark> {
+    fn unpark(&self) {
+        (**self).unpark()
+    }
+}
+
 /// Blocks the current thread using a condition variable.
 ///
 /// Implements the [`Park`] functionality by using a condition variable. An

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 (unreleased)
+
+* Add the ability to specify a custom thread parker.
+
 # 0.1.1 (March 22, 2018)
 
 * Handle futures that panic on the threadpool.

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -15,6 +15,8 @@ extern crate log;
 #[cfg(feature = "unstable-futures")]
 extern crate futures2;
 
+pub mod park;
+
 mod builder;
 mod callback;
 mod config;

--- a/tokio-threadpool/src/park/boxed.rs
+++ b/tokio-threadpool/src/park/boxed.rs
@@ -1,0 +1,39 @@
+use tokio_executor::park::{Park, Unpark};
+
+use std::time::Duration;
+
+pub(crate) type BoxPark = Box<Park<Unpark = BoxUnpark, Error = ()> + Send>;
+pub(crate) type BoxUnpark = Box<Unpark>;
+
+pub(crate) struct Boxed<T>(T);
+
+impl<T> Boxed<T> {
+    pub fn new(inner: T) -> Self {
+        Boxed(inner)
+    }
+}
+
+impl<T: Park + Send> Park for Boxed<T> {
+    type Unpark = BoxUnpark;
+    type Error = ();
+
+    fn unpark(&self) -> Self::Unpark {
+        Box::new(self.0.unpark())
+    }
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.0.park()
+            .map_err(|_| {
+                // TODO: log error
+                ()
+            })
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        self.0.park_timeout(duration)
+            .map_err(|_| {
+                // TODO: log error
+                ()
+            })
+    }
+}

--- a/tokio-threadpool/src/park/default_park.rs
+++ b/tokio-threadpool/src/park/default_park.rs
@@ -1,0 +1,158 @@
+use tokio_executor::park::{Park, Unpark};
+
+use std::sync::{Arc, Mutex, Condvar};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+use std::time::Duration;
+
+/// Parks the thread.
+#[derive(Debug)]
+pub struct DefaultPark {
+    inner: Arc<Inner>,
+}
+
+/// Unparks threads that were parked by `DefaultPark`.
+#[derive(Debug)]
+pub struct DefaultUnpark {
+    inner: Arc<Inner>,
+}
+
+/// Creates `DefaultPark` instances.
+#[derive(Debug)]
+pub struct NewDefaultPark;
+
+/// Error returned by [`ParkThread`]
+///
+/// This currently is never returned, but might at some point in the future.
+///
+/// [`ParkThread`]: struct.ParkThread.html
+#[derive(Debug)]
+pub struct ParkError {
+    _p: (),
+}
+
+#[derive(Debug)]
+struct Inner {
+    state: AtomicUsize,
+    mutex: Mutex<()>,
+    condvar: Condvar,
+}
+
+const IDLE: usize = 0;
+const NOTIFY: usize = 1;
+const SLEEP: usize = 2;
+
+// ===== impl DefaultPark =====
+
+impl DefaultPark {
+    /// Creates a new `DefaultPark` instance.
+    pub fn new() -> DefaultPark {
+        let inner = Arc::new(Inner {
+            state: AtomicUsize::new(IDLE),
+            mutex: Mutex::new(()),
+            condvar: Condvar::new(),
+        });
+
+        DefaultPark { inner }
+    }
+}
+
+impl Park for DefaultPark {
+    type Unpark = DefaultUnpark;
+    type Error = ParkError;
+
+    fn unpark(&self) -> Self::Unpark {
+        let inner = self.inner.clone();
+        DefaultUnpark { inner }
+    }
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.inner.park(None)
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        self.inner.park(Some(duration))
+    }
+}
+
+// ===== impl DefaultUnpark =====
+
+impl Unpark for DefaultUnpark {
+    fn unpark(&self) {
+        self.inner.unpark();
+    }
+}
+
+impl Inner {
+    /// Park the current thread for at most `dur`.
+    fn park(&self, timeout: Option<Duration>) -> Result<(), ParkError> {
+        // If currently notified, then we skip sleeping. This is checked outside
+        // of the lock to avoid acquiring a mutex if not necessary.
+        match self.state.compare_and_swap(NOTIFY, IDLE, SeqCst) {
+            NOTIFY => return Ok(()),
+            IDLE => {},
+            _ => unreachable!(),
+        }
+
+        // If the duration is zero, then there is no need to actually block
+        if let Some(ref dur) = timeout {
+            if *dur == Duration::from_millis(0) {
+                return Ok(());
+            }
+        }
+
+        // The state is currently idle, so obtain the lock and then try to
+        // transition to a sleeping state.
+        let mut m = self.mutex.lock().unwrap();
+
+        // Transition to sleeping
+        match self.state.compare_and_swap(IDLE, SLEEP, SeqCst) {
+            NOTIFY => {
+                // Notified before we could sleep, consume the notification and
+                // exit
+                self.state.store(IDLE, SeqCst);
+                return Ok(());
+            }
+            IDLE => {},
+            _ => unreachable!(),
+        }
+
+        m = match timeout {
+            Some(timeout) => self.condvar.wait_timeout(m, timeout).unwrap().0,
+            None => self.condvar.wait(m).unwrap(),
+        };
+
+        // Transition back to idle. If the state has transitione dto `NOTIFY`,
+        // this will consume that notification
+        self.state.store(IDLE, SeqCst);
+
+        // Explicitly drop the mutex guard. There is no real point in doing it
+        // except that I find it helpful to make it explicit where we want the
+        // mutex to unlock.
+        drop(m);
+
+        Ok(())
+    }
+
+    fn unpark(&self) {
+        // First, try transitioning from IDLE -> NOTIFY, this does not require a
+        // lock.
+        match self.state.compare_and_swap(IDLE, NOTIFY, SeqCst) {
+            IDLE | NOTIFY => return,
+            SLEEP => {}
+            _ => unreachable!(),
+        }
+
+        // The other half is sleeping, this requires a lock
+        let _m = self.mutex.lock().unwrap();
+
+        // Transition from SLEEP -> NOTIFY
+        match self.state.compare_and_swap(SLEEP, NOTIFY, SeqCst) {
+            SLEEP => {}
+            _ => return,
+        }
+
+        // Wakeup the sleeper
+        self.condvar.notify_one();
+    }
+}

--- a/tokio-threadpool/src/park/mod.rs
+++ b/tokio-threadpool/src/park/mod.rs
@@ -1,0 +1,8 @@
+//! Thread parking utilities.
+
+mod boxed;
+mod default_park;
+
+pub use self::default_park::{NewDefaultPark, DefaultPark, DefaultUnpark, ParkError};
+
+pub(crate) use self::boxed::{BoxPark, BoxUnpark, Boxed};

--- a/tokio-threadpool/src/worker.rs
+++ b/tokio-threadpool/src/worker.rs
@@ -13,6 +13,8 @@ use worker_state::{
     WORKER_SIGNALED,
 };
 
+use tokio_executor;
+
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -20,8 +22,6 @@ use std::thread;
 use std::time::Instant;
 use std::sync::atomic::Ordering::{AcqRel, Acquire};
 use std::sync::Arc;
-
-use tokio_executor;
 
 /// Thread worker
 ///
@@ -365,9 +365,7 @@ impl Worker {
 
         // The first part of the sleep process is to transition the worker state
         // to "pushed". Now, it may be that the worker is already pushed on the
-        // sleeper stack, in which case, we don't push again. However, part of
-        // this process is also to do some final state checks to avoid entering
-        // the mutex if at all possible.
+        // sleeper stack, in which case, we don't push again.
 
         loop {
             let mut next = state;
@@ -376,6 +374,9 @@ impl Worker {
                 WORKER_RUNNING => {
                     // Try setting the pushed state
                     next.set_pushed();
+
+                    // Transition the worker state to sleeping
+                    next.set_lifecycle(WORKER_SLEEPING);
                 }
                 WORKER_NOTIFIED | WORKER_SIGNALED => {
                     // No need to sleep, transition back to running and move on.
@@ -417,66 +418,18 @@ impl Worker {
             state = actual;
         }
 
-        // Acquire the sleep mutex, the state is transitioned to sleeping within
-        // the mutex in order to avoid losing wakeup notifications.
-        let mut lock = self.entry().park_mutex.lock().unwrap();
-
-        // Transition the state to sleeping, a CAS is still needed as other
-        // state transitions could happen unrelated to the sleep / wakeup
-        // process. We also have to redo the lifecycle check done above as
-        // the state could have been transitioned before entering the mutex.
-        loop {
-            let mut next = state;
-
-            match state.lifecycle() {
-                WORKER_RUNNING => {}
-                WORKER_NOTIFIED | WORKER_SIGNALED => {
-                    // Release the lock, sleep will not happen this call.
-                    drop(lock);
-
-                    // Transition back to running
-                    loop {
-                        let mut next = state;
-                        next.set_lifecycle(WORKER_RUNNING);
-
-                        let actual = self.entry().state.compare_and_swap(
-                            state.into(), next.into(), AcqRel).into();
-
-                        if actual == state {
-                            return true;
-                        }
-
-                        state = actual;
-                    }
-                }
-                _ => unreachable!(),
-            }
-
-            trace!(" sleeping -- set WORKER_SLEEPING; idx={}", self.idx);
-
-            next.set_lifecycle(WORKER_SLEEPING);
-
-            let actual = self.entry().state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
-
-            if actual == state {
-                break;
-            }
-
-            state = actual;
-        }
-
         trace!("    -> starting to sleep; idx={}", self.idx);
 
         let sleep_until = self.inner.config.keep_alive
             .map(|dur| Instant::now() + dur);
 
-        // The state has been transitioned to sleeping, we can now wait on the
-        // condvar. This is done in a loop as condvars can wakeup spuriously.
+        // The state has been transitioned to sleeping, we can now wait by
+        // calling the parker. This is done in a loop as condvars can wakeup
+        // spuriously.
         loop {
             let mut drop_thread = false;
 
-            lock = match sleep_until {
+            match sleep_until {
                 Some(when) => {
                     let now = Instant::now();
 
@@ -486,14 +439,20 @@ impl Worker {
 
                     let dur = when - now;
 
-                    self.entry().park_condvar
-                        .wait_timeout(lock, dur)
-                        .unwrap().0
+                    unsafe {
+                        (*self.entry().park.get())
+                            .park_timeout(dur)
+                            .unwrap();
+                    }
                 }
                 None => {
-                    self.entry().park_condvar.wait(lock).unwrap()
+                    unsafe {
+                        (*self.entry().park.get())
+                            .park()
+                            .unwrap();
+                    }
                 }
-            };
+            }
 
             trace!("    -> wakeup; idx={}", self.idx);
 
@@ -504,9 +463,6 @@ impl Worker {
                 match state.lifecycle() {
                     WORKER_SLEEPING => {}
                     WORKER_NOTIFIED | WORKER_SIGNALED => {
-                        // Release the lock, done sleeping
-                        drop(lock);
-
                         // Transition back to running
                         loop {
                             let mut next = state;
@@ -526,6 +482,7 @@ impl Worker {
                 }
 
                 if !drop_thread {
+                    // This goees back to the outer loop.
                     break;
                 }
 


### PR DESCRIPTION
This patch allows the user of threadpool to customize how the worker
threads park themselves. This allows custom parking logic to be
injected. For example, this allows embedding a timer on each worker
thread.