### PR TITLE
bounded channel can not have 0 size

### DIFF
--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -111,6 +111,7 @@ pub struct RecvError(());
 /// }));
 /// ```
 pub fn channel<T>(buffer: usize) -> (Sender<T>, Receiver<T>) {
+    assert_eq!(buffer >= 1, true);
     let semaphore = (::semaphore::Semaphore::new(buffer), buffer);
     let (tx, rx) = chan::channel(semaphore);
 

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -66,6 +66,12 @@ fn send_recv_with_buffer() {
 }
 
 #[test]
+#[should_panic]
+fn buffer_gteq_one() {
+    mpsc::channel::<i32>(0);
+}
+
+#[test]
 fn send_recv_unbounded() {
     let (mut tx, mut rx) = mpsc::unbounded_channel::<i32>();
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Disallow a bounded channel from having a 0 size.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add an assert as per Carl's suggestion

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
