### PR TITLE
Try and force Windows Server 2016 for AppVeyor builds.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,4 @@
+image: Visual Studio 2017
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc


### PR DESCRIPTION
## Motivation

Occasionally, `tokio-tls` tests on AppVeyor (CI platform for running on Windows) fail with a `The buffers supplied to a function was too small` error.  Searching points to a bug deep within the Windows `SChannel` framework itself (which `tokio-tls` uses due to being based on `native-tls` which prefers OS-native SSL/TLS libraries) that was only fixed in Windows 10/Windows Server 2016:

https://github.com/dotnet/corefx/issues/31611#issuecomment-410792235
https://github.com/dotnet/corefx/issues/7812#issuecomment-305848835

## Solution

I believe we should able to avoid to avoid these spurious failures by running all Windows builds on Server 2016.  Unfortunately, due to the spurious nature of the bug, we can't really test this easily.. but we can ensure that we're at least running on Server 2016 which should theoretically resolve the issue.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>
