### PR TITLE
Routine dependencies update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ mio = "0.6.14"
 tokio-codec = { version = "0.1.0", path = "tokio-codec" }
 
 bytes = "0.4"
-env_logger = { version = "0.4", default-features = false }
+env_logger = { version = "0.5", default-features = false }
 flate2 = { version = "1", features = ["tokio"] }
 futures-cpupool = "0.1"
 http = "0.1"

--- a/tests/buffered.rs
+++ b/tests/buffered.rs
@@ -22,7 +22,7 @@ macro_rules! t {
 #[test]
 fn echo_server() {
     const N: usize = 1024;
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());

--- a/tests/clock.rs
+++ b/tests/clock.rs
@@ -21,7 +21,7 @@ impl tokio_timer::clock::Now for MockNow {
 
 #[test]
 fn clock_and_timer_concurrent() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let when = Instant::now() + Duration::from_millis(5_000);
     let clock = Clock::new_with_now(MockNow(when));
@@ -48,7 +48,7 @@ fn clock_and_timer_concurrent() {
 
 #[test]
 fn clock_and_timer_single_threaded() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let when = Instant::now() + Duration::from_millis(5_000);
     let clock = Clock::new_with_now(MockNow(when));

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -21,7 +21,7 @@ macro_rules! t {
 
 #[test]
 fn hammer_old() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let threads = (0..10).map(|_| {
         thread::spawn(|| {
@@ -77,7 +77,7 @@ fn hammer_split() {
     const N: usize = 100;
     const ITER: usize = 10;
 
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     for _ in 0..ITER {
         let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));

--- a/tests/line-frames.rs
+++ b/tests/line-frames.rs
@@ -51,7 +51,7 @@ impl Encoder for LineCodec {
 
 #[test]
 fn echo() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let pool = Builder::new()
         .pool_size(1)

--- a/tests/pipe-hup.rs
+++ b/tests/pipe-hup.rs
@@ -63,7 +63,7 @@ impl Evented for MyFile {
 
 #[test]
 fn hup() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let handle = Handle::default();
     unsafe {

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -50,14 +50,14 @@ fn create_client_server_future() -> Box<Future<Item=(), Error=()> + Send> {
 
 #[test]
 fn runtime_tokio_run() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     tokio::run(create_client_server_future());
 }
 
 #[test]
 fn runtime_single_threaded() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new()
         .unwrap();
@@ -67,7 +67,7 @@ fn runtime_single_threaded() {
 
 #[test]
 fn runtime_single_threaded_block_on() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     tokio::runtime::current_thread::block_on_all(create_client_server_future()).unwrap();
 }
@@ -135,7 +135,7 @@ fn runtime_single_threaded_racy_spawn() {
 
 #[test]
 fn runtime_multi_threaded() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let mut runtime = tokio::runtime::Builder::new()
         .build()

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn timer_with_runtime() {
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let when = Instant::now() + Duration::from_millis(100);
     let (tx, rx) = mpsc::channel();
@@ -33,7 +33,7 @@ fn timer_with_runtime() {
 fn starving() {
     use futures::{task, Poll, Async};
 
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     struct Starve(Delay, u64);
 
@@ -75,7 +75,7 @@ fn starving() {
 fn deadline() {
     use futures::future;
 
-    let _ = env_logger::init();
+    let _ = env_logger::try_init();
 
     let when = Instant::now() + Duration::from_millis(20);
     let (tx, rx) = mpsc::channel();

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -24,7 +24,7 @@ tokio-threadpool = { version = "0.1.3", path = "../tokio-threadpool" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
 
 [dev-dependencies]
-rand = "0.4.2"
+rand = "0.5"
 tempdir = "0.3.7"
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
 tokio-codec = { version = "0.1.0", path = "../tokio-codec" }

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -25,7 +25,7 @@ tokio-io = { version = "0.1.6", path = "../tokio-io" }
 
 [dev-dependencies]
 rand = "0.5"
-tempdir = "0.3.7"
+tempfile = "3"
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
 tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
 tokio = { version = "0.1.7", path = ".." }

--- a/tokio-fs/tests/file.rs
+++ b/tokio-fs/tests/file.rs
@@ -1,6 +1,6 @@
 extern crate futures;
 extern crate rand;
-extern crate tempdir;
+extern crate tempfile;
 extern crate tokio_fs;
 extern crate tokio_io;
 extern crate tokio_threadpool;
@@ -13,7 +13,7 @@ use futures::Future;
 use futures::future::poll_fn;
 use futures::sync::oneshot;
 use rand::{thread_rng, Rng};
-use tempdir::TempDir;
+use tempfile::Builder as TmpBuilder;
 
 use std::fs::File as StdFile;
 use std::io::{Read, SeekFrom};
@@ -22,7 +22,7 @@ use std::io::{Read, SeekFrom};
 fn read_write() {
     const NUM_CHARS: usize = 16 * 1_024;
 
-    let dir = TempDir::new("tokio-fs-tests").unwrap();
+    let dir = TmpBuilder::new().prefix("tokio-fs-tests").tempdir().unwrap();
     let file_path = dir.path().join("read_write.txt");
 
     let contents: Vec<u8> = thread_rng().gen_ascii_chars()
@@ -81,7 +81,7 @@ fn read_write() {
 
 #[test]
 fn metadata() {
-    let dir = TempDir::new("tokio-fs-tests").unwrap();
+    let dir = TmpBuilder::new().prefix("tokio-fs-tests").tempdir().unwrap();
     let file_path = dir.path().join("metadata.txt");
 
     let pool = Builder::new().pool_size(1).build();
@@ -111,7 +111,7 @@ fn metadata() {
 
 #[test]
 fn seek() {
-    let dir = TempDir::new("tokio-fs-tests").unwrap();
+    let dir = TmpBuilder::new().prefix("tokio-fs-tests").tempdir().unwrap();
     let file_path = dir.path().join("seek.txt");
 
     let pool = Builder::new().pool_size(1).build();

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -25,4 +25,4 @@ iovec = "0.1"
 futures = "0.1.19"
 
 [dev-dependencies]
-env_logger = { version = "0.4", default-features = false }
+env_logger = { version = "0.5", default-features = false }

--- a/tokio-tcp/tests/echo.rs
+++ b/tokio-tcp/tests/echo.rs
@@ -22,7 +22,7 @@ macro_rules! t {
 
 #[test]
 fn echo_server() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());

--- a/tokio-tcp/tests/stream-buffered.rs
+++ b/tokio-tcp/tests/stream-buffered.rs
@@ -22,7 +22,7 @@ macro_rules! t {
 
 #[test]
 fn echo_server() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());

--- a/tokio-tcp/tests/tcp.rs
+++ b/tokio-tcp/tests/tcp.rs
@@ -20,7 +20,7 @@ macro_rules! t {
 
 #[test]
 fn connect() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let srv = t!(net::TcpListener::bind("127.0.0.1:0"));
     let addr = t!(srv.local_addr());
     let t = thread::spawn(move || {
@@ -37,7 +37,7 @@ fn connect() {
 
 #[test]
 fn accept() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
@@ -61,7 +61,7 @@ fn accept() {
 
 #[test]
 fn accept2() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
@@ -96,7 +96,7 @@ mod unix {
 
     #[test]
     fn poll_hup() {
-        drop(env_logger::init());
+        drop(env_logger::try_init());
 
         let srv = t!(net::TcpListener::bind("127.0.0.1:0"));
         let addr = t!(srv.local_addr());

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 
 [dev-dependencies]
 tokio-timer = "0.1"
-env_logger = "0.4"
+env_logger = "0.5"
 
 # For comparison benchmarks
 futures-cpupool = "0.1.7"

--- a/tokio-threadpool/tests/blocking.rs
+++ b/tokio-threadpool/tests/blocking.rs
@@ -19,7 +19,7 @@ use std::thread;
 
 #[test]
 fn basic() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let pool = Builder::new()
         .pool_size(1)

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -21,7 +21,7 @@ fn ignore_results<F: Future + Send + 'static>(f: F) -> Box<Future<Item = (), Err
 
 #[test]
 fn natural_shutdown_simple_futures() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     for _ in 0..1_000 {
         let num_inc = Arc::new(AtomicUsize::new(0));
@@ -90,7 +90,7 @@ fn natural_shutdown_simple_futures() {
 
 #[test]
 fn force_shutdown_drops_futures() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     for _ in 0..1_000 {
         let num_inc = Arc::new(AtomicUsize::new(0));
@@ -147,7 +147,7 @@ fn force_shutdown_drops_futures() {
 
 #[test]
 fn drop_threadpool_drops_futures() {
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     for _ in 0..1_000 {
         let num_inc = Arc::new(AtomicUsize::new(0));
@@ -208,7 +208,7 @@ fn drop_threadpool_drops_futures() {
 fn thread_shutdown_timeout() {
     use std::sync::Mutex;
 
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     let (shutdown_tx, shutdown_rx) = mpsc::channel();
     let (complete_tx, complete_rx) = mpsc::channel();
@@ -252,7 +252,7 @@ fn thread_shutdown_timeout() {
 fn many_oneshot_futures() {
     const NUM: usize = 10_000;
 
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     for _ in 0..50 {
         let pool = ThreadPool::new();
@@ -283,7 +283,7 @@ fn many_multishot_futures() {
     const CYCLES: usize = 5;
     const TRACKS: usize = 50;
 
-    let _ = ::env_logger::init();
+    let _ = ::env_logger::try_init();
 
     for _ in 0..50 {
         let pool = ThreadPool::new();

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -20,4 +20,4 @@ futures = "0.1.19"
 tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
 
 [dev-dependencies]
-rand = "0.4.2"
+rand = "0.5"

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -27,7 +27,7 @@ tokio-io = { version = "0.1.7", path = "../tokio-io" }
 [dev-dependencies]
 tokio = { version = "0.1", path = "../" }
 cfg-if = "0.1"
-env_logger = { version = "0.4", default-features = false }
+env_logger = { version = "0.5", default-features = false }
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/tokio-tls/tests/bad.rs
+++ b/tokio-tls/tests/bad.rs
@@ -89,7 +89,7 @@ cfg_if! {
 }
 
 fn get_host(host: &'static str) -> Error {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let addr = format!("{}:443", host);
     let addr = t!(addr.to_socket_addrs()).next().unwrap();

--- a/tokio-tls/tests/google.rs
+++ b/tokio-tls/tests/google.rs
@@ -62,7 +62,7 @@ fn native2io(e: native_tls::Error) -> io::Error {
 
 #[test]
 fn fetch_google() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     // First up, resolve google.com
     let addr = t!("google.com:443".to_socket_addrs()).next().unwrap();
@@ -98,7 +98,7 @@ fn fetch_google() {
 #[cfg_attr(all(target_os = "macos", feature = "force-openssl"), ignore)]
 #[test]
 fn wrong_hostname_error() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let addr = t!("google.com:443".to_socket_addrs()).next().unwrap();
 

--- a/tokio-tls/tests/smoke.rs
+++ b/tokio-tls/tests/smoke.rs
@@ -497,7 +497,7 @@ const AMT: u64 = 128 * 1024;
 
 #[test]
 fn client_to_server() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let mut l = t!(Runtime::new());
 
     // Create a server listening on a port, then figure out what that port is
@@ -536,7 +536,7 @@ fn client_to_server() {
 
 #[test]
 fn server_to_client() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let mut l = t!(Runtime::new());
 
     // Create a server listening on a port, then figure out what that port is
@@ -599,7 +599,7 @@ impl<S: AsyncWrite> AsyncWrite for OneByte<S> {
 #[test]
 fn one_byte_at_a_time() {
     const AMT: u64 = 1024;
-    drop(env_logger::init());
+    drop(env_logger::try_init());
     let mut l = t!(Runtime::new());
 
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -26,4 +26,4 @@ log = "0.4"
 futures = "0.1.19"
 
 [dev-dependencies]
-env_logger = { version = "0.4", default-features = false }
+env_logger = { version = "0.5", default-features = false }

--- a/tokio-udp/tests/udp.rs
+++ b/tokio-udp/tests/udp.rs
@@ -218,7 +218,7 @@ impl Encoder for ByteCodec {
 
 #[test]
 fn send_framed() {
-    drop(env_logger::init());
+    drop(env_logger::try_init());
 
     let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
     let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -28,4 +28,4 @@ tokio-io = { version = "0.1.6", path = "../tokio-io" }
 
 [dev-dependencies]
 tokio = { version = "0.1.6", path = "../" }
-tempdir = "0.3.7"
+tempfile = "3"

--- a/tokio-uds/tests/stream.rs
+++ b/tokio-uds/tests/stream.rs
@@ -4,7 +4,7 @@ extern crate futures;
 extern crate tokio;
 extern crate tokio_uds;
 
-extern crate tempdir;
+extern crate tempfile;
 
 use tokio_uds::*;
 
@@ -13,7 +13,7 @@ use tokio::runtime::current_thread::Runtime;
 
 use futures::{Future, Stream};
 use futures::sync::oneshot;
-use tempdir::TempDir;
+use tempfile::Builder;
 
 macro_rules! t {
     ($e:expr) => (match $e {
@@ -24,7 +24,7 @@ macro_rules! t {
 
 #[test]
 fn echo() {
-    let dir = TempDir::new("tokio-uds-tests").unwrap();
+    let dir = Builder::new().prefix("tokio-uds-tests").tempdir().unwrap();
     let sock_path = dir.path().join("connect.sock");
 
     let mut rt = Runtime::new().unwrap();


### PR DESCRIPTION
`env_logger::init()` now panics if it's already initialised.
All the tests passed on Linux.