### PR TITLE
Fix more rustdoc links

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! The specific strategy used to manage the tasks is left up to the
 //! executor. There are two main flavors of executors: single-threaded and
-//! multithreaded. Tokio provides implementation for both of these in the
+//! multi-threaded. Tokio provides implementation for both of these in the
 //! [`runtime`] module.
 //!
 //! # `Executor` trait.

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -132,8 +132,8 @@
 //! [`Poll::poll`]: https://docs.rs/mio/0.6/mio/struct.Poll.html#method.poll
 //! [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
 //! [`PollEvented`]: struct.PollEvented.html
-//! [`std::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-//! [`std::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+//! [`std::io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+//! [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 
 pub use tokio_reactor::{
     Reactor,

--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -13,12 +13,12 @@ use std::io::{self, Read, Write};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
 
-/// Associates an I/O resource that implements the [`std::Read`] and / or
-/// [`std::Write`] traits with the reactor that drives it.
+/// Associates an I/O resource that implements the [`std::io::Read`] and/or
+/// [`std::io::Write`] traits with the reactor that drives it.
 ///
 /// `PollEvented` uses [`Registration`] internally to take a type that
-/// implements [`mio::Evented`] as well as [`std::Read`] and or [`std::Write`]
-/// and associate it with a reactor that will drive it.
+/// implements [`mio::Evented`] as well as [`std::io::Read`] and or
+/// [`std::io::Write`] and associate it with a reactor that will drive it.
 ///
 /// Once the [`mio::Evented`] type is wrapped by `PollEvented`, it can be
 /// used from within the future's execution model. As such, the `PollEvented`
@@ -77,8 +77,8 @@ use std::sync::atomic::Ordering::Relaxed;
 /// These events are included as part of the read readiness event stream. The
 /// write readiness event stream is only for `Ready::writable()` events.
 ///
-/// [`std::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-/// [`std::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+/// [`std::io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
+/// [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 /// [`AsyncRead`]: ../io/trait.AsyncRead.html
 /// [`AsyncWrite`]: ../io/trait.AsyncWrite.html
 /// [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html

--- a/tokio-reactor/src/poll_evented.rs
+++ b/tokio-reactor/src/poll_evented.rs
@@ -85,7 +85,7 @@ use std::sync::atomic::Ordering::Relaxed;
 /// [`Registration`]: struct.Registration.html
 /// [`TcpListener`]: ../net/struct.TcpListener.html
 /// [`clear_read_ready`]: #method.clear_read_ready
-/// [`clear_read_ready`]: #method.clear_read_ready
+/// [`clear_write_ready`]: #method.clear_write_ready
 /// [`poll_read_ready`]: #method.poll_read_ready
 /// [`poll_write_ready`]: #method.poll_write_ready
 pub struct PollEvented<E: Evented> {


### PR DESCRIPTION
Very minor fixes for 3 more links broken recently. Might be worth suggesting that people run `cargo doc` if they are making changes to rustdoc.

This is another dependency for resolving #437.