### PR TITLE
Expose thread_pool::SpawnHandle

### DIFF
--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -158,5 +158,5 @@ pub use blocking::{blocking, BlockingError};
 pub use builder::Builder;
 pub use sender::Sender;
 pub use shutdown::Shutdown;
-pub use thread_pool::ThreadPool;
+pub use thread_pool::{ThreadPool, SpawnHandle};
 pub use worker::{Worker, WorkerId};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`thread_pool::ThreadPool::spawn_handle` is public but its return value type `thread_pool::SpawnHandle` is private.

## Solution

pub use `thread_pool::SpawnHandle` at lib.rs
