### PR TITLE
Add enumerate combinator to Stream

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ macro_rules! if_runtime {
     )*)
 }
 
-#[cfg_attr(feature = "rt-full", macro_use)]
+#[macro_use]
 extern crate futures;
 
 #[cfg(feature = "io")]

--- a/src/util/enumerate.rs
+++ b/src/util/enumerate.rs
@@ -1,0 +1,60 @@
+use futures::{Async, Poll, Stream};
+
+/// A stream combinator which combines the yields the current item
+/// plus its count starting from 0.
+///
+/// This structure is produced by the `Stream::enumerate` method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Enumerate<T> {
+    stream: T,
+    count: usize,
+}
+
+impl<T> Enumerate<T> {
+    pub fn new(stream: T) -> Self {
+        Self { stream, count: 0 }
+    }
+
+    /// Acquires a reference to the underlying stream that this combinator is
+    /// pulling from.
+    pub fn get_ref(&self) -> &T {
+        &self.stream
+    }
+
+    /// Acquires a mutable reference to the underlying stream that this
+    /// combinator is pulling from.
+    ///
+    /// Note that care must be taken to avoid tampering with the state of the
+    /// stream which may otherwise confuse this combinator.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.stream
+    }
+
+    /// Consumes this combinator, returning the underlying stream.
+    ///
+    /// Note that this may discard intermediate state of this combinator, so
+    /// care should be taken to avoid losing resources when this is called.
+    pub fn into_inner(self) -> T {
+        self.stream
+    }
+}
+
+impl<T> Stream for Enumerate<T>
+where
+    T: Stream,
+{
+    type Item = (usize, T::Item);
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, T::Error> {
+        match try_ready!(self.stream.poll()) {
+            Some(item) => {
+                let ret = Some((self.count, item));
+                self.count += 1;
+                Ok(Async::Ready(ret))
+            }
+            None => return Ok(Async::Ready(None)),
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -9,6 +9,7 @@
 
 mod future;
 mod stream;
+mod enumerate;
 
 pub use self::future::FutureExt;
 pub use self::stream::StreamExt;

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -9,7 +9,7 @@ use futures::Stream;
 
 #[cfg(feature = "timer")]
 use std::time::Duration;
-use util::enumerate::Enumerate;
+pub use util::enumerate::Enumerate;
 
 /// An extension trait for `Stream` that provides a variety of convenient
 /// combinator functions.
@@ -98,6 +98,12 @@ pub trait StreamExt: Stream {
     /// The stream returned yields pairs `(i, val)`, where `i` is the
     /// current index of iteration and `val` is the value returned by the
     /// iterator.
+    ///
+    /// # Overflow Behavior
+    ///
+    /// The method does no guarding against overflows, so counting elements of
+    /// an iterator with more than [`std::usize::MAX`] elements either produces the
+    /// wrong result or panics.
     fn enumerate(self) -> Enumerate<Self>
     where Self: Sized,
     {

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -9,7 +9,7 @@ use futures::Stream;
 
 #[cfg(feature = "timer")]
 use std::time::Duration;
-
+use util::enumerate::Enumerate;
 
 /// An extension trait for `Stream` that provides a variety of convenient
 /// combinator functions.
@@ -90,6 +90,18 @@ pub trait StreamExt: Stream {
     where Self: Sized
     {
         Throttle::new(self, duration)
+    }
+
+    /// Creates a new stream which gives the current iteration count as well
+    /// as the next value.
+    ///
+    /// The stream returned yields pairs `(i, val)`, where `i` is the
+    /// current index of iteration and `val` is the value returned by the
+    /// iterator.
+    fn enumerate(self) -> Enumerate<Self>
+    where Self: Sized,
+    {
+        Enumerate::new(self)
     }
 
     /// Creates a new stream which allows `self` until `timeout`.

--- a/tokio-timer/tests/enumerate.rs
+++ b/tokio-timer/tests/enumerate.rs
@@ -1,0 +1,31 @@
+extern crate futures;
+extern crate tokio;
+extern crate tokio_executor;
+extern crate tokio_timer;
+
+#[macro_use]
+mod support;
+
+use futures::prelude::*;
+use futures::sync::mpsc;
+use tokio::util::StreamExt;
+
+#[test]
+fn enumerate() {
+    use futures::*;
+
+    let (mut tx, rx) = mpsc::channel(1);
+
+    std::thread::spawn(|| {
+        for i in 0..5 {
+            tx = tx.send(i * 2).wait().unwrap();
+        }
+    });
+
+    let mut result = rx.enumerate().collect();
+    assert_eq!(
+        result.wait(),
+        Ok(vec![(0, 0), (1, 2), (2, 4), (3, 6), (4, 8)])
+    );
+
+}


### PR DESCRIPTION


## Motivation
Motivation is to provide an enumarete combinator, much like in Iterator. The issue for that can be found here: https://github.com/tokio-rs/tokio/issues/741
## Solution
Simply provided `Stream::enumerate` on `StreamExt`


Since this is my first PR any kind of feedback will be greatly appreaciated :) 