### PR TITLE
Bump subcrate versions

### DIFF
--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.1 (August 6, 2018)
+
+* Implement `std::Error` for misc error types (#501)
+* bugfix: Track tasks pending in spawn queue (#478)
+
 # 0.1.0 (June 13, 2018)
 
 * Extract `tokio::executor::current_thread` to a tokio-current-thread crate (#356)

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-current-thread"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 documentation = "https://docs.rs/tokio-current-thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -22,7 +22,7 @@
 //! [`block_on_all`]: fn.block_on_all.html
 //! [executor module]: https://docs.rs/tokio/0.1/tokio/executor/index.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.1")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate futures;

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.3 (August 6, 2018)
+
+* Implement `Executor` for `Box<E: Executor>` (#420).
+* Improve `EnterError` debug message (#410).
+* Implement `status`, `Send`, and `Sync` for `DefaultExecutor` (#463, #472).
+* Fix race in `ParkThread` (#507).
+* Handle recursive calls into `DefaultExecutor` (#473).
+
 # 0.1.2 (March 30, 2018)
 
 * Implement `Unpark` for `Box<Unpark>`.

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-executor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 documentation = "https://docs.rs/tokio-executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -33,7 +33,7 @@
 //! [`Future::poll`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#tymethod.poll
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.3")]
 
 extern crate futures;
 

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (August 6, 2018)
+
+* Add async equivalents to most of `std::fs` (#494).
+
 # 0.1.2 (July 11, 2018)
 
 * Add `metadata` and `File::metadata` ([#433](https://github.com/tokio-rs/tokio/pull/433), [#385](https://github.com/tokio-rs/tokio/pull/385))

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-fs"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -26,7 +26,7 @@
 //! [tokio-threadpool]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.3")]
 
 #[macro_use]
 extern crate futures;

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (August 6, 2018)
+
+* Misc small fixes (#508)
+
 # 0.1.2 (June 13, 2018)
 
 * Fix deadlock that can happen when shutting down (#409)

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-reactor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -27,7 +27,7 @@
 //! [`PollEvented`]: struct.PollEvented.html
 //! [reactor module]: https://docs.rs/tokio/0.1/tokio/reactor/index.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.3")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 #[macro_use]

--- a/tokio-tcp/CHANGELOG.md
+++ b/tokio-tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
-# 0.1.0 (unreleased)
+# 0.1.1 (August 6, 2018)
+
+* Add `TcpStream::try_clone` (#448)
+
+# 0.1.0 (March 23, 2018)
 
 * Initial release

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-tcp"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -19,7 +19,7 @@
 //! [incoming_method]: struct.TcpListener.html#method.incoming
 //! [`Incoming`]: struct.Incoming.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.1")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.5 (August 6, 2018)
+
+* Add `Interval::interval` shortcut (#492).
+
 # 0.2.4 (June 6, 2018)
 
 * Add `sleep` function for easy interval delays (#347).

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-timer"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -18,7 +18,7 @@
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html
 
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.5")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate tokio_executor;


### PR DESCRIPTION
* tokio-current-thread 0.1.1
* tokio-executor 0.1.3
* tokio-fs 0.1.3
* tokio-reactor 0.1.3
* tokio-tcp 0.1.1
* tokio-timer 0.2.5

This may want to wait until https://github.com/rust-lang-nursery/futures-rs/issues/1170 is inspected as it might relate to https://github.com/tokio-rs/tokio/pull/459.