### PR TITLE
ci: Run `cargo test` with the --no-fail-fast flag

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,4 +16,4 @@ install:
 build: false
 
 test_script:
-  - cargo test --all --target %TARGET%
+  - cargo test --all --no-fail-fast --target %TARGET%

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ script:
         cargo check --all --exclude tokio-tls --target $TARGET
         cargo check --tests --all --exclude tokio-tls --target $TARGET
     else
-        cargo test --all
+        cargo test --all --no-fail-fast
         # Disable these tests for now as they are buggy
         #
         # cargo test --features unstable-futures


### PR DESCRIPTION
## Motivation

Since the CI runs all tests for all tokio crates, it is possible that a
sporadic failure in one crate can mask failures/successes of other
crates' tests.

## Solution

Using the `--no-fail-fast` flag instructs cargo to run *all* tests
before failing the build. This will allow checking to see if any
relevant test cases still pass even if an unrelated test has failed.
