### PR TITLE
Fix a small typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The crates included as part of Tokio are:
 [`tokio-threadpool`]: tokio-threadpool
 [`tokio-timer`]: tokio-timer
 [`tokio-udp`]: tokio-udp
-[`tokio-udp`]: tokio-uds
+[`tokio-uds`]: tokio-uds
 
 ## License
 


### PR DESCRIPTION
Fixed `tokio-uds` crate link.