### PR TITLE
Refactor threadpool task types

### DIFF
--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -181,7 +181,7 @@ impl Pool {
     ///
     /// Called from either inside or outside of the scheduler. If currently on
     /// the scheduler, then a fast path is taken.
-    pub fn submit(&self, task: Task, inner: &Arc<Pool>) {
+    pub fn submit(&self, task: Arc<Task>, inner: &Arc<Pool>) {
         Worker::with_current(|worker| {
             match worker {
                 Some(worker) => {
@@ -203,7 +203,7 @@ impl Pool {
     ///
     /// Called from outside of the scheduler, this function is how new tasks
     /// enter the system.
-    fn submit_external(&self, task: Task, inner: &Arc<Pool>) {
+    fn submit_external(&self, task: Arc<Task>, inner: &Arc<Pool>) {
         use worker::Lifecycle::Notified;
 
         // First try to get a handle to a sleeping worker. This ensures that
@@ -227,7 +227,7 @@ impl Pool {
 
     fn submit_to_external(&self,
                           idx: usize,
-                          task: Task,
+                          task: Arc<Task>,
                           state: worker::State,
                           inner: &Arc<Pool>)
     {

--- a/tokio-threadpool/src/sender.rs
+++ b/tokio-threadpool/src/sender.rs
@@ -168,7 +168,7 @@ impl<'a> tokio_executor::Executor for &'a Sender {
         // execution.
 
         // Create a new task for the future
-        let task = Task::new(future);
+        let task = Arc::new(Task::new(future));
 
         self.inner.submit(task, &self.inner);
 

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -1,0 +1,115 @@
+use task::Task;
+
+use std::cell::UnsafeCell;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::Ordering::{Acquire, Release, AcqRel, Relaxed};
+
+#[derive(Debug)]
+pub(crate) struct Queue {
+    /// Queue head.
+    ///
+    /// This is a strong reference to `Task` (i.e, `Arc<Task>`)
+    head: AtomicPtr<Task>,
+
+    /// Tail pointer. This is `Arc<Task>`.
+    tail: UnsafeCell<*mut Task>,
+
+    /// Stub pointer, used as part of the intrusive mpsc channel algorithm
+    /// described by 1024cores.
+    stub: Box<Task>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Poll {
+    Empty,
+    Inconsistent,
+    Data(Arc<Task>),
+}
+
+// ===== impl Queue =====
+
+impl Queue {
+    /// Create a new, empty, `Queue`.
+    pub fn new() -> Queue {
+        let stub = Box::new(Task::stub());
+        let ptr = &*stub as *const _ as *mut _;
+
+        Queue {
+            head: AtomicPtr::new(ptr),
+            tail: UnsafeCell::new(ptr),
+            stub: stub,
+        }
+    }
+
+    /// Push a task onto the queue.
+    ///
+    /// This function is `Sync`.
+    pub fn push(&self, task: Arc<Task>) {
+        unsafe {
+            self.push2(Arc::into_raw(task));
+        }
+    }
+
+    unsafe fn push2(&self, task: *const Task) {
+        let task = task as *mut Task;
+
+        // Set the next pointer. This does not require an atomic operation as
+        // this node is not accessible. The write will be flushed with the next
+        // operation
+        (*task).next.store(ptr::null_mut(), Relaxed);
+
+        // Update the head to point to the new node. We need to see the previous
+        // node in order to update the next pointer as well as release `task`
+        // to any other threads calling `push`.
+        let prev = self.head.swap(task, AcqRel);
+
+        // Release `task` to the consume end.
+        (*prev).next.store(task, Release);
+    }
+
+    /// Poll a task from the queue.
+    ///
+    /// This function is **not** `Sync` and requires coordination by the caller.
+    pub unsafe fn poll(&self) -> Poll {
+        let mut tail = *self.tail.get();
+        let mut next = (*tail).next.load(Acquire);
+
+        let stub = &*self.stub as *const _ as *mut _;
+
+        if tail == stub {
+            if next.is_null() {
+                return Poll::Empty;
+            }
+
+            *self.tail.get() = next;
+            tail = next;
+            next = (*next).next.load(Acquire);
+        }
+
+        if !next.is_null() {
+            *self.tail.get() = next;
+
+            // No ref_count inc is necessary here as this poll is paired
+            // with a `push` which "forgets" the handle.
+            return Poll::Data(Arc::from_raw(tail));
+        }
+
+        if self.head.load(Acquire) != tail {
+            return Poll::Inconsistent;
+        }
+
+        self.push2(stub);
+
+        next = (*tail).next.load(Acquire);
+
+        if !next.is_null() {
+            *self.tail.get() = next;
+
+            return Poll::Data(Arc::from_raw(tail));
+        }
+
+        Poll::Inconsistent
+    }
+}

--- a/tokio-threadpool/src/task/state.rs
+++ b/tokio-threadpool/src/task/state.rs
@@ -1,0 +1,50 @@
+#[repr(usize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum State {
+    /// Task is currently idle
+    Idle = 0,
+
+    /// Task is currently running
+    Running = 1,
+
+    /// Task is currently running, but has been notified that it must run again.
+    Notified = 2,
+
+    /// Task has been scheduled
+    Scheduled = 3,
+
+    /// Task is complete
+    Complete = 4,
+}
+
+impl State {
+    /// Returns the initial task state.
+    ///
+    /// Tasks start in the scheduled state as they are immediately scheduled on
+    /// creation.
+    pub fn new() -> State {
+        State::Scheduled
+    }
+
+    pub fn stub() -> State {
+        State::Idle
+    }
+}
+
+impl From<usize> for State {
+    fn from(src: usize) -> Self {
+        use self::State::*;
+
+        debug_assert!(
+            src >= Idle as usize &&
+            src <= Complete as usize);
+
+        unsafe { ::std::mem::transmute(src) }
+    }
+}
+
+impl From<State> for usize {
+    fn from(src: State) -> Self {
+        src as usize
+    }
+}

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -309,7 +309,7 @@ impl Worker {
         found_work
     }
 
-    fn run_task(&self, task: Task, notify: &Arc<Notifier>, sender: &mut Sender) {
+    fn run_task(&self, task: Arc<Task>, notify: &Arc<Notifier>, sender: &mut Sender) {
         use task::Run::*;
 
         match task.run(notify, sender) {


### PR DESCRIPTION
This switches `Task` from a homegrown `Arc` implementation to using the implementation provided by `std`.

Besides this, the PR also splits up the file into sub files.