### PR TITLE
docs: fix link to ThreadPool

### DIFF
--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -106,7 +106,7 @@
 //! [timer]: ../timer/index.html
 //! [`Runtime`]: struct.Runtime.html
 //! [`Reactor`]: ../reactor/struct.Reactor.html
-//! [`ThreadPool`]: ../executor/thread_pool/struct.ThreadPool.html
+//! [`ThreadPool`]: https://docs.rs/tokio-threadpool/0.1/tokio_threadpool/struct.ThreadPool.html
 //! [`run`]: fn.run.html
 //! [idle]: struct.Runtime.html#method.shutdown_on_idle
 //! [`tokio::spawn`]: ../executor/fn.spawn.html


### PR DESCRIPTION
In 85f85225, `#[doc(hidden)]` was added to the deprecated re-export of `tokio-threadpool` in the `executor` module. This broke the doc link to `ThreadPool` in the `Runtime` module. This fixes the link by pointing it to the docs.rs for `tokio-threadpool`.