### PR TITLE
Bump version to v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ maintains its own changelog tracking changes made in each respective sub crate.
 
 # 0.1.11 (September 28, 2018)
 
-* Fix `tokio-async-await` dependency.
+* Fix `tokio-async-await` dependency (#675).
 
 # 0.1.10 (September 27, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.11 (September 28, 2018)
+
+* Fix `tokio-async-await` dependency.
+
 # 0.1.10 (September 27, 2018)
 
 * Fix minimal versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.10/tokio/"
+documentation = "https://docs.rs/tokio/0.1.11/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -70,11 +70,11 @@ futures = "0.1.20"
 # Needed until `reactor` is removed from `tokio`.
 mio = "0.6.14"
 
-[target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "0.2.1", path = "tokio-uds" }
-
 # Needed for async/await preview support
 tokio-async-await = { version = "0.1.0", path = "tokio-async-await", optional = true }
+
+[target.'cfg(unix)'.dependencies]
+tokio-uds = { version = "0.2.1", path = "tokio-uds" }
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.11")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,


### PR DESCRIPTION
This fixes the dependency on `tokio-async-await` to not be scoped to
unix platforms.

Fixes #673