### PR TITLE
reactor: replace ATOMIC_USIZE_INIT with AtomicUsize::new(0)

### DIFF
--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -71,7 +71,7 @@ use std::io;
 use std::mem;
 use std::cell::RefCell;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
+use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
@@ -165,7 +165,7 @@ pub(crate) enum Direction {
 }
 
 /// The global fallback reactor.
-static HANDLE_FALLBACK: AtomicUsize = ATOMIC_USIZE_INIT;
+static HANDLE_FALLBACK: AtomicUsize = AtomicUsize::new(0);
 
 /// Tracks the reactor for the current execution context.
 thread_local!(static CURRENT_REACTOR: RefCell<Option<HandlePriv>> = RefCell::new(None));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`ATOMIC_BOOL_INIT` is deprecated since 1.34 because the const fn `AtomicUsize::new` is now preferred. As `deny(warnings)` is set, tokio fails to build on latest nightly.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Changing `ATOMIC_BOOL_INIT` to `AtomicUsize::new(0)` fixes it.

## Compatibility Note

`AtomicUsize::new` in a constant expression does not work before 1.24.0.
