### PR TITLE
Allow nightly builds to fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       cargo check --all
 
   # This runs TSAN against nightly and allows failures to propagate up.
-  - rust: nightly
+  - rust: 1.32.0-nightly
     env: TSAN=yes
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
       cargo check --all
 
   # This runs TSAN against nightly and allows failures to propagate up.
-  - rust: 1.32.0-nightly
+  - rust: nightly-2018-11-18
     env: TSAN=yes
 
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
   - rust: stable
   - rust: beta
   - rust: nightly
+    env: ALLOW_FAILURES=true
   - os: osx
   - env: TARGET=x86_64-unknown-freebsd
   - env: TARGET=i686-unknown-freebsd

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,15 +32,19 @@ matrix:
     script: |
       cd tokio-async-await
       cargo check --all
+
+  # This runs TSAN against nightly and allows failures to propagate up.
+  - rust: nightly
+    env: TSAN=yes
+
   allow_failures:
     - rust: nightly
       env: ALLOW_FAILURES=true
 
-
 script:
   - |
     set -e
-    if [[ "$TRAVIS_RUST_VERSION" == nightly ]]
+    if [[ "$TRAVIS_RUST_VERSION" == nightly && "$TSAN" == yes ]]
     then
         # Make sure the benchmarks compile
         cargo build --benches --all


### PR DESCRIPTION
## Motivation

Currently, the "normal" Rust nightly entry in the build matrix is not allowed to fail, and we've seen a large uptick in recent failures due to nightly that are completely unrelated to the PRs where it fails.  

## Solution

We've added an environment variable to the "normal" nightly entry which should allow it to match the existing `allow_failures` stanza.
