### PR TITLE
Reset stream timeout after every elapse

### DIFF
--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -214,6 +214,7 @@ where T: Stream,
         match self.delay.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
             Ok(Async::Ready(_)) => {
+                self.delay.reset_timeout();
                 Err(Error::elapsed())
             },
             Err(e) => Err(Error::timer(e)),


### PR DESCRIPTION

Timeout stream returns elapsed error after first element's timeout. This fixes that and makes sure that idle stream returns error periodically