### PR TITLE
Enable backtraces in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
 
         export ASAN_OPTIONS="detect_odr_violation=0 detect_leaks=0"
         export TSAN_OPTIONS="suppressions=`pwd`/ci/tsan"
+        export RUST_BACKTRACE=1
 
         # === tokio-timer ====
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,15 +46,18 @@ script:
         RUSTFLAGS="-Z sanitizer=thread" \
         cargo test -p tokio-timer --test hammer --target x86_64-unknown-linux-gnu
 
-        # === tokio-threadpool ====
-
-        # Run address sanitizer
-        RUSTFLAGS="-Z sanitizer=address" \
-        cargo test -p tokio-threadpool --tests
-
-        # Run thread sanitizer
-        RUSTFLAGS="-Z sanitizer=thread" \
-        cargo test -p tokio-threadpool --tests
+        # TODO: Uncomment the sanitizer tests once the fence in steal issue is
+        #       resolved: https://github.com/tokio-rs/tokio/issues/329
+        #
+        # # === tokio-threadpool ====
+        #
+        # # Run address sanitizer
+        # RUSTFLAGS="-Z sanitizer=address" \
+        # cargo test -p tokio-threadpool --tests
+        #
+        # # Run thread sanitizer
+        # RUSTFLAGS="-Z sanitizer=thread" \
+        # cargo test -p tokio-threadpool --tests
     fi
   - |
     set -e


### PR DESCRIPTION
This PR enables backtraces when running tests and disables tsan for the thread pool.

The thread sanitizer was generating too many false positives. Once #329 lands, then it can
be re-enabled.