### PR TITLE
Fix Runtime::new's doc link to tokio::run

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -234,7 +234,7 @@ impl Runtime {
     /// tasks are scheduled to run.
     ///
     /// Most users will not need to call this function directly, instead they
-    /// will use [`tokio::run`][fn.run.html].
+    /// will use [`tokio::run`](fn.run.html).
     ///
     /// See [module level][mod] documentation for more details.
     ///


### PR DESCRIPTION
Fix `Runtime::new`s doc link to `tokio::run`.
It was broken because it was using square brackets instead of parenthesis.