### PR TITLE
executor: impl Unpark for Arc<Unpark>

### DIFF
--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -133,6 +133,12 @@ impl Unpark for Box<Unpark> {
     }
 }
 
+impl Unpark for Arc<Unpark> {
+    fn unpark(&self) {
+        (**self).unpark()
+    }
+}
+
 /// Blocks the current thread using a condition variable.
 ///
 /// Implements the [`Park`] functionality by using a condition variable. An


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

It should be possible to use `Arc<dyn Unpark>` where `Unpark` is required, similar to how `Box<dyn Unpark>` is supported now.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `impl Unpark for Arc<Unpark>` that forwards to the wrapped value's implementation.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
