### PR TITLE
uds: added solaris support in the `ucred` module

### DIFF
--- a/tokio-uds/src/ucred.rs
+++ b/tokio-uds/src/ucred.rs
@@ -15,6 +15,9 @@ pub use self::impl_linux::get_peer_cred;
 #[cfg(any(target_os = "dragonfly", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "openbsd"))]
 pub use self::impl_macos::get_peer_cred;
 
+#[cfg(any(target_os = "solaris"))]
+pub use self::impl_solaris::get_peer_cred;
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub mod impl_linux {
     use libc::{c_void, getsockopt, socklen_t, SOL_SOCKET, SO_PEERCRED};
@@ -84,6 +87,51 @@ pub mod impl_macos {
         }
     }
 }
+
+
+#[cfg(any(target_os = "solaris"))]
+pub mod impl_solaris {
+    use std::io;
+    use std::os::unix::io::AsRawFd;
+    use UnixStream;
+    use std::ptr;
+
+    #[allow(non_camel_case_types)]
+    enum ucred_t {}
+
+    extern "C" {
+        fn ucred_free(cred: *mut ucred_t);
+        fn ucred_geteuid(cred: *const ucred_t) -> super::uid_t;
+        fn ucred_getegid(cred: *const ucred_t) -> super::gid_t;
+
+        fn getpeerucred(fd: ::std::os::raw::c_int, cred: *mut *mut ucred_t) -> ::std::os::raw::c_int;
+    }
+
+    pub fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {
+        unsafe {
+            let raw_fd = sock.as_raw_fd();
+
+            let mut cred = ptr::null_mut::<*mut ucred_t>() as *mut ucred_t;
+
+            let ret = getpeerucred(raw_fd, &mut cred);
+
+            if ret == 0 {
+                let uid = ucred_geteuid(cred);
+                let gid = ucred_getegid(cred);
+
+                ucred_free(cred);
+
+                Ok(super::UCred {
+                    uid,
+                    gid,
+                })
+            } else {
+                Err(io::Error::last_os_error())
+            }
+        }
+    }
+}
+
 
 // Note that LOCAL_PEERCRED is not supported on DragonFly (yet). So do not run tests.
 #[cfg(not(target_os = "dragonfly"))]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
When building for `x86_64-sun-solaris` (Originally to get `reqwest` to work), I got a build error about `get_peer_cred` not being implemented.

The full error message:
```
[root@localhost hello]# cross build --target x86_64-sun-solaris
   Compiling hello v0.1.0 (/project)
   Compiling tokio-uds v0.2.3
error[E0425]: cannot find function `get_peer_cred` in module `ucred`
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/tokio-uds-0.2.3/src/stream.rs:116:16
    |
116 |         ucred::get_peer_cred(self)
    |                ^^^^^^^^^^^^^ not found in `ucred`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0425`.
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I implemented the needed function for the solaris target. It is partially based on https://github.com/LuaDist/libbsd/blob/master/src/getpeereid.c#L103, and by looking at the Oracel man pages (https://docs.oracle.com/cd/E36784_01/html/E36874/getpeerucred-3c.html).
The nessery functions are not exposed by the `libc` crate, so I added them here.

I also built a binary with the `tests` code, and confirmed that it works on a Solaris 11.4 (Since you probably don't run your tests on that).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
