### PR TITLE
chore: tweak tokio dependencies in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,16 +56,16 @@ appveyor = { repository = "carllerche/tokio", id = "s83yxhy9qeb58va7" }
 [dependencies]
 bytes = "0.4"
 num_cpus = "1.8.0"
-tokio-codec = { version = "0.1.0", path = "tokio-codec" }
-tokio-current-thread = { version = "0.1.3", path = "tokio-current-thread" }
-tokio-io = { version = "0.1.6", path = "tokio-io" }
-tokio-executor = { version = "0.1.5", path = "tokio-executor" }
-tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }
-tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool" }
-tokio-tcp = { version = "0.1.0", path = "tokio-tcp" }
-tokio-udp = { version = "0.1.0", path = "tokio-udp" }
-tokio-timer = { version = "0.2.6", path = "tokio-timer" }
-tokio-fs = { version = "0.1.3", path = "tokio-fs" }
+tokio-codec = "0.1.0"
+tokio-current-thread = "0.1.3"
+tokio-io = "0.1.6"
+tokio-executor = "0.1.5"
+tokio-reactor = "0.1.1"
+tokio-threadpool = "0.1.4"
+tokio-tcp = "0.1.0"
+tokio-udp = "0.1.0"
+tokio-timer = { path = "tokio-timer" }
+tokio-fs = "0.1.3"
 
 futures = "0.1.20"
 
@@ -73,10 +73,10 @@ futures = "0.1.20"
 mio = "0.6.14"
 
 # Needed for async/await preview support
-tokio-async-await = { version = "0.1.0", path = "tokio-async-await", optional = true }
+tokio-async-await = { version = "0.1.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "0.2.1", path = "tokio-uds" }
+tokio-uds = "0.2.1"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
@@ -90,20 +90,3 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 time = "0.1"
-
-[patch.crates-io]
-tokio = { path = "." }
-tokio-async-await  = { path = "./tokio-async-await" }
-tokio-codec = { path = "./tokio-codec" }
-tokio-current-thread = { path = "./tokio-current-thread" }
-tokio-executor = { path = "./tokio-executor" }
-tokio-fs = { path = "./tokio-fs" }
-tokio-io = { path = "./tokio-io" }
-tokio-reactor = { path = "./tokio-reactor" }
-tokio-signal = { path = "./tokio-signal" }
-tokio-tcp = { path = "./tokio-tcp" }
-tokio-threadpool = { path = "./tokio-threadpool" }
-tokio-timer = { path = "./tokio-timer" }
-tokio-tls = { path = "./tokio-tls" }
-tokio-udp = { path = "./tokio-udp" }
-tokio-uds = { path = "./tokio-uds" }

--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -21,10 +21,9 @@ async-await-preview = ["futures/nightly"]
 
 [dependencies]
 futures = "0.1.23"
-tokio-io = { version = "0.1.7", path = "../tokio-io" }
+tokio-io = "0.1.7"
 
 [dev-dependencies]
 bytes = "0.4.9"
-tokio = { version = "0.1.8", path = ".." }
-# tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
+tokio = { path = ".." }
 hyper = "0.12.8"

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -18,6 +18,6 @@ Utilities for encoding and decoding frames.
 categories = ["asynchronous"]
 
 [dependencies]
-tokio-io = { version = "0.1.7", path = "../tokio-io" }
+tokio-io = "0.1.7"
 bytes = "0.4.7"
 futures = "0.1.18"

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -19,5 +19,5 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
+tokio-executor = "0.1.5"
 futures = "0.1.19"

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -21,13 +21,12 @@ categories = ["asynchronous", "network-programming", "filesystem"]
 
 [dependencies]
 futures = "0.1.21"
-tokio-threadpool = { version = "0.1.3", path = "../tokio-threadpool" }
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-threadpool = "0.1.3"
+tokio-io = "0.1.6"
 
 [dev-dependencies]
 rand = "0.6"
 tempfile = "3"
 tempdir = "0.3"
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
-tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
-tokio = { version = "0.1.7", path = ".." }
+tokio-codec = { path = "../tokio-codec" }
+tokio = { path = ".." }

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -23,4 +23,4 @@ futures = "0.1.18"
 log = "0.4"
 
 [dev-dependencies]
-tokio-current-thread = { version = "0.1.1", path = "../tokio-current-thread" }
+tokio-current-thread = { path = "../tokio-current-thread" }

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -27,10 +27,10 @@ mio = "0.6.14"
 num_cpus = "1.8.0"
 parking_lot = "0.6.3"
 slab = "0.4.0"
-tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-executor = "0.1.1"
+tokio-io = "0.1.6"
 
 [dev-dependencies]
 num_cpus = "1.8.0"
-tokio = { version = "0.1.7", path = ".." }
+tokio = { path = ".." }
 tokio-io-pool = "0.1.4"

--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -24,9 +24,9 @@ appveyor = { repository = "carllerche/tokio", id = "s83yxhy9qeb58va7" }
 [dependencies]
 futures = "0.1.11"
 mio = "0.6.14"
-tokio-reactor = { version = "0.1.0", path = "../tokio-reactor" }
-tokio-executor = { version = "0.1.0", path = "../tokio-executor" }
-tokio-io = { version = "0.1", path = "../tokio-io" }
+tokio-reactor = "0.1.0"
+tokio-executor = "0.1.0"
+tokio-io = "0.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -34,7 +34,7 @@ mio-uds = "0.6"
 signal-hook = "0.1"
 
 [dev-dependencies]
-tokio = { version = "0.1.8", path = ".." }
+tokio = { path = ".." }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -18,8 +18,8 @@ TCP bindings for tokio.
 categories = ["asynchronous"]
 
 [dependencies]
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
-tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
+tokio-io = "0.1.6"
+tokio-reactor = "0.1.1"
 bytes = "0.4"
 mio = "0.6.14"
 iovec = "0.1"

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
+tokio-executor = "0.1.2"
 futures = "0.1.19"
 crossbeam-deque = "0.6.1"
 crossbeam-utils = "0.6.0"
@@ -27,7 +27,7 @@ rand = "0.6"
 log = "0.4"
 
 [dev-dependencies]
-tokio-timer = "0.1"
+tokio-timer = "0.1.2"
 env_logger = "0.5"
 
 # For comparison benchmarks

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -18,7 +18,7 @@ Timer facilities for Tokio
 
 [dependencies]
 futures = "0.1.19"
-tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
+tokio-executor = "0.1.1"
 crossbeam-utils = "0.6.0"
 
 # Backs `DelayQueue`
@@ -27,4 +27,4 @@ slab = "0.4.1"
 [dev-dependencies]
 rand = "0.6"
 tokio-mock-task = "0.1.0"
-tokio = { version = "0.1.7", path = "../" }
+tokio = { path = ".." }

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -22,10 +22,10 @@ travis-ci = { repository = "tokio-rs/tokio-tls" }
 [dependencies]
 futures = "0.1.23"
 native-tls = "0.2"
-tokio-io = { version = "0.1.7", path = "../tokio-io" }
+tokio-io = "0.1.7"
 
 [dev-dependencies]
-tokio = { version = "0.1", path = "../" }
+tokio = { path = ".." }
 cfg-if = "0.1"
 env_logger = { version = "0.5", default-features = false }
 

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -18,9 +18,9 @@ UDP bindings for tokio.
 categories = ["asynchronous"]
 
 [dependencies]
-tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
-tokio-io = { version = "0.1.7", path = "../tokio-io" }
-tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
+tokio-codec = "0.1.0"
+tokio-io = "0.1.7"
+tokio-reactor = "0.1.1"
 bytes = "0.4"
 mio = "0.6.14"
 log = "0.4"

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -24,9 +24,9 @@ libc = "0.2.42"
 log = "0.4.2"
 mio = "0.6.14"
 mio-uds = "0.6.5"
-tokio-reactor = { version = "0.1.1", path = "../tokio-reactor" }
-tokio-io = { version = "0.1.6", path = "../tokio-io" }
+tokio-reactor = "0.1.1"
+tokio-io = "0.1.6"
 
 [dev-dependencies]
-tokio = { version = "0.1.6", path = "../" }
+tokio = { path = ".." }
 tempfile = "3"


### PR DESCRIPTION
This migrates to a better defined process for managing dependencies
between Tokio sub crates.

Refs #765

# Checklist

* [ ] Update .travis.yml to run with patches as well
* [ ] Update contributing guide.