### PR TITLE
tokio-fs: Implement OS specific FileExt

### DIFF
--- a/tokio-fs/src/file/metadata.rs
+++ b/tokio-fs/src/file/metadata.rs
@@ -19,8 +19,8 @@ impl MetadataFuture {
         MetadataFuture { file: Some(file) }
     }
 
-    fn std(&mut self) -> &mut StdFile {
-        self.file.as_mut().expect(POLL_AFTER_RESOLVE).std()
+    fn std_mut(&mut self) -> &mut StdFile {
+        self.file.as_mut().expect(POLL_AFTER_RESOLVE).std_mut()
     }
 }
 
@@ -30,7 +30,7 @@ impl Future for MetadataFuture {
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let metadata = try_ready!(::blocking_io(|| {
-            StdFile::metadata(self.std())
+            StdFile::metadata(self.std_mut())
         }));
 
         let file = self.file.take().expect(POLL_AFTER_RESOLVE);


### PR DESCRIPTION
Both unix and windows have OS specific traits in std that is implemented
on std::fs::File on those OS's. This change also implements those
FileExt traits on tokio_fs::file::File using would_block.

Because I needed a non-mutable borrow of File::std I renamed the
existing mutable borrowing std function to std_mut and made a new
function called std that does a non-mutable borrow.