### PR TITLE
Bump version to 0.1.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.12 (October 23, 2018)
+
+* runtime: expose `keep_alive` on runtime builder (#676).
+* runtime: create a reactor per worker thread (#660).
+* codec: fix panic in `LengthDelimitedCodec` (#682).
+* io: re-export `tokio_io::io::read` function (#689).
+* runtime: check for executor re-entry in more places (#708).
+
 # 0.1.11 (September 28, 2018)
 
 * Fix `tokio-async-await` dependency (#675).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.11/tokio/"
+documentation = "https://docs.rs/tokio/0.1.12/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.12")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4 (October 23, 2018)
+
+* Provide `File::from_std` (#696).
+
 # 0.1.3 (August 6, 2018)
 
 * Add async equivalents to most of `std::fs` (#494).

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -4,14 +4,15 @@ name = "tokio-fs"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update CHANGELOG.md.
+# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-fs/0.1"
+documentation = "https://docs.rs/tokio-fs/0.1.4/tokio_fs"
 description = """
 Filesystem API for Tokio.
 """

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.4")]
+
 //! Asynchronous file and standard stream adaptation.
 //!
 //! This module contains utility methods and adapter types for input/output to
@@ -24,9 +27,6 @@
 //! [`blocking`]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/fn.blocking.html
 //! [`AsyncRead`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncRead.html
 //! [tokio-threadpool]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool
-
-#![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.3")]
 
 #[macro_use]
 extern crate futures;

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.10 (October 23, 2018)
+
+* Expose inner codec from `Framed` (#686).
+* Implement AsyncRead::prepare_uninitialized_buffer for Take and Chain (#678).
+
 # 0.1.9 (September 27, 2018)
 
 * Fix bug in `AsyncRead::split()` (#655).

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -6,12 +6,12 @@ name = "tokio-io"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.1.9/tokio_io"
+documentation = "https://docs.rs/tokio-io/0.1.10/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.9")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.10")]
 
 //! Core I/O traits and combinators when working with Tokio.
 //!

--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "tokio-signal"
+
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update CHANGELOG.md.
+# - Update doc URL.
+# - Create "v0.2.x" git tag.
 version = "0.2.6"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-signal/0.2"
+documentation = "https://docs.rs/tokio-signal/0.2.6/tokio_signal"
 description = """
 An implementation of an asynchronous Unix signal handling backed futures.
 """

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.8 (October 23, 2018)
+
+* Assign spawned tasks to random worker (#660).
+* Worker threads no longer shutdown (#692).
+* Reduce atomic ops in notifier (#702).
+
 # 0.1.7 (September 27, 2018)
 
 * Add ThreadPool::spawn_handle (#602, #604).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -5,8 +5,8 @@ name = "tokio-threadpool"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
-documentation = "https://docs.rs/tokio-threadpool/0.1.7/tokio_threadpool"
+version = "0.1.8"
+documentation = "https://docs.rs/tokio-threadpool/0.1.8/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.8")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-uds/CHANGELOG.md
+++ b/tokio-uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.3 (October 23, 2018)
+
+* Fix build on NetBSD (#715).
+
 # 0.2.2 (September 27, 2018)
 
 * Fix bug in `UdsStream::read_buf` (#672).

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -5,12 +5,12 @@ name = "tokio-uds"
 # - Update doc url
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-uds/0.2.2/tokio_uds/"
+documentation = "https://docs.rs/tokio-uds/0.2.3/tokio_uds/"
 description = """
 Unix Domain sockets for Tokio
 """

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -1,10 +1,10 @@
+#![cfg(unix)]
+#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.3")]
+#![deny(missing_docs, warnings, missing_debug_implementations)]
+
 //! Unix Domain Sockets for Tokio.
 //!
 //! This crate provides APIs for using Unix Domain Sockets with Tokio.
-
-#![cfg(unix)]
-#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.2")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
 
 extern crate bytes;
 #[macro_use]


### PR DESCRIPTION
Also bumps the following sub-crates:

* tokio-fs (0.1.4)
* tokio-io (0.1.10)
* tokio-signal (0.2.6)
* tokio-threadpool (0.1.8)
* tokio-uds (0.2.3)