### PR TITLE
Bump version to v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+This changelog only applies to the `tokio` crate proper. Each sub crate
+maintains its own changelog tracking changes made in each respective sub crate.
+
+# 0.1.8 (August 23, 2018)
+
+* Extract tokio::executor::current_thread to a sub crate (#370)
+* Add `Runtime::block_on` (#398)
+* Add `runtime::current_thread::block_on_all` (#477)
+* Misc documentation improvements (#450)
+* Implement `std::error::Error` for error types (#501)
+
 # 0.1.7 (June 6, 2018)
 
 * Add `Runtime::block_on` for concurrent runtime (#391).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,15 @@ name = "tokio"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
+documentation = "https://docs.rs/tokio/0.1.8/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio/0.1"
 description = """
 An event-driven, non-blocking I/O platform for writing asynchronous I/O
 backed applications.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,15 +44,15 @@ appveyor = { repository = "carllerche/tokio", id = "s83yxhy9qeb58va7" }
 
 [dependencies]
 tokio-codec = { version = "0.1.0", path = "tokio-codec" }
-tokio-current-thread = { version = "0.1.0", path = "tokio-current-thread" }
+tokio-current-thread = { version = "0.1.1", path = "tokio-current-thread" }
 tokio-io = { version = "0.1.6", path = "tokio-io" }
 tokio-executor = { version = "0.1.2", path = "tokio-executor" }
 tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }
 tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool" }
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp" }
 tokio-udp = { version = "0.1.0", path = "tokio-udp" }
-tokio-timer = { version = "0.2.4", path = "tokio-timer" }
-tokio-fs = { version = "0.1.0", path = "tokio-fs" }
+tokio-timer = { version = "0.2.6", path = "tokio-timer" }
+tokio-fs = { version = "0.1.3", path = "tokio-fs" }
 
 futures = "0.1.20"
 

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4 (August 23, 2018)
+
+* Implement `std::error::Error` for error types (#511).
+
 # 0.1.3 (August 6, 2018)
 
 * Implement `Executor` for `Box<E: Executor>` (#420).

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-executor"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 documentation = "https://docs.rs/tokio-executor/0.1.4/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -4,9 +4,10 @@ name = "tokio-executor"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
 version = "0.1.3"
-documentation = "https://docs.rs/tokio-executor"
+documentation = "https://docs.rs/tokio-executor/0.1.4/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.4")]
+
 //! Task execution related traits and utilities.
 //!
 //! In the Tokio execution model, futures are lazy. When a future is created, no
@@ -31,9 +34,6 @@
 //! [`DefaultExecutor`]: struct.DefaultExecutor.html
 //! [`Park`]: park/index.html
 //! [`Future::poll`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#tymethod.poll
-
-#![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.3")]
 
 extern crate futures;
 

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.8 (August 23, 2018)
+
+* Documentation improvements
+
 # 0.1.7 (June 13, 2018)
 
 * Move `codec::{Encode, Decode, Framed*}` into `tokio-codec` (#353)

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -4,13 +4,14 @@ name = "tokio-io"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.1"
+documentation = "https://docs.rs/tokio-io/0.1.8/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.8")]
+
 //! Core I/O traits and combinators when working with Tokio.
 //!
 //! A description of the high-level I/O combinators can be [found online] in
@@ -5,9 +8,6 @@
 //!
 //! [found online]: https://tokio.rs/docs/getting-started/core/
 //! [low level details]: https://tokio.rs/docs/going-deeper-tokio/core-low-level/
-
-#![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.7")]
 
 #[macro_use]
 extern crate log;

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.4 (August 23, 2018)
+
+* Use a scalable RW lock (#517)
+* Implement std::error::Error for error types (#511)
+* Documentation improvements
+
 # 0.1.3 (August 6, 2018)
 
 * Misc small fixes (#508)

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -4,14 +4,15 @@ name = "tokio-reactor"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1"
+documentation = "https://docs.rs/tokio-reactor/0.1.4/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.4")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
 //! Event loop that drives Tokio I/O resources.
 //!
 //! The reactor is the engine that drives asynchronous I/O resources (like TCP and
@@ -26,9 +29,6 @@
 //! [`Registration`]: struct.Registration.html
 //! [`PollEvented`]: struct.PollEvented.html
 //! [reactor module]: https://docs.rs/tokio/0.1/tokio/reactor/index.html
-
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.3")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate crossbeam_utils;
 #[macro_use]

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.6 (August 23, 2018)
+
+* Misc performance improvements (#466, #468, #470, #475, #534)
+* Documentation improvements (#450)
+* Shutdown backup threads when idle (#489)
+* Implement std::error::Error for error types (#511)
+* Bugfix: handle num_cpus returning zero (#530).
+
 # 0.1.5 (July 3, 2018)
 
 * Fix race condition bug when threads are woken up (#459).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -3,9 +3,10 @@ name = "tokio-threadpool"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
-documentation = "https://docs.rs/tokio-threadpool"
+version = "0.1.6"
+documentation = "https://docs.rs/tokio-threadpool/0.1.6/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.6")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.6 (August 23, 2018)
+
+* Implement `Default` for `timer::Handle` (#553)
+* Provide `DelayQueue` utility (#550)
+* Reduce size of `Delay` struct (#554)
+* Introduce `Timeout`, deprecate `Deadline` (#558)
+
 # 0.2.5 (August 6, 2018)
 
 * Add `Interval::interval` shortcut (#492).

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -3,14 +3,15 @@ name = "tokio-timer"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
+documentation = "https://docs.rs/tokio-timer/0.2.6/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-timer"
 description = """
 Timer facilities for Tokio
 """

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.6")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
 //! Utilities for tracking time.
 //!
 //! This crate provides a number of utilities for working with periods of time:
@@ -21,9 +24,6 @@
 //! [`Timeout`]: struct.Timeout.html
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html
-
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.5")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate tokio_executor;
 

--- a/tokio-udp/CHANGELOG.md
+++ b/tokio-udp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 (August 23, 2018)
+
+* Provide methods to inspect readiness (#522)
+
 # 0.1.1 (June 13, 2018)
 
 * Switch to tokio-codec (#360)

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -4,13 +4,14 @@ name = "tokio-udp"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
+documentation = "https://docs.rs/tokio-udp/0.1.2/tokio_udp"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-udp/0.1"
 description = """
 UDP bindings for tokio.
 """

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.2")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
 //! UDP bindings for `tokio`.
 //!
 //! This module contains the UDP networking types, similar to the standard
@@ -15,9 +18,6 @@
 //! [`SendDgram`]: struct.SendDgram.html
 //! [`UdpFramed`]: struct.UdpFramed.html
 //! [`framed`]: struct.UdpSocket.html#method.framed
-
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.1")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;
 #[macro_use]


### PR DESCRIPTION
This also bumps a number of sub crates:

* tokio-executor (0.1.3)
* tokio-io (0.1.8)
* tokio-reactor (0.1.4)
* tokio-threadpool (0.1.6)
* tokio-timer (0.2.6)
* tokio-udp (0.1.2)