### PR TITLE
Add some missing future::Executor implementations

### DIFF
--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -648,6 +648,23 @@ impl Handle {
 
         Ok(())
     }
+
+    /// Provides a best effort **hint** to whether or not `spawn` will succeed.
+    ///
+    /// This function may return both false positives **and** false negatives.
+    /// If `status` returns `Ok`, then a call to `spawn` will *probably*
+    /// succeed, but may fail. If `status` returns `Err`, a call to `spawn` will
+    /// *probably* fail, but may succeed.
+    ///
+    /// This allows a caller to avoid creating the task if the call to `spawn`
+    /// has a high likelihood of failing.
+    pub fn status(&self) -> Result<(), SpawnError> {
+        if self.shut_down.get() {
+            return Err(SpawnError::shutdown());
+        }
+
+        Ok(())
+    }
 }
 
 // ===== impl TaskExecutor =====


### PR DESCRIPTION
This adds an implementation of future::Executor for
`executor::DefaultExecutor` and `runtime::current_thread::Handle`.