### PR TITLE
Rename `Sleep` to `Delay`

### DIFF
--- a/src/timer.rs
+++ b/src/timer.rs
@@ -3,7 +3,7 @@
 //! This module provides a number of types for executing code after a set period
 //! of time.
 //!
-//! * [`Sleep`][Sleep] is a future that does no work and completes at a specific `Instant`
+//! * [`Delay`][Delay] is a future that does no work and completes at a specific `Instant`
 //!   in time.
 //!
 //! * [`Interval`][Interval] is a stream yielding a value at a fixed period. It
@@ -28,14 +28,14 @@
 //!
 //! ```
 //! use tokio::prelude::*;
-//! use tokio::timer::Sleep;
+//! use tokio::timer::Delay;
 //!
 //! use std::time::{Duration, Instant};
 //!
 //! let when = Instant::now() + Duration::from_millis(100);
 //!
 //! tokio::run({
-//!     Sleep::new(when)
+//!     Delay::new(when)
 //!         .map_err(|e| panic!("timer failed; err={:?}", e))
 //!         .and_then(|_| {
 //!             println!("Hello world!");
@@ -81,5 +81,5 @@ pub use tokio_timer::{
     Deadline,
     DeadlineError,
     Interval,
-    Sleep,
+    Delay,
 };

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -17,7 +17,7 @@ fn timer_with_runtime() {
     let (tx, rx) = mpsc::channel();
 
     tokio::run({
-        Sleep::new(when)
+        Delay::new(when)
             .map_err(|e| panic!("unexpected error; err={:?}", e))
             .and_then(move |_| {
                 assert!(Instant::now() >= when);
@@ -35,7 +35,7 @@ fn starving() {
 
     let _ = env_logger::init();
 
-    struct Starve(Sleep, u64);
+    struct Starve(Delay, u64);
 
     impl Future for Starve {
         type Item = u64;
@@ -55,7 +55,7 @@ fn starving() {
     }
 
     let when = Instant::now() + Duration::from_millis(20);
-    let starve = Starve(Sleep::new(when), 0);
+    let starve = Starve(Delay::new(when), 0);
 
     let (tx, rx) = mpsc::channel();
 

--- a/tokio-timer/src/deadline.rs
+++ b/tokio-timer/src/deadline.rs
@@ -1,6 +1,4 @@
-//! Docs
-
-use Sleep;
+use Delay;
 
 use futures::{Future, Poll, Async};
 
@@ -19,7 +17,7 @@ use std::time::Instant;
 #[derive(Debug)]
 pub struct Deadline<T> {
     future: T,
-    sleep: Sleep,
+    delay: Delay,
 }
 
 /// Error returned by `Deadline` future.
@@ -43,13 +41,13 @@ impl<T> Deadline<T> {
     /// Create a new `Deadline` that completes when `future` completes or when
     /// `deadline` is reached.
     pub fn new(future: T, deadline: Instant) -> Deadline<T> {
-        Deadline::new_with_sleep(future, Sleep::new(deadline))
+        Deadline::new_with_delay(future, Delay::new(deadline))
     }
 
-    pub(crate) fn new_with_sleep(future: T, sleep: Sleep) -> Deadline<T> {
+    pub(crate) fn new_with_delay(future: T, delay: Delay) -> Deadline<T> {
         Deadline {
             future,
-            sleep,
+            delay,
         }
     }
 
@@ -84,7 +82,7 @@ where T: Future,
         }
 
         // Now check the timer
-        match self.sleep.poll() {
+        match self.delay.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Ok(Async::Ready(_)) => {
                 Err(DeadlineError::elapsed())

--- a/tokio-timer/src/interval.rs
+++ b/tokio-timer/src/interval.rs
@@ -1,4 +1,4 @@
-use Sleep;
+use Delay;
 
 use futures::{Future, Stream, Poll};
 
@@ -8,7 +8,7 @@ use std::time::{Instant, Duration};
 #[derive(Debug)]
 pub struct Interval {
     /// Future that completes the next time the `Interval` yields a value.
-    sleep: Sleep,
+    delay: Delay,
 
     /// The duration between values yielded by `Interval`.
     duration: Duration,
@@ -26,12 +26,12 @@ impl Interval {
     pub fn new(at: Instant, duration: Duration) -> Interval {
         assert!(duration > Duration::new(0, 0), "`duration` must be non-zero.");
 
-        Interval::new_with_sleep(Sleep::new(at), duration)
+        Interval::new_with_delay(Delay::new(at), duration)
     }
 
-    pub(crate) fn new_with_sleep(sleep: Sleep, duration: Duration) -> Interval {
+    pub(crate) fn new_with_delay(delay: Delay, duration: Duration) -> Interval {
         Interval {
-            sleep,
+            delay,
             duration,
         }
     }
@@ -42,15 +42,15 @@ impl Stream for Interval {
     type Error = ::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        // Wait for the sleep to be done
-        let _ = try_ready!(self.sleep.poll());
+        // Wait for the delay to be done
+        let _ = try_ready!(self.delay.poll());
 
-        // Get the `now` by looking at the `sleep` deadline
-        let now = self.sleep.deadline();
+        // Get the `now` by looking at the `delay` deadline
+        let now = self.delay.deadline();
 
         // The next interval value is `duration` after the one that just
         // yielded.
-        self.sleep.reset(now + self.duration);
+        self.delay.reset(now + self.duration);
 
         // Return the current instant
         Ok(Some(now).into())

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate provides a number of utilities for working with periods of time:
 //!
-//! * [`Sleep`]: A future that completes at a specified instant in time.
+//! * [`Delay`]: A future that completes at a specified instant in time.
 //!
 //! * [`Interval`] A stream that yields at fixed time intervals.
 //!
@@ -10,10 +10,10 @@
 //!   instant in time, erroring if the future takes too long.
 //!
 //! These three types are backed by a [`Timer`] instance. In order for
-//! [`Sleep`], [`Interval`], and [`Deadline`] to function, the associated
+//! [`Delay`], [`Interval`], and [`Deadline`] to function, the associated
 //! [`Timer`] instance must be running on some thread.
 //!
-//! [`Sleep`]: struct.Sleep.html
+//! [`Delay`]: struct.Delay.html
 //! [`Deadline`]: struct.Deadline.html
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html
@@ -30,12 +30,12 @@ pub mod timer;
 
 mod atomic;
 mod deadline;
+mod delay;
 mod error;
 mod interval;
-mod sleep;
 
 pub use self::deadline::{Deadline, DeadlineError};
+pub use self::delay::Delay;
 pub use self::error::Error;
 pub use self::interval::Interval;
 pub use self::timer::{Timer, with_default};
-pub use self::sleep::Sleep;

--- a/tokio-timer/src/timer/entry.rs
+++ b/tokio-timer/src/timer/entry.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::Ordering::SeqCst;
 use std::time::Instant;
 use std::u64;
 
-/// Internal state shared between a `Sleep` instance and the timer.
+/// Internal state shared between a `Delay` instance and the timer.
 ///
 /// This struct is used as a node in two intrusive data structures:
 ///
@@ -27,7 +27,7 @@ use std::u64;
 #[derive(Debug)]
 pub(crate) struct Entry {
     /// Timer internals. Using a weak pointer allows the timer to shutdown
-    /// without all `Sleep` instances having completed.
+    /// without all `Delay` instances having completed.
     inner: Weak<Inner>,
 
     /// Task to notify once the deadline is reached.
@@ -49,7 +49,7 @@ pub(crate) struct Entry {
     /// counter.
     ///
     /// One might think that it would be easier to just not create the `Entry`.
-    /// The problem is that `Sleep` expects creating a `Registration` to always
+    /// The problem is that `Delay` expects creating a `Registration` to always
     /// return a `Registration` instance. This simplifying factor allows it to
     /// improve the struct layout. To do this, we must always allocate the node.
     counted: bool,
@@ -66,8 +66,8 @@ pub(crate) struct Entry {
     /// When the entry expires, relative to the `start` of the timer
     /// (Inner::start). This is only used by the timer.
     ///
-    /// A `Sleep` instance can be reset to a different deadline by the thread
-    /// that owns the `Sleep` instance. In this case, the timer thread will not
+    /// A `Delay` instance can be reset to a different deadline by the thread
+    /// that owns the `Delay` instance. In this case, the timer thread will not
     /// immediately know that this has happened. The timer thread must know the
     /// last deadline that it saw as it uses this value to locate the entry in
     /// its wheel.

--- a/tokio-timer/src/timer/registration.rs
+++ b/tokio-timer/src/timer/registration.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 
 /// Registration with a timer.
 ///
-/// The association between a `Sleep` instance and a timer is done lazily in
+/// The association between a `Delay` instance and a timer is done lazily in
 /// `poll`
 #[derive(Debug)]
 pub(crate) struct Registration {

--- a/tokio-timer/tests/hammer.rs
+++ b/tokio-timer/tests/hammer.rs
@@ -56,7 +56,7 @@ fn hammer_complete() {
                         rng.gen_range(MIN_DELAY, MAX_DELAY));
 
                     exec.push({
-                        handle.sleep(deadline)
+                        handle.delay(deadline)
                             .and_then(move |_| {
                                 let now = Instant::now();
                                 assert!(now >= deadline, "deadline greater by {:?}", deadline - now);
@@ -120,8 +120,8 @@ fn hammer_cancel() {
 
                     let deadline = cmp::min(deadline1, deadline2);
 
-                    let sleep = handle.sleep(deadline1);
-                    let join = handle.deadline(sleep, deadline2);
+                    let delay = handle.delay(deadline1);
+                    let join = handle.deadline(delay, deadline2);
 
                     exec.push({
                         join
@@ -195,9 +195,9 @@ fn hammer_reset() {
                         rng.gen_range(MIN_DELAY, MAX_DELAY));
 
                     exec.push({
-                        handle.sleep(deadline1)
-                            // Select over a second sleep
-                            .select2(handle.sleep(deadline2))
+                        handle.delay(deadline1)
+                            // Select over a second delay
+                            .select2(handle.delay(deadline2))
                             .map_err(|e| panic!("boom; err={:?}", e))
                             .and_then(move |res| {
                                 use futures::future::Either::*;


### PR DESCRIPTION
This patch renames `Sleep` from tokio-timer and the tokio facade to
`Delay`. Given that the future does not actually put anything to sleep,
the `Delay` name feels more appropriate.

Fixes #263