### PR TITLE
sync: fix mpsc/sempahore when releasing permits

### DIFF
--- a/tokio-sync/src/mpsc/chan.rs
+++ b/tokio-sync/src/mpsc/chan.rs
@@ -346,9 +346,7 @@ impl Semaphore for (::semaphore::Semaphore, usize) {
     }
 
     fn drop_permit(&self, permit: &mut Permit) {
-        if permit.is_acquired() {
-            permit.release(&self.0);
-        }
+        permit.release(&self.0);
     }
 
     fn add_permit(&self) {


### PR DESCRIPTION
This patch fixes Semaphore by adding a missing code path to the release
routine that handles the case where the waiter's node is queued in the
sempahore but has not yet been assigned the permit.

This fix is used by mpsc to handle the case when the Sender has called
`poll_ready` and is dropped before the permit is acquired.

Fixes #900