### PR TITLE
Reexport TaskExecutor from tokio_current_thread

### DIFF
--- a/src/runtime/current_thread/mod.rs
+++ b/src/runtime/current_thread/mod.rs
@@ -72,6 +72,7 @@ mod runtime;
 pub use self::builder::Builder;
 pub use self::runtime::{Runtime, Handle};
 pub use tokio_current_thread::spawn;
+pub use tokio_current_thread::TaskExecutor;
 
 use futures::Future;
 


### PR DESCRIPTION
## Motivation

It seems like there's no way to spawn !Send futures from inside a future spawned on current_thread::runtime.

## Solution

Reexport TaskExecutor from tokio_current_thread.
