### PR TITLE
async-await: streaming hyper body example

### DIFF
--- a/tokio-async-await/examples/src/hyper.rs
+++ b/tokio-async-await/examples/src/hyper.rs
@@ -8,6 +8,7 @@ use tokio::prelude::*;
 use hyper::Client;
 
 use std::time::Duration;
+use std::str;
 
 pub fn main() {
     tokio::run_async(async {
@@ -21,5 +22,12 @@ pub fn main() {
         }).unwrap();
 
         println!("Response: {}", response.status());
+
+        let mut body = response.into_body();
+
+        while let Some(chunk) = await!(body.next()) {
+            let chunk = chunk.unwrap();
+            println!("chunk = {}", str::from_utf8(&chunk[..]).unwrap());
+        }
     });
 }


### PR DESCRIPTION
This patch adds reading the hyper body in the async/await example.

This was made possible by a recent change in nightly. However, an even more recent change broke everything, so you gotta make sure to find the right nightly to try this :)

I tested w/ `nightly-2018-09-17`.