### PR TITLE
tokio-reactor: impl AsRawFd for Reactor

### DIFF
--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -74,6 +74,8 @@ use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::atomic::{AtomicUsize, ATOMIC_USIZE_INIT};
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
+#[cfg(all(unix, not(target_os = "fuchsia")))]
+use std::os::unix::io::{AsRawFd, RawFd};
 
 use log::Level;
 use mio::event::Evented;
@@ -424,6 +426,13 @@ impl Reactor {
         if let Some(task) = wr {
             task.notify();
         }
+    }
+}
+
+#[cfg(all(unix, not(target_os = "fuchsia")))]
+impl AsRawFd for Reactor {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.io.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
## Motivation

I have a use case for a larger system on an embedded target that has a large body of C code running on a single thread multiplexed with libevent.  We are using a mix of Rust and C code and would like to be able to use Rust with tokio on the same thread as the single-threaded libevent reactor in order to avoid potential concurrency problems with the C code being called from a different thread of execution.

Looking at the problem, there are a few ways that the problem could be solved:

1. Implement a tokio reactor that maps into libevent rather then mio::Poll
2. Implement a libevent backend that uses tokio rather than epoll, kqeueue, select, etc.
3. (Assuming unix only) used nested epoll or kqueue file descriptors in order to allow for IO notifications on the foreign, parked reactor to unpark and service the other reactor.

## Solution

This PR exposes the file descriptor for the reactor in order to support the 3rd option.  For an initial PoC I am using this to expose the underlying file descriptor for the Tokio reactor and adding edge-triggered read event notifications on the libevent side that trigger a turn on the tokio runtime (in order to get access to things, I am using a custom runtime based heavily on the current-thread runtime).

This is not a complete solution for the overall problem and still requires that we turn the tokio runtime on a timer from the libevent side as tokio uses a timer wheel in userspace and not kernel timers (a reasonable choice but problematic for this specific integration method).  Nonetheless, this enables low-latency IO notifications for a nested fd use case under unix.