### PR TITLE
async-await: update deps in tokio-async-await

### DIFF
--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["edition", "rename-dependency"]
+cargo-features = ["rename-dependency"]
 
 [package]
 name = "tokio-async-await"
@@ -6,12 +6,12 @@ edition = "2018"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-async-await/0.1.1"
+documentation = "https://docs.rs/tokio-async-await/0.1.3"
 description = """
 Experimental async/await support for Tokio
 """
@@ -32,8 +32,8 @@ tokio = { version = "0.1.8", path = ".." }
 tokio-io = { version = "0.1.7", path = "../tokio-io" }
 tokio-channel = { version = "0.1.0", path = "../tokio-channel", features = ["async-await-preview"] }
 tokio-reactor = { version = "0.1.5", path = "../tokio-reactor", features = ["async-await-preview"] }
-futures-core-preview = { version = "0.3.0-alpha.2" }
-futures-util-preview = { version = "0.3.0-alpha.2" }
+futures-core-preview = { version = "0.3.0-alpha.6" }
+futures-util-preview = { version = "0.3.0-alpha.6" }
 
 [dev-dependencies]
 bytes = "0.4.9"

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(futures_api, await_macro, pin, arbitrary_self_types)]
 
-#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.3")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 
@@ -76,7 +76,6 @@ use futures_core::{
 
 // Rename the `await` macro in `std`
 #[doc(hidden)]
-#[macro_export]
 pub use std::await as std_await;
 
 /// Like `tokio::run`, but takes an `async` block


### PR DESCRIPTION
## Motivation

tokio-async-await does not build with the current nightly compiler.

## Solution

Update the futures preview deps to alpha 6 and prepare a 0.1.3 release (will require a cargo publish).
