### PR TITLE
Implement Runtime::block_on using oneshot

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use executor::spawn;
 #[cfg(feature = "unstable-futures")]
 pub use executor::spawn2;
 
-pub use runtime::run;
+pub use runtime::{block_on, run};
 
 pub mod io {
     //! Asynchronous I/O.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub use executor::spawn;
 #[cfg(feature = "unstable-futures")]
 pub use executor::spawn2;
 
-pub use runtime::{block_on, run};
+pub use runtime::run;
 
 pub mod io {
     //! Asynchronous I/O.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -127,6 +127,7 @@ use std::io;
 
 use tokio_threadpool as threadpool;
 
+use futures;
 use futures::future::Future;
 #[cfg(feature = "unstable-futures")]
 use futures2;
@@ -212,6 +213,63 @@ where F: Future<Item = (), Error = ()> + Send + 'static,
     let mut runtime = Runtime::new().unwrap();
     runtime.spawn(future);
     runtime.shutdown_on_idle().wait().unwrap();
+}
+
+/// Start a Tokio runtime and run the supplied future to completion.
+///
+/// This function is used to execute a single future and retrieve its result.
+/// Internally, it does the following:
+///
+/// * Start the Tokio runtime using a default configuration.
+/// * Spawn the given future onto the thread pool.
+/// * Wait on the future's resolved result using a `oneshot` channel.
+/// * Block the current thread until the runtime shuts down.
+///
+/// If you will be executing many futures in sequence, you should prefer
+/// creating a new [`Runtime`], and calling [`Runtime::block_on`], as this
+/// avoids the cost of setting up and tearing down the runtime for each future.
+///
+/// Note that the function will not return immediately once `future` has
+/// completed. Instead it waits for the entire runtime to become idle.
+///
+/// See the [module level][mod] documentation for more details.
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate tokio;
+/// # extern crate futures;
+/// # use futures::{Future, Stream};
+/// use std::time::{Instant, Duration};
+/// use tokio::timer;
+///
+/// fn after_1s<T>(x: T) -> Box<Future<Item = T, Error = timer::Error> + Send>
+/// where T: Send + 'static {
+///     Box::new(
+///       timer::Delay::new(Instant::now() + Duration::from_secs(1))
+///         .map(move |_| x))
+/// }
+///
+/// # pub fn main() {
+/// assert_eq!(tokio::block_on(after_1s(42)).unwrap(), 42);
+/// # }
+/// ```
+///
+/// # Panics
+///
+/// This function panics if called from the context of an executor.
+///
+/// [mod]: ../index.html
+pub fn block_on<F, R, E>(future: F) -> Result<R, E>
+where
+    F: Send + 'static + Future<Item = R, Error = E>,
+    R: Send + 'static,
+    E: Send + 'static,
+{
+    let mut runtime = Runtime::new().unwrap();
+    let r = runtime.block_on(future);
+    runtime.shutdown_on_idle().wait().unwrap();
+    r
 }
 
 /// Start the Tokio runtime using the supplied future to bootstrap execution.
@@ -363,6 +421,29 @@ impl Runtime {
             self.inner_mut().pool.sender_mut(), Box::new(future)
         ).unwrap();
         self
+    }
+
+    /// Run a future to completion on the Tokio runtime.
+    ///
+    /// This runs the given future on the runtime, blocking until it is
+    /// complete, and yielding its resolved result. Any tasks or timers which
+    /// the future spawns internally will be executed on the runtime.
+    ///
+    /// This method should not be called from an asynchrounous context.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the executor is at capacity, if the provided
+    /// future panics, or if called within an asynchronous execution context.
+    pub fn block_on<F, R, E>(&mut self, future: F) -> Result<R, E>
+    where
+        F: Send + 'static + Future<Item = R, Error = E>,
+        R: Send + 'static,
+        E: Send + 'static,
+    {
+        let (tx, rx) = futures::sync::oneshot::channel();
+        self.spawn(future.then(move |r| tx.send(r).map_err(|_| unreachable!())));
+        rx.wait().unwrap()
     }
 
     /// Signals the runtime to shutdown once it becomes idle.

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -215,63 +215,6 @@ where F: Future<Item = (), Error = ()> + Send + 'static,
     runtime.shutdown_on_idle().wait().unwrap();
 }
 
-/// Start a Tokio runtime and run the supplied future to completion.
-///
-/// This function is used to execute a single future and retrieve its result.
-/// Internally, it does the following:
-///
-/// * Start the Tokio runtime using a default configuration.
-/// * Spawn the given future onto the thread pool.
-/// * Wait on the future's resolved result using a `oneshot` channel.
-/// * Block the current thread until the runtime shuts down.
-///
-/// If you will be executing many futures in sequence, you should prefer
-/// creating a new [`Runtime`], and calling [`Runtime::block_on`], as this
-/// avoids the cost of setting up and tearing down the runtime for each future.
-///
-/// Note that the function will not return immediately once `future` has
-/// completed. Instead it waits for the entire runtime to become idle.
-///
-/// See the [module level][mod] documentation for more details.
-///
-/// # Examples
-///
-/// ```rust
-/// # extern crate tokio;
-/// # extern crate futures;
-/// # use futures::{Future, Stream};
-/// use std::time::{Instant, Duration};
-/// use tokio::timer;
-///
-/// fn after_1s<T>(x: T) -> Box<Future<Item = T, Error = timer::Error> + Send>
-/// where T: Send + 'static {
-///     Box::new(
-///       timer::Delay::new(Instant::now() + Duration::from_secs(1))
-///         .map(move |_| x))
-/// }
-///
-/// # pub fn main() {
-/// assert_eq!(tokio::block_on(after_1s(42)).unwrap(), 42);
-/// # }
-/// ```
-///
-/// # Panics
-///
-/// This function panics if called from the context of an executor.
-///
-/// [mod]: ../index.html
-pub fn block_on<F, R, E>(future: F) -> Result<R, E>
-where
-    F: Send + 'static + Future<Item = R, Error = E>,
-    R: Send + 'static,
-    E: Send + 'static,
-{
-    let mut runtime = Runtime::new().unwrap();
-    let r = runtime.block_on(future);
-    runtime.shutdown_on_idle().wait().unwrap();
-    r
-}
-
 /// Start the Tokio runtime using the supplied future to bootstrap execution.
 ///
 /// Identical to `run` but works with futures 0.2-style futures.

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,9 +1,15 @@
 extern crate tokio;
 extern crate env_logger;
+extern crate futures;
 
+use futures::sync::oneshot;
+use std::sync::{Arc, Mutex};
+use std::thread;
 use tokio::io;
 use tokio::net::{TcpStream, TcpListener};
+use tokio::prelude::future::lazy;
 use tokio::prelude::*;
+use tokio::runtime::Runtime;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -68,4 +74,102 @@ fn runtime_multi_threaded() {
         .unwrap();
     runtime.spawn(create_client_server_future());
     runtime.shutdown_on_idle().wait().unwrap();
+}
+
+#[test]
+fn block_on_timer() {
+    use std::time::{Duration, Instant};
+    use tokio::timer::{Delay, Error};
+
+    fn after_1s<T>(x: T) -> Box<Future<Item = T, Error = Error> + Send>
+    where
+        T: Send + 'static,
+    {
+        Box::new(Delay::new(Instant::now() + Duration::from_millis(100)).map(move |_| x))
+    }
+
+    let mut runtime = Runtime::new().unwrap();
+    assert_eq!(runtime.block_on(after_1s(42)).unwrap(), 42);
+    runtime.shutdown_on_idle().wait().unwrap();
+}
+
+#[test]
+fn spawn_from_block_on() {
+    let cnt = Arc::new(Mutex::new(0));
+    let c = cnt.clone();
+
+    let mut runtime = Runtime::new().unwrap();
+    let msg = runtime
+        .block_on(lazy(move || {
+            {
+                let mut x = c.lock().unwrap();
+                *x = 1 + *x;
+            }
+
+            // Spawn!
+            tokio::spawn(lazy(move || {
+                {
+                    let mut x = c.lock().unwrap();
+                    *x = 1 + *x;
+                }
+                Ok::<(), ()>(())
+            }));
+
+            Ok::<_, ()>("hello")
+        }))
+        .unwrap();
+
+    runtime.shutdown_on_idle().wait().unwrap();
+    assert_eq!(2, *cnt.lock().unwrap());
+    assert_eq!(msg, "hello");
+}
+
+#[test]
+fn block_waits() {
+    let (tx, rx) = oneshot::channel();
+
+    thread::spawn(|| {
+        use std::time::Duration;
+        thread::sleep(Duration::from_millis(1000));
+        tx.send(()).unwrap();
+    });
+
+    let cnt = Arc::new(Mutex::new(0));
+    let c = cnt.clone();
+
+    let mut runtime = Runtime::new().unwrap();
+    runtime
+        .block_on(rx.then(move |_| {
+            {
+                let mut x = c.lock().unwrap();
+                *x = 1 + *x;
+            }
+            Ok::<_, ()>(())
+        }))
+        .unwrap();
+
+    assert_eq!(1, *cnt.lock().unwrap());
+    runtime.shutdown_on_idle().wait().unwrap();
+}
+
+#[test]
+fn spawn_many() {
+    const ITER: usize = 200;
+
+    let cnt = Arc::new(Mutex::new(0));
+    let mut runtime = Runtime::new().unwrap();
+
+    for _ in 0..ITER {
+        let c = cnt.clone();
+        runtime.spawn(lazy(move || {
+            {
+                let mut x = c.lock().unwrap();
+                *x = 1 + *x;
+            }
+            Ok::<(), ()>(())
+        }));
+    }
+
+    runtime.shutdown_on_idle().wait().unwrap();
+    assert_eq!(ITER, *cnt.lock().unwrap());
 }


### PR DESCRIPTION
A new take on #328 in which the provided future is spawned on the runtime, and a `oneshot` channel is used to communicate the result back.