### PR TITLE
Implement AsRawSocket on {TcpListener,TcpStream,UdpSocket} for Windows

### DIFF
--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -248,14 +248,12 @@ mod sys {
 
 #[cfg(windows)]
 mod sys {
-    // TODO: let's land these upstream with mio and then we can add them here.
-    //
-    // use std::os::windows::prelude::*;
-    // use super::{TcpListener;
-    //
-    // impl AsRawHandle for TcpListener {
-    //     fn as_raw_handle(&self) -> RawHandle {
-    //         self.listener.io().as_raw_handle()
-    //     }
-    // }
+    use std::os::windows::prelude::*;
+    use super::TcpListener;
+
+    impl AsRawSocket for TcpListener {
+        fn as_raw_socket(&self) -> RawSocket {
+            self.io.get_ref().as_raw_socket()
+        }
+    }
 }

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -742,14 +742,12 @@ mod sys {
 
 #[cfg(windows)]
 mod sys {
-    // TODO: let's land these upstream with mio and then we can add them here.
-    //
-    // use std::os::windows::prelude::*;
-    // use super::TcpStream;
-    //
-    // impl AsRawHandle for TcpStream {
-    //     fn as_raw_handle(&self) -> RawHandle {
-    //         self.io.get_ref().as_raw_handle()
-    //     }
-    // }
+    use std::os::windows::prelude::*;
+    use super::TcpStream;
+
+    impl AsRawSocket for TcpStream {
+        fn as_raw_socket(&self) -> RawSocket {
+            self.io.get_ref().as_raw_socket()
+        }
+    }
 }

--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -412,14 +412,12 @@ mod sys {
 
 #[cfg(windows)]
 mod sys {
-    // TODO: let's land these upstream with mio and then we can add them here.
-    //
-    // use std::os::windows::prelude::*;
-    // use super::UdpSocket;
-    //
-    // impl AsRawHandle for UdpSocket {
-    //     fn as_raw_handle(&self) -> RawHandle {
-    //         self.io.get_ref().as_raw_handle()
-    //     }
-    // }
+    use std::os::windows::prelude::*;
+    use super::UdpSocket;
+
+    impl AsRawSocket for UdpSocket {
+        fn as_raw_socket(&self) -> RawSocket {
+            self.io.get_ref().as_raw_socket()
+        }
+    }
 }


### PR DESCRIPTION
Implements `AsRawSocket` on TcpListener, TcpStream and UdpSocket for Windows. Only `AsRawSocket` is implemented to follow the way Tokio only implements the UNIX equivalent `AsRawFd`.

This depends on [this Mio PR](https://github.com/carllerche/mio/pull/859).