### PR TITLE
reactor: update to parking_lot 0.7

### DIFF
--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.0.2"
 log = "0.4.1"
 mio = "0.6.14"
 num_cpus = "1.8.0"
-parking_lot = "0.6.3"
+parking_lot = "0.7.0"
 slab = "0.4.0"
 tokio-executor = { version = "0.1.1", path = "../tokio-executor" }
 tokio-io = { version = "0.1.6", path = "../tokio-io" }


### PR DESCRIPTION
Updates reactor parking_lot crate dependency to 0.7.0.  This latest version of parking_lot (and parking_lot_core, lock_api) has minimum rustc 1.24, which is less than tokio's current 1.26, so no problem there.

cc: @Amanieu

## Motivation

I've been waiting/watching for rand* crate duplicates and shim dependencies to go away, and this new parking_lot update removes the last old rand dep, which looked like this (via `cargo tree -d`):

``` txt
 
rand_core v0.2.2
└── rand v0.5.5
    └── parking_lot_core v0.3.1
        └── parking_lot v0.6.4
            └── tokio-reactor v0.1.7 
```