### PR TITLE
threadpool: remove unused fn

### DIFF
--- a/tokio-threadpool/src/pool/backup.rs
+++ b/tokio-threadpool/src/pool/backup.rs
@@ -243,10 +243,6 @@ impl State {
         self.0 & PUSHED == PUSHED
     }
 
-    pub fn set_pushed(&mut self) {
-        self.0 |= PUSHED;
-    }
-
     fn unset_pushed(&mut self) {
         self.0 &= !PUSHED;
     }


### PR DESCRIPTION
The unused lint on nightly has discovered a new unused fn.