### PR TITLE
Bump tokio-tls to v0.2.0

### DIFF
--- a/tokio-tls/CHANGELOG.md
+++ b/tokio-tls/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.2.0 (August 8, 2018)
+
+* Initial release with `tokio` support.

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 name = "tokio-tls"
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Create "tokio-tls-0.2.x" git tag.
 version = "0.2.0"
-authors = ["Carl Lerche <me@carllerche.com>",
-           "Alex Crichton <alex@alexcrichton.com>"]
+authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
@@ -19,7 +22,7 @@ travis-ci = { repository = "tokio-rs/tokio-tls" }
 [dependencies]
 futures = "0.1.23"
 native-tls = "0.2"
-tokio-io = { version = "0.1", path = "../tokio-io" }
+tokio-io = { version = "0.1.7", path = "../tokio-io" }
 
 [dev-dependencies]
 tokio = { version = "0.1", path = "../" }

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -16,7 +16,7 @@
 //! `native-tls` crate.
 
 #![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/tokio-tls/0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-tls/0.2.0")]
 
 extern crate futures;
 extern crate native_tls;


### PR DESCRIPTION
This prepares the crate for release.