### PR TITLE
Bumped rand dependency to 0.6

### DIFF
--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -25,7 +25,7 @@ tokio-threadpool = { version = "0.1.3", path = "../tokio-threadpool" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"
 tempfile = "3"
 tempdir = "0.3"
 tokio-io = { version = "0.1.6", path = "../tokio-io" }

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -23,7 +23,7 @@ futures = "0.1.19"
 crossbeam-deque = "0.6.1"
 crossbeam-utils = "0.6.0"
 num_cpus = "1.2"
-rand = "0.5"
+rand = "0.6"
 log = "0.4"
 
 [dev-dependencies]

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -25,6 +25,6 @@ crossbeam-utils = "0.6.0"
 slab = "0.4.1"
 
 [dev-dependencies]
-rand = "0.5"
+rand = "0.6"
 tokio-mock-task = "0.1.0"
 tokio = { version = "0.1.7", path = "../" }


### PR DESCRIPTION
Bumps the `rand` dependency that several tokio crates have to the latest version.