### PR TITLE
threadpool: Arc instead of Inner in Notifier

### DIFF
--- a/tokio-threadpool/src/notifier.rs
+++ b/tokio-threadpool/src/notifier.rs
@@ -3,7 +3,7 @@ use task::Task;
 
 use std::mem;
 use std::ops;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use futures::executor::Notify;
 
@@ -13,7 +13,7 @@ use futures::executor::Notify;
 /// to poll the future again.
 #[derive(Debug)]
 pub(crate) struct Notifier {
-    pub inner: Weak<Pool>,
+    pub inner: Arc<Pool>,
 }
 
 /// A guard that ensures that the inner value gets forgotten.
@@ -38,9 +38,7 @@ impl Notify for Notifier {
                 // Bump the ref count
                 let task = task.clone();
 
-                if let Some(inner) = self.inner.upgrade() {
-                    let _ = inner.submit(task, &inner);
-                }
+                let _ = self.inner.submit(task, &self.inner);
             }
         }
     }

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -222,7 +222,7 @@ impl Worker {
 
         // Get the notifier.
         let notify = Arc::new(Notifier {
-            inner: Arc::downgrade(&self.inner),
+            inner: self.inner.clone(),
         });
 
         let mut first = true;


### PR DESCRIPTION
## Motivation

Notifying tasks is slow because we call `Arc<Pool>::upgrade()` on every notification, which updates `Arc`-related reference counters, thus creating contention.

## Solution

Use `Arc` instead of `Weak` in `Notifier`. I think it's fine to use a strong reference to the `Pool` because it's destroyed by shutting down (typically by dropping `ThreadPool`) rather than by dropping `Pool`.

The `tokio-reactor` benchmark before this PR:

```
test threadpool::notify_many ... bench:  45,258,071 ns/iter (+/- 2,276,054)
```

After:

```
test threadpool::notify_many ... bench:  40,855,421 ns/iter (+/- 2,894,928)
```

This brings us one more step closer to `tokio-io-pool`:

```
test io_pool::notify_many    ... bench:  32,214,577 ns/iter (+/- 5,228,705)
```