### PR TITLE
Support std::fs::OpenOptions in tokio-fs

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,5 +10,5 @@
 pub use tokio_fs::{
     file,
     File,
-    OpenOptionsExt,
+    OpenOptions, 
 };

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -10,4 +10,5 @@
 pub use tokio_fs::{
     file,
     File,
+    OpenOptionsExt,
 };

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -4,9 +4,11 @@
 
 mod create;
 mod open;
+mod open_options;
 
 pub use self::create::CreateFuture;
 pub use self::open::OpenFuture;
+pub use self::open_options::{OpenOptionsExt, OpenOptionsFuture};
 
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -36,12 +38,18 @@ pub struct File {
 impl File {
     /// Attempts to open a file in read-only mode.
     ///
+    /// See [`std::fs::OpenOptions`] and [`OpenOptionsExt::open_async`] for
+    /// more details.
+    ///
+    /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+    /// [`OpenOptionsExt::open_async`]: trait.OpenOptionsExt.html#tymethod.open_async
+    ///
     /// # Errors
     ///
     /// `OpenFuture` results in an error if called from outside of the Tokio
     /// runtime or if the underlying [`open`] call results in an error.
     ///
-    /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
+    /// [`open`]: https://doc.rust-lang.org/std/fs/struct.File.html#method.open
     pub fn open<P>(path: P) -> OpenFuture<P>
     where P: AsRef<Path> + Send + 'static,
     {
@@ -52,6 +60,14 @@ impl File {
     ///
     /// This function will create a file if it does not exist, and will truncate
     /// it if it does.
+    ///
+    /// See [`std::fs::OpenOptions`] and [`OpenOptionsExt::open_async`] for
+    /// more details.
+    ///
+    /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+    /// [`OpenOptionsExt::open_async`]: trait.OpenOptionsExt.html#tymethod.open_async
+    ///
+    /// # Errors
     ///
     /// `CreateFuture` results in an error if called from outside of the Tokio
     /// runtime or if the underlying [`create`] call results in an error.

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -8,7 +8,7 @@ mod open_options;
 
 pub use self::create::CreateFuture;
 pub use self::open::OpenFuture;
-pub use self::open_options::{OpenOptions, OpenOptionsFuture};
+pub use self::open_options::OpenOptions;
 
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -51,7 +51,7 @@ impl File {
     pub fn open<P>(path: P) -> OpenFuture<P>
     where P: AsRef<Path> + Send + 'static,
     {
-        OpenFuture::new(path)
+        OpenOptions::new().read(true).open(path)
     }
 
     /// Opens a file in write-only mode.

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -8,7 +8,7 @@ mod open_options;
 
 pub use self::create::CreateFuture;
 pub use self::open::OpenFuture;
-pub use self::open_options::{OpenOptionsExt, OpenOptionsFuture};
+pub use self::open_options::{OpenOptions, OpenOptionsFuture};
 
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -38,11 +38,9 @@ pub struct File {
 impl File {
     /// Attempts to open a file in read-only mode.
     ///
-    /// See [`std::fs::OpenOptions`] and [`OpenOptionsExt::open_async`] for
-    /// more details.
+    /// See [`OpenOptions`] for more details.
     ///
-    /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
-    /// [`OpenOptionsExt::open_async`]: trait.OpenOptionsExt.html#tymethod.open_async
+    /// [`OpenOptions`]: struct.OpenOptions.html
     ///
     /// # Errors
     ///
@@ -61,11 +59,9 @@ impl File {
     /// This function will create a file if it does not exist, and will truncate
     /// it if it does.
     ///
-    /// See [`std::fs::OpenOptions`] and [`OpenOptionsExt::open_async`] for
-    /// more details.
+    /// See [`OpenOptions`] for more details.
     ///
-    /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
-    /// [`OpenOptionsExt::open_async`]: trait.OpenOptionsExt.html#tymethod.open_async
+    /// [`OpenOptions`]: struct.OpenOptions.html
     ///
     /// # Errors
     ///

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -189,21 +189,6 @@ impl OpenOptions {
     pub fn open<P>(&self, path: P) -> OpenOptionsFuture<P>
     where P: AsRef<Path> + Send + 'static
     {
-        self.clone().into_open(path)
-    }
-
-    /// Opens a file at `path` with the options specified by `self`, consuming
-    /// `self`.
-    ///
-    /// # Errors
-    ///
-    /// `OpenOptionsFuture` results in an error if called from outside of the
-    /// Tokio runtime or if the underlying [`open`] call results in an error.
-    ///
-    /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
-    pub fn into_open<P>(self, path: P) -> OpenOptionsFuture<P>
-    where P: AsRef<Path> + Send + 'static
-    {
-        OpenOptionsFuture::new(self.0, path)
+        OpenOptionsFuture::new(self.0.clone(), path)
     }
 }

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -1,16 +1,16 @@
 use super::OpenFuture;
 
+use std::convert::From;
 use std::fs::OpenOptions as StdOpenOptions;
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt as UnixOpenOptionsExt;
-#[cfg(windows)]
-use std::os::windows::fs::OpenOptionsExt as WindowsOpenOptionsExt;
 use std::path::Path;
 
 /// Options and flags which can be used to configure how a file is opened.
 ///
 /// This is a specialized version of [`std::fs::OpenOptions`] for usage from
 /// the Tokio runtime.
+///
+/// `From<std::fs::OpenOptions>` is implemented for more advanced configuration
+/// than the methods provided here.
 ///
 /// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
 #[derive(Clone, Debug)]
@@ -81,69 +81,6 @@ impl OpenOptions {
         self
     }
 
-    /// See the underlying [`mode`] call for details.
-    ///
-    /// [`mode`]: https://doc.rust-lang.org/beta/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode
-    #[cfg(unix)]
-    pub fn mode(&mut self, mode: u32) -> &mut OpenOptions {
-        self.0.mode(mode);
-        self
-    }
-
-    /// See the underlying [`custom_flags`] call for details.
-    ///
-    /// [`custom_flags`]: https://doc.rust-lang.org/beta/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.custom_flags
-    #[cfg(unix)]
-    pub fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
-        self.0.custom_flags(flags);
-        self
-    }
-
-    /// See the underlying [`access_mode`] call for details.
-    ///
-    /// [`access_mode`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.access_mode
-    #[cfg(windows)]
-    pub fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
-        self.0.access_mode(access);
-        self
-    }
-
-    /// See the underlying [`share_mode`] call for details.
-    ///
-    /// [`share_mode`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.share_mode
-    #[cfg(windows)]
-    pub fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
-        self.0.share_mode(share);
-        self
-    }
-
-    /// See the underlying [`custom_flags`] call for details.
-    ///
-    /// [`custom_flags`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags
-    #[cfg(windows)]
-    pub fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.0.custom_flags(flags);
-        self
-    }
-
-    /// See the underlying [`attributes`] call for details.
-    ///
-    /// [`attributes`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.attributes
-    #[cfg(windows)]
-    pub fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
-        self.0.attributes(attributes);
-        self
-    }
-
-    /// See the underlying [`security_qos_flags`] call for details.
-    ///
-    /// [`security_qos_flags`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.security_qos_flags
-    #[cfg(windows)]
-    pub fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.0.security_qos_flags(flags);
-        self
-    }
-
     /// Opens a file at `path` with the options specified by `self`.
     ///
     /// # Errors
@@ -156,5 +93,11 @@ impl OpenOptions {
     where P: AsRef<Path> + Send + 'static
     {
         OpenFuture::new(self.0.clone(), path)
+    }
+}
+
+impl From<StdOpenOptions> for OpenOptions {
+    fn from(options: StdOpenOptions) -> OpenOptions {
+        OpenOptions(options)
     }
 }

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -1,0 +1,77 @@
+use super::File;
+
+use futures::{Future, Poll};
+
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
+
+/// Future returned by `OpenOptionsExt::open_async` and resolves to a `File` instance.
+#[derive(Debug)]
+pub struct OpenOptionsFuture<P> {
+    options: OpenOptions,
+    path: P,
+}
+
+impl<P> OpenOptionsFuture<P>
+where P: AsRef<Path> + Send + 'static,
+{
+    pub(crate) fn new(options: OpenOptions, path: P) -> Self {
+        OpenOptionsFuture { options, path }
+    }
+}
+
+impl<P> Future for OpenOptionsFuture<P>
+where P: AsRef<Path> + Send + 'static,
+{
+    type Item = File;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let std = try_ready!(::blocking_io(|| {
+            self.options.open(&self.path)
+        }));
+
+        let file = File::from_std(std);
+        Ok(file.into())
+    }
+}
+
+pub trait OpenOptionsExt {
+    /// Opens a file at `path` with the options specified by `self`.
+    ///
+    /// # Errors
+    ///
+    /// `OpenOptionsFuture` results in an error if called from outside of the
+    /// Tokio runtime or if the underlying [`open`] call results in an error.
+    ///
+    /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
+    fn open_async<P>(&self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static;
+
+    /// Opens a file at `path` with the options specified by `self`, consuming
+    /// `self`.
+    ///
+    /// # Errors
+    ///
+    /// `OpenOptionsFuture` results in an error if called from outside of the
+    /// Tokio runtime or if the underlying [`open`] call results in an error.
+    ///
+    /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
+    fn into_open_async<P>(self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static;
+}
+
+impl OpenOptionsExt for OpenOptions {
+    fn open_async<P: AsRef<Path>>(&self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static,
+    {
+        self.clone().into_open_async(path)
+    }
+
+    fn into_open_async<P: AsRef<Path>>(self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static,
+    {
+        OpenOptionsFuture::new(self, path)
+    }
+}

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -115,6 +115,69 @@ impl OpenOptions {
         self
     }
 
+    /// See the underlying [`mode`] call for details.
+    ///
+    /// [`mode`]: https://doc.rust-lang.org/beta/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode
+    #[cfg(unix)]
+    pub fn mode(&mut self, mode: u32) -> &mut OpenOptions {
+        self.0.mode(mode);
+        self
+    }
+
+    /// See the underlying [`custom_flags`] call for details.
+    ///
+    /// [`custom_flags`]: https://doc.rust-lang.org/beta/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.custom_flags
+    #[cfg(unix)]
+    pub fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
+        self.0.custom_flags(flags);
+        self
+    }
+
+    /// See the underlying [`access_mode`] call for details.
+    ///
+    /// [`access_mode`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.access_mode
+    #[cfg(windows)]
+    pub fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
+        self.0.access_mode(access);
+        self
+    }
+
+    /// See the underlying [`share_mode`] call for details.
+    ///
+    /// [`share_mode`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.share_mode
+    #[cfg(windows)]
+    pub fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
+        self.0.share_mode(share);
+        self
+    }
+
+    /// See the underlying [`custom_flags`] call for details.
+    ///
+    /// [`custom_flags`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.custom_flags
+    #[cfg(windows)]
+    pub fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
+        self.0.custom_flags(flags);
+        self
+    }
+
+    /// See the underlying [`attributes`] call for details.
+    ///
+    /// [`attributes`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.attributes
+    #[cfg(windows)]
+    pub fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
+        self.0.attributes(attributes);
+        self
+    }
+
+    /// See the underlying [`security_qos_flags`] call for details.
+    ///
+    /// [`security_qos_flags`]: https://doc.rust-lang.org/beta/std/os/windows/fs/trait.OpenOptionsExt.html#tymethod.security_qos_flags
+    #[cfg(windows)]
+    pub fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
+        self.0.security_qos_flags(flags);
+        self
+    }
+
     /// Opens a file at `path` with the options specified by `self`.
     ///
     /// # Errors
@@ -142,46 +205,5 @@ impl OpenOptions {
     where P: AsRef<Path> + Send + 'static
     {
         OpenOptionsFuture::new(self.0, path)
-    }
-}
-
-#[cfg(unix)]
-impl UnixOpenOptionsExt for OpenOptions {
-    fn mode(&mut self, mode: u32) -> &mut OpenOptions {
-        self.0.mode(mode);
-        self
-    }
-
-    fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
-        self.0.custom_flags(flags);
-        self
-    }
-}
-
-#[cfg(windows)]
-impl WindowsOpenOptionsExt for OpenOptions {
-    fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
-        self.0.access_mode(access);
-        self
-    }
-
-    fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
-        self.0.share_mode(share);
-        self
-    }
-
-    fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.0.custom_flags(flags);
-        self
-    }
-
-    fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
-        self.0.attributes(attributes);
-        self
-    }
-
-    fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
-        self.0.security_qos_flags(flags);
-        self
     }
 }

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -57,7 +57,7 @@ impl OpenOptions {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```ignore
     /// use tokio::fs::OpenOptions;
     ///
     /// let mut options = OpenOptions::new();

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -2,21 +2,25 @@ use super::File;
 
 use futures::{Future, Poll};
 
-use std::fs::OpenOptions;
+use std::fs::OpenOptions as StdOpenOptions;
 use std::io;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt as UnixOpenOptionsExt;
+#[cfg(windows)]
+use std::os::windows::fs::OpenOptionsExt as WindowsOpenOptionsExt;
 use std::path::Path;
 
-/// Future returned by `OpenOptionsExt::open_async` and resolves to a `File` instance.
+/// Future returned by `OpenOptions::open` and resolves to a `File` instance.
 #[derive(Debug)]
 pub struct OpenOptionsFuture<P> {
-    options: OpenOptions,
+    options: StdOpenOptions,
     path: P,
 }
 
 impl<P> OpenOptionsFuture<P>
 where P: AsRef<Path> + Send + 'static,
 {
-    pub(crate) fn new(options: OpenOptions, path: P) -> Self {
+    pub(crate) fn new(options: StdOpenOptions, path: P) -> Self {
         OpenOptionsFuture { options, path }
     }
 }
@@ -37,7 +41,80 @@ where P: AsRef<Path> + Send + 'static,
     }
 }
 
-pub trait OpenOptionsExt {
+/// Options and flags which can be used to configure how a file is opened.
+///
+/// This is a specialized version of [`std::fs::OpenOptions`] for usage from
+/// the Tokio runtime.
+///
+/// [`std::fs::OpenOptions`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
+#[derive(Clone, Debug)]
+pub struct OpenOptions(StdOpenOptions);
+
+impl OpenOptions {
+    /// Creates a blank new set of options ready for configuration.
+    ///
+    /// All options are initially set to `false`.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::OpenOptions;
+    ///
+    /// let mut options = OpenOptions::new();
+    /// let future = options.read(true).open("foo.txt");
+    /// ```
+    pub fn new() -> OpenOptions {
+        OpenOptions(StdOpenOptions::new())
+    }
+
+    /// See the underlying [`read`] call for details.
+    ///
+    /// [`read`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.read
+    pub fn read(&mut self, read: bool) -> &mut OpenOptions {
+        self.0.read(read);
+        self
+    }
+
+    /// See the underlying [`write`] call for details.
+    ///
+    /// [`write`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.write
+    pub fn write(&mut self, write: bool) -> &mut OpenOptions {
+        self.0.write(write);
+        self
+    }
+
+    /// See the underlying [`append`] call for details.
+    ///
+    /// [`append`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.append
+    pub fn append(&mut self, append: bool) -> &mut OpenOptions {
+        self.0.append(append);
+        self
+    }
+
+    /// See the underlying [`truncate`] call for details.
+    ///
+    /// [`truncate`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.truncate
+    pub fn truncate(&mut self, truncate: bool) -> &mut OpenOptions {
+        self.0.truncate(truncate);
+        self
+    }
+
+    /// See the underlying [`create`] call for details.
+    ///
+    /// [`create`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create
+    pub fn create(&mut self, create: bool) -> &mut OpenOptions {
+        self.0.create(create);
+        self
+    }
+
+    /// See the underlying [`create_new`] call for details.
+    ///
+    /// [`create_new`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.create_new
+    pub fn create_new(&mut self, create_new: bool) -> &mut OpenOptions {
+        self.0.create_new(create_new);
+        self
+    }
+
     /// Opens a file at `path` with the options specified by `self`.
     ///
     /// # Errors
@@ -46,8 +123,11 @@ pub trait OpenOptionsExt {
     /// Tokio runtime or if the underlying [`open`] call results in an error.
     ///
     /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
-    fn open_async<P>(&self, path: P) -> OpenOptionsFuture<P>
-    where P: AsRef<Path> + Send + 'static;
+    pub fn open<P>(&self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static
+    {
+        self.clone().into_open(path)
+    }
 
     /// Opens a file at `path` with the options specified by `self`, consuming
     /// `self`.
@@ -58,20 +138,50 @@ pub trait OpenOptionsExt {
     /// Tokio runtime or if the underlying [`open`] call results in an error.
     ///
     /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
-    fn into_open_async<P>(self, path: P) -> OpenOptionsFuture<P>
-    where P: AsRef<Path> + Send + 'static;
+    pub fn into_open<P>(self, path: P) -> OpenOptionsFuture<P>
+    where P: AsRef<Path> + Send + 'static
+    {
+        OpenOptionsFuture::new(self.0, path)
+    }
 }
 
-impl OpenOptionsExt for OpenOptions {
-    fn open_async<P: AsRef<Path>>(&self, path: P) -> OpenOptionsFuture<P>
-    where P: AsRef<Path> + Send + 'static,
-    {
-        self.clone().into_open_async(path)
+#[cfg(unix)]
+impl UnixOpenOptionsExt for OpenOptions {
+    fn mode(&mut self, mode: u32) -> &mut OpenOptions {
+        self.0.mode(mode);
+        self
     }
 
-    fn into_open_async<P: AsRef<Path>>(self, path: P) -> OpenOptionsFuture<P>
-    where P: AsRef<Path> + Send + 'static,
-    {
-        OpenOptionsFuture::new(self, path)
+    fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
+        self.0.custom_flags(flags);
+        self
+    }
+}
+
+#[cfg(windows)]
+impl WindowsOpenOptionsExt for OpenOptions {
+    fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
+        self.0.access_mode(access);
+        self
+    }
+
+    fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
+        self.0.share_mode(share);
+        self
+    }
+
+    fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
+        self.0.custom_flags(flags);
+        self
+    }
+
+    fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
+        self.0.attributes(attributes);
+        self
+    }
+
+    fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
+        self.0.security_qos_flags(flags);
+        self
     }
 }

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -23,6 +23,7 @@ mod stdout;
 mod stderr;
 
 pub use file::File;
+pub use file::OpenOptionsExt;
 pub use stdin::{stdin, Stdin};
 pub use stdout::{stdout, Stdout};
 pub use stderr::{stderr, Stderr};

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -23,7 +23,7 @@ mod stdout;
 mod stderr;
 
 pub use file::File;
-pub use file::OpenOptionsExt;
+pub use file::OpenOptions;
 pub use stdin::{stdin, Stdin};
 pub use stdout::{stdout, Stdout};
 pub use stderr::{stderr, Stderr};


### PR DESCRIPTION
Adds an OpenOptionsExt::open_async method that wraps OpenOptions::open
just like the rest of tokio-fs.

Documentation for File has been updated to mention OpenOptions and
OpenOptionsExt::open_async similarly to the documentation for
std::fs::File, so that people know it's available.