### PR TITLE
timer: Fix DelayQueue delay reset logic

### DIFF
--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -497,9 +497,7 @@ impl<T> DelayQueue<T> {
         // Normalize the deadline. Values cannot be set to expire in the past.
         let when = self.normalize_deadline(when);
 
-        // This is needed only for the debug assertion inside the if-let, but
-        // calculating it there causes the assertion to fail for some reason.
-        #[cfg(debug_assertions)]
+        // This is needed only for the debug assertion inside the if-let.
         let old = self.start + Duration::from_millis(self.slab[key.index].when);
 
         self.slab[key.index].when = when;

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -153,7 +153,7 @@ pub struct DelayQueue<T> {
 /// An entry in `DelayQueue` that has expired and removed.
 ///
 /// Values are returned by [`DelayQueue::poll`].
-/// 
+///
 /// [`DelayQueue::poll`]: struct.DelayQueue.html#method.poll
 #[derive(Debug)]
 pub struct Expired<T> {
@@ -501,10 +501,13 @@ impl<T> DelayQueue<T> {
 
         self.slab[key.index].when = when;
 
+        let next_poll = self.wheel.poll_at()
+            .map(|t| self.start + Duration::from_millis(t));
+
         if let Some(ref mut delay) = self.delay {
             debug_assert!(old >= delay.deadline());
 
-            if old == delay.deadline() {
+            if next_poll != Some(delay.deadline()) {
                 delay.reset(self.start + Duration::from_millis(when));
             }
         }

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -497,13 +497,15 @@ impl<T> DelayQueue<T> {
         // Normalize the deadline. Values cannot be set to expire in the past.
         let when = self.normalize_deadline(when);
 
+        // This is needed only for the debug assertion inside the if-let, but
+        // calculating it there causes the assertion to fail for some reason.
+        #[cfg(debug_assertions)]
+        let old = self.start + Duration::from_millis(self.slab[key.index].when);
+
         self.slab[key.index].when = when;
 
         if let Some(ref mut delay) = self.delay {
-            debug_assert!({
-                let old = self.start + Duration::from_millis(self.slab[key.index].when);
-                old >= delay.deadline()
-            });
+            debug_assert!(old >= delay.deadline());
 
             let start = self.start;
             let next_poll = self.wheel.poll_at()

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -501,11 +501,12 @@ impl<T> DelayQueue<T> {
 
         self.slab[key.index].when = when;
 
-        let next_poll = self.wheel.poll_at()
-            .map(|t| self.start + Duration::from_millis(t));
-
         if let Some(ref mut delay) = self.delay {
             debug_assert!(old >= delay.deadline());
+
+            let start = self.start;
+            let next_poll = self.wheel.poll_at()
+                .map(move |t| start + Duration::from_millis(t));
 
             if next_poll != Some(delay.deadline()) {
                 delay.reset(self.start + Duration::from_millis(when));

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -496,13 +496,14 @@ impl<T> DelayQueue<T> {
 
         // Normalize the deadline. Values cannot be set to expire in the past.
         let when = self.normalize_deadline(when);
-        let old = self.start + Duration::from_millis(self.slab[key.index].when);
-
 
         self.slab[key.index].when = when;
 
         if let Some(ref mut delay) = self.delay {
-            debug_assert!(old >= delay.deadline());
+            debug_assert!({
+                let old = self.start + Duration::from_millis(self.slab[key.index].when);
+                old >= delay.deadline()
+            });
 
             let start = self.start;
             let next_poll = self.wheel.poll_at()


### PR DESCRIPTION
## Motivation

The `DelayQueue::reset_at` function checks if the deadline of the
queue's current delay is equal to the deadline of the entry being reset
in order to determine whether to reset the delay. However, this is not
always correct: the delay is constructed based on a deadline returned by
calling `poll_at` on the queue's timer wheel, _not_ based directly on
the deadline of any entry in the queue. Since `poll_at` may return the
time the wheel next shifts down, if this is before the nearest deadline,
the queue's delay may be lower than the deadline on _any_ of its
entries.

## Solution

This branch changes the test for when the deadline should be reset to
check if the value of `self.wheel.poll_at` is not equal to the current
deadline. If this is true, it resets the delay.

I've added tests based on the repro @ralith provided for #849. These
tests both fail on master, but now pass.

Fixes: #849