### PR TITLE
Implement status() for DefaultExecutor

### DIFF
--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -79,6 +79,20 @@ impl super::Executor for DefaultExecutor {
             }
         })
     }
+
+    fn status(&self) -> Result<(), SpawnError> {
+        EXECUTOR.with(|current_executor| {
+            match current_executor.get() {
+                Some(executor) => {
+                    let executor = unsafe { &mut *executor };
+                    executor.status()
+                }
+                None => {
+                    Err(SpawnError::shutdown())
+                }
+            }
+        })
+    }
 }
 
 // ===== global spawn fns =====


### PR DESCRIPTION
This is a simple addition that will provide more accurate result for `DefaultExecutor::status()`.

Previously the method used the default implementation that simply returns `Ok(())`.