### PR TITLE
Remove `futures2` feature from Cargo.toml files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,6 @@ futures = "0.1.20"
 # Needed until `reactor` is removed from `tokio`.
 mio = "0.6.14"
 
-# Futures 0.2 integration
-futures2 = { version = "0.1.0", path = "futures2", optional = true }
-
 [dev-dependencies]
 bytes = "0.4"
 env_logger = { version = "0.4", default-features = false }
@@ -67,17 +64,3 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
-
-[patch.crates-io]
-tokio-io = { path = "tokio-io" }
-
-[features]
-unstable-futures = [
-    "futures2",
-    "tokio-reactor/unstable-futures",
-    "tokio-threadpool/unstable-futures",
-    "tokio-executor/unstable-futures",
-    "tokio-tcp/unstable-futures",
-    "tokio-udp/unstable-futures"
-]
-default = []

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -19,10 +19,3 @@ categories = ["concurrency", "asynchronous"]
 
 [dependencies]
 futures = "0.1.19"
-
-# Futures 0.2 integration
-futures2 = { version = "0.1.0", path = "../futures2", optional = true }
-
-[features]
-unstable-futures = ["futures2"]
-default = []

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -24,13 +24,3 @@ mio = "0.6.14"
 slab = "0.4.0"
 tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
-
-# Futures 0.2 integration
-futures2 = { version = "0.1", path = "../futures2", optional = true }
-
-[features]
-unstable-futures = [
-  "futures2",
-  "tokio-executor/unstable-futures",
-]
-default = []

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -24,15 +24,5 @@ mio = "0.6.14"
 iovec = "0.1"
 futures = "0.1.19"
 
-# Futures 0.2 integration
-futures2 = { version = "0.1", path = "../futures2", optional = true }
-
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
-
-[features]
-unstable-futures = [
-  "futures2",
-  "tokio-reactor/unstable-futures",
-]
-default = []

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,9 +20,6 @@ num_cpus = "1.2"
 rand = "0.4"
 log = "0.4"
 
-# Futures 0.2 integration
-futures2 = { version = "0.1", path = "../futures2", optional = true }
-
 [dev-dependencies]
 tokio-timer = "0.1"
 env_logger = "0.4"
@@ -30,10 +27,3 @@ env_logger = "0.4"
 # For comparison benchmarks
 futures-cpupool = "0.1.7"
 threadpool = "1.7.1"
-
-[features]
-unstable-futures = [
-  "futures2",
-  "tokio-executor/unstable-futures",
-]
-default = []

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -24,15 +24,5 @@ mio = "0.6.14"
 log = "0.4"
 futures = "0.1.19"
 
-# Futures 0.2 integration
-futures2 = { version = "0.1", path = "../futures2", optional = true }
-
 [dev-dependencies]
 env_logger = { version = "0.4", default-features = false }
-
-[features]
-unstable-futures = [
-  "futures2",
-  "tokio-reactor/unstable-futures",
-]
-default = []


### PR DESCRIPTION
Currently, the state of the futures2 integration is pretty broken. This
patch removes the feature flag, preventing users from trying to use it.
In the future, it can be brought back when the implementation is fixed.