### PR TITLE
Update documentation for AsyncRead and AsyncWrite

### DIFF
--- a/tokio-io/src/async_read.rs
+++ b/tokio-io/src/async_read.rs
@@ -16,15 +16,16 @@ use split::{ReadHalf, WriteHalf};
 /// Specifically, this means that the `read` function will return one of the
 /// following:
 ///
-/// * `Ok(n)` means that `n` bytes of data was immediately read and placed into
-///   the output buffer, where `n` == 0 implies that EOF has been reached.
+/// * `Ok(Async::Ready(n))` means that `n` bytes of data was immediately read
+///   and placed into the output buffer, where `n` == 0 implies that EOF has
+///   been reached.
 ///
-/// * `Err(e) if e.kind() == ErrorKind::WouldBlock` means that no data was read
-///   into the buffer provided. The I/O object is not currently readable but may
-///   become readable in the future. Most importantly, **the current future's
-///   task is scheduled to get unparked when the object is readable**. This
-///   means that like `Future::poll` you'll receive a notification when the I/O
-///   object is readable again.
+/// * `Ok(Async::WouldBlock)` means that no data was read into the buffer 
+///   provided. The I/O object is not currently readable but may become readable
+///   in the future. Most importantly, **the current future's task is scheduled
+///   to get unparked when the object is readable**. This means that like 
+///   `Future::poll` you'll receive a notification when the I/O object is 
+///   readable again.
 ///
 /// * `Err(e)` for other errors are standard I/O errors coming from the
 ///   underlying object.

--- a/tokio-io/src/async_read.rs
+++ b/tokio-io/src/async_read.rs
@@ -20,7 +20,7 @@ use split::{ReadHalf, WriteHalf};
 ///   and placed into the output buffer, where `n` == 0 implies that EOF has
 ///   been reached.
 ///
-/// * `Ok(Async::WouldBlock)` means that no data was read into the buffer 
+/// * `Ok(Async::NotReady)` means that no data was read into the buffer 
 ///   provided. The I/O object is not currently readable but may become readable
 ///   in the future. Most importantly, **the current future's task is scheduled
 ///   to get unparked when the object is readable**. This means that like 

--- a/tokio-io/src/async_write.rs
+++ b/tokio-io/src/async_write.rs
@@ -16,7 +16,7 @@ use AsyncRead;
 /// * `Ok(Async::Ready(n))` means that `n` bytes of data was immediately
 ///   written.
 ///
-/// * `Ok(Async::WouldBlock)` means that no data was written from the buffer
+/// * `Ok(Async::NotReady)` means that no data was written from the buffer
 ///   provided. The I/O object is not currently writable but may become writable
 ///   in the future. Most importantly, **the current future's task is scheduled
 ///   to get unparked when the object is readable**. This means that like

--- a/tokio-io/src/async_write.rs
+++ b/tokio-io/src/async_write.rs
@@ -13,14 +13,15 @@ use AsyncRead;
 /// Specifically, this means that the `write` function will return one of the
 /// following:
 ///
-/// * `Ok(n)` means that `n` bytes of data was immediately written .
+/// * `Ok(Async::Ready(n))` means that `n` bytes of data was immediately
+///   written.
 ///
-/// * `Err(e) if e.kind() == ErrorKind::WouldBlock` means that no data was
-///   written from the buffer provided. The I/O object is not currently
-///   writable but may become writable in the future. Most importantly, **the
-///   current future's task is scheduled to get unparked when the object is
-///   readable**. This means that like `Future::poll` you'll receive a
-///   notification when the I/O object is writable again.
+/// * `Ok(Async::WouldBlock)` means that no data was written from the buffer
+///   provided. The I/O object is not currently writable but may become writable
+///   in the future. Most importantly, **the current future's task is scheduled
+///   to get unparked when the object is readable**. This means that like
+///   `Future::poll` you'll receive a notification when the I/O object is
+///   writable again.
 ///
 /// * `Err(e)` for other errors are standard I/O errors coming from the
 ///   underlying object.


### PR DESCRIPTION
## Motivation

Documentation of AsyncRead and AsyncWrite do not reflect current API, referencing `Err(e) if e.kind() == ErrorKind::WouldBlock` as a way of identifying incomplete async work. The current implementation uses the `Async` enum in the `Ok` variant of `Result` rather than a special Error type to identify incomplete async work.

## Solution

Updated documentation to reflect the current API.
