### PR TITLE
Bumped crossbeam-utils version

### DIFF
--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -19,7 +19,7 @@ Event loop that drives Tokio I/O resources.
 categories = ["asynchronous", "network-programming"]
 
 [dependencies]
-crossbeam-utils = "0.5.0"
+crossbeam-utils = "0.6.0"
 futures = "0.1.19"
 lazy_static = "1.0.2"
 log = "0.4.1"

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["concurrency", "asynchronous"]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
 crossbeam-deque = "0.6.1"
-crossbeam-utils = "0.5.0"
+crossbeam-utils = "0.6.0"
 num_cpus = "1.2"
 rand = "0.5"
 log = "0.4"

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -19,7 +19,7 @@ Timer facilities for Tokio
 [dependencies]
 futures = "0.1.19"
 tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
-crossbeam-utils = "0.5.0"
+crossbeam-utils = "0.6.0"
 
 # Backs `DelayQueue`
 slab = "0.4.1"


### PR DESCRIPTION
## Motivation

tokio depends on an out of date version of crossbeam-utils, which results in multiple versions of that package being linked in binaries which use other popular libraries.

## Solution

Bump the version; there's no API changes and tests still pass.