### PR TITLE
Remove unncessary mut in `UdpSocket`, add doc about concurrent usage

### DIFF
--- a/tokio-uds/src/datagram.rs
+++ b/tokio-uds/src/datagram.rs
@@ -14,6 +14,12 @@ use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
 
 /// An I/O object representing a Unix datagram socket.
+///
+/// **Note**: Well `UnixDatagram` is `Sync`, the caller must ensure that there
+/// are at most two tasks that use a `UnixDatagram` concurrently, one for
+/// receiving and one for sending. While violating this requirement is "safe"
+/// from a Rust memory model point of view, it will result in unexpected
+/// behavior in the form of lost notifications and tasks hanging.
 pub struct UnixDatagram {
     io: PollEvented<mio_uds::UnixDatagram>,
 }


### PR DESCRIPTION
As discussed in #615, `UdpSocket` requiring `&mut` in poll functions won't prevent concurrent usage and only adds friction.

This changes all poll functions of `UdpSocket` to take `&self` instead of `&mut self`, and adds documentation about concurrent usage in `UdpSocket` as well as `UnixDatagram`.