### PR TITLE
Update  dependencies to same version (v0.4.8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ mio = "0.6.14"
 [dev-dependencies]
 tokio-codec = { version = "0.1.0", path = "tokio-codec" }
 
-bytes = "0.4"
+bytes = "0.4.8"
 env_logger = { version = "0.4", default-features = false }
 flate2 = { version = "1", features = ["tokio"] }
 futures-cpupool = "0.1"

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -18,5 +18,5 @@ categories = ["asynchronous"]
 
 [dependencies]
 tokio-io = { version = "0.1.7", path = "../tokio-io" }
-bytes = "0.4.7"
+bytes = "0.4.8"
 futures = "0.1.18"

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -17,6 +17,6 @@ Core I/O primitives for asynchronous I/O in Rust.
 categories = ["asynchronous"]
 
 [dependencies]
-bytes = "0.4.7"
+bytes = "0.4.8"
 futures = "0.1.18"
 log = "0.4"

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["asynchronous"]
 [dependencies]
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
 tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
-bytes = "0.4"
+bytes = "0.4.8"
 mio = "0.6.14"
 iovec = "0.1"
 futures = "0.1.19"

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["asynchronous"]
 tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
 tokio-io = { version = "0.1.7", path = "../tokio-io" }
 tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
-bytes = "0.4"
+bytes = "0.4.8"
 mio = "0.6.14"
 log = "0.4"
 futures = "0.1.19"


### PR DESCRIPTION
There were previously three different versions of the `bytes` crate used in the project. This single-commit PR updates the versions to be consistent with one another.