### PR TITLE
threadpool: introduce a global task queue

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -20,6 +20,7 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = { version = "0.1.2", path = "../tokio-executor" }
 futures = "0.1.19"
+crossbeam-channel = "0.3.3"
 crossbeam-deque = "0.6.1"
 crossbeam-utils = "0.6.0"
 num_cpus = "1.2"

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -79,6 +79,7 @@
 
 extern crate tokio_executor;
 
+extern crate crossbeam_channel;
 extern crate crossbeam_deque as deque;
 extern crate crossbeam_utils;
 #[macro_use]

--- a/tokio-threadpool/src/sender.rs
+++ b/tokio-threadpool/src/sender.rs
@@ -161,7 +161,10 @@ impl<'a> tokio_executor::Executor for &'a Sender {
         // Create a new task for the future
         let task = Arc::new(Task::new(future));
 
-        self.pool.submit_to_random(task, &self.pool);
+        // Call `submit_external()` in order to place the task into the global
+        // queue. This way all workers have equal chance of running this task,
+        // which means IO handles will be assigned to reactors more evenly.
+        self.pool.submit_external(task, &self.pool);
 
         Ok(())
     }

--- a/tokio-threadpool/src/shutdown.rs
+++ b/tokio-threadpool/src/shutdown.rs
@@ -1,3 +1,4 @@
+use task::Queue;
 use worker;
 
 use futures::{Future, Poll, Async};
@@ -61,25 +62,30 @@ impl Future for Shutdown {
 pub(crate) struct ShutdownTrigger {
     inner: Arc<Mutex<Inner>>,
     workers: Arc<[worker::Entry]>,
+    queue: Arc<Queue>,
 }
 
 unsafe impl Send for ShutdownTrigger {}
 unsafe impl Sync for ShutdownTrigger {}
 
 impl ShutdownTrigger {
-    pub(crate) fn new(workers: Arc<[worker::Entry]>) -> ShutdownTrigger {
+    pub(crate) fn new(workers: Arc<[worker::Entry]>, queue: Arc<Queue>) -> ShutdownTrigger {
         ShutdownTrigger {
             inner: Arc::new(Mutex::new(Inner {
                 task: AtomicTask::new(),
                 completed: false,
             })),
             workers,
+            queue,
         }
     }
 }
 
 impl Drop for ShutdownTrigger {
     fn drop(&mut self) {
+        // Drain the global task queue.
+        while self.queue.pop().is_some() {}
+
         // Notify the task interested in shutdown.
         let mut inner = self.inner.lock().unwrap();
         inner.completed = true;

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -4,7 +4,7 @@ mod queue;
 mod state;
 
 pub(crate) use self::blocking::{Blocking, CanBlock};
-pub(crate) use self::queue::{Queue, Poll};
+pub(crate) use self::queue::Queue;
 use self::blocking_state::BlockingState;
 use self::state::State;
 
@@ -30,9 +30,6 @@ pub(crate) struct Task {
 
     /// Task blocking related state
     blocking: AtomicUsize,
-
-    /// Next pointer in the queue that submits tasks to a worker.
-    next: AtomicPtr<Task>,
 
     /// Next pointer in the queue of tasks pending blocking capacity.
     next_blocking: AtomicPtr<Task>,
@@ -63,7 +60,6 @@ impl Task {
         Task {
             state: AtomicUsize::new(State::new().into()),
             blocking: AtomicUsize::new(BlockingState::new().into()),
-            next: AtomicPtr::new(ptr::null_mut()),
             next_blocking: AtomicPtr::new(ptr::null_mut()),
             future: UnsafeCell::new(Some(task_fut)),
         }
@@ -78,7 +74,6 @@ impl Task {
         Task {
             state: AtomicUsize::new(State::stub().into()),
             blocking: AtomicUsize::new(BlockingState::new().into()),
-            next: AtomicPtr::new(ptr::null_mut()),
             next_blocking: AtomicPtr::new(ptr::null_mut()),
             future: UnsafeCell::new(Some(task_fut)),
         }
@@ -237,7 +232,6 @@ impl Task {
 impl fmt::Debug for Task {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Task")
-            .field("next", &self.next)
             .field("state", &self.state)
             .field("future", &"Spawn<BoxFuture>")
             .finish()

--- a/tokio-threadpool/src/task/queue.rs
+++ b/tokio-threadpool/src/task/queue.rs
@@ -1,33 +1,13 @@
 use task::Task;
 
-use std::cell::UnsafeCell;
-use std::ptr;
 use std::sync::Arc;
-use std::sync::atomic::AtomicPtr;
-use std::sync::atomic::Ordering::{Acquire, Release, AcqRel, Relaxed};
 
-use crossbeam_utils::CachePadded;
+use crossbeam_channel::{unbounded, Receiver, Sender};
 
 #[derive(Debug)]
 pub(crate) struct Queue {
-    /// Queue head.
-    ///
-    /// This is a strong reference to `Task` (i.e, `Arc<Task>`)
-    head: CachePadded<AtomicPtr<Task>>,
-
-    /// Tail pointer. This is `Arc<Task>` unless it points to `stub`.
-    tail: UnsafeCell<*mut Task>,
-
-    /// Stub pointer, used as part of the intrusive mpsc channel algorithm
-    /// described by 1024cores.
-    stub: Box<Task>,
-}
-
-#[derive(Debug)]
-pub(crate) enum Poll {
-    Empty,
-    Inconsistent,
-    Data(Arc<Task>),
+    // TODO(stjepang): Use a custom, faster MPMC queue implementation that supports `steal_many()`.
+    chan: (Sender<Arc<Task>>, Receiver<Arc<Task>>),
 }
 
 // ===== impl Queue =====
@@ -35,93 +15,20 @@ pub(crate) enum Poll {
 impl Queue {
     /// Create a new, empty, `Queue`.
     pub fn new() -> Queue {
-        let stub = Box::new(Task::stub());
-        let ptr = &*stub as *const _ as *mut _;
-
         Queue {
-            head: CachePadded::new(AtomicPtr::new(ptr)),
-            tail: UnsafeCell::new(ptr),
-            stub: stub,
+            chan: unbounded(),
         }
     }
 
     /// Push a task onto the queue.
-    ///
-    /// This function is `Sync`.
+    #[inline]
     pub fn push(&self, task: Arc<Task>) {
-        unsafe {
-            self.push2(Arc::into_raw(task));
-        }
+        self.chan.0.send(task).unwrap();
     }
 
-    unsafe fn push2(&self, task: *const Task) {
-        let task = task as *mut Task;
-
-        // Set the next pointer. This does not require an atomic operation as
-        // this node is not accessible. The write will be flushed with the next
-        // operation
-        (*task).next.store(ptr::null_mut(), Relaxed);
-
-        // Update the head to point to the new node. We need to see the previous
-        // node in order to update the next pointer as well as release `task`
-        // to any other threads calling `push`.
-        let prev = self.head.swap(task, AcqRel);
-
-        // Release `task` to the consume end.
-        (*prev).next.store(task, Release);
-    }
-
-    /// Poll a task from the queue.
-    ///
-    /// This function is **not** `Sync` and requires coordination by the caller.
-    pub unsafe fn poll(&self) -> Poll {
-        let mut tail = *self.tail.get();
-        let mut next = (*tail).next.load(Acquire);
-
-        let stub = &*self.stub as *const _ as *mut _;
-
-        if tail == stub {
-            if next.is_null() {
-                return Poll::Empty;
-            }
-
-            *self.tail.get() = next;
-            tail = next;
-            next = (*next).next.load(Acquire);
-        }
-
-        if !next.is_null() {
-            *self.tail.get() = next;
-
-            // No ref_count inc is necessary here as this poll is paired
-            // with a `push` which "forgets" the handle.
-            return Poll::Data(Arc::from_raw(tail));
-        }
-
-        if self.head.load(Acquire) != tail {
-            return Poll::Inconsistent;
-        }
-
-        self.push2(stub);
-
-        next = (*tail).next.load(Acquire);
-
-        if !next.is_null() {
-            *self.tail.get() = next;
-
-            return Poll::Data(Arc::from_raw(tail));
-        }
-
-        Poll::Inconsistent
-    }
-}
-
-impl Drop for Queue {
-    fn drop(&mut self) {
-        loop {
-            if let Poll::Empty = unsafe { self.poll() } {
-                break
-            }
-        }
+    /// Pop a task from the queue.
+    #[inline]
+    pub fn pop(&self) -> Option<Arc<Task>> {
+        self.chan.1.try_recv().ok()
     }
 }


### PR DESCRIPTION
## Motivation

A performance regression was reported in https://github.com/tokio-rs/tokio/issues/750. The problem is that a task inserted into an inbound queue is stuck there until its worker moves it into its main task queue. While a task is in the inbound queue, no other worker can steal it. This manifests as a spike in latency between spawning and completing the task.

## Solution

We take inspiration from Go's task scheduler. Go has a SPMC queue for every worker and a single global MPMC queue. In this PR we use a similar strategy. Now we have a global MPMC queue where newly spawned tasks get inserted. Every worker occasionally steals tasks from the global queue and moves them into its own queue. This way every runnable task is always ready to be taken by any worker.

Note that spawning a new task results in the task being pushed into the global queue, which means every worker has equal chance of picking it up. That means tasks will still be distributed among workers pretty randomly. 

Benchmarks (before vs after):

```
 name                     before ns/iter  after ns/iter  diff ns/iter  diff %  speedup
 threadpool::notify_many  39,073,764      42,648,110        3,574,346   9.15%   x 0.92
 threadpool::spawn_many   3,095,985       3,377,044           281,059   9.08%   x 0.92
 threadpool::yield_many   11,037,957      10,356,006         -681,951  -6.18%   x 1.07
```

There are some losses and some wins. We can further improve performance to recover losses by taking an implementation of `SegQueue` or `crossbeam_channel::bounded` and simplifying it, but I chose to do that in a follow-up PR in order to keep this one easier to review.

Fixes #750