### PR TITLE
Add `#[doc(hidden)]` to deprecated tokio-threadpool reexports

### DIFF
--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -47,6 +47,7 @@
 pub mod current_thread;
 
 #[deprecated(since = "0.1.8", note = "use tokio-threadpool crate instead")]
+#[doc(hidden)]
 /// Re-exports of [`tokio-threadpool`], deprecated in favor of the crate.
 ///
 /// [`tokio-threadpool`]: https://docs.rs/tokio-threadpool/0.1


### PR DESCRIPTION

## Motivation

The module is already deprecated. It should also be hidden from the docs.

## Solution

Added `#[doc(hidden)]`.

Fixes: #643

Signed-off-by: Eliza Weisman <eliza@buoyant.io>