### PR TITLE
tokio-trace: Extend macros to allow trailing commas

### DIFF
--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -434,7 +434,7 @@ macro_rules! callsite {
 /// # }
 /// ```
 ///
-/// Note that trailing commas for fields are valid.
+/// Note that a trailing comma on the final field is valid.
 /// ```
 /// # #[macro_use]
 /// # extern crate tokio_trace;
@@ -521,8 +521,8 @@ macro_rules! span {
 ///
 /// Note that *unlike `span!`*, `event!` requires a value for all fields. As
 /// events are recorded immediately when the macro is invoked, there is no
-/// opportunity for fields to be recorded later. Trailing commas for fields
-/// are valid.
+/// opportunity for fields to be recorded later. A trailing comma on the final
+/// field is valid.
 ///
 /// For example, the following does not compile:
 /// ```rust,compile_fail
@@ -603,7 +603,7 @@ macro_rules! event {
 ///
 /// When both a message and fields are included, curly braces (`{` and `}`) are
 /// used to delimit the list of fields from the format string for the message.
-/// Trailing commas for fields are valid.
+/// A trailing comma on the final field is valid.
 ///
 /// # Examples
 ///
@@ -676,7 +676,7 @@ macro_rules! trace {
 ///
 /// When both a message and fields are included, curly braces (`{` and `}`) are
 /// used to delimit the list of fields from the format string for the message.
-/// Trailing commas for fields are valid.
+/// A trailing comma on the final field is valid.
 ///
 /// # Examples
 ///
@@ -731,7 +731,7 @@ macro_rules! debug {
 ///
 /// When both a message and fields are included, curly braces (`{` and `}`) are
 /// used to delimit the list of fields from the format string for the message.
-/// Trailing commas for fields are valid.
+/// A trailing comma on the final field is valid.
 ///
 /// # Examples
 ///
@@ -793,7 +793,7 @@ macro_rules! info {
 ///
 /// When both a message and fields are included, curly braces (`{` and `}`) are
 /// used to delimit the list of fields from the format string for the message.
-/// Trailing commas for fields are valid.
+/// A trailing comma on the final field is valid.
 ///
 /// # Examples
 ///
@@ -852,7 +852,7 @@ macro_rules! warn {
 ///
 /// When both a message and fields are included, curly braces (`{` and `}`) are
 /// used to delimit the list of fields from the format string for the message.
-/// Trailing commas for fields are valid.
+/// A trailing comma on the final field is valid.
 ///
 /// # Examples
 ///

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -548,19 +548,19 @@ macro_rules! event {
             }
         }
     });
-    (target: $target:expr, $lvl:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => ({
+    (target: $target:expr, $lvl:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => ({
         event!(target: $target, $lvl, { message = format_args!($($arg)+), $( $k = $val ),* })
     });
-    (target: $target:expr, $lvl:expr, $( $k:ident = $val:expr ),+ ) => (
+    (target: $target:expr, $lvl:expr, $( $k:ident = $val:expr $(,)* ),+ ) => (
         event!(target: $target, $lvl, { $($k = $val),+ })
     );
     (target: $target:expr, $lvl:expr, $($arg:tt)+ ) => (
         event!(target: $target, $lvl, { }, $($arg)+)
     );
-    ( $lvl:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ( $lvl:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $lvl, { message = format_args!($($arg)+), $($k = $val),* })
     );
-    ( $lvl:expr, $( $k:ident = $val:expr ),* ) => (
+    ( $lvl:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(), $lvl, { $($k = $val),* })
     );
     ( $lvl:expr, $($arg:tt)+ ) => (
@@ -603,10 +603,10 @@ macro_rules! event {
 /// ```
 #[macro_export]
 macro_rules! trace {
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    (target: $target:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::TRACE, { $($k = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
+    (target: $target:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: $target, $crate::Level::TRACE, { $($k = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
@@ -617,10 +617,10 @@ macro_rules! trace {
         // the handle won't be used later to add values to them.
         drop(event!(target: $target, $crate::Level::TRACE, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::TRACE, { $($k = $val),* }, $($arg)+)
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(), $crate::Level::TRACE, { $($k = $val),* })
     );
     ($($arg:tt)+ ) => (
@@ -650,19 +650,19 @@ macro_rules! trace {
 /// ```
 #[macro_export]
 macro_rules! debug {
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    (target: $target:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
+    (target: $target:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::DEBUG, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::DEBUG, { $($k = $val),* }, $($arg)+)
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(), $crate::Level::DEBUG, { $($k = $val),* })
     );
     ($($arg:tt)+ ) => (
@@ -699,19 +699,19 @@ macro_rules! debug {
 /// ```
 #[macro_export]
 macro_rules! info {
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    (target: $target:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::INFO, { $($k = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
+    (target: $target:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: $target, $crate::Level::INFO, { $($k = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::INFO, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::INFO, { $($k = $val),* }, $($arg)+)
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(), $crate::Level::INFO, { $($k = $val),* })
     );
     ($($arg:tt)+ ) => (
@@ -745,19 +745,19 @@ macro_rules! info {
 /// ```
 #[macro_export]
 macro_rules! warn {
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    (target: $target:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::WARN, { $($k = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
+    (target: $target:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: $target, $crate::Level::WARN, { $($k = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::WARN, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(),  $crate::Level::WARN, { $($k = $val),* }, $($arg)+)
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(),  $crate::Level::WARN,{ $($k = $val),* })
     );
     ($($arg:tt)+ ) => (
@@ -786,19 +786,19 @@ macro_rules! warn {
 /// ```
 #[macro_export]
 macro_rules! error {
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    (target: $target:expr, { $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::ERROR, { $($k = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
+    (target: $target:expr, $( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: $target, $crate::Level::ERROR, { $($k = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::ERROR, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $k:ident = $val:expr $(,)* ),* }, $($arg:tt)+ ) => (
         event!(target: module_path!(), $crate::Level::ERROR, { $($k = $val),* }, $($arg)+)
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $k:ident = $val:expr $(,)* ),* ) => (
         event!(target: module_path!(), $crate::Level::ERROR, { $($k = $val),* })
     );
     ($($arg:tt)+ ) => (

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -9,97 +9,121 @@ extern crate tokio_trace;
 #[test]
 fn event() {
     event!(tokio_trace::Level::DEBUG, foo = 3, bar = 2, baz = false);
+    event!(tokio_trace::Level::DEBUG, foo = 3, bar = 3,);
     event!(tokio_trace::Level::DEBUG, "foo");
     event!(tokio_trace::Level::DEBUG, "foo: {}", 3);
     event!(tokio_trace::Level::DEBUG, { foo = 3, bar = 80 }, "baz");
     event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
     event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 78, }, "baz");
     event!(target: "foo_events", tokio_trace::Level::DEBUG, foo = 3, bar = 2, baz = false);
+    event!(target: "foo_events", tokio_trace::Level::DEBUG, foo = 3, bar = 3,);
     event!(target: "foo_events", tokio_trace::Level::DEBUG, "foo");
     event!(target: "foo_events", tokio_trace::Level::DEBUG, "foo: {}", 3);
     event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 3, bar = 80 }, "baz");
     event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
     event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]
 fn trace() {
     trace!(foo = 3, bar = 2, baz = false);
+    trace!(foo = 3, bar = 3,);
     trace!("foo");
     trace!("foo: {}", 3);
     trace!({ foo = 3, bar = 80 }, "baz");
     trace!({ foo = 2, bar = 79 }, "baz {:?}", true);
     trace!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    trace!({ foo = 2, bar = 78, }, "baz");
     trace!(target: "foo_events", foo = 3, bar = 2, baz = false);
+    trace!(target: "foo_events", foo = 3, bar = 3,);
     trace!(target: "foo_events", "foo");
     trace!(target: "foo_events", "foo: {}", 3);
     trace!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
     trace!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
     trace!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    trace!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]
 fn debug() {
     debug!(foo = 3, bar = 2, baz = false);
+    debug!(foo = 3, bar = 3,);
     debug!("foo");
     debug!("foo: {}", 3);
     debug!({ foo = 3, bar = 80 }, "baz");
     debug!({ foo = 2, bar = 79 }, "baz {:?}", true);
     debug!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    debug!({ foo = 2, bar = 78, }, "baz");
     debug!(target: "foo_events", foo = 3, bar = 2, baz = false);
+    debug!(target: "foo_events", foo = 3, bar = 3,);
     debug!(target: "foo_events", "foo");
     debug!(target: "foo_events", "foo: {}", 3);
     debug!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
     debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
     debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
     debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]
 fn info() {
     info!(foo = 3, bar = 2, baz = false);
+    info!(foo = 3, bar = 3,);
     info!("foo");
     info!("foo: {}", 3);
     info!({ foo = 3, bar = 80 }, "baz");
     info!({ foo = 2, bar = 79 }, "baz {:?}", true);
     info!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    info!({ foo = 2, bar = 78, }, "baz");
     info!(target: "foo_events", foo = 3, bar = 2, baz = false);
+    info!(target: "foo_events", foo = 3, bar = 3,);
     info!(target: "foo_events", "foo");
     info!(target: "foo_events", "foo: {}", 3);
     info!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
     info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
     info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
     info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]
 fn warn() {
     warn!(foo = 3, bar = 2, baz = false);
+    warn!(foo = 3, bar = 3,);
     warn!("foo");
     warn!("foo: {}", 3);
     warn!({ foo = 3, bar = 80 }, "baz");
     warn!({ foo = 2, bar = 79 }, "baz {:?}", true);
     warn!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    warn!({ foo = 2, bar = 78 }, "baz");
     warn!(target: "foo_events", foo = 3, bar = 2, baz = false);
+    warn!(target: "foo_events", foo = 3, bar = 3,);
     warn!(target: "foo_events", "foo");
     warn!(target: "foo_events", "foo: {}", 3);
     warn!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
     warn!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
     warn!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    warn!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]
 fn error() {
     error!(foo = 3, bar = 2, baz = false);
+    error!(foo = 3, bar = 3,);
     error!("foo");
     error!("foo: {}", 3);
     error!({ foo = 3, bar = 80 }, "baz");
     error!({ foo = 2, bar = 79 }, "baz {:?}", true);
     error!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    error!({ foo = 2, bar = 78, }, "baz");
     error!(target: "foo_events", foo = 3, bar = 2, baz = false);
+    error!(target: "foo_events", foo = 3, bar = 3,);
     error!(target: "foo_events", "foo");
     error!(target: "foo_events", "foo: {}", 3);
     error!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
     error!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
     error!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    error!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
 }


### PR DESCRIPTION
Trailing commas are optional when fields are included, and when fields
are delimited from the format string for the message.

Before these would error:
```
event!(tokio_trace::Level::DEBUG, foo = 3, bar = 3,);
event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 78, }, "baz");
```

Now they do not. Tests have been extended.

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
