### PR TITLE
docs: updating use ? & Result instead of unwrap

### DIFF
--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -49,11 +49,12 @@
 //! use bytes::Bytes;
 //! use futures::{Sink, Future};
 //!
-//! fn write_frame<T: AsyncRead + AsyncWrite>(io: T) {
+//! fn write_frame<T: AsyncRead + AsyncWrite>(io: T) -> Result<(), Box<std::error::Error>> {
 //!     let mut transport = Framed::new(io, LengthDelimitedCodec::new());
 //!     let frame = Bytes::from("hello world");
 //!
-//!     transport.send(frame).wait().unwrap();
+//!     transport.send(frame).wait()?;
+//!     Ok(())
 //! }
 //! #
 //! # pub fn main() {}


### PR DESCRIPTION
Following on from https://github.com/tokio-rs/tokio/issues/657

Fixing doc test to use ? with Result instead of unwrap() just to (hopefully) show better practice.

## Motivation

@liranringel had mentioned that the examples needed updating but that doc tests were still to do. I checked all the remaining tests and this was the only one left that could do with a change, albeit a minor improvement.

## Solution

Simply changing unwrap() to use ? operator and change function signature to return Result which would be more idiomatic for someone coming to copy this code for their own use.

This hopefully lets us close out https://github.com/tokio-rs/tokio/issues/657