### PR TITLE
async-await: bump version to v0.1.2

### DIFF
--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(futures_api, await_macro, pin, arbitrary_self_types)]
 
-#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.2")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
Release tokio-async-await v0.1.2.