### PR TITLE
tokio-trace: Extend `span!` rules

### DIFF
--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -443,9 +443,7 @@ macro_rules! callsite {
 ///     "my span",
 ///     foo = 2,
 ///     bar = "a string",
-/// ).enter(|| {
-///     // do work inside the span...
-/// });
+/// );
 /// # }
 /// ```
 ///
@@ -460,9 +458,7 @@ macro_rules! callsite {
 ///     "my span",
 ///     foo = 3,
 ///     bar = "another string"
-/// ).enter(|| {
-///     // do work inside the span...
-/// });
+/// );
 /// # }
 /// ```
 ///
@@ -526,12 +522,12 @@ macro_rules! span {
         span!(target: module_path!(), level: $lvl, $name,)
     };
     ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
-        span!(target: module_path!(), level: $crate::Level::DEBUG, $name, $($k $( = $val)*),*)
+        span!(target: module_path!(), level: $crate::Level::TRACE, $name, $($k $( = $val)*),*)
     };
     ($name:expr, $($k:ident $( = $val:expr)*),*) => {
-        span!(target: module_path!(), level: $crate::Level::DEBUG, $name, $($k $( = $val)*),*)
+        span!(target: module_path!(), level: $crate::Level::TRACE, $name, $($k $( = $val)*),*)
     };
-    ($name:expr) => { span!(target: module_path!(), level: $crate::Level::DEBUG, $name,) };
+    ($name:expr) => { span!(target: module_path!(), level: $crate::Level::TRACE, $name,) };
 }
 
 /// Constructs a new `Event`.

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -434,7 +434,7 @@ macro_rules! callsite {
 /// # }
 /// ```
 ///
-/// Note that a trailing comma on the final field is valid.
+/// Note that a trailing comma on the final field is valid:
 /// ```
 /// # #[macro_use]
 /// # extern crate tokio_trace;
@@ -443,6 +443,23 @@ macro_rules! callsite {
 ///     "my span",
 ///     foo = 2,
 ///     bar = "a string",
+/// ).enter(|| {
+///     // do work inside the span...
+/// });
+/// # }
+/// ```
+///
+/// Creating a span with custom target and log level:
+/// ```
+/// # #[macro_use]
+/// # extern crate tokio_trace;
+/// # fn main() {
+/// span!(
+///     target: "app_span",
+///     level: tokio_trace::Level::TRACE,
+///     "my span",
+///     foo = 3,
+///     bar = "another string"
 /// ).enter(|| {
 ///     // do work inside the span...
 /// });
@@ -475,15 +492,19 @@ macro_rules! callsite {
 /// ```
 #[macro_export]
 macro_rules! span {
-    ($name:expr) => { span!($name,) };
-    ($name:expr, $($k:ident $( = $val:expr )* ),*,) => {
-        span!($name, $($k $( = $val)* ),*)
+    (target: $target:expr, level: $lvl:expr, $name:expr, $($k:ident $( = $val:expr )* ),*,) => {
+        span!(target: $target, level: $lvl, $name, $($k $( = $val)*),*)
     };
-    ($name:expr, $($k:ident $( = $val:expr )* ),*) => {
+    (target: $target:expr, level: $lvl:expr, $name:expr, $($k:ident $( = $val:expr )* ),*) => {
         {
             use $crate::{callsite, field::{Value, ValueSet, AsField}, Span};
             use $crate::callsite::Callsite;
-            let callsite = callsite! { name: $name, fields: $( $k ),* };
+            let callsite = callsite! {
+                name: $name,
+                target: $target,
+                level: $lvl,
+                fields: $($k),*
+            };
             if is_enabled!(callsite) {
                 let meta = callsite.metadata();
                 Span::new(meta, &valueset!(meta.fields(), $($k $( = $val)*),*))
@@ -492,6 +513,25 @@ macro_rules! span {
             }
         }
     };
+    (target: $target:expr, level: $lvl:expr, $name:expr) => {
+        span!(target: $target, level: $lvl, $name,)
+    };
+    (level: $lvl:expr, $name:expr, $($k:ident $( = $val:expr )* ),*,) => {
+        span!(target: module_path!(), level: $lvl, $name, $($k $( = $val)*),*)
+    };
+    (level: $lvl:expr, $name:expr, $($k:ident $( = $val:expr )* ),*) => {
+        span!(target: module_path!(), level: $lvl, $name, $($k $( = $val)*),*)
+    };
+    (level: $lvl:expr, $name:expr) => {
+        span!(target: module_path!(), level: $lvl, $name,)
+    };
+    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+        span!(target: module_path!(), level: $crate::Level::DEBUG, $name, $($k $( = $val)*),*)
+    };
+    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+        span!(target: module_path!(), level: $crate::Level::DEBUG, $name, $($k $( = $val)*),*)
+    };
+    ($name:expr) => { span!(target: module_path!(), level: $crate::Level::DEBUG, $name,) };
 }
 
 /// Constructs a new `Event`.

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -7,6 +7,22 @@ extern crate tokio_trace;
 // failures, and producing them with a macro would muddy the waters a bit.
 
 #[test]
+fn span() {
+    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 3);
+    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 4,);
+    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo");
+    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "bar",);
+    span!(level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 3);
+    span!(level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 4,);
+    span!(level: tokio_trace::Level::DEBUG, "foo");
+    span!(level: tokio_trace::Level::DEBUG, "bar",);
+    span!("foo", bar = 2, baz = 3);
+    span!("foo", bar = 2, baz = 4,);
+    span!("foo");
+    span!("bar",);
+}
+
+#[test]
 fn event() {
     event!(tokio_trace::Level::DEBUG, foo = 3, bar = 2, baz = false);
     event!(tokio_trace::Level::DEBUG, foo = 3, bar = 3,);

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -7,6 +7,7 @@ use std::thread;
 use tokio_trace::{
     dispatcher,
     field::{debug, display},
+    subscriber::with_default,
     Dispatch, Level, Span,
 };
 
@@ -452,6 +453,25 @@ fn add_fields_only_after_new_span() {
         span.record("bar", &5);
         span.record("baz", &true);
         span.enter(|| {})
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
+fn new_span_with_target_and_log_level() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            span::mock()
+                .named("foo")
+                .with_target("app_span")
+                .at_level(tokio_trace::Level::DEBUG),
+        )
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        span!(target: "app_span", level: tokio_trace::Level::DEBUG, "foo");
     });
 
     handle.assert_finished();


### PR DESCRIPTION
Add the ability to define a target and log level for
individual spans.

`level: ...` must be included since both `$lvl` and `$name` are `expr`.

The macro tests and documentation tests have been extended.

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
