### PR TITLE
Fix a race in thread wakeup

### DIFF
--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -41,7 +41,6 @@ use futures2;
 /// use std::time::Duration;
 ///
 /// # pub fn main() {
-/// // Create a thread pool with default configuration values
 /// let thread_pool = Builder::new()
 ///     .pool_size(4)
 ///     .keep_alive(Some(Duration::from_secs(30)))
@@ -86,7 +85,6 @@ impl Builder {
     /// use std::time::Duration;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .pool_size(4)
     ///     .keep_alive(Some(Duration::from_secs(30)))
@@ -131,7 +129,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .pool_size(4)
     ///     .build();
@@ -164,7 +161,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .max_blocking(200)
     ///     .build();
@@ -196,7 +192,6 @@ impl Builder {
     /// use std::time::Duration;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .keep_alive(Some(Duration::from_secs(30)))
     ///     .build();
@@ -224,7 +219,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .name_prefix("my-pool-")
     ///     .build();
@@ -251,7 +245,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .stack_size(32 * 1024)
     ///     .build();
@@ -265,7 +258,7 @@ impl Builder {
     /// Execute function `f` on each worker thread.
     ///
     /// This function is provided a handle to the worker and is expected to call
-    /// `Worker::run`, otherwise the worker thread will shutdown without doing
+    /// [`Worker::run`], otherwise the worker thread will shutdown without doing
     /// any work.
     ///
     /// # Examples
@@ -276,7 +269,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .around_worker(|worker, _| {
     ///         println!("worker is starting up");
@@ -286,6 +278,8 @@ impl Builder {
     ///     .build();
     /// # }
     /// ```
+    ///
+    /// [`Worker::run`]: struct.Worker.html#method.run
     pub fn around_worker<F>(&mut self, f: F) -> &mut Self
         where F: Fn(&Worker, &mut Enter) + Send + Sync + 'static
     {
@@ -306,7 +300,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .after_start(|| {
     ///         println!("thread started");
@@ -333,7 +326,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .before_stop(|| {
     ///         println!("thread stopping");
@@ -362,7 +354,6 @@ impl Builder {
     /// # fn decorate<F>(f: F) -> F { f }
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .custom_park(|_| {
     ///         use tokio_threadpool::park::DefaultPark;
@@ -402,7 +393,6 @@ impl Builder {
     /// # use tokio_threadpool::Builder;
     ///
     /// # pub fn main() {
-    /// // Create a thread pool with default configuration values
     /// let thread_pool = Builder::new()
     ///     .build();
     /// # }

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -29,8 +29,12 @@ use std::time::{Duration, Instant};
 
 /// Thread worker
 ///
-/// This is passed to the `around_worker` callback set on `Builder`. This
-/// callback is only expected to call `run` on it.
+/// This is passed to the [`around_worker`] callback set on [`Builder`]. This
+/// callback is only expected to call [`run`] on it.
+///
+/// [`Builder`]: struct.Builder.html
+/// [`around_worker`]: struct.Builder.html#method.around_worker
+/// [`run`]: struct.Worker.html#method.run
 #[derive(Debug)]
 pub struct Worker {
     // Shared scheduler data


### PR DESCRIPTION
When unparking a worker thread, we do the following steps:

1. Try transitioning IDLE -> NOTIFY.
2. Lock the mutex.
3. Try transitioning SLEEP -> NOTIFY and wakeup on success.

The problem occurs if the thread transitions from SLEEP to IDLE between steps 1 and 2. In that case, step 3 will fail to transition and simply return from `unpark`.

This PR changes the step 3 so that we *always* transition to NOTIFY, no matter what the previous state was.

The park/unpark mechanism in `std::thread` works somewhat similarly. In step 3, it attempts to CAS from SLEEP to NOTIFY, but jumps back to step 1 if the previous state was IDLE. See [here](https://github.com/rust-lang/rust/blob/6e5e63a48c3be7de2faf914c2a9e194ff7cede9e/src/libstd/thread/mod.rs#L1066). I've decided to unconditionally move to state NOTIFY instead - the end result should be the same.

In addition to that, I did a bunch of random improvements to the documentation.