### PR TITLE
Add compiler derictive to ignore doc warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@
 
 #![doc(html_root_url = "https://docs.rs/tokio/0.1.5")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
+#![allow(intra_doc_link_resolution_failure)]
 
 extern crate bytes;
 #[macro_use]

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -12,6 +12,7 @@
 
 #![deny(missing_docs, missing_debug_implementations, warnings)]
 #![doc(html_root_url = "https://docs.rs/tokio-codec/0.1.0")]
+#![allow(intra_doc_link_resolution_failure)]
 
 extern crate bytes;
 extern crate tokio_io;

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
+#![allow(intra_doc_link_resolution_failure)]
 #![doc(html_root_url = "https://docs.rs/tokio-io/0.1.8")]
 
 //! Core I/O traits and combinators when working with Tokio.

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(feature = "async-await-preview", feature(
         pin,
         ))]
+#![allow(intra_doc_link_resolution_failure)]
+
 
 //! Event loop that drives Tokio I/O resources.
 //!

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.6")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
+#![allow(intra_doc_link_resolution_failure)]
 
 //! Utilities for tracking time.
 //!


### PR DESCRIPTION
Fixes `cargo +nightly doc`.

```
$ cargo +nightly doc
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
```

## Motivation

Fixes https://github.com/tokio-rs/tokio/issues/437

## Solution

Add `#![allow(intra_doc_link_resolution_failure)]` to `lib.rs` where we get doc errors