### PR TITLE
tcp: deprecate `TcpStream::try_clone()`

### DIFF
--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -46,6 +46,7 @@
 
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossbeam_utils::sync::{Parker, Unparker};

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -781,6 +781,8 @@ impl TcpStream {
     /// # Ok(())
     /// # }
     /// ```
+    #[deprecated(since = "0.1.14", note = "use `split()` instead")]
+    #[doc(hidden)]
     pub fn try_clone(&self) -> io::Result<TcpStream> {
         let io = self.io.get_ref().try_clone()?;
         Ok(TcpStream::new(io))

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -784,8 +784,11 @@ impl TcpStream {
     #[deprecated(since = "0.1.14", note = "use `split()` instead")]
     #[doc(hidden)]
     pub fn try_clone(&self) -> io::Result<TcpStream> {
-        let io = self.io.get_ref().try_clone()?;
-        Ok(TcpStream::new(io))
+        // Rationale for deprecation:
+        // - https://github.com/tokio-rs/tokio/pull/824
+        // - https://github.com/tokio-rs/tokio/issues/774#issuecomment-451059317
+        let msg = "`TcpStream::split()` is deprecated because it doesn't work as intended";
+        Err(io::Error::new(io::ErrorKind::Other, msg))
     }
 }
 


### PR DESCRIPTION
## Motivation

`TcpStream::clone()` creates a copy of a TCP stream that may be accidentally tied to a different reactor than the original. See [here](https://github.com/tokio-rs/tokio/issues/774#issuecomment-442632537) for a reproducible bug and [here](https://github.com/tokio-rs/tokio/issues/774#issuecomment-443519689) for a more elaborate explanation.

## Solution

Deprecate `TcpStream::try_clone()` and nudge users towards `TcpStream::split()` instead.

Closes #774.