### PR TITLE
Allow deprecated Error::cause

### DIFF
--- a/src/runtime/current_thread/runtime.rs
+++ b/src/runtime/current_thread/runtime.rs
@@ -92,6 +92,10 @@ impl Error for RunError {
     fn description(&self) -> &str {
         self.inner.description()
     }
+
+    // FIXME(taiki-e): When the minimum support version of tokio reaches Rust 1.30,
+    // replace this with Error::source.
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&Error> {
         self.inner.cause()
     }

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -161,6 +161,9 @@ impl<T: StdError + 'static> StdError for ThrottleError<T> {
         }
     }
 
+    // FIXME(taiki-e): When the minimum support version of tokio reaches Rust 1.30,
+    // replace this with Error::source.
+    #[allow(deprecated)]
     fn cause(&self) -> Option<&StdError> {
         match self.0 {
             Either::A(ref err) => Some(err),


### PR DESCRIPTION
## Motivation

#817

Error::cause is deprecated in Rust 1.33, but Error::source, which replaces it, has been stabilized in Rust 1.30 ([the minimum version of tokio is Rust 1.26](https://github.com/tokio-rs/tokio/blob/master/.travis.yml#L15))..

## Solution

Allow Error::cause until the minimum supported version of tokio is Rust 1.30.

When the minimum support version of tokio reaches Rust 1.30, replace Error::cause with Error::source.