### PR TITLE
fix tsan errors

### DIFF
--- a/ci/tsan
+++ b/ci/tsan
@@ -31,3 +31,7 @@ race:crossbeam_deque*steal
 race:Backup::next_sleeper
 race:Backup::set_next_sleeper
 race:WorkerEntry::set_next_sleeper
+
+# This ignores a false positive caused by `thread::park()`/`thread::unpark()`.
+# See: https://github.com/rust-lang/rust/pull/54806#issuecomment-436193353
+race:pthread_cond_destroy


### PR DESCRIPTION
The last few builds have been failing due to thread sanitizer errors.
See https://github.com/rust-lang/rust/pull/54806#issuecomment-436193353 for why this is happening.

This PR adds a rule to the tsan suppresions list.