### PR TITLE
Correct documentation on return value of `copy`

### DIFF
--- a/tokio-io/src/io/copy.rs
+++ b/tokio-io/src/io/copy.rs
@@ -29,9 +29,9 @@ pub struct Copy<R, W> {
 /// EOF and all bytes have been written to and flushed from the `writer`
 /// provided.
 ///
-/// On success the number of bytes is returned and the `reader` and `writer` are
-/// consumed. On error the error is returned and the I/O objects are consumed as
-/// well.
+/// On success returns a tuple containing the amount of bytes copied, along with
+/// the `reader` and `writer`. On error returns error and consumes `reader` and
+/// `writer`.
 pub fn copy<R, W>(reader: R, writer: W) -> Copy<R, W>
     where R: AsyncRead,
           W: AsyncWrite,

--- a/tokio-io/src/io/copy.rs
+++ b/tokio-io/src/io/copy.rs
@@ -29,7 +29,7 @@ pub struct Copy<R, W> {
 /// EOF and all bytes have been written to and flushed from the `writer`
 /// provided.
 ///
-/// On success returns a tuple containing the amount of bytes copied, along with
+/// On success returns a tuple containing the number of bytes copied, along with
 /// the `reader` and `writer`. On error returns error and consumes `reader` and
 /// `writer`.
 pub fn copy<R, W>(reader: R, writer: W) -> Copy<R, W>


### PR DESCRIPTION
I've corrected the documentation regarding the return value of `tokio::io::copy`.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
Documentation of the return value for tokio::io::copy was that it returned(on success) the number of bytes, and consumed the I/O objects. This is inconsistent with the actual return value of  `(u64, tokio::io::ReadHalf<tokio::net::TcpStream>, tokio::io::WriteHalf<tokio::net::TcpStream>)`. Which consists of the amount of bytes copied, and the I/O objects (not consumed).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Corrected documentation to match actual return value
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
