### PR TITLE
exposing ability to submit to specific worker.

### DIFF
--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -85,7 +85,6 @@ impl Pool {
         let total_size = max_blocking + pool_size;
 
         // Create the set of backup entries
-        //
         // This is `backup + pool_size` because the core thread pool running the
         // workers is spawned from backup as well.
         let backup = (0..total_size).map(|_| {
@@ -319,7 +318,11 @@ impl Pool {
         let idx = self.rand_usize() % len;
 
         trace!("  -> submitting to random; idx={}", idx);
+        self.submit_external_to_worker(idx, task, inner);
+    }
 
+    /// Submit a task to a specific worker within the pool
+    pub fn submit_external_to_worker(&self, idx: usize, task: Arc<Task>, inner: &Arc<Pool>) {
         let state = self.workers[idx].load_state();
         self.submit_to_external(idx, task, state, inner);
     }

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -586,3 +586,23 @@ fn multi_threadpool() {
 
     done_rx.recv().unwrap();
 }
+
+#[test]
+fn test_submit_external_to_worker() {
+    let mut pool = ThreadPool::new();
+    let idx = 0;
+
+    struct F;
+
+    #[cfg(not(feature = "unstable-futures"))]
+    impl Future for F {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<(), ()> {
+            Ok(Async::Ready(()))
+        }
+    }
+
+    pool.sender_mut().spawn_to_worker(idx, F{});
+}


### PR DESCRIPTION
Hello,

I don't think this is a final API, but wanted to start a conversation.

I think it would be valuable to be able to submit tasks to specific workers. This would be in a situation where I would like to distribute some load more evenly. I've been toying with making a virtual machine that uses tokio's event loop, and one thing I would like to do is spawn a seed future onto each worker, which would in turn spawn multiple other futures into the same worker. 

Looking to see what the best pattern would be for a exposing more control around the pool. Thanks!