### PR TITLE
Implement throttle combinator

### DIFF
--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -1,4 +1,7 @@
-use tokio_timer::{Throttle, Timeout};
+use tokio_timer::{
+    throttle::Throttle,
+    Timeout,
+};
 
 use futures::Stream;
 

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -37,7 +37,7 @@ pub trait StreamExt: Stream {
     {
         const NANOS_PER_SEC: f64 = 1000_000_000f64;
 
-        Throttle::new(self, Duration::new(
+        self.throttle(Duration::new(
             (1f64 / max_per_sec) as u64,
             (NANOS_PER_SEC / max_per_sec % NANOS_PER_SEC) as u32,
         ))

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -35,9 +35,12 @@ pub trait StreamExt: Stream {
     fn rate_limit(self, max_per_sec: f64) -> Throttle<Self>
     where Self: Sized
     {
-        let pause = 1_000_000_000f64 / max_per_sec;
+        const NANOS_PER_SEC: f64 = 1000_000_000f64;
 
-        Throttle::new(self, Duration::from_nanos(pause as u64))
+        Throttle::new(self, Duration::new(
+            (1f64 / max_per_sec) as u64,
+            (NANOS_PER_SEC / max_per_sec % NANOS_PER_SEC) as u32,
+        ))
     }
 
     /// Creates a new stream which allows `self` until `timeout`.

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -28,21 +28,6 @@ pub trait StreamExt: Stream {
         Throttle::new(self, duration)
     }
 
-    /// Throttle down the stream by enforcing that a maximum of `rate_per_sec`
-    /// items will be passed through per second.
-    ///
-    /// Errors are also delayed.
-    fn rate_limit(self, max_per_sec: f64) -> Throttle<Self>
-    where Self: Sized
-    {
-        const NANOS_PER_SEC: f64 = 1000_000_000f64;
-
-        self.throttle(Duration::new(
-            (1f64 / max_per_sec) as u64,
-            (NANOS_PER_SEC / max_per_sec % NANOS_PER_SEC) as u32,
-        ))
-    }
-
     /// Creates a new stream which allows `self` until `timeout`.
     ///
     /// This combinator creates a new stream which wraps the receiving stream

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -34,6 +34,7 @@ extern crate slab;
 
 pub mod clock;
 pub mod delay_queue;
+pub mod throttle;
 pub mod timeout;
 pub mod timer;
 
@@ -54,6 +55,7 @@ pub use self::delay::Delay;
 pub use self::error::Error;
 pub use self::interval::Interval;
 #[doc(inline)]
+pub use self::throttle::Throttle;
 pub use self::timeout::Timeout;
 pub use self::timer::{with_default, Timer};
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -9,6 +9,8 @@
 //!
 //! * [`Interval`] A stream that yields at fixed time intervals.
 //!
+//! * [`Throttle`]: Slow down a stream by enforcing a delay between items.
+//!
 //! * [`Timeout`]: Wraps a future or stream, setting an upper bound to the
 //!   amount of time it is allowed to execute. If the future or stream does not
 //!   complete in time, then it is canceled and an error is returned.
@@ -21,6 +23,7 @@
 //! [`Timer`] instance must be running on some thread.
 //!
 //! [`Delay`]: struct.Delay.html
+//! [`Throttle`]: struct.Throttle.html
 //! [`Timeout`]: struct.Timeout.html
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -58,7 +58,6 @@ pub use self::delay::Delay;
 pub use self::error::Error;
 pub use self::interval::Interval;
 #[doc(inline)]
-pub use self::throttle::Throttle;
 pub use self::timeout::Timeout;
 pub use self::timer::{with_default, Timer};
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! * [`Interval`] A stream that yields at fixed time intervals.
 //!
-//! * [`Throttle`]: Slow down a stream by enforcing a delay between items.
+//! * [`Throttle`]: Throttle down a stream by enforcing a fixed delay between items.
 //!
 //! * [`Timeout`]: Wraps a future or stream, setting an upper bound to the
 //!   amount of time it is allowed to execute. If the future or stream does not
@@ -23,7 +23,7 @@
 //! [`Timer`] instance must be running on some thread.
 //!
 //! [`Delay`]: struct.Delay.html
-//! [`Throttle`]: struct.Throttle.html
+//! [`Throttle`]: throttle/struct.Throttle.html
 //! [`Timeout`]: struct.Timeout.html
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -1,0 +1,68 @@
+//! Slow down a stream by enforcing a delay between items.
+
+use {Delay, Error};
+
+use futures::{Async, Future, Poll, Stream};
+use futures::future::Either;
+
+use std::time::{Duration, Instant};
+
+/// Slow down a stream by enforcing a delay between items.
+#[derive(Debug)]
+pub struct Throttle<T> {
+    delay: Option<Delay>,
+    duration: Duration,
+    stream: Option<T>,
+}
+
+impl<T> Throttle<T> {
+    /// Slow down a stream by enforcing a delay between items.
+    pub fn new(stream: T, duration: Duration) -> Self {
+        Self {
+            delay: None,
+            duration: duration,
+            stream: Some(stream),
+        }
+    }
+}
+
+impl<T: Stream> Stream for Throttle<T> {
+    type Item = T::Item;
+    type Error = Either<T::Error, Error>;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        // 1. Is there a better way than nested match statements?
+        // 2. What about having a delay and the underlying stream error'd?
+
+        match self.delay.take() {
+            Some(mut d) => match d.poll() {
+                Ok(Async::Ready(_)) => self.poll(),
+                Ok(Async::NotReady) => {
+                    self.delay = Some(d);
+
+                    Ok(Async::NotReady)
+                },
+                Err(e) => Err(Either::B(e)),
+            },
+
+            None => match self.stream.take() {
+                Some(mut s) => match s.poll() {
+                    Ok(Async::Ready(Some(it))) => {
+                        self.delay = Some(Delay::new(Instant::now() + self.duration));
+                        self.stream = Some(s);
+
+                        Ok(Async::Ready(Some(it)))
+                    },
+                    Ok(Async::Ready(None)) => Ok(Async::Ready(None)),
+                    Ok(Async::NotReady) => {
+                        self.stream = Some(s);
+
+                        Ok(Async::NotReady)
+                    },
+                    Err(e) => Err(Either::A(e)),
+                },
+                None => Ok(Async::Ready(None)),
+            },
+        }
+    }
+}

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -34,6 +34,29 @@ impl<T> Throttle<T> {
             stream: stream,
         }
     }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &T {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this combinator
+    /// is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the stream
+    /// which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.stream
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so care
+    /// should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> T {
+        self.stream
+    }
 }
 
 impl<T: Stream> Stream for Throttle<T> {

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -1,11 +1,11 @@
 //! Slow down a stream by enforcing a delay between items.
 
-use {Delay, Error};
+use {clock, Delay, Error};
 
 use futures::{Async, Future, Poll, Stream};
 use futures::future::Either;
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Slow down a stream by enforcing a delay between items.
 #[derive(Debug)]
@@ -44,7 +44,7 @@ impl<T: Stream> Stream for Throttle<T> {
         let value = try_ready!(self.stream.poll().map_err(Either::A));
 
         if value.is_some() {
-            self.delay = Some(Delay::new(Instant::now() + self.duration));
+            self.delay = Some(Delay::new(clock::now() + self.duration));
         }
 
         Ok(Async::Ready(value))

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -13,6 +13,7 @@ use std::{
 
 /// Slow down a stream by enforcing a delay between items.
 #[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
 pub struct Throttle<T> {
     delay: Option<Delay>,
     duration: Duration,

--- a/tokio-timer/tests/throttle.rs
+++ b/tokio-timer/tests/throttle.rs
@@ -1,0 +1,57 @@
+extern crate futures;
+extern crate tokio;
+extern crate tokio_executor;
+extern crate tokio_timer;
+
+#[macro_use]
+mod support;
+use support::*;
+
+use futures::{
+    prelude::*,
+    sync::mpsc,
+};
+use tokio::util::StreamExt;
+
+#[test]
+fn throttle() {
+    mocked(|timer, _| {
+        let (tx, rx) = mpsc::unbounded();
+        let mut stream = rx.throttle(ms(1))
+            .map_err(|e| panic!("{:?}", e));
+
+        assert_not_ready!(stream);
+
+        for i in 0..3 {
+            tx.unbounded_send(i).unwrap();
+        }
+        for i in 0..3 {
+            assert_ready_eq!(stream, Some(i));
+            assert_not_ready!(stream);
+
+            advance(timer, ms(1));
+        }
+
+        assert_not_ready!(stream);
+    });
+}
+
+#[test]
+fn throttle_dur_0() {
+    mocked(|_, _| {
+        let (tx, rx) = mpsc::unbounded();
+        let mut stream = rx.throttle(ms(0))
+            .map_err(|e| panic!("{:?}", e));
+
+        assert_not_ready!(stream);
+
+        for i in 0..3 {
+            tx.unbounded_send(i).unwrap();
+        }
+        for i in 0..3 {
+            assert_ready_eq!(stream, Some(i));
+        }
+
+        assert_not_ready!(stream);
+    });
+}


### PR DESCRIPTION
Second combinator implementing https://github.com/tokio-rs/tokio/pull/732#issuecomment-434719438.

I'm not really sure on the design of this one (especially since errors of the underlying stream will be delayed as well, but I assume this is a necessary evil since you'd want to use this to slow down things like `stream::repeat(_)` that produce items at unbounded speeds), so I'm eager on your feedback.

You might notice I added two extensions to `Stream`, one that enforces a given delay, and another one that enforces a rate of items (and calculates the required delay from that). Not sure if both are necessary, but I felt they fit quite nicely.