### PR TITLE
Make CurrentThread::turn() more fair by always parking with 0 timeout…

### DIFF
--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -481,14 +481,16 @@ impl<'a, P: Park> Entered<'a, P> {
     pub fn turn(&mut self, duration: Option<Duration>)
         -> Result<Turn, TurnError>
     {
-        let res = self.executor.park.park_timeout(Duration::from_millis(0));
+        const ZERO_DURATION: Duration = Duration::from_millis(0);
+
+        let res = self.executor.park.park_timeout(ZERO_DURATION);
         if res.is_err() {
             return Err(TurnError { _p: () });
         }
 
         let mut polled = self.tick();
 
-        if !polled {
+        if !polled && duration.map(|d| d > ZERO_DURATION).unwrap_or(true) {
             let res = match duration {
                 Some(duration) => self.executor.park.park_timeout(duration),
                 None => self.executor.park.park(),

--- a/tests/current_thread.rs
+++ b/tests/current_thread.rs
@@ -2,6 +2,7 @@
 
 extern crate tokio;
 extern crate tokio_executor;
+extern crate tokio_reactor;
 extern crate futures;
 
 use tokio::executor::current_thread::{self, block_on_all, CurrentThread};
@@ -390,6 +391,150 @@ fn hammer_turn() {
             th.join().unwrap();
         }
     }
+}
+
+#[test]
+fn turn_has_polled() {
+    let mut current_thread = CurrentThread::new();
+
+    // Spawn oneshot receiver
+    let (sender, receiver) = oneshot::channel::<()>();
+    current_thread.spawn(receiver.then(|_| Ok(())));
+
+    // Turn once...
+    let res = current_thread.turn(Some(Duration::from_millis(0))).unwrap();
+
+    // Should've polled the receiver once, but considered it not ready
+    assert!(res.has_polled());
+
+    // Turn another time
+    let res = current_thread.turn(Some(Duration::from_millis(0))).unwrap();
+
+    // Should've polled nothing, the receiver is not ready yet
+    assert!(!res.has_polled());
+
+    // Make the receiver ready
+    sender.send(()).unwrap();
+
+    // Turn another time
+    let res = current_thread.turn(Some(Duration::from_millis(0))).unwrap();
+
+    // Should've polled the receiver, it's ready now
+    assert!(res.has_polled());
+
+    // Now the executor should be empty
+    assert!(current_thread.is_idle());
+    let res = current_thread.turn(Some(Duration::from_millis(0))).unwrap();
+
+    // So should've polled nothing
+    assert!(!res.has_polled());
+}
+
+#[test]
+fn turn_fair() {
+    use std::net as std_net;
+    use tokio::net as tokio_net;
+
+    let receiver_socket = tokio_net::UdpSocket::bind(&"0.0.0.0:0".parse().unwrap()).unwrap();
+    let local_addr = receiver_socket.local_addr().unwrap();
+    let sender_socket = std_net::UdpSocket::bind("0.0.0.0:0").unwrap();
+
+    let (sender, receiver) = oneshot::channel::<()>();
+
+    let (sender_2, receiver_2) = oneshot::channel::<()>();
+
+    let reactor = tokio_reactor::Reactor::new().unwrap();
+
+    reactor.set_fallback().unwrap();
+    let handle = reactor.handle();
+    let mut enter = ::tokio_executor::enter().unwrap();
+    let mut current_thread = CurrentThread::new_with_park(reactor);
+
+    let receiver_1_done = Rc::new(Cell::new(false));
+    let receiver_1_done_clone = receiver_1_done.clone();
+
+    // Once an item is received on the oneshot channel, it will immediately
+    // immediately make the second oneshot channel ready
+    current_thread.spawn(receiver
+        .map_err(|_| unreachable!())
+        .and_then(move |_| {
+            sender_2.send(()).unwrap();
+            receiver_1_done_clone.set(true);
+
+            Ok(())
+        })
+    );
+
+    let receiver_2_done = Rc::new(Cell::new(false));
+    let receiver_2_done_clone = receiver_2_done.clone();
+
+    current_thread.spawn(receiver_2
+        .map_err(|_| unreachable!())
+        .and_then(move |_| {
+            receiver_2_done_clone.set(true);
+            Ok(())
+        })
+    );
+
+    let count = Rc::new(Cell::new(0));
+    let count_clone = count.clone();
+    // Just count the number of packets we received
+    current_thread.spawn(receiver_socket.recv_dgram(vec![0; 128])
+        .map_err(|_| unreachable!())
+        .and_then(move |(_socket, _buf, _len, _addr)| {
+            count_clone.set(1 + count_clone.get());
+
+            Ok(())
+        })
+    );
+
+    tokio_reactor::with_default(&handle, &mut enter, move |enter| {
+        // First turn should've polled both and considered them not ready
+        let res = current_thread.enter(enter).turn(Some(Duration::from_millis(0))).unwrap();
+        assert!(res.has_polled());
+
+        // Next turn should've polled nothing
+        let res = current_thread.enter(enter).turn(Some(Duration::from_millis(0))).unwrap();
+        assert!(!res.has_polled());
+
+        assert_eq!(count.get(), 0);
+        assert!(!receiver_1_done.get());
+        assert!(!receiver_2_done.get());
+
+        // After this the receiver future will wake up the second receiver future,
+        // so there are pending futures again
+        sender.send(()).unwrap();
+
+        // Now the first receiver should be done, the second receiver should be ready
+        // to be polled again and the socket not yet
+        let res = current_thread.enter(enter).turn(None).unwrap();
+        assert!(res.has_polled());
+
+        assert_eq!(count.get(), 0);
+        assert!(receiver_1_done.get());
+        assert!(!receiver_2_done.get());
+
+        // After this the receiver socket would be ready to be polled again, but
+        // CurrentThread will only know about that if it parked the thread at least
+        // shortly, i.e. polled the reactor
+        sender_socket.send_to(&vec![1, 2, 3], &local_addr).unwrap();
+
+        // This should resolve the second receiver directly, but also poll the socket
+        // and read the packet from it. If it didn't do both here, we would handle
+        // futures that are woken up from the reactor and directly unfairly and would
+        // favour the ones that are woken up directly.
+        let res = current_thread.enter(enter).turn(None).unwrap();
+        assert!(res.has_polled());
+
+        assert_eq!(count.get(), 1);
+        assert!(receiver_1_done.get());
+        assert!(receiver_2_done.get());
+
+        // Now we should be idle and turning should not poll anything
+        assert!(current_thread.is_idle());
+        let res = current_thread.enter(enter).turn(None).unwrap();
+        assert!(!res.has_polled());
+    });
 }
 
 fn ok() -> future::FutureResult<(), ()> {


### PR DESCRIPTION
… first

This ensures that all fd-based futures are put into the queue for the
current tick, if the CurrentThread is parking via the Reactor.

Otherwise, if there are queued up futures already, only those would be
polled in the turn. These futures could then notify others/themselves to
have the queue still non-empty on the next turn. Which then potentially
allows the reactor to never be polled, and thus fd-based futures are
never queued up and polled.

Also return in the Turn return value whether any futures were polled at
all, which allows the caller to know if any work was done at all in this
turn and based on that adjust behaviour.

https://github.com/tokio-rs/tokio/issues/310