### PR TITLE
Reduce log level of loop process

### DIFF
--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -376,7 +376,7 @@ impl Reactor {
 
         if let Some(start) = start {
             let dur = start.elapsed();
-            debug!("loop process - {} events, {}.{:03}s",
+            trace!("loop process - {} events, {}.{:03}s",
                    events,
                    dur.as_secs(),
                    dur.subsec_nanos() / 1_000_000);


### PR DESCRIPTION
In using Tokio, I have noticed that `tokio_reactor` logs a lot of a single message at the debug level that isn't particularly useful. I would personally expect this log message to be at the `trace` level, based on my experience with other crates in the Rust ecosystem.

Would there be any opposition to reducing this to a `trace`?

Sample (contiguous) output from a real application:

```
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 0 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 0 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 0 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 2 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 0 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 0 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 2 events, 0.000s
DEBUG 2018-10-31T19:16:25Z: tokio_reactor: loop process - 1 events, 0.000s
```

This is with many dependencies and doing actual work, including postgres, redis, and kafka, and no one else logged during this entire block, including my own application code which frequently logs.
