### PR TITLE
Fix non-terminating loop in `tokio_io::length_delimited::FramedWrite`

### DIFF
--- a/tests/length_delimited.rs
+++ b/tests/length_delimited.rs
@@ -473,6 +473,16 @@ fn write_update_max_frame_len_in_flight() {
     assert!(io.get_ref().calls.is_empty());
 }
 
+#[test]
+fn write_zero() {
+    let mut io = length_delimited::Builder::new()
+        .new_write(mock! { });
+
+    assert!(io.start_send(Bytes::from("abcdef")).unwrap().is_ready());
+    assert_eq!(io.poll_complete().unwrap_err().kind(), io::ErrorKind::WriteZero);
+    assert!(io.get_ref().calls.is_empty());
+}
+
 // ===== Test utils =====
 
 fn would_block() -> io::Error {

--- a/tokio-io/src/length_delimited.rs
+++ b/tokio-io/src/length_delimited.rs
@@ -455,7 +455,12 @@ impl<T: AsyncWrite, B: IntoBuf> FramedWrite<T, B> {
 
         loop {
             let frame = self.frame.as_mut().unwrap();
-            try_ready!(self.inner.write_buf(frame));
+            if try_ready!(self.inner.write_buf(frame)) == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write frame to transport",
+                ));
+            }
 
             if !frame.has_remaining() {
                 break;

--- a/tokio-io/tests/length_delimited.rs
+++ b/tokio-io/tests/length_delimited.rs
@@ -434,6 +434,16 @@ fn write_max_frame_len() {
 }
 
 #[test]
+fn write_zero() {
+    let mut io = Builder::new()
+        .new_write(mock! { });
+
+    assert!(io.start_send("abcdef").unwrap().is_ready());
+    assert_eq!(io.poll_complete().unwrap_err().kind(), io::ErrorKind::WriteZero);
+    assert!(io.get_ref().calls.is_empty());
+}
+
+#[test]
 fn write_update_max_frame_len_at_rest() {
     let mut io = Builder::new()
         .new_write(mock! {


### PR DESCRIPTION
## Motivation

There is currently an issue in the deprecated
`length_delimited::FramedWrite` implementation in the `tokio-io` crate:
when the underlying writer returns `Ok(0)` (indicating that it can no
longer accept any additional bytes), the `FramedWrite` continues to loop
rather than returning a `WriteZero` error. This issue does _not_ exist
in the `FramedWrite` type added to `tokio::codec::length_delimited` in
#575, as this is just a type alias for the `codec::FramedWrite` type
with a length-delimited `Encoder`, and the issue does not exist there.

## Solution

This branch adds tests for this issue to the tests for both versions of
`length_delimited`, and fixes the (deprecated)
`tokio::io::length_delimited::FramedWrite` type so that both tests pass.
Since the new `tokio::codec::length_delimited::FramedWrite` alias does
not have this bug, no additional work was necessary for its version of
the test to pass.

Fixes: #497, #500

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
