### PR TITLE
threadpool: impl Drop for Queue

### DIFF
--- a/ci/tsan
+++ b/ci/tsan
@@ -29,4 +29,5 @@ race:crossbeam_deque*steal
 # original pop operation will fail due to the ABA guard, but tsan still picks
 # up the access on the next pointer.
 race:Backup::next_sleeper
+race:Backup::set_next_sleeper
 race:WorkerEntry::set_next_sleeper

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -115,3 +115,13 @@ impl Queue {
         Poll::Inconsistent
     }
 }
+
+impl Drop for Queue {
+    fn drop(&mut self) {
+        loop {
+            if let Poll::Empty = unsafe { self.poll() } {
+                break
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need to drain the queue when dropping, or else those `Arc<Task>`s
will be leaked.

This seems to fix #542.