### PR TITLE
Fix description of BlockingError as io::Error

### DIFF
--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -59,6 +59,6 @@ where F: FnOnce() -> io::Result<T>,
 }
 
 fn blocking_err() -> io::Error {
-    io::Error::new(Other, "tokio-fs::File::open must be called \
+    io::Error::new(Other, "`blocking` annotated I/O must be called \
                    from the context of the Tokio runtime.")
 }


### PR DESCRIPTION
The `blocking_err` fn is used by tokio-fs `blocking_io` and `would_block` for many more I/O operations than just `tokio-fs::File::open`, so make the error more generic.

This is intentionally a minimal, one line fix. Alternatively could use exact same error message as BlockingError ([/tokio-threadpool/src/blocking.rs#L161](https://github.com/tokio-rs/tokio/blob/master/tokio-threadpool/src/blocking.rs#L161)):

``` rust
> "`blocking` annotation used from outside the context of a thread pool"
```
…made potentially nicer via an `impl From<BlockingError> for io::Error`?
