### PR TITLE
fs: gen_ascii_chars has been deprecated

### DIFF
--- a/tokio-fs/tests/file.rs
+++ b/tokio-fs/tests/file.rs
@@ -12,7 +12,7 @@ use tokio_threadpool::*;
 use futures::Future;
 use futures::future::poll_fn;
 use futures::sync::oneshot;
-use rand::{thread_rng, Rng};
+use rand::{thread_rng, Rng, distributions};
 use tempfile::Builder as TmpBuilder;
 
 use std::fs::File as StdFile;
@@ -25,7 +25,8 @@ fn read_write() {
     let dir = TmpBuilder::new().prefix("tokio-fs-tests").tempdir().unwrap();
     let file_path = dir.path().join("read_write.txt");
 
-    let contents: Vec<u8> = thread_rng().gen_ascii_chars()
+    let contents: Vec<u8> = thread_rng()
+        .sample_iter(&distributions::Alphanumeric)
         .take(NUM_CHARS)
         .collect::<String>()
         .into();


### PR DESCRIPTION
Use sample_iter() instead.

## Motivation

`gen_ascii_chars()` has been deprecated since [rand 0.5.0](https://github.com/rust-random/rand/blob/22d6607651d8f813ad04de9e748a1d1221953f64/CHANGELOG.md#050---2018-05-21).

## Solution

Use `sample_iter()` instead.