### PR TITLE
Bump Tokio to v0.1.15.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.15 (January 24, 2019)
+
+### Added
+- Re-export tokio-sync APIs (#839).
+- Stream enumerate combinator (#832).
+
 # 0.1.14 (January 6, 2019)
 
 * Use feature flags to break up the crate, allowing users to pick & choose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,17 @@
 [package]
 name = "tokio"
-
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
-# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.14"
+version = "0.1.15"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.14/tokio/"
+documentation = "https://docs.rs/tokio/0.1.15/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.14/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.15/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 The API docs for the master branch are published [here][master-dox].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.14")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.15")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(feature = "async-await-preview", feature(
         async_await,

--- a/tokio-sync/CHANGELOG.md
+++ b/tokio-sync/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (January 24, 2019)
+
+- Initial Release

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "tokio-sync"
-
 # When releasing to crates.io:
 # - Update html_root_url.
 # - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
 version = "0.1.0"

--- a/tokio-sync/README.md
+++ b/tokio-sync/README.md
@@ -1,0 +1,19 @@
+# tokio-sync
+
+Synchronization utilities
+
+[Documentation](https://docs.rs/tokio-sync/0.1.0/tokio_sync/)
+
+## Overview
+
+This crate provides synchronization utilities for usage with Tokio.
+
+## License
+
+This project is licensed under the [MIT license](LICENSE).
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in Tokio by you, shall be licensed as MIT, without any additional
+terms or conditions.

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.11 (January 24, 2019)
+
+### Fixed
+- Drop incomplete tasks when threadpool is dropped (#722).
+
 # 0.1.10 (January 6, 2019)
 
 * Fix deadlock bug in `blocking` (#795).

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -2,11 +2,13 @@
 name = "tokio-threadpool"
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
-# - Update doc URL.
 # - Create "v0.1.x" git tag.
-version = "0.1.10"
-documentation = "https://docs.rs/tokio-threadpool/0.1.10/tokio_threadpool"
+version = "0.1.11"
+documentation = "https://docs.rs/tokio-threadpool/0.1.11/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.10/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.11/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.11")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.9 (January 24, 2019)
+
+### Fixed
+- `DelayQueue` timing logic when inserting / resetting a delay (#851, #863).
+- Documentation links (#842, #844, #845)
+
 # 0.2.8 (November 21, 2018)
 
 * Implement throttle combinator (#736).

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -2,14 +2,16 @@
 name = "tokio-timer"
 # When releasing to crates.io:
 # - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
-# - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.8"
+version = "0.2.9"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.8/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.9/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,7 +2,7 @@
 
 Timer facilities for Tokio
 
-[Documentation](https://tokio-rs.github.io/tokio/tokio_timer/)
+[Documentation](https://docs.rs/tokio-timer/0.2.9/tokio_timer/)
 
 ## Overview
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.9")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Utilities for tracking time.


### PR DESCRIPTION
Also bumps:

- tokio-sync (0.1.0)
- tokio-threadpool (0.1.11)
- tokio-timer (0.2.9)