### PR TITLE
 udp: add `into_parts` to `RecvDgram`

### DIFF
--- a/tokio-udp/src/recv_dgram.rs
+++ b/tokio-udp/src/recv_dgram.rs
@@ -31,37 +31,6 @@ impl<T> RecvDgram<T> {
         RecvDgram { state: Some(inner) }
     }
 
-    /// Consume the `RecvDgram`, returning the socket.
-    ///
-    /// ```
-    /// # extern crate tokio_udp;
-    ///
-    /// use tokio_udp::UdpSocket;
-    ///
-    /// # pub fn main() {
-    ///
-    /// let socket = UdpSocket::bind(&([127, 0, 0, 1], 0).into()).unwrap();
-    /// let mut buffer = vec![0; 4096];
-    ///
-    /// let future = socket.recv_dgram(buffer);
-    ///
-    /// // ... polling `future` ... giving up (e.g. after timeout)
-    ///
-    /// let socket = future.into_inner();
-    ///
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// If called after the future has completed.
-    pub fn into_inner(mut self) -> UdpSocket {
-        let state = self.state
-            .take()
-            .expect("into_inner called after completion");
-        state.socket
-    }
-
     /// Consume the `RecvDgram`, returning the socket and buffer.
     ///
     /// ```
@@ -111,4 +80,3 @@ impl<T> Future for RecvDgram<T>
         Ok(Async::Ready((inner.socket, inner.buffer, n, addr)))
     }
 }
-

--- a/tokio-udp/src/recv_dgram.rs
+++ b/tokio-udp/src/recv_dgram.rs
@@ -33,6 +33,25 @@ impl<T> RecvDgram<T> {
 
     /// Consume the `RecvDgram`, returning the socket.
     ///
+    /// ```
+    /// # extern crate tokio_udp;
+    ///
+    /// use tokio_udp::UdpSocket;
+    ///
+    /// # pub fn main() {
+    ///
+    /// let socket = UdpSocket::bind(&([127, 0, 0, 1], 0).into()).unwrap();
+    /// let mut buffer = vec![0; 4096];
+    ///
+    /// let future = socket.recv_dgram(buffer);
+    ///
+    /// // ... polling `future` ... giving up (e.g. after timeout)
+    ///
+    /// let socket = future.into_inner();
+    ///
+    /// # }
+    /// ```
+    ///
     /// # Panics
     ///
     /// If called after the future has completed.
@@ -45,6 +64,24 @@ impl<T> RecvDgram<T> {
 
     /// Consume the `RecvDgram`, returning the socket and buffer.
     ///
+    /// ```
+    /// # extern crate tokio_udp;
+    ///
+    /// use tokio_udp::UdpSocket;
+    ///
+    /// # pub fn main() {
+    ///
+    /// let socket = UdpSocket::bind(&([127, 0, 0, 1], 0).into()).unwrap();
+    /// let mut buffer = vec![0; 4096];
+    ///
+    /// let future = socket.recv_dgram(buffer);
+    ///
+    /// // ... polling `future` ... giving up (e.g. after timeout)
+    ///
+    /// let (socket, buffer) = future.into_parts();
+    ///
+    /// # }
+    /// ```
     /// # Panics
     ///
     /// If called after the future has completed.

--- a/tokio-udp/src/recv_dgram.rs
+++ b/tokio-udp/src/recv_dgram.rs
@@ -30,6 +30,30 @@ impl<T> RecvDgram<T> {
         let inner = RecvDgramInner { socket: socket, buffer: buffer };
         RecvDgram { state: Some(inner) }
     }
+
+    /// Consume the `RecvDgram`, returning the socket.
+    ///
+    /// # Panics
+    ///
+    /// If called after the future has completed.
+    pub fn into_inner(mut self) -> UdpSocket {
+        let state = self.state
+            .take()
+            .expect("into_inner called after completion");
+        state.socket
+    }
+
+    /// Consume the `RecvDgram`, returning the socket and buffer.
+    ///
+    /// # Panics
+    ///
+    /// If called after the future has completed.
+    pub fn into_parts(mut self) -> (UdpSocket, T) {
+        let state = self.state
+            .take()
+            .expect("into_parts called after completion");
+        (state.socket, state.buffer)
+    }
 }
 
 impl<T> Future for RecvDgram<T>
@@ -50,3 +74,4 @@ impl<T> Future for RecvDgram<T>
         Ok(Async::Ready((inner.socket, inner.buffer, n, addr)))
     }
 }
+

--- a/tokio-udp/src/recv_dgram.rs
+++ b/tokio-udp/src/recv_dgram.rs
@@ -24,6 +24,17 @@ struct RecvDgramInner<T> {
     buffer: T
 }
 
+/// Components of a `RecvDgram` future, returned from `into_parts`.
+#[derive(Debug)]
+pub struct Parts<T> {
+    /// The socket
+    pub socket: UdpSocket,
+    /// The buffer
+    pub buffer: T,
+
+    _priv: ()
+}
+
 impl<T> RecvDgram<T> {
     /// Create a new future to receive UDP Datagram
     pub(crate) fn new(socket: UdpSocket, buffer: T) -> RecvDgram<T> {
@@ -47,18 +58,26 @@ impl<T> RecvDgram<T> {
     ///
     /// // ... polling `future` ... giving up (e.g. after timeout)
     ///
-    /// let (socket, buffer) = future.into_parts();
+    /// let parts = future.into_parts();
+    ///
+    /// let socket = parts.socket; // extract the socket
+    /// let buffer = parts.buffer; // extract the buffer
     ///
     /// # }
     /// ```
     /// # Panics
     ///
     /// If called after the future has completed.
-    pub fn into_parts(mut self) -> (UdpSocket, T) {
+    pub fn into_parts(mut self) -> Parts<T> {
         let state = self.state
             .take()
             .expect("into_parts called after completion");
-        (state.socket, state.buffer)
+
+        Parts {
+            socket: state.socket,
+            buffer: state.buffer,
+            _priv: ()
+        }
     }
 }
 


### PR DESCRIPTION
Add ~~methods `RecvDgram::into_inner` and~~ `RecvDgram::into_parts` to allow deconstructing a `RecvDgram` future in case it can not be driven to completion.

## Motivation

If the `RecvDgram` future can not be driven to completion, it may become necessary to get back the `UdpSocket` and buffer, which is currently not possible. Since UDP is unreliable, it is advisable to use timeouts when receiving datagrams. After a timeout, one would probably retry sending and receiving, which requires the socket, however since it cannot be pulled out of `RecvDgram` again, `RecvDgram` is virtually impossible to use together with timeouts.

## Solution

With ~~`into_inner` and~~ `into_parts` the socket and buffer can be retrieved by consuming the future. This allows to continue using those values.