### PR TITLE
signal: miscellaneous tweaks and improvements

### DIFF
--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+### Changed
+* `unix::Signal` now implements `Sync`
 
 ## 0.2.6 - (October 26, 2018)
 ### Changed

--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Changed
 * `unix::Signal` now implements `Sync`
 
+### Fixes
+* `unix::Signal` now avoids extraneous wakeups generated as a result of
+dropping other instances
+
 ## 0.2.6 - (October 26, 2018)
 ### Changed
 * Use the `signal-hook` crate for managing signal registrations

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -347,8 +347,9 @@ impl Signal {
                 let driver = try!(Driver::new(&handle));
 
                 // One wakeup in a queue is enough, no need for us to buffer up any
-                // more.
-                let (tx, rx) = channel(1);
+                // more. NB: channels always guarantee at least one slot per sender,
+                // so we don't need additional slots
+                let (tx, rx) = channel(0);
                 let tx = Box::new(tx);
                 let id: *const _ = &*tx;
                 let idx = signal as usize;

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -46,10 +46,12 @@ pub mod bsd {
 // (FreeBSD has 33)
 const SIGNUM: usize = 33;
 
+type SignalSender = Sender<c_int>;
+
 struct SignalInfo {
     pending: AtomicBool,
     // The ones interested in this signal
-    recipients: Mutex<Vec<Box<Sender<c_int>>>>,
+    recipients: Mutex<Vec<Box<SignalSender>>>,
 
     init: Once,
     initialized: AtomicBool,
@@ -59,6 +61,40 @@ struct Globals {
     sender: UnixStream,
     receiver: UnixStream,
     signals: Vec<SignalInfo>,
+}
+
+impl Globals {
+    /// Register a new `Signal` instance's channel sender.
+    /// Returns a `SignalId` which should be later used for deregistering
+    /// this sender.
+    fn register_signal_sender(signal: c_int, tx: SignalSender) -> SignalId {
+        let tx = Box::new(tx);
+        let id = SignalId::from(&tx);
+
+        let idx = signal as usize;
+        globals().signals[idx].recipients.lock().unwrap().push(tx);
+        id
+    }
+
+    /// Deregister a `Signal` instance's channel sender because the `Signal`
+    /// is no longer interested in receiving events (e.g. dropped).
+    fn deregister_signal_receiver(signal: c_int, id: SignalId) {
+        let idx = signal as usize;
+        let mut list = globals().signals[idx].recipients.lock().unwrap();
+        list.retain(|sender| SignalId::from(sender) != id);
+    }
+}
+
+/// A newtype which represents a unique identifier for each `Signal` instance.
+/// The id is derived by boxing the channel `Sender` associated with this instance
+/// and using its address in memory.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+struct SignalId(usize);
+
+impl<'a> From<&'a Box<SignalSender>> for SignalId {
+    fn from(tx: &'a Box<SignalSender>) -> Self {
+        SignalId(&**tx as *const _ as usize)
+    }
 }
 
 impl Default for SignalInfo {
@@ -274,18 +310,9 @@ impl Driver {
 pub struct Signal {
     driver: Driver,
     signal: c_int,
-    // Used only as an identifier. We place the real sender into a Box, so it
-    // stays on the same address forever. That gives us a unique pointer, so we
-    // can use this to identify the sender in a Vec and delete it when we are
-    // dropped.
-    id: *const Sender<c_int>,
+    id: SignalId,
     rx: Receiver<c_int>,
 }
-
-// The raw pointer prevents the compiler from determining it as Send
-// automatically. But the only thing we use the raw pointer for is to identify
-// the correct Box to delete, not manipulate any data through that.
-unsafe impl Send for Signal {}
 
 impl Signal {
     /// Creates a new stream which will receive notifications when the current
@@ -350,10 +377,7 @@ impl Signal {
                 // more. NB: channels always guarantee at least one slot per sender,
                 // so we don't need additional slots
                 let (tx, rx) = channel(0);
-                let tx = Box::new(tx);
-                let id: *const _ = &*tx;
-                let idx = signal as usize;
-                globals().signals[idx].recipients.lock().unwrap().push(tx);
+                let id = Globals::register_signal_sender(signal, tx);
                 Ok(Signal {
                     driver: driver,
                     rx: rx,
@@ -379,8 +403,39 @@ impl Stream for Signal {
 
 impl Drop for Signal {
     fn drop(&mut self) {
-        let idx = self.signal as usize;
-        let mut list = globals().signals[idx].recipients.lock().unwrap();
-        list.retain(|sender| &**sender as *const _ != self.id);
+        Globals::deregister_signal_receiver(self.signal, self.id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate tokio;
+
+    use super::*;
+
+    #[test]
+    fn dropped_signal_senders_are_cleaned_up() {
+        let mut rt = self::tokio::runtime::current_thread::Runtime::new()
+            .expect("failed to init runtime");
+
+        let signum = libc::SIGUSR1;
+        let signal = rt.block_on(Signal::new(signum))
+            .expect("failed to create signal");
+
+        {
+            let recipients = globals().signals[signum as usize].recipients.lock().unwrap();
+            assert!(!recipients.is_empty());
+        }
+
+        drop(signal);
+
+        unsafe {
+            assert_eq!(libc::kill(libc::getpid(), signum), 0);
+        }
+
+        {
+            let recipients = globals().signals[signum as usize].recipients.lock().unwrap();
+            assert!(recipients.is_empty());
+        }
     }
 }


### PR DESCRIPTION
## Motivation

Several internal performance improvements to `tokio-signal`:
* Optimize out an extra channel allocation
* Lift the artificial `!Sync` restriction on `unix::Signal`
* Avoid extraneous wake ups whenever any `unix::Signal` channel disconnects
