### PR TITLE
uds: add NetBSD support

### DIFF
--- a/tokio-uds/src/ucred.rs
+++ b/tokio-uds/src/ucred.rs
@@ -12,7 +12,7 @@ pub struct UCred {
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::impl_linux::get_peer_cred;
 
-#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 pub use self::impl_macos::get_peer_cred;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -61,7 +61,7 @@ pub mod impl_linux {
     }
 }
 
-#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 pub mod impl_macos {
     use libc::getpeereid;
     use std::{io, mem};
@@ -95,6 +95,7 @@ mod test {
 
     #[test]
     #[cfg_attr(target_os = "freebsd", ignore = "Requires FreeBSD 12.0 or later. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=176419")]
+    #[cfg_attr(target_os = "netbsd", ignore = "NetBSD does not support getpeereid() for sockets created by socketpair()")]
     fn test_socket_pair() {
         let (a, b) = UnixStream::pair().unwrap();
         let cred_a = a.peer_cred().unwrap();


### PR DESCRIPTION
`test_socket_pair()` is ignored as `getpeereid()` does not work with sockets created by `socketpair()` on NetBSD.

I did not add new test for this, hope it is OK.

## Motivation

tokio-uds cannot be built on NetBSD due to the following error.

```
$ cargo build
   Compiling tokio-uds v0.2.2 (file:///work/rust/tokio/tokio-uds)
error[E0425]: cannot find function `get_peer_cred` in module `ucred`
   --> tokio-uds/src/stream.rs:116:16
    |
116 |         ucred::get_peer_cred(self)                                                                               
    |                ^^^^^^^^^^^^^ not found in `ucre
```

## Solution

`target_os = "netbsd"` is added as well as other BSD OS's.
