### PR TITLE
io: allow deprecated code in length_delimited test

### DIFF
--- a/tokio-io/tests/length_delimited.rs
+++ b/tokio-io/tests/length_delimited.rs
@@ -1,3 +1,6 @@
+// This file is testing deprecated code.
+#![allow(deprecated)]
+
 extern crate tokio_io;
 extern crate futures;
 


### PR DESCRIPTION
This file is testing deprecated code, so it should be permitted to
access deprecated code.

Fixes #731