### PR TITLE
Fixed broken link in tokio-fs documentation

### DIFF
--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -1,6 +1,6 @@
 //! Types for working with [`File`].
 //!
-//! [`File`]: struct.File.html
+//! [`File`]: file/struct.File.html
 
 mod create;
 mod open;


### PR DESCRIPTION
I noticed that the link in `modules` section of https://tokio-rs.github.io/tokio/tokio_fs/ is broken.