### PR TITLE
Add free block_on_all in current thread Runtime

### DIFF
--- a/src/runtime/current_thread/mod.rs
+++ b/src/runtime/current_thread/mod.rs
@@ -68,3 +68,24 @@ mod runtime;
 
 pub use self::builder::Builder;
 pub use self::runtime::{Runtime, Handle};
+
+use futures::Future;
+
+/// Run the provided future to completion with a runtime running on the current
+/// thread.
+///
+/// This creates a new [`Runtime`], and calls [`Runtime::block_on`] with the
+/// provided future, which blocks the current thread until the provided future
+/// completes.
+///
+/// Note that this function will **also** execute any spawned futures on the
+/// current thread, but will **not** block until these other spawned futures
+/// have completed. Once the function returns, any uncompleted futures are
+/// dropped.
+pub fn block_on<F>(future: F) -> Result<F::Item, F::Error>
+where
+    F: Future,
+{
+    let mut r = Runtime::new().expect("failed to start runtime on current thread");
+    r.block_on(future)
+}

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -66,6 +66,13 @@ fn runtime_single_threaded() {
 }
 
 #[test]
+fn runtime_single_threaded_block_on() {
+    let _ = env_logger::init();
+
+    tokio::runtime::current_thread::block_on(create_client_server_future()).unwrap();
+}
+
+#[test]
 fn runtime_multi_threaded() {
     let _ = env_logger::init();
 

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -69,7 +69,34 @@ fn runtime_single_threaded() {
 fn runtime_single_threaded_block_on() {
     let _ = env_logger::init();
 
-    tokio::runtime::current_thread::block_on(create_client_server_future()).unwrap();
+    tokio::runtime::current_thread::block_on_all(create_client_server_future()).unwrap();
+}
+
+#[test]
+fn runtime_single_threaded_block_on_all() {
+    let cnt = Arc::new(Mutex::new(0));
+    let c = cnt.clone();
+
+    let msg = tokio::runtime::current_thread::block_on_all(lazy(move || {
+        {
+            let mut x = c.lock().unwrap();
+            *x = 1 + *x;
+        }
+
+        // Spawn!
+        tokio::spawn(lazy(move || {
+            {
+                let mut x = c.lock().unwrap();
+                *x = 1 + *x;
+            }
+            Ok::<(), ()>(())
+        }));
+
+        Ok::<_, ()>("hello")
+    })).unwrap();
+
+    assert_eq!(2, *cnt.lock().unwrap());
+    assert_eq!(msg, "hello");
 }
 
 #[test]


### PR DESCRIPTION
Adds a free-standing fn in `runtime::current_thread` that starts a `current_thread::Runtime` and blocks on the provided future (and any spawned futures).

Resolves the concerns with #393.