### PR TITLE
threadpool: spawn new tasks onto a random worker

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,3 +89,20 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
+
+[patch.crates-io]
+tokio = { path = "." }
+tokio-async-await  = { path = "./tokio-async-await" }
+tokio-codec = { path = "./tokio-codec" }
+tokio-current-thread = { path = "./tokio-current-thread" }
+tokio-executor = { path = "./tokio-executor" }
+tokio-fs = { path = "./tokio-fs" }
+tokio-io = { path = "./tokio-io" }
+tokio-reactor = { path = "./tokio-reactor" }
+tokio-signal = { path = "./tokio-signal" }
+tokio-tcp = { path = "./tokio-tcp" }
+tokio-threadpool = { path = "./tokio-threadpool" }
+tokio-timer = { path = "./tokio-timer" }
+tokio-tls = { path = "./tokio-tls" }
+tokio-udp = { path = "./tokio-udp" }
+tokio-uds = { path = "./tokio-uds" }

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -27,9 +27,10 @@ mio = "0.6.14"
 num_cpus = "1.8.0"
 parking_lot = "0.6.3"
 slab = "0.4.0"
-tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
-tokio-io = { version = "0.1.9", path = "../tokio-io" }
+tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
+tokio-io = { version = "0.1.6", path = "../tokio-io" }
 
 [dev-dependencies]
-tokio = { version = "0.1.11", path = ".." }
+num_cpus = "1.8.0"
+tokio = { version = "0.1.7", path = ".." }
 tokio-io-pool = "0.1.4"

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -27,9 +27,9 @@ mio = "0.6.14"
 num_cpus = "1.8.0"
 parking_lot = "0.6.3"
 slab = "0.4.0"
-tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
+tokio-io = { version = "0.1.9", path = "../tokio-io" }
 
 [dev-dependencies]
-num_cpus = "1.8.0"
-tokio = { version = "0.1.7", path = ".." }
+tokio = { version = "0.1.11", path = ".." }
+tokio-io-pool = "0.1.4"

--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -317,6 +317,16 @@ impl Pool {
 
         // All workers are active, so pick a random worker and submit the
         // task to it.
+        self.submit_to_random(task, inner);
+    }
+
+    /// Submit a task to a random worker
+    ///
+    /// Called from outside of the scheduler, this function is how new tasks
+    /// enter the system.
+    pub fn submit_to_random(&self, task: Arc<Task>, inner: &Arc<Pool>) {
+        debug_assert_eq!(*self, **inner);
+
         let len = self.workers.len();
         let idx = self.rand_usize() % len;
 

--- a/tokio-threadpool/src/sender.rs
+++ b/tokio-threadpool/src/sender.rs
@@ -161,7 +161,7 @@ impl<'a> tokio_executor::Executor for &'a Sender {
         // Create a new task for the future
         let task = Arc::new(Task::new(future));
 
-        self.inner.submit(task, &self.inner);
+        self.inner.submit_to_random(task, &self.inner);
 
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Once an IO handle gets assigned to a reactor, it stays assigned to it forever. A handle is assigned to a reactor the first time it is polled.

Now that every worker thread in `tokio-threadpool` drives its own reactor, we'd like to distribute the IO work among reactors as equally as possible. This is only possible if each newly spawned task is polled the first time on a random worker.

Currently, when spawning a new task inside threadpool, it always goes into the local worker's queue. If a task spawns a bunch of child IO tasks, that means a disproportionate number of them will be polled the first time by the current worker thread. Work stealing doesn't help much in this case - it turns out a lot of tasks will be polled before other worker threads get a chance to steal them, thus skewing the IO handle distribution onto reactors.

## Solution

When spawning a new task, *always* pick a random worker and push the task into that worker's inbound queue.

Note: this heuristic is not perfect, but seems to be an improvement over the current task spawning strategy. We might tweak it further in the future.

I've expanded the `tokio-reactor` benchmark. Here's our baseline using `tokio-io-pool`:

```
test io_pool::notify_many    ... bench:  34,479,546 ns/iter (+/- 10,232,063)
```

This is `tokio-threadpool` before PR #660 (at commit 886511c), with a single global reactor:

```
test threadpool::notify_many ... bench:  87,539,637 ns/iter (+/- 4,874,898)
```

After PR #660 (commit d35d051), with a reactor per worker thread:

```
test threadpool::notify_many ... bench:  57,666,138 ns/iter (+/- 6,762,130)
```

Finally, this PR, with randomized task submission:

```
test threadpool::notify_many ... bench:  46,792,382 ns/iter (+/- 5,140,460)
```

Still not as fast as `tokio-io-pool`, but we're getting there.

cc @jonhoo