### PR TITLE
Threadpool blocking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,11 @@ script:
 
         # Run address sanitizer
         RUSTFLAGS="-Z sanitizer=address" \
-        cargo test -p tokio-threadpool
+        cargo test -p tokio-threadpool --tests
 
         # Run thread sanitizer
         RUSTFLAGS="-Z sanitizer=thread" \
-        cargo test -p tokio-threadpool
+        cargo test -p tokio-threadpool --tests
     fi
   - |
     set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,15 +35,28 @@ script:
         # Make sure the benchmarks compile
         cargo build --benches --all
 
+        export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
+        export TSAN_OPTIONS="suppressions=`pwd`/ci/tsan"
+
+        # === tokio-timer ====
+
         # Run address sanitizer
-        ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0" \
         RUSTFLAGS="-Z sanitizer=address" \
         cargo test -p tokio-timer --test hammer --target x86_64-unknown-linux-gnu
 
         # Run thread sanitizer
-        TSAN_OPTIONS="suppressions=`pwd`/ci/tsan" \
         RUSTFLAGS="-Z sanitizer=thread" \
         cargo test -p tokio-timer --test hammer --target x86_64-unknown-linux-gnu
+
+        # === tokio-threadpool ====
+
+        # Run address sanitizer
+        RUSTFLAGS="-Z sanitizer=address" \
+        cargo test -p tokio-threadpool
+
+        # Run thread sanitizer
+        RUSTFLAGS="-Z sanitizer=thread" \
+        cargo test -p tokio-threadpool
     fi
   - |
     set -e

--- a/ci/tsan
+++ b/ci/tsan
@@ -13,3 +13,12 @@ race:std*mpsc_queue
 #
 # TODO: It would be nice to not have to filter this out.
 race:try_steal_task
+
+# This filters out an expected data race in the treiber stack implementation.
+# Treiber stacks are inherently racy. The pop operation will attempt to access
+# the "next" pointer on the node it is attempting to pop. However, at this
+# point it has not gained ownership of the node and another thread might beat
+# it and take ownership of the node first (touching the next pointer). The
+# original pop operation will fail due to the ABA guard, but tsan still picks
+# up the access on the next pointer.
+race:Backup::next_sleeper

--- a/ci/tsan
+++ b/ci/tsan
@@ -5,3 +5,4 @@
 race:Arc*drop
 race:arc*Weak*drop
 race:crossbeam_deque
+race:std*mpsc_queue

--- a/ci/tsan
+++ b/ci/tsan
@@ -6,3 +6,10 @@ race:Arc*drop
 race:arc*Weak*drop
 race:crossbeam_deque
 race:std*mpsc_queue
+
+# This is excluded as this race shows up due to using the stealing features of
+# the deque. Unfortunately, the implementation uses a fence, which makes tsan
+# unhappy.
+#
+# TODO: It would be nice to not have to filter this out.
+race:try_steal_task

--- a/ci/tsan
+++ b/ci/tsan
@@ -4,3 +4,4 @@
 # This causes many false positives.
 race:Arc*drop
 race:arc*Weak*drop
+race:crossbeam_deque

--- a/ci/tsan
+++ b/ci/tsan
@@ -4,8 +4,16 @@
 # This causes many false positives.
 race:Arc*drop
 race:arc*Weak*drop
-race:crossbeam_deque
+
+# `std` mpsc is not used in any Tokio code base. This race is triggered by some
+# rust runtime logic.
 race:std*mpsc_queue
+
+# Probably more fences in std.
+race:__call_tls_dtors
+
+# The crossbeam deque uses fences.
+race:crossbeam_deque
 
 # This is excluded as this race shows up due to using the stealing features of
 # the deque. Unfortunately, the implementation uses a fence, which makes tsan

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -26,7 +26,10 @@ futures2 = { version = "0.1", path = "../futures2", optional = true }
 [dev-dependencies]
 tokio-timer = "0.1"
 env_logger = "0.4"
+
+# For comparison benchmarks
 futures-cpupool = "0.1.7"
+threadpool = "1.7.1"
 
 [features]
 unstable-futures = [

--- a/tokio-threadpool/benches/blocking.rs
+++ b/tokio-threadpool/benches/blocking.rs
@@ -1,0 +1,148 @@
+#![feature(test)]
+#![deny(warnings)]
+
+extern crate futures;
+extern crate rand;
+extern crate tokio_threadpool;
+extern crate threadpool;
+extern crate test;
+
+const ITER: usize = 1_000;
+
+mod blocking {
+    use super::*;
+
+    use futures::future::*;
+    use tokio_threadpool::{Builder, blocking};
+
+    #[bench]
+    fn cpu_bound(b: &mut test::Bencher) {
+        let pool = Builder::new()
+            .pool_size(2)
+            .max_blocking(20)
+            .build();
+
+        b.iter(|| {
+            let count_down = Arc::new(CountDown::new(::ITER));
+
+            for _ in 0..::ITER {
+                let count_down = count_down.clone();
+
+                pool.spawn(lazy(move || {
+                    poll_fn(|| {
+                        blocking(|| {
+                            perform_complex_computation()
+                        })
+                        .map_err(|_| panic!())
+                    })
+                    .and_then(move |_| {
+                        // Do something with the value
+                        count_down.dec();
+                        Ok(())
+                    })
+                }));
+            }
+
+            count_down.wait();
+        })
+    }
+}
+
+mod message_passing {
+    use super::*;
+
+    use futures::future::*;
+    use futures::sync::oneshot;
+    use tokio_threadpool::Builder;
+
+    #[bench]
+    fn cpu_bound(b: &mut test::Bencher) {
+        let pool = Builder::new()
+            .pool_size(2)
+            .max_blocking(20)
+            .build();
+
+        let blocking = threadpool::ThreadPool::new(20);
+
+        b.iter(|| {
+            let count_down = Arc::new(CountDown::new(::ITER));
+
+            for _ in 0..::ITER {
+                let count_down = count_down.clone();
+                let blocking = blocking.clone();
+
+                pool.spawn(lazy(move || {
+                    // Create a channel to receive the return value.
+                    let (tx, rx) = oneshot::channel();
+
+                    // Spawn a task on the blocking thread pool to process the
+                    // computation.
+                    blocking.execute(move || {
+                        let res = perform_complex_computation();
+                        tx.send(res).unwrap();
+                    });
+
+                    rx.and_then(move |_| {
+                        count_down.dec();
+                        Ok(())
+                    }).map_err(|_| panic!())
+                }));
+            }
+
+            count_down.wait();
+        })
+    }
+}
+
+fn perform_complex_computation() -> usize {
+    use rand::*;
+
+    // Simulate a CPU heavy computation
+    let mut rng = rand::thread_rng();
+    rng.gen()
+}
+
+// Util for waiting until the tasks complete
+
+use std::sync::*;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::*;
+
+struct CountDown {
+    rem: AtomicUsize,
+    mutex: Mutex<()>,
+    condvar: Condvar,
+}
+
+impl CountDown {
+    fn new(rem: usize) -> Self {
+        CountDown {
+            rem: AtomicUsize::new(rem),
+            mutex: Mutex::new(()),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn dec(&self) {
+        let prev = self.rem.fetch_sub(1, AcqRel);
+
+        if prev != 1 {
+            return;
+        }
+
+        let _lock = self.mutex.lock().unwrap();
+        self.condvar.notify_all();
+    }
+
+    fn wait(&self) {
+        let mut lock = self.mutex.lock().unwrap();
+
+        loop {
+            if self.rem.load(Acquire) == 0 {
+                return;
+            }
+
+            lock = self.condvar.wait(lock).unwrap();
+        }
+    }
+}

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -12,7 +12,7 @@ pub struct BlockingError {
 ///
 /// The `blocking` function annotates a section of code that performs a blocking
 /// operation, either by issuing a blocking syscall or by performing a long
-/// running CPU bound computation.
+/// running CPU-bound computation.
 ///
 /// When the `blocking` function enters, it hands off the responsibility of
 /// processing the current work queue to another thread. Then, it calls the

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -1,0 +1,83 @@
+use worker::Worker;
+
+use futures::Poll;
+
+/// Error raised by `blocking`.
+#[derive(Debug)]
+pub struct BlockingError {
+    _p: (),
+}
+
+/// Enter a blocking section of code.
+///
+/// The `blocking` function annotates a section of code that performs a blocking
+/// operation, either by issuing a blocking syscall or by performing a long
+/// running CPU bound computation.
+///
+/// When the `blocking` function enters, it hands off the responsibility of
+/// processing the current work queue to another thread. Then, it calls the
+/// supplied closure. The closure is permitted to block indefinitely.
+///
+/// If the maximum number of concurrent `blocking` calls has been reached, then
+/// `NotReady` is returned and the task is notified once existing `blocking`
+/// calls complete. The maximum value is specified when creating a thread pool
+/// using [`Builder::max_blocking`][build]
+///
+/// [build]: struct.Builder.html#method.max_blocking
+///
+/// # Background
+///
+/// By default, the Tokio thread pool expects that tasks will only run for short
+/// periods at a time before yielding back to the thread pool. This is the basic
+/// premise of cooperative multitasking.
+///
+/// However, it is common to want to perform a blocking operation while
+/// processing an asynchronous computation. Examples of blocking operation
+/// include:
+///
+/// * Performing synchronous file operations (reading and writing).
+/// * Blocking on acquiring a mutex.
+/// * Performing a CPU bound computation, like cryptographic encryption or
+///   decryption.
+///
+/// One option for dealing with blocking operations in an asynchronous context
+/// is to use a thread pool dedicated to performing these operations. This not
+/// ideal as it requires bidirectional message passing as well as a channel to
+/// communicate which adds a level of buffering.
+///
+/// Instead, `blocking` hands off the responsiblity of processing the work queue
+/// to another thread. This hand off is light compared to a channel and does not
+/// require buffering.
+///
+/// # Panics
+///
+/// This function panics if not called from the context of a thread pool worker.
+pub fn blocking<F, T>(f: F) -> Poll<T, BlockingError>
+where F: FnOnce() -> T,
+{
+    let res = Worker::with_current(|worker| {
+        let worker = worker.expect("not called from a runtime thread");
+
+        // Transition the worker state to blocking. This will exit the fn early
+        // with `NotRead` if the pool does not have enough capacity to enter
+        // blocking mode.
+        worker.transition_to_blocking()
+    });
+
+    // If the transition cannot happen, exit early
+    try_ready!(res);
+
+    // Currently in blocking mode, so call the inner closure
+    let ret = f();
+
+    // Try to transition out of blocking mode. This is a fast path that takes
+    // back ownership of the worker if the worker handoff didn't complete yet.
+    Worker::with_current(|worker| {
+        // Worker must be set since it was above.
+        worker.unwrap()
+            .transition_from_blocking();
+    });
+
+    // Return the result
+    Ok(ret.into())
+}

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -289,7 +289,27 @@ impl Builder {
         self
     }
 
-    /// TODO: Dox
+    /// Execute function `f` after each thread is started but before it starts
+    /// doing work.
+    ///
+    /// This is intended for bookkeeping and monitoring use cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_threadpool;
+    /// # extern crate futures;
+    /// # use tokio_threadpool::Builder;
+    ///
+    /// # pub fn main() {
+    /// // Create a thread pool with default configuration values
+    /// let thread_pool = Builder::new()
+    ///     .after_start(|| {
+    ///         println!("thread started");
+    ///     })
+    ///     .build();
+    /// # }
+    /// ```
     pub fn after_start<F>(&mut self, f: F) -> &mut Self
         where F: Fn() + Send + Sync + 'static
     {
@@ -297,7 +317,26 @@ impl Builder {
         self
     }
 
-    /// TODO: Dox
+    /// Execute function `f` before each thread stops.
+    ///
+    /// This is intended for bookkeeping and monitoring use cases.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_threadpool;
+    /// # extern crate futures;
+    /// # use tokio_threadpool::Builder;
+    ///
+    /// # pub fn main() {
+    /// // Create a thread pool with default configuration values
+    /// let thread_pool = Builder::new()
+    ///     .before_stop(|| {
+    ///         println!("thread stopping");
+    ///     })
+    ///     .build();
+    /// # }
+    /// ```
     pub fn before_stop<F>(&mut self, f: F) -> &mut Self
         where F: Fn() + Send + Sync + 'static
     {

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -147,6 +147,10 @@ impl Builder {
 
     /// Set the maximum number of concurrent blocking sections.
     ///
+    /// When the maximum concurrent `blocking` calls is reached, any further
+    /// calls to `blocking` will return `NotReady` and the task is notified once
+    /// previously in-flight calls to `blocking` return.
+    ///
     /// This must be a number between 1 and 32,768 though it is advised to keep
     /// this value on the smaller side.
     ///

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -1,18 +1,32 @@
 use callback::Callback;
 
+use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 /// Thread pool specific configuration values
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct Config {
     pub keep_alive: Option<Duration>,
     // Used to configure a worker thread
     pub name_prefix: Option<String>,
     pub stack_size: Option<usize>,
     pub around_worker: Option<Callback>,
+    pub after_start: Option<Arc<Fn() + Send + Sync>>,
+    pub before_stop: Option<Arc<Fn() + Send + Sync>>,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can
 /// fit in the scheduler state. Note, that this is the max number of **active**
 /// threads. There can be more standby threads.
 pub(crate) const MAX_WORKERS: usize = 1 << 15;
+
+impl fmt::Debug for Config {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Config")
+            .field("keep_alive", &self.keep_alive)
+            .field("name_prefix", &self.name_prefix)
+            .field("stack_size", &self.stack_size)
+            .finish()
+    }
+}

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -4,8 +4,10 @@
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate tokio_executor;
-extern crate futures;
+
 extern crate crossbeam_deque as deque;
+#[macro_use]
+extern crate futures;
 extern crate num_cpus;
 extern crate rand;
 
@@ -17,6 +19,7 @@ extern crate futures2;
 
 pub mod park;
 
+mod blocking;
 mod builder;
 mod callback;
 mod config;
@@ -31,6 +34,7 @@ mod task;
 mod thread_pool;
 mod worker;
 
+pub use blocking::{blocking, BlockingError};
 pub use builder::Builder;
 pub use sender::Sender;
 pub use shutdown::Shutdown;

--- a/tokio-threadpool/src/notifier.rs
+++ b/tokio-threadpool/src/notifier.rs
@@ -2,6 +2,7 @@ use pool::Pool;
 use task::Task;
 
 use std::mem;
+use std::ops;
 use std::sync::{Arc, Weak};
 
 use futures::executor::Notify;
@@ -15,14 +16,22 @@ pub(crate) struct Notifier {
     pub inner: Weak<Pool>,
 }
 
+/// A guard that ensures that the inner value gets forgotten.
+#[derive(Debug)]
+struct Forget<T>(Option<T>);
+
 impl Notify for Notifier {
     fn notify(&self, id: usize) {
         trace!("Notifier::notify; id=0x{:x}", id);
 
         unsafe {
             let ptr = id as *const Task;
-            let task = Arc::from_raw(ptr);
 
+            // We did not actually take ownership of the `Arc` in this function
+            // so we must ensure that the Arc is forgotten.
+            let task = Forget::new(Arc::from_raw(ptr));
+
+            // TODO: Unify this with Task::notify
             if task.schedule() {
                 // TODO: Check if the pool is still running
                 //
@@ -33,9 +42,6 @@ impl Notify for Notifier {
                     let _ = inner.submit(task, &inner);
                 }
             }
-
-            // We did not actually take ownership of the `Arc` in this function.
-            mem::forget(task);
         }
     }
 
@@ -47,15 +53,12 @@ impl Notify for Notifier {
         // is to call `Arc::from_raw` which returns a strong ref. So, to
         // maintain the invariants, `t1` has to be forgotten. This prevents the
         // ref count from being decremented.
-        let t1 = unsafe { Arc::from_raw(ptr) };
-        let t2 = t1.clone();
-
-        mem::forget(t1);
+        let t1 = Forget::new(unsafe { Arc::from_raw(ptr) });
 
         // t2 is forgotten so that the fn exits without decrementing the ref
         // count. The caller of `clone_id` ensures that `drop_id` is called when
         // the ref count needs to be decremented.
-        mem::forget(t2);
+        let _ = Forget::new(t1.clone());
 
         id
     }
@@ -65,5 +68,27 @@ impl Notify for Notifier {
             let ptr = id as *const Task;
             let _ = Arc::from_raw(ptr);
         }
+    }
+}
+
+// ===== impl Forget =====
+
+impl<T> Forget<T> {
+    fn new(t: T) -> Self {
+        Forget(Some(t))
+    }
+}
+
+impl<T> ops::Deref for Forget<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.0.as_ref().unwrap()
+    }
+}
+
+impl<T> Drop for Forget<T> {
+    fn drop(&mut self) {
+        mem::forget(self.0.take());
     }
 }

--- a/tokio-threadpool/src/notifier.rs
+++ b/tokio-threadpool/src/notifier.rs
@@ -55,7 +55,7 @@ impl Notify for Notifier {
         // ref count from being decremented.
         let t1 = Forget::new(unsafe { Arc::from_raw(ptr) });
 
-        // t2 is forgotten so that the fn exits without decrementing the ref
+        // The clone is forgotten so that the fn exits without decrementing the ref
         // count. The caller of `clone_id` ensures that `drop_id` is called when
         // the ref count needs to be decremented.
         let _ = Forget::new(t1.clone());

--- a/tokio-threadpool/src/pool/backup.rs
+++ b/tokio-threadpool/src/pool/backup.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::Ordering::{self, Acquire, AcqRel, Relaxed};
 /// token (`WorkerId`) is handed off to that running thread. If none are found,
 /// a new thread is spawned.
 ///
-/// This state is manages the exchange. A thread that is idle, not assigned to a
+/// This state manages the exchange. A thread that is idle, not assigned to a
 /// work queue, sits around for a specified amount of time. When the worker
 /// token is handed off, it is first stored in `handoff`. The backup thread is
 /// then signaled. At this point, the backup thread wakes up from sleep and

--- a/tokio-threadpool/src/pool/backup.rs
+++ b/tokio-threadpool/src/pool/backup.rs
@@ -1,0 +1,280 @@
+use park::DefaultPark;
+use worker::{WorkerId};
+
+use std::cell::UnsafeCell;
+use std::fmt;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{self, Acquire, AcqRel, Relaxed};
+
+#[derive(Debug)]
+pub(crate) struct Backup {
+    /// Worker ID that is being handed to this thread.
+    handoff: UnsafeCell<Option<WorkerId>>,
+
+    /// Thread state.
+    ///
+    /// This tracks:
+    ///
+    /// * Is queued flag
+    /// * If the pool is shutting down.
+    /// * If the thread is running
+    state: AtomicUsize,
+
+    /// Next entry in the treiber stack.
+    next_sleeper: UnsafeCell<BackupId>,
+
+    /// Used to put the thread to sleep
+    park: DefaultPark,
+}
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub(crate) struct BackupId(pub(crate) usize);
+
+#[derive(Debug)]
+pub(crate) enum Handoff {
+    Worker(WorkerId),
+    Idle,
+    Terminated,
+}
+
+/// Tracks thread state.
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct State(usize);
+
+/// Set when the worker is pushed onto the scheduler's stack of sleeping
+/// threads.
+///
+/// This flag also serves as a "notification" bit. If another thread is
+/// attempting to hand off a worker to the backup thread, then the pushed bit
+/// will not be set when the thread tries to shutdown.
+pub const PUSHED: usize = 0b001;
+
+/// Set when the thread is running
+pub const RUNNING: usize = 0b010;
+
+/// Set when the thread pool has terminated
+pub const TERMINATED: usize = 0b100;
+
+// ===== impl Backup =====
+
+impl Backup {
+    pub fn new() -> Backup {
+        Backup {
+            handoff: UnsafeCell::new(None),
+            state: AtomicUsize::new(State::new().into()),
+            next_sleeper: UnsafeCell::new(BackupId(0)),
+            park: DefaultPark::new(),
+        }
+    }
+
+    /// Called when the thread is starting
+    pub fn start(&self, worker_id: &WorkerId) {
+        debug_assert!({
+            let state: State = self.state.load(Relaxed).into();
+
+            debug_assert!(!state.is_pushed());
+            debug_assert!(state.is_running());
+            debug_assert!(!state.is_terminated());
+
+            true
+        });
+
+        // The handoff value is equal to `worker_id`
+        debug_assert_eq!(unsafe { (*self.handoff.get()).as_ref()  }, Some(worker_id));
+
+        unsafe { *self.handoff.get() = None; }
+    }
+
+    pub fn is_running(&self) -> bool {
+        let state: State = self.state.load(Relaxed).into();
+        state.is_running()
+    }
+
+    /// Hands off the worker to a thread.
+    ///
+    /// Returns `true` if the thread needs to be spawned.
+    pub fn worker_handoff(&self, worker_id: WorkerId) -> bool {
+        unsafe {
+            // The backup worker should not already have been handoff a worker.
+            debug_assert!((*self.handoff.get()).is_none());
+
+            // Set the handoff
+            *self.handoff.get() = Some(worker_id);
+        }
+
+        // This *probably* can just be `Release`... memory orderings, how do
+        // they work?
+        let prev = State::worker_handoff(&self.state);
+        debug_assert!(prev.is_pushed());
+
+        if prev.is_running() {
+            // Wakeup the backup thread
+            self.park.notify();
+            false
+        } else {
+            true
+        }
+    }
+
+    /// Terminate the worker
+    pub fn signal_stop(&self) {
+        let prev: State = self.state.fetch_xor(TERMINATED | PUSHED, AcqRel).into();
+
+        debug_assert!(!prev.is_terminated());
+        debug_assert!(prev.is_pushed());
+
+        if prev.is_running() {
+            self.park.notify();
+        }
+    }
+
+    /// Release the worker
+    pub fn release(&self) {
+        let prev: State = self.state.fetch_xor(RUNNING, AcqRel).into();
+
+        debug_assert!(prev.is_running());
+    }
+
+    /// Wait for a worker handoff
+    pub fn wait_for_handoff(&self, sleep: bool) -> Handoff {
+        let mut state: State = self.state.load(Acquire).into();
+
+        // Run in a loop since there can be spurious wakeups
+        loop {
+            if !state.is_pushed() {
+                if state.is_terminated() {
+                    return Handoff::Terminated;
+                }
+
+                let worker_id = unsafe {
+                    (*self.handoff.get()).take()
+                        .expect("no worker handoff")
+                };
+
+                return Handoff::Worker(worker_id);
+            }
+
+            if sleep {
+                // TODO: Park with a timeout
+                self.park.park_sync(None);
+
+                // Reload the state
+                state = self.state.load(Acquire).into();
+                debug_assert!(state.is_running());
+            } else {
+                debug_assert!(state.is_running());
+
+                // Transition out of running
+                let mut next = state;
+                next.unset_running();
+
+                let actual = self.state.compare_and_swap(
+                    state.into(),
+                    next.into(),
+                    AcqRel).into();
+
+                if actual == state {
+                    debug_assert!(!next.is_running());
+
+                    return Handoff::Idle;
+                }
+
+                state = actual;
+            }
+        }
+    }
+
+    pub fn set_pushed(&self, ordering: Ordering) {
+        let prev: State = self.state.fetch_or(PUSHED, ordering).into();
+        debug_assert!(!prev.is_pushed());
+    }
+
+    #[inline]
+    pub fn next_sleeper(&self) -> BackupId {
+        unsafe { *self.next_sleeper.get() }
+    }
+
+    #[inline]
+    pub fn set_next_sleeper(&self, val: BackupId) {
+        unsafe { *self.next_sleeper.get() = val; }
+    }
+}
+
+// ===== impl State =====
+
+impl State {
+    /// Returns a new, default, thread `State`
+    pub fn new() -> State {
+        State(0)
+    }
+
+    /// Returns true if the thread entry is pushed in the sleeper stack
+    pub fn is_pushed(&self) -> bool {
+        self.0 & PUSHED == PUSHED
+    }
+
+    pub fn set_pushed(&mut self) {
+        self.0 |= PUSHED;
+    }
+
+    fn unset_pushed(&mut self) {
+        self.0 &= !PUSHED;
+    }
+
+    pub fn is_running(&self) -> bool {
+        self.0 & RUNNING == RUNNING
+    }
+
+    pub fn set_running(&mut self) {
+        self.0 |= RUNNING;
+    }
+
+    pub fn unset_running(&mut self) {
+        self.0 &= !RUNNING;
+    }
+
+    pub fn is_terminated(&self) -> bool {
+        self.0 & TERMINATED == TERMINATED
+    }
+
+    fn worker_handoff(state: &AtomicUsize) -> State {
+        let mut curr: State = state.load(Acquire).into();
+
+        loop {
+            let mut next = curr;
+            next.set_running();
+            next.unset_pushed();
+
+            let actual = state.compare_and_swap(
+                curr.into(), next.into(), AcqRel).into();
+
+            if actual == curr {
+                return curr;
+            }
+
+            curr = actual;
+        }
+    }
+}
+
+impl From<usize> for State {
+    fn from(src: usize) -> State {
+        State(src)
+    }
+}
+
+impl From<State> for usize {
+    fn from(src: State) -> usize {
+        src.0
+    }
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("backup::State")
+            .field("is_pushed", &self.is_pushed())
+            .field("is_running", &self.is_running())
+            .field("is_terminated", &self.is_terminated())
+            .finish()
+    }
+}

--- a/tokio-threadpool/src/pool/backup.rs
+++ b/tokio-threadpool/src/pool/backup.rs
@@ -184,6 +184,11 @@ impl Backup {
         }
     }
 
+    pub fn is_pushed(&self) -> bool {
+        let state: State = self.state.load(Relaxed).into();
+        state.is_pushed()
+    }
+
     pub fn set_pushed(&self, ordering: Ordering) {
         let prev: State = self.state.fetch_or(PUSHED, ordering).into();
         debug_assert!(!prev.is_pushed());

--- a/tokio-threadpool/src/pool/backup_stack.rs
+++ b/tokio-threadpool/src/pool/backup_stack.rs
@@ -124,6 +124,7 @@ impl BackupStack {
             }
 
             debug_assert!(head.0 < MAX_BACKUP);
+            debug_assert!(entries[head.0].is_pushed());
 
             let mut next = state;
 

--- a/tokio-threadpool/src/pool/backup_stack.rs
+++ b/tokio-threadpool/src/pool/backup_stack.rs
@@ -124,7 +124,6 @@ impl BackupStack {
             }
 
             debug_assert!(head.0 < MAX_BACKUP);
-            debug_assert!(entries[head.0].is_pushed());
 
             let mut next = state;
 
@@ -143,6 +142,7 @@ impl BackupStack {
                 state.into(), next.into(), AcqRel).into();
 
             if actual == state {
+                debug_assert!(entries[head.0].is_pushed());
                 return Ok(Some(head));
             }
 

--- a/tokio-threadpool/src/pool/backup_stack.rs
+++ b/tokio-threadpool/src/pool/backup_stack.rs
@@ -1,0 +1,184 @@
+use pool::{Backup, BackupId};
+
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{Acquire, AcqRel};
+
+#[derive(Debug)]
+pub(crate) struct BackupStack {
+    state: AtomicUsize,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+struct State(usize);
+
+pub(crate) const MAX_BACKUP: usize = 1 << 15;
+
+/// Extracts the head of the backup stack from the state
+const STACK_MASK: usize = ((1 << 16) - 1);
+
+/// Used to mark the stack as empty
+pub(crate) const EMPTY: BackupId = BackupId(MAX_BACKUP);
+
+/// Used to mark the stack as terminated
+pub(crate) const TERMINATED: BackupId = BackupId(EMPTY.0 + 1);
+
+/// How many bits the treiber ABA guard is offset by
+const ABA_GUARD_SHIFT: usize = 16;
+
+#[cfg(target_pointer_width = "64")]
+const ABA_GUARD_MASK: usize = (1 << (64 - ABA_GUARD_SHIFT)) - 1;
+
+#[cfg(target_pointer_width = "32")]
+const ABA_GUARD_MASK: usize = (1 << (32 - ABA_GUARD_SHIFT)) - 1;
+
+// ===== impl BackupStack =====
+
+impl BackupStack {
+    pub fn new() -> BackupStack {
+        let state = AtomicUsize::new(State::new().into());
+        BackupStack { state }
+    }
+
+    /// Push a backup thread onto the stack
+    ///
+    /// # Return
+    ///
+    /// Returns `Ok` on success.
+    ///
+    /// Returns `Err` if the pool has transitioned to the `TERMINATED` state.
+    /// Whene terminated, pushing new entries is no longer permitted.
+    pub fn push(&self, entries: &[Backup], id: BackupId) -> Result<(), ()> {
+        let mut state: State = self.state.load(Acquire).into();
+
+        entries[id.0].set_pushed(AcqRel);
+
+        loop {
+            let mut next = state;
+
+            let head = state.head();
+
+            if head == TERMINATED {
+                // The pool is terminated, cannot push the sleeper.
+                return Err(());
+            }
+
+            entries[id.0].set_next_sleeper(head);
+            next.set_head(id);
+
+            let actual = self.state.compare_and_swap(
+                state.into(), next.into(), AcqRel).into();
+
+            if state == actual {
+                return Ok(());
+            }
+
+            state = actual;
+        }
+    }
+
+    /// Pop a backup thread off the stack.
+    ///
+    /// If `terminate` is set and the stack is empty when this function is
+    /// called, the state of the stack is transitioned to "terminated". At this
+    /// point, no further entries can be pushed onto the stack.
+    ///
+    /// # Return
+    ///
+    /// * Returns the index of the popped worker and the worker's observed
+    ///   state.
+    ///
+    /// * `Ok(None)` if the stack is empty.
+    /// * `Err(_)` is returned if the pool has been shutdown.
+    pub fn pop(&self, entries: &[Backup], terminate: bool) -> Result<Option<BackupId>, ()> {
+        // Figure out the empty value
+        let terminal = match terminate {
+            true => TERMINATED,
+            false => EMPTY,
+        };
+
+        let mut state: State = self.state.load(Acquire).into();
+
+        loop {
+            let head = state.head();
+
+            if head == EMPTY {
+                let mut next = state;
+                next.set_head(terminal);
+
+                if next == state {
+                    debug_assert!(terminal == EMPTY);
+                    return Ok(None);
+                }
+
+                let actual = self.state.compare_and_swap(
+                    state.into(), next.into(), AcqRel).into();
+
+                if actual != state {
+                    state = actual;
+                    continue;
+                }
+
+                return Ok(None);
+            } else if head == TERMINATED {
+                return Err(());
+            }
+
+            debug_assert!(head.0 < MAX_BACKUP);
+
+            let mut next = state;
+
+            let next_head = entries[head.0].next_sleeper();
+
+            // TERMINATED can never be set as the "next pointer" on a worker.
+            debug_assert!(next_head != TERMINATED);
+
+            if next_head == EMPTY {
+                next.set_head(terminal);
+            } else {
+                next.set_head(next_head);
+            }
+
+            let actual = self.state.compare_and_swap(
+                state.into(), next.into(), AcqRel).into();
+
+            if actual == state {
+                return Ok(Some(head));
+            }
+
+            state = actual;
+        }
+    }
+}
+
+// ===== impl State =====
+
+impl State {
+    fn new() -> State {
+        State(EMPTY.0)
+    }
+
+    fn head(&self) -> BackupId {
+        BackupId(self.0 & STACK_MASK)
+    }
+
+    fn set_head(&mut self, val: BackupId) {
+        let val = val.0;
+
+        // The ABA guard protects against the ABA problem w/ treiber stacks
+        let aba_guard = ((self.0 >> ABA_GUARD_SHIFT) + 1) & ABA_GUARD_MASK;
+
+        self.0 = (aba_guard << ABA_GUARD_SHIFT) | val;
+    }
+}
+
+impl From<usize> for State {
+    fn from(src: usize) -> Self {
+        State(src)
+    }
+}
+
+impl From<State> for usize {
+    fn from(src: State) -> Self {
+        src.0
+    }
+}

--- a/tokio-threadpool/src/shutdown.rs
+++ b/tokio-threadpool/src/shutdown.rs
@@ -1,8 +1,6 @@
 use pool::Pool;
 use sender::Sender;
 
-use std::sync::atomic::Ordering::{Acquire};
-
 use futures::{Future, Poll, Async};
 #[cfg(feature = "unstable-futures")]
 use futures2;
@@ -35,11 +33,10 @@ impl Future for Shutdown {
 
     fn poll(&mut self) -> Poll<(), ()> {
         use futures::task;
-        trace!("Shutdown::poll");
 
         self.inner().shutdown_task.task1.register_task(task::current());
 
-        if 0 != self.inner().num_workers.load(Acquire) {
+        if !self.inner().is_shutdown() {
             return Ok(Async::NotReady);
         }
 

--- a/tokio-threadpool/src/task/blocking.rs
+++ b/tokio-threadpool/src/task/blocking.rs
@@ -1,0 +1,499 @@
+use pool::Pool;
+use task::{Task, BlockingState};
+
+use futures::{Poll, Async};
+
+use std::cell::UnsafeCell;
+use std::fmt;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::{Acquire, Release, AcqRel, Relaxed};
+use std::thread;
+
+/// Manages the state around entering a blocking section and tasks that are
+/// queued pending the ability to block.
+///
+/// This is a hybrid counter and instrusive mpsc channel (like `Queue`).
+#[derive(Debug)]
+pub(crate) struct Blocking {
+    /// Queue head.
+    ///
+    /// This is either the current remaining capacity for blocking sections
+    /// **or** if the max has been reached, the head of a pending blocking
+    /// capacity channel of tasks.
+    ///
+    /// When this points to a task, it represents a strong reference, i.e.
+    /// `Arc<Task>`.
+    state: AtomicUsize,
+
+    /// Tail pointer. This is `Arc<Task>` unless it points to `stub`.
+    tail: UnsafeCell<*mut Task>,
+
+    /// Stub pointer, used as part of the intrusive mpsc channel algorithm
+    /// described by 1024cores.
+    stub: Box<Task>,
+
+    /// The channel algorithm is MPSC. This means that, in order to pop tasks,
+    /// coordination is required.
+    ///
+    /// Since it doesn't matter *which* task pops & notifies the queued task, we
+    /// can avoid a full mutex and make the "lock" lock free.
+    ///
+    /// Instead, threads race to set the "entered" bit. When the transition is
+    /// successfully made, the thread has permission to pop tasks off of the
+    /// queue. If a thread loses the race, instead of waiting to pop a task, it
+    /// signals to the winning thread that it should pop an additional task.
+    lock: AtomicUsize,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum CanBlock {
+    /// Blocking capacity has been allocated to this task.
+    ///
+    /// The capacity allocation is initially checked before a task is polled. If
+    /// capacity has been allocated, it is consumed and tracked as `Allocated`.
+    Allocated,
+
+    /// Allocation capacity must be either available to the task when it is
+    /// polled or not available. This means that a task can only ask for
+    /// capacity once. This state is used to track a task that has not yet asked
+    /// for blocking capacity. When a task needs blocking capacity, if it is in
+    /// this state, it can immediately try to get an allocation.
+    CanRequest,
+
+    /// The task has requested blocking capacity, but none is available.
+    NoCapacity,
+}
+
+/// Decorates the `usize` value of `Blocking::state`, providing fns to
+/// manipulate the state instead of requiring bit ops.
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct State(usize);
+
+/// Flag differentiating between remaining capacity and task pointers.
+///
+/// If we assume pointers are properly aligned, then the least significant bit
+/// will always be zero. So, we use that bit to track if the value represents a
+/// number.
+const NUM_FLAG: usize = 1;
+
+/// When representing "numbers", the state has to be shifted this much (to get
+/// rid of the flag bit).
+const NUM_SHIFT: usize = 1;
+
+// ====== impl Blocking =====
+//
+impl Blocking {
+    /// Create a new `Blocking`.
+    pub fn new(capacity: usize) -> Blocking {
+        assert!(capacity > 0, "blocking capacity must be greater than zero");
+
+        let stub = Box::new(Task::stub());
+        let ptr = &*stub as *const _ as *mut _;
+
+        // Allocations are aligned
+        debug_assert!(ptr as usize & NUM_FLAG == 0);
+
+        // The initial state value. This starts at the max capacity.
+        let init = State::new(capacity);
+
+        Blocking {
+            state: AtomicUsize::new(init.into()),
+            tail: UnsafeCell::new(ptr),
+            stub: stub,
+            lock: AtomicUsize::new(0),
+        }
+    }
+
+    /// Atomically either acquire blocking capacity or queue the task to be
+    /// notified once capacity becomes available.
+    ///
+    /// The caller must ensure that `task` has not previously been queued to be
+    /// notified when capacity becomes available.
+    pub fn poll_blocking_capacity(&self, task: &Arc<Task>) -> Poll<(), ::BlockingError> {
+        // This requires atomically claiming blocking capacity and if none is
+        // available, queuing &task.
+
+        // The task cannot be queued at this point. The caller must ensure this.
+        debug_assert!(!BlockingState::from(task.blocking.load(Acquire)).is_queued());
+
+        // Don't bump the ref count unless necessary.
+        let mut strong: Option<*const Task> = None;
+
+        // Load the state
+        let mut curr: State = self.state.load(Acquire).into();
+
+        loop {
+            let mut next = curr;
+
+            if !next.claim_capacity(&self.stub) {
+                debug_assert!(curr.ptr().is_some());
+
+                // Unable to claim capacity, so we must queue `task` onto the
+                // channel.
+                //
+                // This guard also serves to ensure that queuing work that is
+                // only needed to run once only gets run once.
+                if strong.is_none() {
+                    // First, transition the task to a "queued" state. This
+                    // prevents double queuing.
+                    //
+                    // This is also the only thread that can set the queued flag
+                    // at this point. And, the goal is for this to only be
+                    // visible when the task node is polled from the channel.
+                    // The memory ordering is established by MPSC queue
+                    // operation.
+                    //
+                    // Note that, if the task doesn't get queued (because the
+                    // CAS fails and capacity is now available) then this flag
+                    // must be unset. Again, there is no race because until the
+                    // task is queued, no other thread can see it.
+                    let prev = BlockingState::toggle_queued(&task.blocking, Relaxed);
+                    debug_assert!(!prev.is_queued());
+
+                    // Bump the ref count
+                    strong = Some(Arc::into_raw(task.clone()));
+
+                    // Set the next pointer. This does not require an atomic
+                    // operation as this node is not currently accessible to
+                    // other threads via the queue.
+                    task.next_blocking.store(ptr::null_mut(), Relaxed);
+                }
+
+                let ptr = strong.unwrap();
+
+                // Update the head to point to the new node. We need to see the
+                // previous node in order to update the next pointer as well as
+                // release `task` to any other threads calling `push`.
+                next.set_ptr(ptr);
+            }
+
+            debug_assert_ne!(curr.0, 0);
+            debug_assert_ne!(next.0, 0);
+
+            let actual = self.state.compare_and_swap(
+                curr.into(),
+                next.into(),
+                AcqRel).into();
+
+            if curr == actual {
+                break;
+            }
+
+            curr = actual;
+        }
+
+        match curr.ptr() {
+            Some(prev) => {
+                let ptr = strong.unwrap();
+
+                // Finish pushing
+                unsafe {
+                    (*prev).next_blocking
+                        .store(ptr as *mut _, Release);
+                }
+
+                // The node was queued to be notified once capacity is made
+                // available.
+                Ok(Async::NotReady)
+            }
+            None => {
+                debug_assert!(curr.remaining_capacity() > 0);
+
+                // If `strong` is set, gotta undo a bunch of work
+                if let Some(ptr) = strong {
+                    let _ = unsafe { Arc::from_raw(ptr) };
+
+                    // Unset the queued flag.
+                    let prev = BlockingState::toggle_queued(&task.blocking, Relaxed);
+                    debug_assert!(prev.is_queued());
+                }
+
+                // Capacity has been obtained
+                Ok(().into())
+            }
+        }
+    }
+
+    unsafe fn push_stub(&self) {
+        let task: *mut Task = &*self.stub as *const _ as *mut _;
+
+        // Set the next pointer. This does not require an atomic operation as
+        // this node is not accessible. The write will be flushed with the next
+        // operation
+        (*task).next_blocking.store(ptr::null_mut(), Relaxed);
+
+        // Update the head to point to the new node. We need to see the previous
+        // node in order to update the next pointer as well as release `task`
+        // to any other threads calling `push`.
+        let prev = self.state.swap(task as usize, AcqRel);
+
+        // The stub is only pushed when there are pending tasks. Because of
+        // this, the state must *always* be in pointer mode.
+        debug_assert!(State::from(prev).is_ptr());
+
+        let prev = prev as *const Task;
+
+        // We don't want the *existing* pointer to be a stub.
+        debug_assert_ne!(prev, task);
+
+        // Release `task` to the consume end.
+        (*prev).next_blocking.store(task, Release);
+    }
+
+    pub fn notify_task(&self, pool: &Arc<Pool>) {
+        let prev = self.lock.fetch_add(1, AcqRel);
+
+
+        if prev != 0 {
+            // Another thread has the lock and will be responsible for notifying
+            // pending tasks.
+            return;
+        }
+
+        let mut dec = 1;
+
+        loop {
+            let mut remaining_pops = dec;
+            while remaining_pops > 0 {
+                remaining_pops -= 1;
+
+                let task = match self.pop(remaining_pops) {
+                    Some(t) => t,
+                    None => break,
+                };
+
+                Task::notify_blocking(task, pool);
+            }
+
+            // Decrement the number of handled notifications
+            let actual = self.lock.fetch_sub(dec, AcqRel);
+
+            if actual == dec {
+                break;
+            }
+
+            // This can only be greater than expected as we are the only thread
+            // that is decrementing.
+            debug_assert!(actual > dec);
+            dec = actual - dec;
+        }
+    }
+
+    /// Pop a task
+    ///
+    /// `rem` represents the remaining number of times the caller will pop. If
+    /// there are no more tasks to pop, `rem` is used to set the remaining
+    /// capacity.
+    fn pop(&self, rem: usize) -> Option<Arc<Task>> {
+        'outer:
+        loop {
+            unsafe {
+                let mut tail = *self.tail.get();
+                let mut next = (*tail).next_blocking.load(Acquire);
+
+                let stub = &*self.stub as *const _ as *mut _;
+
+                if tail == stub {
+                    if next.is_null() {
+                        // This loop is not part of the standard intrusive mpsc
+                        // channel algorithm. This is where we atomically pop
+                        // the last task and add `rem` to the remaining capacity.
+                        //
+                        // This modification to the pop algorithm works because,
+                        // at this point, we have not done any work (only done
+                        // reading). We have a *pretty* good idea that there is
+                        // no concurrent pusher.
+                        //
+                        // The capacity is then atomically added by doing an
+                        // AcqRel CAS on `state`. The `state` cell is the
+                        // linchpin of the algorithm.
+                        //
+                        // By successfully CASing `head` w/ AcqRel, we ensure
+                        // that, if any thread was racing and entered a push, we
+                        // see that and abort pop, retrying as it is
+                        // "inconsistent".
+                        let mut curr: State = self.state.load(Acquire).into();
+
+                        loop {
+                            if curr.has_task(&self.stub) {
+                                // Inconsistent state, yield the thread and try
+                                // again.
+                                thread::yield_now();
+                                continue 'outer;
+                            }
+
+                            let mut after = curr;
+
+                            // +1 here because `rem` represents the number of
+                            // pops that will come after the current one.
+                            after.add_capacity(rem + 1, &self.stub);
+
+                            let actual: State = self.state.compare_and_swap(
+                                curr.into(),
+                                after.into(),
+                                AcqRel).into();
+
+                            if actual == curr {
+                                // Successfully returned the remaining capacity
+                                return None;
+                            }
+
+                            curr = actual;
+                        }
+                    }
+
+                    *self.tail.get() = next;
+                    tail = next;
+                    next = (*next).next_blocking.load(Acquire);
+                }
+
+                if !next.is_null() {
+                    *self.tail.get() = next;
+
+                    // No ref_count inc is necessary here as this poll is paired
+                    // with a `push` which "forgets" the handle.
+                    return Some(Arc::from_raw(tail));
+                }
+
+                let state = self.state.load(Acquire);
+
+                // This must always be a pointer
+                debug_assert!(State::from(state).is_ptr());
+
+                if state != tail as usize {
+                    // Try aain
+                    thread::yield_now();
+                    continue 'outer;
+                }
+
+                self.push_stub();
+
+                next = (*tail).next_blocking.load(Acquire);
+
+                if !next.is_null() {
+                    *self.tail.get() = next;
+
+                    return Some(Arc::from_raw(tail));
+                }
+
+                thread::yield_now();
+                // Try again
+            }
+        }
+    }
+}
+
+// ====== impl State =====
+
+impl State {
+    /// Return a new `State` representing the remaining capacity at the maximum
+    /// value.
+    fn new(capacity: usize) -> State {
+        State((capacity << NUM_SHIFT) | NUM_FLAG)
+    }
+
+    fn remaining_capacity(&self) -> usize {
+        if !self.has_remaining_capacity() {
+            return 0;
+        }
+
+        self.0 >> 1
+    }
+
+    fn has_remaining_capacity(&self) -> bool {
+        self.0 & NUM_FLAG == NUM_FLAG
+    }
+
+    fn has_task(&self, stub: &Task) -> bool {
+        !(self.has_remaining_capacity() || self.is_stub(stub))
+    }
+
+    fn is_stub(&self, stub: &Task) -> bool {
+        self.0 == stub as *const _ as usize
+    }
+
+    /// Try to claim blocking capacity.
+    ///
+    /// # Return
+    ///
+    /// Returns `true` if the capacity was claimed, `false` otherwise. If
+    /// `false` is returned, it can be assumed that `State` represents the head
+    /// pointer in the mpsc channel.
+    fn claim_capacity(&mut self, stub: &Task) -> bool {
+        if !self.has_remaining_capacity() {
+            return false;
+        }
+
+        debug_assert!(self.0 != 1);
+
+        self.0 -= 1 << NUM_SHIFT;
+
+        if self.0 == NUM_FLAG {
+            // Set the state to the stub pointer.
+            self.0 = stub as *const _ as usize;
+        }
+
+        true
+    }
+
+    /// Add blockin capacity.
+    fn add_capacity(&mut self, capacity: usize, stub: &Task) -> bool {
+        debug_assert!(capacity > 0);
+
+        if self.is_stub(stub) {
+            self.0 = (capacity << NUM_SHIFT) | NUM_FLAG;
+            true
+        } else if self.has_remaining_capacity() {
+            self.0 += capacity << NUM_SHIFT;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn is_ptr(&self) -> bool {
+        self.0 & NUM_FLAG == 0
+    }
+
+    fn ptr(&self) -> Option<*const Task> {
+        if self.is_ptr() {
+            Some(self.0 as *const Task)
+        } else {
+            None
+        }
+    }
+
+    fn set_ptr(&mut self, ptr: *const Task) {
+        let ptr = ptr as usize;
+        debug_assert!(ptr & NUM_FLAG == 0);
+        self.0 = ptr
+    }
+}
+
+impl From<usize> for State {
+    fn from(src: usize) -> State {
+        State(src)
+    }
+}
+
+impl From<State> for usize {
+    fn from(src: State) -> usize {
+        src.0
+    }
+}
+
+impl fmt::Debug for State {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        let mut fmt = fmt.debug_struct("State");
+
+        if self.is_ptr() {
+            fmt.field("ptr", &self.0);
+        } else {
+            fmt.field("remaining", &self.remaining_capacity());
+        }
+
+        fmt.finish()
+    }
+}

--- a/tokio-threadpool/src/task/blocking_state.rs
+++ b/tokio-threadpool/src/task/blocking_state.rs
@@ -1,0 +1,89 @@
+use task::CanBlock;
+
+use std::fmt;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// State tracking task level state to support `blocking`.
+///
+/// This tracks two separate flags.
+///
+/// a) If the task is queued in the pending blocking channel. This prevents
+///    double queuing (which would break the linked list).
+///
+/// b) If the task has been allocated capacity to block.
+#[derive(Eq, PartialEq)]
+pub(crate) struct BlockingState(usize);
+
+const QUEUED: usize = 0b01;
+const ALLOCATED: usize = 0b10;
+
+impl BlockingState {
+    /// Create a new, default, `BlockingState`.
+    pub fn new() -> BlockingState {
+        BlockingState(0)
+    }
+
+    /// Returns `true` if the state represents the associated task being queued
+    /// in the pending blocking capacity channel
+    pub fn is_queued(&self) -> bool {
+        self.0 & QUEUED == QUEUED
+    }
+
+    /// Toggle the queued flag
+    ///
+    /// Returns the state before the flag has been toggled.
+    pub fn toggle_queued(state: &AtomicUsize, ordering: Ordering) -> BlockingState {
+        state.fetch_xor(QUEUED, ordering).into()
+    }
+
+    /// Returns `true` if the state represents the associated task having been
+    /// allocated capacity to block.
+    pub fn is_allocated(&self) -> bool {
+        self.0 & ALLOCATED == ALLOCATED
+    }
+
+    /// Atomically consume the capacity allocation and return if the allocation
+    /// was present.
+    ///
+    /// If this returns `true`, then the task has the ability to block for the
+    /// duration of the `poll`.
+    pub fn consume_allocation(state: &AtomicUsize, ordering: Ordering) -> CanBlock {
+        let state: Self = state.fetch_and(!ALLOCATED, ordering).into();
+
+        if state.is_allocated() {
+            CanBlock::Allocated
+        } else if state.is_queued() {
+            CanBlock::NoCapacity
+        } else {
+            CanBlock::CanRequest
+        }
+    }
+
+    pub fn notify_blocking(state: &AtomicUsize, ordering: Ordering) {
+        let prev: Self = state.fetch_xor(ALLOCATED | QUEUED, ordering).into();
+
+        debug_assert!(prev.is_queued());
+        debug_assert!(!prev.is_allocated());
+    }
+}
+
+impl From<usize> for BlockingState {
+    fn from(src: usize) -> BlockingState {
+        BlockingState(src)
+    }
+}
+
+impl From<BlockingState> for usize {
+    fn from(src: BlockingState) -> usize {
+        src.0
+    }
+}
+
+impl fmt::Debug for BlockingState {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("BlockingState")
+            .field("is_queued", &self.is_queued())
+            .field("is_allocated", &self.is_allocated())
+            .finish()
+    }
+}

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -13,7 +13,7 @@ pub(crate) struct Queue {
     /// This is a strong reference to `Task` (i.e, `Arc<Task>`)
     head: AtomicPtr<Task>,
 
-    /// Tail pointer. This is `Arc<Task>`.
+    /// Tail pointer. This is `Arc<Task>` unless it points to `stub`.
     tail: UnsafeCell<*mut Task>,
 
     /// Stub pointer, used as part of the intrusive mpsc channel algorithm

--- a/tokio-threadpool/src/task/state.rs
+++ b/tokio-threadpool/src/task/state.rs
@@ -17,6 +17,8 @@ pub(crate) enum State {
     Complete = 4,
 }
 
+// ===== impl State =====
+
 impl State {
     /// Returns the initial task state.
     ///
@@ -37,7 +39,7 @@ impl From<usize> for State {
 
         debug_assert!(
             src >= Idle as usize &&
-            src <= Complete as usize);
+            src <= Complete as usize, "actual={}", src);
 
         unsafe { ::std::mem::transmute(src) }
     }

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -137,7 +137,7 @@ impl WorkerEntry {
     /// Returns `Ok` when the worker was successfully signaled.
     ///
     /// Returns `Err` if the worker has already terminated.
-    pub fn signal_stop(&self, mut state: State) -> Result<(), ()> {
+    pub fn signal_stop(&self, mut state: State) {
         use worker::Lifecycle::*;
 
         // Transition the worker state to signaled
@@ -146,7 +146,7 @@ impl WorkerEntry {
 
             match state.lifecycle() {
                 Shutdown => {
-                    return Err(());
+                    return;
                 }
                 Running | Sleeping => {}
                 Notified | Signaled => {
@@ -161,7 +161,7 @@ impl WorkerEntry {
                     // b) The shutdown signal is stored as the head of the
                     // sleep, stack which will prevent the worker from going to
                     // sleep again.
-                    return Ok(());
+                    return;
                 }
             }
 
@@ -179,8 +179,6 @@ impl WorkerEntry {
 
         // Wakeup the worker
         self.wakeup();
-
-        Ok(())
     }
 
     /// Pop a task

--- a/tokio-threadpool/src/worker/stack.rs
+++ b/tokio-threadpool/src/worker/stack.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::Ordering::{Acquire, AcqRel, Relaxed};
 ///
 /// Treiber stack: https://en.wikipedia.org/wiki/Treiber_Stack
 #[derive(Debug)]
-pub(crate) struct SleepStack {
+pub(crate) struct Stack {
     state: AtomicUsize,
 }
 
@@ -36,6 +36,8 @@ pub(crate) struct SleepStack {
 pub struct State(usize);
 
 /// Extracts the head of the worker stack from the scheduler state
+///
+/// The 16 relates to the value of MAX_WORKERS
 const STACK_MASK: usize = ((1 << 16) - 1);
 
 /// Used to mark the stack as empty
@@ -53,13 +55,13 @@ const ABA_GUARD_MASK: usize = (1 << (64 - ABA_GUARD_SHIFT)) - 1;
 #[cfg(target_pointer_width = "32")]
 const ABA_GUARD_MASK: usize = (1 << (32 - ABA_GUARD_SHIFT)) - 1;
 
-// ===== impl SleepStack =====
+// ===== impl Stack =====
 
-impl SleepStack {
-    /// Create a new `SleepStack` representing the empty state.
-    pub fn new() -> SleepStack {
+impl Stack {
+    /// Create a new `Stack` representing the empty state.
+    pub fn new() -> Stack {
         let state = AtomicUsize::new(State::new().into());
-        SleepStack { state }
+        Stack { state }
     }
 
     /// Push a worker onto the stack
@@ -98,7 +100,6 @@ impl SleepStack {
             state = actual;
         }
     }
-
 
     /// Pop a worker off the stack.
     ///

--- a/tokio-threadpool/src/worker/state.rs
+++ b/tokio-threadpool/src/worker/state.rs
@@ -18,7 +18,7 @@ pub(crate) enum Lifecycle {
     /// The worker does not currently have an associated thread.
     Shutdown = 0 << LIFECYCLE_SHIFT,
 
-    /// The worker is currently processing its task.
+    /// The worker is doing work
     Running = 1 << LIFECYCLE_SHIFT,
 
     /// The worker is currently asleep in the condvar

--- a/tokio-threadpool/tests/blocking.rs
+++ b/tokio-threadpool/tests/blocking.rs
@@ -1,0 +1,410 @@
+extern crate tokio_threadpool;
+
+extern crate env_logger;
+#[macro_use]
+extern crate futures;
+extern crate rand;
+
+use tokio_threadpool::*;
+
+use futures::*;
+use futures::future::{lazy, poll_fn};
+use rand::*;
+
+use std::sync::*;
+use std::sync::atomic::*;
+use std::sync::atomic::Ordering::*;
+use std::time::Duration;
+use std::thread;
+
+#[test]
+fn basic() {
+    let _ = ::env_logger::init();
+
+    let pool = Builder::new()
+        .pool_size(1)
+        .max_blocking(1)
+        .build();
+
+    let (tx1, rx1) = mpsc::channel();
+    let (tx2, rx2) = mpsc::channel();
+
+    pool.spawn(lazy(move || {
+        let res = blocking(|| {
+            let v = rx1.recv().unwrap();
+            tx2.send(v).unwrap();
+        }).unwrap();
+
+        assert!(res.is_ready());
+        Ok(().into())
+    }));
+
+    pool.spawn(lazy(move || {
+        tx1.send(()).unwrap();
+        Ok(().into())
+    }));
+
+    rx2.recv().unwrap();
+}
+
+#[test]
+fn notify_task_on_capacity() {
+    const BLOCKING: usize = 10;
+
+    let pool = Builder::new()
+        .pool_size(1)
+        .max_blocking(1)
+        .build();
+
+    let rem = Arc::new(AtomicUsize::new(BLOCKING));
+    let (tx, rx) = mpsc::channel();
+
+    for _ in 0..BLOCKING {
+        let rem = rem.clone();
+        let tx = tx.clone();
+
+        pool.spawn(lazy(move || {
+            poll_fn(move || {
+                blocking(|| {
+                    thread::sleep(Duration::from_millis(100));
+                    let prev = rem.fetch_sub(1, Relaxed);
+
+                    if prev == 1 {
+                        tx.send(()).unwrap();
+                    }
+                }).map_err(|e| panic!("blocking err {:?}", e))
+            })
+        }));
+    }
+
+    rx.recv().unwrap();
+
+    assert_eq!(0, rem.load(Relaxed));
+}
+
+#[test]
+fn capacity_is_use_it_or_lose_it() {
+    use futures::*;
+    use futures::Async::*;
+    use futures::sync::oneshot;
+    use futures::task::Task;
+
+    // TODO: Run w/ bigger pool size
+
+    let pool = Builder::new()
+        .pool_size(1)
+        .max_blocking(1)
+        .build();
+
+    let (tx1, rx1) = mpsc::channel();
+    let (tx2, rx2) = oneshot::channel();
+    let (tx3, rx3) = mpsc::channel();
+    let (tx4, rx4) = mpsc::channel();
+
+    // First, fill the blocking capacity
+    pool.spawn(lazy(move || {
+        poll_fn(move || {
+            blocking(|| {
+                rx1.recv().unwrap();
+            }).map_err(|_| panic!())
+        })
+    }));
+
+    pool.spawn(lazy(move || {
+        rx2
+            .map_err(|_| panic!())
+            .and_then(|task: Task| {
+                poll_fn(move || {
+                    blocking(|| {
+                        // Notify the other task
+                        task.notify();
+
+                        // Block until woken
+                        rx3.recv().unwrap();
+                    }).map_err(|_| panic!())
+                })
+            })
+    }));
+
+    // Spawn a future that will try to block, get notified, then not actually
+    // use the blocking
+    let mut i = 0;
+    let mut tx2 = Some(tx2);
+
+    pool.spawn(lazy(move || {
+        poll_fn(move || {
+            match i {
+                0 => {
+                    i = 1;
+
+                    let res = blocking(|| unreachable!())
+                        .map_err(|_| panic!());
+
+                    assert!(res.unwrap().is_not_ready());
+
+                    // Unblock the first blocker
+                    tx1.send(()).unwrap();
+
+                    return Ok(NotReady);
+                }
+                1 => {
+                    i = 2;
+
+                    // Skip blocking, and notify the second task that it should
+                    // start blocking
+                    let me = task::current();
+                    tx2.take().unwrap().send(me).unwrap();
+
+                    return Ok(NotReady);
+                }
+                2 => {
+                    let res = blocking(|| unreachable!())
+                        .map_err(|_| panic!());
+
+                    assert!(res.unwrap().is_not_ready());
+
+                    // Unblock the first blocker
+                    tx3.send(()).unwrap();
+                    tx4.send(()).unwrap();
+                    Ok(().into())
+                }
+                _ => unreachable!(),
+            }
+        })
+    }));
+
+    rx4.recv().unwrap();
+}
+
+#[test]
+fn blocking_thread_does_not_take_over_shutdown_worker_thread() {
+    let pool = Builder::new()
+        .pool_size(2)
+        .max_blocking(1)
+        .build();
+
+    let (enter_tx, enter_rx) = mpsc::channel();
+    let (exit_tx, exit_rx) = mpsc::channel();
+    let (try_tx, try_rx) = mpsc::channel();
+
+    let exited = Arc::new(AtomicBool::new(false));
+
+    {
+        let exited = exited.clone();
+
+        pool.spawn(lazy(move || {
+            poll_fn(move || {
+                blocking(|| {
+                    enter_tx.send(()).unwrap();
+                    exit_rx.recv().unwrap();
+                    exited.store(true, Relaxed);
+                }).map_err(|_| panic!())
+            })
+        }));
+    }
+
+    // Wait for the task to block
+    let _ = enter_rx.recv().unwrap();
+
+    // Spawn another task that attempts to block
+    pool.spawn(lazy(move || {
+        poll_fn(move || {
+            let res = blocking(|| {
+
+            }).unwrap();
+
+            assert_eq!(
+                res.is_ready(),
+                exited.load(Relaxed));
+
+            try_tx.send(res.is_ready()).unwrap();
+
+            Ok(res)
+        })
+    }));
+
+    // Wait for the second task to try to block (and not be ready).
+    let res = try_rx.recv().unwrap();
+    assert!(!res);
+
+    // Unblock the first task
+    exit_tx.send(()).unwrap();
+
+    // Wait for the second task to successfully block.
+    let res = try_rx.recv().unwrap();
+    assert!(res);
+
+    drop(pool);
+}
+
+#[test]
+fn blockin_one_time_gets_capacity_for_multiple_blocks() {
+    const ITER: usize = 1;
+    const BLOCKING: usize = 2;
+
+    for _ in 0..ITER {
+        let pool = Builder::new()
+            .pool_size(4)
+            .max_blocking(1)
+            .build();
+
+        let rem = Arc::new(AtomicUsize::new(BLOCKING));
+        let (tx, rx) = mpsc::channel();
+
+        for _ in 0..BLOCKING {
+            let rem = rem.clone();
+            let tx = tx.clone();
+
+            pool.spawn(lazy(move || {
+                poll_fn(move || {
+                    // First block
+                    let res = blocking(|| {
+                        thread::sleep(Duration::from_millis(100));
+                    }).map_err(|e| panic!("blocking err {:?}", e));
+
+                    try_ready!(res);
+
+                    let res = blocking(|| {
+                        thread::sleep(Duration::from_millis(100));
+                        let prev = rem.fetch_sub(1, Relaxed);
+
+                        if prev == 1 {
+                            tx.send(()).unwrap();
+                        }
+                    });
+
+                    assert!(res.unwrap().is_ready());
+
+                    Ok(().into())
+                })
+            }));
+        }
+
+        rx.recv().unwrap();
+
+        assert_eq!(0, rem.load(Relaxed));
+    }
+}
+
+#[test]
+fn shutdown() {
+    const ITER: usize = 1_000;
+    const BLOCKING: usize = 10;
+
+    for _ in 0..ITER {
+        let num_inc = Arc::new(AtomicUsize::new(0));
+        let num_dec = Arc::new(AtomicUsize::new(0));
+        let (tx, rx) = mpsc::channel();
+
+        let pool = {
+            let num_inc = num_inc.clone();
+            let num_dec = num_dec.clone();
+
+            Builder::new()
+                .pool_size(1)
+                .max_blocking(BLOCKING)
+                .after_start(move || { num_inc.fetch_add(1, Relaxed); })
+                .before_stop(move || { num_dec.fetch_add(1, Relaxed); })
+                .build()
+        };
+
+        let barrier = Arc::new(Barrier::new(BLOCKING));
+
+        for _ in 0..BLOCKING {
+            let barrier = barrier.clone();
+            let tx = tx.clone();
+
+            pool.spawn(lazy(move || {
+                let res = blocking(|| {
+                    barrier.wait();
+                    Ok::<_, ()>(())
+                }).unwrap();
+
+                tx.send(()).unwrap();
+
+                assert!(res.is_ready());
+                Ok(().into())
+            }));
+        }
+
+        for _ in 0..BLOCKING {
+            rx.recv().unwrap();
+        }
+
+        // Shutdown
+        drop(pool);
+
+        assert_eq!(11, num_inc.load(Relaxed));
+        assert_eq!(11, num_dec.load(Relaxed));
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum Sleep {
+    Skip,
+    Yield,
+    Rand,
+    Fixed(Duration),
+}
+
+#[test]
+fn hammer() {
+    use self::Sleep::*;
+
+    const ITER: usize = 5;
+
+    let combos = [
+        (2, 4, 1_000, Skip),
+        (2, 4, 1_000, Yield),
+        (2, 4, 100, Rand),
+        (2, 4, 100, Fixed(Duration::from_millis(3))),
+        (2, 4, 100, Fixed(Duration::from_millis(12))),
+    ];
+
+    for &(size, max_blocking, n, sleep) in &combos {
+        for _ in 0..ITER {
+            let pool = Builder::new()
+                .pool_size(size)
+                .max_blocking(max_blocking)
+                .build();
+
+            let cnt_task = Arc::new(AtomicUsize::new(0));
+            let cnt_block = Arc::new(AtomicUsize::new(0));
+
+            for _ in 0..n {
+                let cnt_task = cnt_task.clone();
+                let cnt_block = cnt_block.clone();
+
+                pool.spawn(lazy(move || {
+                    cnt_task.fetch_add(1, Relaxed);
+
+                    poll_fn(move || {
+                        blocking(|| {
+                            match sleep {
+                                Skip => {}
+                                Yield => {
+                                    thread::yield_now();
+                                }
+                                Rand => {
+                                    let ms = thread_rng().gen_range(3, 12);
+                                    thread::sleep(Duration::from_millis(ms));
+                                }
+                                Fixed(dur) => {
+                                    thread::sleep(dur);
+                                }
+                            }
+
+                            cnt_block.fetch_add(1, Relaxed);
+                        }).map_err(|_| panic!())
+                    })
+                }));
+            }
+
+            // Wait for the work to complete
+            pool.shutdown_on_idle().wait().unwrap();
+
+            assert_eq!(n, cnt_task.load(Relaxed));
+            assert_eq!(n, cnt_block.load(Relaxed));
+        }
+    }
+}

--- a/tokio-threadpool/tests/hammer.rs
+++ b/tokio-threadpool/tests/hammer.rs
@@ -1,0 +1,107 @@
+extern crate futures;
+extern crate tokio_threadpool;
+
+use tokio_threadpool::*;
+
+use futures::{Future, Stream, Sink, Poll};
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::*;
+
+#[test]
+fn hammer() {
+    use futures::future;
+    use futures::sync::{oneshot, mpsc};
+
+    const N: usize = 1000;
+    const ITER: usize = 20;
+
+    struct Counted<T> {
+        cnt: Arc<AtomicUsize>,
+        inner: T,
+    }
+
+    impl<T: Future> Future for Counted<T> {
+        type Item = T::Item;
+        type Error = T::Error;
+
+        fn poll(&mut self) -> Poll<T::Item, T::Error> {
+            self.inner.poll()
+        }
+    }
+
+    impl<T> Drop for Counted<T> {
+        fn drop(&mut self) {
+            self.cnt.fetch_add(1, Relaxed);
+        }
+    }
+
+    for _ in 0.. ITER {
+        let pool = Builder::new()
+            // .pool_size(30)
+            .build();
+
+        let cnt = Arc::new(AtomicUsize::new(0));
+
+        let (listen_tx, listen_rx) = mpsc::unbounded::<oneshot::Sender<oneshot::Sender<()>>>();
+        let mut listen_tx = listen_tx.wait();
+
+        pool.spawn({
+            let c1 = cnt.clone();
+            let c2 = cnt.clone();
+            let pool = pool.sender().clone();
+            let task = listen_rx
+                .map_err(|e| panic!("accept error = {:?}", e))
+                .for_each(move |tx| {
+                    let task = future::lazy(|| {
+                        let (tx2, rx2) = oneshot::channel();
+
+                        tx.send(tx2).unwrap();
+                        rx2
+                    })
+                    .map_err(|e| panic!("e={:?}", e))
+                    .and_then(|_| {
+                        Ok(())
+                    });
+
+                    pool.spawn(Counted {
+                        inner: task,
+                        cnt: c1.clone(),
+                    }).unwrap();
+
+                    Ok(())
+                });
+
+            Counted {
+                inner: task,
+                cnt: c2,
+            }
+        });
+
+        for _ in 0..N {
+            let cnt = cnt.clone();
+            let (tx, rx) = oneshot::channel();
+            listen_tx.send(tx).unwrap();
+
+            pool.spawn({
+                let task = rx
+                    .map_err(|e| panic!("rx err={:?}", e))
+                    .and_then(|tx| {
+                        tx.send(()).unwrap();
+                        Ok(())
+                    });
+
+                Counted {
+                    inner: task,
+                    cnt,
+                }
+            });
+        }
+
+        drop(listen_tx);
+
+        pool.shutdown_on_idle().wait().unwrap();
+        assert_eq!(N * 2 + 1, cnt.load(Relaxed));
+    }
+}


### PR DESCRIPTION
This patch adds a `blocking` to `tokio-threadpool`. This function serves as a
way to annotate sections of code that will perform blocking operations. This
informs the thread pool that an additional thread needs to be spawned to
replace the current thread, which will no longer be able to process the work
queue.

By default, the Tokio thread pool expects that tasks will only run for short
periods at a time before yielding back to the thread pool. This is the basic
premise of cooperative multitasking.

However, it is common to want to perform a blocking operation while
processing an asynchronous computation. Examples of blocking operation
include:

 * Performing synchronous file operations (reading and writing).
 * Blocking on acquiring a mutex.
 * Performing a CPU bound computation, like cryptographic encryption or
   decryption.

One option for dealing with blocking operations in an asynchronous context
is to use a thread pool dedicated to performing these operations. This not
ideal as it requires bidirectional message passing as well as a channel to
communicate which adds a level of buffering.

Instead, `blocking` hands off the responsiblity of processing the work queue
to another thread. This hand off is light compared to a channel and does not
require buffering.