### PR TITLE
Make TlsConnector and TlsAcceptor Clone

### DIFF
--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -43,12 +43,14 @@ pub struct TlsStream<S> {
 
 /// A wrapper around a `native_tls::TlsConnector`, providing an async `connect`
 /// method.
+#[derive(Clone)]
 pub struct TlsConnector {
     inner: native_tls::TlsConnector,
 }
 
 /// A wrapper around a `native_tls::TlsAcceptor`, providing an async `accept`
 /// method.
+#[derive(Clone)]
 pub struct TlsAcceptor {
     inner: native_tls::TlsAcceptor,
 }


### PR DESCRIPTION
The underlying types are Clone, so these should be as well. It's common to configure a single connector and use it throughout an application, so being able to clone it is quite convenient.