### PR TITLE
Bump version to v0.1.10, fixing minimal versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.10 (September 27, 2018)
+
+* Fix minimal versions
+
 # 0.1.9 (September 27, 2018)
 
 * Experimental async/await improvements (#661).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.9/tokio/"
+documentation = "https://docs.rs/tokio/0.1.10/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -55,9 +55,9 @@ appveyor = { repository = "carllerche/tokio", id = "s83yxhy9qeb58va7" }
 [dependencies]
 bytes = "0.4"
 tokio-codec = { version = "0.1.0", path = "tokio-codec" }
-tokio-current-thread = { version = "0.1.1", path = "tokio-current-thread" }
+tokio-current-thread = { version = "0.1.3", path = "tokio-current-thread" }
 tokio-io = { version = "0.1.6", path = "tokio-io" }
-tokio-executor = { version = "0.1.2", path = "tokio-executor" }
+tokio-executor = { version = "0.1.5", path = "tokio-executor" }
 tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }
 tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool" }
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.9")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.10")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,

--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (September 27, 2018)
+
+* Fix minimal versions
+
 # 0.1.2 (September 26, 2018)
 
 * Implement `futures::Executor` for executor types (#563)

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -6,8 +6,8 @@ name = "tokio-current-thread"
 # - Update doc URL
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
-documentation = "https://docs.rs/tokio-current-thread/0.1.2/tokio_current_thread"
+version = "0.1.3"
+documentation = "https://docs.rs/tokio-current-thread/0.1.3/tokio_current_thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"
@@ -19,5 +19,5 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
+tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
 futures = "0.1.19"

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.3")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A single-threaded executor which executes tasks on the same thread from which


### PR DESCRIPTION
Some minimal versions were not correctly updated.

Also updates:

* tokio-current-thread (v0.1.3).