### PR TITLE
Bump version of a number of sub crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ have greater guarantees of stability.
 
 The crates included as part of Tokio are:
 
+* [`tokio-codec`]: Utilities for encoding and decoding protocol frames.
+
+* [`tokio-current-thread`]: Schedule the execution of futures on the current
+  thread.
+
 * [`tokio-executor`]: Task execution related traits and utilities.
 
 * [`tokio-fs`]: Filesystem (and standard in / out) APIs.
@@ -132,6 +137,8 @@ The crates included as part of Tokio are:
 * [`tokio-uds`]: Unix Domain Socket bindings for use with `tokio-io` and
   `tokio-reactor`.
 
+[`tokio-codec`]: tokio-codec
+[`tokio-current-thread`]: tokio-current-thread
 [`tokio-executor`]: tokio-executor
 [`tokio-fs`]: tokio-fs
 [`tokio-io`]: tokio-io

--- a/tokio-codec/CHANGELOG.md
+++ b/tokio-codec/CHANGELOG.md
@@ -1,3 +1,3 @@
-# Unreleased
+# # 0.1.0 (June 12, 2018)
 
 * Initial release (#353)

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -17,6 +17,6 @@ Utilities for encoding and decoding frames.
 categories = ["asynchronous"]
 
 [dependencies]
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-io = { version = "0.1.7", path = "../tokio-io" }
 bytes = "0.4.7"
 futures = "0.1.18"

--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,3 @@
-# Unreleased
+# 0.1.0 (June 12, 2018)
 
 * Extract `tokio::executor::current_thread` to a tokio-current-thread crate (#356)

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,5 +1,7 @@
-# Unreleased
+# 0.1.1 (June 12, 2018)
 
+* Add `OpenOptions` (#390)
+* Add `into_std` to `File` (#403)
 * Use `tokio-codec` in examples
 
 # 0.1.0 (May 2, 2018)

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-fs"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -12,6 +12,9 @@
 //!
 //! [blocking]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/fn.blocking.html
 
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.1")]
+
 #[macro_use]
 extern crate futures;
 extern crate tokio_io;

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.1.7 (June 12, 2018)
 
 * Move `codec::{Encode, Decode, Framed*}` into `tokio-codec` (#353)
 

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-io"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -7,7 +7,7 @@
 //! [low level details]: https://tokio.rs/docs/going-deeper-tokio/core-low-level/
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.7")]
 
 #[macro_use]
 extern crate log;

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2 (June 12, 2018)
+
+* Fix deadlock that can happen when shutting down (#409)
+* Handle::default() lazily binds to reactor (#350)
+
 # 0.1.1 (March 22, 2018)
 
 * Fix threading bugs (#227)

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-reactor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -27,7 +27,7 @@
 //! [`PollEvented`]: struct.PollEvented.html
 //! [reactor module]: https://docs.rs/tokio/0.1/tokio/reactor/index.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.2")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 #[macro_use]

--- a/tokio-udp/CHANGELOG.md
+++ b/tokio-udp/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0 (unreleased)
+# 0.1.1 (June 12, 2018)
+
+* Switch to tokio-codec (#360)
+
+# 0.1.0 (Mar 23, 2018)
 
 * Initial release

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-udp"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
@@ -18,7 +18,7 @@ categories = ["asynchronous"]
 
 [dependencies]
 tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-io = { version = "0.1.7", path = "../tokio-io" }
 tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
 bytes = "0.4"
 mio = "0.6.14"

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -16,7 +16,7 @@
 //! [`UdpFramed`]: struct.UdpFramed.html
 //! [`framed`]: struct.UdpSocket.html#method.framed
 
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.1")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;


### PR DESCRIPTION
This includes:

* tokio-codec (0.1.0)
* tokio-current-thread (0.1.0)
* tokio-fs (0.1.1)
* tokio-io (0.1.7)
* tokio-reactor (0.1.2)
* tokio-udp (0.1.1)