### PR TITLE
Bump minimum supported Rust to 1.25.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   # This represents the minimum Rust version supported by Tokio. Updating this
   # should be done in a dedicated PR and cannot be greater than two 0.x
   # releases prior to the current stable.
-  - rust: 1.21.0
+  - rust: 1.25.0
   - rust: stable
   - rust: beta
   - rust: nightly


### PR DESCRIPTION
Currently, 1.27 is the latest released Rust version.

This is in preparation to bump the crossbeam dependency to 0.4.

cc/ @seanmonstar @stjepang 