### PR TITLE
Build both x86 and x64 on Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,14 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+    platform: x64
+  - TARGET: i686-pc-windows-msvc
+    platform: x86
+
 install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host x86_64-pc-windows-msvc
+  - rustup-init.exe -y --default-host %TARGET%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
-  - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%
 
   - rustc -V
   - cargo -V


### PR DESCRIPTION
Add target `i686-pc-windows-msvc` for win builds to configure CI to catch errors for 32-bit builds. See https://github.com/tokio-rs/tokio/pull/274.

https://ci.appveyor.com/project/carllerche/tokio/build/1.0.456/job/shryotsk1bl8955p#L145