### PR TITLE
Bump version to v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.1.7 (June 6, 2018)
+
+* Add `Runtime::block_on` for concurrent runtime (#391).
+* Provide handle to `current_thread::Runtime` that allows spawning tasks from
+  other threads (#340).
+* Provide `clock::now()`, a configurable source of time (#381).
+
 # 0.1.6 (May 2, 2018)
 
 * Add asynchronous filesystem APIs (#323).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
@@ -44,10 +44,10 @@ tokio-codec = { version = "0.1.0", path = "tokio-codec" }
 tokio-io = { version = "0.1.6", path = "tokio-io" }
 tokio-executor = { version = "0.1.2", path = "tokio-executor" }
 tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }
-tokio-threadpool = { version = "0.1.3", path = "tokio-threadpool" }
+tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool" }
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp" }
 tokio-udp = { version = "0.1.0", path = "tokio-udp" }
-tokio-timer = { version = "0.2.1", path = "tokio-timer" }
+tokio-timer = { version = "0.2.4", path = "tokio-timer" }
 tokio-fs = { version = "0.1.0", path = "tokio-fs" }
 
 futures = "0.1.20"

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4 (June 6, 2018)
+
+* Fix bug that can occur with multiple pools in a process (#375).
+
 # 0.1.3 (May 2, 2018)
 
 * Add `blocking` annotation (#317).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "tokio-threadpool"
-version = "0.1.3"
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag.
+version = "0.1.4"
 documentation = "https://docs.rs/tokio-threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,6 +1,6 @@
 //! A work-stealing based thread pool for executing futures.
 
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.4")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate tokio_executor;

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,6 +1,13 @@
-# 0.2.2 (May 2, 2018)
+# 0.2.4 (June 6, 2018)
+
+* Add `sleep` function for easy interval delays (#347).
+* Provide `clock::now()`, a configurable source of time (#381).
+
+# 0.2.3 (May 2, 2018)
 
 * Improve parking semantics (#327).
+
+# 0.2.2 (Skipped due to failure in counting module)
 
 # 0.2.1 (April 2, 2018)
 

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "tokio-timer"
-version = "0.2.3"
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Create "v0.2.x" git tag.
+version = "0.2.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -18,7 +18,7 @@
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.4")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate tokio_executor;


### PR DESCRIPTION
This also bumps the versions of:

* tokio-threadpool
* tokio-timer