### PR TITLE
Fix `parking_lot` dependency breaking Rust 1.25.0 build

### DIFF
--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -30,7 +30,7 @@ lazy_static = "1.0.2"
 log = "0.4.1"
 mio = "0.6.14"
 num_cpus = "1.8.0"
-parking_lot = "0.6.3"
+parking_lot = "=0.6.3"
 slab = "0.4.0"
 tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }


### PR DESCRIPTION
## Motivation

Version 0.3.0 of `parking_lot_core` breaks compatibility with Rust 1.25
(see Amanieu/parking_lot#89). Unfortunately, version 0.6.4 of
`parking_lot` changes the dependency on `parking_lot_core` from `^0.2`
to `^0.3`, so it is also incompatible with Rust 1.25. Since we depend on
`parking_lot` using a version string without any operators, Cargo treats
it as a `^` dependency, which will accept semver non-breaking updates.
Therefore, our dependency on `parking_lot` "0.6.3" will pull in version
0.6.4, breaking the build on Rust 1.25.

## Solution

This branch changes the specified version of `parking_lot` to "=0.6.3",
which will _not_ accept version 0.6.4.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>