### PR TITLE
tokio: Link to tokio_current_thread::spawn

### DIFF
--- a/src/runtime/current_thread/mod.rs
+++ b/src/runtime/current_thread/mod.rs
@@ -15,6 +15,12 @@
 //! Note that [`current_thread::Runtime`][rt] does not implement `Send` itself
 //! and cannot be safely moved to other threads.
 //!
+//! # Spawning futures that are not `Send`.
+//!
+//! The runtime uses the [`tokio-current-thread`](https://docs.rs/tokio-current-thread) under the
+//! hood. Use the functions from there, specifically
+//! [`tokio_current_thread::spawn`](https://docs.rs/tokio-current-thread/*/tokio_current_thread/fn.spawn.html).
+//!
 //! # Spawning from other threads
 //!
 //! While [`current_thread::Runtime`][rt] does not implement `Send` and cannot


### PR DESCRIPTION
Since deprecating the tokio::executor::current_thread, it is quite hard
to find any way to spawn non-Send tasks. At least link it from the
single threaded runtime.

I'm not 100% sure this is the best place, but I think it should be mentioned *somewhere*.