### PR TITLE
Remove `tokio-codec` dependency from `tokio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ futures = "0.1.20"
 mio = "0.6.14"
 
 [dev-dependencies]
+tokio-codec = { version = "0.1.0", path = "tokio-codec" }
+
 bytes = "0.4"
 env_logger = { version = "0.4", default-features = false }
 flate2 = { version = "1", features = ["tokio"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ travis-ci = { repository = "tokio-rs/tokio" }
 appveyor = { repository = "carllerche/tokio", id = "s83yxhy9qeb58va7" }
 
 [dependencies]
-tokio-codec = { version = "0.1.0", path = "tokio-codec" }
 tokio-io = { version = "0.1.6", path = "tokio-io" }
 tokio-executor = { version = "0.1.2", path = "tokio-executor" }
 tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }


### PR DESCRIPTION
This will be added again later once types are re-exported.