### PR TITLE
tokio-channel: fix race with dropping Receiver

### DIFF
--- a/tokio-channel/tests/mpsc.rs
+++ b/tokio-channel/tests/mpsc.rs
@@ -423,7 +423,8 @@ fn stress_try_send_as_receiver_closes() {
     // When we detect that a successfully sent item is still in the
     // queue after a disconnect, we spin for up to 100ms to confirm that
     // it is a persistent condition and not a concurrency illusion.
-    const SPIN_TIMEOUT: Duration = Duration::from_millis(100);
+    const SPIN_TIMEOUT: Duration = Duration::from_secs(10);
+    const SPIN_SLEEP: Duration = Duration::from_millis(10);
 
     struct TestRx {
         rx: mpsc::Receiver<Arc<()>>,
@@ -533,6 +534,7 @@ fn stress_try_send_as_receiver_closes() {
                                     i, attempted_sends, successful_sends, spins
                                 );
                                 spins += 1;
+                                thread::sleep(SPIN_SLEEP);
                             }
                         }
                     }

--- a/tokio-channel/tests/mpsc.rs
+++ b/tokio-channel/tests/mpsc.rs
@@ -543,6 +543,9 @@ fn stress_try_send_as_receiver_closes() {
             attempted_sends += 1;
         }
     }
+
+    drop(cmd_tx);
+
     bg.join()
         .expect("background thread join")
         .expect("background thread result");


### PR DESCRIPTION
This branch adds a stress test to `tokio-channel` for a race condition
that can occur when the `Receiver` end of a channel is dropped as the
`Sender` end calls `try_send`, leaving the sent data in the queue. This
is based on the repro written by @simmons for
rust-lang-nursery/futures-rs#909; since the `tokio-channel` code is
based on the `futures-rs` channel implementation, the issue exists here
as well.

Note that since this branch does not _resolve_ the issue, the stress
test currently fails.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>