### PR TITLE
Handle::default() should lazily bind to reactor.

### DIFF
--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -160,7 +160,12 @@ where E: Evented
     /// Creates a new `PollEvented` associated with the specified reactor.
     pub fn new_with_handle(io: E, handle: &Handle) -> io::Result<Self> {
         let ret = PollEvented::new(io);
-        ret.inner.registration.register_with(ret.io.as_ref().unwrap(), handle)?;
+
+        if let Some(handle) = handle.as_priv() {
+            ret.inner.registration
+                .register_with_priv(ret.io.as_ref().unwrap(), handle)?;
+        }
+
         Ok(ret)
     }
 

--- a/tokio-reactor/src/registration.rs
+++ b/tokio-reactor/src/registration.rs
@@ -1,4 +1,4 @@
-use {Handle, Direction, Task};
+use {Handle, HandlePriv, Direction, Task};
 
 use futures::{Async, Poll, task};
 use mio::{self, Evented};
@@ -59,7 +59,7 @@ pub struct Registration {
 
 #[derive(Debug)]
 struct Inner {
-    handle: Handle,
+    handle: HandlePriv,
     token: usize,
 }
 
@@ -117,7 +117,7 @@ impl Registration {
     pub fn register<T>(&self, io: &T) -> io::Result<bool>
     where T: Evented,
     {
-        self.register2(io, || Handle::try_current())
+        self.register2(io, || HandlePriv::try_current())
     }
 
     /// Deregister the I/O resource from the reactor it is associatd with.
@@ -164,12 +164,23 @@ impl Registration {
     pub fn register_with<T>(&self, io: &T, handle: &Handle) -> io::Result<bool>
     where T: Evented,
     {
+        self.register2(io, || {
+            match handle.as_priv() {
+                Some(handle) => Ok(handle.clone()),
+                None => HandlePriv::try_current(),
+            }
+        })
+    }
+
+    pub(crate) fn register_with_priv<T>(&self, io: &T, handle: &HandlePriv) -> io::Result<bool>
+    where T: Evented,
+    {
         self.register2(io, || Ok(handle.clone()))
     }
 
     fn register2<T, F>(&self, io: &T, f: F) -> io::Result<bool>
     where T: Evented,
-          F: Fn() -> io::Result<Handle>,
+          F: Fn() -> io::Result<HandlePriv>,
     {
         let mut state = self.state.load(SeqCst);
 
@@ -434,7 +445,7 @@ unsafe impl Sync for Registration {}
 // ===== impl Inner =====
 
 impl Inner {
-    fn new<T>(io: &T, handle: Handle) -> (Self, io::Result<()>)
+    fn new<T>(io: &T, handle: HandlePriv) -> (Self, io::Result<()>)
     where T: Evented,
     {
         let mut res = Ok(());


### PR DESCRIPTION
Currently, not specifying a `Handle` is different than using
`Handle::default()`. This is because `Handle::default()` will
immediately bind to the reactor for the current context vs. not
specifying a `Handle`, which binds to a reactor when it is polled.

This patch changes the `Handle::default()` behavior, bringing it inline
with actual defaults.

`Handle::current()` still immediately binds to the current reactor.

Fixes #307