### PR TITLE
fs: fix minor documentation error for MetadataFuture

### DIFF
--- a/tokio-fs/src/file/metadata.rs
+++ b/tokio-fs/src/file/metadata.rs
@@ -8,7 +8,7 @@ use std::io;
 
 const POLL_AFTER_RESOLVE: &str = "Cannot poll MetadataFuture after it resolves";
 
-/// Future returned by `File::metadata` and resolves to a `(Metadata, File)` instance.
+/// Future returned by `File::metadata` and resolves to a `(File, Metadata)` instance.
 #[derive(Debug)]
 pub struct MetadataFuture {
     file: Option<File>,


### PR DESCRIPTION
Documentation says the future resolves to `(Metadata, File)` but it's actually `(File, Metadata)`.