### PR TITLE
fs: add more tests

### DIFF
--- a/tokio-fs/tests/link.rs
+++ b/tokio-fs/tests/link.rs
@@ -1,0 +1,64 @@
+extern crate futures;
+extern crate tempdir;
+extern crate tokio_fs;
+
+use futures::Future;
+use std::fs;
+use std::io::prelude::*;
+use std::io::BufReader;
+use tempdir::TempDir;
+use tokio_fs::*;
+
+mod pool;
+
+#[test]
+fn test_hard_link() {
+    let dir = TempDir::new("base").unwrap();
+    let src = dir.path().join("src.txt");
+    let dst = dir.path().join("dst.txt");
+
+    {
+        let mut file = fs::File::create(&src).unwrap();
+        file.write_all(b"hello").unwrap();
+    }
+
+    pool::run({ hard_link(src, dst.clone()) });
+
+    let mut content = String::new();
+
+    {
+        let file = fs::File::open(dst).unwrap();
+        let mut reader = BufReader::new(file);
+        reader.read_to_string(&mut content).unwrap();
+    }
+
+    assert!(content == "hello");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_symlink() {
+    let dir = TempDir::new("base").unwrap();
+    let src = dir.path().join("src.txt");
+    let dst = dir.path().join("dst.txt");
+
+    {
+        let mut file = fs::File::create(&src).unwrap();
+        file.write_all(b"hello").unwrap();
+    }
+
+    pool::run({ os::unix::symlink(src.clone(), dst.clone()) });
+
+    let mut content = String::new();
+
+    {
+        let file = fs::File::open(dst.clone()).unwrap();
+        let mut reader = BufReader::new(file);
+        reader.read_to_string(&mut content).unwrap();
+    }
+
+    assert!(content == "hello");
+
+    pool::run({ read_link(dst.clone()).map(move |x| assert!(x == src)) });
+    pool::run({ symlink_metadata(dst.clone()).map(move |x| assert!(x.file_type().is_symlink())) });
+}

--- a/tokio-fs/tests/pool/mod.rs
+++ b/tokio-fs/tests/pool/mod.rs
@@ -1,0 +1,17 @@
+extern crate futures;
+extern crate tokio_threadpool;
+
+use self::tokio_threadpool::Builder;
+use futures::sync::oneshot;
+use futures::Future;
+use std::io;
+
+pub fn run<F>(f: F)
+where
+    F: Future<Item = (), Error = io::Error> + Send + 'static,
+{
+    let pool = Builder::new().pool_size(1).build();
+    let (tx, rx) = oneshot::channel::<()>();
+    pool.spawn(f.then(|_| tx.send(())));
+    rx.wait().unwrap()
+}


### PR DESCRIPTION
Fixes #704.

## Motivation

Same as #724, this change adds more tests around tokio-fs

## Solution

The structure follows the previous request. I added link.rs for hard_link.rs, read_link.rs and symlink_metadata.rs