### PR TITLE
Steal multiple tasks from another worker at a time

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
-crossbeam-deque = { git = "https://github.com/stjepang/crossbeam-deque.git", branch = "steal-many" }
+crossbeam-deque = "0.6.0"
 crossbeam-utils = "0.5.0"
 num_cpus = "1.2"
 rand = "0.5"

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
-crossbeam-deque = "0.5.0"
+crossbeam-deque = { git = "https://github.com/stjepang/crossbeam-deque.git", branch = "steal-many" }
 crossbeam-utils = "0.5.0"
 num_cpus = "1.2"
 rand = "0.5"

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -192,12 +192,16 @@ impl WorkerEntry {
         self.worker.pop()
     }
 
-    /// Steal a task
+    /// Steal tasks
     ///
     /// This is called by *other* workers to steal a task for processing. This
     /// function is `Sync`.
-    pub fn steal_task(&self) -> Option<Arc<Task>> {
-        self.stealer.steal()
+    ///
+    /// At the same time, this method steals some additional tasks and moves
+    /// them into `dest` in order to balance the work distribution among
+    /// workers.
+    pub fn steal_tasks(&self, dest: &Self) -> deque::Steal<Arc<Task>> {
+        self.stealer.steal_many(&dest.worker)
     }
 
     /// Drain (and drop) all tasks that are queued for work.

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -188,7 +188,7 @@ impl WorkerEntry {
     ///
     /// This **must** only be called by the thread that owns the worker entry.
     /// This function is not `Sync`.
-    pub fn pop_task(&self) -> Option<Arc<Task>> {
+    pub fn pop_task(&self) -> deque::Pop<Arc<Task>> {
         self.worker.pop()
     }
 
@@ -208,7 +208,14 @@ impl WorkerEntry {
     ///
     /// This is called when the pool is shutting down.
     pub fn drain_tasks(&self) {
-        while let Some(_) = self.worker.pop() {
+        use deque::Pop;
+
+        loop {
+            match self.worker.pop() {
+                Pop::Data(_) => {}
+                Pop::Empty => break,
+                Pop::Retry => {}
+            }
         }
     }
 

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -398,29 +398,36 @@ impl Worker {
     ///
     /// Returns `true` if work was found
     fn try_steal_task(&self, notify: &Arc<Notifier>, sender: &mut Sender) -> bool {
+        use deque::Steal;
+
         debug_assert!(!self.is_blocking.get());
 
         let len = self.inner.workers.len();
         let mut idx = self.inner.rand_usize() % len;
+        let mut found_work = false;
         let start = idx;
 
         loop {
             if idx < len {
-                if let Some(task) = self.inner.workers[idx].steal_task() {
-                    trace!("stole task");
+                match self.inner.workers[idx].steal_tasks(self.entry()) {
+                    Steal::Data(task) => {
+                        trace!("stole task");
 
-                    self.run_task(task, notify, sender);
+                        self.run_task(task, notify, sender);
 
-                    trace!("try_steal_task -- signal_work; self={}; from={}",
-                           self.id.0, idx);
+                        trace!("try_steal_task -- signal_work; self={}; from={}",
+                               self.id.0, idx);
 
-                    // Signal other workers that work is available
-                    //
-                    // TODO: Should this be called here or before
-                    // `run_task`?
-                    self.inner.signal_work(&self.inner);
+                        // Signal other workers that work is available
+                        //
+                        // TODO: Should this be called here or before
+                        // `run_task`?
+                        self.inner.signal_work(&self.inner);
 
-                    return true;
+                        return true;
+                    }
+                    Steal::Empty => {}
+                    Steal::Retry => found_work = true,
                 }
 
                 idx += 1;
@@ -433,7 +440,7 @@ impl Worker {
             }
         }
 
-        false
+        found_work
     }
 
     fn run_task(&self, task: Arc<Task>, notify: &Arc<Notifier>, sender: &mut Sender) {


### PR DESCRIPTION
Use the new `Stealer::steal_many` method in `crossbeam-deque` that steals multiple tasks from another worker at a time.

In addition to that, the number of calls to `thread::yield_now` is reduced, which was the main culprit for the recently reported slowdowns by @tobz.

Benchmarks:

```
 name                    before ns/iter  after ns/iter  diff ns/iter  diff %  speedup
 threadpool::spawn_many  3,568,671       3,594,856            26,185   0.73%   x 0.99
 threadpool::yield_many  12,021,606      11,546,606         -475,000  -3.95%   x 1.04
```

Some wins are due to spinning, and some are due to `steal_many`.

@tobz, can you verify that this PR fixes the performance losses on your machine?