### PR TITLE
Fix tokio-async-await tests compile errors

### DIFF
--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -28,7 +28,7 @@ name = "tokio"
 
 [dependencies]
 futures = "0.1.23"
-tokio = { version = "0.1.8", path = ".." }
+tokio_main = { package = "tokio", version = "0.1.8", path = ".." }
 tokio-io = { version = "0.1.7", path = "../tokio-io" }
 tokio-channel = { version = "0.1.0", path = "../tokio-channel", features = ["async-await-preview"] }
 tokio-reactor = { version = "0.1.5", path = "../tokio-reactor", features = ["async-await-preview"] }

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -11,7 +11,7 @@ extern crate futures_core;
 extern crate futures_util;
 
 // Re-export all of Tokio
-pub use tokio::{
+pub use tokio_main::{
     // Modules
     clock,
     codec,
@@ -53,7 +53,7 @@ pub mod prelude {
     //!
     //! The prelude may grow over time as additional items see ubiquitous use.
 
-    pub use tokio::prelude::*;
+    pub use tokio_main::prelude::*;
 
     #[doc(inline)]
     pub use crate::async_await::{


### PR DESCRIPTION
## Motivation

Fix #624 (`tokio-async-await` tests didn't compile).

## Solution

1. Import the main tokio crate as `tokio_main`.
2. Remove an unnecessary `#[macro_export]`