### PR TITLE
executor: fix build

### DIFF
--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -46,6 +46,7 @@
 
 use std::marker::PhantomData;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
 use crossbeam_utils::sync::{Parker, Unparker};


### PR DESCRIPTION
Two unrelated PRs to the same file resulted in a broken build. This
patch fixes the build by including `Arc`.