### PR TITLE
 current_thread: make underlying `Park` instance accessible 

### DIFF
--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -383,6 +383,16 @@ impl<P: Park> CurrentThread<P> {
         }
     }
 
+    /// Returns a reference to the underlying `Park` instance.
+    pub fn get_park(&self) -> &P {
+        &self.park
+    }
+
+    /// Returns a mutable reference to the underlying `Park` instance.
+    pub fn get_park_mut(&mut self) -> &mut P {
+        &mut self.park
+    }
+
     fn borrow(&mut self) -> Borrow<P::Unpark> {
         Borrow {
             scheduler: &mut self.scheduler,
@@ -505,6 +515,16 @@ impl<'a, P: Park> Entered<'a, P> {
         let polled = self.tick();
 
         Ok(Turn { polled })
+    }
+
+    /// Returns a reference to the underlying `Park` instance.
+    pub fn get_park(&self) -> &P {
+        &self.executor.park
+    }
+
+    /// Returns a mutable reference to the underlying `Park` instance.
+    pub fn get_park_mut(&mut self) -> &mut P {
+        &mut self.executor.park
     }
 
     fn run_timeout2(&mut self, dur: Option<Duration>)

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -17,6 +17,6 @@ Core I/O primitives for asynchronous I/O in Rust.
 categories = ["asynchronous"]
 
 [dependencies]
-bytes = "0.4.1"
+bytes = "0.4.7"
 futures = "0.1.18"
 log = "0.4"


### PR DESCRIPTION
Similar to `Timer` nested `Park` instances should be made accessible.

Also fix broken `bytes` dependency in `tokio-io` from #324 (my `Cargo.lock` had `bytes-0.4.6` and failed to build).