### PR TITLE
num_cpus="1.2" -> num_cpus="1.8" in tokio-threadpool

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["concurrency", "asynchronous"]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.3"
-num_cpus = "1.2"
+num_cpus = "1.8"
 rand = "0.4"
 log = "0.4"
 


### PR DESCRIPTION
- target support (wasm, redox)
- more reliable result on Android
- checks sched_affinity on linux
