### PR TITLE
Implement `Default` for `tokio_timer::Handle`

### DIFF
--- a/tokio-timer/src/timer/entry.rs
+++ b/tokio-timer/src/timer/entry.rs
@@ -1,6 +1,6 @@
 use Error;
 use atomic::AtomicU64;
-use timer::{Handle, Inner};
+use timer::{HandlePriv, Inner};
 
 use futures::Poll;
 use futures::task::AtomicTask;
@@ -121,7 +121,7 @@ const SHUTDOWN: *mut Entry = 1 as *mut _;
 // ===== impl Entry =====
 
 impl Entry {
-    pub fn new(when: u64, handle: Handle) -> Entry {
+    pub fn new(when: u64, handle: HandlePriv) -> Entry {
         assert!(when > 0 && when < u64::MAX);
 
         Entry {
@@ -137,7 +137,7 @@ impl Entry {
         }
     }
 
-    pub fn new_elapsed(handle: Handle) -> Entry {
+    pub fn new_elapsed(handle: HandlePriv) -> Entry {
         Entry {
             inner: handle.into_inner(),
             task: AtomicTask::new(),

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -38,6 +38,7 @@ mod now;
 mod registration;
 
 use self::entry::Entry;
+use self::handle::HandlePriv;
 use self::level::{Level, Expiration};
 
 pub use self::handle::{Handle, with_default};

--- a/tokio-timer/src/timer/registration.rs
+++ b/tokio-timer/src/timer/registration.rs
@@ -1,5 +1,5 @@
 use Error;
-use timer::{Handle, Entry};
+use timer::{HandlePriv, Entry};
 
 use futures::Poll;
 
@@ -20,13 +20,13 @@ impl Registration {
         fn is_send<T: Send + Sync>() {}
         is_send::<Registration>();
 
-        match Handle::try_current() {
+        match HandlePriv::try_current() {
             Ok(handle) => Registration::new_with_handle(deadline, handle),
             Err(_) => Registration::new_error(),
         }
     }
 
-    pub fn new_with_handle(deadline: Instant, handle: Handle) -> Registration {
+    pub fn new_with_handle(deadline: Instant, handle: HandlePriv) -> Registration {
         let inner = match handle.inner() {
             Some(inner) => inner,
             None => return Registration::new_error(),

--- a/tokio-timer/tests/delay.rs
+++ b/tokio-timer/tests/delay.rs
@@ -7,6 +7,7 @@ mod support;
 use support::*;
 
 use tokio_timer::*;
+use tokio_timer::timer::Handle;
 
 use futures::Future;
 
@@ -482,6 +483,22 @@ fn reset_future_delay_after_fire() {
 
         turn(timer, ms(1000));
         assert_eq!(time.advanced(), ms(110));
+
+        assert_ready!(delay);
+    });
+}
+
+#[test]
+fn delay_with_default_handle() {
+    let handle = Handle::default();
+    let now = Instant::now();
+
+    let mut delay = handle.delay(now + ms(1));
+
+    mocked_with_now(now, |timer, _time| {
+        assert_not_ready!(delay);
+
+        turn(timer, ms(1));
 
         assert_ready!(delay);
     });


### PR DESCRIPTION
This patch implements `Default` for `tokio_timer::Handle`. It returns a
`Handle` instance that is not bound to a specific timer. Instead, it
will use the timer for the current execution context. This is the same
strategy used by `tokio_reactor::Handle`.

Fixes #547