### PR TITLE
Asynchronous Seek and Seek implementation for File

### DIFF
--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -20,7 +20,7 @@ use futures::Poll;
 use std::fs::{File as StdFile, Metadata, Permissions};
 use std::io::{self, Read, Seek, Write};
 use std::path::Path;
-use tokio_io::{AsyncRead, AsyncWrite};
+use tokio_io::{AsyncRead, AsyncWrite, AsyncSeek};
 
 /// A reference to an open file on the filesystem.
 ///
@@ -502,6 +502,14 @@ impl AsyncWrite for File {
         })
     }
 }
+
+impl Seek for File {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        ::would_block(|| self.std().seek(pos))
+    }
+}
+
+impl AsyncSeek for File { }
 
 impl Drop for File {
     fn drop(&mut self) {

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -192,9 +192,7 @@ impl File {
     ///
     /// tokio::run(task);
     /// ```
-    #[deprecated(since = "0.1.7", note = "use tokio::io::AsyncSeek instead")]
     #[doc(hidden)]
-    #[allow(deprecated)]
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
         crate::blocking_io(|| self.std().seek(pos))
     }

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -14,6 +14,7 @@ pub use self::create::CreateFuture;
 pub use self::metadata::MetadataFuture;
 pub use self::open::OpenFuture;
 pub use self::open_options::OpenOptions;
+#[allow(deprecated)]
 pub use self::seek::SeekFuture;
 
 use futures::Poll;
@@ -191,6 +192,9 @@ impl File {
     ///
     /// tokio::run(task);
     /// ```
+    #[deprecated(since = "0.2", note = "use tokio::io::AsyncSeek instead")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
         crate::blocking_io(|| self.std().seek(pos))
     }
@@ -217,6 +221,9 @@ impl File {
     ///
     /// tokio::run(task);
     /// ```
+    #[deprecated(since = "0.2", note = "use tokio::io::seek instead")]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn seek(self, pos: io::SeekFrom) -> SeekFuture {
         SeekFuture::new(self, pos)
     }

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -510,13 +510,11 @@ impl AsyncWrite for File {
     }
 }
 
-impl Seek for File {
-    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
-        ::would_block(|| self.std().seek(pos))
+impl AsyncSeek for File {
+    fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
+        crate::blocking_io(|| self.std().seek(pos))
     }
 }
-
-impl AsyncSeek for File { }
 
 impl Drop for File {
     fn drop(&mut self) {

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -192,7 +192,7 @@ impl File {
     ///
     /// tokio::run(task);
     /// ```
-    #[deprecated(since = "0.2", note = "use tokio::io::AsyncSeek instead")]
+    #[deprecated(since = "0.1.7", note = "use tokio::io::AsyncSeek instead")]
     #[doc(hidden)]
     #[allow(deprecated)]
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
@@ -221,7 +221,7 @@ impl File {
     ///
     /// tokio::run(task);
     /// ```
-    #[deprecated(since = "0.2", note = "use tokio::io::seek instead")]
+    #[deprecated(since = "0.1.7", note = "use tokio::io::seek instead")]
     #[doc(hidden)]
     #[allow(deprecated)]
     pub fn seek(self, pos: io::SeekFrom) -> SeekFuture {

--- a/tokio-fs/src/file/seek.rs
+++ b/tokio-fs/src/file/seek.rs
@@ -4,7 +4,7 @@ use futures::{try_ready, Future, Poll};
 use std::io;
 
 /// Future returned by `File::seek`.
-#[deprecated(since = "0.2", note = "use tokio::io::Seek<File> instead")]
+#[deprecated(since = "0.1.7", note = "use tokio::io::Seek<File> instead")]
 #[doc(hidden)]
 #[derive(Debug)]
 pub struct SeekFuture {

--- a/tokio-fs/src/file/seek.rs
+++ b/tokio-fs/src/file/seek.rs
@@ -1,8 +1,11 @@
+#![allow(deprecated)]
 use super::File;
 use futures::{try_ready, Future, Poll};
 use std::io;
 
 /// Future returned by `File::seek`.
+#[deprecated(since = "0.2", note = "use tokio::io::Seek<File> instead")]
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct SeekFuture {
     inner: Option<File>,

--- a/tokio-fs/tests/file.rs
+++ b/tokio-fs/tests/file.rs
@@ -182,3 +182,30 @@ fn clone() {
 
     assert_eq!(dst, b"clone successful")
 }
+
+#[test]
+#[allow(unused_imports)]
+fn poll_seek_deprecated() {
+    // bring AsyncSeek into scope to test for potential collision with
+    // poll_seek
+    use tokio_io::AsyncSeek;
+
+    let dir = TmpBuilder::new()
+        .prefix("tokio-fs-tests")
+        .tempdir()
+        .unwrap();
+
+    let file_path = dir.path().join("seek.txt");
+
+    pool::run({
+        OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .open(file_path)
+            .and_then(|mut file| {
+                let _poll = file.poll_seek(SeekFrom::Start(0));
+                Ok(())
+            })
+    });
+}

--- a/tokio-fs/tests/file.rs
+++ b/tokio-fs/tests/file.rs
@@ -131,11 +131,11 @@ fn seek() {
             .write(true)
             .open(file_path)
             .and_then(|file| io::write_all(file, "Hello, world!"))
-            .and_then(|(file, _)| file.seek(SeekFrom::End(-6)))
+            .and_then(|(file, _)| io::seek(file, SeekFrom::End(-6)))
             .and_then(|(file, _)| io::read_exact(file, vec![0; 5]))
             .and_then(|(file, buf)| {
                 assert_eq!(buf, b"world");
-                file.seek(SeekFrom::Start(0))
+                io::seek(file, SeekFrom::Start(0))
             })
             .and_then(|(file, _)| io::read_exact(file, vec![0; 5]))
             .and_then(|(_, buf)| {

--- a/tokio-io/src/async_seek.rs
+++ b/tokio-io/src/async_seek.rs
@@ -12,11 +12,9 @@ use AsyncWrite;
 /// Specifically, this means that the `poll_seek` function will return one of
 /// the following:
 ///
-
 /// * `Ok(Async::Ready(n))` means that the seek was successful, and `n` is the
 ///   new position in the file.
 ///
-
 /// * `Ok(Async::NotReady)` means that the I/O object is not currently seekable
 ///   but may become seekable in the future. Most importantly, **the current
 ///   future's task is scheduled to get unparked when the object is seekable**.

--- a/tokio-io/src/async_seek.rs
+++ b/tokio-io/src/async_seek.rs
@@ -1,0 +1,63 @@
+use std::io as std_io;
+use futures::{Async, Poll};
+
+use AsyncWrite;
+
+/// Seek files asynchronously.
+///
+/// This trait inherits from `std::io::Seek` and indicates that an I/O object is
+/// **non-blocking**. All non-blocking I/O objects must return an error when
+/// seeking is unavailable instead of blocking the current thread.
+///
+/// Specifically, this means that the `poll_seek` function will return one of
+/// the following:
+///
+
+/// * `Ok(Async::Ready(n))` means that the seek was successful, and `n` is the
+///   new position in the file.
+///
+
+/// * `Ok(Async::NotReady)` means that the I/O object is not currently seekable
+///   but may become seekable in the future. Most importantly, **the current
+///   future's task is scheduled to get unparked when the object is seekable**.
+///   This means that like `Future::poll` you'll receive a notification when
+///   the I/O object is seekable again.
+///
+/// * `Err(e)` for other errors are standard I/O errors coming from the
+///   underlying object.
+///
+/// This trait importantly means that the `seek` method only works in the
+/// context of a future's task. The object may panic if used outside of a task.
+pub trait AsyncSeek: std_io::Seek {
+    /// Seek to an offset, in bytes, in a stream.
+    ///
+    /// A seek beyond the end of a stream is allowed, but implementation
+    /// defined.
+    ///
+    /// If the seek operation completed successfully, this method returns the
+    /// new position from the start of the stream. That position can be used
+    /// later with `SeekFrom::Start`.
+    ///
+    /// # Errors
+    ///
+    /// Seeking to a negative offset is considered an error.
+    fn poll_seek(&mut self, pos: std_io::SeekFrom) -> Poll<u64, std_io::Error> {
+        match self.seek(pos) {
+            Ok(t) => Ok(Async::Ready(t)),
+            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => {
+                return Ok(Async::NotReady)
+            }
+            Err(e) => return Err(e.into())
+        }
+    }
+}
+
+impl<T: ?Sized + AsyncSeek> AsyncSeek for Box<T> { }
+
+impl<'a, T: ?Sized + AsyncSeek> AsyncSeek for &'a mut T { }
+
+impl<T: AsRef<[u8]>> AsyncSeek for std_io::Cursor<T> { }
+
+impl<T: AsyncSeek> AsyncSeek for std_io::BufReader<T> { }
+
+impl<T: AsyncSeek + AsyncWrite> AsyncSeek for std_io::BufWriter<T> { }

--- a/tokio-io/src/io/mod.rs
+++ b/tokio-io/src/io/mod.rs
@@ -17,6 +17,7 @@ mod read_to_end;
 mod read_until;
 mod shutdown;
 mod write_all;
+mod seek;
 
 pub use self::copy::{copy, Copy};
 pub use self::flush::{flush, Flush};
@@ -26,6 +27,7 @@ pub use self::read_to_end::{read_to_end, ReadToEnd};
 pub use self::read_until::{read_until, ReadUntil};
 pub use self::shutdown::{shutdown, Shutdown};
 pub use self::write_all::{write_all, WriteAll};
+pub use self::seek::{seek, Seek};
 pub use crate::allow_std::AllowStdIo;
 pub use crate::lines::{lines, Lines};
 pub use crate::split::{ReadHalf, WriteHalf};

--- a/tokio-io/src/io/seek.rs
+++ b/tokio-io/src/io/seek.rs
@@ -1,0 +1,47 @@
+use std::io;
+
+use futures::{try_ready, Future, Poll};
+
+use crate::AsyncSeek;
+
+/// A future used to seek an I/O object.
+///
+/// Created by the [`seek`] function.
+///
+/// [`seek`]: fn.seek.html
+#[derive(Debug)]
+pub struct Seek<A> {
+    a: Option<A>,
+    pos: io::SeekFrom,
+}
+
+/// Creates a future which will seek an IO object, and then yield the
+/// new position in the object and the object itself.
+///
+/// In the case of an error, the object will be discarded.
+pub fn seek<A>(a: A, pos: io::SeekFrom) -> Seek<A>
+    where A: AsyncSeek,
+{
+    Seek {
+        a: Some(a),
+        pos,
+    }
+}
+
+impl<A> Future for Seek<A>
+    where A: AsyncSeek,
+{
+    type Item = (A, u64);
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let pos = try_ready!(
+            self.a
+                .as_mut()
+                .expect("Cannot poll `Seek` after it resolves")
+                .poll_seek(self.pos)
+        );
+        let a = self.a.take().unwrap();
+        Ok((a, pos).into())
+    }
+}

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -46,6 +46,7 @@ pub mod _tokio_codec;
 mod allow_std;
 mod async_read;
 mod async_write;
+mod async_seek;
 mod framed;
 mod framed_read;
 mod framed_write;
@@ -56,6 +57,7 @@ mod window;
 
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;
+pub use self::async_seek::AsyncSeek;
 
 fn _assert_objects() {
     fn _assert<T>() {}

--- a/tokio-io/tests/async_seek.rs
+++ b/tokio-io/tests/async_seek.rs
@@ -1,0 +1,59 @@
+extern crate tokio_io;
+extern crate bytes;
+extern crate futures;
+
+use tokio_io::AsyncSeek;
+use futures::Async;
+
+use std::io::{self, Seek, SeekFrom};
+
+#[test]
+fn poll_seek_success() {
+    struct S;
+
+    impl Seek for S {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Ok(11)
+        }
+    }
+
+    impl AsyncSeek for S {}
+
+    let n = match S.poll_seek(SeekFrom::Start(0)).unwrap() {
+        Async::Ready(n) => n,
+        _ => panic!(),
+    };
+
+    assert_eq!(11, n);
+}
+
+#[test]
+fn poll_seek_error() {
+    struct S;
+
+    impl Seek for S {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Err(io::Error::new(io::ErrorKind::Other, "other"))
+        }
+    }
+
+    impl AsyncSeek for S {}
+
+    let err = S.poll_seek(SeekFrom::Start(0)).unwrap_err();
+    assert_eq!(err.kind(), io::ErrorKind::Other);
+}
+
+#[test]
+fn poll_seek_translate_wouldblock_to_not_ready() {
+    struct S;
+
+    impl Seek for S {
+        fn seek(&mut self, _pos: SeekFrom) -> io::Result<u64> {
+            Err(io::Error::new(io::ErrorKind::WouldBlock, ""))
+        }
+    }
+
+    impl AsyncSeek for S {}
+
+    assert!(!S.poll_seek(SeekFrom::Start(0)).unwrap().is_ready());
+}

--- a/tokio/src/io.rs
+++ b/tokio/src/io.rs
@@ -45,7 +45,11 @@
 //! [`ErrorKind`]: enum.ErrorKind.html
 //! [`Result`]: type.Result.html
 
-pub use tokio_io::{AsyncRead, AsyncWrite};
+pub use tokio_io::{
+    AsyncRead,
+    AsyncWrite,
+    AsyncSeek,
+};
 
 // standard input, output, and error
 #[cfg(feature = "fs")]
@@ -53,8 +57,8 @@ pub use tokio_fs::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
 
 // Utils
 pub use tokio_io::io::{
-    copy, flush, lines, read, read_exact, read_to_end, read_until, shutdown, write_all, Copy,
-    Flush, Lines, ReadExact, ReadHalf, ReadToEnd, ReadUntil, Shutdown, WriteAll, WriteHalf,
+    copy, flush, lines, read, read_exact, read_to_end, read_until, seek, shutdown, write_all, Copy,
+    Flush, Lines, ReadExact, ReadHalf, ReadToEnd, ReadUntil, Seek, Shutdown, WriteAll, WriteHalf,
 };
 
 // Re-export io::Error so that users don't have to deal


### PR DESCRIPTION
(Original issue: #776)

## Motivation

`AsyncRead` and `AsyncWrite` provide a way to do asynchronous I/O without caring about the specific underlying implementation. No such interface exists for seeking, though.

## Solution

I implemented `AsyncSeek`, modeled after `AsyncRead` and `AsyncWrite`. Like those, it comes with a default implementation that relies on the underlying `Seek` implementation to use `WouldBlock` errors.

I also added `tokio_io::io::seek`, a future-flavored seek call built on top of `AsyncSeek`. The future it returns is almost an exact copy of `SeekFuture` from `tokio_fs`, but I kept both structs around since one has a type argument and one does not.

Finally, I implemented `AsyncSeek` on `File`, and changed the existing test to use the new `io::seek`. The methods `seek` and `poll_seek` on `File` (as well as `SeekFuture`) should probably be deprecated, but I'm not sure how that works.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
