### PR TITLE
Update minimal version of bytes to 0.4.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ mio = "0.6.14"
 futures2 = { version = "0.1.0", path = "futures2", optional = true }
 
 [dev-dependencies]
-bytes = "0.4"
+bytes = "0.4.7"
 env_logger = { version = "0.4", default-features = false }
 flate2 = { version = "1", features = ["tokio"] }
 futures-cpupool = "0.1"


### PR DESCRIPTION
On 0.4.6 I got the following:

```
error[E0599]: no method named `get_uint_be` found for type `std::io::Cursor<&mut bytes::BytesMut>` in the current scope
   --> tokio-io/src/length_delimited.rs:294:21
    |
294 |                 src.get_uint_be(field_len)
    |                     ^^^^^^^^^^^

error[E0599]: no method named `get_uint_le` found for type `std::io::Cursor<&mut bytes::BytesMut>` in the current scope
   --> tokio-io/src/length_delimited.rs:296:21
    |
296 |                 src.get_uint_le(field_len)
    |                     ^^^^^^^^^^^

error[E0599]: no method named `put_uint_be` found for type `bytes::BytesMut` in the current scope
   --> tokio-io/src/length_delimited.rs:482:18
    |
482 |             head.put_uint_be(n as u64, self.builder.length_field_len);
    |                  ^^^^^^^^^^^

error[E0599]: no method named `put_uint_le` found for type `bytes::BytesMut` in the current scope
   --> tokio-io/src/length_delimited.rs:484:18
    |
484 |             head.put_uint_le(n as u64, self.builder.length_field_len);
    |                  ^^^^^^^^^^^

error: aborting due to 4 previous errors

For more information about this error, try `rustc --explain E0599`.
error: Could not compile `tokio-io`.
warning: build failed, waiting for other jobs to finish...
error: build failed
humbug@home:~/tokio$ ^C
humbug@home:~/tokio$ cargo update
    Updating registry `https://github.com/rust-lang/crates.io-index`
    Updating bitflags v1.0.1 -> v1.0.2
    Updating bytes v0.4.6 -> v0.4.7
    Updating cc v1.0.10 -> v1.0.14
    Updating proc-macro2 v0.3.7 -> v0.3.8
    Updating syn v0.13.1 -> v0.13.4
humbug@home:~/tokio$ cargo build -j8
   Compiling bytes v0.4.7
   Compiling tokio-io v0.1.6 (file:///home/humbug/tokio/tokio-io)
   Compiling tokio-reactor v0.1.1 (file:///home/humbug/tokio/tokio-reactor)
   Compiling tokio-udp v0.1.0 (file:///home/humbug/tokio/tokio-udp)
   Compiling tokio-tcp v0.1.0 (file:///home/humbug/tokio/tokio-tcp)
   Compiling tokio v0.1.5 (file:///home/humbug/tokio)
    Finished dev [unoptimized + debuginfo] target(s) in 7.15 secs
```