### PR TITLE
Fix warning: variable does not need to be mutable

### DIFF
--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -254,7 +254,7 @@ fn drop_threadpool_drops_futures() {
         let a = num_inc.clone();
         let b = num_dec.clone();
 
-        let mut pool = Builder::new()
+        let pool = Builder::new()
             .around_worker(move |w, _| {
                 a.fetch_add(1, Relaxed);
                 w.run();


### PR DESCRIPTION
   --> tokio-threadpool/tests/threadpool.rs:257:13
    |
257 |         let mut pool = Builder::new()
    |             ^^^^^^^^
    |
    = note: #[warn(unused_mut)] on by default