### PR TITLE
Create a mock timer API

### DIFF
--- a/tokio-timer/src/timer/mock.rs
+++ b/tokio-timer/src/timer/mock.rs
@@ -1,0 +1,115 @@
+// TODO: Remove this when finished
+#![allow(dead_code, unused_imports, missing_docs)]
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio_executor::park::{Park, Unpark};
+
+#[derive(Debug, Clone)]
+pub struct Clock(Arc<Mutex<Instant>>);
+
+impl Clock {
+    pub fn new() -> Clock {
+        Clock(Arc::new(Mutex::new(Instant::now())))
+    }
+
+    pub fn sleep(&self, duration: Duration) {
+        let mut time = self.0.lock().expect("Clock's mutex was poisoned");
+        *time += duration;
+    }
+
+    pub fn now(&self) -> Instant {
+        self.0.lock().expect("Clock's mutex was poisoned").clone()
+    }
+}
+
+/// A `Park` implementation which will return immediately, while allowing time
+/// on the underlying `Clock` to progress.
+#[derive(Debug, Clone)]
+pub struct NopPark(Clock);
+
+impl NopPark {
+    pub(crate) fn new(clock: Clock) -> NopPark {
+        NopPark(clock.clone())
+    }
+}
+
+/// By default whenever we `park()` the current thread, the clock should advance
+/// by 1000ns (1us).
+const PARK_DELAY: u32 = 1_000;
+
+impl Park for NopPark {
+    type Unpark = NopUnpark;
+    type Error = ();
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.0.sleep(Duration::new(0, PARK_DELAY));
+        Ok(())
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        self.0.sleep(duration);
+        Ok(())
+    }
+
+    fn unpark(&self) -> Self::Unpark {
+        NopUnpark
+    }
+}
+
+/// An `Unpark` which does nothing.
+#[derive(Debug, Clone)]
+pub struct NopUnpark;
+
+impl Unpark for NopUnpark {
+    fn unpark(&self) {
+        // a NopPark will never block, so there's no unparking to be done.
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clock_can_sleep() {
+        let c = Clock::new();
+        let start = c.now();
+
+        let dur = Duration::new(1, 0);
+        let should_be = start + dur;
+
+        c.sleep(dur);
+        let got = c.now();
+        assert_eq!(got, should_be);
+    }
+
+    /// This ensures "time" will always progress while the current thread is
+    /// parked, preventing accidental deadlocks.
+    #[test]
+    fn nop_park_always_progresses_time() {
+        let c = Clock::new();
+        let mut nop = NopPark::new(c.clone());
+
+        let before = c.now();
+        nop.park().unwrap();
+        let after = c.now();
+
+        assert!(after > before);
+    }
+
+    #[test]
+    fn nop_park_timeout_progresses_by_exactly_the_duration() {
+        let c = Clock::new();
+        let start = c.now();
+
+        let dur = Duration::new(1, 0);
+        let should_be = start + dur;
+
+        let mut nop = NopPark::new(c.clone());
+        nop.park_timeout(dur).unwrap();
+
+        let got = c.now();
+        assert_eq!(got, should_be);
+    }
+}

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -32,6 +32,7 @@ mod handle;
 mod level;
 mod now;
 mod registration;
+mod mock;
 
 use self::entry::Entry;
 use self::level::{Level, Expiration};

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -40,6 +40,7 @@ use self::level::{Level, Expiration};
 pub use self::handle::{Handle, with_default};
 pub use self::now::{Now, SystemNow};
 pub(crate) use self::registration::Registration;
+pub use self::mock::{NopPark, NopUnpark, Clock, MockNow};
 
 use Error;
 use atomic::AtomicU64;
@@ -514,6 +515,18 @@ where T: Park,
     }
 }
 
+impl Timer<NopPark, MockNow> {
+    /// Create a mocked timer to simulate the passage of time.
+    pub fn mock() -> (Self, Clock) {
+        let c = Clock::new();
+        let park = NopPark::new(c.clone());
+        let now = MockNow::new(c.clone());
+
+        let timer = Timer::new_with_now(park, now);
+        (timer, c)
+    }
+}
+
 impl<T, N> Drop for Timer<T, N> {
     fn drop(&mut self) {
         // Shutdown the stack of entries to process, preventing any new entries
@@ -616,6 +629,7 @@ fn ms(duration: Duration, round: Round) -> u64 {
 #[cfg(test)]
 mod test {
     use super::*;
+    use futures::Future;
 
     #[test]
     fn test_level_for() {
@@ -642,5 +656,41 @@ mod test {
                 }
             }
         }
+    }
+
+    /// The target API for a mocked timer.
+    /// 
+    /// Shamelessly stolen from https://github.com/tokio-rs/tokio/issues/127
+    #[test]
+    #[ignore] // FIXME: How do I handle "no Task is currently running"?
+    fn mocked_timer_api() {
+        let (timer, clock) = Timer::mock();
+
+        let sleep_duration = Duration::from_secs(30);
+        let deadline = clock.now() + sleep_duration;
+
+        let mut fut = timer.handle().delay(deadline);
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        clock.advance(Duration::from_secs(29));
+        assert!(fut.poll().unwrap().is_not_ready());
+
+        clock.advance(Duration::from_secs(1));
+        assert!(fut.poll().unwrap().is_ready());
+    }
+
+    #[test]
+    #[ignore] // FIXME: why doesn't the future progress?
+    fn delay_future_from_mocked_timer_actually_completes() {
+        let (timer, clock) = Timer::mock();
+
+        let sleep_duration = Duration::from_secs(30);
+        let deadline = clock.now() + sleep_duration;
+
+        let fut = timer.handle().delay(deadline);
+
+        // if this doesn't deadlock because we didn't manually make the clock
+        // progress, the test passes.
+        fut.wait().unwrap();
     }
 }


### PR DESCRIPTION
This is the beginnings of a timer mocking. Hopefully this PR will allow people to test things depending on `tokio-timer` without having to actually wait in real time. 

The target API looks somewhat like the `delay_future_from_mocked_timer_actually_completes` test.

```rust
    #[test]
    fn delay_future_from_mocked_timer_actually_completes() {
        let (timer, clock) = Timer::mock();

        let sleep_duration = Duration::from_secs(30);
        let deadline = clock.now() + sleep_duration;

        let fut = timer.handle().delay(deadline);

        // if this doesn't deadlock because we didn't manually make the clock
        // progress, the test passes.
        fut.wait().unwrap();
    }
```

(fixes #295)