### PR TITLE
[tokio-async-await] Fix minimum version to export tokio::codec module

### DIFF
--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -24,7 +24,7 @@ name = "tokio"
 
 [dependencies]
 futures = "0.1.23"
-tokio = { version = "0.1.7", path = ".." }
+tokio = { version = "0.1.8", path = ".." }
 tokio-io = { version = "0.1.7", path = "../tokio-io" }
 tokio-channel = { version = "0.1.0", path = "../tokio-channel", features = ["async-await-preview"] }
 tokio-reactor = { version = "0.1.5", path = "../tokio-reactor", features = ["async-await-preview"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`tokio-async-await` fails to build if there is no other package that depends on tokio 0.1.8, because it uses 0.1.7 of tokio. tokio-async-await trys to export "all" items from tokio explicitly, includes `tokio::codec`. But tokio 0.1.7 doesn't export that item.

https://github.com/tokio-rs/tokio/blob/tokio-0.1.7/src/lib.rs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Simply upgrade the minimum version in `Cargo.toml`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
