### PR TITLE
Add tokio_fs::metadata

### DIFF
--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -31,11 +31,33 @@ pub use stdin::{stdin, Stdin};
 pub use stdout::{stdout, Stdout};
 pub use stderr::{stderr, Stderr};
 
-use futures::Poll;
+use futures::{Future, Poll};
 use futures::Async::*;
 
+use std::fs::{self, Metadata};
 use std::io;
 use std::io::ErrorKind::{Other, WouldBlock};
+use std::path::PathBuf;
+
+/// Queries the file system metadata for a path
+pub fn metadata(path: PathBuf) -> MetadataFuture {
+    MetadataFuture { path }
+}
+
+/// Future returned by `metadata`
+#[derive(Debug)]
+pub struct MetadataFuture {
+    path: PathBuf,
+}
+
+impl Future for MetadataFuture {
+    type Item = Metadata;
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        blocking_io(|| fs::metadata(&self.path))
+    }
+}
 
 fn blocking_io<F, T>(f: F) -> Poll<T, io::Error>
 where F: FnOnce() -> io::Result<T>,


### PR DESCRIPTION
Questions:

* is it worth exposing this as `poll_metadata`?
* could this use `impl Future` to avoid exposing the concrete return type?