### PR TITLE
Bump version to v0.1.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.13 (November 21, 2018)
+
+* Fix `Runtime::reactor()` when no tasks are spawned (#721).
+* `runtime::Builder` no longer uses deprecated methods (#749).
+* Provide `after_start` and `before_stop` configuration settings for
+  `Runtime` (#756).
+* Implement throttle stream combinator (#736).
+
 # 0.1.12 (October 23, 2018)
 
 * runtime: expose `keep_alive` on runtime builder (#676).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.12"
+version = "0.1.13"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.12/tokio/"
+documentation = "https://docs.rs/tokio/0.1.13/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -64,7 +64,7 @@ tokio-reactor = { version = "0.1.1", path = "tokio-reactor" }
 tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool" }
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp" }
 tokio-udp = { version = "0.1.0", path = "tokio-udp" }
-tokio-timer = { version = "0.2.6", path = "tokio-timer" }
+tokio-timer = { version = "0.2.8", path = "tokio-timer" }
 tokio-fs = { version = "0.1.3", path = "tokio-fs" }
 
 futures = "0.1.20"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.12")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.13")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,

--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.4 (November 21, 2018)
+
+* Fix shutdown on idle (#763).
+
 # 0.1.3 (September 27, 2018)
 
 * Fix minimal versions

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -6,8 +6,8 @@ name = "tokio-current-thread"
 # - Update doc URL
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.3"
-documentation = "https://docs.rs/tokio-current-thread/0.1.3/tokio_current_thread"
+version = "0.1.4"
+documentation = "https://docs.rs/tokio-current-thread/0.1.4/tokio_current_thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.3")]
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.4")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A single-threaded executor which executes tasks on the same thread from which

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.7 (November 21, 2018)
+
+* Reduce log level to trace (#734).
+* Bump internal dependency versions (#746).
+
 # 0.1.6 (September 27, 2018)
 
 * Fix panic when reactor is stored in a thread-local (#628).

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-reactor"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1.6/tokio_reactor"
+documentation = "https://docs.rs/tokio-reactor/0.1.7/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.7")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -1,6 +1,7 @@
-## Unreleased
+## 0.2.7 - (November 21, 2018)
 ### Changed
 * `unix::Signal` now implements `Sync`
+* minimize allocations
 
 ### Fixes
 * `unix::Signal` now avoids extraneous wakeups generated as a result of

--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -6,12 +6,12 @@ name = "tokio-signal"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-signal/0.2.6/tokio_signal"
+documentation = "https://docs.rs/tokio-signal/0.2.7/tokio_signal"
 description = """
 An implementation of an asynchronous Unix signal handling backed futures.
 """

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -67,7 +67,7 @@
 //! # fn main() {}
 //! ```
 
-#![doc(html_root_url = "https://docs.rs/tokio-signal/0.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-signal/0.2.7")]
 #![deny(missing_docs)]
 
 extern crate futures;

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.9 (November 21, 2018)
+
+* Bump internal dependency versions (#746, #753).
+* Internal refactors (#768, #769).
+
 # 0.1.8 (October 23, 2018)
 
 * Assign spawned tasks to random worker (#660).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -5,8 +5,8 @@ name = "tokio-threadpool"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
-documentation = "https://docs.rs/tokio-threadpool/0.1.8/tokio_threadpool"
+version = "0.1.9"
+documentation = "https://docs.rs/tokio-threadpool/0.1.9/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.9")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.8 (November 21, 2018)
+
+* Implement throttle combinator (#736).
+* Derive `Clone` for `delay_queue::Key` (#730).
+* Bump internal dependencies (#753).
+
 # 0.2.7 (September 27, 2018)
 
 * Fix `Timeout` on error bug (#648).

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -5,11 +5,11 @@ name = "tokio-timer"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.7/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.8/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.7")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.8")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Utilities for tracking time.

--- a/tokio-udp/CHANGELOG.md
+++ b/tokio-udp/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3 (November 21, 2018)
+
+* Add `RecvDgram::into_parts` (#710).
+
 # 0.1.2 (August 23, 2018)
 
 * Provide methods to inspect readiness (#522)

--- a/tokio-udp/Cargo.toml
+++ b/tokio-udp/Cargo.toml
@@ -6,10 +6,10 @@ name = "tokio-udp"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
-documentation = "https://docs.rs/tokio-udp/0.1.2/tokio_udp"
+documentation = "https://docs.rs/tokio-udp/0.1.3/tokio_udp"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.3")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! UDP bindings for `tokio`.

--- a/tokio-uds/CHANGELOG.md
+++ b/tokio-uds/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.2.4 (November 24, 2018)
+
+* Implement `UnixDatagramFramed`, providing a `Stream + Sink` layer for
+  unix domain sockets (#453).
+* Add solaris support for `ucred` (#733).
+* Documentation tweaks (#754).
+
 # 0.2.3 (October 23, 2018)
 
 * Fix build on NetBSD (#715).

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -5,12 +5,12 @@ name = "tokio-uds"
 # - Update doc url
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-uds/0.2.3/tokio_uds/"
+documentation = "https://docs.rs/tokio-uds/0.2.4/tokio_uds/"
 description = """
 Unix Domain sockets for Tokio
 """

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(unix)]
-#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.3")]
+#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.4")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Unix Domain Sockets for Tokio.


### PR DESCRIPTION
This also bumps the following sub crate versions:

* tokio-current-thread (0.1.4)
* tokio-reactor (0.1.7)
* tokio-signal (0.2.7)
* tokio-threadpool (0.1.9)
* tokio-timer (0.2.8)
* tokio-udp (0.1.3)
* tokio-uds (0.2.4)