### PR TITLE
Removing unnecessary (seemingly) asserts from timer

### DIFF
--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -335,13 +335,9 @@ where T: Park,
     }
 
     fn set_elapsed(&mut self, when: u64) {
-        assert!(self.elapsed <= when, "elapsed={:?}; when={:?}", self.elapsed, when);
-
         if when > self.elapsed {
             self.elapsed = when;
             self.inner.elapsed.store(when, SeqCst);
-        } else {
-            assert_eq!(self.elapsed, when);
         }
     }
 


### PR DESCRIPTION
I've been running into an issue where the timer occasionally hits the assertion in set_elapsed. As far as I can tell, the assertion doesn't actually prevent us from getting into a bad state and ultimately seems unnecessary. 

Running on Mac, I have yet to see this happen but it can be reproduced fairly reliably on an arm Android device.

If anything starting a discussion about this might be nice, to get a better understanding of why the assert is here and if there might be a better approach to preventing the assert from getting hit.

Thanks 😸 🦀 