### PR TITLE
Deprecate and replace Runtime::threadpool_builder

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -76,6 +76,11 @@ impl Builder {
     }
 
     /// Set builder to set up the thread pool instance.
+    #[deprecated(
+        since="0.1.9",
+        note="use the `core_threads`, `blocking_threads`, `name_prefix`, \
+              and `stack_size` functions on `runtime::Builder`, instead")]
+    #[doc(hidden)]
     pub fn threadpool_builder(&mut self, val: ThreadPoolBuilder) -> &mut Self {
         self.threadpool_builder = val;
         self

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -86,6 +86,114 @@ impl Builder {
         self
     }
 
+    /// Set the maximum number of worker threads for the `Runtime`'s thread pool.
+    ///
+    /// This must be a number between 1 and 32,768 though it is advised to keep
+    /// this value on the smaller side.
+    ///
+    /// The default value is the number of cores available to the system.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio;
+    /// # extern crate futures;
+    /// # use tokio::runtime;
+    ///
+    /// # pub fn main() {
+    /// let mut rt = runtime::Builder::new()
+    ///     .core_threads(4)
+    ///     .build()
+    ///     .unwrap();
+    /// # }
+    /// ```
+    pub fn core_threads(&mut self, val: usize) -> &mut Self {
+        self.threadpool_builder.pool_size(val);
+        self
+    }
+
+    /// Set the maximum number of concurrent blocking sections in the `Runtime`'s
+    /// thread pool.
+    ///
+    /// When the maximum concurrent `blocking` calls is reached, any further
+    /// calls to `blocking` will return `NotReady` and the task is notified once
+    /// previously in-flight calls to `blocking` return.
+    ///
+    /// This must be a number between 1 and 32,768 though it is advised to keep
+    /// this value on the smaller side.
+    ///
+    /// The default value is 100.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio;
+    /// # extern crate futures;
+    /// # use tokio::runtime;
+    ///
+    /// # pub fn main() {
+    /// let mut rt = runtime::Builder::new()
+    ///     .blocking_threads(200)
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn blocking_threads(&mut self, val: usize) -> &mut Self {
+        self.threadpool_builder.max_blocking(val);
+        self
+    }
+
+    /// Set name prefix of threads spawned by the `Runtime`'s thread pool.
+    ///
+    /// Thread name prefix is used for generating thread names. For example, if
+    /// prefix is `my-pool-`, then threads in the pool will get names like
+    /// `my-pool-1` etc.
+    ///
+    /// The default prefix is "tokio-runtime-worker-".
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio;
+    /// # extern crate futures;
+    /// # use tokio::runtime;
+    ///
+    /// # pub fn main() {
+    /// let mut rt = runtime::Builder::new()
+    ///     .name_prefix("my-pool-")
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn name_prefix<S: Into<String>>(&mut self, val: S) -> &mut Self {
+        self.threadpool_builder.name_prefix(val);
+        self
+    }
+
+    /// Set the stack size (in bytes) for worker threads.
+    ///
+    /// The actual stack size may be greater than this value if the platform
+    /// specifies minimal stack size.
+    ///
+    /// The default stack size for spawned threads is 2 MiB, though this
+    /// particular stack size is subject to change in the future.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio;
+    /// # extern crate futures;
+    /// # use tokio::runtime;
+    ///
+    /// # pub fn main() {
+    /// let mut rt = runtime::Builder::new()
+    ///     .stack_size(32 * 1024)
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn stack_size(&mut self, val: usize) -> &mut Self {
+        self.threadpool_builder.stack_size(val);
+        self
+    }
+
     /// Create the configured `Runtime`.
     ///
     /// The returned `ThreadPool` instance is ready to spawn tasks.


### PR DESCRIPTION
## Problem

Currently, the concurrent Runtime is configured by passing in a
threadpool builder. This is problematic for two reasons:

1. It exposes `tokio-threadpool` as part of the `tokio` public API,
   preventing `tokio` from transparently bumping the version used
   internally. 
2. All the options on the threadpool builder cannot be
   maintained. There are some that the Runtime must set, overwriting
   previously set values.

## Solution

This branch makes the following changes:

1. Hide and deprecate `threadpool_builder`.
2. Add `core_threads` representing `pool_size` on the threadpool builder.
3. Add `blocking_threads` representing `max_blocking` on the threadpool builder.
4. Add `name_prefix`, mirroring the same fn on the threadpool builder.
5. Add `stack_size`, mirroring the same fn on the threadpool builder.

Fixes: #642

Signed-off-by: Eliza Weisman <eliza@buoyant.io>