### PR TITLE
Add tokio_fs::File::seek

### DIFF
--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -6,11 +6,13 @@ mod create;
 mod metadata;
 mod open;
 mod open_options;
+mod seek;
 
 pub use self::create::CreateFuture;
 pub use self::metadata::MetadataFuture;
 pub use self::open::OpenFuture;
 pub use self::open_options::OpenOptions;
+pub use self::seek::SeekFuture;
 
 use tokio_io::{AsyncRead, AsyncWrite};
 
@@ -98,6 +100,16 @@ impl File {
     /// Seeking to a negative offset is considered an error.
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
         ::blocking_io(|| self.std().seek(pos))
+    }
+
+    /// Seek to an offset, in bytes, in a stream.
+    ///
+    /// Similar to `poll_seek`, but returning a `Future`.
+    ///
+    /// This method consumes the `File` and returns it back when the future
+    /// completes.
+    pub fn seek(self, pos: io::SeekFrom) -> SeekFuture {
+        SeekFuture::new(self, pos)
     }
 
     /// Attempts to sync all OS-internal metadata to disk.

--- a/tokio-fs/src/file/seek.rs
+++ b/tokio-fs/src/file/seek.rs
@@ -1,0 +1,37 @@
+use super::File;
+
+use futures::{Future, Poll};
+
+use std::io;
+
+/// Future returned by `File::seek`
+#[derive(Debug)]
+pub struct SeekFuture {
+    inner: Option<File>,
+    pos: io::SeekFrom,
+}
+
+impl SeekFuture {
+    pub(crate) fn new(file: File, pos: io::SeekFrom) -> Self {
+        Self {
+            pos,
+            inner: Some(file),
+        }
+    }
+}
+
+impl Future for SeekFuture {
+    type Item = (File, u64);
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let pos = try_ready!(
+            self.inner
+                .as_mut()
+                .expect("Cannot poll `SeekFuture` after it resolves")
+                .poll_seek(self.pos)
+        );
+        let inner = self.inner.take().unwrap();
+        Ok((inner, pos).into())
+    }
+}


### PR DESCRIPTION
Should this use `impl Future`?

cc @shepmaster, since this is related to #385 wrt. the return tuple order and the error message duplication.