### PR TITLE
Provide `tokio::spawn_handle` that returns a handle to the task 

### DIFF
--- a/src/executor/current_thread/mod.rs
+++ b/src/executor/current_thread/mod.rs
@@ -111,11 +111,13 @@ pub use tokio_current_thread::{
     Handle,
     RunError,
     RunTimeoutError,
+    SpawnHandle,
     TaskExecutor,
     Turn,
     TurnError,
     block_on_all,
     spawn,
+    spawn_handle,
 };
 
 use std::cell::Cell;

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -59,7 +59,14 @@ pub mod thread_pool {
     };
 }
 
-pub use tokio_executor::{Executor, DefaultExecutor, SpawnError};
+pub use tokio_executor::{
+    spawn_handle,
+    Executor,
+    DefaultExecutor,
+    SpawnHandle,
+    SpawnHandleError,
+    SpawnError,
+};
 
 use futures::{Future, IntoFuture};
 use futures::future::{self, FutureResult};

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -59,8 +59,10 @@ pub mod thread_pool {
     };
 }
 
+/// BLORF
+pub use tokio_executor::spawn_handle;
+
 pub use tokio_executor::{
-    spawn_handle,
     Executor,
     DefaultExecutor,
     SpawnHandle,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@ pub mod runtime;
 pub mod timer;
 pub mod util;
 
-pub use executor::spawn;
+pub use executor::{spawn, spawn_handle};
 pub use runtime::run;
 
 mod length_delimited;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,12 @@ pub mod runtime;
 pub mod timer;
 pub mod util;
 
-pub use executor::{spawn, spawn_handle};
+pub use executor::{
+    spawn,
+    spawn_handle,
+    SpawnHandle,
+    SpawnHandleError,
+};
 pub use runtime::run;
 
 mod length_delimited;

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -32,10 +32,10 @@ mod scheduler;
 
 use self::scheduler::Scheduler;
 
-use tokio_executor::{Enter, SpawnError};
+use tokio_executor::{Enter, SpawnError, SpawnHandleError};
 use tokio_executor::park::{Park, Unpark, ParkThread};
 
-use futures::{executor, Async, Future};
+use futures::{executor, sync::oneshot, Async, Future, Poll};
 use futures::future::{Executor, ExecuteError, ExecuteErrorKind};
 
 use std::fmt;
@@ -100,6 +100,32 @@ impl Turn {
 pub struct Entered<'a, P: Park + 'a> {
     executor: &'a mut CurrentThread<P>,
     enter: &'a mut Enter,
+}
+
+/// Future returned by the [`spawn_handle`] function.
+///
+/// A `SpawnHandle` will finish with either the `Item` type of the spawned
+/// future or a [`SpawnHandleError`] which either contains the spawned future's
+/// `Error` type or indicates that the spawned future was canceled before it
+/// completed.
+///
+/// In addition, the [`cancel`] method will cancel the spawned future, causing
+/// it to finish executing the next time it is polled.
+///
+/// [`spawn_handle`]: fn.spawn_handle.html
+/// [`SpawnHandleError`]: struct.SpawnHandleError.html
+/// [`cancel`]: #method.cancel
+#[derive(Debug)]
+pub struct SpawnHandle<T, E> {
+    cancel_tx: oneshot::Sender<()>,
+    rx: oneshot::Receiver<Result<T, E>>,
+}
+
+#[derive(Debug)]
+struct SpawnedWithHandle<F: Future> {
+    cancel_rx: oneshot::Receiver<()>,
+    tx: Option<oneshot::Sender<Result<F::Item, F::Error>>>,
+    future: F,
 }
 
 /// Error returned by the `run` function.
@@ -251,6 +277,67 @@ where F: Future<Item = (), Error = ()> + 'static
     TaskExecutor::current()
         .spawn_local(Box::new(future))
         .unwrap();
+}
+
+/// Submits a future for execution on the current thread, returning a
+/// [`SpawnHandle`] that allows access to the result of the spawned future
+/// and can cancel it if it is no longer necessary.
+///
+/// Spawning the future behaves similarly to the [`spawn`] function, but with
+/// the addition of returning a `SpawnHandle`. A `SpawnHandle` is itself a
+/// future which will eventually complete with the value returned by the
+/// spawned future.
+///
+/// If the spawned future is no longer needed, the [`SpawnHandle::cancel`]
+/// method will cancel it. Dropping the `SpawnHandle` will *not* cancel the
+/// spawned future, but will result in the item returned by the spawned future
+/// being discarded.
+///
+/// Unlike [`tokio::spawn_handle`], this function will always spawn on a
+/// `CurrentThread` executor and is able to spawn futures that are not `Send`.
+///
+/// # Panics
+///
+/// This function can only be invoked from the context of a `run` call; any
+/// other use will result in a panic.
+///
+/// # Examples
+///
+/// ```rust
+/// # extern crate futures;
+/// # extern crate tokio_current_thread;
+/// # use tokio_current_thread::{spawn_handle, SpawnHandle};
+/// use futures::Future;
+/// use futures::future::lazy;
+///
+/// # pub fn dox() {
+/// let handle: SpawnHandle<&'static str, ()> = spawn_handle(lazy(|| {
+///     Ok("hello from the future!")
+/// }));
+/// # }
+/// # pub fn main() {}
+/// ```
+///
+/// [`SpawnHandle`]: struct.SpawnHandle.html
+/// [`spawn`]: fn.spawn.html
+/// [`SpawnHandle::cancel`]: struct.SpawnHandle.html#method.cancel
+/// [`tokio::spawn_handle`]: ../fn.spawn_handle.html
+pub fn spawn_handle<T>(future: T) -> SpawnHandle<T::Item, T::Error>
+where
+    T: Future + 'static,
+{
+    let (tx, rx) = oneshot::channel();
+    let (cancel_tx, cancel_rx) = oneshot::channel();
+    let f = SpawnedWithHandle {
+        cancel_rx,
+        tx: Some(tx),
+        future,
+    };
+    spawn(f);
+    SpawnHandle {
+        cancel_tx,
+        rx,
+    }
 }
 
 // ===== impl CurrentThread =====
@@ -804,6 +891,60 @@ unsafe fn hide_lt<'a>(p: *mut (SpawnLocal + 'a)) -> *mut (SpawnLocal + 'static) 
     use std::mem;
     mem::transmute(p)
 }
+
+
+// ===== impl SpawnHandle =====
+
+// NOTE: It's unfortunate that this code (and the code for `SpawnedWithHandle`)
+// has to be duplicated from `tokio-executor`. However, there was no way for
+// `tokio-current-thread` to construct new `SpawnHandle`s or
+// `SpawnedWithHandle`s without making their constructors public to all users of
+// the `tokio-executor` crate as well.
+impl<T, E> Future for SpawnHandle<T, E> {
+    type Item = T;
+    type Error = SpawnHandleError<E>;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        match self.rx.poll() {
+            Ok(Async::NotReady) => Ok(Async::NotReady),
+            Ok(Async::Ready(i)) => Ok(Async::Ready(i?)),
+            Err(oneshot::Canceled) => Err(SpawnHandleError::canceled()),
+        }
+    }
+}
+
+impl<T, E> SpawnHandle<T, E> {
+    /// Cancel the spawned future.
+    pub fn cancel(self) {
+        let _ = self.cancel_tx.send(());
+    }
+}
+
+impl<F: Future> Future for SpawnedWithHandle<F> {
+    type Item = ();
+    type Error = ();
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        // First, check if the task has been canceled.  If `cancel_rx.poll()`
+        // returns an error, that indicates that the `SpawnHandle` has been
+        // dropped, which is fine.
+        if let Ok(Async::Ready(())) = self.cancel_rx.poll() {
+            return Ok(Async::Ready(()));
+        }
+        // Otherwise, poll the wrapped future.
+        let (result, retval) = match self.future.poll() {
+            Ok(Async::NotReady) => return Ok(Async::NotReady),
+            Ok(Async::Ready(i)) => (Ok(i), Ok(Async::Ready(()))),
+            Err(e) => (Err(e), Err(())),
+        };
+        // If `send` returns an error, that is because the `SpawnHandle` was
+        // dropped, canceling the receiver. This is fine.
+        let _ = self.tx.take()
+            .expect("polled after ready")
+            .send(result);
+        retval
+    }
+}
+
 
 // ===== impl RunTimeoutError =====
 

--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -229,7 +229,6 @@ where
         cancel_tx,
         rx,
     }
-
 }
 
 /// Set the default executor for the duration of the closure
@@ -291,9 +290,7 @@ impl<T, E> Future for SpawnHandle<T, E> {
         match self.rx.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Ok(Async::Ready(i)) => Ok(Async::Ready(i?)),
-            Err(oneshot::Canceled) => Err(SpawnHandleError {
-                kind: SpawnHandleErrorKind::Canceled,
-            }),
+            Err(oneshot::Canceled) => Err(SpawnHandleError::canceled()),
         }
     }
 }
@@ -346,6 +343,14 @@ impl<E> SpawnHandleError<E> {
         match self.kind {
             SpawnHandleErrorKind::Canceled => true,
             _ => false,
+        }
+    }
+
+    /// Returns a new `SpawnHandleError` indicating that the spawned future was
+    /// canceled.
+    pub fn canceled() -> Self {
+        SpawnHandleError {
+            kind: SpawnHandleErrorKind::Canceled,
         }
     }
 

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -42,7 +42,14 @@ mod global;
 pub mod park;
 
 pub use enter::{enter, Enter, EnterError};
-pub use global::{spawn, with_default, DefaultExecutor};
+pub use global::{
+    spawn,
+    spawn_handle,
+    with_default,
+    DefaultExecutor,
+    SpawnHandle,
+    SpawnHandleError
+};
 
 use futures::Future;
 


### PR DESCRIPTION
## Motivation

Spawning tasks results in a computation that happens in the background
decoupled from the spawner. It is common to want to get the result of
the computation or to be able to cancel the task from the spawner.

## Solution

This branch adds a new free function `spawn_handle` in `tokio-executor`. This
function takes a future with arbitrary `Send` item and error types, spawns it on
the default executor, and returns a `SpawnHandle`. The `SpawnHandle` is a future
which will eventually resolve with the `Item` or `Error` values of the spawned
future, and provides a method that consumes the handle and cancels the spawned
future.

This type is implemented using two `futures::sync::oneshot` channels: one from
the spawned future to the `SpawnHandle`, which sends the result or error of the
spawned future; and one from the `SpawnHandle` to the spawned future, which is
used to signal cancellations. 

In addition, there is a similar function and types defined for the
`current_thread` executor. All of these functions are re-exported by the `tokio`
crate.

Fixes: #626

Signed-off-by: Eliza Weisman <eliza@buoyant.io>