### PR TITLE
Bump minimum supported version & document support policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   # This represents the minimum Rust version supported by Tokio. Updating this
   # should be done in a dedicated PR and cannot be greater than two 0.x
   # releases prior to the current stable.
-  - rust: 1.25.0
+  - rust: 1.26.0
   - rust: stable
   - rust: beta
   - rust: nightly

--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ The crates included as part of Tokio are:
 
 This project is licensed under the [MIT license](LICENSE).
 
+## Supported Rust Versions
+
+Tokio is built against the latest stable, nightly, and beta Rust releases. The
+minimum version supported is the stable release from three months before the
+current stable release version. For example, if the latest stable Rust is 1.29,
+the minimum version supported is 1.26. The current Tokio version is not
+guaranteed to build on Rust versions earlier than the minimum supported version.
+
 ### Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally submitted


### PR DESCRIPTION
A recent release of the `parking_lot` crate broke compatibility with
Rust 1.25. To resolve this without pinning the dependency on an 0._x_
version, (or releasing a new crate version of Tokio) we are  ncrementing
the minimum supported Rust version to 1.26, in accordance with the
policy described in the `.travis.yml` file. In addition, the policy is
now documented in the README.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>