### PR TITLE
Add max line length to `LinesCodec`

### DIFF
--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -12,12 +12,44 @@ pub struct LinesCodec {
     // The next time `decode` is called with `abcde\n`, the method will
     // only look at `de\n` before returning.
     next_index: usize,
+
+    /// The maximum length for a given line. If `None`, lines will be read
+    /// until a `\n` character is reached.
+    max_length: Option<usize>,
 }
 
 impl LinesCodec {
     /// Returns a `LinesCodec` for splitting up data into lines.
     pub fn new() -> LinesCodec {
-        LinesCodec { next_index: 0 }
+        LinesCodec {
+            next_index: 0,
+            max_length: None,
+        }
+    }
+
+    /// Sets a limit on the maximum line length when decoding.
+    ///
+    /// If this is set, lines will be ended when a `\n` character is read, _or_
+    /// when they reach the provided number of bytes. Otherwise, lines will
+    /// only be ended when a `\n` character is read.
+    pub fn set_decode_max_line_length(&mut self, limit: usize) -> &mut Self {
+        self.max_length = Some(limit);
+        self
+    }
+
+    /// Returns the current maximum line length when decoding, if one is set.
+    ///
+    /// ```
+    /// use tokio_codec::LinesCodec;
+    ///
+    /// let mut codec = LinesCodec::new();
+    /// assert_eq!(codec.decode_max_line_length(), None);
+    ///
+    /// codec.set_decode_max_line_length(256);
+    /// assert_eq!(codec.decode_max_line_length(), Some(256));
+    /// ```
+    pub fn decode_max_line_length(&self) -> Option<usize> {
+        self.max_length
     }
 }
 
@@ -41,12 +73,33 @@ impl Decoder for LinesCodec {
     type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
-        if let Some(newline_offset) =
-            buf[self.next_index..].iter().position(|b| *b == b'\n')
-        {
-            let newline_index = newline_offset + self.next_index;
+        let mut trim_and_offset = None;
+        for (offset, b) in buf[self.next_index..].iter().enumerate() {
+           trim_and_offset = match (b, self.max_length) {
+                // The current character is a newline, split here.
+                (b'\n', _) => Some((1, offset)),
+                // There's a maximum line length set, and we've reached it.
+                (_, Some(max_len)) if offset == max_len =>
+                    // If we're at the line length limit, check if the next
+                    // character(s) is a newline --- if so, slice that off
+                    // as well, so that the next call to `decode` doesn't
+                    // return an empty line.
+                    match buf[offset + 1] {
+                        b'\r' if buf[offset + 2] == b'\n' =>
+                            Some((2, offset + 2)),
+                        b'\n' => Some((1, offset + 1)),
+                        _ => Some((0, offset)),
+                    },
+                // The current character isn't a newline, and we aren't at the
+                // length limit, so keep going.
+                _ => continue,
+            };
+            break;
+        };
+        if let Some((trim_amt, offset)) = trim_and_offset {
+            let newline_index = offset + self.next_index;
             let line = buf.split_to(newline_index + 1);
-            let line = &line[..line.len()-1];
+            let line = &line[..line.len() - trim_amt];
             let line = without_carriage_return(line);
             let line = utf8(line)?;
             self.next_index = 0;

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -20,6 +20,15 @@ pub struct LinesCodec {
 
 impl LinesCodec {
     /// Returns a `LinesCodec` for splitting up data into lines.
+    ///
+    /// # Note
+    ///
+    /// The returned `LinesCodec` will not have an upper bound on the length
+    /// of a buffered line. See the documentation for
+    /// [`set_decode_max_line_length`] for information on why this could be
+    /// a potential security risk.
+    ///
+    /// [`set_decode_max_line_length`]: #method.set_decode_max_line_length
     pub fn new() -> LinesCodec {
         LinesCodec {
             next_index: 0,
@@ -32,6 +41,14 @@ impl LinesCodec {
     /// If this is set, lines will be ended when a `\n` character is read, _or_
     /// when they reach the provided number of bytes. Otherwise, lines will
     /// only be ended when a `\n` character is read.
+    ///
+    /// # Note
+    ///
+    /// Setting a length limit is highly recommended for any `LinesCodec` which
+    /// will be exposed to untrusted input. Otherwise, the size of the buffer
+    /// that holds the line currently being read is unbounded. An attacker could
+    /// exploit this unbounded buffer by sending an unbounded amount of input
+    /// without any `\n` characters, causing unbounded memory consumption.
     pub fn set_decode_max_line_length(&mut self, limit: usize) -> &mut Self {
         self.max_length = Some(limit);
         self

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -24,11 +24,10 @@ impl LinesCodec {
     /// # Note
     ///
     /// The returned `LinesCodec` will not have an upper bound on the length
-    /// of a buffered line. See the documentation for
-    /// [`set_decode_max_line_length`] for information on why this could be
-    /// a potential security risk.
+    /// of a buffered line. See the documentation for [`with_max_length`]
+    /// for information on why this could be a potential security risk.
     ///
-    /// [`set_decode_max_line_length`]: #method.set_decode_max_line_length
+    /// [`with_max_length`]: #method.with_max_length
     pub fn new() -> LinesCodec {
         LinesCodec {
             next_index: 0,
@@ -36,7 +35,7 @@ impl LinesCodec {
         }
     }
 
-    /// Sets a limit on the maximum line length when decoding.
+    /// Returns a `LinesCodec` with a maximum line length limit.
     ///
     /// If this is set, lines will be ended when a `\n` character is read, _or_
     /// when they reach the provided number of bytes. Otherwise, lines will
@@ -49,9 +48,11 @@ impl LinesCodec {
     /// that holds the line currently being read is unbounded. An attacker could
     /// exploit this unbounded buffer by sending an unbounded amount of input
     /// without any `\n` characters, causing unbounded memory consumption.
-    pub fn set_decode_max_line_length(&mut self, limit: usize) -> &mut Self {
-        self.max_length = Some(limit - 1);
-        self
+    pub fn with_max_length(limit: usize) -> Self {
+        LinesCodec {
+            max_length: Some(limit - 1),
+            ..LinesCodec::new()
+        }
     }
 
     /// Returns the current maximum line length when decoding, if one is set.
@@ -59,13 +60,16 @@ impl LinesCodec {
     /// ```
     /// use tokio_codec::LinesCodec;
     ///
-    /// let mut codec = LinesCodec::new();
-    /// assert_eq!(codec.decode_max_line_length(), None);
-    ///
-    /// codec.set_decode_max_line_length(256);
-    /// assert_eq!(codec.decode_max_line_length(), Some(256));
+    /// let codec = LinesCodec::new();
+    /// assert_eq!(codec.decode_max_length(), None);
     /// ```
-    pub fn decode_max_line_length(&self) -> Option<usize> {
+    /// ```
+    /// use tokio_codec::LinesCodec;
+    ///
+    /// let codec = LinesCodec::with_max_length(256);
+    /// assert_eq!(codec.decode_max_length(), Some(256));
+    /// ```
+    pub fn decode_max_length(&self) -> Option<usize> {
         self.max_length.map(|len| len + 1)
     }
 }

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -50,7 +50,7 @@ impl LinesCodec {
     /// exploit this unbounded buffer by sending an unbounded amount of input
     /// without any `\n` characters, causing unbounded memory consumption.
     pub fn set_decode_max_line_length(&mut self, limit: usize) -> &mut Self {
-        self.max_length = Some(limit);
+        self.max_length = Some(limit - 1);
         self
     }
 

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -122,7 +122,8 @@ impl Decoder for LinesCodec {
                         _ => {
                             // We've reached the length limit, and we're not at
                             // the end of a line. Subsequent calls to decode
-                            // will now discard from the buffer until
+                            // will now discard from the buffer until we reach
+                            // a new line.
                             self.is_discarding = true;
                             self.next_index += offset;
                             return Err(io::Error::new(

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -116,9 +116,9 @@ impl Decoder for LinesCodec {
                     // If we're at the line length limit, check if the next
                     // character(s) is a newline before we decide to return an
                     // error.
-                    match (buf[offset + 1], buf[offset + 2]) {
-                        (b'\n', _) => Some((1, offset + 1)),
-                        (b'\r', b'\n') => Some((2, offset + 2)),
+                    match (buf.get(offset + 1), buf.get(offset + 2)) {
+                        (Some(&b'\n'), _) => Some((1, offset + 1)),
+                        (Some(&b'\r'), Some(&b'\n')) => Some((2, offset + 2)),
                         _ => {
                             // We've reached the length limit, and we're not at
                             // the end of a line. Subsequent calls to decode

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -66,7 +66,7 @@ impl LinesCodec {
     /// assert_eq!(codec.decode_max_line_length(), Some(256));
     /// ```
     pub fn decode_max_line_length(&self) -> Option<usize> {
-        self.max_length
+        self.max_length.map(|len| len + 1)
     }
 }
 

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -92,7 +92,7 @@ impl Decoder for LinesCodec {
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
         let mut trim_and_offset = None;
         for (offset, b) in buf[self.next_index..].iter().enumerate() {
-           trim_and_offset = match (b, self.max_length) {
+            trim_and_offset = match (b, self.max_length) {
                 // The current character is a newline, split here.
                 (&b'\n', _) => Some((1, offset)),
                 // There's a maximum line length set, and we've reached it.
@@ -101,11 +101,10 @@ impl Decoder for LinesCodec {
                     // character(s) is a newline --- if so, slice that off
                     // as well, so that the next call to `decode` doesn't
                     // return an empty line.
-                    match buf[offset + 1] {
-                        b'\r' if buf[offset + 2] == b'\n' =>
-                            Some((2, offset + 2)),
-                        b'\n' => Some((1, offset + 1)),
-                        _ => Some((0, offset)),
+                    match &buf[offset + 1..=offset + 2] {
+                        &[b'\n', _] => Some((1, offset + 1)),
+                        &[b'\r', b'\n'] => Some((2, offset + 2)),
+                        _ => Some((0, offset))
                     },
                 // The current character isn't a newline, and we aren't at the
                 // length limit, so keep going.

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -94,7 +94,7 @@ impl Decoder for LinesCodec {
         for (offset, b) in buf[self.next_index..].iter().enumerate() {
            trim_and_offset = match (b, self.max_length) {
                 // The current character is a newline, split here.
-                (b'\n', _) => Some((1, offset)),
+                (&b'\n', _) => Some((1, offset)),
                 // There's a maximum line length set, and we've reached it.
                 (_, Some(max_len)) if offset == max_len =>
                     // If we're at the line length limit, check if the next

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -91,6 +91,11 @@ fn lines_decoder_max_length() {
 
     assert_eq!(None, codec.decode(buf).unwrap());
     assert_eq!(None, codec.decode_eof(buf).unwrap());
+
+    // Line that's one character too long. This could cause an out of bounds
+    // error if we peek at the next characters using slice indexing.
+    buf.put("aaabbbc");
+    assert!(codec.decode(buf).is_err());
 }
 
 #[test]

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -97,6 +97,20 @@ fn lines_decoder_max_length() {
     buf.put("aaabbbc");
     assert!(codec.decode(buf).is_err());
 }
+#[test]
+fn lines_decoder_max_length_underrun() {
+    const MAX_LENGTH: usize = 6;
+
+    let mut codec = LinesCodec::with_max_length(MAX_LENGTH);
+    let buf = &mut BytesMut::new();
+    buf.put("line ");
+    assert_eq!(None, codec.decode(buf).unwrap());
+
+    buf.put("too l");
+    assert_eq!(None, codec.decode(buf).unwrap());
+    buf.put("ong\n");
+    assert_eq!("line too long", codec.decode(buf).unwrap().unwrap());
+}
 
 #[test]
 fn lines_encoder() {

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -57,22 +57,48 @@ fn lines_decoder() {
 
 #[test]
 fn lines_decoder_max_length() {
+    const MAX_LENGTH: usize = 6;
+
     let mut codec = LinesCodec::new();
-    codec.set_decode_max_line_length(5);
+    codec.set_decode_max_line_length(MAX_LENGTH);
     let buf = &mut BytesMut::new();
+
     buf.reserve(200);
     buf.put("line 1 is too long\nline 2\r\nline 3\n\r\n\r");
-    assert_eq!("line 1", codec.decode(buf).unwrap().unwrap());
-    assert_eq!(" is to", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("o long", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("line 2", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("line 3", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("", codec.decode(buf).unwrap().unwrap());
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!("line 1", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!(" is to", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!("o long", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!("line 2", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!("line 3", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert_eq!("", line);
+
     assert_eq!(None, codec.decode(buf).unwrap());
     assert_eq!(None, codec.decode_eof(buf).unwrap());
     buf.put("k");
     assert_eq!(None, codec.decode(buf).unwrap());
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
     assert_eq!("\rk", codec.decode_eof(buf).unwrap().unwrap());
+
     assert_eq!(None, codec.decode(buf).unwrap());
     assert_eq!(None, codec.decode_eof(buf).unwrap());
 }
@@ -86,14 +112,31 @@ fn lines_decoder_max_length_in_flight() {
 
     assert_eq!("line 1 is too long", codec.decode(buf).unwrap().unwrap());
 
-    codec.set_decode_max_line_length(5);
-    assert_eq!("line 2", codec.decode(buf).unwrap().unwrap());
-    assert_eq!(" is to", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("o long", codec.decode(buf).unwrap().unwrap());
+    let max_length = 6;
+    codec.set_decode_max_line_length(max_length);
 
-    codec.set_decode_max_line_length(256);
-    assert_eq!("line 3 is too long", codec.decode(buf).unwrap().unwrap());
-    assert_eq!("", codec.decode(buf).unwrap().unwrap());
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
+    assert_eq!("line 2", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
+    assert_eq!(" is to", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
+    assert_eq!("o long", line);
+
+    let max_length = 256;
+    codec.set_decode_max_line_length(max_length);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
+    assert_eq!("line 3 is too long", line);
+
+    let line = codec.decode(buf).unwrap().unwrap();
+    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
+    assert_eq!("", line);
 
 }
 

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -65,17 +65,8 @@ fn lines_decoder_max_length() {
     buf.reserve(200);
     buf.put("line 1 is too long\nline 2\r\nline 3\n\r\n\r");
 
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
-    assert_eq!("line 1", line);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
-    assert_eq!(" is to", line);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
-    assert_eq!("o long", line);
+    assert!(codec.decode(buf).is_err());
+    assert!(codec.decode(buf).is_err());
 
     let line = codec.decode(buf).unwrap().unwrap();
     assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -59,8 +59,7 @@ fn lines_decoder() {
 fn lines_decoder_max_length() {
     const MAX_LENGTH: usize = 6;
 
-    let mut codec = LinesCodec::new();
-    codec.set_decode_max_line_length(MAX_LENGTH);
+    let mut codec = LinesCodec::with_max_length(MAX_LENGTH);
     let buf = &mut BytesMut::new();
 
     buf.reserve(200);
@@ -101,43 +100,6 @@ fn lines_decoder_max_length() {
 
     assert_eq!(None, codec.decode(buf).unwrap());
     assert_eq!(None, codec.decode_eof(buf).unwrap());
-}
-
-#[test]
-fn lines_decoder_max_length_in_flight() {
-    let mut codec = LinesCodec::new();
-    let buf = &mut BytesMut::new();
-    buf.reserve(200);
-    buf.put("line 1 is too long\nline 2 is too long\r\nline 3 is too long\n\r\n\r");
-
-    assert_eq!("line 1 is too long", codec.decode(buf).unwrap().unwrap());
-
-    let max_length = 6;
-    codec.set_decode_max_line_length(max_length);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
-    assert_eq!("line 2", line);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
-    assert_eq!(" is to", line);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
-    assert_eq!("o long", line);
-
-    let max_length = 256;
-    codec.set_decode_max_line_length(max_length);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
-    assert_eq!("line 3 is too long", line);
-
-    let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= max_length, "{:?}.len() <= {:?}", line, max_length);
-    assert_eq!("", line);
-
 }
 
 #[test]

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -95,9 +95,9 @@ fn lines_decoder_max_length() {
     buf.put("k");
     assert_eq!(None, codec.decode(buf).unwrap());
 
-    let line = codec.decode(buf).unwrap().unwrap();
+    let line = codec.decode_eof(buf).unwrap().unwrap();
     assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
-    assert_eq!("\rk", codec.decode_eof(buf).unwrap().unwrap());
+    assert_eq!("\rk", line);
 
     assert_eq!(None, codec.decode(buf).unwrap());
     assert_eq!(None, codec.decode_eof(buf).unwrap());


### PR DESCRIPTION
## Motivation

Currently, there is a potential denial of service vulnerability in the
`lines` codec. Since there is no bound on the buffer that holds data
before it is split into a new line, an attacker could send an unbounded
amount of data without sending a `\n` character. 

## Solution

This branch adds a `set_decode_max_line_length` function on `LinesCodec`
that configures a limit on the maximum number of bytes per line. When
the limit is reached, the buffer will be broken into a new "line"
regardless of the presence of a newline character. It was also necessary
to add some special-case logic to avoid creating an empty line when the
length limit is reached at the character immediately _before_ a `\r` or
`\n` character.

Additionally, this branch adds new tests for this function, including a
test for changing the line limit in-flight.

Fixes: #186 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>