### PR TITLE
Update to crossbeam-utils 0.5.0, fix imports

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["concurrency", "asynchronous"]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.5.0"
-crossbeam-utils = "0.4.1"
+crossbeam-utils = "0.5.0"
 num_cpus = "1.2"
 rand = "0.5"
 log = "0.4"

--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -28,7 +28,7 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
 use std::thread;
 
-use crossbeam_utils::cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 use rand;
 
 #[derive(Debug)]

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicPtr;
 use std::sync::atomic::Ordering::{Acquire, Release, AcqRel, Relaxed};
 
-use crossbeam_utils::cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 
 #[derive(Debug)]
 pub(crate) struct Queue {

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::atomic::Ordering::{Acquire, AcqRel, Relaxed};
 
-use crossbeam_utils::cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 use deque;
 
 // TODO: None of the fields should be public


### PR DESCRIPTION
On current master, with #468 merged, there are both crossbeam-utils 0.4 and 0.5 in the dependencies:

``` text
crossbeam-utils v0.4.1
└── tokio-threadpool v0.1.5 
│   [...]

crossbeam-utils v0.5.0
├── crossbeam-deque v0.5.2
│   └── tokio-threadpool v0.1.5 
│       [...]
└── crossbeam-epoch v0.5.2
    └── crossbeam-deque v0.5.2 (*)
```

This updates the dependency in tokio-threadpool so its back to one crossbeam-utils.

@stjepang anything to be concerned about or report with this update? 