### PR TITLE
tokio-reactor: deprecates `Handle::current()`

### DIFF
--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -455,7 +455,8 @@ impl fmt::Debug for Reactor {
 // ===== impl Handle =====
 
 impl Handle {
-    /// Returns a handle to the current reactor.
+    #[doc(hidden)]
+    #[deprecated(note = "semantics were sometimes surprising, use Handle::default()")]
     pub fn current() -> Handle {
         // TODO: Should this panic on error?
         HandlePriv::try_current()


### PR DESCRIPTION
The side effects of calling `Handle::current()` from outside of a
runtime could be very surprising, since it would start up a background
reactor.

Discussed in https://github.com/hyperium/hyper/issues/1736.