### PR TITLE
Include a ~~single-threaded~~ manually built runtime example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -49,6 +49,9 @@ A high level description of each example is:
 
 * [`udp-client`](udp-client.rs) - a simple `send_dgram`/`recv_dgram` example.
 
+* [`single-threaded`](single-threaded.rs) - manually composing a single-threaded
+  runtime.
+
 If you've got an example you'd like to see here, please feel free to open an
 issue. Otherwise if you've got an example you'd like to add, please feel free
 to make a PR!

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,8 +49,7 @@ A high level description of each example is:
 
 * [`udp-client`](udp-client.rs) - a simple `send_dgram`/`recv_dgram` example.
 
-* [`single-threaded`](single-threaded.rs) - manually composing a single-threaded
-  runtime.
+* [`manual-runtime`](manual-runtime.rs) - manually composing a runtime.
 
 If you've got an example you'd like to see here, please feel free to open an
 issue. Otherwise if you've got an example you'd like to add, please feel free

--- a/examples/single-threaded.rs
+++ b/examples/single-threaded.rs
@@ -1,0 +1,85 @@
+//! An example how to manually assemble a single-threaded runtime and run some tasks on it.
+//!
+//! Note that the error handling is a bit left out. Also, the `run_singlethreaded` could be
+//! modified to return the result of the provided future.
+//!
+//! Also, if you just need to run a single-threaded runtime, you can use
+//! `tokio::runtime::current_thread::Runtime::new()`. This is a demonstration of how to assemble
+//! it manually in case some building block needs to be replaced or something tweaked in a way the
+//! provided runtimes don't allow.
+
+extern crate futures;
+extern crate tokio;
+extern crate tokio_executor;
+extern crate tokio_reactor;
+extern crate tokio_timer;
+
+use std::io::Error as IoError;
+use std::time::{Duration, Instant};
+
+use futures::{future, Future};
+use tokio::executor::current_thread::{self, CurrentThread};
+use tokio_reactor::Reactor;
+use tokio_timer::timer::{self, Timer};
+
+/// Creates a single-threaded „runtime“.
+///
+/// This is similar to running a runtime, but uses only the current thread.
+fn run_singlethreaded<F: Future<Item = (), Error = ()>>(f: F) -> Result<(), IoError> {
+    // We need a reactor to receive events about IO objects from kernel
+    let reactor = Reactor::new()?;
+    let reactor_handle = reactor.handle();
+    // Place a timer wheel on top of the reactor. If there are no timeouts to fire, it'll let the
+    // reactor pick up some new external events.
+    let timer = Timer::new(reactor);
+    let timer_handle = timer.handle();
+    // And now put a single-threaded executor on top of the timer. When there are no futures ready
+    // to do something, it'll let the timer or the reactor generate some new stimuli for the
+    // futures to continue in their life.
+    let mut executor = CurrentThread::new_with_park(timer);
+    // Binds an executor to this thread
+    let mut enter = tokio_executor::enter().expect("Multiple executors at once");
+    // This will set the default handle and timer to use inside the closure and run the future.
+    tokio_reactor::with_default(&reactor_handle, &mut enter, |enter| {
+        timer::with_default(&timer_handle, enter, |enter| {
+            // The TaskExecutor is a fake executor that looks into the current single-threaded
+            // executor when used. This is a trick, because we need two mutable references to the
+            // executor (one to run the provided future, another to install as the default one). We
+            // use the fake one here as the default one.
+            let mut default_executor = current_thread::TaskExecutor::current();
+            tokio_executor::with_default(&mut default_executor, enter, |enter| {
+                let mut executor = executor.enter(enter);
+                // Run the provided future
+                executor.block_on(f).unwrap();
+                // Run all the other futures that are still left in the executor
+                executor.run().unwrap();
+            });
+        });
+    });
+    Ok(())
+}
+
+fn main() {
+    run_singlethreaded(future::lazy(|| {
+        // Here comes the application logic. It can spawn further tasks by current_thread::spawn().
+        // It also can use the default reactor and create timeouts.
+
+        // Connect somewhere. And then do nothing with it. Yes, useless.
+        //
+        // This will use the default reactor which runs in the current thread.
+        let connect = tokio::net::TcpStream::connect(&"127.0.0.1:53".parse().unwrap())
+            .map(|_| println!("Connected"))
+            .map_err(|e| println!("Failed to connect: {}", e));
+        // We can spawn it without requiring Send. This would panic if we run it outside of the
+        // `run_singlethreaded` (or outside of anything else)
+        current_thread::spawn(connect);
+
+        // We can also create timeouts.
+        let deadline = tokio::timer::Delay::new(Instant::now() + Duration::from_secs(5))
+            .map(|()| println!("5 seconds are over"))
+            .map_err(|e| println!("Failed to wait: {}", e));
+        // We can spawn on the default executor, which is also the local one.
+        tokio::executor::spawn(deadline);
+        Ok(())
+    })).unwrap();
+}


### PR DESCRIPTION
People ask about this quite often. And I think it is easier than the multi-threaded setup, so it might be a good step to understanding how the things work together.

I plan on writing some documentation describing it for the tokio.rs website.