### PR TITLE
Make reason for try_send errors clearer

### DIFF
--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -219,6 +219,24 @@ impl<T> TrySendError<T> {
     pub fn into_inner(self) -> T {
         self.value
     }
+
+    /// Did the send fail because the channel has been closed?
+    pub fn was_closed(&self) -> bool {
+        if let ErrorKind::Closed = self.kind {
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Did the send fail because the channel was at capacity?
+    pub fn was_full(&self) -> bool {
+        if let ErrorKind::NoCapacity = self.kind {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 impl<T: fmt::Debug> fmt::Display for TrySendError<T> {

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -221,7 +221,7 @@ impl<T> TrySendError<T> {
     }
 
     /// Did the send fail because the channel has been closed?
-    pub fn was_closed(&self) -> bool {
+    pub fn is_closed(&self) -> bool {
         if let ErrorKind::Closed = self.kind {
             true
         } else {
@@ -230,7 +230,7 @@ impl<T> TrySendError<T> {
     }
 
     /// Did the send fail because the channel was at capacity?
-    pub fn was_full(&self) -> bool {
+    pub fn is_full(&self) -> bool {
         if let ErrorKind::NoCapacity = self.kind {
             true
         } else {

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -28,7 +28,7 @@ pub struct UnboundedReceiver<T> {
 #[derive(Debug)]
 pub struct UnboundedSendError(());
 
-/// Error returned by `UnboundedSender::try_send`.
+/// Returned by `UnboundedSender::try_send` when the channel has been closed.
 #[derive(Debug)]
 pub struct UnboundedTrySendError<T>(T);
 

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -227,7 +227,7 @@ fn try_send_fail() {
     tx.try_send("hello").unwrap();
 
     // This should fail
-    assert!(tx.try_send("fail").unwrap_err().was_full());
+    assert!(tx.try_send("fail").unwrap_err().is_full());
 
     assert_eq!(rx.next().unwrap().unwrap(), "hello");
 
@@ -280,7 +280,7 @@ fn dropping_rx_closes_channel_for_try() {
     tx.try_send(msg.clone()).unwrap();
 
     drop(rx);
-    assert!(tx.try_send(msg.clone()).unwrap_err().was_closed());
+    assert!(tx.try_send(msg.clone()).unwrap_err().is_closed());
 
     assert_eq!(1, Arc::strong_count(&msg));
 }


### PR DESCRIPTION
When you call `try_send` on a channel and the call fails, it often matters to the caller _why_ the call failed. For unbounded senders, we know that it must be because the receiver went away, whereas for bounded channels it may either be because the receiver went away or because there was no available capacity. This PR explicitly calls out in the docs that errors on `UnboundedSender::try_send` can only occur if the channel receiver has gone away, and adds `was_closed` and `was_full` methods to the error returned by `BoundedSender::try_send` so the caller can figure out which of the two error cases they're in.