### PR TITLE
Adds `Decoder::required_bytes_to_continue`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,11 +129,11 @@ time = "0.1"
 [patch.crates-io]
 #tokio = { path = "." }
 #tokio-async-await  = { path = "./tokio-async-await" }
-#tokio-codec = { path = "./tokio-codec" }
+tokio-codec = { path = "./tokio-codec" }
 #tokio-current-thread = { path = "./tokio-current-thread" }
 #tokio-executor = { path = "./tokio-executor" }
 #tokio-fs = { path = "./tokio-fs" }
-#tokio-io = { path = "./tokio-io" }
+tokio-io = { path = "./tokio-io" }
 #tokio-reactor = { path = "./tokio-reactor" }
 #tokio-signal = { path = "./tokio-signal" }
 #tokio-tcp = { path = "./tokio-tcp" }

--- a/src/codec/length_delimited.rs
+++ b/src/codec/length_delimited.rs
@@ -553,6 +553,15 @@ impl Decoder for LengthDelimitedCodec {
             None => Ok(None),
         }
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        let head_bytes = self.builder.num_head_bytes();
+        match self.state {
+            DecodeState::Head if buf.len() < head_bytes => Some(head_bytes - buf.len()),
+            DecodeState::Data(len) if buf.len() < len => Some(len - buf.len()),
+            _ => None,
+        }
+    }
 }
 
 impl Encoder for LengthDelimitedCodec {

--- a/tokio-io/src/_tokio_codec/framed.rs
+++ b/tokio-io/src/_tokio_codec/framed.rs
@@ -233,6 +233,10 @@ impl<T, U: Decoder> Decoder for Fuse<T, U> {
     fn decode_eof(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.1.decode_eof(buffer)
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        self.1.required_bytes_to_continue(buf)
+    }
 }
 
 impl<T, U: Encoder> Encoder for Fuse<T, U> {

--- a/tokio-io/src/_tokio_codec/framed_read.rs
+++ b/tokio-io/src/_tokio_codec/framed_read.rs
@@ -7,7 +7,7 @@ use codec::Decoder;
 use super::framed::Fuse;
 
 use futures::{Async, Poll, Stream, Sink, StartSend};
-use bytes::BytesMut;
+use bytes::{BytesMut, BufMut};
 
 /// A `Stream` of messages decoded from an `AsyncRead`.
 pub struct FramedRead<T, D> {
@@ -200,12 +200,38 @@ impl<T> Stream for FramedRead2<T>
 
             assert!(!self.eof);
 
-            // Otherwise, try to read more data and try again. Make sure we've
-            // got room for at least one byte to read to ensure that we don't
-            // get a spurious 0 that looks like EOF
-            self.buffer.reserve(1);
-            if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
-                self.eof = true;
+            if let Some(read) = self.inner.required_bytes_to_continue(&self.buffer) {
+                // We need to read at least one byte, otherwise it could look like a spurious EOF.
+                assert!(read > 0);
+
+                let remaining = self.buffer.remaining_mut();
+                if read > remaining {
+                    self.buffer.reserve(read - remaining);
+                }
+
+                let n = unsafe {
+                    let buf = &mut self.buffer.bytes_mut()[..read];
+
+                    self.inner.prepare_uninitialized_buffer(buf);
+
+                    try_ready!(self.inner.poll_read(buf))
+                };
+
+                if n == 0 {
+                    self.eof = true;
+                }
+
+                unsafe {
+                    self.buffer.advance_mut(n);
+                }
+            } else {
+                // Otherwise, try to read more data and try again. Make sure we've
+                // got room for at least one byte to read to ensure that we don't
+                // get a spurious 0 that looks like EOF
+                self.buffer.reserve(1);
+                if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
+                    self.eof = true;
+                }
             }
 
             self.is_readable = true;

--- a/tokio-io/src/_tokio_codec/framed_write.rs
+++ b/tokio-io/src/_tokio_codec/framed_write.rs
@@ -222,6 +222,10 @@ impl<T: Decoder> Decoder for FramedWrite2<T> {
     fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
         self.inner.decode_eof(src)
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        self.inner.required_bytes_to_continue(buf)
+    }
 }
 
 impl<T: Read> Read for FramedWrite2<T> {

--- a/tokio-io/src/codec/decoder.rs
+++ b/tokio-io/src/codec/decoder.rs
@@ -114,4 +114,13 @@ pub trait Decoder {
     {
         Framed::new(io, self)
     }
+
+    /// Returns the number of bytes the decoder requires to continue decoding.
+    ///
+    /// The default and if the decoder does not need any fixed number of bytes is to return `None`.
+    ///
+    /// The given `buf` argument is the current buffer that holds all bytes read.
+    fn required_bytes_to_continue(&self, _buf: &BytesMut) -> Option<usize> {
+        None
+    }
 }

--- a/tokio-io/src/framed.rs
+++ b/tokio-io/src/framed.rs
@@ -209,6 +209,10 @@ impl<T, U: Decoder> Decoder for Fuse<T, U> {
     fn decode_eof(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         self.1.decode_eof(buffer)
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        self.1.required_bytes_to_continue(buf)
+    }
 }
 
 impl<T, U: Encoder> Encoder for Fuse<T, U> {

--- a/tokio-io/src/framed_write.rs
+++ b/tokio-io/src/framed_write.rs
@@ -226,6 +226,10 @@ impl<T: Decoder> Decoder for FramedWrite2<T> {
     fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
         self.inner.decode_eof(src)
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        self.inner.required_bytes_to_continue(buf)
+    }
 }
 
 impl<T: Read> Read for FramedWrite2<T> {

--- a/tokio-io/src/length_delimited.rs
+++ b/tokio-io/src/length_delimited.rs
@@ -386,6 +386,15 @@ impl codec::Decoder for Decoder {
             None => Ok(None),
         }
     }
+
+    fn required_bytes_to_continue(&self, buf: &BytesMut) -> Option<usize> {
+        let head_bytes = self.builder.num_head_bytes();
+        match self.state {
+            DecodeState::Head if buf.len() < head_bytes => Some(head_bytes - buf.len()),
+            DecodeState::Data(len) if buf.len() < len => Some(len - buf.len()),
+            _ => None,
+        }
+    }
 }
 
 // ===== impl FramedWrite =====


### PR DESCRIPTION
This new function returns the number of bytes the decoder requires to
continue decoding. The default implementation returns `None` and this
results in the old behavior of reading as much bytes as possible.

The `LengthDelimitedCodec` makes use of this function, to always read
exactly the number of bytes for the header/body. All data that is not
required to decode one frame, will stay on the stream.

This feature is useful for supporting protocol switches, without knowing
in advance how the protocol looks like.

Off-topic: While looking over the source code, `BytesCodec` and `LineCodec` do not reserve any bytes in the buffer as `LengthDelimitedCodec` is doing it. But they always use `split_to `to split of a buffer. After the initial capacity is used, the buffer will always just read one byte as there is only `reserve(1)` before polling the inner io object.