### PR TITLE
move doc comments inside macro invocations

### DIFF
--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -194,17 +194,21 @@ struct CurrentRunner {
     id: Cell<Option<u64>>,
 }
 
-/// Current thread's task runner. This is set in `TaskRunner::with`
-thread_local!(static CURRENT: CurrentRunner = CurrentRunner {
-    spawn: Cell::new(None),
-    id: Cell::new(None),
-});
+thread_local!{
+    /// Current thread's task runner. This is set in `TaskRunner::with`
+    static CURRENT: CurrentRunner = CurrentRunner {
+        spawn: Cell::new(None),
+        id: Cell::new(None),
+    }
+}
 
-/// Unique ID to assign to each new executor launched on this thread.
-///
-/// The unique ID is used to determine if the currently running executor matches the one referred
-/// to by a `Handle` so that direct task dispatch can be used.
-thread_local!(static EXECUTOR_ID: Cell<u64> = Cell::new(0));
+thread_local!{
+    /// Unique ID to assign to each new executor launched on this thread.
+    ///
+    /// The unique ID is used to determine if the currently running executor matches the one
+    /// referred to by a `Handle` so that direct task dispatch can be used.
+    static EXECUTOR_ID: Cell<u64> = Cell::new(0)
+}
 
 /// Run the executor bootstrapping the execution with the provided future.
 ///

--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -64,8 +64,10 @@ enum State {
     Active
 }
 
-/// Thread-local tracking the current executor
-thread_local!(static EXECUTOR: Cell<State> = Cell::new(State::Empty));
+thread_local!{
+    /// Thread-local tracking the current executor
+    static EXECUTOR: Cell<State> = Cell::new(State::Empty)
+}
 
 // ===== impl DefaultExecutor =====
 

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -167,8 +167,10 @@ pub(crate) enum Direction {
 /// The global fallback reactor.
 static HANDLE_FALLBACK: AtomicUsize = AtomicUsize::new(0);
 
-/// Tracks the reactor for the current execution context.
-thread_local!(static CURRENT_REACTOR: RefCell<Option<HandlePriv>> = RefCell::new(None));
+thread_local!{
+    /// Tracks the reactor for the current execution context.
+    static CURRENT_REACTOR: RefCell<Option<HandlePriv>> = RefCell::new(None)
+}
 
 const TOKEN_SHIFT: usize = 22;
 

--- a/tokio-timer/src/clock/clock.rs
+++ b/tokio-timer/src/clock/clock.rs
@@ -20,8 +20,10 @@ pub struct Clock {
     now: Option<Arc<Now>>,
 }
 
-/// Thread-local tracking the current clock
-thread_local!(static CLOCK: Cell<Option<*const Clock>> = Cell::new(None));
+thread_local!{
+    /// Thread-local tracking the current clock
+    static CLOCK: Cell<Option<*const Clock>> = Cell::new(None)
+}
 
 /// Returns an `Instant` corresponding to "now".
 ///

--- a/tokio-timer/src/timer/handle.rs
+++ b/tokio-timer/src/timer/handle.rs
@@ -44,8 +44,10 @@ pub(crate) struct HandlePriv {
     inner: Weak<Inner>,
 }
 
-/// Tracks the timer for the current execution context.
-thread_local!(static CURRENT_TIMER: RefCell<Option<HandlePriv>> = RefCell::new(None));
+thread_local!{
+    /// Tracks the timer for the current execution context.
+    static CURRENT_TIMER: RefCell<Option<HandlePriv>> = RefCell::new(None)
+}
 
 /// Set the default timer for the duration of the closure.
 ///


### PR DESCRIPTION
[rust-lang/rust#57882](https://github.com/rust-lang/rust/pull/57882) is modifying the `unused_doc_comments` lint to fire on mistakenly documented macro expansions. Note that these doc comments are not currently used, since they are eliminated when the macro is expanded. A crater run detected that this crate will break due to this change, likely because of the use of `deny(unused_doc_comments)` or `deny(warnings)`.

While this kind of breakage is allowed under Rust's stability guarantees, I am opening PRs to affected crates to reduce the impact.

This PR protects your crate from future breakage by moving the offending doc comments to the items they are intended to document, inside the macro invocations.