### PR TITLE
threadpool: bump minimal version of executor

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
+tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.3"
 num_cpus = "1.2"


### PR DESCRIPTION
```rust
     Running `/usr/bin/rustc --crate-name tokio_threadpool src/lib.rs --crate-type lib --emit=dep-info,link -C opt-level=3 --cfg 'feature="default"' -C metadata=e95cb707bdea30f8 -C extra-filename=-e95cb707bdea30f8 --out-dir /builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps -L dependency=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps --extern log=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/liblog-fa14a88080f9a687.rlib --extern futures=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/libfutures-610eb0fdded3070f.rlib --extern tokio_executor=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/libtokio_executor-62542ea0b6879923.rlib --extern crossbeam_deque=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/libcrossbeam_deque-8e399a1e8758fd91.rlib --extern rand=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/librand-9c9dadd4ba24c308.rlib --extern num_cpus=/builddir/build/BUILD/tokio-threadpool-0.1.2/target/release/deps/libnum_cpus-b9b8bc33749e0024.rlib -Copt-level=3 -Cdebuginfo=2 -Clink-arg=-Wl,-z,relro,-z,now`
error[E0277]: the trait bound `std::boxed::Box<tokio_executor::park::Unpark + 'static>: tokio_executor::park::Unpark` is not satisfied
  --> src/park/boxed.rs:17:22
   |
17 | impl<T: Park + Send> Park for BoxedPark<T>
   |                      ^^^^ the trait `tokio_executor::park::Unpark` is not implemented for `std::boxed::Box<tokio_executor::park::Unpark + 'static>`
```