### PR TITLE
reactor: use LocalKey::try_with in sharded RW lock

### DIFF
--- a/tokio-reactor/src/sharded_rwlock.rs
+++ b/tokio-reactor/src/sharded_rwlock.rs
@@ -150,11 +150,12 @@ impl<'a, T> DerefMut for RwLockWriteGuard<'a, T> {
 
 /// Returns a `usize` that identifies the current thread.
 ///
-/// Each thread is associated with an 'index'. While there are no particular guarantees, indices
-/// usually tend to be consecutive numbers between 0 and the number of running threads.
+/// Each thread is associated with an 'index'. Indices usually tend to be consecutive numbers
+/// between 0 and the number of running threads, but there are no guarantees. During TLS teardown
+/// the associated index might change.
 #[inline]
 pub fn thread_index() -> usize {
-    REGISTRATION.with(|reg| reg.index)
+    REGISTRATION.try_with(|reg| reg.index).unwrap_or(0)
 }
 
 /// The global registry keeping track of registered threads and indices.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

@jonhoo reported a panic in the call to `LocalKey::with`, which occurs when the reactor is dropped in the middle of TLS teardown.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Change the call to `LocalKey::try_with` and handle the case when the thread-local value has already been destroyed.