### PR TITLE
re-export io::{ReadHalf/WriteHalf} timer::Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,12 @@ pub mod io {
         ReadToEnd,
         read_until,
         ReadUntil,
+        ReadHalf,
         shutdown,
         Shutdown,
         write_all,
         WriteAll,
+        WriteHalf,
     };
 
     // Re-export io::Error so that users don't have to deal

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -80,6 +80,7 @@
 pub use tokio_timer::{
     Deadline,
     DeadlineError,
+    Error,
     Interval,
     Delay,
 };


### PR DESCRIPTION
Re-export ReadHalf/WriteHalf from the io module.
Otherwise, using the return type of AsyncRead::split requires an explicit import of tokio_io.

Re-export Error from the timer module.
DeadlineError already is exported, Error should also be.
