### PR TITLE
sync: drop old tasks in oneshot

### DIFF
--- a/tokio-sync/tests/fuzz_oneshot.rs
+++ b/tokio-sync/tests/fuzz_oneshot.rs
@@ -5,6 +5,7 @@ extern crate loom;
 #[allow(warnings)]
 mod oneshot;
 
+use futures::{Async, Future};
 use loom::thread;
 use loom::futures::block_on;
 
@@ -19,5 +20,77 @@ fn smoke() {
 
         let value = block_on(rx).unwrap();
         assert_eq!(1, value);
+    });
+}
+
+#[test]
+fn changing_rx_task() {
+    loom::fuzz(|| {
+        let (tx, mut rx) = oneshot::channel();
+
+        thread::spawn(move || {
+            tx.send(1).unwrap();
+        });
+
+        let rx = thread::spawn(move || {
+            let t1 = block_on(futures::future::poll_fn(|| {
+                Ok::<_, ()>(rx.poll().into())
+            })).unwrap();
+
+            match t1 {
+                Ok(Async::Ready(value)) => {
+                    // ok
+                    assert_eq!(1, value);
+                    None
+                },
+                Ok(Async::NotReady) => {
+                    Some(rx)
+                },
+                Err(_) => unreachable!(),
+            }
+        }).join().unwrap();
+
+
+        if let Some(rx) = rx {
+            // Previous task parked, use a new task...
+            let value = block_on(rx).unwrap();
+            assert_eq!(1, value);
+        }
+
+    });
+}
+
+#[test]
+fn changing_tx_task() {
+    loom::fuzz(|| {
+        let (mut tx, rx) = oneshot::channel::<i32>();
+
+        thread::spawn(move || {
+            drop(rx);
+        });
+
+        let tx = thread::spawn(move || {
+            let t1 = block_on(futures::future::poll_fn(|| {
+                Ok::<_, ()>(tx.poll_close().into())
+            })).unwrap();
+
+            match t1 {
+                Ok(Async::Ready(())) => {
+                    None
+                },
+                Ok(Async::NotReady) => {
+                    Some(tx)
+                },
+                Err(_) => unreachable!(),
+            }
+        }).join().unwrap();
+
+
+        if let Some(mut tx) = tx {
+            // Previous task parked, use a new task...
+            block_on(futures::future::poll_fn(move || {
+                tx.poll_close()
+            })).unwrap();
+        }
     });
 }

--- a/tokio-sync/tests/oneshot.rs
+++ b/tokio-sync/tests/oneshot.rs
@@ -208,9 +208,15 @@ fn receiver_changes_task() {
         assert_not_ready!(rx.poll());
     });
 
+    assert_eq!(2, task1.notifier_ref_count());
+    assert_eq!(1, task2.notifier_ref_count());
+
     task2.enter(|| {
         assert_not_ready!(rx.poll());
     });
+
+    assert_eq!(1, task1.notifier_ref_count());
+    assert_eq!(2, task2.notifier_ref_count());
 
     tx.send(1).unwrap();
 
@@ -231,9 +237,15 @@ fn sender_changes_task() {
         assert_not_ready!(tx.poll_close());
     });
 
+    assert_eq!(2, task1.notifier_ref_count());
+    assert_eq!(1, task2.notifier_ref_count());
+
     task2.enter(|| {
         assert_not_ready!(tx.poll_close());
     });
+
+    assert_eq!(1, task1.notifier_ref_count());
+    assert_eq!(2, task2.notifier_ref_count());
 
     drop(rx);
 


### PR DESCRIPTION
When changing tasks in oneshot, the previous `Task` would get leaked because `ManuallyDrop::drop` was never called.