### PR TITLE
Release crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.9 (September 27, 2018)
+
+* Experimental async/await improvements (#661).
+* Re-export `TaskExecutor` from `tokio-current-thread` (#652).
+* Improve `Runtime` builder API (#645).
+* `tokio::run` panics when called from the context of an executor
+  (#646).
+* Introduce `StreamExt` with a `timeout` helper (#573).
+* Move `length_delimited` into `tokio` (#575).
+* Re-organize `tokio::net` module (#548).
+* Re-export `tokio-current-thread::spawn` in current_thread runtime
+  (#579).
+
 # 0.1.8 (August 23, 2018)
 
 * Extract tokio::executor::current_thread to a sub crate (#370)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.8/tokio/"
+documentation = "https://docs.rs/tokio/0.1.9/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,11 @@
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.9")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![cfg_attr(feature = "async-await-preview", feature(
+        async_await,
+        await_macro,
+        futures_api,
+        ))]
+
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!
 //! Tokio is an event-driven, non-blocking I/O platform for writing asynchronous
@@ -63,14 +71,6 @@
 //!     tokio::run(server);
 //! }
 //! ```
-
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.5")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
-#![cfg_attr(feature = "async-await-preview", feature(
-        async_await,
-        await_macro,
-        futures_api,
-        ))]
 
 extern crate bytes;
 #[macro_use]

--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-async-await"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -8,7 +8,7 @@
     pin,
     )]
 
-#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.4")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/tokio-codec/CHANGELOG.md
+++ b/tokio-codec/CHANGELOG.md
@@ -1,3 +1,7 @@
-# # 0.1.0 (June 13, 2018)
+# 0.1.1 (September 26, 2018)
+
+* Allow setting max line length with `LinesCodec` (#632)
+
+# 0.1.0 (June 13, 2018)
 
 * Initial release (#353)

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -3,14 +3,15 @@ name = "tokio-codec"
 
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc URL.
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>", "Bryan Burgers <bryan@burgers.io>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-codec/0.1"
+documentation = "https://docs.rs/tokio-codec/0.1.1/tokio_codec"
 description = """
 Utilities for encoding and decoding frames.
 """

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![doc(html_root_url = "https://docs.rs/tokio-codec/0.1.1")]
+
 //! Utilities for encoding and decoding frames.
 //!
 //! Contains adapters to go from streams of bytes, [`AsyncRead`] and
@@ -9,9 +12,6 @@
 //! [`Sink`]: #
 //! [`Stream`]: #
 //! [transports]: #
-
-#![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-codec/0.1.0")]
 
 extern crate bytes;
 extern crate tokio_io;

--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.2 (September 26, 2018)
+
+* Implement `futures::Executor` for executor types (#563)
+* Spawning performance improvements (#565)
+
 # 0.1.1 (August 6, 2018)
 
 * Implement `std::Error` for misc error types (#501)

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -3,10 +3,11 @@ name = "tokio-current-thread"
 
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc URL
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
-documentation = "https://docs.rs/tokio-current-thread"
+version = "0.1.2"
+documentation = "https://docs.rs/tokio-current-thread/0.1.2/tokio_current_thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.2")]
+#![deny(warnings, missing_docs, missing_debug_implementations)]
+
 //! A single-threaded executor which executes tasks on the same thread from which
 //! they are spawned.
 //!
@@ -21,9 +24,6 @@
 //! [`spawn`]: fn.spawn.html
 //! [`block_on_all`]: fn.block_on_all.html
 //! [executor module]: https://docs.rs/tokio/0.1/tokio/executor/index.html
-
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.1")]
-#![deny(warnings, missing_docs, missing_debug_implementations)]
 
 extern crate futures;
 extern crate tokio_executor;

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.5 (September 26, 2018)
+
+* Implement `futures::Executor` for `DefaultExecutor` (#563).
+* Add `Enter::block_on(future)` (#646)
+
 # 0.1.4 (August 23, 2018)
 
 * Implement `std::error::Error` for error types (#511).

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -6,8 +6,8 @@ name = "tokio-executor"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.4"
-documentation = "https://docs.rs/tokio-executor/0.1.4/tokio_executor"
+version = "0.1.5"
+documentation = "https://docs.rs/tokio-executor/0.1.5/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.5")]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.9 (September 27, 2018)
+
+* Fix bug in `AsyncRead::split()` (#655).
+* Fix non-terminating loop in `length_delimited::FramedWrite` (#576).
+
 # 0.1.8 (August 23, 2018)
 
 * Documentation improvements

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -6,12 +6,12 @@ name = "tokio-io"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.1.8/tokio_io"
+documentation = "https://docs.rs/tokio-io/0.1.9/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.9")]
 
 //! Core I/O traits and combinators when working with Tokio.
 //!

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.6 (September 27, 2018)
+
+* Fix panic when reactor is stored in a thread-local (#628).
+
 # 0.1.5 (August 27, 2018)
 
 * Experimental async / await support.

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-reactor"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1.5/tokio_reactor"
+documentation = "https://docs.rs/tokio-reactor/0.1.6/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.6")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-tcp/CHANGELOG.md
+++ b/tokio-tcp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2 (September 27, 2018)
+
+* Documentation tweaks
+
 # 0.1.1 (August 6, 2018)
 
 * Add `TcpStream::try_clone` (#448)

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -3,14 +3,15 @@ name = "tokio-tcp"
 
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc url
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-tcp/0.1"
+documentation = "https://docs.rs/tokio-tcp/0.1.2/tokio_tcp"
 description = """
 TCP bindings for tokio.
 """

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.2")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
 //! TCP bindings for `tokio`.
 //!
 //! This module contains the TCP networking types, similar to the standard
@@ -18,9 +21,6 @@
 //! [`TcpListener`]: struct.TcpListener.html
 //! [incoming_method]: struct.TcpListener.html#method.incoming
 //! [`Incoming`]: struct.Incoming.html
-
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.1")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;
 #[macro_use]

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.7 (September 27, 2018)
+
+* Add ThreadPool::spawn_handle (#602, #604).
+* Fix spawned future leak (#649).
+
 # 0.1.6 (August 23, 2018)
 
 * Misc performance improvements (#466, #468, #470, #475, #534)

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -5,8 +5,8 @@ name = "tokio-threadpool"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.6"
-documentation = "https://docs.rs/tokio-threadpool/0.1.6/tokio_threadpool"
+version = "0.1.7"
+documentation = "https://docs.rs/tokio-threadpool/0.1.7/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.7")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.7 (September 27, 2018)
+
+* Fix `Timeout` on error bug (#648).
+* Miscellaneous documentation improvements.
+
 # 0.2.6 (August 23, 2018)
 
 * Implement `Default` for `timer::Handle` (#553)

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -5,11 +5,11 @@ name = "tokio-timer"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.6/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.7/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.7")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Utilities for tracking time.


### PR DESCRIPTION
Bump version to v0.1.9

This also includes bumps to subcrates.

* tokio-async-await (0.1.4)
* tokio-codec (0.1.1)
* tokio-current-thread (0.1.2)
* tokio-executor (0.1.5)
* tokio-io (0.1.9)
* tokio-reactor (0.1.6)
* tokio-tcp (0.1.2)
* tokio-threadpool (0.1.7)
* tokio-timer (0.2.7)