### PR TITLE
util: Include throttle in summary of tokio::util::StreamExt

### DIFF
--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -13,8 +13,8 @@ use std::time::Duration;
 /// An extension trait for `Stream` that provides a variety of convenient
 /// combinator functions.
 ///
-/// Currently, there only is a [`timeout`] function, but this will increase
-/// over time.
+/// Currently, there are only [`timeout`] and [`throttle`] functions, but
+/// this will increase over time.
 ///
 /// Users are not expected to implement this trait. All types that implement
 /// `Stream` already implement `StreamExt`.


### PR DESCRIPTION
The `throttle` was not mentioned in the summary block but is listed as a method for the trait. This PR updates the top-level summary to include it.
