### PR TITLE
[WIP] threadpool: make inbound queue stealable

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
+crossbeam = "0.5.0"
 crossbeam-deque = "0.6.1"
 crossbeam-utils = "0.6.0"
 num_cpus = "1.2"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.9")]
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+// #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.
 //!
@@ -79,6 +79,7 @@
 
 extern crate tokio_executor;
 
+extern crate crossbeam;
 extern crate crossbeam_deque as deque;
 extern crate crossbeam_utils;
 #[macro_use]

--- a/tokio-threadpool/src/worker/entry.rs
+++ b/tokio-threadpool/src/worker/entry.rs
@@ -205,7 +205,8 @@ impl WorkerEntry {
         use deque::Steal::*;
         match self.stealer.steal_many(&dest.worker) {
             Data(task) => Data(task),
-            Empty | Retry => match self.inbound.try_pop() {
+            Retry => Retry,
+            Empty => match self.inbound.try_pop() {
                 None => Empty,
                 Some(task) => Data(task),
             }


### PR DESCRIPTION
This is just an experiment. We're trying to see if this fixes #750.

The hypothesis is that tasks getting stuck in the inbound MPSC queue before it's drained are a source of latency spikes. If that is true, then allowing other workers to steal tasks from the inbound queue should fix the problem.

cc @tobz @carllerche @jsgf