### PR TITLE
timer: Require that `Now` is cloneable

### DIFF
--- a/tokio-timer/src/timer/now.rs
+++ b/tokio-timer/src/timer/now.rs
@@ -4,13 +4,13 @@ use std::time::Instant;
 ///
 /// This allows customizing the source of time which is especially useful for
 /// testing.
-pub trait Now {
+pub trait Now: Clone {
     /// Returns an instant corresponding to "now".
     fn now(&mut self) -> Instant;
 }
 
 /// Returns the instant corresponding to now using a monotonic clock.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SystemNow(());
 
 impl SystemNow {

--- a/tokio-timer/tests/support/mod.rs
+++ b/tokio-timer/tests/support/mod.rs
@@ -31,7 +31,7 @@ macro_rules! assert_elapsed {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MockTime {
     inner: Inner,
     _p: PhantomData<Rc<()>>,

--- a/tokio-timer/tests/support/mod.rs
+++ b/tokio-timer/tests/support/mod.rs
@@ -37,7 +37,7 @@ pub struct MockTime {
     _p: PhantomData<Rc<()>>,
 }
 
-#[derive(Clone Debug)]
+#[derive(Clone, Debug)]
 pub struct MockNow {
     inner: Inner,
     _p: PhantomData<Rc<()>>,

--- a/tokio-timer/tests/support/mod.rs
+++ b/tokio-timer/tests/support/mod.rs
@@ -37,7 +37,7 @@ pub struct MockTime {
     _p: PhantomData<Rc<()>>,
 }
 
-#[derive(Debug)]
+#[derive(Clone Debug)]
 pub struct MockNow {
     inner: Inner,
     _p: PhantomData<Rc<()>>,


### PR DESCRIPTION
When dealing with a time source, especially a mocked time source, one
frequently wants to pass this time source to multiple components.

In order to facilitate this, I propose that `Now` require that
implementations implement `Clone` as well.

If we are reticent to add this requirement on `Now`, I suggest that we
at least add this to `SystemNow`; though I'd prefer to not have to take
on the boilerplate of `Now + Clone`.