### PR TITLE
threadpool: rename inner to something more descriptive

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -153,7 +153,7 @@ pub struct Runtime {
 
 #[derive(Debug)]
 struct Inner {
-     /// A handle to the reactor in the background thread.
+    /// A handle to the reactor in the background thread.
     reactor_handle: Handle,
 
     // TODO: This should go away in 0.2

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -409,18 +409,18 @@ impl Builder {
         }
 
         // Create the pool
-        let inner = Arc::new(
+        let pool = Arc::new(
             Pool::new(
                 workers.into_boxed_slice(),
                 self.max_blocking,
                 self.config.clone()));
 
         // Wrap with `Sender`
-        let inner = Some(Sender {
-            inner
+        let sender = Some(Sender {
+            pool
         });
 
-        ThreadPool { inner }
+        ThreadPool { sender }
     }
 }
 

--- a/tokio-threadpool/src/notifier.rs
+++ b/tokio-threadpool/src/notifier.rs
@@ -13,7 +13,7 @@ use futures::executor::Notify;
 /// to poll the future again.
 #[derive(Debug)]
 pub(crate) struct Notifier {
-    pub inner: Arc<Pool>,
+    pub pool: Arc<Pool>,
 }
 
 /// A guard that ensures that the inner value gets forgotten.
@@ -38,7 +38,7 @@ impl Notify for Notifier {
                 // Bump the ref count
                 let task = task.clone();
 
-                let _ = self.inner.submit(task, &self.inner);
+                let _ = self.pool.submit(task, &self.pool);
             }
         }
     }

--- a/tokio-threadpool/src/shutdown.rs
+++ b/tokio-threadpool/src/shutdown.rs
@@ -16,12 +16,12 @@ use futures::{Future, Poll, Async};
 /// [`shutdown_now`]: struct.ThreadPool.html#method.shutdown_now
 #[derive(Debug)]
 pub struct Shutdown {
-    pub(crate) inner: Sender,
+    pub(crate) sender: Sender,
 }
 
 impl Shutdown {
-    fn inner(&self) -> &Pool {
-        &*self.inner.inner
+    fn pool(&self) -> &Pool {
+        &*self.sender.pool
     }
 }
 
@@ -32,9 +32,9 @@ impl Future for Shutdown {
     fn poll(&mut self) -> Poll<(), ()> {
         use futures::task;
 
-        self.inner().shutdown_task.task.register_task(task::current());
+        self.pool().shutdown_task.task.register_task(task::current());
 
-        if !self.inner().is_shutdown() {
+        if !self.pool().is_shutdown() {
             return Ok(Async::NotReady);
         }
 

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -39,7 +39,7 @@ use std::time::Duration;
 #[derive(Debug)]
 pub struct Worker {
     // Shared scheduler data
-    pub(crate) inner: Arc<Pool>,
+    pub(crate) pool: Arc<Pool>,
 
     // WorkerEntry index
     pub(crate) id: WorkerId,
@@ -86,9 +86,9 @@ pub struct WorkerId(pub(crate) usize);
 thread_local!(static CURRENT_WORKER: Cell<*const Worker> = Cell::new(0 as *const _));
 
 impl Worker {
-    pub(crate) fn new(id: WorkerId, backup_id: BackupId, inner: Arc<Pool>) -> Worker {
+    pub(crate) fn new(id: WorkerId, backup_id: BackupId, pool: Arc<Pool>) -> Worker {
         Worker {
-            inner,
+            pool,
             id,
             backup_id,
             current_task: CurrentTask::new(),
@@ -111,14 +111,14 @@ impl Worker {
         CURRENT_WORKER.with(|c| {
             c.set(self as *const _);
 
-            let inner = self.inner.clone();
-            let mut sender = Sender { inner };
+            let pool = self.pool.clone();
+            let mut sender = Sender { pool };
 
             // Enter an execution context
             let mut enter = tokio_executor::enter().unwrap();
 
             tokio_executor::with_default(&mut sender, &mut enter, |enter| {
-                if let Some(ref callback) = self.inner.config.around_worker {
+                if let Some(ref callback) = self.pool.config.around_worker {
                     callback.call(self, enter);
                 } else {
                     self.run();
@@ -165,7 +165,7 @@ impl Worker {
                 // Atomically attempt to acquire blocking capacity, and if none
                 // is available, register the task to be notified once capacity
                 // becomes available.
-                match self.inner.poll_blocking_capacity(task_ref)? {
+                match self.pool.poll_blocking_capacity(task_ref)? {
                     Async::Ready(()) => {
                         self.current_task.set_can_block(Allocated);
                     }
@@ -192,7 +192,7 @@ impl Worker {
         // Transitioning to blocking requires handing over the worker state to
         // another thread so that the work queue can continue to be processed.
 
-        self.inner.spawn_thread(self.id.clone(), &self.inner);
+        self.pool.spawn_thread(self.id.clone(), &self.pool);
 
         // Track that the thread has now fully entered the blocking state.
         self.is_blocking.set(true);
@@ -222,7 +222,7 @@ impl Worker {
 
         // Get the notifier.
         let notify = Arc::new(Notifier {
-            inner: self.inner.clone(),
+            pool: self.pool.clone(),
         });
 
         let mut first = true;
@@ -286,7 +286,7 @@ impl Worker {
         //
         // The returned result is ignored because `Err` represents the pool
         // shutting down. We are currently aware of this fact.
-        let _ = self.inner.release_backup(self.backup_id);
+        let _ = self.pool.release_backup(self.backup_id);
 
         self.should_finalize.set(true);
     }
@@ -315,7 +315,7 @@ impl Worker {
         let mut state: State = self.entry().state.load(Acquire).into();
 
         loop {
-            let pool_state: pool::State = self.inner.state.load(Acquire).into();
+            let pool_state: pool::State = self.pool.state.load(Acquire).into();
 
             if pool_state.is_terminated() {
                 return false;
@@ -373,7 +373,7 @@ impl Worker {
             trace!("Worker::check_run_state; delegate signal");
             // This worker is not ready to be signaled, so delegate the signal
             // to another worker.
-            self.inner.signal_work(&self.inner);
+            self.pool.signal_work(&self.pool);
         }
 
         true
@@ -404,14 +404,14 @@ impl Worker {
 
         debug_assert!(!self.is_blocking.get());
 
-        let len = self.inner.workers.len();
-        let mut idx = self.inner.rand_usize() % len;
+        let len = self.pool.workers.len();
+        let mut idx = self.pool.rand_usize() % len;
         let mut found_work = false;
         let start = idx;
 
         loop {
             if idx < len {
-                match self.inner.workers[idx].steal_tasks(self.entry()) {
+                match self.pool.workers[idx].steal_tasks(self.entry()) {
                     Steal::Data(task) => {
                         trace!("stole task");
 
@@ -424,7 +424,7 @@ impl Worker {
                         //
                         // TODO: Should this be called here or before
                         // `run_task`?
-                        self.inner.signal_work(&self.inner);
+                        self.pool.signal_work(&self.pool);
 
                         return true;
                     }
@@ -466,19 +466,19 @@ impl Worker {
                     //
                     // We have to call `submit_external` instead of `submit`
                     // here because `self` is still set as the current worker.
-                    self.inner.submit_external(task, &self.inner);
+                    self.pool.submit_external(task, &self.pool);
                 } else {
                     self.entry().push_internal(task);
                 }
             }
             Complete => {
-                let mut state: pool::State = self.inner.state.load(Acquire).into();
+                let mut state: pool::State = self.pool.state.load(Acquire).into();
 
                 loop {
                     let mut next = state;
                     next.dec_num_futures();
 
-                    let actual = self.inner.state.compare_and_swap(
+                    let actual = self.pool.state.compare_and_swap(
                         state.into(), next.into(), AcqRel).into();
 
                     if actual == state {
@@ -490,7 +490,7 @@ impl Worker {
                             // up any sleeping worker so that they can notice
                             // the shutdown state.
                             if next.is_terminated() {
-                                self.inner.terminate_sleeping_workers();
+                                self.pool.terminate_sleeping_workers();
                             }
                         }
 
@@ -528,7 +528,7 @@ impl Worker {
                 // transitioned to blocking in this call, then another task has
                 // to be notified.
                 if self.allocated_at_run && !self.worker.is_blocking.get() {
-                    self.worker.inner.notify_blocking_task(&self.worker.inner);
+                    self.worker.pool.notify_blocking_task(&self.worker.pool);
                 }
 
                 self.worker.current_task.clear();
@@ -571,7 +571,7 @@ impl Worker {
                         // not be better to only signal when work was found
                         // after waking up?
                         trace!("found work while draining; signal_work");
-                        self.inner.signal_work(&self.inner);
+                        self.pool.signal_work(&self.pool);
                     }
 
                     return true;
@@ -579,7 +579,7 @@ impl Worker {
                 Inconsistent => {
                     if found_work {
                         trace!("found work while draining; signal_work");
-                        self.inner.signal_work(&self.inner);
+                        self.pool.signal_work(&self.pool);
                     }
 
                     return false;
@@ -649,7 +649,7 @@ impl Worker {
 
                     // We obtained permission to push the worker into the
                     // sleeper queue.
-                    if let Err(_) = self.inner.push_sleeper(self.id.0) {
+                    if let Err(_) = self.pool.push_sleeper(self.id.0) {
                         trace!("  sleeping -- push to stack failed; idx={}", self.id.0);
                         // The push failed due to the pool being terminated.
                         //
@@ -726,7 +726,7 @@ impl Worker {
 
     fn entry(&self) -> &Entry {
         debug_assert!(!self.is_blocking.get());
-        &self.inner.workers[self.id.0]
+        &self.pool.workers[self.id.0]
     }
 }
 

--- a/tokio-threadpool/tests/blocking.rs
+++ b/tokio-threadpool/tests/blocking.rs
@@ -1,7 +1,6 @@
 extern crate tokio_threadpool;
 
 extern crate env_logger;
-#[macro_use]
 extern crate futures;
 extern crate rand;
 


### PR DESCRIPTION
`inner` is a fitting name for variables of type named `Inner`, but in other cases I find them confusing - sometimes `inner` refers to a `Pool`, sometimes to a `Sender`. I renamed a bunch of variables named `inner` to be more descriptive.

This PR is the first step in an effort of splitting https://github.com/tokio-rs/tokio/pull/722#issuecomment-439552671 into multiple PRs.