### PR TITLE
Fix docs for tokio::runtime::Builder to no longer use deprecated methods

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -31,6 +31,8 @@ use tokio_timer::timer::{self, Timer};
 /// extern crate tokio;
 /// extern crate tokio_timer;
 ///
+/// use std::time::Duration;
+///
 /// use tokio::runtime::Builder;
 /// use tokio_timer::clock::Clock;
 ///
@@ -40,6 +42,7 @@ use tokio_timer::timer::{self, Timer};
 ///         .blocking_threads(4)
 ///         .clock(Clock::system())
 ///         .core_threads(4)
+///         .keep_alive(Some(Duration::from_secs(60)))
 ///         .name_prefix("my-custom-name-")
 ///         .stack_size(3 * 1024 * 1024)
 ///         .build()

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -28,24 +28,25 @@ use tokio_timer::timer::{self, Timer};
 /// # Examples
 ///
 /// ```
-/// # extern crate tokio;
-/// # extern crate tokio_threadpool;
-/// # use tokio::runtime::Builder;
+/// extern crate tokio;
+/// extern crate tokio_timer;
 ///
-/// # pub fn main() {
-/// // create and configure ThreadPool
-/// let mut threadpool_builder = tokio_threadpool::Builder::new();
-/// threadpool_builder
-///     .name_prefix("my-runtime-worker-")
-///     .pool_size(4);
+/// use tokio::runtime::Builder;
+/// use tokio_timer::clock::Clock;
 ///
-/// // build Runtime
-/// let runtime = Builder::new()
-///     .threadpool_builder(threadpool_builder)
-///     .build();
-/// // ... call runtime.run(...)
-/// # let _ = runtime;
-/// # }
+/// fn main() {
+///     // build Runtime
+///     let mut runtime = Builder::new()
+///         .blocking_threads(4)
+///         .clock(Clock::system())
+///         .core_threads(4)
+///         .name_prefix("my-custom-name-")
+///         .stack_size(3 * 1024 * 1024)
+///         .build()
+///         .unwrap();
+///
+///     // use runtime ...
+/// }
 /// ```
 #[derive(Debug)]
 pub struct Builder {


### PR DESCRIPTION
A quick fix to the **Examples** section of the docs for `tokio::runtime::Builder` so that the example provided no longer uses deprecated methods but instead uses the latest, up-to-date API.