### PR TITLE
Bump version to 0.1.14.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.14 (January 6, 2019)
+
+* Use feature flags to break up the crate, allowing users to pick & choose
+  components (#808).
+* Export `UnixDatagram` and `UnixDatagramFramed` (#772).
+
 # 0.1.13 (November 21, 2018)
 
 * Fix `Runtime::reactor()` when no tasks are spawned (#721).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ name = "tokio"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.13"
+version = "0.1.14"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.13/tokio/"
+documentation = "https://docs.rs/tokio/0.1.14/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.14/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 The API docs for the master branch are published [here][master-dox].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.14")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,

--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-async-await"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
@@ -26,5 +26,4 @@ tokio-io = { version = "0.1.7", path = "../tokio-io" }
 [dev-dependencies]
 bytes = "0.4.9"
 tokio = { version = "0.1.8", path = ".." }
-# tokio-codec = { version = "0.1.0", path = "../tokio-codec" }
 hyper = "0.12.8"

--- a/tokio-async-await/LICENSE
+++ b/tokio-async-await/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -7,7 +7,7 @@
     futures_api,
     )]
 
-#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.5")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/tokio-buf/LICENSE
+++ b/tokio-buf/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-channel/LICENSE
+++ b/tokio-channel/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-codec/LICENSE
+++ b/tokio-codec/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-current-thread/LICENSE
+++ b/tokio-current-thread/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.6 (January 6, 2019)
+
+* Implement `Unpark` for `Arc<Unpark>` (#802).
+* Switch to crossbeam's Parker / Unparker (#528).
+
 # 0.1.5 (September 26, 2018)
 
 * Implement `futures::Executor` for `DefaultExecutor` (#563).

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -5,9 +5,11 @@ name = "tokio-executor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Update doc URL.
+#   - Cargo.toml
+#   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
-documentation = "https://docs.rs/tokio-executor/0.1.5/tokio_executor"
+version = "0.1.6"
+documentation = "https://docs.rs/tokio-executor/0.1.6/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-executor/LICENSE
+++ b/tokio-executor/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,7 +2,7 @@
 
 Task execution related traits and utilities.
 
-[Documentation](https://tokio-rs.github.io/tokio/tokio_executor/)
+[Documentation](https://docs.rs/tokio-executor/0.1.6/tokio_executor)
 
 ## Overview
 

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.6")]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.5 (January 6, 2019)
+
+* Add examples to `File` API docs (#786).
+
 # 0.1.4 (October 23, 2018)
 
 * Provide `File::from_std` (#696).

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -5,14 +5,16 @@ name = "tokio-fs"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Update doc URL.
+#   - Cargo.toml
+#   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-fs/0.1.4/tokio_fs"
+documentation = "https://docs.rs/tokio-fs/0.1.5/tokio_fs"
 description = """
 Filesystem API for Tokio.
 """

--- a/tokio-fs/LICENSE
+++ b/tokio-fs/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-fs/README.md
+++ b/tokio-fs/README.md
@@ -2,7 +2,7 @@
 
 Asynchronous filesystem manipulation operations (and stdin, stdout, stderr).
 
-[Documentation](https://tokio-rs.github.io/tokio/tokio_fs/)
+[Documentation](https://docs.rs/tokio-fs/0.1.5/tokio_fs)
 
 ## Overview
 

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.5")]
 
 //! Asynchronous file and standard stream adaptation.
 //!

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.11 (January 6, 2019)
+
+* Fix minor error in Decoder::decode API documentation (#797).
+
 # 0.1.10 (October 23, 2018)
 
 * Expose inner codec from `Framed` (#686).

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -5,13 +5,15 @@ name = "tokio-io"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Update doc URL.
+#   - Cargo.toml
+#   - Readme.md
 # - Create "v0.1.x" git tag.
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.1.10/tokio_io"
+documentation = "https://docs.rs/tokio-io/0.1.11/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """

--- a/tokio-io/LICENSE
+++ b/tokio-io/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-io/README.md
+++ b/tokio-io/README.md
@@ -4,7 +4,7 @@ Core I/O abstractions for the Tokio stack.
 
 [![Build Status](https://travis-ci.org/tokio-rs/tokio-io.svg?branch=master)](https://travis-ci.org/tokio-rs/tokio-io)
 
-[Documentation](https://docs.rs/tokio-io)
+[Documentation](https://docs.rs/tokio-io/0.1.11/tokio_io)
 
 ## Usage
 

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.11")]
 
 //! Core I/O traits and combinators when working with Tokio.
 //!

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.8 (January 6, 2019)
+
+* Update to `parking_lot` 0.7 (#778).
+* Deprecate `Handle::current()` (#805).
+
 # 0.1.7 (November 21, 2018)
 
 * Reduce log level to trace (#734).

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -5,14 +5,16 @@ name = "tokio-reactor"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Update doc URL.
+#   - Cargo.toml
+#   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1.7/tokio_reactor"
+documentation = "https://docs.rs/tokio-reactor/0.1.8/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/LICENSE
+++ b/tokio-reactor/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -2,7 +2,7 @@
 
 Event loop that drives Tokio I/O resources.
 
-[Documentation](https://tokio-rs.github.io/tokio/tokio_reactor/)
+[Documentation](https://docs.rs/tokio-reactor/0.1.8/tokio_reactor)
 
 ## Overview
 

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.8")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-signal/LICENSE
+++ b/tokio-signal/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2018 Tokio contributors
+Copyright (c) 2019 Tokio contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-tcp/CHANGELOG.md
+++ b/tokio-tcp/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.3 (January 6, 2019)
+
+* Deprecate `TcpStream::try_clone()` (#824).
+* Add examples to TcpListener and TcpStream API docs (#775).
+
 # 0.1.2 (September 27, 2018)
 
 * Documentation tweaks

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -4,14 +4,16 @@ name = "tokio-tcp"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-tcp/0.1.2/tokio_tcp"
+documentation = "https://docs.rs/tokio-tcp/0.1.3/tokio_tcp"
 description = """
 TCP bindings for tokio.
 """

--- a/tokio-tcp/LICENSE
+++ b/tokio-tcp/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-tcp/README.md
+++ b/tokio-tcp/README.md
@@ -2,7 +2,7 @@
 
 TCP bindings for `tokio`.
 
-[Documentation](https://tokio-rs.github.io/tokio/tokio_tcp/)
+[Documentation](https://docs.rs/tokio-tcp/0.1.3/tokio_tcp)
 
 ## License
 

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.3")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! TCP bindings for `tokio`.

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.10 (January 6, 2019)
+
+* Fix deadlock bug in `blocking` (#795).
+* Introduce global task queue (#798).
+* Use crossbeam's Parker / Unparker (#529).
+* Panic if worker thread cannot be spawned (#826).
+* Improve `blocking` API documentation (#789).
+
 # 0.1.9 (November 21, 2018)
 
 * Bump internal dependency versions (#746, #753).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -5,8 +5,8 @@ name = "tokio-threadpool"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.9"
-documentation = "https://docs.rs/tokio-threadpool/0.1.9/tokio_threadpool"
+version = "0.1.10"
+documentation = "https://docs.rs/tokio-threadpool/0.1.10/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/LICENSE
+++ b/tokio-threadpool/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,6 +3,8 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
+[Documentation](https://docs.rs/tokio-threadpool/0.1.10/tokio_threadpool)
+
 ### Why not Rayon?
 
 Rayon is designed to handle parallelizing single computations by breaking them

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.9")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.10")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-timer/LICENSE
+++ b/tokio-timer/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-tls/CHANGELOG.md
+++ b/tokio-tls/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.1 (January 6, 2019)
+
+* Implement `Clone` for `TlsConnector` and `TlsAcceptor` (#777)
+
 # 0.2.0 (August 8, 2018)
 
 * Initial release with `tokio` support.

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -4,12 +4,12 @@ name = "tokio-tls"
 # - Update html_root_url.
 # - Update CHANGELOG.md.
 # - Create "tokio-tls-0.2.x" git tag.
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-tls"
+documentation = "https://docs.rs/tokio-tls/0.2.1/tokio_tls/"
 description = """
 An implementation of TLS/SSL streams for Tokio giving an implementation of TLS
 for nonblocking I/O streams.

--- a/tokio-tls/LICENSE
+++ b/tokio-tls/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-tls/README.md
+++ b/tokio-tls/README.md
@@ -3,7 +3,7 @@
 An implementation of TLS/SSL streams for Tokio built on top of the [`native-tls`
 crate]
 
-[Documentation](https://docs.rs/tokio-tls)
+[Documentation](https://docs.rs/tokio-tls/0.2.1/tokio_tls/)
 
 [`native-tls` crate]: https://github.com/sfackler/rust-native-tls
 

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(missing_docs)]
+#![doc(html_root_url = "https://docs.rs/tokio-tls/0.2.1")]
+
 //! Async TLS streams
 //!
 //! This library is an implementation of TLS streams using the most appropriate
@@ -14,9 +17,6 @@
 //! functionality provided by the `native-tls` crate, on which this crate is
 //! built. Configuration of TLS parameters is still primarily done through the
 //! `native-tls` crate.
-
-#![deny(missing_docs)]
-#![doc(html_root_url = "https://docs.rs/tokio-tls/0.2.0")]
 
 extern crate futures;
 extern crate native_tls;

--- a/tokio-udp/LICENSE
+++ b/tokio-udp/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-uds/CHANGELOG.md
+++ b/tokio-uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.5 (January 6, 2019)
+
+* Fix bug in `UnixDatagram::send` (#782).
+
 # 0.2.4 (November 24, 2018)
 
 * Implement `UnixDatagramFramed`, providing a `Stream + Sink` layer for

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -3,14 +3,16 @@ name = "tokio-uds"
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-uds/0.2.4/tokio_uds/"
+documentation = "https://docs.rs/tokio-uds/0.2.5/tokio_uds/"
 description = """
 Unix Domain sockets for Tokio
 """

--- a/tokio-uds/LICENSE
+++ b/tokio-uds/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018 Tokio Contributors
+Copyright (c) 2019 Tokio Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/tokio-uds/README.md
+++ b/tokio-uds/README.md
@@ -2,7 +2,7 @@
 
 An implementation of Unix Domain Sockets for Tokio
 
-[Documentation](https://docs.rs/tokio-uds)
+[Documentation](https://docs.rs/tokio-uds/0.2.5/tokio_uds/)
 
 ## License
 

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(unix)]
-#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.5")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Unix Domain Sockets for Tokio.


### PR DESCRIPTION
Also bumps:

* tokio-async-await (0.1.5)
* tokio-executor (0.1.6)
* tokio-fs (0.1.5)
* tokio-io (0.1.11)
* tokio-reactor (0.1.8)
* tokio-tcp (0.1.3)
* tokio-threadpool (0.1.10)
* tokio-tls (0.2.1)
* tokio-uds (0.2.5)

...and updates LICENSE files to 2019.

Refs: #835