### PR TITLE
io: ensure ReadHalf/WriteHalf do not return WouldBlock directly

### DIFF
--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -21,3 +21,6 @@ categories = ["asynchronous"]
 bytes = "0.4.7"
 futures = "0.1.18"
 log = "0.4"
+
+[dev-dependencies]
+tokio-current-thread = "0.1.1"

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -23,4 +23,4 @@ futures = "0.1.18"
 log = "0.4"
 
 [dev-dependencies]
-tokio-current-thread = "0.1.1"
+tokio-current-thread = { version = "0.1.1", path = "../tokio-current-thread" }


### PR DESCRIPTION
## Motivation

These facades were passing back `Err(io::Error::WouldBlock)` when the internal `BiLock` couldn't be acquired, which does not fit the intended behavior.

## Solution

Simply change the logic to return `Ok(Async::NotReady)` instead.

Fixes #654 