### PR TITLE
current-thread: fix shutdown on idle

### DIFF
--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -653,6 +653,13 @@ impl Handle {
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
+        if thread::current().id() == self.thread {
+            let mut e = TaskExecutor::current();
+            if e.id() == Some(self.id) {
+                return e.spawn_local(Box::new(future));
+            }
+        }
+
         if self.shut_down.get() {
             return Err(SpawnError::shutdown());
         }
@@ -667,13 +674,6 @@ impl Handle {
             self.shut_down.set(true);
 
             return Err(SpawnError::shutdown());
-        }
-
-        if thread::current().id() == self.thread {
-            let mut e = TaskExecutor::current();
-            if e.id() == Some(self.id) {
-                return e.spawn_local(Box::new(future));
-            }
         }
 
         self.sender.send(Box::new(future))

--- a/tokio-current-thread/tests/current_thread.rs
+++ b/tokio-current-thread/tests/current_thread.rs
@@ -778,6 +778,25 @@ fn spawn_from_other_thread_unpark() {
     ).unwrap();
 }
 
+#[test]
+fn spawn_from_executor_with_handle() {
+    let mut current_thread = CurrentThread::new();
+    let handle = current_thread.handle();
+    let (tx, rx) = oneshot::channel();
+
+    current_thread.spawn(lazy(move || {
+        handle.spawn(lazy(move || {
+            tx.send(()).unwrap();
+            Ok(())
+        })).unwrap();
+        Ok::<_, ()>(())
+    }));
+
+    current_thread.run();
+
+    rx.wait().unwrap();
+}
+
 fn ok() -> future::FutureResult<(), ()> {
     future::ok(())
 }


### PR DESCRIPTION
When spawning using `Handle` while on the executor, tasks were being
double counted. This prevented the number of active tasks to reach zero,
thus preventing the executor from shutting down.

This changes `spawn` to check if being called from the executor
**before** incrementing the number of active tasks.

Fixes #760