### PR TITLE
Derive Clone for delay_queue::Key

### DIFF
--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -171,7 +171,7 @@ pub struct Expired<T> {
 /// documentation for more details.
 ///
 /// [`DelayQueue`]: struct.DelayQueue.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Key {
     index: usize,
 }


### PR DESCRIPTION
Improves API ergonomics with minimal forwards-compatibility hazard.