### PR TITLE
Finally ALLOW_FAILURES=false in travis for cargo +nightly doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,8 +63,8 @@ matrix:
         cargo test -p tokio-threadpool --tests --target x86_64-unknown-linux-gnu
 
   # This runs cargo +nightly doc
-  - rust: nightly
-    env: ALLOW_FAILURES=true # FIXME remove this live after #437 is resolved
+  - name: nightly_docs
+    rust: nightly
     script: cargo doc
 
   allow_failures:


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`cargo +nightly doc` Works

## Solution

Do not allow failures in Travis on nightly to build docs


Closes https://github.com/tokio-rs/tokio/issues/437