### PR TITLE
Reexport tokio-current-thread::spawn

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -39,7 +39,10 @@
 //! [`Executor`]: trait.Executor.html
 //! [`spawn`]: fn.spawn.html
 
-#[deprecated(since = "0.1.8", note = "use tokio-current-thread crate instead")]
+#[deprecated(
+    since = "0.1.8",
+    note = "use tokio-current-thread crate or functions in tokio::runtime::current_thread instead",
+)]
 #[doc(hidden)]
 pub mod current_thread;
 

--- a/src/runtime/current_thread/mod.rs
+++ b/src/runtime/current_thread/mod.rs
@@ -71,6 +71,7 @@ mod runtime;
 
 pub use self::builder::Builder;
 pub use self::runtime::{Runtime, Handle};
+pub use tokio_current_thread::spawn;
 
 use futures::Future;
 


### PR DESCRIPTION
Reexport it inside the tokio::runtime::current_thread, as the original
place (tokio::executor::current_thread) is hidden from documentation and
users need some way to spawn non-Send futures.
