### PR TITLE
Add a verbose error message for BlockingError

### DIFF
--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -6,7 +6,6 @@ use std::error::Error;
 use std::fmt;
 
 /// Error raised by `blocking`.
-#[derive(Debug)]
 pub struct BlockingError {
     _p: (),
 }
@@ -153,6 +152,14 @@ where F: FnOnce() -> T,
 impl fmt::Display for BlockingError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{}", self.description())
+    }
+}
+
+impl fmt::Debug for BlockingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BlockingError")
+            .field("reason", &self.description())
+            .finish()
     }
 }
 


### PR DESCRIPTION
Add a verbose error message for EnterError while trying to run tokio_threadpool::blocking on a current_thread::Runtime

Links: #432

Test:

```diff
diff --git a/tests/runtime.rs b/tests/runtime.rs
index 06ada9c..c943568 100644
--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -1,4 +1,5 @@
 extern crate tokio;
+extern crate tokio_threadpool;
 extern crate env_logger;
 extern crate futures;
 
@@ -49,6 +50,18 @@ fn create_client_server_future() -> Box<Future<Item=(), Error=()> + Send> {
 }
 
 #[test]
+fn current_thread_blocking() {
+    let _ = env_logger::init();
+
+    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+
+    runtime.block_on(lazy(|| {
+        tokio_threadpool::blocking(|| {
+        })
+    })).unwrap();
+}
+
+#[test]
 fn runtime_tokio_run() {
     let _ = env_logger::init();
```

Output:

```
---- current_thread_blocking stdout ----
thread 'current_thread_blocking' panicked at 'called `Result::unwrap()` on an `Err` value: BlockingError { reason: "`blocking` annotation used from outside the context of a thread pool" }', libcore/result.rs:945:5
note: Run with `RUST_BACKTRACE=1` for a backtrace.
```

cc @danburkert