### PR TITLE
Improve the documentation of `blocking`

### DIFF
--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -25,6 +25,11 @@ pub struct BlockingError {
 /// calls complete. The maximum value is specified when creating a thread pool
 /// using [`Builder::max_blocking`][build]
 ///
+/// NB: This does not directly spawn a new thread; the entire task that called
+/// `blocking` is blocked whenever the supplied closure blocks. If this is
+/// not desired, ensure that `blocking` runs in its own task (e.g. using
+/// `futures::sync::oneshot::spawn`).
+///
 /// [build]: struct.Builder.html#method.max_blocking
 ///
 /// # Return

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -25,10 +25,12 @@ pub struct BlockingError {
 /// calls complete. The maximum value is specified when creating a thread pool
 /// using [`Builder::max_blocking`][build]
 ///
-/// NB: This does not directly spawn a new thread; the entire task that called
-/// `blocking` is blocked whenever the supplied closure blocks. If this is
-/// not desired, ensure that `blocking` runs in its own task (e.g. using
-/// `futures::sync::oneshot::spawn`).
+/// NB: The entire task that called `blocking` is blocked whenever the supplied
+/// closure blocks, even if you have used future combinators such as `select` -
+/// the other futures in this task will not make progress until the closure
+/// returns.
+/// If this is not desired, ensure that `blocking` runs in its own task (e.g.
+/// using `futures::sync::oneshot::spawn`).
 ///
 /// [build]: struct.Builder.html#method.max_blocking
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

As seen in issue #618, experienced engineers get confused by the current documentation of `blocking`, because it blocks the whole task, not just a single future. While cleverer people than me are working on a more general solution, let's improve the documentation slightly to help out current users.

## Solution

Make the lack of a new thread explicit in the documentation, and point users of this function towards already existing mechanisms for creating new tasks if they need them. This is just a stop-gap while issue #629 is being worked on.