### PR TITLE
codec: Fix panic in `LengthDelimitedCodec::encode`

### DIFF
--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -578,6 +578,12 @@ impl Encoder for LengthDelimitedCodec {
             "provided length would overflow after adjustment",
         ))?;
 
+        // If there's no room to write the length field in `dst`, reserve more
+        // capacity so we don't overflow the buffer.
+        if dst.remaining_mut() < self.builder.length_field_len {
+            dst.reserve(self.builder.length_field_len);
+        }
+
         if self.builder.length_field_is_big_endian {
             dst.put_uint_be(n as u64, self.builder.length_field_len);
         } else {

--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -578,11 +578,9 @@ impl Encoder for LengthDelimitedCodec {
             "provided length would overflow after adjustment",
         ))?;
 
-        // If there's no room to write the length field in `dst`, reserve more
-        // capacity so we don't overflow the buffer.
-        if dst.remaining_mut() < self.builder.length_field_len {
-            dst.reserve(self.builder.length_field_len);
-        }
+        // Reserve capacity in the destination buffer to fit the frame and
+        // length field (plus adjustment).
+        dst.reserve(self.builder.length_field_len + n);
 
         if self.builder.length_field_is_big_endian {
             dst.put_uint_be(n as u64, self.builder.length_field_len);


### PR DESCRIPTION
Fixes: #681 

## Motivation

Currently, a potential panic exists in `LengthDelimitedCodec::encode`.
Writing the length field to the `dst` buffer can exceed the buffer
capacity, as `BufMut::put_uint_{le,be}` doesn't reserve more capacity. 

## Solution

This branch adds a check that there's sufficient remaining buffer
capacity to hold the length field, and resizes the buffer to hold the
length field if there is no capacity left.

I've also added a test that reproduces the issue. The test panics on
master, but passes after making this change.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>