### PR TITLE
tcp: add usage examples to TcpListener and TcpStream

### DIFF
--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -27,3 +27,4 @@ futures = "0.1.19"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
+tokio = { path = ".." }

--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -16,30 +16,32 @@ use tokio_reactor::{Handle, PollEvented};
 ///
 /// # Examples
 ///
-/// ```
-/// # extern crate tokio_tcp;
-/// # extern crate futures;
-/// # use futures::stream::Stream;
+/// ```no_run
+/// extern crate tokio;
+/// extern crate futures;
+///
+/// use futures::stream::Stream;
 /// use std::net::SocketAddr;
-/// use tokio_tcp::{TcpListener, TcpStream};
+/// use tokio::net::{TcpListener, TcpStream};
 ///
 /// fn process_socket(socket: TcpStream) {
 ///     // ...
 /// }
 ///
-/// # fn process() -> Result<(), Box<std::error::Error>> {
-/// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-/// let listener = TcpListener::bind(&addr)?;
+/// fn main() -> Result<(), Box<std::error::Error>> {
+///     let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+///     let listener = TcpListener::bind(&addr)?;
 ///
-/// // accept connections and process them
-/// listener.incoming()
-///     .map_err(|e| eprintln!("failed to accept stream; error = {:?}", e))
-///     .for_each(|socket| {
-///         process_socket(socket);
-///         Ok(())
-///     });
-/// # Ok(())
-/// # }
+///     // accept connections and process them
+///     tokio::run(listener.incoming()
+///         .map_err(|e| eprintln!("failed to accept socket; error = {:?}", e))
+///         .for_each(|socket| {
+///             process_socket(socket);
+///             Ok(())
+///         })
+///     );
+///     Ok(())
+/// }
 /// ```
 pub struct TcpListener {
     io: PollEvented<mio::net::TcpListener>,
@@ -54,9 +56,9 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// use std::net::SocketAddr;
-    /// use tokio_tcp::TcpListener;
+    /// use tokio::net::TcpListener;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
@@ -100,10 +102,10 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
     /// use std::net::SocketAddr;
-    /// use tokio_tcp::TcpListener;
+    /// use tokio::net::TcpListener;
     /// use futures::Async;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -158,10 +160,10 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```no_run
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
     /// use std::net::SocketAddr;
-    /// use tokio_tcp::TcpListener;
+    /// use tokio::net::TcpListener;
     /// use futures::Async;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -205,7 +207,7 @@ impl TcpListener {
     ///
     /// Finally, the `handle` argument is the event loop that this listener will
     /// be bound to.
-    /// Use `Handle::default()` to lazily bind to an event loop, just like `bind` does.
+    /// Use [`Handle::default()`] to lazily bind to an event loop, just like `bind` does.
     ///
     /// The platform specific behavior of this function looks like:
     ///
@@ -217,15 +219,15 @@ impl TcpListener {
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
     ///
+    /// [`Handle::default()`]: ../reactor/struct.Handle.html
     /// # Examples
     ///
-    /// ```
-    /// # extern crate tokio_tcp;
+    /// ```no_run
+    /// # extern crate tokio;
     /// # extern crate tokio_reactor;
-    ///
-    /// # use tokio_tcp::TcpListener;
+    /// use tokio::net::TcpListener;
     /// use std::net::TcpListener as StdTcpListener;
-    /// use tokio_reactor::Handle;
+    /// use tokio::reactor::Handle;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let std_listener = StdTcpListener::bind("127.0.0.1:8080")?;
@@ -254,8 +256,8 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
-    /// # use tokio_tcp::TcpListener;
+    /// # extern crate tokio;
+    /// use tokio::net::TcpListener;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -289,10 +291,10 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpListener;
-    /// # use futures::stream::Stream;
+    /// use tokio::net::TcpListener;
+    /// use futures::stream::Stream;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -321,7 +323,8 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```
-    /// # use tokio_tcp::TcpListener;
+    /// # extern crate tokio;
+    /// use tokio::net::TcpListener;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
@@ -344,7 +347,8 @@ impl TcpListener {
     /// # Examples
     ///
     /// ```
-    /// # use tokio_tcp::TcpListener;
+    /// # extern crate tokio;
+    /// use tokio::net::TcpListener;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -19,6 +19,28 @@ use tokio_reactor::{Handle, PollEvented};
 /// [`connect`]: struct.TcpStream.html#method.connect
 /// [accepting]: struct.TcpListener.html#method.accept
 /// [listener]: struct.TcpListener.html
+///
+/// # Examples
+///
+/// ```
+/// # extern crate tokio_io;
+/// # extern crate tokio_tcp;
+/// # extern crate futures;
+/// # use futures::Future;
+/// # use tokio_io::AsyncWrite;
+/// # use tokio_tcp::TcpStream;
+/// use std::net::SocketAddr;
+///
+/// # fn main() -> Result<(), Box<std::error::Error>> {
+/// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
+/// let connect_future = TcpStream::connect(&addr);
+/// connect_future.map(|mut stream| {
+///     // Attempt to write bytes asynchronously to the stream
+///     stream.poll_write(&[1]);
+/// });
+/// # Ok(())
+/// # }
+/// ```
 pub struct TcpStream {
     io: PollEvented<mio::net::TcpStream>,
 }
@@ -46,6 +68,24 @@ impl TcpStream {
     /// the `addr` provided. The returned future will be resolved once the
     /// stream has successfully connected, or it will return an error if one
     /// occurs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_io;
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use futures::Future;
+    /// # use tokio_tcp::TcpStream;
+    /// # use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
+    /// let connect_future = TcpStream::connect(&addr)
+    ///     .map(|_stream| println!("successfully connected"));
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn connect(addr: &SocketAddr) -> ConnectFuture {
         use self::ConnectFutureState::*;
 
@@ -67,6 +107,23 @@ impl TcpStream {
     /// This function will convert a TCP stream created by the standard library
     /// to a TCP stream ready to be used with the provided event loop handle.
     /// Use `Handle::default()` to lazily bind to an event loop, just like `connect` does.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # extern crate tokio_tcp;
+    /// # extern crate tokio_reactor;
+    ///
+    /// # use tokio_tcp::TcpStream;
+    /// use std::net::TcpStream as StdTcpStream;
+    /// use tokio_reactor::Handle;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let std_stream = StdTcpStream::connect("127.0.0.1:34254")?;
+    /// let stream = TcpStream::from_std(std_stream, &Handle::default())?;
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn from_std(stream: net::TcpStream, handle: &Handle)
         -> io::Result<TcpStream>
     {
@@ -131,6 +188,31 @@ impl TcpStream {
     ///
     /// * `ready` includes writable.
     /// * called from outside of a task context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_io;
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use futures::Async;
+    /// # use futures::Future;
+    /// # use tokio_tcp::TcpStream;
+    /// # use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
+    /// let fut = TcpStream::connect(&addr);
+    /// fut.map(|stream| {
+    ///     match stream.poll_read_ready(mio::Ready::readable()) {
+    ///         Ok(Async::Ready(_)) => println!("read ready"),
+    ///         Ok(Async::NotReady) => println!("not read ready"),
+    ///         Err(e) => eprintln!("got error: {}", e),
+    /// }
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn poll_read_ready(&self, mask: mio::Ready) -> Poll<mio::Ready, io::Error> {
         self.io.poll_read_ready(mask)
     }
@@ -149,16 +231,80 @@ impl TcpStream {
     /// # Panics
     ///
     /// This function panics if called from outside of a task context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_io;
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use futures::Async;
+    /// # use futures::Future;
+    /// # use tokio_tcp::TcpStream;
+    /// # use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
+    /// let fut = TcpStream::connect(&addr);
+    /// fut.map(|stream| {
+    ///     match stream.poll_write_ready() {
+    ///         Ok(Async::Ready(_)) => println!("write ready"),
+    ///         Ok(Async::NotReady) => println!("not write ready"),
+    ///         Err(e) => eprintln!("got error: {}", e),
+    /// }
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn poll_write_ready(&self) -> Poll<mio::Ready, io::Error> {
         self.io.poll_write_ready()
     }
 
     /// Returns the local address that this stream is bound to.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     assert_eq!(stream.local_addr().unwrap(),
+    ///         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().local_addr()
     }
 
     /// Returns the remote address that this stream is connected to.
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     assert_eq!(stream.peer_addr().unwrap(),
+    ///         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().peer_addr()
     }
@@ -190,6 +336,31 @@ impl TcpStream {
     /// # Panics
     ///
     /// This function will panic if called from outside of a task context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Async;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|mut stream| {
+    ///     let mut buf = [0; 10];
+    ///     match stream.poll_peek(&mut buf) {
+    ///        Ok(Async::Ready(len)) => println!("read {} bytes", len),
+    ///        Ok(Async::NotReady) => println!("no data available"),
+    ///        Err(e) => eprintln!("got error: {}", e),
+    ///     }
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn poll_peek(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
         try_ready!(self.io.poll_read_ready(mio::Ready::readable()));
 
@@ -208,6 +379,25 @@ impl TcpStream {
     /// This function will cause all pending and future I/O on the specified
     /// portions to return immediately with an appropriate value (see the
     /// documentation of `Shutdown`).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::{Shutdown, SocketAddr};
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.shutdown(Shutdown::Both)
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.io.get_ref().shutdown(how)
     }
@@ -217,6 +407,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_nodelay`].
     ///
     /// [`set_nodelay`]: #method.set_nodelay
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_nodelay(true).expect("set_nodelay call failed");;
+    ///     assert_eq!(stream.nodelay().unwrap_or(false), true);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn nodelay(&self) -> io::Result<bool> {
         self.io.get_ref().nodelay()
     }
@@ -228,6 +438,25 @@ impl TcpStream {
     /// small amount of data. When not set, data is buffered until there is a
     /// sufficient amount to send out, thereby avoiding the frequent sending of
     /// small packets.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_nodelay(true).expect("set_nodelay call failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
         self.io.get_ref().set_nodelay(nodelay)
     }
@@ -237,6 +466,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_recv_buffer_size`].
     ///
     /// [`set_recv_buffer_size`]: #tymethod.set_recv_buffer_size
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_recv_buffer_size(100).expect("set_recv_buffer_size failed");
+    ///     assert_eq!(stream.recv_buffer_size().unwrap_or(0), 100);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn recv_buffer_size(&self) -> io::Result<usize> {
         self.io.get_ref().recv_buffer_size()
     }
@@ -245,6 +494,25 @@ impl TcpStream {
     ///
     /// Changes the size of the operating system's receive buffer associated
     /// with the socket.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_recv_buffer_size(100).expect("set_recv_buffer_size failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_recv_buffer_size(&self, size: usize) -> io::Result<()> {
         self.io.get_ref().set_recv_buffer_size(size)
     }
@@ -254,6 +522,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_send_buffer`].
     ///
     /// [`set_send_buffer`]: #tymethod.set_send_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_send_buffer_size(100).expect("set_send_buffer_size failed");
+    ///     assert_eq!(stream.send_buffer_size().unwrap_or(0), 100);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn send_buffer_size(&self) -> io::Result<usize> {
         self.io.get_ref().send_buffer_size()
     }
@@ -262,6 +550,25 @@ impl TcpStream {
     ///
     /// Changes the size of the operating system's send buffer associated with
     /// the socket.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_send_buffer_size(100).expect("set_send_buffer_size failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_send_buffer_size(&self, size: usize) -> io::Result<()> {
         self.io.get_ref().set_send_buffer_size(size)
     }
@@ -272,6 +579,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_keepalive`].
     ///
     /// [`set_keepalive`]: #tymethod.set_keepalive
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_keepalive(None).expect("set_keepalive failed");
+    ///     assert_eq!(stream.keepalive().unwrap(), None);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn keepalive(&self) -> io::Result<Option<Duration>> {
         self.io.get_ref().keepalive()
     }
@@ -288,6 +615,25 @@ impl TcpStream {
     ///
     /// Some platforms specify this value in seconds, so sub-second
     /// specifications may be omitted.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_keepalive(None).expect("set_keepalive failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_keepalive(&self, keepalive: Option<Duration>) -> io::Result<()> {
         self.io.get_ref().set_keepalive(keepalive)
     }
@@ -297,6 +643,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_ttl`].
     ///
     /// [`set_ttl`]: #tymethod.set_ttl
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_ttl(100).expect("set_ttl failed");
+    ///     assert_eq!(stream.ttl().unwrap_or(0), 100);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn ttl(&self) -> io::Result<u32> {
         self.io.get_ref().ttl()
     }
@@ -305,6 +671,25 @@ impl TcpStream {
     ///
     /// This value sets the time-to-live field that is used in every packet sent
     /// from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_ttl(100).expect("set_ttl failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.io.get_ref().set_ttl(ttl)
     }
@@ -315,6 +700,26 @@ impl TcpStream {
     /// For more information about this option, see [`set_linger`].
     ///
     /// [`set_linger`]: #tymethod.set_linger
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_linger(None).expect("set_linger failed");
+    ///     assert_eq!(stream.linger().unwrap(), None);
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn linger(&self) -> io::Result<Option<Duration>> {
         self.io.get_ref().linger()
     }
@@ -330,6 +735,25 @@ impl TcpStream {
     /// If `SO_LINGER` is not specified, and the stream is closed, the system
     /// handles the call in a way that allows the process to continue as quickly
     /// as possible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     stream.set_linger(None).expect("set_linger failed");
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
         self.io.get_ref().set_linger(dur)
     }
@@ -340,6 +764,25 @@ impl TcpStream {
     /// object references. Both handles will read and write the same stream of
     /// data, and options set on one stream will be propagated to the other
     /// stream.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio_tcp;
+    /// # extern crate futures;
+    /// # use tokio_tcp::TcpStream;
+    /// # use futures::Future;
+    /// use std::net::SocketAddr;
+    ///
+    /// # fn main() -> Result<(), Box<std::error::Error>> {
+    /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    /// let future = TcpStream::connect(&addr);
+    /// future.map(|stream| {
+    ///     let clone = stream.try_clone().unwrap();
+    /// });
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn try_clone(&self) -> io::Result<TcpStream> {
         let io = self.io.get_ref().try_clone()?;
         Ok(TcpStream::new(io))

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -192,6 +192,7 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
+    /// # extern crate mio;
     /// # extern crate tokio_io;
     /// # extern crate tokio_tcp;
     /// # extern crate futures;

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -23,18 +23,17 @@ use tokio_reactor::{Handle, PollEvented};
 /// # Examples
 ///
 /// ```
-/// # extern crate tokio_io;
-/// # extern crate tokio_tcp;
+/// # extern crate tokio;
 /// # extern crate futures;
-/// # use futures::Future;
-/// # use tokio_io::AsyncWrite;
-/// # use tokio_tcp::TcpStream;
+/// use futures::Future;
+/// use tokio::io::AsyncWrite;
+/// use tokio::net::TcpStream;
 /// use std::net::SocketAddr;
 ///
 /// # fn main() -> Result<(), Box<std::error::Error>> {
 /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
-/// let connect_future = TcpStream::connect(&addr);
-/// connect_future.map(|mut stream| {
+/// let stream = TcpStream::connect(&addr);
+/// stream.map(|mut stream| {
 ///     // Attempt to write bytes asynchronously to the stream
 ///     stream.poll_write(&[1]);
 /// });
@@ -72,17 +71,17 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_io;
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use futures::Future;
-    /// # use tokio_tcp::TcpStream;
-    /// # use std::net::SocketAddr;
+    /// use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
-    /// let connect_future = TcpStream::connect(&addr)
-    ///     .map(|_stream| println!("successfully connected"));
+    /// let stream = TcpStream::connect(&addr)
+    ///     .map(|stream| 
+    ///         println!("successfully connected to {}", stream.local_addr().unwrap()));
     /// # Ok(())
     /// # }
     /// ```
@@ -111,10 +110,9 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```no_run
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate tokio_reactor;
-    ///
-    /// # use tokio_tcp::TcpStream;
+    /// use tokio::net::TcpStream;
     /// use std::net::TcpStream as StdTcpStream;
     /// use tokio_reactor::Handle;
     ///
@@ -193,19 +191,19 @@ impl TcpStream {
     ///
     /// ```
     /// # extern crate mio;
-    /// # extern crate tokio_io;
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use futures::Async;
-    /// # use futures::Future;
-    /// # use tokio_tcp::TcpStream;
-    /// # use std::net::SocketAddr;
+    /// use mio::Ready;
+    /// use futures::Async;
+    /// use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
-    /// let fut = TcpStream::connect(&addr);
-    /// fut.map(|stream| {
-    ///     match stream.poll_read_ready(mio::Ready::readable()) {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
+    ///     match stream.poll_read_ready(Ready::readable()) {
     ///         Ok(Async::Ready(_)) => println!("read ready"),
     ///         Ok(Async::NotReady) => println!("not read ready"),
     ///         Err(e) => eprintln!("got error: {}", e),
@@ -236,18 +234,17 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_io;
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use futures::Async;
-    /// # use futures::Future;
-    /// # use tokio_tcp::TcpStream;
-    /// # use std::net::SocketAddr;
+    /// use futures::Async;
+    /// use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:34254".parse::<SocketAddr>()?;
-    /// let fut = TcpStream::connect(&addr);
-    /// fut.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     match stream.poll_write_ready() {
     ///         Ok(Async::Ready(_)) => println!("write ready"),
     ///         Ok(Async::NotReady) => println!("not write ready"),
@@ -266,16 +263,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     assert_eq!(stream.local_addr().unwrap(),
     ///         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
     /// });
@@ -290,16 +287,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     assert_eq!(stream.peer_addr().unwrap(),
     ///         SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 8080)));
     /// });
@@ -341,17 +338,17 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Async;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Async;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|mut stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|mut stream| {
     ///     let mut buf = [0; 10];
     ///     match stream.poll_peek(&mut buf) {
     ///        Ok(Async::Ready(len)) => println!("read {} bytes", len),
@@ -384,16 +381,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::{Shutdown, SocketAddr};
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.shutdown(Shutdown::Both)
     /// });
     /// # Ok(())
@@ -412,16 +409,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_nodelay(true).expect("set_nodelay call failed");;
     ///     assert_eq!(stream.nodelay().unwrap_or(false), true);
     /// });
@@ -443,16 +440,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_nodelay(true).expect("set_nodelay call failed");
     /// });
     /// # Ok(())
@@ -471,16 +468,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_recv_buffer_size(100).expect("set_recv_buffer_size failed");
     ///     assert_eq!(stream.recv_buffer_size().unwrap_or(0), 100);
     /// });
@@ -499,16 +496,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_recv_buffer_size(100).expect("set_recv_buffer_size failed");
     /// });
     /// # Ok(())
@@ -527,16 +524,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_send_buffer_size(100).expect("set_send_buffer_size failed");
     ///     assert_eq!(stream.send_buffer_size().unwrap_or(0), 100);
     /// });
@@ -555,16 +552,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_send_buffer_size(100).expect("set_send_buffer_size failed");
     /// });
     /// # Ok(())
@@ -584,16 +581,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_keepalive(None).expect("set_keepalive failed");
     ///     assert_eq!(stream.keepalive().unwrap(), None);
     /// });
@@ -620,16 +617,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_keepalive(None).expect("set_keepalive failed");
     /// });
     /// # Ok(())
@@ -648,16 +645,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_ttl(100).expect("set_ttl failed");
     ///     assert_eq!(stream.ttl().unwrap_or(0), 100);
     /// });
@@ -676,16 +673,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_ttl(100).expect("set_ttl failed");
     /// });
     /// # Ok(())
@@ -705,16 +702,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_linger(None).expect("set_linger failed");
     ///     assert_eq!(stream.linger().unwrap(), None);
     /// });
@@ -740,16 +737,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     stream.set_linger(None).expect("set_linger failed");
     /// });
     /// # Ok(())
@@ -769,16 +766,16 @@ impl TcpStream {
     /// # Examples
     ///
     /// ```
-    /// # extern crate tokio_tcp;
+    /// # extern crate tokio;
     /// # extern crate futures;
-    /// # use tokio_tcp::TcpStream;
-    /// # use futures::Future;
+    /// use tokio::net::TcpStream;
+    /// use futures::Future;
     /// use std::net::SocketAddr;
     ///
     /// # fn main() -> Result<(), Box<std::error::Error>> {
     /// let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    /// let future = TcpStream::connect(&addr);
-    /// future.map(|stream| {
+    /// let stream = TcpStream::connect(&addr);
+    /// stream.map(|stream| {
     ///     let clone = stream.try_clone().unwrap();
     /// });
     /// # Ok(())


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Request by the Networking Working Group to help document tokio. 
https://github.com/rust-lang-nursery/wg-net/issues/54

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adding doc tests and usage examples to the public methods
of `TcpListener` and `TcpStream`. The documented methods are:
- tokio-tcp/src/listener.rs#bind
- tokio-tcp/src/listener.rs#accept
- tokio-tcp/src/listener.rs#poll_accept
- tokio-tcp/src/listener.rs#accept_std
- tokio-tcp/src/listener.rs#poll_accept_std
- tokio-tcp/src/listener.rs#from_std
- tokio-tcp/src/listener.rs#local_addr
- tokio-tcp/src/listener.rs#incoming
- tokio-tcp/src/listener.rs#ttl
- tokio-tcp/src/listener.rs#set_ttl
- tokio-tcp/src/stream.rs#connect
- tokio-tcp/src/stream.rs#from_std
- tokio-tcp/src/stream.rs#poll_read_ready
- tokio-tcp/src/stream.rs#poll_write_ready
- tokio-tcp/src/stream.rs#local_addr
- tokio-tcp/src/stream.rs#peer_addr
- tokio-tcp/src/stream.rs#peek
- tokio-tcp/src/stream.rs#poll_peek
- tokio-tcp/src/stream.rs#shutdown
- tokio-tcp/src/stream.rs#nodelay
- tokio-tcp/src/stream.rs#set_nodelay
- tokio-tcp/src/stream.rs#recv_buffer_size
- tokio-tcp/src/stream.rs#set_recv_buffer_size
- tokio-tcp/src/stream.rs#send_buffer_size
- tokio-tcp/src/stream.rs#set_send_buffer_size
- tokio-tcp/src/stream.rs#keepalive
- tokio-tcp/src/stream.rs#set_keepalive
- tokio-tcp/src/stream.rs#ttl
- tokio-tcp/src/stream.rs#set_ttl
- tokio-tcp/src/stream.rs#linger
- tokio-tcp/src/stream.rs#set_linger
- tokio-tcp/src/stream.rs#try_clone

Refs: https://github.com/rust-lang-nursery/wg-net/issues/54
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->