### PR TITLE
Use spawn_local to spawn from local Handles

### DIFF
--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -67,7 +67,7 @@ pub struct CurrentThread<P: Park = ParkThread> {
     spawn_receiver: mpsc::Receiver<Box<Future<Item = (), Error = ()> + Send + 'static>>,
 
     /// The thread-local ID assigned to this executor.
-    id: usize,
+    id: u64,
 }
 
 /// Executes futures on the current thread.
@@ -180,7 +180,7 @@ impl<T: fmt::Debug> Error for BlockError<T> {
 
 /// This is mostly split out to make the borrow checker happy.
 struct Borrow<'a, U: 'a> {
-    id: usize,
+    id: u64,
     scheduler: &'a mut Scheduler<U>,
     num_futures: &'a atomic::AtomicUsize,
 }
@@ -191,7 +191,7 @@ trait SpawnLocal {
 
 struct CurrentRunner {
     spawn: Cell<Option<*mut SpawnLocal>>,
-    id: Cell<Option<usize>>,
+    id: Cell<Option<u64>>,
 }
 
 /// Current thread's task runner. This is set in `TaskRunner::with`
@@ -204,7 +204,7 @@ thread_local!(static CURRENT: CurrentRunner = CurrentRunner {
 ///
 /// The unique ID is used to determine if the currently running executor matches the one referred
 /// to by a `Handle` so that direct task dispatch can be used.
-thread_local!(static EXECUTOR_ID: Cell<usize> = Cell::new(0));
+thread_local!(static EXECUTOR_ID: Cell<u64> = Cell::new(0));
 
 /// Run the executor bootstrapping the execution with the provided future.
 ///
@@ -630,7 +630,7 @@ pub struct Handle {
     thread: thread::ThreadId,
 
     /// The thread-local ID assigned to this Handle's executor.
-    id: usize,
+    id: u64,
 }
 
 // Manual implementation because the Sender does not implement Debug
@@ -700,7 +700,7 @@ impl TaskExecutor {
     }
 
     /// Get the current executor's thread-local ID.
-    fn id(&self) -> Option<usize> {
+    fn id(&self) -> Option<u64> {
         CURRENT.with(|current| {
             current.id.get()
         })

--- a/tokio-current-thread/src/scheduler.rs
+++ b/tokio-current-thread/src/scheduler.rs
@@ -210,7 +210,7 @@ where U: Unpark,
     ///
     /// This function should be called whenever the caller is notified via a
     /// wakeup.
-    pub fn tick(&mut self, eid: usize, enter: &mut Enter, num_futures: &AtomicUsize) -> bool
+    pub fn tick(&mut self, eid: u64, enter: &mut Enter, num_futures: &AtomicUsize) -> bool
     {
         let mut ret = false;
         let tick = self.inner.tick_num.fetch_add(1, SeqCst)


### PR DESCRIPTION
Previously, every call to `current_thread::Handle::spawn` would go through a `mpsc` channel. This is unnecessary when the `Handle` is still on the same thread as the current thread executor. This patch fixes that by storing the `ThreadId` of the executor when it is created, and then comparing against that when `Handle::spawn` is called. If the call is made from the same thread, `spawn_local` is used directly.

Fixes #562.