### PR TITLE
Update rand dep from 0.4 to 0.5

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -21,7 +21,7 @@ tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.3"
 num_cpus = "1.2"
-rand = "0.4"
+rand = "0.5"
 log = "0.4"
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes `cargo doc` warnings like:

```
warning: `[1]` cannot be resolved, ignoring it...
  --> /home/humbug/.cargo/registry/src/github.com-1ecc6299db9ec823/rand-0.4.2/src/prng/isaac.rs:29:61
   |
29 | /// A random number generator that uses the ISAAC algorithm[1].
   |                                                             ^ cannot be resolved, ignoring
```
