### PR TITLE
Make `tokio::run` panic if called from inside `tokio::run`

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -125,6 +125,7 @@ use reactor::{Background, Handle};
 
 use std::io;
 
+use tokio_executor::enter;
 use tokio_threadpool as threadpool;
 
 use futures;
@@ -208,6 +209,7 @@ struct Inner {
 pub fn run<F>(future: F)
 where F: Future<Item = (), Error = ()> + Send + 'static,
 {
+    enter().expect("nested tokio::run");
     let mut runtime = Runtime::new().unwrap();
     runtime.spawn(future);
     runtime.shutdown_on_idle().wait().unwrap();

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -209,10 +209,11 @@ struct Inner {
 pub fn run<F>(future: F)
 where F: Future<Item = (), Error = ()> + Send + 'static,
 {
-    let mut enter = enter().expect("nested tokio::run");
     let mut runtime = Runtime::new().unwrap();
     runtime.spawn(future);
-    enter.block_on(runtime.shutdown_on_idle()).unwrap();
+    enter().expect("nested tokio::run")
+        .block_on(runtime.shutdown_on_idle())
+        .unwrap();
 }
 
 impl Runtime {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -209,10 +209,10 @@ struct Inner {
 pub fn run<F>(future: F)
 where F: Future<Item = (), Error = ()> + Send + 'static,
 {
-    enter().expect("nested tokio::run");
+    let mut enter = enter().expect("nested tokio::run");
     let mut runtime = Runtime::new().unwrap();
     runtime.spawn(future);
-    runtime.shutdown_on_idle().wait().unwrap();
+    enter.block_on(runtime.shutdown_on_idle()).unwrap();
 }
 
 impl Runtime {

--- a/tests/runtime.rs
+++ b/tests/runtime.rs
@@ -390,3 +390,15 @@ mod from_block_on_all {
         test(|f| { tokio::spawn(f); })
     }
 }
+
+#[test]
+fn run_in_run() {
+    use std::panic;
+
+    tokio::run(lazy(|| {
+        panic::catch_unwind(|| {
+            tokio::run(lazy(|| { Ok::<(), ()>(()) }))
+        }).unwrap_err();
+        Ok::<(), ()>(())
+    }));
+}

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -3,6 +3,8 @@ use std::cell::Cell;
 use std::error::Error;
 use std::fmt;
 
+use futures::{self, Future};
+
 thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
 
 /// Represents an executor context.
@@ -80,6 +82,13 @@ impl Enter {
     pub fn make_permanent(mut self) {
         self.permanent = true;
     }
+
+    /// Blocks the thread on the specified future, returning the value with
+    /// which that future completes.
+    pub fn block_on<F: Future>(&mut self, f: F) -> Result<F::Item, F::Error> {
+        futures::executor::spawn(f).wait_future()
+    }
+
 }
 
 impl fmt::Debug for Enter {


### PR DESCRIPTION
## Motivation

The documentation for `tokio::run` states that:
> This function panics if called from the context of an executor.

However, this is not currently the case --- `tokio::run` can be called
from inside a future itself passed to `tokio::run`, which will lead to
all other currently executing futures on that executor starving. See
#504 for details.

## Solution

This branch adds a `block_on` method to `tokio_executor::Enter`, which
internally functions equivalently to `Future::wait`, but requires an 
`Enter`. It then changes `tokio::run` to use `Enter::block_on` rather
than `tokio::wait`, so that a nested call to `tokio::run` will also 
attempt to `enter` and panic as expected. It also adds a test ensuring
that this works as expected.

Fixes: #504

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
