### PR TITLE
io: fix minor documentation errors for Async{Read,Write}

### DIFF
--- a/tokio-io/src/async_write.rs
+++ b/tokio-io/src/async_write.rs
@@ -10,8 +10,8 @@ use AsyncRead;
 /// **nonblocking**. All non-blocking I/O objects must return an error when
 /// bytes cannot be written instead of blocking the current thread.
 ///
-/// Specifically, this means that the `write` function will return one of the
-/// following:
+/// Specifically, this means that the `poll_write` function will return one of
+/// the following:
 ///
 /// * `Ok(Async::Ready(n))` means that `n` bytes of data was immediately
 ///   written.
@@ -19,7 +19,7 @@ use AsyncRead;
 /// * `Ok(Async::NotReady)` means that no data was written from the buffer
 ///   provided. The I/O object is not currently writable but may become writable
 ///   in the future. Most importantly, **the current future's task is scheduled
-///   to get unparked when the object is readable**. This means that like
+///   to get unparked when the object is writable**. This means that like
 ///   `Future::poll` you'll receive a notification when the I/O object is
 ///   writable again.
 ///
@@ -40,7 +40,7 @@ pub trait AsyncWrite: std_io::Write {
     /// On success, returns `Ok(Async::Ready(num_bytes_written))`.
     ///
     /// If the object is not ready for writing, the method returns
-    /// `Ok(Async::Pending)` and arranges for the current task (via
+    /// `Ok(Async::NotReady)` and arranges for the current task (via
     /// `cx.waker()`) to receive a notification when the object becomes
     /// readable or is closed.
     fn poll_write(&mut self, buf: &[u8]) -> Poll<usize, std_io::Error> {
@@ -59,7 +59,7 @@ pub trait AsyncWrite: std_io::Write {
     /// On success, returns `Ok(Async::Ready(()))`.
     ///
     /// If flushing cannot immediately complete, this method returns
-    /// `Ok(Async::Pending)` and arranges for the current task (via
+    /// `Ok(Async::NotReady)` and arranges for the current task (via
     /// `cx.waker()`) to receive a notification when the object can make
     /// progress towards flushing.
     fn poll_flush(&mut self) -> Poll<(), std_io::Error> {


### PR DESCRIPTION
This fixes a few documentation errors for the `AsyncRead` and `AsyncWrite` traits.