### PR TITLE
Fix async await README example

### DIFF
--- a/tokio-async-await/README.md
+++ b/tokio-async-await/README.md
@@ -20,7 +20,7 @@ cargo-features = ["edition"]
 edition = "2018"
 
 # In the `[dependencies]` section
-tokio-async-await = "0.1.0"
+tokio = {version = "0.1.0", features = ["async-await-preview"]}
 ```
 
 Then, get started. In your application, add:

--- a/tokio-async-await/README.md
+++ b/tokio-async-await/README.md
@@ -13,9 +13,6 @@ To use this crate, you need to start with a Rust 2018 edition crate.
 Add this to your `Cargo.toml`:
 
 ```toml
-# At the very top of the file
-cargo-features = ["edition"]
-
 # In the `[packages]` section
 edition = "2018"
 


### PR DESCRIPTION
#661 updated async-await examples with new way of depending on async tokio with await support. This PR does the same for the example shown in the README file