### PR TITLE
Add CloneFuture for File::try_clone

### DIFF
--- a/tokio-fs/src/file/clone.rs
+++ b/tokio-fs/src/file/clone.rs
@@ -5,7 +5,11 @@ use futures::{Future, Poll};
 use std::io;
 
 /// Future returned by `File::try_clone`.
+///
 /// Clones a file handle into two file handles.
+///
+/// # Panics
+///
 /// Will panic if polled after returning an item or error.
 #[derive(Debug)]
 pub struct CloneFuture {

--- a/tokio-fs/src/file/clone.rs
+++ b/tokio-fs/src/file/clone.rs
@@ -1,0 +1,33 @@
+use super::File;
+
+use futures::{Future, Poll};
+
+use std::io;
+
+/// Future returned by `File::try_clone`.
+/// Clones a file handle into two file handles.
+/// Will panic if polled after returning an item or error.
+#[derive(Debug)]
+pub struct CloneFuture {
+    file: Option<File>,
+}
+
+impl CloneFuture {
+    pub(crate) fn new(file: File) -> Self {
+        Self { file: Some(file) }
+    }
+}
+
+impl Future for CloneFuture {
+    type Item = (File, File);
+    type Error = (File, io::Error);
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        self.file
+            .as_mut()
+            .expect("Cannot poll `CloneFuture` after it resolves")
+            .poll_try_clone()
+            .map(|inner| inner.map(|cloned| (self.file.take().unwrap(), cloned)))
+            .map_err(|err| (self.file.take().unwrap(), err))
+    }
+}

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -2,12 +2,14 @@
 //!
 //! [`File`]: file/struct.File.html
 
+mod clone;
 mod create;
 mod metadata;
 mod open;
 mod open_options;
 mod seek;
 
+pub use self::clone::CloneFuture;
 pub use self::create::CreateFuture;
 pub use self::metadata::MetadataFuture;
 pub use self::open::OpenFuture;
@@ -19,7 +21,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use futures::Poll;
 
 use std::fs::{File as StdFile, Metadata, Permissions};
-use std::io::{self, Read, Write, Seek};
+use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 
 /// A reference to an open file on the filesystem.
@@ -41,16 +43,16 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-/// 
+///
 /// use tokio::prelude::{AsyncWrite, Future};
-/// 
+///
 /// fn main() {
 ///     let task = tokio::fs::File::create("foo.txt")
 ///         .and_then(|mut file| file.poll_write(b"hello, world!"))
 ///         .map(|res| {
 ///             println!("{:?}", res);
 ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-/// 
+///
 ///     tokio::run(task);
 /// }
 /// ```
@@ -59,9 +61,9 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-/// 
+///
 /// use tokio::prelude::{AsyncRead, Future};
-/// 
+///
 /// fn main() {
 ///     let task = tokio::fs::File::open("foo.txt")
 ///         .and_then(|mut file| {
@@ -110,7 +112,8 @@ impl File {
     /// }
     /// ```
     pub fn open<P>(path: P) -> OpenFuture<P>
-    where P: AsRef<Path> + Send + 'static,
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         OpenOptions::new().read(true).open(path)
     }
@@ -149,7 +152,8 @@ impl File {
     /// }
     /// ```
     pub fn create<P>(path: P) -> CreateFuture<P>
-    where P: AsRef<Path> + Send + 'static,
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         CreateFuture::new(path)
     }
@@ -163,7 +167,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use std::fs::File;
-    /// 
+    ///
     /// fn main() {
     ///     let std_file = File::open("foo.txt").unwrap();
     ///     let file = tokio::fs::File::from_std(std_file);
@@ -192,7 +196,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::open("foo.txt")
     ///         // move cursor 6 bytes from the start of the file
@@ -200,7 +204,7 @@ impl File {
     ///         .map(|res| {
     ///             println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -221,7 +225,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.seek(SeekFrom::Start(6)))
@@ -229,7 +233,7 @@ impl File {
     ///             // handle returned file ..
     ///             # println!("{:?}", file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -247,7 +251,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -258,7 +262,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -280,7 +284,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -291,7 +295,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -316,7 +320,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -326,7 +330,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -341,14 +345,14 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
     ///         .map(|metadata| {
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -363,7 +367,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_metadata())
@@ -371,7 +375,7 @@ impl File {
     ///             // metadata is of type Async::Ready<Metadata>
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -381,14 +385,14 @@ impl File {
 
     /// Create a new `File` instance that shares the same underlying file handle
     /// as the existing `File` instance. Reads, writes, and seeks will affect both
-    /// File instances simultaneously.
+    /// `File` instances simultaneously.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_try_clone())
@@ -396,7 +400,7 @@ impl File {
     ///             // do something with the clone
     ///             # println!("{:?}", clone);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -405,6 +409,38 @@ impl File {
             let std = self.std().try_clone()?;
             Ok(File::from_std(std))
         })
+    }
+
+    /// Create a new `File` instance that shares the same underlying file handle
+    /// as the existing `File` instance. Reads, writes, and seeks will affect both
+    /// File instances simultaneously.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// # extern crate tokio;
+    /// use tokio::prelude::Future;
+    ///
+    /// fn main() {
+    ///     let task = tokio::fs::File::create("foo.txt")
+    ///         .and_then(|file| {
+    ///             file.try_clone()
+    ///                 .map(|(file, clone)| {
+    ///                     // do something with the file and the clone
+    ///                     # println!("{:?} {:?}", file, clone);
+    ///                 })
+    ///                 .map_err(|(file, err)| {
+    ///                     // you get the original file back if there's an error
+    ///                     # println!("{:?}", file);
+    ///                     err
+    ///                 })
+    ///         })
+    ///         .map_err(|err| eprintln!("IO error: {:?}", err));
+    ///
+    ///     tokio::run(task);
+    /// }
+    /// ```
+    pub fn try_clone(self) -> CloneFuture {
+        CloneFuture::new(self)
     }
 
     /// Changes the permissions on the underlying file.
@@ -428,7 +464,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
@@ -440,7 +476,7 @@ impl File {
     ///                 _ => println!("permissions set!"),
     ///             }
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -461,7 +497,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .map(|file| {
@@ -469,7 +505,7 @@ impl File {
     ///             // do something with the std::fs::File
     ///             # println!("{:?}", std_file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -21,7 +21,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use futures::Poll;
 
 use std::fs::{File as StdFile, Metadata, Permissions};
-use std::io::{self, Read, Seek, Write};
+use std::io::{self, Read, Write, Seek};
 use std::path::Path;
 
 /// A reference to an open file on the filesystem.
@@ -43,16 +43,16 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-///
+/// 
 /// use tokio::prelude::{AsyncWrite, Future};
-///
+/// 
 /// fn main() {
 ///     let task = tokio::fs::File::create("foo.txt")
 ///         .and_then(|mut file| file.poll_write(b"hello, world!"))
 ///         .map(|res| {
 ///             println!("{:?}", res);
 ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-///
+/// 
 ///     tokio::run(task);
 /// }
 /// ```
@@ -61,9 +61,9 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-///
+/// 
 /// use tokio::prelude::{AsyncRead, Future};
-///
+/// 
 /// fn main() {
 ///     let task = tokio::fs::File::open("foo.txt")
 ///         .and_then(|mut file| {
@@ -112,8 +112,7 @@ impl File {
     /// }
     /// ```
     pub fn open<P>(path: P) -> OpenFuture<P>
-    where
-        P: AsRef<Path> + Send + 'static,
+    where P: AsRef<Path> + Send + 'static,
     {
         OpenOptions::new().read(true).open(path)
     }
@@ -152,8 +151,7 @@ impl File {
     /// }
     /// ```
     pub fn create<P>(path: P) -> CreateFuture<P>
-    where
-        P: AsRef<Path> + Send + 'static,
+    where P: AsRef<Path> + Send + 'static,
     {
         CreateFuture::new(path)
     }
@@ -167,7 +165,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use std::fs::File;
-    ///
+    /// 
     /// fn main() {
     ///     let std_file = File::open("foo.txt").unwrap();
     ///     let file = tokio::fs::File::from_std(std_file);
@@ -196,7 +194,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::open("foo.txt")
     ///         // move cursor 6 bytes from the start of the file
@@ -204,7 +202,7 @@ impl File {
     ///         .map(|res| {
     ///             println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -225,7 +223,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.seek(SeekFrom::Start(6)))
@@ -233,7 +231,7 @@ impl File {
     ///             // handle returned file ..
     ///             # println!("{:?}", file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -251,7 +249,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -262,7 +260,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -284,7 +282,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -295,7 +293,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -320,7 +318,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -330,7 +328,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -345,14 +343,14 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
     ///         .map(|metadata| {
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -367,7 +365,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_metadata())
@@ -375,7 +373,7 @@ impl File {
     ///             // metadata is of type Async::Ready<Metadata>
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -385,14 +383,14 @@ impl File {
 
     /// Create a new `File` instance that shares the same underlying file handle
     /// as the existing `File` instance. Reads, writes, and seeks will affect both
-    /// `File` instances simultaneously.
+    /// File instances simultaneously.
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_try_clone())
@@ -400,7 +398,7 @@ impl File {
     ///             // do something with the clone
     ///             # println!("{:?}", clone);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -464,7 +462,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
@@ -476,7 +474,7 @@ impl File {
     ///                 _ => println!("permissions set!"),
     ///             }
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```
@@ -497,7 +495,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    ///
+    /// 
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .map(|file| {
@@ -505,7 +503,7 @@ impl File {
     ///             // do something with the std::fs::File
     ///             # println!("{:?}", std_file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
+    /// 
     ///     tokio::run(task);
     /// }
     /// ```


### PR DESCRIPTION
## Motivation

As explained in https://github.com/tokio-rs/tokio/issues/848, there's no existing future for cloning a file, and using something like `future::poll_fn` doesn't work since that would require moving the file.

## Solution

Create a future that returns a tuple of files, or the original file and the error if there's an error during cloning.

Closes #848.
