### PR TITLE
Bump version to v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.5 (March 30, 2018)
+
+* Provide timer API (#266)
+
 # 0.1.4 (March 22, 2018)
 
 * Fix build on FreeBSD (#218)

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.2 (unreleased)
+# 0.1.2 (March 30, 2018)
 
 * Implement `Unpark` for `Box<Unpark>`.
 

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-executor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 documentation = "https://docs.rs/tokio-executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -31,7 +31,7 @@
 //! [`Park`]: park/index.html
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.2")]
 
 extern crate futures;
 

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.2 (unreleased)
+# 0.1.2 (March 30, 2018)
 
 * Add the ability to specify a custom thread parker.
 

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-threadpool"
-version = "0.1.1"
+version = "0.1.2"
 documentation = "https://docs.rs/tokio-threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,6 +1,6 @@
 //! A work-stealing based thread pool for executing futures.
 
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.2")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate tokio_executor;

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0 (unreleased)
+# 0.2.0 (March 30, 2018)
 
 * Rewrite from scratch using a hierarchical wheel strategy (#249).
 


### PR DESCRIPTION
This also bumps:

* tokio-executor to v0.1.2
* tokio-threadpool to v0.1.2
* tokio-timer to v0.2.0