### PR TITLE
Fix tokio-uds version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ futures = "0.1.20"
 mio = "0.6.14"
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "0.2.0", path = "tokio-uds" }
+tokio-uds = { version = "0.2.1", path = "tokio-uds" }
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }


### PR DESCRIPTION
`ConnectFuture` seems not to be exported in `0.2.0` of `tokio-uds` making it incompatible. This PR bumps the version to `0.2.1`.

The futures crate has this in its CI which detected this:
```
cargo update -Zminimal-versions
cargo test --all --all-features
```