### PR TITLE
Add a verbose error message for EnterError

### DIFF
--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -250,14 +250,16 @@ impl<P: Park> CurrentThread<P> {
         -> Result<F::Item, BlockError<F::Error>>
     where F: Future
     {
-        let mut enter = tokio_executor::enter().unwrap();
+        let mut enter = tokio_executor::enter()
+            .expect("failed to start `current_thread::Runtime`");
         self.enter(&mut enter).block_on(future)
     }
 
     /// Run the executor to completion, blocking the thread until **all**
     /// spawned futures have completed.
     pub fn run(&mut self) -> Result<(), RunError> {
-        let mut enter = tokio_executor::enter().unwrap();
+        let mut enter = tokio_executor::enter()
+            .expect("failed to start `current_thread::Runtime`");
         self.enter(&mut enter).run()
     }
 
@@ -266,7 +268,8 @@ impl<P: Park> CurrentThread<P> {
     pub fn run_timeout(&mut self, duration: Duration)
         -> Result<(), RunTimeoutError>
     {
-        let mut enter = tokio_executor::enter().unwrap();
+        let mut enter = tokio_executor::enter()
+            .expect("failed to start `current_thread::Runtime`");
         self.enter(&mut enter).run_timeout(duration)
     }
 
@@ -276,7 +279,8 @@ impl<P: Park> CurrentThread<P> {
     pub fn turn(&mut self, duration: Option<Duration>)
         -> Result<Turn, TurnError>
     {
-        let mut enter = tokio_executor::enter().unwrap();
+        let mut enter = tokio_executor::enter()
+            .expect("failed to start `current_thread::Runtime`");
         self.enter(&mut enter).turn(duration)
     }
 

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -20,9 +20,16 @@ pub struct Enter {
 
 /// An error returned by `enter` if an execution scope has already been
 /// entered.
-#[derive(Debug)]
 pub struct EnterError {
     _a: (),
+}
+
+impl fmt::Debug for EnterError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("EnterError")
+            .field("reason", &"attempted to run an executor while another executor is already running")
+            .finish()
+    }
 }
 
 /// Marks the current thread as being within the dynamic extent of an


### PR DESCRIPTION
Fixes #410

Test:
```
#[test]
fn test_current_thread_error() {
	tokio::run(future::lazy(move || {
		let to_spawn = future::ok::<(), ()>(());
		::tokio::executor::current_thread::block_on_all(to_spawn).unwrap();
		Ok(())
	}));
}
```

Output:
```
thread 'tokio-runtime-worker-0' panicked at 'failed to start `current_thread::Runtime`: EnterError { reason: "attempted to run an executor while another executor is already running" }', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.

```