### PR TITLE
Bump version to v0.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.6 (May 2, 2018)
+
+* Add asynchronous filesystem APIs (#323).
+* Add "current thread" runtime variant (#308).
+* `CurrentThread`: Expose inner `Park` instance.
+* Improve fairness of `CurrentThread` executor (#313).
+
 # 0.1.5 (March 30, 2018)
 
 * Provide timer API (#266)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -109,23 +109,29 @@ The crates included as part of Tokio are:
 
 * [`tokio-executor`]: Task execution related traits and utilities.
 
+* [`tokio-fs`]: Filesystem (and standard in / out) APIs.
+
 * [`tokio-io`]: Asynchronous I/O related traits and utilities.
 
 * [`tokio-reactor`]: Event loop that drives I/O resources (like TCP and UDP
   sockets).
 
+* [`tokio-tcp`]: TCP bindings for use with `tokio-io` and `tokio-reactor`.
+
 * [`tokio-threadpool`]: Schedules the execution of futures across a pool of
   threads.
 
-* [`tokio-tcp`]: TCP bindings for use with `tokio-io` and `tokio-reactor`.
+* [ `tokio-timer`]: Time related APIs.
 
 * [`tokio-udp`]: UDP bindings for use with `tokio-io` and `tokio-reactor`.
 
 [`tokio-executor`]: tokio-executor
+[`tokio-fs`]: tokio-fs
 [`tokio-io`]: tokio-io
 [`tokio-reactor`]: tokio-reactor
-[`tokio-threadpool`]: tokio-threadpool
 [`tokio-tcp`]: tokio-tcp
+[`tokio-threadpool`]: tokio-threadpool
+[`tokio-timer`]: tokio-timer
 [`tokio-udp`]: tokio-udp
 
 ## License

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 (unreleased)
+# 0.1.0 (May 2, 2018)
 
 * Initial release

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (May 2, 2018)
+
+* Add `blocking` annotation (#317).
+
 # 0.1.2 (March 30, 2018)
 
 * Add the ability to specify a custom thread parker.

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-threadpool"
-version = "0.1.2"
+version = "0.1.3"
 documentation = "https://docs.rs/tokio-threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.2 (May 2, 2018)
+
+* Improve parking semantics (#327).
+
 # 0.2.1 (April 2, 2018)
 
 * Fix build on 32-bit systems (#274).

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-timer"
-version = "0.2.1"
+version = "0.2.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
This bumps the Tokio version to v0.1.6.

This also includes the initial release of `tokio-fs` and bumps the version of the following sub crates:

* `tokio-threadpool`
* `tokio-timer`