### PR TITLE
Reset the delay of the queue in case an item that expires sooner than…

### DIFF
--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -338,6 +338,16 @@ impl<T> DelayQueue<T> {
 
         self.insert_idx(when, key);
 
+        // Set a new delay if the current's deadline is later than the one of the new item
+        let should_set_delay =  if let Some(ref delay) = self.delay {
+            let current_exp = self.normalize_deadline(delay.deadline());
+            current_exp > when
+        } else  { false };
+
+        if should_set_delay {
+            self.delay = Some(self.handle.delay(self.start + Duration::from_millis(when)));
+        }
+
         Key::new(key)
     }
 


### PR DESCRIPTION

## Motivation
This should fix #854 

## Solution
The solution is to simply check whether the expiration of the item to be inserted is sooner than the one which has been polled last. In that case we simply clear the `delay`
