### PR TITLE
Fix `tokio-timer` compilation issue.

### DIFF
--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -44,6 +44,7 @@ mod imp {
 #[cfg(not(target_pointer_width = "64"))]
 mod imp {
     use std::sync::Mutex;
+    use std::sync::atomic::Ordering;
 
     #[derive(Debug)]
     pub struct AtomicU64 {


### PR DESCRIPTION
`std::sync::atomic::Ordering` wasn't imported in 32-bits targets.

****

Compilation failed previously with these errors:

```
error[E0412]: cannot find type `Ordering` in this scope
  --> tokio-timer-0.2.0/src/atomic.rs:60:31
   |
60 |         pub fn load(&self, _: Ordering) -> u64 {
   |                               ^^^^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
   |
46 |     use std::cmp::Ordering;
   |
46 |     use std::sync::atomic::Ordering;
   |

error[E0412]: cannot find type `Ordering` in this scope
  --> tokio-timer-0.2.0/src/atomic.rs:64:42
   |
64 |         pub fn store(&self, val: u64, _: Ordering) {
   |                                          ^^^^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
   |
46 |     use std::cmp::Ordering;
   |
46 |     use std::sync::atomic::Ordering;
   |

error[E0412]: cannot find type `Ordering` in this scope
  --> tokio-timer-0.2.0/src/atomic.rs:68:45
   |
68 |         pub fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
   |                                             ^^^^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
   |
46 |     use std::cmp::Ordering;
   |
46 |     use std::sync::atomic::Ordering;
   |

error[E0412]: cannot find type `Ordering` in this scope
  --> tokio-timer-0.2.0/src/atomic.rs:75:63
   |
75 |         pub fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
   |                                                               ^^^^^^^^ not found in this scope
help: possible candidates are found in other modules, you can import them into scope
   |
46 |     use std::cmp::Ordering;
   |
46 |     use std::sync::atomic::Ordering;
```