### PR TITLE
Add ThreadPool::spawn_handle

### DIFF
--- a/tokio-threadpool/src/thread_pool.rs
+++ b/tokio-threadpool/src/thread_pool.rs
@@ -3,7 +3,26 @@ use pool::Pool;
 use sender::Sender;
 use shutdown::Shutdown;
 
-use futures::Future;
+use futures::{Future, Poll};
+use futures::sync::oneshot;
+
+/// Handle returned from ThreadPool::spawn_handle.
+/// 
+/// This handle is a future representing the completion of a different future 
+/// spawned on to the thread pool. Created through the ThreadPool::spawn_handle 
+/// function this handle will resolve when the future provided resolves on the 
+/// thread pool.
+#[derive(Debug)]
+pub struct SpawnHandle<T, E>(oneshot::SpawnHandle<T, E>);
+
+impl<T, E> Future for SpawnHandle<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<T, E> {
+        self.0.poll()
+    }
+}
 
 /// Work-stealing based thread pool for executing futures.
 ///
@@ -62,6 +81,49 @@ impl ThreadPool {
     where F: Future<Item = (), Error = ()> + Send + 'static,
     {
         self.sender().spawn(future).unwrap();
+    }
+
+    /// Spawn a future on to the thread pool, return a future representing 
+    /// the produced value.
+    /// 
+    /// The SpawnHandle returned is a future that is a proxy for future itself. 
+    /// When future completes on this thread pool then the SpawnHandle will itself 
+    /// be resolved.
+    /// 
+    /// # Examples
+    ///
+    /// ```rust
+    /// # extern crate tokio_threadpool;
+    /// # extern crate futures;
+    /// # use tokio_threadpool::ThreadPool;
+    /// use futures::future::{Future, lazy};
+    ///
+    /// # pub fn main() {
+    /// // Create a thread pool with default configuration values
+    /// let thread_pool = ThreadPool::new();
+    ///
+    /// let handle = thread_pool.spawn_handle(lazy(|| -> Result<_, ()> {
+    ///     Ok(42)
+    /// }));
+    /// 
+    /// let value = handle.wait().unwrap();
+    /// assert_eq!(value, 42);
+    ///
+    /// // Gracefully shutdown the threadpool
+    /// thread_pool.shutdown().wait().unwrap();
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if the spawn fails. 
+    pub fn spawn_handle<F>(&self, future: F) -> SpawnHandle<F::Item, F::Error>
+    where 
+        F: Future + Send + 'static,
+        F::Item: Send + 'static,
+        F::Error: Send + 'static,
+    {
+        SpawnHandle(oneshot::spawn(future, self.sender()))
     }
 
     /// Return a reference to the sender handle


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`tokio_threadpool::ThreadPool::spawn` has no return value.

## Solution

Add `ThreadPool::spawn_handle` which calls `futures::sync::oneshot::spawn` to return a future represents the return value.
