### PR TITLE
channel: fix mpsc::Sender::poll_complete impl

### DIFF
--- a/tokio-channel/src/mpsc/mod.rs
+++ b/tokio-channel/src/mpsc/mod.rs
@@ -640,7 +640,8 @@ impl<T> Sink for Sender<T> {
     }
 
     fn poll_complete(&mut self) -> Poll<(), SendError<T>> {
-        Ok(Async::Ready(()))
+        self.poll_ready()
+            .or_else(|_| Ok(().into()))
     }
 
     fn close(&mut self) -> Poll<(), SendError<T>> {

--- a/tokio-channel/tests/mpsc.rs
+++ b/tokio-channel/tests/mpsc.rs
@@ -10,6 +10,7 @@ use tokio_channel::oneshot;
 
 use futures::prelude::*;
 use futures::future::lazy;
+use futures::Async::*;
 
 use std::thread;
 use std::sync::{Arc, Mutex};
@@ -478,4 +479,25 @@ fn try_send_fail() {
 
     assert_eq!(rx.next(), Some(Ok("goodbye")));
     assert!(rx.next().is_none());
+}
+
+#[test]
+fn bounded_is_really_bounded() {
+    let (mut tx, mut rx) = mpsc::channel(0);
+
+    lazy(|| {
+        assert!(tx.start_send(1).unwrap().is_ready());
+
+        // Not ready until we receive
+        assert!(!tx.poll_complete().unwrap().is_ready());
+
+        // Receive the value
+
+        assert_eq!(rx.poll().unwrap(), Ready(Some(1)));
+
+        // Now the sender is ready
+        assert!(tx.poll_complete().unwrap().is_ready());
+
+        Ok::<_, ()>(())
+    }).wait().unwrap();
 }


### PR DESCRIPTION
## Motivation

There has been a long standing problem with bounded channels. The following was not bounded:

```rust
// tx exists 
input.for_each(|value| {
    tx.clone().send(value)
})
```

`tx` must be cloned as `send` takes ownership.

Previously, this pattern resulted in the channel being effectively unbounded.

## Solution

Fix the `poll_complete` implementation to be correct and return ready once the value has been sent.