### PR TITLE
Refactor `codec::length_delimited`

### DIFF
--- a/src/length_delimited.rs
+++ b/src/length_delimited.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 use {
     codec::{self, Decoder, Encoder},
     io::{AsyncRead, AsyncWrite},

--- a/src/length_delimited.rs
+++ b/src/length_delimited.rs
@@ -9,7 +9,7 @@ use std::{cmp, fmt};
 use std::error::Error as StdError;
 use std::io::{self, Cursor};
 
-/// Configure length delimited `Codec`s.
+/// Configure length delimited `LengthDelimitedCodec`s.
 ///
 /// `Builder` enables constructing configured length delimited codecs. Note
 /// that not all configuration settings apply to both encoding and decoding. See
@@ -42,14 +42,14 @@ pub struct Builder {
 /// See [module level] documentation for more detail.
 ///
 /// [module level]: index.html
-pub type Framed<T> = codec::Framed<T, Codec>;
+pub type Framed<T> = codec::Framed<T, LengthDelimitedCodec>;
 
 /// Adapts a byte stream to a `Stream` yielding entire frame values.
 ///
 /// See [module level] documentation for more detail.
 ///
 /// [module level]: index.html
-pub type FramedRead<T> = codec::FramedRead<T, Codec>;
+pub type FramedRead<T> = codec::FramedRead<T, LengthDelimitedCodec>;
 
 
 /// Adapts a byte stream to a `Sink` accepting entire frame values.
@@ -57,7 +57,7 @@ pub type FramedRead<T> = codec::FramedRead<T, Codec>;
 /// See [module level] documentation for more detail.
 ///
 /// [module level]: index.html
-pub type FramedWrite<T> = codec::FramedWrite<T, Codec>;
+pub type FramedWrite<T> = codec::FramedWrite<T, LengthDelimitedCodec>;
 
 /// An error when the number of bytes read is more than max frame length.
 pub struct FrameTooBig {
@@ -73,7 +73,7 @@ pub struct FrameTooBig {
 ///
 /// [module level]: index.html
 #[derive(Debug)]
-pub struct Codec {
+pub struct LengthDelimitedCodec {
     // Configuration values
     builder: Builder,
 
@@ -87,10 +87,10 @@ enum DecodeState {
     Data(usize),
 }
 
-// ===== impl Codec ======
+// ===== impl LengthDelimitedCodec ======
 
-impl Codec {
-    /// Creates a new length-delimited `Codec` with the default configuration values.
+impl LengthDelimitedCodec {
+    /// Creates a new `LengthDelimitedCodec` with the default configuration values.
     pub fn new() -> Self {
         Self {
             builder: Builder::new(),
@@ -185,7 +185,7 @@ impl Codec {
     }
 }
 
-impl Decoder for Codec {
+impl Decoder for LengthDelimitedCodec {
     type Item = BytesMut;
     type Error = io::Error;
 
@@ -218,7 +218,7 @@ impl Decoder for Codec {
     }
 }
 
-impl Encoder for Codec {
+impl Encoder for LengthDelimitedCodec {
     type Item = Bytes;
     type Error = io::Error;
 
@@ -507,7 +507,7 @@ impl Builder {
         self
     }
 
-    /// Create a configured length delimited `Codec`
+    /// Create a configured length delimited `LengthDelimitedCodec`
     ///
     /// # Examples
     ///
@@ -524,8 +524,8 @@ impl Builder {
     ///     .new_codec();
     /// # }
     /// ```
-    pub fn new_codec(&self) -> Codec {
-        Codec {
+    pub fn new_codec(&self) -> LengthDelimitedCodec {
+        LengthDelimitedCodec {
             builder: *self,
             state: DecodeState::Head,
         }

--- a/src/length_delimited.rs
+++ b/src/length_delimited.rs
@@ -100,6 +100,24 @@ impl Codec {
         }
     }
 
+    /// Returns the current max frame setting
+    ///
+    /// This is the largest size this codec will accept from the wire. Larger
+    /// frames will be rejected.
+    pub fn max_frame_length(&self) -> usize {
+        self.builder.max_frame_len
+    }
+
+    /// Updates the max frame setting.
+    ///
+    /// The change takes effect the next time a frame is decoded. In other
+    /// words, if a frame is currently in process of being decoded with a frame
+    /// size greater than `val` but less than the max frame length in effect
+    /// before calling this function, then the frame will be allowed.
+    pub fn set_max_frame_length(&mut self, val: usize) {
+        self.builder.max_frame_length(val);
+    }
+
     fn decode_head(&mut self, src: &mut BytesMut) -> io::Result<Option<usize>> {
         let head_len = self.builder.num_head_bytes();
         let field_len = self.builder.length_field_len;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,19 +135,20 @@ pub mod codec {
         //! # Getting started
         //!
         //! If implementing a protocol from scratch, using length delimited framing
-        //! is an easy way to get started. [`Framed::new()`] will adapt a
-        //! full-duplex byte stream with a length delimited framer using default
-        //! configuration values.
+        //! is an easy way to get started. [`Codec::new()`] will return a length
+        //! delimited codec using default configuration values. This can then be
+        //! used to construct a framer to adapt a full-duplex byte stream into a
+        //! stream of frames.
         //!
         //! ```
         //! # extern crate tokio;
         //! use tokio::io::{AsyncRead, AsyncWrite};
-        //! use tokio::codec::length_delimited;
+        //! use tokio::codec::{self, length_delimited};
         //!
         //! fn bind_transport<T: AsyncRead + AsyncWrite>(io: T)
         //!     -> length_delimited::Framed<T>
         //! {
-        //!     length_delimited::Framed::new(io)
+        //!     codec::Framed::new(io, length_delimited::Codec::new())
         //! }
         //! # pub fn main() {}
         //! ```
@@ -170,13 +171,13 @@ pub mod codec {
         //! # extern crate futures;
         //! #
         //! use tokio::io::{AsyncRead, AsyncWrite};
-        //! use tokio::codec::length_delimited;
-        //! use bytes::BytesMut;
+        //! use tokio::codec::{self, length_delimited};
+        //! use bytes::Bytes;
         //! use futures::{Sink, Future};
         //!
         //! fn write_frame<T: AsyncRead + AsyncWrite>(io: T) {
-        //!     let mut transport = length_delimited::Framed::new(io);
-        //!     let frame = BytesMut::from("hello world");
+        //!     let mut transport = codec::Framed::new(io, length_delimited::Codec::new());
+        //!     let frame = Bytes::from("hello world");
         //!
         //!     transport.send(frame).wait().unwrap();
         //! }
@@ -454,7 +455,7 @@ pub mod codec {
         //! # use tokio::codec::length_delimited;
         //! # use bytes::BytesMut;
         //! # fn write_frame<T: AsyncWrite>(io: T) {
-        //! # let _: length_delimited::FramedWrite<T, BytesMut> =
+        //! # let _: length_delimited::FramedWrite<T> =
         //! length_delimited::Builder::new()
         //!     .length_field_length(2)
         //!     .new_write(io);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,9 +146,9 @@ pub mod codec {
         //! use tokio::codec::*;
         //!
         //! fn bind_transport<T: AsyncRead + AsyncWrite>(io: T)
-        //!     -> length_delimited::Framed<T>
+        //!     -> Framed<T, LengthDelimitedCodec>
         //! {
-        //!     codec::Framed::new(io, LengthDelimitedCodec::new())
+        //!     Framed::new(io, LengthDelimitedCodec::new())
         //! }
         //! # pub fn main() {}
         //! ```
@@ -176,7 +176,7 @@ pub mod codec {
         //! use futures::{Sink, Future};
         //!
         //! fn write_frame<T: AsyncRead + AsyncWrite>(io: T) {
-        //!     let mut transport = codec::Framed::new(io, LengthDelimitedCodec::new());
+        //!     let mut transport = Framed::new(io, LengthDelimitedCodec::new());
         //!     let frame = Bytes::from("hello world");
         //!
         //!     transport.send(frame).wait().unwrap();
@@ -455,7 +455,7 @@ pub mod codec {
         //! # use tokio::codec::length_delimited;
         //! # use bytes::BytesMut;
         //! # fn write_frame<T: AsyncWrite>(io: T) {
-        //! # let _: length_delimited::FramedWrite<T> =
+        //! # let _ =
         //! length_delimited::Builder::new()
         //!     .length_field_length(2)
         //!     .new_write(io);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,12 +143,12 @@ pub mod codec {
         //! ```
         //! # extern crate tokio;
         //! use tokio::io::{AsyncRead, AsyncWrite};
-        //! use tokio::codec::{self, length_delimited};
+        //! use tokio::codec::*;
         //!
         //! fn bind_transport<T: AsyncRead + AsyncWrite>(io: T)
         //!     -> length_delimited::Framed<T>
         //! {
-        //!     codec::Framed::new(io, length_delimited::Codec::new())
+        //!     codec::Framed::new(io, LengthDelimitedCodec::new())
         //! }
         //! # pub fn main() {}
         //! ```
@@ -171,12 +171,12 @@ pub mod codec {
         //! # extern crate futures;
         //! #
         //! use tokio::io::{AsyncRead, AsyncWrite};
-        //! use tokio::codec::{self, length_delimited};
+        //! use tokio::codec::*;
         //! use bytes::Bytes;
         //! use futures::{Sink, Future};
         //!
         //! fn write_frame<T: AsyncRead + AsyncWrite>(io: T) {
-        //!     let mut transport = codec::Framed::new(io, length_delimited::Codec::new());
+        //!     let mut transport = codec::Framed::new(io, LengthDelimitedCodec::new());
         //!     let frame = Bytes::from("hello world");
         //!
         //!     transport.send(frame).wait().unwrap();
@@ -479,6 +479,8 @@ pub mod codec {
         //! [`BytesMut`]: https://docs.rs/bytes/0.4/bytes/struct.BytesMut.html
         pub use ::length_delimited::*;
     }
+
+    pub use self::length_delimited::LengthDelimitedCodec;
 }
 
 pub mod io {

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -1,0 +1,554 @@
+extern crate tokio;
+extern crate futures;
+extern crate bytes;
+
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::codec::*;
+
+use bytes::Bytes;
+use futures::{Stream, Sink, Poll};
+use futures::Async::*;
+
+use std::io;
+use std::collections::VecDeque;
+
+macro_rules! mock {
+    ($($x:expr,)*) => {{
+        let mut v = VecDeque::new();
+        v.extend(vec![$($x),*]);
+        Mock { calls: v }
+    }};
+}
+
+
+#[test]
+fn read_empty_io_yields_nothing() {
+    let mut io = FramedRead::new(mock!(), length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_frame_one_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_frame_one_packet_little_endian() {
+    let mut io = length_delimited::Builder::new()
+        .little_endian()
+        .new_read(mock! {
+            Ok(b"\x09\x00\x00\x00abcdefghi"[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_frame_one_packet_native_endian() {
+    let data = if cfg!(target_endian = "big") {
+        b"\x00\x00\x00\x09abcdefghi"
+    } else {
+        b"\x09\x00\x00\x00abcdefghi"
+    };
+    let mut io = length_delimited::Builder::new()
+        .native_endian()
+        .new_read(mock! {
+            Ok(data[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_multi_frame_one_packet() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"\x00\x00\x00\x09abcdefghi");
+    data.extend_from_slice(b"\x00\x00\x00\x03123");
+    data.extend_from_slice(b"\x00\x00\x00\x0bhello world");
+
+    let mut io = FramedRead::new(mock! {
+        Ok(data.into()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"123"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"hello world"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_frame_multi_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00"[..].into()),
+        Ok(b"\x00\x09abc"[..].into()),
+        Ok(b"defghi"[..].into()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_multi_frame_multi_packet() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00"[..].into()),
+        Ok(b"\x00\x09abc"[..].into()),
+        Ok(b"defghi"[..].into()),
+        Ok(b"\x00\x00\x00\x0312"[..].into()),
+        Ok(b"3\x00\x00\x00\x0bhello world"[..].into()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"123"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"hello world"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_frame_multi_packet_wait() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00"[..].into()),
+        Err(would_block()),
+        Ok(b"\x00\x09abc"[..].into()),
+        Err(would_block()),
+        Ok(b"defghi"[..].into()),
+        Err(would_block()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_multi_frame_multi_packet_wait() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00"[..].into()),
+        Err(would_block()),
+        Ok(b"\x00\x09abc"[..].into()),
+        Err(would_block()),
+        Ok(b"defghi"[..].into()),
+        Err(would_block()),
+        Ok(b"\x00\x00\x00\x0312"[..].into()),
+        Err(would_block()),
+        Ok(b"3\x00\x00\x00\x0bhello world"[..].into()),
+        Err(would_block()),
+    }, length_delimited::Codec::new());
+
+
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"123"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"hello world"[..].into())));
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_incomplete_head() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00"[..].into()),
+    }, length_delimited::Codec::new());
+
+    assert!(io.poll().is_err());
+}
+
+#[test]
+fn read_incomplete_head_multi() {
+    let mut io = FramedRead::new(mock! {
+        Err(would_block()),
+        Ok(b"\x00"[..].into()),
+        Err(would_block()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert!(io.poll().is_err());
+}
+
+#[test]
+fn read_incomplete_payload() {
+    let mut io = FramedRead::new(mock! {
+        Ok(b"\x00\x00\x00\x09ab"[..].into()),
+        Err(would_block()),
+        Ok(b"cd"[..].into()),
+        Err(would_block()),
+    }, length_delimited::Codec::new());
+
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert_eq!(io.poll().unwrap(), NotReady);
+    assert!(io.poll().is_err());
+}
+
+#[test]
+fn read_max_frame_len() {
+    let mut io = length_delimited::Builder::new()
+        .max_frame_length(5)
+        .new_read(mock! {
+            Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
+}
+
+// #[test]
+// fn read_update_max_frame_len_at_rest() {
+//     let mut io = length_delimited::Builder::new()
+//         .new_read(mock! {
+//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+//         });
+
+//     assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+//     io.set_max_frame_length(5);
+//     assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
+// }
+
+// #[test]
+// fn read_update_max_frame_len_in_flight() {
+//     let mut io = length_delimited::Builder::new()
+//         .new_read(mock! {
+//             Ok(b"\x00\x00\x00\x09abcd"[..].into()),
+//             Err(would_block()),
+//             Ok(b"efghi"[..].into()),
+//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+//         });
+
+//     assert_eq!(io.poll().unwrap(), NotReady);
+//     io.set_max_frame_length(5);
+//     assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+//     assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
+// }
+
+#[test]
+fn read_one_byte_length_field() {
+    let mut io = length_delimited::Builder::new()
+        .length_field_length(1)
+        .new_read(mock! {
+            Ok(b"\x09abcdefghi"[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_header_offset() {
+    let mut io = length_delimited::Builder::new()
+        .length_field_length(2)
+        .length_field_offset(4)
+        .new_read(mock! {
+            Ok(b"zzzz\x00\x09abcdefghi"[..].into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_multi_frame_one_packet_skip_none_adjusted() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"xx\x00\x09abcdefghi");
+    data.extend_from_slice(b"yy\x00\x03123");
+    data.extend_from_slice(b"zz\x00\x0bhello world");
+
+    let mut io = length_delimited::Builder::new()
+        .length_field_length(2)
+        .length_field_offset(2)
+        .num_skip(0)
+        .length_adjustment(4)
+        .new_read(mock! {
+            Ok(data.into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"xx\x00\x09abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"yy\x00\x03123"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"zz\x00\x0bhello world"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn read_single_multi_frame_one_packet_length_includes_head() {
+    let mut data: Vec<u8> = vec![];
+    data.extend_from_slice(b"\x00\x0babcdefghi");
+    data.extend_from_slice(b"\x00\x05123");
+    data.extend_from_slice(b"\x00\x0dhello world");
+
+    let mut io = length_delimited::Builder::new()
+        .length_field_length(2)
+        .length_adjustment(-2)
+        .new_read(mock! {
+            Ok(data.into()),
+        });
+
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"123"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"hello world"[..].into())));
+    assert_eq!(io.poll().unwrap(), Ready(None));
+}
+
+#[test]
+fn write_single_frame_length_adjusted() {
+    let mut io = length_delimited::Builder::new()
+        .length_adjustment(-2)
+        .new_write(mock! {
+            Ok(b"\x00\x00\x00\x0b"[..].into()),
+            Ok(b"abcdefghi"[..].into()),
+            Ok(Flush),
+        });
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_nothing_yields_nothing() {
+    let mut io: length_delimited::FramedWrite<_> = FramedWrite::new(
+        mock!(),
+        length_delimited::Codec::new()
+    );
+    assert!(io.poll_complete().unwrap().is_ready());
+}
+
+#[test]
+fn write_single_frame_one_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(b"\x00\x00\x00\x09"[..].into()),
+        Ok(b"abcdefghi"[..].into()),
+        Ok(Flush),
+    }, length_delimited::Codec::new());
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_single_multi_frame_one_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(b"\x00\x00\x00\x09"[..].into()),
+        Ok(b"abcdefghi"[..].into()),
+        Ok(b"\x00\x00\x00\x03"[..].into()),
+        Ok(b"123"[..].into()),
+        Ok(b"\x00\x00\x00\x0b"[..].into()),
+        Ok(b"hello world"[..].into()),
+        Ok(Flush),
+    }, length_delimited::Codec::new());
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.start_send(Bytes::from("123")).unwrap().is_ready());
+    assert!(io.start_send(Bytes::from("hello world")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_single_multi_frame_multi_packet() {
+    let mut io = FramedWrite::new(mock! {
+        Ok(b"\x00\x00\x00\x09"[..].into()),
+        Ok(b"abcdefghi"[..].into()),
+        Ok(Flush),
+        Ok(b"\x00\x00\x00\x03"[..].into()),
+        Ok(b"123"[..].into()),
+        Ok(Flush),
+        Ok(b"\x00\x00\x00\x0b"[..].into()),
+        Ok(b"hello world"[..].into()),
+        Ok(Flush),
+    }, length_delimited::Codec::new());
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.start_send(Bytes::from("123")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.start_send(Bytes::from("hello world")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_single_frame_would_block() {
+    let mut io = FramedWrite::new(mock! {
+        Err(would_block()),
+        Ok(b"\x00\x00"[..].into()),
+        Err(would_block()),
+        Ok(b"\x00\x09"[..].into()),
+        Ok(b"abcdefghi"[..].into()),
+        Ok(Flush),
+    }, length_delimited::Codec::new());
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(!io.poll_complete().unwrap().is_ready());
+    assert!(!io.poll_complete().unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_single_frame_little_endian() {
+    let mut io = length_delimited::Builder::new()
+        .little_endian()
+        .new_write(mock! {
+            Ok(b"\x09\x00\x00\x00"[..].into()),
+            Ok(b"abcdefghi"[..].into()),
+            Ok(Flush),
+        });
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+
+#[test]
+fn write_single_frame_with_short_length_field() {
+    let mut io = length_delimited::Builder::new()
+        .length_field_length(1)
+        .new_write(mock! {
+            Ok(b"\x09"[..].into()),
+            Ok(b"abcdefghi"[..].into()),
+            Ok(Flush),
+        });
+
+    assert!(io.start_send(Bytes::from("abcdefghi")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
+fn write_max_frame_len() {
+    let mut io = length_delimited::Builder::new()
+        .max_frame_length(5)
+        .new_write(mock! { });
+
+    assert_eq!(io.start_send(Bytes::from("abcdef")).unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    assert!(io.get_ref().calls.is_empty());
+}
+
+// #[test]
+// fn write_update_max_frame_len_at_rest() {
+//     let mut io = length_delimited::Builder::new()
+//         .new_write(mock! {
+//             Ok(b"\x00\x00\x00\x06"[..].into()),
+//             Ok(b"abcdef"[..].into()),
+//             Ok(Flush),
+//         });
+
+//     assert!(io.start_send(Bytes::from("abcdef").unwrap().is_ready());
+//     assert!(io.poll_complete().unwrap().is_ready());
+//     io.set_max_frame_length(5);
+//     assert_eq!(io.start_send(Bytes::from("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
+//     assert!(io.get_ref().calls.is_empty());
+// }
+
+// #[test]
+// fn write_update_max_frame_len_in_flight() {
+//     let mut io = length_delimited::Builder::new()
+//         .new_write(mock! {
+//             Ok(b"\x00\x00\x00\x06"[..].into()),
+//             Ok(b"ab"[..].into()),
+//             Err(would_block()),
+//             Ok(b"cdef"[..].into()),
+//             Ok(Flush),
+//         });
+
+//     assert!(io.start_send(Bytes::from("abcdef").unwrap().is_ready());
+//     assert!(!io.poll_complete().unwrap().is_ready());
+//     io.set_max_frame_length(5);
+//     assert!(io.poll_complete().unwrap().is_ready());
+//     assert_eq!(io.start_send(Bytes::from("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
+//     assert!(io.get_ref().calls.is_empty());
+// }
+
+// ===== Test utils =====
+
+fn would_block() -> io::Error {
+    io::Error::new(io::ErrorKind::WouldBlock, "would block")
+}
+
+struct Mock {
+    calls: VecDeque<io::Result<Op>>,
+}
+
+enum Op {
+    Data(Vec<u8>),
+    Flush,
+}
+
+use self::Op::*;
+
+impl io::Read for Mock {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        match self.calls.pop_front() {
+            Some(Ok(Op::Data(data))) => {
+                debug_assert!(dst.len() >= data.len());
+                dst[..data.len()].copy_from_slice(&data[..]);
+                Ok(data.len())
+            }
+            Some(Ok(_)) => panic!(),
+            Some(Err(e)) => Err(e),
+            None => Ok(0),
+        }
+    }
+}
+
+impl AsyncRead for Mock {
+}
+
+impl io::Write for Mock {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        match self.calls.pop_front() {
+            Some(Ok(Op::Data(data))) => {
+                let len = data.len();
+                assert!(src.len() >= len, "expect={:?}; actual={:?}", data, src);
+                assert_eq!(&data[..], &src[..len]);
+                Ok(len)
+            }
+            Some(Ok(_)) => panic!(),
+            Some(Err(e)) => Err(e),
+            None => Ok(0),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self.calls.pop_front() {
+            Some(Ok(Op::Flush)) => {
+                Ok(())
+            }
+            Some(Ok(_)) => panic!(),
+            Some(Err(e)) => Err(e),
+            None => Ok(()),
+        }
+    }
+}
+
+impl AsyncWrite for Mock {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        Ok(Ready(()))
+    }
+}
+
+impl<'a> From<&'a [u8]> for Op {
+    fn from(src: &'a [u8]) -> Op {
+        Op::Data(src.into())
+    }
+}
+
+impl From<Vec<u8>> for Op {
+    fn from(src: Vec<u8>) -> Op {
+        Op::Data(src)
+    }
+}

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -204,34 +204,34 @@ fn read_max_frame_len() {
     assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
 }
 
-// #[test]
-// fn read_update_max_frame_len_at_rest() {
-//     let mut io = length_delimited::Builder::new()
-//         .new_read(mock! {
-//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
-//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
-//         });
+#[test]
+fn read_update_max_frame_len_at_rest() {
+    let mut io = length_delimited::Builder::new()
+        .new_read(mock! {
+            Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+            Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+        });
 
-//     assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
-//     io.set_max_frame_length(5);
-//     assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
-// }
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    io.decoder_mut().set_max_frame_length(5);
+    assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
+}
 
-// #[test]
-// fn read_update_max_frame_len_in_flight() {
-//     let mut io = length_delimited::Builder::new()
-//         .new_read(mock! {
-//             Ok(b"\x00\x00\x00\x09abcd"[..].into()),
-//             Err(would_block()),
-//             Ok(b"efghi"[..].into()),
-//             Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
-//         });
+#[test]
+fn read_update_max_frame_len_in_flight() {
+    let mut io = length_delimited::Builder::new()
+        .new_read(mock! {
+            Ok(b"\x00\x00\x00\x09abcd"[..].into()),
+            Err(would_block()),
+            Ok(b"efghi"[..].into()),
+            Ok(b"\x00\x00\x00\x09abcdefghi"[..].into()),
+        });
 
-//     assert_eq!(io.poll().unwrap(), NotReady);
-//     io.set_max_frame_length(5);
-//     assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
-//     assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
-// }
+    assert_eq!(io.poll().unwrap(), NotReady);
+    io.decoder_mut().set_max_frame_length(5);
+    assert_eq!(io.poll().unwrap(), Ready(Some(b"abcdefghi"[..].into())));
+    assert_eq!(io.poll().unwrap_err().kind(), io::ErrorKind::InvalidData);
+}
 
 #[test]
 fn read_one_byte_length_field() {
@@ -438,40 +438,40 @@ fn write_max_frame_len() {
     assert!(io.get_ref().calls.is_empty());
 }
 
-// #[test]
-// fn write_update_max_frame_len_at_rest() {
-//     let mut io = length_delimited::Builder::new()
-//         .new_write(mock! {
-//             Ok(b"\x00\x00\x00\x06"[..].into()),
-//             Ok(b"abcdef"[..].into()),
-//             Ok(Flush),
-//         });
+#[test]
+fn write_update_max_frame_len_at_rest() {
+    let mut io = length_delimited::Builder::new()
+        .new_write(mock! {
+            Ok(b"\x00\x00\x00\x06"[..].into()),
+            Ok(b"abcdef"[..].into()),
+            Ok(Flush),
+        });
 
-//     assert!(io.start_send(Bytes::from("abcdef").unwrap().is_ready());
-//     assert!(io.poll_complete().unwrap().is_ready());
-//     io.set_max_frame_length(5);
-//     assert_eq!(io.start_send(Bytes::from("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
-//     assert!(io.get_ref().calls.is_empty());
-// }
+    assert!(io.start_send(Bytes::from("abcdef")).unwrap().is_ready());
+    assert!(io.poll_complete().unwrap().is_ready());
+    io.encoder_mut().set_max_frame_length(5);
+    assert_eq!(io.start_send(Bytes::from("abcdef")).unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    assert!(io.get_ref().calls.is_empty());
+}
 
-// #[test]
-// fn write_update_max_frame_len_in_flight() {
-//     let mut io = length_delimited::Builder::new()
-//         .new_write(mock! {
-//             Ok(b"\x00\x00\x00\x06"[..].into()),
-//             Ok(b"ab"[..].into()),
-//             Err(would_block()),
-//             Ok(b"cdef"[..].into()),
-//             Ok(Flush),
-//         });
+#[test]
+fn write_update_max_frame_len_in_flight() {
+    let mut io = length_delimited::Builder::new()
+        .new_write(mock! {
+            Ok(b"\x00\x00\x00\x06"[..].into()),
+            Ok(b"ab"[..].into()),
+            Err(would_block()),
+            Ok(b"cdef"[..].into()),
+            Ok(Flush),
+        });
 
-//     assert!(io.start_send(Bytes::from("abcdef").unwrap().is_ready());
-//     assert!(!io.poll_complete().unwrap().is_ready());
-//     io.set_max_frame_length(5);
-//     assert!(io.poll_complete().unwrap().is_ready());
-//     assert_eq!(io.start_send(Bytes::from("abcdef").unwrap_err().kind(), io::ErrorKind::InvalidInput);
-//     assert!(io.get_ref().calls.is_empty());
-// }
+    assert!(io.start_send(Bytes::from("abcdef")).unwrap().is_ready());
+    assert!(!io.poll_complete().unwrap().is_ready());
+    io.encoder_mut().set_max_frame_length(5);
+    assert!(io.poll_complete().unwrap().is_ready());
+    assert_eq!(io.start_send(Bytes::from("abcdef")).unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    assert!(io.get_ref().calls.is_empty());
+}
 
 // ===== Test utils =====
 

--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -316,7 +316,7 @@ fn write_single_frame_length_adjusted() {
 
 #[test]
 fn write_nothing_yields_nothing() {
-    let mut io: length_delimited::FramedWrite<_> = FramedWrite::new(
+    let mut io = FramedWrite::new(
         mock!(),
         LengthDelimitedCodec::new()
     );


### PR DESCRIPTION
## Motivation

The current `tokio::codec::length_delimited` module provides its own
`Framed`, `FramedRead`, and `FramedWrite` types which provide the same
functionality as the types of the same name in the `codec` module.
However, it's not currently possible to use the `codec::Framed{Read, Write}`
 types with the length-delimited codec; instead, the separate
types in the `length_delimited` module must be used.

## Solution

This branch unifies `length_delimited` with the rest of `tokio::codec`,
by replacing the private `length_delimited::Decoder` type with a public
`length_delimited::Codec` that implements both `codec::Encoder` and
`codec::Decoder`. It may now be used with the `Framed`, `FramedRead`,
and `FramedWrite` types in `tokio_codec`. This branch also updates the
API documentation and tests to reflect these changes.

Refs: #500 