### PR TITLE
expose tokio_uds from the root crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ futures = "0.1.20"
 # Needed until `reactor` is removed from `tokio`.
 mio = "0.6.14"
 
+[target.'cfg(unix)'.dependencies]
+tokio-uds = { version = "0.2.0", path = "tokio-uds" }
+
 [dev-dependencies]
 tokio-codec = { version = "0.1.0", path = "tokio-codec" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,9 @@ extern crate tokio_timer;
 extern crate tokio_tcp;
 extern crate tokio_udp;
 
+#[cfg(unix)]
+extern crate tokio_uds;
+
 pub mod clock;
 pub mod executor;
 pub mod fs;

--- a/src/net.rs
+++ b/src/net.rs
@@ -39,3 +39,16 @@
 pub use tokio_tcp::{TcpStream, ConnectFuture};
 pub use tokio_tcp::{TcpListener, Incoming};
 pub use tokio_udp::{UdpSocket, UdpFramed, SendDgram, RecvDgram};
+
+#[cfg(unix)]
+pub mod unix {
+    //! Unix domain socket bindings for `tokio`.
+
+    pub use tokio_uds::{
+        ConnectFuture, Incoming, RecvDgram, SendDgram, UCred, UnixDatagram, UnixListener,
+        UnixStream,
+    };
+}
+
+#[cfg(unix)]
+pub use self::unix::{UnixListener, UnixStream};


### PR DESCRIPTION
This is the start of the work to expose `tokio_uds` like `tokio_tcp` and `tokio_udp`. Just like in the std lib the export is only effective for unix systems.

There is to some points to discuss:
- I choose to follow the 3-letters convention with `uds` is that ok?
- Should there be more symbol exported (e.g. `SendDgram`, `RecvDgram`)? If so how to handle name conflict?
- I couldn't find how to handle the plateform-specific documentation.