### PR TITLE
threadpool: panic if a worker thread cannot be spawned

### DIFF
--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -397,7 +397,8 @@ impl Pool {
         });
 
         if let Err(e) = res {
-            warn!("failed to spawn worker thread; err={:?}", e);
+            error!("failed to spawn worker thread; err={:?}", e);
+            panic!("failed to spawn worker thread: {:?}", e);
         }
     }
 


### PR DESCRIPTION
## Motivation

It is possible that spawning a worker thread fails due to resource exhaustion on the machine. See #809 for details. In that case, we're logging a warning and continuing execution, but we should make it a harder error instead.

## Solution

If thread spawning fails, log an `error!` and panic.

Closes #809