### PR TITLE
Update crossbeam-deque

### DIFF
--- a/ci/tsan
+++ b/ci/tsan
@@ -12,15 +12,14 @@ race:std*mpsc_queue
 # Probably more fences in std.
 race:__call_tls_dtors
 
-# The crossbeam deque uses fences.
-race:crossbeam_deque
+# The epoch-based GC uses fences.
+race:crossbeam_epoch
 
-# This is excluded as this race shows up due to using the stealing features of
-# the deque. Unfortunately, the implementation uses a fence, which makes tsan
-# unhappy.
-#
-# TODO: It would be nice to not have to filter this out.
-race:try_steal_task
+# Push and steal operations in crossbeam-deque may cause data races, but such
+# data races are safe. If a data race happens, the value read by `steal` is
+# forgotten and the steal operation is then retried.
+race:crossbeam_deque*push
+race:crossbeam_deque*steal
 
 # This filters out expected data race in the treiber stack implementations.
 # Treiber stacks are inherently racy. The pop operation will attempt to access

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
-crossbeam-deque = "0.3"
+crossbeam-deque = "0.5.0"
 num_cpus = "1.2"
 rand = "0.4"
 log = "0.4"

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -377,16 +377,13 @@ impl Worker {
     ///
     /// Returns `true` if work was found.
     fn try_run_owned_task(&self, notify: &Arc<Notifier>, sender: &mut Sender) -> bool {
-        use deque::Steal::*;
-
         // Poll the internal queue for a task to run
         match self.entry().pop_task() {
-            Data(task) => {
+            Some(task) => {
                 self.run_task(task, notify, sender);
                 true
             }
-            Empty => false,
-            Retry => true,
+            None => false,
         }
     }
 
@@ -394,36 +391,29 @@ impl Worker {
     ///
     /// Returns `true` if work was found
     fn try_steal_task(&self, notify: &Arc<Notifier>, sender: &mut Sender) -> bool {
-        use deque::Steal::*;
-
         debug_assert!(!self.is_blocking.get());
 
         let len = self.inner.workers.len();
         let mut idx = self.inner.rand_usize() % len;
-        let mut found_work = false;
         let start = idx;
 
         loop {
             if idx < len {
-                match self.inner.workers[idx].steal_task() {
-                    Data(task) => {
-                        trace!("stole task");
+                if let Some(task) = self.inner.workers[idx].steal_task() {
+                    trace!("stole task");
 
-                        self.run_task(task, notify, sender);
+                    self.run_task(task, notify, sender);
 
-                        trace!("try_steal_task -- signal_work; self={}; from={}",
-                               self.id.0, idx);
+                    trace!("try_steal_task -- signal_work; self={}; from={}",
+                           self.id.0, idx);
 
-                        // Signal other workers that work is available
-                        //
-                        // TODO: Should this be called here or before
-                        // `run_task`?
-                        self.inner.signal_work(&self.inner);
+                    // Signal other workers that work is available
+                    //
+                    // TODO: Should this be called here or before
+                    // `run_task`?
+                    self.inner.signal_work(&self.inner);
 
-                        return true;
-                    }
-                    Empty => {}
-                    Retry => found_work = true,
+                    return true;
                 }
 
                 idx += 1;
@@ -436,7 +426,7 @@ impl Worker {
             }
         }
 
-        found_work
+        false
     }
 
     fn run_task(&self, task: Arc<Task>, notify: &Arc<Notifier>, sender: &mut Sender) {


### PR DESCRIPTION
Update crossbeam-deque to 0.5.0.

This version has better-optimized support for deques that process tasks in FIFO order (previously we'd call `Deque::steal()` to pop tasks from the opposite end of `Deque::push()`, which is sort of a hack).

Moreover, some internal fields of the deque are now directly inlined into the worker side in order to avoid false sharing.

Benchmark results:

```
 name                    before ns/iter  after ns/iter  diff ns/iter  diff %  speedup
 threadpool::spawn_many  4,633,930       4,216,334          -417,596  -9.01%   x 1.10
 threadpool::yield_many  11,931,281      12,263,546          332,265   2.78%   x 0.97
```

Closes #329.