### PR TITLE
[WIP] Assign a home worker to each task

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@
 //! ```
 
 #![doc(html_root_url = "https://docs.rs/tokio/0.1.5")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+// #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;
 #[macro_use]

--- a/src/runtime/shutdown.rs
+++ b/src/runtime/shutdown.rs
@@ -11,19 +11,9 @@ pub struct Shutdown {
 
 impl Shutdown {
     pub(super) fn shutdown_now(inner: Inner) -> Self {
-        let inner = Box::new({
-            let pool = inner.pool;
-            let reactor = inner.reactor;
-
-            pool.shutdown_now().and_then(|_| {
-                reactor.shutdown_now()
-                    .then(|_| {
-                        Ok(())
-                    })
-            })
-        });
-
-        Shutdown { inner }
+        Shutdown {
+            inner: Box::new(inner.pool.shutdown_on_idle())
+        }
     }
 }
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.6")]
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+// #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.
 //!


### PR DESCRIPTION
This is still very much a WIP, but I'm submitting early to get feedback.

So far, performance improvements seem to be pretty good. The running time of `bench-poll` has gone down from 460 ms to 390 ms, but this is just the beginning.

In `reactor::Builder`, rather than creating one reactor that is running in a background thread, now we create one reactor per worker thread. Each `Reactor` (remember, it impls `Park`) is hooked up to the per-worker `Timer` (also impls `Park` but can embed another `Park` inside it).

When we spawn a new task, it is submitted to a random worker's queue and that worker becomes its home worker. If we steal a task from another worker, poll the future, and it isn't completed yet, we *always* push the `Arc<Task>` back into its home worker's queue. In other words, every uncompleted task can only be in its home worker's queue. Tasks never move between different worker queues.

So what happens when we steal a task from another worker? Before polling the task, we must call `tokio_reactor::with_default` to begin using its home worker's reactor. Also recall that we cannot nest calls to `with_default`. Before this PR, we used to set up the reactor, clock, and timer inside the `around_worker` callback once to initialize the worker thread, but now we must be more clever.

Currently, this PR uses a rather simple and stupid strategy. The `around_worker` callback is now called just before executing each task. Previously, the `around_worker` callback was called only once before the worker thread started executing. Since that callback sets up the default reactor and we have multiple reactors, now we must call it before running each task in order to choose its appropriate reactor.

Calling the `around_worker` callback every time we run a task is very slow. The good thing is that even despite the slowness we got performance wins. :) So anyways, how do we fix that? I think we should call the `around_worker` callback only once while we're popping tasks from our worker's queue. Once we run out of tasks and steal a task from another worker, that's when we should call the callback again to set up a different reactor. So in the common case we shouldn't call the callback very often.

The major challenge here (but not impossible to solve) is that due to the callback nature of `around_worker`, we need to keep some state in `Worker`. For example, in order to run a stolen task, we store the `Arc<Task>` and `Arc<Notifier>` in a `Worker`'s private field, run the `around_worker` callback, which in turn calls our `run` method. Inside `run` we read the `Arc<Task>` and `Arc<Notifier>` and poll the task. Once we're done we store the result (the result is what to do with the task: reschedule it, drop it, or do something else) into a local field, too. We return from `run`, return from the `around_worker` callback, and read the result, then figure out how to proceed with that.

Things get much more hairy when we do the optimization mention above (which is call the `around_worker` callback only once while we're running tasks from our own queue).

There are several API changes that are not strictly necessary, but would make life much easier:

* Make `with_default` functions reentrant (currently attempting to nest calls to `with_default` will panic). So when we set a new default reactor/timer/clock/whatever, we temporarily swap out the old one and put it back once we're done.

* Make it possible to return a value in the `around_worker` callback, i.e. change `F: FnOnce(...)` to `F: FnOnce(...) -> R`.

* Make the actual `usize` inside `WorkerId` public. See how we I use it in `reactor::Builder::build`. Rayon does something similar in the form of [`current_thread_index`](https://docs.rs/rayon/1.0.2/rayon/struct.ThreadPool.html#method.current_thread_index).

What do you think, should we do that?

Also, what should we do about the getter method `Runtime::reactor` (and its deprecated equivalent `Runtime::handle`)? It doesn't make much sense once we go with multiple reactors.