### PR TITLE
tokio-udp: add sender's SocketAddr to the error type of UdpFramed

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -216,7 +216,7 @@ mod udp {
             } else {
                 None
             }
-        });
+        }).map_err(|(e, _)| e);
 
         Box::new(future::lazy(|| {
             tokio::spawn(forward_stdin);

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -43,7 +43,7 @@ fn main() {
             i += 1;
             println!("[a] recv: {}", String::from_utf8_lossy(&msg));
             (format!("PING {}", i).into(), addr)
-        });
+        }).map_err(|(e, _)| e);
         a_sink.send_all(a_stream)
     });
 
@@ -52,7 +52,7 @@ fn main() {
     let b_stream = b_stream.map(|(msg, addr)| {
         println!("[b] recv: {}", String::from_utf8_lossy(&msg));
         ("PONG".into(), addr)
-    });
+    }).map_err(|(e, _)| e);;
     let b = b_sink.send_all(b_stream);
 
     // Spawn the sender of pongs and then wait for our pinger to finish.

--- a/tokio-udp/tests/udp.rs
+++ b/tokio-udp/tests/udp.rs
@@ -232,7 +232,7 @@ fn send_framed() {
         let msg = b"4567".to_vec();
 
         let send = a.send((msg.clone(), b_addr));
-        let recv = b.into_future().map_err(|e| e.0);
+        let recv = b.into_future().map_err(|e| (e.0).0);
         let (sendt, received) = t!(send.join(recv).wait());
 
         let (data, addr) = received.0.unwrap();
@@ -250,7 +250,7 @@ fn send_framed() {
         let msg = b"".to_vec();
 
         let send = a.send((msg.clone(), b_addr));
-        let recv = b.into_future().map_err(|e| e.0);
+        let recv = b.into_future().map_err(|e| (e.0).0);
         let received = t!(send.join(recv).wait()).1;
 
         let (data, addr) = received.0.unwrap();


### PR DESCRIPTION
## Motivation

Fixes https://github.com/tokio-rs/tokio/issues/693

## Solution

Adds optional sender's SocketAddr to the error type of UdpFramed.