### PR TITLE
Stablize pin feature

### DIFF
--- a/tokio-async-await/README.md
+++ b/tokio-async-await/README.md
@@ -8,7 +8,8 @@ guarantees. You are living on the edge here.**
 
 ## Usage
 
-To use this crate, you need to start with a Rust 2018 edition crate.
+To use this crate, you need to start with a Rust 2018 edition crate, with rustc
+1.33.0-nightly or later.
 
 Add this to your `Cargo.toml`:
 

--- a/tokio-async-await/src/compat/backward.rs
+++ b/tokio-async-await/src/compat/backward.rs
@@ -19,7 +19,7 @@ pub struct Compat<T>(Pin<Box<T>>);
 impl<T> Compat<T> {
     /// Create a new `Compat` backed by `future`.
     pub fn new(future: T) -> Compat<T> {
-        Compat(Box::pinned(future))
+        Compat(Box::pin(future))
     }
 }
 

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -5,7 +5,6 @@
     async_await,
     await_macro,
     futures_api,
-    pin,
     )]
 
 #![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.4")]


### PR DESCRIPTION
## Motivation

#813 

Box::pinned has been renamed to Box::pin. Meanwhile, the pin feature no longer requires an attribute to enable.

## Solution

Change `Box::pinned(...)` to `Box::pin(...)`, and remove pin feature attribute.
