### PR TITLE
fix deprecation warning in test for FutureExt::deadline()

### DIFF
--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -93,3 +93,24 @@ fn deadline() {
 
     rx.recv().unwrap();
 }
+
+#[test]
+fn timeout() {
+    use futures::future;
+
+    let _ = env_logger::try_init();
+
+    let (tx, rx) = mpsc::channel();
+
+    tokio::run({
+        future::empty::<(), ()>()
+            .timeout(Duration::from_millis(20))
+            .then(move |res| {
+                assert!(res.is_err());
+                tx.send(()).unwrap();
+                Ok(())
+            })
+    });
+
+    rx.recv().unwrap();
+}

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -80,6 +80,7 @@ fn deadline() {
     let when = Instant::now() + Duration::from_millis(20);
     let (tx, rx) = mpsc::channel();
 
+    #[allow(deprecated)]
     tokio::run({
         future::empty::<(), ()>()
             .deadline(when)

--- a/tokio-timer/tests/deadline.rs
+++ b/tokio-timer/tests/deadline.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 extern crate futures;
 extern crate tokio_executor;
 extern crate tokio_timer;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Currently, running `cargo test` gives a deprecation warning on both stable and nightly:

```
warning: use of deprecated item 'tokio::util::FutureExt::deadline': use `timeout` instead
  --> tests/timer.rs:85:14
   |
85 |             .deadline(when)
   |              ^^^^^^^^
   |
   = note: #[warn(deprecated)] on by default
```
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Just do what the error message says: use `timeout()` instead.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
