### PR TITLE
Update tokio-threadpool minimum version for tokio crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ tokio-fs = { version = "0.1.3", path = "tokio-fs", optional = true }
 tokio-io = { version = "0.1.6", path = "tokio-io", optional = true }
 tokio-executor = { version = "0.1.5", path = "tokio-executor", optional = true }
 tokio-reactor = { version = "0.1.1", path = "tokio-reactor", optional = true }
-tokio-threadpool = { version = "0.1.4", path = "tokio-threadpool", optional = true }
+tokio-threadpool = { version = "0.1.8", path = "tokio-threadpool", optional = true }
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp", optional = true }
 tokio-udp = { version = "0.1.0", path = "tokio-udp", optional = true }
 tokio-timer = { version = "0.2.8", path = "tokio-timer", optional = true }


### PR DESCRIPTION
I updated to `tokio = "0.1.14"` in a directory that already had tokio dependencies installed, and the compiler started to error that `WorkerId::to_usize` did not exist.