### PR TITLE
tokio-sync: add into_inner for TrySendErrors

### DIFF
--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -214,6 +214,13 @@ impl ::std::error::Error for SendError {
 
 // ===== impl TrySendError =====
 
+impl<T> TrySendError<T> {
+    /// Get the inner value.
+    pub fn into_inner(self) -> T {
+        self.value
+    }
+}
+
 impl<T: fmt::Debug> fmt::Display for TrySendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -136,6 +136,13 @@ impl ::std::error::Error for UnboundedSendError {
 
 // ===== impl TrySendError =====
 
+impl<T> UnboundedTrySendError<T> {
+    /// Get the inner value.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T: fmt::Debug> fmt::Display for UnboundedTrySendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use std::error::Error;


### PR DESCRIPTION
As I tried replacing `futures::sync::mpsc` with tokio-sync in hyper, I noticed this didn't exist.