### PR TITLE
Remove T: Debug flag on mpsc Debug impls

### DIFF
--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -7,7 +7,6 @@ use std::fmt;
 /// Send values to the associated `Receiver`.
 ///
 /// Instances are created by the [`channel`](fn.channel.html) function.
-#[derive(Debug)]
 pub struct Sender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -18,13 +17,28 @@ impl<T> Clone for Sender<T> {
     }
 }
 
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Sender")
+            .field("chan", &self.chan)
+            .finish()
+    }
+}
+
 /// Receive values from the associated `Sender`.
 ///
 /// Instances are created by the [`channel`](fn.channel.html) function.
-#[derive(Debug)]
 pub struct Receiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,
+}
+
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("Receiver")
+            .field("chan", &self.chan)
+            .finish()
+    }
 }
 
 /// Error returned by the `Sender`.

--- a/tokio-sync/src/mpsc/list.rs
+++ b/tokio-sync/src/mpsc/list.rs
@@ -212,7 +212,7 @@ impl<T> Tx<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Tx<T> {
+impl<T> fmt::Debug for Tx<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use std::sync::atomic::Ordering::Relaxed;
 
@@ -318,7 +318,7 @@ impl<T> Rx<T> {
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for Rx<T> {
+impl<T> fmt::Debug for Rx<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         fmt.debug_struct("Rx")
             .field("head", &self.head)

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -9,7 +9,6 @@ use std::fmt;
 ///
 /// Instances are created by the
 /// [`unbounded_channel`](fn.unbounded_channel.html) function.
-#[derive(Debug)]
 pub struct UnboundedSender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -20,14 +19,29 @@ impl<T> Clone for UnboundedSender<T> {
     }
 }
 
+impl<T> fmt::Debug for UnboundedSender<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("UnboundedSender")
+            .field("chan", &self.chan)
+            .finish()
+    }
+}
+
 /// Receive values from the associated `UnboundedSender`.
 ///
 /// Instances are created by the
 /// [`unbounded_channel`](fn.unbounded_channel.html) function.
-#[derive(Debug)]
 pub struct UnboundedReceiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,
+}
+
+impl<T> fmt::Debug for UnboundedReceiver<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("UnboundedReceiver")
+            .field("chan", &self.chan)
+            .finish()
+    }
 }
 
 /// Error returned by the `UnboundedSender`.

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -92,33 +92,31 @@ fn send_recv_unbounded() {
 }
 
 #[test]
-fn clone_sender_no_t_clone_buffer() {
-    #[derive(Debug, PartialEq, Eq)]
-    struct NotClone;
-    let (mut tx, mut rx) = mpsc::channel(100);
-    tx.try_send(NotClone).unwrap();
-    tx.clone().try_send(NotClone).unwrap();
+fn no_t_bounds_buffer() {
+    struct NoImpls;
+    let (tx, mut rx) = mpsc::channel(100);
 
-    let val = assert_ready!(rx.poll());
-    assert_eq!(val, Some(NotClone));
-
-    let val = assert_ready!(rx.poll());
-    assert_eq!(val, Some(NotClone));
+    // sender should be Debug even though T isn't Debug
+    println!("{:?}", tx);
+    // same with Receiver
+    println!("{:?}", rx);
+    // and sender should be Clone even though T isn't Clone
+    assert!(tx.clone().try_send(NoImpls).is_ok());
+    assert!(assert_ready!(rx.poll()).is_some());
 }
 
 #[test]
-fn clone_sender_no_t_clone_unbounded() {
-    #[derive(Debug, PartialEq, Eq)]
-    struct NotClone;
-    let (mut tx, mut rx) = mpsc::unbounded_channel();
-    tx.try_send(NotClone).unwrap();
-    tx.clone().try_send(NotClone).unwrap();
+fn no_t_bounds_unbounded() {
+    struct NoImpls;
+    let (tx, mut rx) = mpsc::unbounded_channel();
 
-    let val = assert_ready!(rx.poll());
-    assert_eq!(val, Some(NotClone));
-
-    let val = assert_ready!(rx.poll());
-    assert_eq!(val, Some(NotClone));
+    // sender should be Debug even though T isn't Debug
+    println!("{:?}", tx);
+    // same with Receiver
+    println!("{:?}", rx);
+    // and sender should be Clone even though T isn't Clone
+    assert!(tx.clone().try_send(NoImpls).is_ok());
+    assert!(assert_ready!(rx.poll()).is_some());
 }
 
 #[test]


### PR DESCRIPTION
Following from https://github.com/tokio-rs/tokio/pull/865, this PR removes `#[derive(Debug)]` on `mpsc` sender and receiver types in favor of explicit `impl fmt::Debug` blocks that don't have a `T: fmt::Debug` bound.