### PR TITLE
Pad fields to cacheline size to avoid false sharing

### DIFF
--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -84,7 +84,7 @@ impl super::Executor for DefaultExecutor {
         EXECUTOR.with(|current_executor| {
             match current_executor.get() {
                 Some(executor) => {
-                    let executor = unsafe { &mut *executor };
+                    let executor = unsafe { &*executor };
                     executor.status()
                 }
                 None => {

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["concurrency", "asynchronous"]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.3"
+crossbeam-utils = "0.4.1"
 num_cpus = "1.2"
 rand = "0.4"
 log = "0.4"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -116,6 +116,7 @@
 extern crate tokio_executor;
 
 extern crate crossbeam_deque as deque;
+extern crate crossbeam_utils;
 #[macro_use]
 extern crate futures;
 extern crate num_cpus;

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -6,12 +6,14 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicPtr;
 use std::sync::atomic::Ordering::{Acquire, Release, AcqRel, Relaxed};
 
+use crossbeam_utils::cache_padded::CachePadded;
+
 #[derive(Debug)]
 pub(crate) struct Queue {
     /// Queue head.
     ///
     /// This is a strong reference to `Task` (i.e, `Arc<Task>`)
-    head: AtomicPtr<Task>,
+    head: CachePadded<AtomicPtr<Task>>,
 
     /// Tail pointer. This is `Arc<Task>` unless it points to `stub`.
     tail: UnsafeCell<*mut Task>,
@@ -37,7 +39,7 @@ impl Queue {
         let ptr = &*stub as *const _ as *mut _;
 
         Queue {
-            head: AtomicPtr::new(ptr),
+            head: CachePadded::new(AtomicPtr::new(ptr)),
             tail: UnsafeCell::new(ptr),
             stub: stub,
         }

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::atomic::Ordering::{Acquire, AcqRel, Relaxed};
 
+use crossbeam_utils::cache_padded::CachePadded;
 use deque;
 
 // TODO: None of the fields should be public
@@ -19,7 +20,7 @@ pub(crate) struct WorkerEntry {
     //
     // The `usize` value is deserialized to a `worker::State` instance. See
     // comments on that type.
-    pub state: AtomicUsize,
+    pub state: CachePadded<AtomicUsize>,
 
     // Next entry in the parked Trieber stack
     next_sleeper: UnsafeCell<usize>,
@@ -46,7 +47,7 @@ impl WorkerEntry {
         let s = w.stealer();
 
         WorkerEntry {
-            state: AtomicUsize::new(State::default().into()),
+            state: CachePadded::new(AtomicUsize::new(State::default().into())),
             next_sleeper: UnsafeCell::new(0),
             deque: w,
             steal: s,


### PR DESCRIPTION
This PR adds padding to fields commonly shared among multiple thread in order to avoid false sharing.

Benchmark results:

```
 name                    before ns/iter  after ns/iter  diff ns/iter   diff %  speedup
 threadpool::spawn_many  4,651,455       4,140,478          -510,977  -10.99%   x 1.12
 threadpool::yield_many  11,908,059      11,805,160         -102,899   -0.86%   x 1.01
```