### PR TITLE
Make WorkerId public

### DIFF
--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -149,4 +149,4 @@ pub use builder::Builder;
 pub use sender::Sender;
 pub use shutdown::Shutdown;
 pub use thread_pool::ThreadPool;
-pub use worker::Worker;
+pub use worker::{Worker, WorkerId};

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -70,7 +70,7 @@ struct CurrentTask {
     can_block: Cell<CanBlock>,
 }
 
-/// Identifiers a thread pool worker.
+/// Identifies a thread pool worker.
 ///
 /// This identifier is unique scoped by the thread pool. It is possible that
 /// different thread pool instances share worker identifier values.


### PR DESCRIPTION
`WorkerId` is returned by a public function, but it's private to the crate. Let's make it public.