### PR TITLE
chore: apply rustfmt to all crates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,10 @@ matrix:
     script: |
       cargo check --all
 
-  # Test combinations of enabled features.
+  # Test combinations of enabled features and rustfmt
   - rust: stable
     script: |
+      cargo fmt --all -- --check
       shopt -s expand_aliases
       alias check="cargo check --no-default-features"
       check

--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -10,8 +10,8 @@ use std::io;
 use std::net::SocketAddr;
 use std::thread;
 
-use futures::sync::oneshot;
 use futures::sync::mpsc;
+use futures::sync::oneshot;
 use futures::{Future, Poll, Sink, Stream};
 use test::Bencher;
 use tokio::net::UdpSocket;
@@ -57,7 +57,6 @@ fn udp_echo_latency(b: &mut Bencher) {
     let (tx, rx) = oneshot::channel();
 
     let child = thread::spawn(move || {
-
         let socket = tokio::net::UdpSocket::bind(&any_addr).unwrap();
         tx.send(socket.local_addr().unwrap()).unwrap();
 
@@ -66,7 +65,6 @@ fn udp_echo_latency(b: &mut Bencher) {
         let server = server.map_err(|_| ());
         server.wait().unwrap();
     });
-
 
     let client = std::net::UdpSocket::bind(&any_addr).unwrap();
 

--- a/benches/mio-ops.rs
+++ b/benches/mio-ops.rs
@@ -3,14 +3,13 @@
 #![feature(test)]
 #![deny(warnings)]
 
-extern crate test;
 extern crate mio;
+extern crate test;
 
 use test::Bencher;
 
 use mio::tcp::TcpListener;
-use mio::{Token, Ready, PollOpt};
-
+use mio::{PollOpt, Ready, Token};
 
 #[bench]
 fn mio_register_deregister(b: &mut Bencher) {
@@ -22,8 +21,8 @@ fn mio_register_deregister(b: &mut Bencher) {
     const CLIENT: Token = Token(1);
 
     b.iter(|| {
-        poll.register(&sock, CLIENT, Ready::readable(),
-              PollOpt::edge()).unwrap();
+        poll.register(&sock, CLIENT, Ready::readable(), PollOpt::edge())
+            .unwrap();
         poll.deregister(&sock).unwrap();
     });
 }
@@ -36,12 +35,12 @@ fn mio_reregister(b: &mut Bencher) {
     let poll = mio::Poll::new().unwrap();
 
     const CLIENT: Token = Token(1);
-    poll.register(&sock, CLIENT, Ready::readable(),
-    PollOpt::edge()).unwrap();
+    poll.register(&sock, CLIENT, Ready::readable(), PollOpt::edge())
+        .unwrap();
 
     b.iter(|| {
-        poll.reregister(&sock, CLIENT, Ready::readable(),
-        PollOpt::edge()).unwrap();
+        poll.reregister(&sock, CLIENT, Ready::readable(), PollOpt::edge())
+            .unwrap();
     });
     poll.deregister(&sock).unwrap();
 }

--- a/examples/chat-combinator.rs
+++ b/examples/chat-combinator.rs
@@ -21,17 +21,17 @@
 
 #![deny(warnings)]
 
-extern crate tokio;
 extern crate futures;
+extern crate tokio;
 
 use tokio::io;
 use tokio::net::TcpListener;
 use tokio::prelude::*;
 
 use std::collections::HashMap;
-use std::iter;
 use std::env;
-use std::io::{BufReader};
+use std::io::BufReader;
+use std::iter;
 use std::sync::{Arc, Mutex};
 
 fn main() -> Result<(), Box<std::error::Error>> {
@@ -48,8 +48,12 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     // The server task asynchronously iterates over and processes each incoming
     // connection.
-    let srv = socket.incoming()
-        .map_err(|e| {println!("failed to accept socket; error = {:?}", e); e})
+    let srv = socket
+        .incoming()
+        .map_err(|e| {
+            println!("failed to accept socket; error = {:?}", e);
+            e
+        })
         .for_each(move |stream| {
             // The client's socket address
             let addr = stream.peer_addr()?;
@@ -91,9 +95,7 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
                 // Convert the bytes we read into a string, and then send that
                 // string to all other connected clients.
-                let line = line.map(|(reader, vec)| {
-                    (reader, String::from_utf8(vec))
-                });
+                let line = line.map(|(reader, vec)| (reader, String::from_utf8(vec)));
 
                 // Move the connection state into the closure below.
                 let connections = connections_inner.clone();
@@ -105,15 +107,17 @@ fn main() -> Result<(), Box<std::error::Error>> {
                     if let Ok(msg) = message {
                         // For each open connection except the sender, send the
                         // string via the channel.
-                        let iter = conns.iter_mut()
-                                        .filter(|&(&k, _)| k != addr)
-                                        .map(|(_, v)| v);
+                        let iter = conns
+                            .iter_mut()
+                            .filter(|&(&k, _)| k != addr)
+                            .map(|(_, v)| v);
                         for tx in iter {
                             tx.unbounded_send(format!("{}: {}", addr, msg)).unwrap();
                         }
                     } else {
                         let tx = conns.get_mut(&addr).unwrap();
-                        tx.unbounded_send("You didn't send valid UTF-8.".to_string()).unwrap();
+                        tx.unbounded_send("You didn't send valid UTF-8.".to_string())
+                            .unwrap();
                     }
 
                     reader

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -16,11 +16,11 @@
 extern crate futures;
 extern crate tokio;
 
-use std::{env, io};
 use std::net::SocketAddr;
+use std::{env, io};
 
-use tokio::prelude::*;
 use tokio::net::UdpSocket;
+use tokio::prelude::*;
 
 struct Server {
     socket: UdpSocket,

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -54,7 +54,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // connections made to the server).  The return value of the `for_each`
     // method is itself a future representing processing the entire stream of
     // connections, and ends up being our server.
-    let done = socket.incoming()
+    let done = socket
+        .incoming()
         .map_err(|e| println!("failed to accept socket; error = {:?}", e))
         .for_each(move |socket| {
             // Once we're inside this closure this represents an accepted client
@@ -88,7 +89,6 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
                 Ok(())
             });
-
 
             // And this is where much of the magic of this server happens. We
             // crucially want all clients to make progress concurrently, rather than

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -25,20 +25,21 @@ pub fn main() -> Result<(), Box<std::error::Error>> {
     // Open a TCP stream to the socket address.
     //
     // Note that this is the Tokio TcpStream, which is fully async.
-    let client = TcpStream::connect(&addr).and_then(|stream| {
-        println!("created stream");
-        io::write_all(stream, "hello world\n").then(|result| {
-            println!("wrote to stream; success={:?}", result.is_ok());
-            Ok(())
+    let client = TcpStream::connect(&addr)
+        .and_then(|stream| {
+            println!("created stream");
+            io::write_all(stream, "hello world\n").then(|result| {
+                println!("wrote to stream; success={:?}", result.is_ok());
+                Ok(())
+            })
         })
-    })
-    .map_err(|err| {
-        // All tasks must have an `Error` type of `()`. This forces error
-        // handling and helps avoid silencing failures.
-        //
-        // In our example, we are only going to log the error to STDOUT.
-        println!("connection error = {:?}", err);
-    });
+        .map_err(|err| {
+            // All tasks must have an `Error` type of `()`. This forces error
+            // handling and helps avoid silencing failures.
+            //
+            // In our example, we are only going to log the error to STDOUT.
+            println!("connection error = {:?}", err);
+        });
 
     // Start the Tokio runtime.
     //

--- a/examples/print_each_packet.rs
+++ b/examples/print_each_packet.rs
@@ -57,10 +57,10 @@
 extern crate tokio;
 extern crate tokio_codec;
 
-use tokio_codec::BytesCodec;
+use tokio::codec::Decoder;
 use tokio::net::TcpListener;
 use tokio::prelude::*;
-use tokio::codec::Decoder;
+use tokio_codec::BytesCodec;
 
 use std::env;
 use std::net::SocketAddr;

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -23,12 +23,12 @@ extern crate time;
 extern crate tokio;
 extern crate tokio_io;
 
-use std::{env, fmt, io};
 use std::net::SocketAddr;
+use std::{env, fmt, io};
 
-use tokio::net::{TcpStream, TcpListener};
+use tokio::codec::{Decoder, Encoder};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
-use tokio::codec::{Encoder, Decoder};
 
 use bytes::BytesMut;
 use http::header::HeaderValue;
@@ -44,7 +44,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
     println!("Listening on: {}", addr);
 
     tokio::run({
-        listener.incoming()
+        listener
+            .incoming()
             .map_err(|e| println!("failed to accept socket; error = {:?}", e))
             .for_each(|socket| {
                 process(socket);
@@ -64,14 +65,13 @@ fn process(socket: TcpStream) {
         .split();
 
     // Map all requests into responses and send them back to the client.
-    let task = tx.send_all(rx.and_then(respond))
-        .then(|res| {
-            if let Err(e) = res {
-                println!("failed to process connection; error = {:?}", e);
-            }
+    let task = tx.send_all(rx.and_then(respond)).then(|res| {
+        if let Err(e) = res {
+            println!("failed to process connection; error = {:?}", e);
+        }
 
-            Ok(())
-        });
+        Ok(())
+    });
 
     // Spawn the task that handles the connection.
     tokio::spawn(task);
@@ -82,9 +82,7 @@ fn process(socket: TcpStream) {
 /// This function is a map from and HTTP request to a future of a response and
 /// represents the various handling a server might do. Currently the contents
 /// here are pretty uninteresting.
-fn respond(req: Request<()>)
-    -> Box<Future<Item = Response<String>, Error = io::Error> + Send>
-{
+fn respond(req: Request<()>) -> Box<Future<Item = Response<String>, Error = io::Error> + Send> {
     let f = future::lazy(move || {
         let mut response = Response::builder();
         let body = match req.uri().path() {
@@ -99,14 +97,18 @@ fn respond(req: Request<()>)
                 struct Message {
                     message: &'static str,
                 }
-                serde_json::to_string(&Message { message: "Hello, World!" })?
+                serde_json::to_string(&Message {
+                    message: "Hello, World!",
+                })?
             }
             _ => {
                 response.status(StatusCode::NOT_FOUND);
                 String::new()
             }
         };
-        let response = response.body(body).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        let response = response
+            .body(body)
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
         Ok(response)
     });
 
@@ -124,12 +126,19 @@ impl Encoder for Http {
     fn encode(&mut self, item: Response<String>, dst: &mut BytesMut) -> io::Result<()> {
         use std::fmt::Write;
 
-        write!(BytesWrite(dst), "\
-            HTTP/1.1 {}\r\n\
-            Server: Example\r\n\
-            Content-Length: {}\r\n\
-            Date: {}\r\n\
-        ", item.status(), item.body().len(), date::now()).unwrap();
+        write!(
+            BytesWrite(dst),
+            "\
+             HTTP/1.1 {}\r\n\
+             Server: Example\r\n\
+             Content-Length: {}\r\n\
+             Date: {}\r\n\
+             ",
+            item.status(),
+            item.body().len(),
+            date::now()
+        )
+        .unwrap();
 
         for (k, v) in item.headers() {
             dst.extend_from_slice(k.as_str().as_bytes());
@@ -198,13 +207,18 @@ impl Decoder for Http {
                 headers[i] = Some((k, v));
             }
 
-            (toslice(r.method.unwrap().as_bytes()),
-             toslice(r.path.unwrap().as_bytes()),
-             r.version.unwrap(),
-             amt)
+            (
+                toslice(r.method.unwrap().as_bytes()),
+                toslice(r.path.unwrap().as_bytes()),
+                r.version.unwrap(),
+                amt,
+            )
         };
         if version != 1 {
-            return Err(io::Error::new(io::ErrorKind::Other, "only HTTP/1.1 accepted"))
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "only HTTP/1.1 accepted",
+            ));
         }
         let data = src.split_to(amt).freeze();
         let mut ret = Request::builder();
@@ -216,15 +230,13 @@ impl Decoder for Http {
                 Some((ref k, ref v)) => (k, v),
                 None => break,
             };
-            let value = unsafe {
-                HeaderValue::from_shared_unchecked(data.slice(v.0, v.1))
-            };
+            let value = unsafe { HeaderValue::from_shared_unchecked(data.slice(v.0, v.1)) };
             ret.header(&data[k.0..k.1], value);
         }
 
-        let req = ret.body(()).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, e)
-        })?;
+        let req = ret
+            .body(())
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
         Ok(Some(req))
     }
 }

--- a/examples/udp-client.rs
+++ b/examples/udp-client.rs
@@ -51,7 +51,8 @@ fn main() -> Result<(), Box<std::error::Error>> {
         "0.0.0.0:0"
     } else {
         "[::]:0"
-    }.parse()?;
+    }
+    .parse()?;
     let socket = UdpSocket::bind(&local_addr)?;
     const MAX_DATAGRAM_SIZE: usize = 65_507;
     socket

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -8,15 +8,15 @@
 
 #![deny(warnings)]
 
+extern crate env_logger;
 extern crate tokio;
 extern crate tokio_codec;
 extern crate tokio_io;
-extern crate env_logger;
 
 use std::net::SocketAddr;
 
+use tokio::net::{UdpFramed, UdpSocket};
 use tokio::prelude::*;
-use tokio::net::{UdpSocket, UdpFramed};
 use tokio_codec::BytesCodec;
 
 fn main() -> Result<(), Box<std::error::Error>> {

--- a/src/async_await.rs
+++ b/src/async_await.rs
@@ -1,4 +1,4 @@
-use std::future::{Future as StdFuture};
+use std::future::Future as StdFuture;
 
 async fn map_ok<T: StdFuture>(future: T) -> Result<(), ()> {
     let _ = await!(future);
@@ -7,7 +7,8 @@ async fn map_ok<T: StdFuture>(future: T) -> Result<(), ()> {
 
 /// Like `tokio::run`, but takes an `async` block
 pub fn run_async<F>(future: F)
-where F: StdFuture<Output = ()> + Send + 'static,
+where
+    F: StdFuture<Output = ()> + Send + 'static,
 {
     use tokio_async_await::compat::backward;
     let future = backward::Compat::new(map_ok(future));
@@ -17,7 +18,8 @@ where F: StdFuture<Output = ()> + Send + 'static,
 
 /// Like `tokio::spawn`, but takes an `async` block
 pub fn spawn_async<F>(future: F)
-where F: StdFuture<Output = ()> + Send + 'static,
+where
+    F: StdFuture<Output = ()> + Send + 'static,
 {
     use tokio_async_await::compat::backward;
     let future = backward::Compat::new(map_ok(future));

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -11,14 +11,7 @@
 //! [transports]: https://tokio.rs/docs/going-deeper/frames/
 
 pub use tokio_codec::{
-    Decoder,
-    Encoder,
-    Framed,
-    FramedParts,
-    FramedRead,
-    FramedWrite,
-    BytesCodec,
-    LinesCodec,
+    BytesCodec, Decoder, Encoder, Framed, FramedParts, FramedRead, FramedWrite, LinesCodec,
 };
 
 pub mod length_delimited;

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -7,7 +7,9 @@
 //! the context of the Tokio runtime as they require Tokio specific features to
 //! function.
 
-pub use tokio_fs::{create_dir, create_dir_all, file, hard_link, metadata, os, read_dir, read_link};
-pub use tokio_fs::{remove_dir, remove_file, rename, set_permissions, symlink_metadata, File};
 pub use tokio_fs::OpenOptions;
+pub use tokio_fs::{
+    create_dir, create_dir_all, file, hard_link, metadata, os, read_dir, read_link,
+};
 pub use tokio_fs::{read, write, ReadFile, WriteFile};
+pub use tokio_fs::{remove_dir, remove_file, rename, set_permissions, symlink_metadata, File};

--- a/src/io.rs
+++ b/src/io.rs
@@ -45,51 +45,18 @@
 //! [`ErrorKind`]: enum.ErrorKind.html
 //! [`Result`]: type.Result.html
 
-pub use tokio_io::{
-    AsyncRead,
-    AsyncWrite,
-};
+pub use tokio_io::{AsyncRead, AsyncWrite};
 
 // standard input, output, and error
 #[cfg(feature = "fs")]
-pub use tokio_fs::{
-    stdin,
-    Stdin,
-    stdout,
-    Stdout,
-    stderr,
-    Stderr,
-};
+pub use tokio_fs::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
 
 // Utils
 pub use tokio_io::io::{
-    copy,
-    Copy,
-    flush,
-    Flush,
-    lines,
-    Lines,
-    read,
-    read_exact,
-    ReadExact,
-    read_to_end,
-    ReadToEnd,
-    read_until,
-    ReadUntil,
-    ReadHalf,
-    shutdown,
-    Shutdown,
-    write_all,
-    WriteAll,
-    WriteHalf,
+    copy, flush, lines, read, read_exact, read_to_end, read_until, shutdown, write_all, Copy,
+    Flush, Lines, ReadExact, ReadHalf, ReadToEnd, ReadUntil, Shutdown, WriteAll, WriteHalf,
 };
 
 // Re-export io::Error so that users don't have to deal
 // with conflicts when `use`ing `futures::io` and `std::io`.
-pub use ::std::io::{
-    Error,
-    ErrorKind,
-    Result,
-    Read,
-    Write,
-};
+pub use std::io::{Error, ErrorKind, Read, Result, Write};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![doc(html_root_url = "https://docs.rs/tokio/0.1.15")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
-#![cfg_attr(feature = "async-await-preview", feature(
-        async_await,
-        await_macro,
-        futures_api,
-        ))]
+#![cfg_attr(
+    feature = "async-await-preview",
+    feature(async_await, await_macro, futures_api,)
+)]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!
@@ -88,24 +87,24 @@ extern crate bytes;
 extern crate mio;
 #[cfg(feature = "rt-full")]
 extern crate num_cpus;
-#[cfg(feature = "rt-full")]
-extern crate tokio_current_thread;
-#[cfg(feature = "io")]
-extern crate tokio_io;
 #[cfg(feature = "codec")]
 extern crate tokio_codec;
+#[cfg(feature = "rt-full")]
+extern crate tokio_current_thread;
 #[cfg(feature = "fs")]
 extern crate tokio_fs;
+#[cfg(feature = "io")]
+extern crate tokio_io;
 #[cfg(feature = "reactor")]
 extern crate tokio_reactor;
-#[cfg(feature = "rt-full")]
-extern crate tokio_threadpool;
 #[cfg(feature = "sync")]
 extern crate tokio_sync;
-#[cfg(feature = "timer")]
-extern crate tokio_timer;
 #[cfg(feature = "tcp")]
 extern crate tokio_tcp;
+#[cfg(feature = "rt-full")]
+extern crate tokio_threadpool;
+#[cfg(feature = "timer")]
+extern crate tokio_timer;
 #[cfg(feature = "udp")]
 extern crate tokio_udp;
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,45 +11,18 @@
 //! The prelude may grow over time as additional items see ubiquitous use.
 
 #[cfg(feature = "io")]
-pub use tokio_io::{
-    AsyncRead,
-    AsyncWrite,
-};
+pub use tokio_io::{AsyncRead, AsyncWrite};
 
-pub use util::{
-    FutureExt,
-    StreamExt,
-};
+pub use util::{FutureExt, StreamExt};
 
-pub use ::std::io::{
-    Read,
-    Write,
-};
+pub use std::io::{Read, Write};
 
-pub use futures::{
-    Future,
-    future,
-    Stream,
-    stream,
-    Sink,
-    IntoFuture,
-    Async,
-    AsyncSink,
-    Poll,
-    task,
-};
+pub use futures::{future, stream, task, Async, AsyncSink, Future, IntoFuture, Poll, Sink, Stream};
 
 #[cfg(feature = "async-await-preview")]
 #[doc(inline)]
 pub use tokio_async_await::{
-    io::{
-        AsyncReadExt,
-        AsyncWriteExt,
-    },
-    sink::{
-        SinkExt,
-    },
-    stream::{
-        StreamExt as StreamAsyncExt,
-    },
+    io::{AsyncReadExt, AsyncWriteExt},
+    sink::SinkExt,
+    stream::StreamExt as StreamAsyncExt,
 };

--- a/src/reactor/mod.rs
+++ b/src/reactor/mod.rs
@@ -136,12 +136,7 @@
 //! [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
 
 pub use tokio_reactor::{
-    Reactor,
-    Handle,
-    Background,
-    Turn,
-    Registration,
-    PollEvented as PollEvented2,
+    Background, Handle, PollEvented as PollEvented2, Reactor, Registration, Turn,
 };
 
 mod poll_evented;

--- a/src/reactor/poll_evented.rs
+++ b/src/reactor/poll_evented.rs
@@ -10,9 +10,9 @@
 
 use std::fmt;
 use std::io::{self, Read, Write};
-use std::sync::Mutex;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Mutex;
 
 use futures::{task, Async, Poll};
 use mio::event::Evented;
@@ -41,9 +41,7 @@ struct Inner {
 
 impl<E: fmt::Debug> fmt::Debug for PollEvented<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("PollEvented")
-         .field("io", &self.io)
-         .finish()
+        f.debug_struct("PollEvented").field("io", &self.io).finish()
     }
 }
 
@@ -51,7 +49,8 @@ impl<E> PollEvented<E> {
     /// Creates a new readiness stream associated with the provided
     /// `loop_handle` and for the given `source`.
     pub fn new(io: E, handle: &Handle) -> io::Result<PollEvented<E>>
-        where E: Evented,
+    where
+        E: Evented,
     {
         let registration = Registration::new();
         registration.register(&io)?;
@@ -153,7 +152,9 @@ impl<E> PollEvented<E> {
         };
 
         // Cache the value
-        self.inner.write_readiness.store(ready2usize(ready), Relaxed);
+        self.inner
+            .write_readiness
+            .store(ready2usize(ready), Relaxed);
 
         ().into()
     }
@@ -334,17 +335,17 @@ impl<E> PollEvented<E> {
     /// method is called, and will likely return an error if this `PollEvented`
     /// was created on a separate event loop from the `handle` specified.
     pub fn deregister(&self) -> io::Result<()>
-        where E: Evented,
+    where
+        E: Evented,
     {
-        self.inner.registration.lock().unwrap()
-            .deregister(&self.io)
+        self.inner.registration.lock().unwrap().deregister(&self.io)
     }
 }
 
 impl<E: Read> Read for PollEvented<E> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_read() {
-            return Err(io::ErrorKind::WouldBlock.into())
+            return Err(io::ErrorKind::WouldBlock.into());
         }
 
         let r = self.get_mut().read(buf);
@@ -353,14 +354,14 @@ impl<E: Read> Read for PollEvented<E> {
             self.need_read()?;
         }
 
-        return r
+        return r;
     }
 }
 
 impl<E: Write> Write for PollEvented<E> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if let Async::NotReady = self.poll_write() {
-            return Err(io::ErrorKind::WouldBlock.into())
+            return Err(io::ErrorKind::WouldBlock.into());
         }
 
         let r = self.get_mut().write(buf);
@@ -369,12 +370,12 @@ impl<E: Write> Write for PollEvented<E> {
             self.need_write()?;
         }
 
-        return r
+        return r;
     }
 
     fn flush(&mut self) -> io::Result<()> {
         if let Async::NotReady = self.poll_write() {
-            return Err(io::ErrorKind::WouldBlock.into())
+            return Err(io::ErrorKind::WouldBlock.into());
         }
 
         let r = self.get_mut().flush();
@@ -383,12 +384,11 @@ impl<E: Write> Write for PollEvented<E> {
             self.need_write()?;
         }
 
-        return r
+        return r;
     }
 }
 
-impl<E: Read> AsyncRead for PollEvented<E> {
-}
+impl<E: Read> AsyncRead for PollEvented<E> {}
 
 impl<E: Write> AsyncWrite for PollEvented<E> {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
@@ -430,8 +430,8 @@ fn usize2ready(bits: usize) -> Ready {
 
 #[cfg(unix)]
 mod platform {
-    use mio::Ready;
     use mio::unix::UnixReady;
+    use mio::Ready;
 
     const HUP: usize = 1 << 2;
     const ERROR: usize = 1 << 3;
@@ -476,14 +476,22 @@ mod platform {
         bits
     }
 
-    #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "ios",
-              target_os = "macos"))]
+    #[cfg(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos"
+    ))]
     fn usize2ready_aio(ready: &mut UnixReady) {
         ready.insert(UnixReady::aio());
     }
 
-    #[cfg(not(any(target_os = "dragonfly",
-        target_os = "freebsd", target_os = "ios", target_os = "macos")))]
+    #[cfg(not(any(
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "ios",
+        target_os = "macos"
+    )))]
     fn usize2ready_aio(_ready: &mut UnixReady) {
         // aio not available here → empty
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,7 +10,4 @@
 //! - [mpsc](mpsc/index.html), a multi-producer, single-consumer channel for
 //!   sending values between tasks.
 
-pub use tokio_sync::{
-    mpsc,
-    oneshot,
-};
+pub use tokio_sync::{mpsc, oneshot};

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -82,15 +82,7 @@
 //! [Interval]: struct.Interval.html
 //! [`DelayQueue`]: struct.DelayQueue.html
 
-pub use tokio_timer::{
-    delay_queue,
-    DelayQueue,
-    Error,
-    Interval,
-    Delay,
-    Timeout,
-    timeout,
-};
+pub use tokio_timer::{delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout};
 
 #[deprecated(since = "0.1.8", note = "use Timeout instead")]
 #[allow(deprecated)]

--- a/src/util/enumerate.rs
+++ b/src/util/enumerate.rs
@@ -1,4 +1,4 @@
-use futures::{Async, Poll, Stream, Sink, StartSend};
+use futures::{Async, Poll, Sink, StartSend, Stream};
 
 /// A stream combinator which combines the yields the current item
 /// plus its count starting from 0.
@@ -13,7 +13,10 @@ pub struct Enumerate<T> {
 
 impl<T> Enumerate<T> {
     pub(crate) fn new(stream: T) -> Self {
-        Self { inner: stream, count: 0 }
+        Self {
+            inner: stream,
+            count: 0,
+        }
     }
 
     /// Acquires a reference to the underlying stream that this combinator is
@@ -61,7 +64,8 @@ where
 
 // Forwarding impl of Sink from the underlying stream
 impl<T> Sink for Enumerate<T>
-    where T: Sink
+where
+    T: Sink,
 {
     type SinkItem = T::SinkItem;
     type SinkError = T::SinkError;

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -7,8 +7,7 @@ use tokio_timer::Timeout;
 use futures::Future;
 
 #[cfg(feature = "timer")]
-use std::time::{Instant, Duration};
-
+use std::time::{Duration, Instant};
 
 /// An extension trait for `Future` that provides a variety of convenient
 /// combinator functions.
@@ -24,7 +23,6 @@ use std::time::{Instant, Duration};
 ///
 /// [`timeout`]: #method.timeout
 pub trait FutureExt: Future {
-
     /// Creates a new future which allows `self` until `timeout`.
     ///
     /// This combinator creates a new future which wraps the receiving future
@@ -60,7 +58,8 @@ pub trait FutureExt: Future {
     /// ```
     #[cfg(feature = "timer")]
     fn timeout(self, timeout: Duration) -> Timeout<Self>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
         Timeout::new(self, timeout)
     }
@@ -70,7 +69,8 @@ pub trait FutureExt: Future {
     #[allow(deprecated)]
     #[doc(hidden)]
     fn deadline(self, deadline: Instant) -> Deadline<Self>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
         Deadline::new(self, deadline)
     }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -7,9 +7,9 @@
 //! [`FutureExt`]: trait.FutureExt.html
 //! [`StreamExt`]: trait.StreamExt.html
 
+mod enumerate;
 mod future;
 mod stream;
-mod enumerate;
 
 pub use self::future::FutureExt;
 pub use self::stream::StreamExt;

--- a/src/util/stream.rs
+++ b/src/util/stream.rs
@@ -1,8 +1,5 @@
 #[cfg(feature = "timer")]
-use tokio_timer::{
-    throttle::Throttle,
-    Timeout,
-};
+use tokio_timer::{throttle::Throttle, Timeout};
 
 use futures::Stream;
 
@@ -29,7 +26,8 @@ pub trait StreamExt: Stream {
     /// Errors are also delayed.
     #[cfg(feature = "timer")]
     fn throttle(self, duration: Duration) -> Throttle<Self>
-    where Self: Sized
+    where
+        Self: Sized,
     {
         Throttle::new(self, duration)
     }
@@ -47,7 +45,8 @@ pub trait StreamExt: Stream {
     /// an iterator with more than [`std::usize::MAX`] elements either produces the
     /// wrong result or panics.
     fn enumerate(self) -> Enumerate<Self>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
         Enumerate::new(self)
     }
@@ -86,7 +85,8 @@ pub trait StreamExt: Stream {
     /// ```
     #[cfg(feature = "timer")]
     fn timeout(self, timeout: Duration) -> Timeout<Self>
-    where Self: Sized,
+    where
+        Self: Sized,
     {
         Timeout::new(self, timeout)
     }

--- a/tests/buffered.rs
+++ b/tests/buffered.rs
@@ -3,20 +3,22 @@ extern crate futures;
 extern crate tokio;
 extern crate tokio_io;
 
+use std::io::{BufReader, BufWriter, Read, Write};
 use std::net::TcpStream;
 use std::thread;
-use std::io::{Read, Write, BufReader, BufWriter};
 
-use futures::Future;
 use futures::stream::Stream;
-use tokio_io::io::copy;
+use futures::Future;
 use tokio::net::TcpListener;
+use tokio_io::io::copy;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]

--- a/tests/clock.rs
+++ b/tests/clock.rs
@@ -1,7 +1,7 @@
+extern crate env_logger;
 extern crate futures;
 extern crate tokio;
 extern crate tokio_timer;
-extern crate env_logger;
 
 use tokio::prelude::*;
 use tokio::runtime::{self, current_thread};
@@ -26,10 +26,7 @@ fn clock_and_timer_concurrent() {
     let when = Instant::now() + Duration::from_millis(5_000);
     let clock = Clock::new_with_now(MockNow(when));
 
-    let mut rt = runtime::Builder::new()
-        .clock(clock)
-        .build()
-        .unwrap();
+    let mut rt = runtime::Builder::new().clock(clock).build().unwrap();
 
     let (tx, rx) = mpsc::channel();
 
@@ -53,10 +50,7 @@ fn clock_and_timer_single_threaded() {
     let when = Instant::now() + Duration::from_millis(5_000);
     let clock = Clock::new_with_now(MockNow(when));
 
-    let mut rt = current_thread::Builder::new()
-        .clock(clock)
-        .build()
-        .unwrap();
+    let mut rt = current_thread::Builder::new().clock(clock).build().unwrap();
 
     rt.block_on({
         Delay::new(when)
@@ -65,5 +59,6 @@ fn clock_and_timer_single_threaded() {
                 assert!(Instant::now() < when);
                 Ok(())
             })
-    }).unwrap();
+    })
+    .unwrap();
 }

--- a/tests/drop-core.rs
+++ b/tests/drop-core.rs
@@ -1,8 +1,8 @@
-extern crate tokio;
 extern crate futures;
+extern crate tokio;
 
-use std::thread;
 use std::net;
+use std::thread;
 
 use futures::future;
 use futures::prelude::*;

--- a/tests/enumerate.rs
+++ b/tests/enumerate.rs
@@ -23,5 +23,4 @@ fn enumerate() {
         result.wait(),
         Ok(vec![(0, 0), (1, 2), (2, 4), (3, 6), (4, 8)])
     );
-
 }

--- a/tests/global.rs
+++ b/tests/global.rs
@@ -1,42 +1,48 @@
+extern crate env_logger;
 extern crate futures;
 extern crate tokio;
 extern crate tokio_io;
-extern crate env_logger;
 
-use std::{io, thread};
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
+use std::{io, thread};
 
 use futures::prelude::*;
-use tokio::net::{TcpStream, TcpListener};
+use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
 fn hammer_old() {
     let _ = env_logger::try_init();
 
-    let threads = (0..10).map(|_| {
-        thread::spawn(|| {
-            let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));
-            let addr = t!(srv.local_addr());
-            let mine = TcpStream::connect(&addr);
-            let theirs = srv.incoming().into_future()
-                .map(|(s, _)| s.unwrap())
-                .map_err(|(s, _)| s);
-            let (mine, theirs) = t!(mine.join(theirs).wait());
+    let threads = (0..10)
+        .map(|_| {
+            thread::spawn(|| {
+                let srv = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));
+                let addr = t!(srv.local_addr());
+                let mine = TcpStream::connect(&addr);
+                let theirs = srv
+                    .incoming()
+                    .into_future()
+                    .map(|(s, _)| s.unwrap())
+                    .map_err(|(s, _)| s);
+                let (mine, theirs) = t!(mine.join(theirs).wait());
 
-            assert_eq!(t!(mine.local_addr()), t!(theirs.peer_addr()));
-            assert_eq!(t!(theirs.local_addr()), t!(mine.peer_addr()));
+                assert_eq!(t!(mine.local_addr()), t!(theirs.peer_addr()));
+                assert_eq!(t!(theirs.local_addr()), t!(mine.peer_addr()));
+            })
         })
-    }).collect::<Vec<_>>();
+        .collect::<Vec<_>>();
     for thread in threads {
         thread.join().unwrap();
     }
@@ -51,8 +57,7 @@ impl io::Read for Rd {
     }
 }
 
-impl tokio_io::AsyncRead for Rd {
-}
+impl tokio_io::AsyncRead for Rd {}
 
 impl io::Write for Wr {
     fn write(&mut self, src: &[u8]) -> io::Result<usize> {

--- a/tests/reactor.rs
+++ b/tests/reactor.rs
@@ -6,8 +6,8 @@ extern crate tokio_tcp;
 use tokio_reactor::Reactor;
 use tokio_tcp::TcpListener;
 
-use futures::{Future, Stream};
 use futures::executor::{spawn, Notify, Spawn};
+use futures::{Future, Stream};
 
 use std::mem;
 use std::net::TcpStream;
@@ -62,7 +62,8 @@ fn test_drop_on_notify() {
 
     // Define a task that just drains the listener
     let task = Box::new({
-        listener.incoming()
+        listener
+            .incoming()
             .for_each(|_| Ok(()))
             .map_err(|_| panic!())
     }) as Box<Future<Item = (), Error = ()>>;
@@ -75,7 +76,8 @@ fn test_drop_on_notify() {
     tokio_reactor::with_default(&reactor.handle(), &mut enter, |_| {
         let id = &*task as *const Task as usize;
 
-        task.lock().unwrap()
+        task.lock()
+            .unwrap()
             .poll_future_notify(&notify, id)
             .unwrap();
     });

--- a/tests/timer.rs
+++ b/tests/timer.rs
@@ -1,7 +1,7 @@
+extern crate env_logger;
 extern crate futures;
 extern crate tokio;
 extern crate tokio_io;
-extern crate env_logger;
 
 use tokio::prelude::*;
 use tokio::timer::*;
@@ -31,7 +31,7 @@ fn timer_with_runtime() {
 
 #[test]
 fn starving() {
-    use futures::{task, Poll, Async};
+    use futures::{task, Async, Poll};
 
     let _ = env_logger::try_init();
 
@@ -60,12 +60,11 @@ fn starving() {
     let (tx, rx) = mpsc::channel();
 
     tokio::run({
-        starve
-            .and_then(move |_ticks| {
-                assert!(Instant::now() >= when);
-                tx.send(()).unwrap();
-                Ok(())
-            })
+        starve.and_then(move |_ticks| {
+            assert!(Instant::now() >= when);
+            tx.send(()).unwrap();
+            Ok(())
+        })
     });
 
     rx.recv().unwrap();
@@ -82,13 +81,11 @@ fn deadline() {
 
     #[allow(deprecated)]
     tokio::run({
-        future::empty::<(), ()>()
-            .deadline(when)
-            .then(move |res| {
-                assert!(res.is_err());
-                tx.send(()).unwrap();
-                Ok(())
-            })
+        future::empty::<(), ()>().deadline(when).then(move |res| {
+            assert!(res.is_err());
+            tx.send(()).unwrap();
+            Ok(())
+        })
     });
 
     rx.recv().unwrap();

--- a/tokio-async-await/src/await.rs
+++ b/tokio-async-await/src/await.rs
@@ -2,15 +2,15 @@
 #[macro_export]
 macro_rules! await {
     ($e:expr) => {{
-        use $crate::std_await;
-        #[allow(unused_imports)]
-        use $crate::compat::forward::IntoAwaitable as IntoAwaitableForward;
         #[allow(unused_imports)]
         use $crate::compat::backward::IntoAwaitable as IntoAwaitableBackward;
+        #[allow(unused_imports)]
+        use $crate::compat::forward::IntoAwaitable as IntoAwaitableForward;
+        use $crate::std_await;
 
         #[allow(unused_mut)]
         let mut e = $e;
         let e = e.into_awaitable();
         std_await!(e)
-    }}
+    }};
 }

--- a/tokio-async-await/src/compat/backward.rs
+++ b/tokio-async-await/src/compat/backward.rs
@@ -1,16 +1,9 @@
 use futures::{Future, Poll};
 
+use std::future::Future as StdFuture;
 use std::pin::Pin;
-use std::future::{
-    Future as StdFuture,
-};
 use std::ptr::NonNull;
-use std::task::{
-    LocalWaker,
-    Poll as StdPoll,
-    UnsafeWake,
-    Waker,
-};
+use std::task::{LocalWaker, Poll as StdPoll, UnsafeWake, Waker};
 
 /// Convert an 0.3 `Future` to an 0.1 `Future`.
 #[derive(Debug)]
@@ -31,7 +24,8 @@ pub trait IntoAwaitable {
 }
 
 impl<T> IntoAwaitable for T
-where T: StdFuture,
+where
+    T: StdFuture,
 {
     type Awaitable = Self;
 
@@ -41,7 +35,8 @@ where T: StdFuture,
 }
 
 impl<T, Item, Error> Future for Compat<T>
-where T: StdFuture<Output = Result<Item, Error>>,
+where
+    T: StdFuture<Output = Result<Item, Error>>,
 {
     type Item = Item;
     type Error = Error;
@@ -80,8 +75,7 @@ unsafe impl UnsafeWake for NoopWaker {
         noop_waker()
     }
 
-    unsafe fn drop_raw(&self) {
-    }
+    unsafe fn drop_raw(&self) {}
 
     unsafe fn wake(&self) {
         unimplemented!("async-await-preview currently only supports futures 0.1. Use the compatibility layer of futures 0.3 instead, if you want to use futures 0.3.");

--- a/tokio-async-await/src/compat/forward.rs
+++ b/tokio-async-await/src/compat/forward.rs
@@ -1,8 +1,7 @@
+use futures::{Async, Future};
 
-use futures::{Future, Async};
-
-use std::marker::Unpin;
 use std::future::Future as StdFuture;
+use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{LocalWaker, Poll as StdPoll};
 
@@ -11,7 +10,7 @@ use std::task::{LocalWaker, Poll as StdPoll};
 pub struct Compat<T>(T);
 
 pub(crate) fn convert_poll<T, E>(poll: Result<Async<T>, E>) -> StdPoll<Result<T, E>> {
-    use futures::Async::{Ready, NotReady};
+    use futures::Async::{NotReady, Ready};
 
     match poll {
         Ok(Ready(val)) => StdPoll::Ready(Ok(val)),
@@ -21,9 +20,9 @@ pub(crate) fn convert_poll<T, E>(poll: Result<Async<T>, E>) -> StdPoll<Result<T,
 }
 
 pub(crate) fn convert_poll_stream<T, E>(
-    poll: Result<Async<Option<T>>, E>) -> StdPoll<Option<Result<T, E>>>
-{
-    use futures::Async::{Ready, NotReady};
+    poll: Result<Async<Option<T>>, E>,
+) -> StdPoll<Option<Result<T, E>>> {
+    use futures::Async::{NotReady, Ready};
 
     match poll {
         Ok(Ready(Some(val))) => StdPoll::Ready(Some(Ok(val))),
@@ -50,12 +49,13 @@ impl<T: Future + Unpin> IntoAwaitable for T {
 }
 
 impl<T> StdFuture for Compat<T>
-where T: Future + Unpin
+where
+    T: Future + Unpin,
 {
     type Output = Result<T::Item, T::Error>;
 
     fn poll(mut self: Pin<&mut Self>, _lw: &LocalWaker) -> StdPoll<Self::Output> {
-        use futures::Async::{Ready, NotReady};
+        use futures::Async::{NotReady, Ready};
 
         // TODO: wire in cx
 

--- a/tokio-async-await/src/compat/mod.rs
+++ b/tokio-async-await/src/compat/mod.rs
@@ -1,4 +1,4 @@
 #![doc(hidden)]
 
-pub mod forward;
 pub mod backward;
+pub mod forward;

--- a/tokio-async-await/src/io/flush.rs
+++ b/tokio-async-await/src/io/flush.rs
@@ -1,8 +1,7 @@
 use tokio_io::AsyncWrite;
 
-
-use std::io;
 use std::future::Future;
+use std::io;
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{LocalWaker, Poll};

--- a/tokio-async-await/src/io/read.rs
+++ b/tokio-async-await/src/io/read.rs
@@ -19,10 +19,7 @@ impl<'a, T: ?Sized> Unpin for Read<'a, T> {}
 
 impl<'a, T: AsyncRead + ?Sized> Read<'a, T> {
     pub(super) fn new(reader: &'a mut T, buf: &'a mut [u8]) -> Read<'a, T> {
-        Read {
-            reader,
-            buf,
-        }
+        Read { reader, buf }
     }
 }
 

--- a/tokio-async-await/src/io/read_exact.rs
+++ b/tokio-async-await/src/io/read_exact.rs
@@ -20,10 +20,7 @@ impl<'a, T: ?Sized> Unpin for ReadExact<'a, T> {}
 
 impl<'a, T: AsyncRead + ?Sized> ReadExact<'a, T> {
     pub(super) fn new(reader: &'a mut T, buf: &'a mut [u8]) -> ReadExact<'a, T> {
-        ReadExact {
-            reader,
-            buf,
-        }
+        ReadExact { reader, buf }
     }
 }
 
@@ -47,7 +44,7 @@ impl<'a, T: AsyncRead + ?Sized> Future for ReadExact<'a, T> {
                 this.buf = rest;
             }
             if n == 0 {
-                return Poll::Ready(Err(eof()))
+                return Poll::Ready(Err(eof()));
             }
         }
 

--- a/tokio-async-await/src/io/write.rs
+++ b/tokio-async-await/src/io/write.rs
@@ -19,10 +19,7 @@ impl<'a, T: ?Sized> Unpin for Write<'a, T> {}
 
 impl<'a, T: AsyncWrite + ?Sized> Write<'a, T> {
     pub(super) fn new(writer: &'a mut T, buf: &'a [u8]) -> Write<'a, T> {
-        Write {
-            writer,
-            buf,
-        }
+        Write { writer, buf }
     }
 }
 

--- a/tokio-async-await/src/io/write_all.rs
+++ b/tokio-async-await/src/io/write_all.rs
@@ -20,10 +20,7 @@ impl<'a, T: ?Sized> Unpin for WriteAll<'a, T> {}
 
 impl<'a, T: AsyncWrite + ?Sized> WriteAll<'a, T> {
     pub(super) fn new(writer: &'a mut T, buf: &'a [u8]) -> WriteAll<'a, T> {
-        WriteAll {
-            writer,
-            buf,
-        }
+        WriteAll { writer, buf }
     }
 }
 
@@ -48,7 +45,7 @@ impl<'a, T: AsyncWrite + ?Sized> Future for WriteAll<'a, T> {
             }
 
             if n == 0 {
-                return Poll::Ready(Err(zero_write()))
+                return Poll::Ready(Err(zero_write()));
             }
         }
 

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -4,9 +4,8 @@
     arbitrary_self_types,
     async_await,
     await_macro,
-    futures_api,
-    )]
-
+    futures_api
+)]
 #![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.5")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
@@ -23,12 +22,10 @@ macro_rules! try_ready {
     ($x:expr) => {
         match $x {
             std::task::Poll::Ready(Ok(x)) => x,
-            std::task::Poll::Ready(Err(e)) =>
-                return std::task::Poll::Ready(Err(e.into())),
-            std::task::Poll::Pending =>
-                return std::task::Poll::Pending,
+            std::task::Poll::Ready(Err(e)) => return std::task::Poll::Ready(Err(e.into())),
+            std::task::Poll::Pending => return std::task::Poll::Pending,
         }
-    }
+    };
 }
 
 #[macro_use]

--- a/tokio-async-await/src/sink/send.rs
+++ b/tokio-async-await/src/sink/send.rs
@@ -30,7 +30,7 @@ impl<T: Sink + Unpin + ?Sized> Future for Send<'_, T> {
 
     fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll;
-        use futures::AsyncSink::{Ready, NotReady};
+        use futures::AsyncSink::{NotReady, Ready};
 
         if let Some(item) = self.item.take() {
             match self.sink.start_send(item) {

--- a/tokio-buf/src/ext/collect.rs
+++ b/tokio-buf/src/ext/collect.rs
@@ -1,5 +1,5 @@
-use BufStream;
 use super::FromBufStream;
+use BufStream;
 
 use futures::{Future, Poll};
 
@@ -53,29 +53,26 @@ where
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         loop {
-            let res = self.stream.poll_buf()
-                .map_err(|err| {
-                    let inner = Error::Stream(err);
-                    CollectError { inner }
-                });
+            let res = self.stream.poll_buf().map_err(|err| {
+                let inner = Error::Stream(err);
+                CollectError { inner }
+            });
 
             match try_ready!(res) {
                 Some(mut buf) => {
                     let builder = self.builder.as_mut().expect("cannot poll after done");
 
-                    U::extend(builder, &mut buf, &self.stream.size_hint())
-                        .map_err(|err| {
-                            let inner = Error::Collect(err);
-                            CollectError { inner }
-                        })?;
+                    U::extend(builder, &mut buf, &self.stream.size_hint()).map_err(|err| {
+                        let inner = Error::Collect(err);
+                        CollectError { inner }
+                    })?;
                 }
                 None => {
                     let builder = self.builder.take().expect("cannot poll after done");
-                    let value = U::build(builder)
-                        .map_err(|err| {
-                            let inner = Error::Collect(err);
-                            CollectError { inner }
-                        })?;
+                    let value = U::build(builder).map_err(|err| {
+                        let inner = Error::Collect(err);
+                        CollectError { inner }
+                    })?;
                     return Ok(value.into());
                 }
             }

--- a/tokio-buf/src/ext/from.rs
+++ b/tokio-buf/src/ext/from.rs
@@ -43,7 +43,9 @@ pub trait FromBufStream<T: Buf>: Sized {
 
 /// Error returned from collecting into a `Vec<u8>`
 #[derive(Debug)]
-pub struct CollectVecError { _p: () }
+pub struct CollectVecError {
+    _p: (),
+}
 
 impl<T: Buf> FromBufStream<T> for Vec<u8> {
     type Builder = Vec<u8>;
@@ -70,7 +72,7 @@ impl<T: Buf> FromBufStream<T> for Vec<u8> {
             Some(upper) if upper <= 64 => {
                 reserve = upper as usize;
             }
-            _ => {},
+            _ => {}
         }
 
         // hint.lower() represents the minimum amount of data that will be

--- a/tokio-buf/src/ext/limit.rs
+++ b/tokio-buf/src/ext/limit.rs
@@ -40,10 +40,10 @@ where
             return Err(LimitError { inner: None });
         }
 
-        let res = self.stream.poll_buf()
-            .map_err(|err| {
-                LimitError { inner: Some(err) }
-            });
+        let res = self
+            .stream
+            .poll_buf()
+            .map_err(|err| LimitError { inner: Some(err) });
 
         match res {
             Ok(Ready(Some(ref buf))) => {

--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -16,21 +16,21 @@ extern crate either;
 #[macro_use]
 extern crate futures;
 
+pub mod errors;
 #[cfg(feature = "ext")]
 pub mod ext;
-pub mod errors;
 mod size_hint;
 mod str;
 
+pub use self::size_hint::SizeHint;
 #[doc(inline)]
 #[cfg(feature = "ext")]
 pub use ext::BufStreamExt;
-pub use self::size_hint::SizeHint;
 
-use futures::Poll;
 use bytes::{Buf, Bytes, BytesMut};
-use std::io;
 use errors::internal::Never;
+use futures::Poll;
+use std::io;
 
 /// An asynchronous stream of bytes.
 ///
@@ -151,9 +151,7 @@ impl BufStream for BytesMut {
     }
 }
 
-fn poll_bytes<T: Default>(buf: &mut T)
-    -> Poll<Option<io::Cursor<T>>, Never>
-{
+fn poll_bytes<T: Default>(buf: &mut T) -> Poll<Option<io::Cursor<T>>, Never> {
     use std::mem;
 
     let bytes = mem::replace(buf, Default::default());

--- a/tokio-buf/src/str.rs
+++ b/tokio-buf/src/str.rs
@@ -1,5 +1,5 @@
-use BufStream;
 use errors::internal::Never;
+use BufStream;
 
 use futures::Poll;
 

--- a/tokio-buf/tests/buf_stream.rs
+++ b/tokio-buf/tests/buf_stream.rs
@@ -1,11 +1,10 @@
-extern crate tokio_buf;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_buf;
 
-use tokio_buf::{BufStream, SizeHint};
 use bytes::Buf;
 use futures::Async::*;
-
+use tokio_buf::{BufStream, SizeHint};
 
 #[macro_use]
 mod support;

--- a/tokio-buf/tests/buf_stream_ext.rs
+++ b/tokio-buf/tests/buf_stream_ext.rs
@@ -1,13 +1,13 @@
 #![cfg(feature = "ext")]
 
-extern crate tokio_buf;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_buf;
 
-use tokio_buf::{BufStream, BufStreamExt};
-use futures::Future;
-use futures::Async::*;
 use bytes::Buf;
+use futures::Async::*;
+use futures::Future;
+use tokio_buf::{BufStream, BufStreamExt};
 
 #[macro_use]
 mod support;
@@ -27,8 +27,7 @@ fn chain() {
     assert_none!(bs.poll_buf());
 
     // Chain multi with multi
-    let mut bs = list(&["foo", "bar"])
-        .chain(list(&["baz", "bok"]));
+    let mut bs = list(&["foo", "bar"]).chain(list(&["baz", "bok"]));
 
     assert_buf_eq!(bs.poll_buf(), "foo");
     assert_buf_eq!(bs.poll_buf(), "bar");
@@ -38,11 +37,7 @@ fn chain() {
 
     // Chain includes a not ready call
     //
-    let mut bs = new_mock(&[
-        Ok(Ready("foo")),
-        Ok(NotReady),
-        Ok(Ready("bar"))
-    ]).chain(one("baz"));
+    let mut bs = new_mock(&[Ok(Ready("foo")), Ok(NotReady), Ok(Ready("bar"))]).chain(one("baz"));
 
     assert_buf_eq!(bs.poll_buf(), "foo");
     assert_not_ready!(bs.poll_buf());
@@ -62,8 +57,7 @@ fn collect_vec() {
     //
     let bs = one("hello world");
 
-    let vec: Vec<u8> = bs.collect()
-        .wait().unwrap();
+    let vec: Vec<u8> = bs.collect().wait().unwrap();
 
     assert_eq!(vec, b"hello world");
     assert_eq!(vec.capacity(), 64);
@@ -73,8 +67,7 @@ fn collect_vec() {
     let mut bs = one("hello world");
     bs.size_hint.set_lower(11);
 
-    let vec: Vec<u8> = bs.collect()
-        .wait().unwrap();
+    let vec: Vec<u8> = bs.collect().wait().unwrap();
 
     assert_eq!(vec, b"hello world");
     assert_eq!(vec.capacity(), 64);
@@ -84,8 +77,7 @@ fn collect_vec() {
     let mut bs = one("hello world");
     bs.size_hint.set_lower(10);
 
-    let vec: Vec<u8> = bs.collect()
-        .wait().unwrap();
+    let vec: Vec<u8> = bs.collect().wait().unwrap();
 
     assert_eq!(vec, b"hello world");
     assert_eq!(vec.capacity(), 64);
@@ -94,8 +86,7 @@ fn collect_vec() {
     //
     let bs = list(&["hello", " ", "world", ", one two three"]);
 
-    let vec: Vec<u8> = bs.collect()
-        .wait().unwrap();
+    let vec: Vec<u8> = bs.collect().wait().unwrap();
 
     assert_eq!(vec, b"hello world, one two three");
 }
@@ -109,42 +100,38 @@ fn limit() {
     let res = one("hello world")
         .limit(100)
         .collect::<Vec<_>>()
-        .wait().unwrap();
+        .wait()
+        .unwrap();
 
     assert_eq!(res, b"hello world");
 
     let res = list(&["hello", " ", "world"])
         .limit(100)
         .collect::<Vec<_>>()
-        .wait().unwrap();
+        .wait()
+        .unwrap();
 
     assert_eq!(res, b"hello world");
 
     let res = list(&["hello", " ", "world"])
         .limit(11)
         .collect::<Vec<_>>()
-        .wait().unwrap();
+        .wait()
+        .unwrap();
 
     assert_eq!(res, b"hello world");
 
     // Limited
 
-    let res = one("hello world")
-        .limit(5)
-        .collect::<Vec<_>>()
-        .wait();
+    let res = one("hello world").limit(5).collect::<Vec<_>>().wait();
 
     assert!(res.is_err());
 
-    let res = one("hello world")
-        .limit(10)
-        .collect::<Vec<_>>()
-        .wait();
+    let res = one("hello world").limit(10).collect::<Vec<_>>().wait();
 
     assert!(res.is_err());
 
-    let mut bs = list(&["hello", " ", "world"])
-        .limit(9);
+    let mut bs = list(&["hello", " ", "world"]).limit(9);
 
     assert_buf_eq!(bs.poll_buf(), "hello");
     assert_buf_eq!(bs.poll_buf(), " ");

--- a/tokio-buf/tests/support.rs
+++ b/tokio-buf/tests/support.rs
@@ -1,13 +1,13 @@
 #![allow(unused)]
 
-extern crate tokio_buf;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_buf;
 
-use tokio_buf::{BufStream, SizeHint};
 use bytes::Buf;
-use futures::Poll;
 use futures::Async::*;
+use futures::Poll;
+use tokio_buf::{BufStream, SizeHint};
 
 use std::collections::VecDeque;
 use std::io::Cursor;
@@ -32,7 +32,7 @@ macro_rules! assert_none {
             Ok(Ready(None)) => {}
             actual => panic!("expected None; actual = {:?}", actual),
         }
-    }
+    };
 }
 
 macro_rules! assert_not_ready {
@@ -41,7 +41,7 @@ macro_rules! assert_not_ready {
             Ok(NotReady) => {}
             actual => panic!("expected NotReady; actual = {:?}", actual),
         }
-    }
+    };
 }
 
 // ===== Test utils =====
@@ -130,4 +130,3 @@ impl Buf for MockBuf {
         self.data.advance(cnt)
     }
 }
-

--- a/tokio-codec/src/bytes_codec.rs
+++ b/tokio-codec/src/bytes_codec.rs
@@ -1,6 +1,6 @@
-use bytes::{Bytes, BufMut, BytesMut};
-use tokio_io::_tokio_codec::{Encoder, Decoder};
+use bytes::{BufMut, Bytes, BytesMut};
 use std::io;
+use tokio_io::_tokio_codec::{Decoder, Encoder};
 
 /// A simple `Codec` implementation that just ships bytes around.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -8,7 +8,9 @@ pub struct BytesCodec(());
 
 impl BytesCodec {
     /// Creates a new `BytesCodec` for shipping around raw bytes.
-    pub fn new() -> BytesCodec { BytesCodec(())  }
+    pub fn new() -> BytesCodec {
+        BytesCodec(())
+    }
 }
 
 impl Decoder for BytesCodec {

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -19,14 +19,7 @@ extern crate tokio_io;
 mod bytes_codec;
 mod lines_codec;
 
-pub use tokio_io::_tokio_codec::{
-    Decoder,
-    Encoder,
-    Framed,
-    FramedParts,
-    FramedRead,
-    FramedWrite,
-};
+pub use tokio_io::_tokio_codec::{Decoder, Encoder, Framed, FramedParts, FramedRead, FramedWrite};
 
 pub use bytes_codec::BytesCodec;
 pub use lines_codec::LinesCodec;

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -1,6 +1,6 @@
 use bytes::{BufMut, BytesMut};
-use tokio_io::_tokio_codec::{Encoder, Decoder};
 use std::{cmp, io, str, usize};
+use tokio_io::_tokio_codec::{Decoder, Encoder};
 
 /// A simple `Codec` implementation that splits up data into lines.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -103,10 +103,8 @@ impl LinesCodec {
 }
 
 fn utf8(buf: &[u8]) -> Result<&str, io::Error> {
-    str::from_utf8(buf).map_err(|_|
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            "Unable to decode input as UTF8"))
+    str::from_utf8(buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Unable to decode input as UTF8"))
 }
 
 fn without_carriage_return(s: &[u8]) -> &[u8] {
@@ -153,7 +151,7 @@ impl Decoder for LinesCodec {
                     self.is_discarding = true;
                     Err(io::Error::new(
                         io::ErrorKind::Other,
-                        "line length limit exceeded"
+                        "line length limit exceeded",
                     ))
                 } else {
                     // We didn't find a line or reach the length limit, so the next

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -1,8 +1,8 @@
-extern crate tokio_codec;
 extern crate bytes;
+extern crate tokio_codec;
 
-use bytes::{BytesMut, Bytes, BufMut};
-use tokio_codec::{BytesCodec, LinesCodec, Decoder, Encoder};
+use bytes::{BufMut, Bytes, BytesMut};
+use tokio_codec::{BytesCodec, Decoder, Encoder, LinesCodec};
 
 #[test]
 fn bytes_decoder() {
@@ -27,13 +27,17 @@ fn bytes_encoder() {
     const INLINE_CAP: usize = 4 * 4 - 1;
 
     let mut buf = BytesMut::new();
-    codec.encode(Bytes::from_static(&[0; INLINE_CAP + 1]), &mut buf).unwrap();
+    codec
+        .encode(Bytes::from_static(&[0; INLINE_CAP + 1]), &mut buf)
+        .unwrap();
 
     // Default capacity of Framed Read
     const INITIAL_CAPACITY: usize = 8 * 1024;
 
     let mut buf = BytesMut::with_capacity(INITIAL_CAPACITY);
-    codec.encode(Bytes::from_static(&[0; INITIAL_CAPACITY + 1]), &mut buf).unwrap();
+    codec
+        .encode(Bytes::from_static(&[0; INITIAL_CAPACITY + 1]), &mut buf)
+        .unwrap();
 }
 
 #[test]
@@ -68,17 +72,32 @@ fn lines_decoder_max_length() {
     assert!(codec.decode(buf).is_err());
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert!(
+        line.len() <= MAX_LENGTH,
+        "{:?}.len() <= {:?}",
+        line,
+        MAX_LENGTH
+    );
     assert_eq!("line 2", line);
 
     assert!(codec.decode(buf).is_err());
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert!(
+        line.len() <= MAX_LENGTH,
+        "{:?}.len() <= {:?}",
+        line,
+        MAX_LENGTH
+    );
     assert_eq!("line 4", line);
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert!(
+        line.len() <= MAX_LENGTH,
+        "{:?}.len() <= {:?}",
+        line,
+        MAX_LENGTH
+    );
     assert_eq!("", line);
 
     assert_eq!(None, codec.decode(buf).unwrap());
@@ -87,7 +106,12 @@ fn lines_decoder_max_length() {
     assert_eq!(None, codec.decode(buf).unwrap());
 
     let line = codec.decode_eof(buf).unwrap().unwrap();
-    assert!(line.len() <= MAX_LENGTH, "{:?}.len() <= {:?}", line, MAX_LENGTH);
+    assert!(
+        line.len() <= MAX_LENGTH,
+        "{:?}.len() <= {:?}",
+        line,
+        MAX_LENGTH
+    );
     assert_eq!("\rk", line);
 
     assert_eq!(None, codec.decode(buf).unwrap());

--- a/tokio-codec/tests/framed.rs
+++ b/tokio-codec/tests/framed.rs
@@ -1,13 +1,13 @@
-extern crate tokio_codec;
-extern crate tokio_io;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_codec;
+extern crate tokio_io;
 
-use futures::{Stream, Future};
+use bytes::{Buf, BufMut, BytesMut, IntoBuf};
+use futures::{Future, Stream};
 use std::io::{self, Read};
-use tokio_codec::{Framed, FramedParts, Decoder, Encoder};
+use tokio_codec::{Decoder, Encoder, Framed, FramedParts};
 use tokio_io::AsyncRead;
-use bytes::{BytesMut, Buf, BufMut, IntoBuf};
 
 const INITIAL_CAPACITY: usize = 8 * 1024;
 
@@ -45,8 +45,10 @@ struct DontReadIntoThis;
 
 impl Read for DontReadIntoThis {
     fn read(&mut self, _: &mut [u8]) -> io::Result<usize> {
-        Err(io::Error::new(io::ErrorKind::Other,
-                           "Read into something you weren't supposed to."))
+        Err(io::Error::new(
+            io::ErrorKind::Other,
+            "Read into something you weren't supposed to.",
+        ))
     }
 }
 
@@ -61,9 +63,7 @@ fn can_read_from_existing_buf() {
 
     let num = framed
         .into_future()
-        .map(|(first_num, _)| {
-            first_num.unwrap()
-        })
+        .map(|(first_num, _)| first_num.unwrap())
         .wait()
         .map_err(|e| e.0)
         .unwrap();

--- a/tokio-codec/tests/framed_read.rs
+++ b/tokio-codec/tests/framed_read.rs
@@ -1,17 +1,17 @@
-extern crate tokio_codec;
-extern crate tokio_io;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_codec;
+extern crate tokio_io;
 
+use tokio_codec::{Decoder, FramedRead};
 use tokio_io::AsyncRead;
-use tokio_codec::{FramedRead, Decoder};
 
-use bytes::{BytesMut, Buf, IntoBuf};
+use bytes::{Buf, BytesMut, IntoBuf};
+use futures::Async::{NotReady, Ready};
 use futures::Stream;
-use futures::Async::{Ready, NotReady};
 
-use std::io::{self, Read};
 use std::collections::VecDeque;
+use std::io::{self, Read};
 
 macro_rules! mock {
     ($($x:expr,)*) => {{
@@ -212,5 +212,4 @@ impl Read for Mock {
     }
 }
 
-impl AsyncRead for Mock {
-}
+impl AsyncRead for Mock {}

--- a/tokio-codec/tests/framed_write.rs
+++ b/tokio-codec/tests/framed_write.rs
@@ -1,16 +1,16 @@
-extern crate tokio_codec;
-extern crate tokio_io;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_codec;
+extern crate tokio_io;
 
-use tokio_io::AsyncWrite;
 use tokio_codec::{Encoder, FramedWrite};
+use tokio_io::AsyncWrite;
 
-use futures::{Sink, Poll};
-use bytes::{BytesMut, BufMut};
+use bytes::{BufMut, BytesMut};
+use futures::{Poll, Sink};
 
-use std::io::{self, Write};
 use std::collections::VecDeque;
+use std::io::{self, Write};
 
 macro_rules! mock {
     ($($x:expr,)*) => {{

--- a/tokio-current-thread/src/scheduler.rs
+++ b/tokio-current-thread/src/scheduler.rs
@@ -1,20 +1,20 @@
 use super::Borrow;
-use tokio_executor::Enter;
 use tokio_executor::park::Unpark;
+use tokio_executor::Enter;
 
-use futures::{Future, Async};
-use futures::executor::{self, Spawn, UnsafeNotify, NotifyHandle};
+use futures::executor::{self, NotifyHandle, Spawn, UnsafeNotify};
+use futures::{Async, Future};
 
 use std::cell::UnsafeCell;
 use std::fmt::{self, Debug};
+use std::marker::PhantomData;
 use std::mem;
 use std::ptr;
-use std::sync::atomic::Ordering::{Relaxed, SeqCst, Acquire, Release, AcqRel};
+use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicUsize};
 use std::sync::{Arc, Weak};
-use std::usize;
 use std::thread;
-use std::marker::PhantomData;
+use std::usize;
 
 /// A generic task-aware scheduler.
 ///
@@ -135,7 +135,8 @@ pub struct Scheduled<'a, U: 'a> {
 }
 
 impl<U> Scheduler<U>
-where U: Unpark,
+where
+    U: Unpark,
 {
     /// Constructs a new, empty `Scheduler`
     ///
@@ -200,9 +201,7 @@ where U: Unpark,
     pub fn has_pending_futures(&mut self) -> bool {
         // See function definition for why the unsafe is needed and
         // correctly used here
-        unsafe {
-            self.inner.has_pending_futures()
-        }
+        unsafe { self.inner.has_pending_futures() }
     }
 
     /// Advance the scheduler state, returning `true` if any futures were
@@ -210,11 +209,9 @@ where U: Unpark,
     ///
     /// This function should be called whenever the caller is notified via a
     /// wakeup.
-    pub fn tick(&mut self, eid: u64, enter: &mut Enter, num_futures: &AtomicUsize) -> bool
-    {
+    pub fn tick(&mut self, eid: u64, enter: &mut Enter, num_futures: &AtomicUsize) -> bool {
         let mut ret = false;
-        let tick = self.inner.tick_num.fetch_add(1, SeqCst)
-            .wrapping_add(1);
+        let tick = self.inner.tick_num.fetch_add(1, SeqCst).wrapping_add(1);
 
         loop {
             let node = match unsafe { self.inner.dequeue(Some(tick)) } {
@@ -246,7 +243,7 @@ where U: Unpark,
                     let node = ptr2arc(node);
                     assert!((*node.next_all.get()).is_null());
                     assert!((*node.prev_all.get()).is_null());
-                    continue
+                    continue;
                 };
 
                 // We're going to need to be very careful if the `poll`
@@ -369,8 +366,7 @@ impl Task {
 
 impl fmt::Debug for Task {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Task")
-            .finish()
+        fmt.debug_struct("Task").finish()
     }
 }
 
@@ -580,7 +576,7 @@ impl<U> List<U> {
 
         self.len += 1;
 
-        return ptr
+        return ptr;
     }
 
     /// Pop an element from the front of the list
@@ -632,7 +628,7 @@ impl<U> List<U> {
 
         self.len -= 1;
 
-        return node
+        return node;
     }
 }
 
@@ -749,7 +745,7 @@ impl<U> Drop for Node<U> {
 fn arc2ptr<T>(ptr: Arc<T>) -> *const T {
     let addr = &*ptr as *const T;
     mem::forget(ptr);
-    return addr
+    return addr;
 }
 
 unsafe fn ptr2arc<T>(ptr: *const T) -> Arc<T> {

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -1,7 +1,7 @@
-use std::prelude::v1::*;
 use std::cell::Cell;
 use std::error::Error;
 use std::fmt;
+use std::prelude::v1::*;
 
 use futures::{self, Future};
 
@@ -70,7 +70,10 @@ pub fn enter() -> Result<Enter, EnterError> {
 impl Enter {
     /// Register a callback to be invoked if and when the thread
     /// ceased to act as an executor.
-    pub fn on_exit<F>(&mut self, f: F) where F: FnOnce() + 'static {
+    pub fn on_exit<F>(&mut self, f: F)
+    where
+        F: FnOnce() + 'static,
+    {
         self.on_exit.push(Box::new(f));
     }
 
@@ -88,7 +91,6 @@ impl Enter {
     pub fn block_on<F: Future>(&mut self, f: F) -> Result<F::Item, F::Error> {
         futures::executor::spawn(f).wait_future()
     }
-
 }
 
 impl fmt::Debug for Enter {
@@ -103,7 +105,7 @@ impl Drop for Enter {
             assert!(c.get());
 
             if self.permanent {
-                return
+                return;
             }
 
             for callback in self.on_exit.drain(..) {

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -134,8 +134,10 @@ pub trait Executor {
     /// # }
     /// # fn main() {}
     /// ```
-    fn spawn(&mut self, future: Box<Future<Item = (), Error = ()> + Send>)
-             -> Result<(), SpawnError>;
+    fn spawn(
+        &mut self,
+        future: Box<Future<Item = (), Error = ()> + Send>,
+    ) -> Result<(), SpawnError>;
 
     /// Provides a best effort **hint** to whether or not `spawn` will succeed.
     ///
@@ -178,9 +180,10 @@ pub trait Executor {
 }
 
 impl<E: Executor + ?Sized> Executor for Box<E> {
-    fn spawn(&mut self, future: Box<Future<Item = (), Error = ()> + Send>)
-        -> Result<(), SpawnError>
-    {
+    fn spawn(
+        &mut self,
+        future: Box<Future<Item = (), Error = ()> + Send>,
+    ) -> Result<(), SpawnError> {
         (**self).spawn(future)
     }
 

--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -190,7 +190,8 @@ impl ParkThread {
 
     /// Get a reference to the `ParkThread` handle for this thread.
     fn with_current<F, R>(&self, f: F) -> R
-        where F: FnOnce(&Parker) -> R,
+    where
+        F: FnOnce(&Parker) -> R,
     {
         CURRENT_PARKER.with(|inner| f(inner))
     }

--- a/tokio-executor/tests/executor.rs
+++ b/tokio-executor/tests/executor.rs
@@ -1,15 +1,15 @@
-extern crate tokio_executor;
 extern crate futures;
+extern crate tokio_executor;
 
+use futures::{future::lazy, Future};
 use tokio_executor::*;
-use futures::{Future, future::lazy};
 
 mod out_of_executor_context {
     use super::*;
 
     fn test<F, E>(spawn: F)
     where
-        F: Fn(Box<Future<Item=(), Error=()> + Send>) -> Result<(), E>,
+        F: Fn(Box<Future<Item = (), Error = ()> + Send>) -> Result<(), E>,
     {
         let res = spawn(Box::new(lazy(|| Ok(()))));
         assert!(res.is_err());

--- a/tokio-fs/examples/std-echo.rs
+++ b/tokio-fs/examples/std-echo.rs
@@ -2,39 +2,35 @@
 #![deny(deprecated, warnings)]
 
 extern crate futures;
-extern crate tokio_fs;
 extern crate tokio_codec;
+extern crate tokio_fs;
 extern crate tokio_threadpool;
 
-use tokio_fs::{stdin, stdout, stderr};
 use tokio_codec::{FramedRead, FramedWrite, LinesCodec};
+use tokio_fs::{stderr, stdin, stdout};
 use tokio_threadpool::Builder;
 
-use futures::{Future, Stream, Sink};
+use futures::{Future, Sink, Stream};
 
 use std::io;
 
 pub fn main() -> Result<(), Box<std::error::Error>> {
-    let pool = Builder::new()
-        .pool_size(1)
-        .build();
+    let pool = Builder::new().pool_size(1).build();
 
     pool.spawn({
         let input = FramedRead::new(stdin(), LinesCodec::new());
 
-        let output = FramedWrite::new(stdout(), LinesCodec::new())
-            .with(|line: String| {
-                let mut out = "OUT: ".to_string();
-                out.push_str(&line);
-                Ok::<_, io::Error>(out)
-            });
+        let output = FramedWrite::new(stdout(), LinesCodec::new()).with(|line: String| {
+            let mut out = "OUT: ".to_string();
+            out.push_str(&line);
+            Ok::<_, io::Error>(out)
+        });
 
-        let error = FramedWrite::new(stderr(), LinesCodec::new())
-            .with(|line: String| {
-                let mut out = "ERR: ".to_string();
-                out.push_str(&line);
-                Ok::<_, io::Error>(out)
-            });
+        let error = FramedWrite::new(stderr(), LinesCodec::new()).with(|line: String| {
+            let mut out = "ERR: ".to_string();
+            out.push_str(&line);
+            Ok::<_, io::Error>(out)
+        });
 
         let dst = output.fanout(error);
 
@@ -44,6 +40,8 @@ pub fn main() -> Result<(), Box<std::error::Error>> {
             .map_err(|e| panic!("io error = {:?}", e))
     });
 
-    pool.shutdown_on_idle().wait().map_err(|_| "failed to shutdown the thread pool")?;
+    pool.shutdown_on_idle()
+        .wait()
+        .map_err(|_| "failed to shutdown the thread pool")?;
     Ok(())
 }

--- a/tokio-fs/src/create_dir.rs
+++ b/tokio-fs/src/create_dir.rs
@@ -17,30 +17,28 @@ pub fn create_dir<P: AsRef<Path>>(path: P) -> CreateDirFuture<P> {
 #[derive(Debug)]
 pub struct CreateDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
 }
 
 impl<P> CreateDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P) -> CreateDirFuture<P> {
-        CreateDirFuture {
-            path: path,
-        }
+        CreateDirFuture { path: path }
     }
 }
 
 impl<P> Future for CreateDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::create_dir(&self.path) )
+        ::blocking_io(|| fs::create_dir(&self.path))
     }
 }

--- a/tokio-fs/src/create_dir_all.rs
+++ b/tokio-fs/src/create_dir_all.rs
@@ -18,30 +18,28 @@ pub fn create_dir_all<P: AsRef<Path>>(path: P) -> CreateDirAllFuture<P> {
 #[derive(Debug)]
 pub struct CreateDirAllFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
 }
 
 impl<P> CreateDirAllFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P) -> CreateDirAllFuture<P> {
-        CreateDirAllFuture {
-            path: path,
-        }
+        CreateDirAllFuture { path: path }
     }
 }
 
 impl<P> Future for CreateDirAllFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::create_dir_all(&self.path) )
+        ::blocking_io(|| fs::create_dir_all(&self.path))
     }
 }

--- a/tokio-fs/src/file/create.rs
+++ b/tokio-fs/src/file/create.rs
@@ -13,7 +13,8 @@ pub struct CreateFuture<P> {
 }
 
 impl<P> CreateFuture<P>
-where P: AsRef<Path> + Send + 'static,
+where
+    P: AsRef<Path> + Send + 'static,
 {
     pub(crate) fn new(path: P) -> Self {
         CreateFuture { path }
@@ -21,15 +22,14 @@ where P: AsRef<Path> + Send + 'static,
 }
 
 impl<P> Future for CreateFuture<P>
-where P: AsRef<Path> + Send + 'static,
+where
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = File;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let std = try_ready!(::blocking_io(|| {
-            StdFile::create(&self.path)
-        }));
+        let std = try_ready!(::blocking_io(|| StdFile::create(&self.path)));
 
         let file = File::from_std(std);
         Ok(file.into())

--- a/tokio-fs/src/file/metadata.rs
+++ b/tokio-fs/src/file/metadata.rs
@@ -29,9 +29,7 @@ impl Future for MetadataFuture {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let metadata = try_ready!(::blocking_io(|| {
-            StdFile::metadata(self.std())
-        }));
+        let metadata = try_ready!(::blocking_io(|| StdFile::metadata(self.std())));
 
         let file = self.file.take().expect(POLL_AFTER_RESOLVE);
         Ok((file, metadata).into())

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -21,7 +21,7 @@ use tokio_io::{AsyncRead, AsyncWrite};
 use futures::Poll;
 
 use std::fs::{File as StdFile, Metadata, Permissions};
-use std::io::{self, Read, Write, Seek};
+use std::io::{self, Read, Seek, Write};
 use std::path::Path;
 
 /// A reference to an open file on the filesystem.
@@ -43,16 +43,16 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-/// 
+///
 /// use tokio::prelude::{AsyncWrite, Future};
-/// 
+///
 /// fn main() {
 ///     let task = tokio::fs::File::create("foo.txt")
 ///         .and_then(|mut file| file.poll_write(b"hello, world!"))
 ///         .map(|res| {
 ///             println!("{:?}", res);
 ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-/// 
+///
 ///     tokio::run(task);
 /// }
 /// ```
@@ -61,9 +61,9 @@ use std::path::Path;
 ///
 /// ```no_run
 /// extern crate tokio;
-/// 
+///
 /// use tokio::prelude::{AsyncRead, Future};
-/// 
+///
 /// fn main() {
 ///     let task = tokio::fs::File::open("foo.txt")
 ///         .and_then(|mut file| {
@@ -112,7 +112,8 @@ impl File {
     /// }
     /// ```
     pub fn open<P>(path: P) -> OpenFuture<P>
-    where P: AsRef<Path> + Send + 'static,
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         OpenOptions::new().read(true).open(path)
     }
@@ -151,7 +152,8 @@ impl File {
     /// }
     /// ```
     pub fn create<P>(path: P) -> CreateFuture<P>
-    where P: AsRef<Path> + Send + 'static,
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         CreateFuture::new(path)
     }
@@ -165,7 +167,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use std::fs::File;
-    /// 
+    ///
     /// fn main() {
     ///     let std_file = File::open("foo.txt").unwrap();
     ///     let file = tokio::fs::File::from_std(std_file);
@@ -194,7 +196,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::open("foo.txt")
     ///         // move cursor 6 bytes from the start of the file
@@ -202,7 +204,7 @@ impl File {
     ///         .map(|res| {
     ///             println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -223,7 +225,7 @@ impl File {
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
     /// use std::io::SeekFrom;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.seek(SeekFrom::Start(6)))
@@ -231,7 +233,7 @@ impl File {
     ///             // handle returned file ..
     ///             # println!("{:?}", file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -249,7 +251,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -260,7 +262,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -282,7 +284,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::{AsyncWrite, Future};
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -293,7 +295,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -318,7 +320,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| {
@@ -328,7 +330,7 @@ impl File {
     ///             // handle returned result ..
     ///             # println!("{:?}", res);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -343,14 +345,14 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
     ///         .map(|metadata| {
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -365,7 +367,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_metadata())
@@ -373,7 +375,7 @@ impl File {
     ///             // metadata is of type Async::Ready<Metadata>
     ///             println!("{:?}", metadata);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -390,7 +392,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|mut file| file.poll_try_clone())
@@ -398,7 +400,7 @@ impl File {
     ///             // do something with the clone
     ///             # println!("{:?}", clone);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -462,7 +464,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .and_then(|file| file.metadata())
@@ -474,7 +476,7 @@ impl File {
     ///                 _ => println!("permissions set!"),
     ///             }
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```
@@ -495,7 +497,7 @@ impl File {
     /// ```no_run
     /// # extern crate tokio;
     /// use tokio::prelude::Future;
-    /// 
+    ///
     /// fn main() {
     ///     let task = tokio::fs::File::create("foo.txt")
     ///         .map(|file| {
@@ -503,7 +505,7 @@ impl File {
     ///             // do something with the std::fs::File
     ///             # println!("{:?}", std_file);
     ///         }).map_err(|err| eprintln!("IO error: {:?}", err));
-    /// 
+    ///
     ///     tokio::run(task);
     /// }
     /// ```

--- a/tokio-fs/src/file/open.rs
+++ b/tokio-fs/src/file/open.rs
@@ -14,7 +14,8 @@ pub struct OpenFuture<P> {
 }
 
 impl<P> OpenFuture<P>
-where P: AsRef<Path> + Send + 'static,
+where
+    P: AsRef<Path> + Send + 'static,
 {
     pub(crate) fn new(options: StdOpenOptions, path: P) -> Self {
         OpenFuture { options, path }
@@ -22,15 +23,14 @@ where P: AsRef<Path> + Send + 'static,
 }
 
 impl<P> Future for OpenFuture<P>
-where P: AsRef<Path> + Send + 'static,
+where
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = File;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let std = try_ready!(::blocking_io(|| {
-            self.options.open(&self.path)
-        }));
+        let std = try_ready!(::blocking_io(|| self.options.open(&self.path)));
 
         let file = File::from_std(std);
         Ok(file.into())

--- a/tokio-fs/src/file/open_options.rs
+++ b/tokio-fs/src/file/open_options.rs
@@ -90,7 +90,8 @@ impl OpenOptions {
     ///
     /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
     pub fn open<P>(&self, path: P) -> OpenFuture<P>
-    where P: AsRef<Path> + Send + 'static
+    where
+        P: AsRef<Path> + Send + 'static,
     {
         OpenFuture::new(self.0.clone(), path)
     }

--- a/tokio-fs/src/file/seek.rs
+++ b/tokio-fs/src/file/seek.rs
@@ -25,12 +25,11 @@ impl Future for SeekFuture {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let pos = try_ready!(
-            self.inner
-                .as_mut()
-                .expect("Cannot poll `SeekFuture` after it resolves")
-                .poll_seek(self.pos)
-        );
+        let pos = try_ready!(self
+            .inner
+            .as_mut()
+            .expect("Cannot poll `SeekFuture` after it resolves")
+            .poll_seek(self.pos));
         let inner = self.inner.take().unwrap();
         Ok((inner, pos).into())
     }

--- a/tokio-fs/src/hard_link.rs
+++ b/tokio-fs/src/hard_link.rs
@@ -21,7 +21,7 @@ pub fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> HardLinkFutu
 pub struct HardLinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     src: P,
     dst: Q,
@@ -30,25 +30,22 @@ where
 impl<P, Q> HardLinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> HardLinkFuture<P, Q> {
-        HardLinkFuture {
-            src: src,
-            dst: dst,
-        }
+        HardLinkFuture { src: src, dst: dst }
     }
 }
 
 impl<P, Q> Future for HardLinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::hard_link(&self.src, &self.dst) )
+        ::blocking_io(|| fs::hard_link(&self.src, &self.dst))
     }
 }

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -39,16 +39,16 @@ pub mod file;
 mod hard_link;
 mod metadata;
 pub mod os;
+mod read;
 mod read_dir;
 mod read_link;
-mod read;
 mod remove_dir;
 mod remove_file;
 mod rename;
 mod set_permissions;
+mod stderr;
 mod stdin;
 mod stdout;
-mod stderr;
 mod symlink_metadata;
 mod write;
 
@@ -58,27 +58,28 @@ pub use file::File;
 pub use file::OpenOptions;
 pub use hard_link::{hard_link, HardLinkFuture};
 pub use metadata::{metadata, MetadataFuture};
-pub use read_dir::{read_dir, ReadDirFuture, ReadDir, DirEntry};
-pub use read_link::{read_link, ReadLinkFuture};
 pub use read::{read, ReadFile};
+pub use read_dir::{read_dir, DirEntry, ReadDir, ReadDirFuture};
+pub use read_link::{read_link, ReadLinkFuture};
 pub use remove_dir::{remove_dir, RemoveDirFuture};
 pub use remove_file::{remove_file, RemoveFileFuture};
 pub use rename::{rename, RenameFuture};
 pub use set_permissions::{set_permissions, SetPermissionsFuture};
+pub use stderr::{stderr, Stderr};
 pub use stdin::{stdin, Stdin};
 pub use stdout::{stdout, Stdout};
-pub use stderr::{stderr, Stderr};
 pub use symlink_metadata::{symlink_metadata, SymlinkMetadataFuture};
 pub use write::{write, WriteFile};
 
-use futures::Poll;
 use futures::Async::*;
+use futures::Poll;
 
 use std::io;
 use std::io::ErrorKind::{Other, WouldBlock};
 
 fn blocking_io<F, T>(f: F) -> Poll<T, io::Error>
-where F: FnOnce() -> io::Result<T>,
+where
+    F: FnOnce() -> io::Result<T>,
 {
     match tokio_threadpool::blocking(f) {
         Ok(Ready(Ok(v))) => Ok(v.into()),
@@ -89,7 +90,8 @@ where F: FnOnce() -> io::Result<T>,
 }
 
 fn would_block<F, T>(f: F) -> io::Result<T>
-where F: FnOnce() -> io::Result<T>,
+where
+    F: FnOnce() -> io::Result<T>,
 {
     match tokio_threadpool::blocking(f) {
         Ok(Ready(Ok(v))) => Ok(v),
@@ -103,6 +105,9 @@ where F: FnOnce() -> io::Result<T>,
 }
 
 fn blocking_err() -> io::Error {
-    io::Error::new(Other, "`blocking` annotated I/O must be called \
-                   from the context of the Tokio runtime.")
+    io::Error::new(
+        Other,
+        "`blocking` annotated I/O must be called \
+         from the context of the Tokio runtime.",
+    )
 }

--- a/tokio-fs/src/os/unix.rs
+++ b/tokio-fs/src/os/unix.rs
@@ -1,8 +1,8 @@
 //! Unix-specific extensions to primitives in the `tokio_fs` module.
 
 use std::io;
-use std::path::Path;
 use std::os::unix::fs;
+use std::path::Path;
 
 use futures::{Future, Poll};
 
@@ -22,7 +22,7 @@ pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkFuture<
 pub struct SymlinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     src: P,
     dst: Q,
@@ -31,25 +31,22 @@ where
 impl<P, Q> SymlinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkFuture<P, Q> {
-        SymlinkFuture {
-            src: src,
-            dst: dst,
-        }
+        SymlinkFuture { src: src, dst: dst }
     }
 }
 
 impl<P, Q> Future for SymlinkFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::symlink(&self.src, &self.dst) )
+        ::blocking_io(|| fs::symlink(&self.src, &self.dst))
     }
 }

--- a/tokio-fs/src/os/windows/symlink_dir.rs
+++ b/tokio-fs/src/os/windows/symlink_dir.rs
@@ -1,6 +1,6 @@
 use std::io;
-use std::path::Path;
 use std::os::windows::fs;
+use std::path::Path;
 
 use futures::{Future, Poll};
 
@@ -21,7 +21,7 @@ pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkDir
 pub struct SymlinkDirFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     src: P,
     dst: Q,
@@ -30,25 +30,22 @@ where
 impl<P, Q> SymlinkDirFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkDirFuture<P, Q> {
-        SymlinkDirFuture {
-            src: src,
-            dst: dst,
-        }
+        SymlinkDirFuture { src: src, dst: dst }
     }
 }
 
 impl<P, Q> Future for SymlinkDirFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::symlink_dir(&self.src, &self.dst) )
+        ::blocking_io(|| fs::symlink_dir(&self.src, &self.dst))
     }
 }

--- a/tokio-fs/src/os/windows/symlink_file.rs
+++ b/tokio-fs/src/os/windows/symlink_file.rs
@@ -1,6 +1,6 @@
 use std::io;
-use std::path::Path;
 use std::os::windows::fs;
+use std::path::Path;
 
 use futures::{Future, Poll};
 
@@ -21,7 +21,7 @@ pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkFi
 pub struct SymlinkFileFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     src: P,
     dst: Q,
@@ -30,25 +30,22 @@ where
 impl<P, Q> SymlinkFileFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkFileFuture<P, Q> {
-        SymlinkFileFuture {
-            src: src,
-            dst: dst,
-        }
+        SymlinkFileFuture { src: src, dst: dst }
     }
 }
 
 impl<P, Q> Future for SymlinkFileFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::symlink_file(&self.src, &self.dst) )
+        ::blocking_io(|| fs::symlink_file(&self.src, &self.dst))
     }
 }

--- a/tokio-fs/src/read.rs
+++ b/tokio-fs/src/read.rs
@@ -1,7 +1,7 @@
-use {file, File};
 use futures::{Async, Future, Poll};
 use std::{io, mem, path::Path};
 use tokio_io;
+use {file, File};
 
 /// Creates a future which will open a file for reading and read the entire
 /// contents into a buffer and return said buffer.

--- a/tokio-fs/src/read_dir.rs
+++ b/tokio-fs/src/read_dir.rs
@@ -1,5 +1,5 @@
 use std::ffi::OsString;
-use std::fs::{self, DirEntry as StdDirEntry, ReadDir as StdReadDir, FileType, Metadata};
+use std::fs::{self, DirEntry as StdDirEntry, FileType, Metadata, ReadDir as StdReadDir};
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::DirEntryExt;
@@ -30,12 +30,10 @@ where
 
 impl<P> ReadDirFuture<P>
 where
-    P: AsRef<Path> + Send + 'static
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> ReadDirFuture<P> {
-        ReadDirFuture {
-            path: path,
-        }
+        ReadDirFuture { path: path }
     }
 }
 
@@ -75,12 +73,10 @@ impl Stream for ReadDir {
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        ::blocking_io(|| {
-            match self.0.next() {
-                Some(Err(err)) => Err(err),
-                Some(Ok(item)) => Ok(Some(DirEntry(item))),
-                None => Ok(None)
-            }
+        ::blocking_io(|| match self.0.next() {
+            Some(Err(err)) => Err(err),
+            Some(Ok(item)) => Ok(Some(DirEntry(item))),
+            None => Ok(None),
         })
     }
 }

--- a/tokio-fs/src/read_link.rs
+++ b/tokio-fs/src/read_link.rs
@@ -17,30 +17,28 @@ pub fn read_link<P: AsRef<Path>>(path: P) -> ReadLinkFuture<P> {
 #[derive(Debug)]
 pub struct ReadLinkFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
 }
 
 impl<P> ReadLinkFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P) -> ReadLinkFuture<P> {
-        ReadLinkFuture {
-            path: path,
-        }
+        ReadLinkFuture { path: path }
     }
 }
 
 impl<P> Future for ReadLinkFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = PathBuf;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::read_link(&self.path) )
+        ::blocking_io(|| fs::read_link(&self.path))
     }
 }

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -17,30 +17,28 @@ pub fn remove_dir<P: AsRef<Path>>(path: P) -> RemoveDirFuture<P> {
 #[derive(Debug)]
 pub struct RemoveDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
 }
 
 impl<P> RemoveDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P) -> RemoveDirFuture<P> {
-        RemoveDirFuture {
-            path: path,
-        }
+        RemoveDirFuture { path: path }
     }
 }
 
 impl<P> Future for RemoveDirFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::remove_dir(&self.path) )
+        ::blocking_io(|| fs::remove_dir(&self.path))
     }
 }

--- a/tokio-fs/src/remove_file.rs
+++ b/tokio-fs/src/remove_file.rs
@@ -21,30 +21,28 @@ pub fn remove_file<P: AsRef<Path>>(path: P) -> RemoveFileFuture<P> {
 #[derive(Debug)]
 pub struct RemoveFileFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
 }
 
 impl<P> RemoveFileFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P) -> RemoveFileFuture<P> {
-        RemoveFileFuture {
-            path: path,
-        }
+        RemoveFileFuture { path: path }
     }
 }
 
 impl<P> Future for RemoveFileFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::remove_file(&self.path) )
+        ::blocking_io(|| fs::remove_file(&self.path))
     }
 }

--- a/tokio-fs/src/rename.rs
+++ b/tokio-fs/src/rename.rs
@@ -21,7 +21,7 @@ pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> RenameFuture<P,
 pub struct RenameFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     from: P,
     to: Q,
@@ -30,25 +30,22 @@ where
 impl<P, Q> RenameFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     fn new(from: P, to: Q) -> RenameFuture<P, Q> {
-        RenameFuture {
-            from: from,
-            to: to,
-        }
+        RenameFuture { from: from, to: to }
     }
 }
 
 impl<P, Q> Future for RenameFuture<P, Q>
 where
     P: AsRef<Path>,
-    Q: AsRef<Path>
+    Q: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::rename(&self.from, &self.to) )
+        ::blocking_io(|| fs::rename(&self.from, &self.to))
     }
 }

--- a/tokio-fs/src/set_permissions.rs
+++ b/tokio-fs/src/set_permissions.rs
@@ -17,7 +17,7 @@ pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> SetPer
 #[derive(Debug)]
 pub struct SetPermissionsFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     path: P,
     perm: fs::Permissions,
@@ -25,7 +25,7 @@ where
 
 impl<P> SetPermissionsFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     fn new(path: P, perm: fs::Permissions) -> SetPermissionsFuture<P> {
         SetPermissionsFuture {
@@ -37,12 +37,12 @@ where
 
 impl<P> Future for SetPermissionsFuture<P>
 where
-    P: AsRef<Path>
+    P: AsRef<Path>,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        ::blocking_io(|| fs::set_permissions(&self.path, self.perm.clone()) )
+        ::blocking_io(|| fs::set_permissions(&self.path, self.perm.clone()))
     }
 }

--- a/tokio-fs/src/stderr.rs
+++ b/tokio-fs/src/stderr.rs
@@ -1,8 +1,8 @@
-use tokio_io::{AsyncWrite};
+use tokio_io::AsyncWrite;
 
 use futures::Poll;
 
-use std::io::{self, Write, Stderr as StdStderr};
+use std::io::{self, Stderr as StdStderr, Write};
 
 /// A handle to the standard error stream of a process.
 ///
@@ -42,4 +42,3 @@ impl AsyncWrite for Stderr {
         Ok(().into())
     }
 }
-

--- a/tokio-fs/src/stdin.rs
+++ b/tokio-fs/src/stdin.rs
@@ -1,4 +1,4 @@
-use tokio_io::{AsyncRead};
+use tokio_io::AsyncRead;
 
 use std::io::{self, Read, Stdin as StdStdin};
 

--- a/tokio-fs/src/stdout.rs
+++ b/tokio-fs/src/stdout.rs
@@ -1,8 +1,8 @@
-use tokio_io::{AsyncWrite};
+use tokio_io::AsyncWrite;
 
 use futures::Poll;
 
-use std::io::{self, Write, Stdout as StdStdout};
+use std::io::{self, Stdout as StdStdout, Write};
 
 /// A handle to the standard output stream of a process.
 ///

--- a/tokio-fs/src/write.rs
+++ b/tokio-fs/src/write.rs
@@ -1,7 +1,7 @@
-use {file, File};
 use futures::{Async, Future, Poll};
-use std::{io, mem, path::Path, fmt};
+use std::{fmt, io, mem, path::Path};
 use tokio_io;
+use {file, File};
 
 /// Creates a future that will open a file for writing and write the entire
 /// contents of `contents` to it.

--- a/tokio-io/src/_tokio_codec/framed_read.rs
+++ b/tokio-io/src/_tokio_codec/framed_read.rs
@@ -2,12 +2,12 @@
 
 use std::fmt;
 
-use AsyncRead;
-use codec::Decoder;
 use super::framed::Fuse;
+use codec::Decoder;
+use AsyncRead;
 
-use futures::{Async, Poll, Stream, Sink, StartSend};
 use bytes::BytesMut;
+use futures::{Async, Poll, Sink, StartSend, Stream};
 
 /// A `Stream` of messages decoded from an `AsyncRead`.
 pub struct FramedRead<T, D> {
@@ -26,8 +26,9 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 // ===== impl FramedRead =====
 
 impl<T, D> FramedRead<T, D>
-    where T: AsyncRead,
-          D: Decoder,
+where
+    T: AsyncRead,
+    D: Decoder,
 {
     /// Creates a new `FramedRead` with the given `decoder`.
     pub fn new(inner: T, decoder: D) -> FramedRead<T, D> {
@@ -79,8 +80,9 @@ impl<T, D> FramedRead<T, D> {
 }
 
 impl<T, D> Stream for FramedRead<T, D>
-    where T: AsyncRead,
-          D: Decoder,
+where
+    T: AsyncRead,
+    D: Decoder,
 {
     type Item = D::Item;
     type Error = D::Error;
@@ -91,15 +93,13 @@ impl<T, D> Stream for FramedRead<T, D>
 }
 
 impl<T, D> Sink for FramedRead<T, D>
-    where T: Sink,
+where
+    T: Sink,
 {
     type SinkItem = T::SinkItem;
     type SinkError = T::SinkError;
 
-    fn start_send(&mut self,
-                  item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, Self::SinkError>
-    {
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
         self.inner.inner.0.start_send(item)
     }
 
@@ -113,8 +113,9 @@ impl<T, D> Sink for FramedRead<T, D>
 }
 
 impl<T, D> fmt::Debug for FramedRead<T, D>
-    where T: fmt::Debug,
-          D: fmt::Debug,
+where
+    T: fmt::Debug,
+    D: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FramedRead")
@@ -170,7 +171,8 @@ impl<T> FramedRead2<T> {
 }
 
 impl<T> Stream for FramedRead2<T>
-    where T: AsyncRead + Decoder,
+where
+    T: AsyncRead + Decoder,
 {
     type Item = T::Item;
     type Error = T::Error;

--- a/tokio-io/src/_tokio_codec/framed_write.rs
+++ b/tokio-io/src/_tokio_codec/framed_write.rs
@@ -1,14 +1,14 @@
 #![allow(deprecated)]
 
-use std::io::{self, Read};
 use std::fmt;
+use std::io::{self, Read};
 
-use {AsyncRead, AsyncWrite};
-use codec::{Decoder, Encoder};
 use super::framed::Fuse;
+use codec::{Decoder, Encoder};
+use {AsyncRead, AsyncWrite};
 
-use futures::{Async, AsyncSink, Poll, Stream, Sink, StartSend};
 use bytes::BytesMut;
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 /// A `Sink` of frames encoded to an `AsyncWrite`.
 pub struct FramedWrite<T, E> {
@@ -24,8 +24,9 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 const BACKPRESSURE_BOUNDARY: usize = INITIAL_CAPACITY;
 
 impl<T, E> FramedWrite<T, E>
-    where T: AsyncWrite,
-          E: Encoder,
+where
+    T: AsyncWrite,
+    E: Encoder,
 {
     /// Creates a new `FramedWrite` with the given `encoder`.
     pub fn new(inner: T, encoder: E) -> FramedWrite<T, E> {
@@ -77,8 +78,9 @@ impl<T, E> FramedWrite<T, E> {
 }
 
 impl<T, E> Sink for FramedWrite<T, E>
-    where T: AsyncWrite,
-          E: Encoder,
+where
+    T: AsyncWrite,
+    E: Encoder,
 {
     type SinkItem = E::Item;
     type SinkError = E::Error;
@@ -97,7 +99,8 @@ impl<T, E> Sink for FramedWrite<T, E>
 }
 
 impl<T, D> Stream for FramedWrite<T, D>
-    where T: Stream,
+where
+    T: Stream,
 {
     type Item = T::Item;
     type Error = T::Error;
@@ -108,15 +111,16 @@ impl<T, D> Stream for FramedWrite<T, D>
 }
 
 impl<T, U> fmt::Debug for FramedWrite<T, U>
-    where T: fmt::Debug,
-          U: fmt::Debug,
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FramedWrite")
-         .field("inner", &self.inner.get_ref().0)
-         .field("encoder", &self.inner.get_ref().1)
-         .field("buffer", &self.inner.buffer)
-         .finish()
+            .field("inner", &self.inner.get_ref().0)
+            .field("encoder", &self.inner.get_ref().1)
+            .field("buffer", &self.inner.buffer)
+            .finish()
     }
 }
 
@@ -159,7 +163,8 @@ impl<T> FramedWrite2<T> {
 }
 
 impl<T> Sink for FramedWrite2<T>
-    where T: AsyncWrite + Encoder,
+where
+    T: AsyncWrite + Encoder,
 {
     type SinkItem = T::Item;
     type SinkError = T::Error;
@@ -189,8 +194,12 @@ impl<T> Sink for FramedWrite2<T>
             let n = try_ready!(self.inner.poll_write(&self.buffer));
 
             if n == 0 {
-                return Err(io::Error::new(io::ErrorKind::WriteZero, "failed to \
-                                          write frame to transport").into());
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to \
+                     write frame to transport",
+                )
+                .into());
             }
 
             // TODO: Add a way to `bytes` to do this w/o returning the drained

--- a/tokio-io/src/allow_std.rs
+++ b/tokio-io/src/allow_std.rs
@@ -1,6 +1,6 @@
-use {AsyncRead, AsyncWrite};
 use futures::{Async, Poll};
 use std::{fmt, io};
+use {AsyncRead, AsyncWrite};
 
 /// A simple wrapper type which allows types that only implement
 /// `std::io::Read` or `std::io::Write` to be used in contexts which expect
@@ -37,7 +37,10 @@ impl<T> AllowStdIo<T> {
     }
 }
 
-impl<T> io::Write for AllowStdIo<T> where T: io::Write {
+impl<T> io::Write for AllowStdIo<T>
+where
+    T: io::Write,
+{
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.0.write(buf)
     }
@@ -52,13 +55,19 @@ impl<T> io::Write for AllowStdIo<T> where T: io::Write {
     }
 }
 
-impl<T> AsyncWrite for AllowStdIo<T> where T: io::Write {
+impl<T> AsyncWrite for AllowStdIo<T>
+where
+    T: io::Write,
+{
     fn shutdown(&mut self) -> Poll<(), io::Error> {
         Ok(Async::Ready(()))
     }
 }
 
-impl<T> io::Read for AllowStdIo<T> where T: io::Read {
+impl<T> io::Read for AllowStdIo<T>
+where
+    T: io::Read,
+{
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.0.read(buf)
     }
@@ -75,7 +84,10 @@ impl<T> io::Read for AllowStdIo<T> where T: io::Read {
     }
 }
 
-impl<T> AsyncRead for AllowStdIo<T> where T: io::Read {
+impl<T> AsyncRead for AllowStdIo<T>
+where
+    T: io::Read,
+{
     // TODO: override prepare_uninitialized_buffer once `Read::initializer` is stable.
     // See rust-lang/rust #42788
 }

--- a/tokio-io/src/async_read.rs
+++ b/tokio-io/src/async_read.rs
@@ -1,11 +1,11 @@
-use std::io as std_io;
 use bytes::BufMut;
 use futures::{Async, Poll};
+use std::io as std_io;
 
-use {framed, split, AsyncWrite};
 #[allow(deprecated)]
 use codec::{Decoder, Encoder, Framed};
 use split::{ReadHalf, WriteHalf};
+use {framed, split, AsyncWrite};
 
 /// Read bytes asynchronously.
 ///
@@ -80,9 +80,7 @@ pub trait AsyncRead: std_io::Read {
     fn poll_read(&mut self, buf: &mut [u8]) -> Poll<usize, std_io::Error> {
         match self.read(buf) {
             Ok(t) => Ok(Async::Ready(t)),
-            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => {
-                return Ok(Async::NotReady)
-            }
+            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => return Ok(Async::NotReady),
             Err(e) => return Err(e.into()),
         }
     }
@@ -94,7 +92,8 @@ pub trait AsyncRead: std_io::Read {
     /// will be advanced if any bytes were read. Note that this method typically
     /// will not reallocate the buffer provided.
     fn read_buf<B: BufMut>(&mut self, buf: &mut B) -> Poll<usize, std_io::Error>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         if !buf.has_remaining_mut() {
             return Ok(Async::Ready(0));
@@ -134,7 +133,8 @@ pub trait AsyncRead: std_io::Read {
     #[deprecated(since = "0.1.7", note = "Use tokio_codec::Decoder::framed instead")]
     #[allow(deprecated)]
     fn framed<T: Encoder + Decoder>(self, codec: T) -> Framed<Self, T>
-        where Self: AsyncWrite + Sized,
+    where
+        Self: AsyncWrite + Sized,
     {
         framed::framed(self, codec)
     }
@@ -144,7 +144,8 @@ pub trait AsyncRead: std_io::Read {
     /// The two halves returned implement the `Read` and `Write` traits,
     /// respectively.
     fn split(self) -> (ReadHalf<Self>, WriteHalf<Self>)
-        where Self: AsyncWrite + Sized,
+    where
+        Self: AsyncWrite + Sized,
     {
         split::split(self)
     }

--- a/tokio-io/src/async_write.rs
+++ b/tokio-io/src/async_write.rs
@@ -1,6 +1,6 @@
-use std::io as std_io;
 use bytes::Buf;
 use futures::{Async, Poll};
+use std::io as std_io;
 
 use AsyncRead;
 
@@ -46,9 +46,7 @@ pub trait AsyncWrite: std_io::Write {
     fn poll_write(&mut self, buf: &[u8]) -> Poll<usize, std_io::Error> {
         match self.write(buf) {
             Ok(t) => Ok(Async::Ready(t)),
-            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => {
-                return Ok(Async::NotReady)
-            }
+            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => return Ok(Async::NotReady),
             Err(e) => return Err(e.into()),
         }
     }
@@ -65,9 +63,7 @@ pub trait AsyncWrite: std_io::Write {
     fn poll_flush(&mut self) -> Poll<(), std_io::Error> {
         match self.flush() {
             Ok(t) => Ok(Async::Ready(t)),
-            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => {
-                return Ok(Async::NotReady)
-            }
+            Err(ref e) if e.kind() == std_io::ErrorKind::WouldBlock => return Ok(Async::NotReady),
             Err(e) => return Err(e.into()),
         }
     }
@@ -137,7 +133,8 @@ pub trait AsyncWrite: std_io::Write {
     /// Note that this method will advance the `buf` provided automatically by
     /// the number of bytes written.
     fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, std_io::Error>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         if !buf.has_remaining() {
             return Ok(Async::Ready(0));
@@ -179,8 +176,9 @@ impl<T: AsyncRead> AsyncRead for std_io::Take<T> {
 }
 
 impl<T, U> AsyncRead for std_io::Chain<T, U>
-    where T: AsyncRead,
-          U: AsyncRead,
+where
+    T: AsyncRead,
+    U: AsyncRead,
 {
     unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
         let (t, u) = self.get_ref();
@@ -203,8 +201,7 @@ impl<T: AsyncRead> AsyncRead for std_io::BufReader<T> {
     }
 }
 
-impl<T: AsRef<[u8]>> AsyncRead for std_io::Cursor<T> {
-}
+impl<T: AsRef<[u8]>> AsyncRead for std_io::Cursor<T> {}
 
 impl<'a> AsyncWrite for std_io::Cursor<&'a mut [u8]> {
     fn shutdown(&mut self) -> Poll<(), std_io::Error> {

--- a/tokio-io/src/codec/bytes_codec.rs
+++ b/tokio-io/src/codec/bytes_codec.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 
-use bytes::{Bytes, BufMut, BytesMut};
-use codec::{Encoder, Decoder};
+use bytes::{BufMut, Bytes, BytesMut};
+use codec::{Decoder, Encoder};
 use std::io;
 
 /// A simple `Codec` implementation that just ships bytes around.
@@ -11,7 +11,9 @@ pub struct BytesCodec(());
 
 impl BytesCodec {
     /// Creates a new `BytesCodec` for shipping around raw bytes.
-    pub fn new() -> BytesCodec { BytesCodec(())  }
+    pub fn new() -> BytesCodec {
+        BytesCodec(())
+    }
 }
 
 impl Decoder for BytesCodec {

--- a/tokio-io/src/codec/decoder.rs
+++ b/tokio-io/src/codec/decoder.rs
@@ -1,10 +1,10 @@
-use std::io;
 use bytes::BytesMut;
+use std::io;
 
-use {AsyncWrite, AsyncRead};
 use super::encoder::Encoder;
+use {AsyncRead, AsyncWrite};
 
-use ::_tokio_codec::Framed;
+use _tokio_codec::Framed;
 
 /// Decoding of frames via buffers.
 ///
@@ -85,8 +85,7 @@ pub trait Decoder {
                 if buf.is_empty() {
                     Ok(None)
                 } else {
-                    Err(io::Error::new(io::ErrorKind::Other,
-                                       "bytes remaining on stream").into())
+                    Err(io::Error::new(io::ErrorKind::Other, "bytes remaining on stream").into())
                 }
             }
         }
@@ -110,7 +109,8 @@ pub trait Decoder {
     /// calling `split` on the `Framed` returned by this method, which will
     /// break them into separate objects, allowing them to interact more easily.
     fn framed<T: AsyncRead + AsyncWrite + Sized>(self, io: T) -> Framed<T, Self>
-        where Self: Encoder + Sized,
+    where
+        Self: Encoder + Sized,
     {
         Framed::new(io, self)
     }

--- a/tokio-io/src/codec/encoder.rs
+++ b/tokio-io/src/codec/encoder.rs
@@ -1,5 +1,5 @@
-use std::io;
 use bytes::BytesMut;
+use std::io;
 
 /// Trait of helper objects to write out messages as bytes, for use with
 /// `FramedWrite`.
@@ -21,6 +21,5 @@ pub trait Encoder {
     /// This method will encode `item` into the byte buffer provided by `dst`.
     /// The `dst` provided is an internal buffer of the `Framed` instance and
     /// will be written out when possible.
-    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut)
-              -> Result<(), Self::Error>;
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
 }

--- a/tokio-io/src/codec/lines_codec.rs
+++ b/tokio-io/src/codec/lines_codec.rs
@@ -1,7 +1,7 @@
 #![allow(deprecated)]
 
 use bytes::{BufMut, BytesMut};
-use codec::{Encoder, Decoder};
+use codec::{Decoder, Encoder};
 use std::{io, str};
 
 /// A simple `Codec` implementation that splits up data into lines.
@@ -25,10 +25,8 @@ impl LinesCodec {
 }
 
 fn utf8(buf: &[u8]) -> Result<&str, io::Error> {
-    str::from_utf8(buf).map_err(|_|
-        io::Error::new(
-            io::ErrorKind::InvalidData,
-            "Unable to decode input as UTF8"))
+    str::from_utf8(buf)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "Unable to decode input as UTF8"))
 }
 
 fn without_carriage_return(s: &[u8]) -> &[u8] {
@@ -44,12 +42,10 @@ impl Decoder for LinesCodec {
     type Error = io::Error;
 
     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
-        if let Some(newline_offset) =
-            buf[self.next_index..].iter().position(|b| *b == b'\n')
-        {
+        if let Some(newline_offset) = buf[self.next_index..].iter().position(|b| *b == b'\n') {
             let newline_index = newline_offset + self.next_index;
             let line = buf.split_to(newline_index + 1);
-            let line = &line[..line.len()-1];
+            let line = &line[..line.len() - 1];
             let line = without_carriage_return(line);
             let line = utf8(line)?;
             self.next_index = 0;

--- a/tokio-io/src/codec/mod.rs
+++ b/tokio-io/src/codec/mod.rs
@@ -18,14 +18,14 @@
 #![doc(hidden)]
 #![allow(deprecated)]
 
+mod bytes_codec;
 mod decoder;
 mod encoder;
-mod bytes_codec;
 mod lines_codec;
 
+pub use self::bytes_codec::BytesCodec;
 pub use self::decoder::Decoder;
 pub use self::encoder::Encoder;
-pub use self::bytes_codec::BytesCodec;
 pub use self::lines_codec::LinesCodec;
 
 pub use framed::{Framed, FramedParts};
@@ -374,5 +374,5 @@ pub mod length_delimited {
     //! [`Encoder`]: ../trait.Encoder.html
     //! [`BytesMut`]: https://docs.rs/bytes/0.4/bytes/struct.BytesMut.html
 
-    pub use ::length_delimited::*;
+    pub use length_delimited::*;
 }

--- a/tokio-io/src/framed.rs
+++ b/tokio-io/src/framed.rs
@@ -1,15 +1,15 @@
 #![allow(deprecated)]
 
-use std::io::{self, Read, Write};
 use std::fmt;
+use std::io::{self, Read, Write};
 
-use {AsyncRead, AsyncWrite};
 use codec::{Decoder, Encoder};
 use framed_read::{framed_read2, framed_read2_with_buffer, FramedRead2};
 use framed_write::{framed_write2, framed_write2_with_buffer, FramedWrite2};
+use {AsyncRead, AsyncWrite};
 
-use futures::{Stream, Sink, StartSend, Poll};
-use bytes::{BytesMut};
+use bytes::BytesMut;
+use futures::{Poll, Sink, StartSend, Stream};
 
 /// A unified `Stream` and `Sink` interface to an underlying I/O object, using
 /// the `Encoder` and `Decoder` traits to encode and decode frames.
@@ -26,8 +26,9 @@ pub struct Framed<T, U> {
 pub struct Fuse<T, U>(pub T, pub U);
 
 pub fn framed<T, U>(inner: T, codec: U) -> Framed<T, U>
-    where T: AsyncRead + AsyncWrite,
-          U: Decoder + Encoder,
+where
+    T: AsyncRead + AsyncWrite,
+    U: Decoder + Encoder,
 {
     Framed {
         inner: framed_read2(framed_write2(Fuse(inner, codec))),
@@ -55,10 +56,12 @@ impl<T, U> Framed<T, U> {
     /// If you want to work more directly with the streams and sink, consider
     /// calling `split` on the `Framed` returned by this method, which will
     /// break them into separate objects, allowing them to interact more easily.
-    pub fn from_parts(parts: FramedParts<T>, codec: U) -> Framed<T, U>
-    {
+    pub fn from_parts(parts: FramedParts<T>, codec: U) -> Framed<T, U> {
         Framed {
-            inner: framed_read2_with_buffer(framed_write2_with_buffer(Fuse(parts.inner, codec), parts.writebuf), parts.readbuf),
+            inner: framed_read2_with_buffer(
+                framed_write2_with_buffer(Fuse(parts.inner, codec), parts.writebuf),
+                parts.readbuf,
+            ),
         }
     }
 
@@ -100,7 +103,11 @@ impl<T, U> Framed<T, U> {
     pub fn into_parts(self) -> FramedParts<T> {
         let (inner, readbuf) = self.inner.into_parts();
         let (inner, writebuf) = inner.into_parts();
-        FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }
+        FramedParts {
+            inner: inner.0,
+            readbuf: readbuf,
+            writebuf: writebuf,
+        }
     }
 
     /// Consumes the `Frame`, returning its underlying I/O stream and the buffer
@@ -116,13 +123,21 @@ impl<T, U> Framed<T, U> {
     pub fn into_parts_and_codec(self) -> (FramedParts<T>, U) {
         let (inner, readbuf) = self.inner.into_parts();
         let (inner, writebuf) = inner.into_parts();
-        (FramedParts { inner: inner.0, readbuf: readbuf, writebuf: writebuf }, inner.1)
+        (
+            FramedParts {
+                inner: inner.0,
+                readbuf: readbuf,
+                writebuf: writebuf,
+            },
+            inner.1,
+        )
     }
 }
 
 impl<T, U> Stream for Framed<T, U>
-    where T: AsyncRead,
-          U: Decoder,
+where
+    T: AsyncRead,
+    U: Decoder,
 {
     type Item = U::Item;
     type Error = U::Error;
@@ -133,17 +148,15 @@ impl<T, U> Stream for Framed<T, U>
 }
 
 impl<T, U> Sink for Framed<T, U>
-    where T: AsyncWrite,
-          U: Encoder,
-          U::Error: From<io::Error>,
+where
+    T: AsyncWrite,
+    U: Encoder,
+    U::Error: From<io::Error>,
 {
     type SinkItem = U::Item;
     type SinkError = U::Error;
 
-    fn start_send(&mut self,
-                  item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, Self::SinkError>
-    {
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
         self.inner.get_mut().start_send(item)
     }
 
@@ -157,14 +170,15 @@ impl<T, U> Sink for Framed<T, U>
 }
 
 impl<T, U> fmt::Debug for Framed<T, U>
-    where T: fmt::Debug,
-          U: fmt::Debug,
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Framed")
-         .field("io", &self.inner.get_ref().get_ref().0)
-         .field("codec", &self.inner.get_ref().get_ref().1)
-         .finish()
+            .field("io", &self.inner.get_ref().get_ref().0)
+            .field("codec", &self.inner.get_ref().get_ref().1)
+            .finish()
     }
 }
 
@@ -224,12 +238,11 @@ impl<T, U: Encoder> Encoder for Fuse<T, U> {
 /// It can be used to construct a new `Framed` with a different codec.
 /// It contains all current buffers and the inner transport.
 #[derive(Debug)]
-pub struct FramedParts<T>
-{
+pub struct FramedParts<T> {
     /// The inner transport used to read bytes to and write bytes to
     pub inner: T,
     /// The buffer with read but unprocessed data.
     pub readbuf: BytesMut,
     /// A buffer with unprocessed data which are not written yet.
-    pub writebuf: BytesMut
+    pub writebuf: BytesMut,
 }

--- a/tokio-io/src/framed_read.rs
+++ b/tokio-io/src/framed_read.rs
@@ -2,12 +2,12 @@
 
 use std::fmt;
 
-use AsyncRead;
 use codec::Decoder;
 use framed::Fuse;
+use AsyncRead;
 
-use futures::{Async, Poll, Stream, Sink, StartSend};
 use bytes::BytesMut;
+use futures::{Async, Poll, Sink, StartSend, Stream};
 
 /// A `Stream` of messages decoded from an `AsyncRead`.
 #[deprecated(since = "0.1.7", note = "Moved to tokio-codec")]
@@ -30,8 +30,9 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 // ===== impl FramedRead =====
 
 impl<T, D> FramedRead<T, D>
-    where T: AsyncRead,
-          D: Decoder,
+where
+    T: AsyncRead,
+    D: Decoder,
 {
     /// Creates a new `FramedRead` with the given `decoder`.
     pub fn new(inner: T, decoder: D) -> FramedRead<T, D> {
@@ -83,8 +84,9 @@ impl<T, D> FramedRead<T, D> {
 }
 
 impl<T, D> Stream for FramedRead<T, D>
-    where T: AsyncRead,
-          D: Decoder,
+where
+    T: AsyncRead,
+    D: Decoder,
 {
     type Item = D::Item;
     type Error = D::Error;
@@ -95,15 +97,13 @@ impl<T, D> Stream for FramedRead<T, D>
 }
 
 impl<T, D> Sink for FramedRead<T, D>
-    where T: Sink,
+where
+    T: Sink,
 {
     type SinkItem = T::SinkItem;
     type SinkError = T::SinkError;
 
-    fn start_send(&mut self,
-                  item: Self::SinkItem)
-                  -> StartSend<Self::SinkItem, Self::SinkError>
-    {
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
         self.inner.inner.0.start_send(item)
     }
 
@@ -117,8 +117,9 @@ impl<T, D> Sink for FramedRead<T, D>
 }
 
 impl<T, D> fmt::Debug for FramedRead<T, D>
-    where T: fmt::Debug,
-          D: fmt::Debug,
+where
+    T: fmt::Debug,
+    D: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FramedRead")
@@ -174,7 +175,8 @@ impl<T> FramedRead2<T> {
 }
 
 impl<T> Stream for FramedRead2<T>
-    where T: AsyncRead + Decoder,
+where
+    T: AsyncRead + Decoder,
 {
     type Item = T::Item;
     type Error = T::Error;

--- a/tokio-io/src/framed_write.rs
+++ b/tokio-io/src/framed_write.rs
@@ -1,14 +1,14 @@
 #![allow(deprecated)]
 
-use std::io::{self, Read};
 use std::fmt;
+use std::io::{self, Read};
 
-use {AsyncRead, AsyncWrite};
 use codec::{Decoder, Encoder};
 use framed::Fuse;
+use {AsyncRead, AsyncWrite};
 
-use futures::{Async, AsyncSink, Poll, Stream, Sink, StartSend};
 use bytes::BytesMut;
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 /// A `Sink` of frames encoded to an `AsyncWrite`.
 #[deprecated(since = "0.1.7", note = "Moved to tokio-codec")]
@@ -28,8 +28,9 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 const BACKPRESSURE_BOUNDARY: usize = INITIAL_CAPACITY;
 
 impl<T, E> FramedWrite<T, E>
-    where T: AsyncWrite,
-          E: Encoder,
+where
+    T: AsyncWrite,
+    E: Encoder,
 {
     /// Creates a new `FramedWrite` with the given `encoder`.
     pub fn new(inner: T, encoder: E) -> FramedWrite<T, E> {
@@ -81,8 +82,9 @@ impl<T, E> FramedWrite<T, E> {
 }
 
 impl<T, E> Sink for FramedWrite<T, E>
-    where T: AsyncWrite,
-          E: Encoder,
+where
+    T: AsyncWrite,
+    E: Encoder,
 {
     type SinkItem = E::Item;
     type SinkError = E::Error;
@@ -101,7 +103,8 @@ impl<T, E> Sink for FramedWrite<T, E>
 }
 
 impl<T, D> Stream for FramedWrite<T, D>
-    where T: Stream,
+where
+    T: Stream,
 {
     type Item = T::Item;
     type Error = T::Error;
@@ -112,15 +115,16 @@ impl<T, D> Stream for FramedWrite<T, D>
 }
 
 impl<T, U> fmt::Debug for FramedWrite<T, U>
-    where T: fmt::Debug,
-          U: fmt::Debug,
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("FramedWrite")
-         .field("inner", &self.inner.get_ref().0)
-         .field("encoder", &self.inner.get_ref().1)
-         .field("buffer", &self.inner.buffer)
-         .finish()
+            .field("inner", &self.inner.get_ref().0)
+            .field("encoder", &self.inner.get_ref().1)
+            .field("buffer", &self.inner.buffer)
+            .finish()
     }
 }
 
@@ -163,7 +167,8 @@ impl<T> FramedWrite2<T> {
 }
 
 impl<T> Sink for FramedWrite2<T>
-    where T: AsyncWrite + Encoder,
+where
+    T: AsyncWrite + Encoder,
 {
     type SinkItem = T::Item;
     type SinkError = T::Error;
@@ -193,8 +198,12 @@ impl<T> Sink for FramedWrite2<T>
             let n = try_ready!(self.inner.poll_write(&self.buffer));
 
             if n == 0 {
-                return Err(io::Error::new(io::ErrorKind::WriteZero, "failed to
-                                          write frame to transport").into());
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to
+                                          write frame to transport",
+                )
+                .into());
             }
 
             // TODO: Add a way to `bytes` to do this w/o returning the drained

--- a/tokio-io/src/io/copy.rs
+++ b/tokio-io/src/io/copy.rs
@@ -33,8 +33,9 @@ pub struct Copy<R, W> {
 /// consumed. On error the error is returned and the I/O objects are consumed as
 /// well.
 pub fn copy<R, W>(reader: R, writer: W) -> Copy<R, W>
-    where R: AsyncRead,
-          W: AsyncWrite,
+where
+    R: AsyncRead,
+    W: AsyncWrite,
 {
     Copy {
         reader: Some(reader),
@@ -48,8 +49,9 @@ pub fn copy<R, W>(reader: R, writer: W) -> Copy<R, W>
 }
 
 impl<R, W> Future for Copy<R, W>
-    where R: AsyncRead,
-          W: AsyncWrite,
+where
+    R: AsyncRead,
+    W: AsyncWrite,
 {
     type Item = (u64, R, W);
     type Error = io::Error;
@@ -74,8 +76,10 @@ impl<R, W> Future for Copy<R, W>
                 let writer = self.writer.as_mut().unwrap();
                 let i = try_ready!(writer.poll_write(&self.buf[self.pos..self.cap]));
                 if i == 0 {
-                    return Err(io::Error::new(io::ErrorKind::WriteZero,
-                                              "write zero byte into writer"));
+                    return Err(io::Error::new(
+                        io::ErrorKind::WriteZero,
+                        "write zero byte into writer",
+                    ));
                 } else {
                     self.pos += i;
                     self.amt += i as u64;
@@ -89,7 +93,7 @@ impl<R, W> Future for Copy<R, W>
                 try_ready!(self.writer.as_mut().unwrap().poll_flush());
                 let reader = self.reader.take().unwrap();
                 let writer = self.writer.take().unwrap();
-                return Ok((self.amt, reader, writer).into())
+                return Ok((self.amt, reader, writer).into());
             }
         }
     }

--- a/tokio-io/src/io/flush.rs
+++ b/tokio-io/src/io/flush.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use futures::{Poll, Future, Async};
+use futures::{Async, Future, Poll};
 
 use AsyncWrite;
 
@@ -23,15 +23,15 @@ pub struct Flush<A> {
 /// otherwise it will repeatedly call `flush` until it sees `Ok(())`, scheduling
 /// a retry if `WouldBlock` is seen along the way.
 pub fn flush<A>(a: A) -> Flush<A>
-    where A: AsyncWrite,
+where
+    A: AsyncWrite,
 {
-    Flush {
-        a: Some(a),
-    }
+    Flush { a: Some(a) }
 }
 
 impl<A> Future for Flush<A>
-    where A: AsyncWrite,
+where
+    A: AsyncWrite,
 {
     type Item = A;
     type Error = io::Error;
@@ -41,4 +41,3 @@ impl<A> Future for Flush<A>
         Ok(Async::Ready(self.a.take().unwrap()))
     }
 }
-

--- a/tokio-io/src/io/mod.rs
+++ b/tokio-io/src/io/mod.rs
@@ -18,15 +18,15 @@ mod read_until;
 mod shutdown;
 mod write_all;
 
-pub use allow_std::AllowStdIo;
 pub use self::copy::{copy, Copy};
 pub use self::flush::{flush, Flush};
-pub use lines::{lines, Lines};
 pub use self::read::{read, Read};
 pub use self::read_exact::{read_exact, ReadExact};
 pub use self::read_to_end::{read_to_end, ReadToEnd};
 pub use self::read_until::{read_until, ReadUntil};
 pub use self::shutdown::{shutdown, Shutdown};
+pub use self::write_all::{write_all, WriteAll};
+pub use allow_std::AllowStdIo;
+pub use lines::{lines, Lines};
 pub use split::{ReadHalf, WriteHalf};
 pub use window::Window;
-pub use self::write_all::{write_all, WriteAll};

--- a/tokio-io/src/io/read.rs
+++ b/tokio-io/src/io/read.rs
@@ -7,10 +7,7 @@ use AsyncRead;
 
 #[derive(Debug)]
 enum State<R, T> {
-    Pending {
-        rd: R,
-        buf: T,
-    },
+    Pending { rd: R, buf: T },
     Empty,
 }
 
@@ -20,10 +17,13 @@ enum State<R, T> {
 /// The returned future will resolve to both the I/O stream and the buffer
 /// as well as the number of bytes read once the read operation is completed.
 pub fn read<R, T>(rd: R, buf: T) -> Read<R, T>
-    where R: AsyncRead,
-          T: AsMut<[u8]>
+where
+    R: AsyncRead,
+    T: AsMut<[u8]>,
 {
-    Read { state: State::Pending { rd: rd, buf: buf } }
+    Read {
+        state: State::Pending { rd: rd, buf: buf },
+    }
 }
 
 /// A future which can be used to easily read available number of bytes to fill
@@ -36,15 +36,19 @@ pub struct Read<R, T> {
 }
 
 impl<R, T> Future for Read<R, T>
-    where R: AsyncRead,
-          T: AsMut<[u8]>
+where
+    R: AsyncRead,
+    T: AsMut<[u8]>,
 {
     type Item = (R, T, usize);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<(R, T, usize), io::Error> {
         let nread = match self.state {
-            State::Pending { ref mut rd, ref mut buf } => try_ready!(rd.poll_read(&mut buf.as_mut()[..])),
+            State::Pending {
+                ref mut rd,
+                ref mut buf,
+            } => try_ready!(rd.poll_read(&mut buf.as_mut()[..])),
             State::Empty => panic!("poll a Read after it's done"),
         };
 

--- a/tokio-io/src/io/shutdown.rs
+++ b/tokio-io/src/io/shutdown.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use futures::{Poll, Future, Async};
+use futures::{Async, Future, Poll};
 
 use AsyncWrite;
 
@@ -24,15 +24,15 @@ pub struct Shutdown<A> {
 /// otherwise it will repeatedly call `shutdown` until it sees `Ok(())`,
 /// scheduling a retry if `WouldBlock` is seen along the way.
 pub fn shutdown<A>(a: A) -> Shutdown<A>
-    where A: AsyncWrite,
+where
+    A: AsyncWrite,
 {
-    Shutdown {
-        a: Some(a),
-    }
+    Shutdown { a: Some(a) }
 }
 
 impl<A> Future for Shutdown<A>
-    where A: AsyncWrite,
+where
+    A: AsyncWrite,
 {
     type Item = A;
     type Error = io::Error;

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -34,18 +34,21 @@ pub type IoStream<T> = Box<Stream<Item = T, Error = std_io::Error> + Send>;
 /// it indicates `WouldBlock` or otherwise `Err` is returned.
 #[macro_export]
 macro_rules! try_nb {
-    ($e:expr) => (match $e {
-        Ok(t) => t,
-        Err(ref e) if e.kind() == ::std::io::ErrorKind::WouldBlock => {
-            return Ok(::futures::Async::NotReady)
+    ($e:expr) => {
+        match $e {
+            Ok(t) => t,
+            Err(ref e) if e.kind() == ::std::io::ErrorKind::WouldBlock => {
+                return Ok(::futures::Async::NotReady);
+            }
+            Err(e) => return Err(e.into()),
         }
-        Err(e) => return Err(e.into()),
-    })
+    };
 }
 
-pub mod io;
 pub mod codec;
+pub mod io;
 
+pub mod _tokio_codec;
 mod allow_std;
 mod async_read;
 mod async_write;
@@ -56,7 +59,6 @@ mod length_delimited;
 mod lines;
 mod split;
 mod window;
-pub mod _tokio_codec;
 
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;

--- a/tokio-io/src/lines.rs
+++ b/tokio-io/src/lines.rs
@@ -20,7 +20,8 @@ pub struct Lines<A> {
 /// lines that the object contains. The returned stream will reach its end once
 /// `a` reaches EOF.
 pub fn lines<A>(a: A) -> Lines<A>
-    where A: AsyncRead + BufRead,
+where
+    A: AsyncRead + BufRead,
 {
     Lines {
         io: a,
@@ -39,7 +40,8 @@ impl<A> Lines<A> {
 }
 
 impl<A> Stream for Lines<A>
-    where A: AsyncRead + BufRead,
+where
+    A: AsyncRead + BufRead,
 {
     type Item = String;
     type Error = io::Error;
@@ -47,7 +49,7 @@ impl<A> Stream for Lines<A>
     fn poll(&mut self) -> Poll<Option<String>, io::Error> {
         let n = try_nb!(self.io.read_line(&mut self.line));
         if n == 0 && self.line.len() == 0 {
-            return Ok(None.into())
+            return Ok(None.into());
         }
         if self.line.ends_with("\n") {
             self.line.pop();

--- a/tokio-io/src/split.rs
+++ b/tokio-io/src/split.rs
@@ -1,8 +1,8 @@
 use std::io::{self, Read, Write};
 
-use futures::{Async, Poll};
-use futures::sync::BiLock;
 use bytes::{Buf, BufMut};
+use futures::sync::BiLock;
+use futures::{Async, Poll};
 
 use {AsyncRead, AsyncWrite};
 
@@ -66,7 +66,8 @@ impl<T: AsyncWrite> AsyncWrite for WriteHalf<T> {
     }
 
     fn write_buf<B: Buf>(&mut self, buf: &mut B) -> Poll<usize, io::Error>
-        where Self: Sized,
+    where
+        Self: Sized,
     {
         let mut l = try_ready!(wrap_as_io(self.handle.poll_lock()));
         l.write_buf(buf)
@@ -83,8 +84,8 @@ mod tests {
 
     use super::{AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
     use bytes::{BytesMut, IntoBuf};
-    use futures::{Async, Poll, future::lazy, future::ok};
     use futures::sync::BiLock;
+    use futures::{future::lazy, future::ok, Async, Poll};
 
     use std::io::{self, Read, Write};
 
@@ -138,7 +139,8 @@ mod tests {
             assert!(rx.read_buf(&mut buf).unwrap().is_ready());
 
             ok::<(), ()>(())
-        })).unwrap();
+        }))
+        .unwrap();
     }
 
     #[test]
@@ -166,6 +168,7 @@ mod tests {
             assert!(tx.write_buf(&mut buf).unwrap().is_ready());
 
             ok::<(), ()>(())
-        })).unwrap();
+        }))
+        .unwrap();
     }
 }

--- a/tokio-io/tests/async_read.rs
+++ b/tokio-io/tests/async_read.rs
@@ -1,10 +1,10 @@
-extern crate tokio_io;
 extern crate bytes;
 extern crate futures;
+extern crate tokio_io;
 
-use tokio_io::AsyncRead;
-use bytes::{BytesMut, BufMut};
+use bytes::{BufMut, BytesMut};
 use futures::Async;
+use tokio_io::AsyncRead;
 
 use std::io::{self, Read};
 

--- a/tokio-reactor/benches/basic.rs
+++ b/tokio-reactor/benches/basic.rs
@@ -16,10 +16,10 @@ mod threadpool {
     use super::*;
     use std::sync::mpsc;
 
-    use test::Bencher;
     use futures::{future, Async};
-    use tokio_reactor::Registration;
+    use test::Bencher;
     use tokio::runtime::Runtime;
+    use tokio_reactor::Registration;
 
     #[bench]
     fn notify_many(b: &mut Bencher) {
@@ -42,22 +42,20 @@ mod threadpool {
                         let mut r = Some(r);
                         let tx = tx.clone();
 
-                        tokio::spawn(future::poll_fn(move || {
-                            loop {
-                                let is_ready = registration.poll_read_ready().unwrap().is_ready();
+                        tokio::spawn(future::poll_fn(move || loop {
+                            let is_ready = registration.poll_read_ready().unwrap().is_ready();
 
-                                if is_ready {
-                                    rem -= 1;
+                            if is_ready {
+                                rem -= 1;
 
-                                    if rem == 0 {
-                                        r.take().unwrap();
-                                        tx.send(()).unwrap();
-                                        return Ok(Async::Ready(()));
-                                    }
-                                } else {
-                                    s.set_readiness(mio::Ready::readable()).unwrap();
-                                    return Ok(Async::NotReady);
+                                if rem == 0 {
+                                    r.take().unwrap();
+                                    tx.send(()).unwrap();
+                                    return Ok(Async::Ready(()));
                                 }
+                            } else {
+                                s.set_readiness(mio::Ready::readable()).unwrap();
+                                return Ok(Async::NotReady);
                             }
                         }));
 
@@ -66,7 +64,8 @@ mod threadpool {
                 }
 
                 Ok(())
-            })).unwrap();
+            }))
+            .unwrap();
 
             for _ in 0..tasks {
                 rx.recv().unwrap();
@@ -105,22 +104,20 @@ mod io_pool {
                         let mut r = Some(r);
                         let tx = tx.clone();
 
-                        tokio::spawn(future::poll_fn(move || {
-                            loop {
-                                let is_ready = registration.poll_read_ready().unwrap().is_ready();
+                        tokio::spawn(future::poll_fn(move || loop {
+                            let is_ready = registration.poll_read_ready().unwrap().is_ready();
 
-                                if is_ready {
-                                    rem -= 1;
+                            if is_ready {
+                                rem -= 1;
 
-                                    if rem == 0 {
-                                        r.take().unwrap();
-                                        tx.send(()).unwrap();
-                                        return Ok(Async::Ready(()));
-                                    }
-                                } else {
-                                    s.set_readiness(mio::Ready::readable()).unwrap();
-                                    return Ok(Async::NotReady);
+                                if rem == 0 {
+                                    r.take().unwrap();
+                                    tx.send(()).unwrap();
+                                    return Ok(Async::Ready(()));
                                 }
+                            } else {
+                                s.set_readiness(mio::Ready::readable()).unwrap();
+                                return Ok(Async::NotReady);
                             }
                         }));
 
@@ -129,7 +126,8 @@ mod io_pool {
                 }
 
                 Ok(())
-            })).unwrap();
+            }))
+            .unwrap();
 
             for _ in 0..tasks {
                 rx.recv().unwrap();

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -23,8 +23,8 @@ mod platform {
         println!("Waiting for SIGINT or SIGTERM");
         println!(
             "  TIP: use `pkill -sigint multiple` from a second terminal \
-         to send a SIGINT to all processes named 'multiple' \
-         (i.e. this binary)"
+             to send a SIGINT to all processes named 'multiple' \
+             (i.e. this binary)"
         );
         let (item, _rest) = ::tokio::runtime::current_thread::block_on_all(stream.into_future())
             .map_err(|_| "failed to wait for signals")?;
@@ -44,7 +44,9 @@ mod platform {
 
 #[cfg(not(unix))]
 mod platform {
-    pub fn main() -> Result<(), Box<::std::error::Error>> {Ok(())}
+    pub fn main() -> Result<(), Box<::std::error::Error>> {
+        Ok(())
+    }
 }
 
 fn main() -> Result<(), Box<std::error::Error>> {

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -16,8 +16,8 @@ mod platform {
         println!("Waiting for SIGHUPS (Ctrl+C to quit)");
         println!(
             "  TIP: use `pkill -sighup sighup-example` from a second terminal \
-         to send a SIGHUP to all processes named 'sighup-example' \
-         (i.e. this binary)"
+             to send a SIGHUP to all processes named 'sighup-example' \
+             (i.e. this binary)"
         );
 
         // for_each is a powerful primitive provided by the Futures crate
@@ -26,8 +26,8 @@ mod platform {
         let future = stream.for_each(|the_signal| {
             println!(
                 "*Got signal {:#x}* I should probably reload my config \
-             or something",
-             the_signal
+                 or something",
+                the_signal
             );
             Ok(())
         });
@@ -43,7 +43,9 @@ mod platform {
 
 #[cfg(not(unix))]
 mod platform {
-    pub fn main() -> Result<(), Box<::std::error::Error>> {Ok(())}
+    pub fn main() -> Result<(), Box<::std::error::Error>> {
+        Ok(())
+    }
 }
 
 fn main() -> Result<(), Box<std::error::Error>> {

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -15,15 +15,15 @@ use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Once, ONCE_INIT};
 
+use self::winapi::shared::minwindef::*;
+use self::winapi::um::wincon::*;
 use futures::future;
 use futures::stream::Fuse;
 use futures::sync::mpsc;
 use futures::sync::oneshot;
 use futures::{Async, Future, IntoFuture, Poll, Stream};
-use tokio_reactor::{Handle, PollEvented};
 use mio::Ready;
-use self::winapi::shared::minwindef::*;
-use self::winapi::um::wincon::*;
+use tokio_reactor::{Handle, PollEvented};
 
 use IoFuture;
 

--- a/tokio-signal/tests/drop_multi_loop.rs
+++ b/tokio-signal/tests/drop_multi_loop.rs
@@ -10,14 +10,12 @@ const TEST_SIGNAL: libc::c_int = libc::SIGUSR1;
 #[test]
 fn dropping_loops_does_not_cause_starvation() {
     let (mut rt, signal) = {
-        let mut first_rt = CurrentThreadRuntime::new()
-            .expect("failed to init first runtime");
+        let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
 
         let first_signal = run_with_timeout(&mut first_rt, Signal::new(TEST_SIGNAL))
             .expect("failed to register first signal");
 
-        let mut second_rt = CurrentThreadRuntime::new()
-            .expect("failed to init second runtime");
+        let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
 
         let second_signal = run_with_timeout(&mut second_rt, Signal::new(TEST_SIGNAL))
             .expect("failed to register second signal");
@@ -30,10 +28,7 @@ fn dropping_loops_does_not_cause_starvation() {
 
     send_signal(TEST_SIGNAL);
 
-    let signal_future = signal.into_future()
-        .map_err(|(e, _)| e);
+    let signal_future = signal.into_future().map_err(|(e, _)| e);
 
-    run_with_timeout(&mut rt, signal_future)
-        .expect("failed to get signal");
+    run_with_timeout(&mut rt, signal_future).expect("failed to get signal");
 }
-

--- a/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
+++ b/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
@@ -12,14 +12,13 @@ fn dropping_signal_does_not_deregister_any_other_instances() {
     // NB: Deadline requires a timer registration which is provided by
     // tokio's `current_thread::Runtime`, but isn't available by just using
     // tokio's default CurrentThread executor which powers `current_thread::block_on_all`.
-    let mut rt = CurrentThreadRuntime::new()
-        .expect("failed to init runtime");
+    let mut rt = CurrentThreadRuntime::new().expect("failed to init runtime");
 
     // NB: Testing for issue #38: signals should not starve based on ordering
     let first_duplicate_signal = run_with_timeout(&mut rt, Signal::new(TEST_SIGNAL))
         .expect("failed to register first duplicate signal");
-    let signal = run_with_timeout(&mut rt, Signal::new(TEST_SIGNAL))
-        .expect("failed to register signal");
+    let signal =
+        run_with_timeout(&mut rt, Signal::new(TEST_SIGNAL)).expect("failed to register signal");
     let second_duplicate_signal = run_with_timeout(&mut rt, Signal::new(TEST_SIGNAL))
         .expect("failed to register second duplicate signal");
 

--- a/tokio-signal/tests/multi_loop.rs
+++ b/tokio-signal/tests/multi_loop.rs
@@ -22,7 +22,9 @@ fn multi_loop() {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
                     let signal = run_with_timeout(&mut rt, Signal::new(libc::SIGHUP)).unwrap();
                     sender.send(()).unwrap();
-                    run_with_timeout(&mut rt, signal.into_future()).ok().unwrap();
+                    run_with_timeout(&mut rt, signal.into_future())
+                        .ok()
+                        .unwrap();
                 })
             })
             .collect();

--- a/tokio-signal/tests/notify_both.rs
+++ b/tokio-signal/tests/notify_both.rs
@@ -8,11 +8,11 @@ use support::*;
 #[test]
 fn notify_both() {
     let mut rt = CurrentThreadRuntime::new().unwrap();
-    let signal1 = run_with_timeout(&mut rt, Signal::new(libc::SIGUSR2))
-        .expect("failed to create signal1");
+    let signal1 =
+        run_with_timeout(&mut rt, Signal::new(libc::SIGUSR2)).expect("failed to create signal1");
 
-    let signal2 = run_with_timeout(&mut rt, Signal::new(libc::SIGUSR2))
-        .expect("failed to create signal2");
+    let signal2 =
+        run_with_timeout(&mut rt, Signal::new(libc::SIGUSR2)).expect("failed to create signal2");
 
     send_signal(libc::SIGUSR2);
     run_with_timeout(&mut rt, signal1.into_future().join(signal2.into_future()))

--- a/tokio-signal/tests/signal.rs
+++ b/tokio-signal/tests/signal.rs
@@ -7,14 +7,11 @@ use support::*;
 
 #[test]
 fn tokio_simple() {
-    let signal_future = Signal::new(libc::SIGUSR1)
-        .and_then(|signal| {
-            send_signal(libc::SIGUSR1);
-            signal.into_future().map(|_| ()).map_err(|(err, _)| err)
-        });
+    let signal_future = Signal::new(libc::SIGUSR1).and_then(|signal| {
+        send_signal(libc::SIGUSR1);
+        signal.into_future().map(|_| ()).map_err(|(err, _)| err)
+    });
 
-    let mut rt = CurrentThreadRuntime::new()
-        .expect("failed to init runtime");
-    run_with_timeout(&mut rt, signal_future)
-        .expect("failed");
+    let mut rt = CurrentThreadRuntime::new().expect("failed to init runtime");
+    run_with_timeout(&mut rt, signal_future).expect("failed");
 }

--- a/tokio-signal/tests/simple.rs
+++ b/tokio-signal/tests/simple.rs
@@ -8,8 +8,8 @@ use support::*;
 #[test]
 fn simple() {
     let mut rt = CurrentThreadRuntime::new().unwrap();
-    let signal = run_with_timeout(&mut rt, Signal::new(libc::SIGUSR1))
-        .expect("failed to create signal");
+    let signal =
+        run_with_timeout(&mut rt, Signal::new(libc::SIGUSR1)).expect("failed to create signal");
 
     send_signal(libc::SIGUSR1);
 

--- a/tokio-signal/tests/support.rs
+++ b/tokio-signal/tests/support.rs
@@ -1,31 +1,33 @@
 #![cfg(unix)]
 
-extern crate libc;
 extern crate futures;
+extern crate libc;
 extern crate tokio;
 extern crate tokio_signal;
 
 use self::libc::{c_int, getpid, kill};
-use std::time::Duration;
 use self::tokio::timer::Timeout;
+use std::time::Duration;
 
 pub use self::futures::{Future, Stream};
 pub use self::tokio::runtime::current_thread::{self, Runtime as CurrentThreadRuntime};
 pub use self::tokio_signal::unix::Signal;
 
 pub fn with_timeout<F: Future>(future: F) -> impl Future<Item = F::Item, Error = F::Error> {
-    Timeout::new(future, Duration::from_secs(1))
-        .map_err(|e| if e.is_timer() {
+    Timeout::new(future, Duration::from_secs(1)).map_err(|e| {
+        if e.is_timer() {
             panic!("failed to register timer");
         } else if e.is_elapsed() {
             panic!("timed out")
         } else {
             e.into_inner().expect("missing inner error")
-        })
+        }
+    })
 }
 
 pub fn run_with_timeout<F>(rt: &mut CurrentThreadRuntime, future: F) -> Result<F::Item, F::Error>
-    where F: Future
+where
+    F: Future,
 {
     rt.block_on(with_timeout(future))
 }

--- a/tokio-signal/tests/twice.rs
+++ b/tokio-signal/tests/twice.rs
@@ -11,9 +11,13 @@ fn twice() {
     let signal = run_with_timeout(&mut rt, Signal::new(libc::SIGUSR1)).unwrap();
 
     send_signal(libc::SIGUSR1);
-    let (num, signal) = run_with_timeout(&mut rt, signal.into_future()).ok().unwrap();
+    let (num, signal) = run_with_timeout(&mut rt, signal.into_future())
+        .ok()
+        .unwrap();
     assert_eq!(num, Some(libc::SIGUSR1));
 
     send_signal(libc::SIGUSR1);
-    run_with_timeout(&mut rt, signal.into_future()).ok().unwrap();
+    run_with_timeout(&mut rt, signal.into_future())
+        .ok()
+        .unwrap();
 }

--- a/tokio-sync/benches/mpsc.rs
+++ b/tokio-sync/benches/mpsc.rs
@@ -1,15 +1,15 @@
 #![feature(test)]
 #![cfg_attr(test, deny(warnings))]
 
-extern crate tokio_sync;
 extern crate futures;
 extern crate test;
+extern crate tokio_sync;
 
 mod tokio {
-    use tokio_sync::mpsc::*;
-    use futures::{future, Async, Future, Stream, Sink};
-    use test::{self, Bencher};
+    use futures::{future, Async, Future, Sink, Stream};
     use std::thread;
+    use test::{self, Bencher};
+    use tokio_sync::mpsc::*;
 
     #[bench]
     fn bounded_new(b: &mut Bencher) {
@@ -46,7 +46,9 @@ mod tokio {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -58,7 +60,9 @@ mod tokio {
                 assert!(tx.poll_ready().unwrap().is_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -71,7 +75,9 @@ mod tokio {
                 assert!(tx.poll_ready().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -83,7 +89,9 @@ mod tokio {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -99,7 +107,9 @@ mod tokio {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -160,8 +170,7 @@ mod tokio {
 
             drop(tx);
 
-            let rx = rx.wait()
-                .take(4 * 1_000);
+            let rx = rx.wait().take(4 * 1_000);
 
             for v in rx {
                 let _ = test::black_box(v);
@@ -206,8 +215,7 @@ mod tokio {
 
             drop(tx);
 
-            let rx = rx.wait()
-                .take(THREADS * ITERS);
+            let rx = rx.wait().take(THREADS * ITERS);
 
             for v in rx {
                 let _ = test::black_box(v);
@@ -223,10 +231,10 @@ mod tokio {
 }
 
 mod legacy {
-    use futures::{future, Async, Future, Stream, Sink};
     use futures::sync::mpsc::*;
-    use test::{self, Bencher};
+    use futures::{future, Async, Future, Sink, Stream};
     use std::thread;
+    use test::{self, Bencher};
 
     #[bench]
     fn bounded_new(b: &mut Bencher) {
@@ -263,7 +271,9 @@ mod legacy {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -275,7 +285,9 @@ mod legacy {
                 assert!(tx.poll_ready().unwrap().is_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -288,7 +300,9 @@ mod legacy {
                 assert!(tx.poll_ready().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -300,7 +314,9 @@ mod legacy {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -316,7 +332,9 @@ mod legacy {
                 assert!(rx.poll().unwrap().is_not_ready());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         })
     }
 
@@ -376,8 +394,7 @@ mod legacy {
 
             drop(tx);
 
-            let rx = rx.wait()
-                .take(4 * 1_000);
+            let rx = rx.wait().take(4 * 1_000);
 
             for v in rx {
                 let _ = test::black_box(v);
@@ -422,8 +439,7 @@ mod legacy {
 
             drop(tx);
 
-            let rx = rx.wait()
-                .take(THREADS * ITERS);
+            let rx = rx.wait().take(THREADS * ITERS);
 
             for v in rx {
                 let _ = test::black_box(v);

--- a/tokio-sync/benches/oneshot.rs
+++ b/tokio-sync/benches/oneshot.rs
@@ -1,14 +1,14 @@
 #![feature(test)]
 #![cfg_attr(test, deny(warnings))]
 
-extern crate tokio_sync;
 extern crate futures;
 extern crate test;
+extern crate tokio_sync;
 
 mod tokio {
     use futures::{future, Async, Future};
+    use test::Bencher;
     use tokio_sync::oneshot;
-    use test::{Bencher};
 
     #[bench]
     fn new(b: &mut Bencher) {
@@ -43,7 +43,9 @@ mod tokio {
                 assert_eq!(Async::Ready(1), rx.poll().unwrap());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         });
     }
 
@@ -58,7 +60,7 @@ mod tokio {
             loop {
                 match f.poll() {
                     Ok(Ready(v)) => return Ok(v),
-                    Ok(_) => {},
+                    Ok(_) => {}
                     Err(e) => return Err(e),
                 }
             }
@@ -95,7 +97,9 @@ mod tokio {
                 }
 
                 Ok::<(), ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         });
 
         future::lazy(|| {
@@ -112,14 +116,16 @@ mod tokio {
             });
 
             Ok::<(), ()>(())
-        }).wait().unwrap();
+        })
+        .wait()
+        .unwrap();
     }
 }
 
 mod legacy {
-    use futures::{future, Async, Future};
     use futures::sync::oneshot;
-    use test::{Bencher};
+    use futures::{future, Async, Future};
+    use test::Bencher;
 
     #[bench]
     fn new(b: &mut Bencher) {
@@ -154,7 +160,9 @@ mod legacy {
                 assert_eq!(Async::Ready(1), rx.poll().unwrap());
 
                 Ok::<_, ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         });
     }
 
@@ -169,7 +177,7 @@ mod legacy {
             loop {
                 match f.poll() {
                     Ok(Ready(v)) => return Ok(v),
-                    Ok(_) => {},
+                    Ok(_) => {}
                     Err(e) => return Err(e),
                 }
             }
@@ -206,7 +214,9 @@ mod legacy {
                 }
 
                 Ok::<(), ()>(())
-            }).wait().unwrap();
+            })
+            .wait()
+            .unwrap();
         });
 
         future::lazy(|| {
@@ -223,6 +233,8 @@ mod legacy {
             });
 
             Ok::<(), ()>(())
-        }).wait().unwrap();
+        })
+        .wait()
+        .unwrap();
     }
 }

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -23,7 +23,7 @@ macro_rules! if_fuzz {
 }
 
 mod loom;
-pub mod oneshot;
 pub mod mpsc;
+pub mod oneshot;
 pub mod semaphore;
 pub mod task;

--- a/tokio-sync/src/loom.rs
+++ b/tokio-sync/src/loom.rs
@@ -1,6 +1,6 @@
 pub(crate) mod futures {
     pub(crate) use futures::task;
-    pub(crate) use ::task::AtomicTask;
+    pub(crate) use task::AtomicTask;
 }
 
 pub(crate) mod sync {

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -13,7 +13,9 @@ pub struct Sender<T> {
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
-        Sender { chan: self.chan.clone() }
+        Sender {
+            chan: self.chan.clone(),
+        }
     }
 }
 
@@ -144,11 +146,9 @@ impl<T> Stream for Receiver<T> {
     type Error = RecvError;
 
     fn poll(&mut self) -> Poll<Option<T>, Self::Error> {
-        self.chan.recv()
-            .map_err(|_| RecvError(()))
+        self.chan.recv().map_err(|_| RecvError(()))
     }
 }
-
 
 impl<T> Sender<T> {
     pub(crate) fn new(chan: chan::Tx<T, Semaphore>) -> Sender<T> {
@@ -176,8 +176,7 @@ impl<T> Sender<T> {
     ///   capacity is available;
     /// - `Err(SendError)` if the receiver has been dropped.
     pub fn poll_ready(&mut self) -> Poll<(), SendError> {
-        self.chan.poll_ready()
-            .map_err(|_| SendError(()))
+        self.chan.poll_ready().map_err(|_| SendError(()))
     }
 
     /// Attempts to send a message on this `Sender`, returning the message
@@ -193,17 +192,15 @@ impl<T> Sink for Sender<T> {
     type SinkError = SendError;
 
     fn start_send(&mut self, msg: T) -> StartSend<T, Self::SinkError> {
-        use futures::AsyncSink;
         use futures::Async::*;
+        use futures::AsyncSink;
 
         match self.poll_ready()? {
             Ready(_) => {
                 self.try_send(msg).map_err(|_| SendError(()))?;
                 Ok(AsyncSink::Ready)
             }
-            NotReady => {
-                Ok(AsyncSink::NotReady(msg))
-            }
+            NotReady => Ok(AsyncSink::NotReady(msg)),
         }
     }
 
@@ -283,7 +280,7 @@ impl<T> From<(T, chan::TrySendError)> for TrySendError<T> {
             kind: match err {
                 chan::TrySendError::Closed => ErrorKind::Closed,
                 chan::TrySendError::NoPermits => ErrorKind::NoCapacity,
-            }
+            },
         }
     }
 }

--- a/tokio-sync/src/mpsc/mod.rs
+++ b/tokio-sync/src/mpsc/mod.rs
@@ -40,32 +40,16 @@ mod chan;
 mod list;
 mod unbounded;
 
-pub use self::bounded::{
-    channel,
-    Receiver,
-    Sender
-};
+pub use self::bounded::{channel, Receiver, Sender};
 
-pub use self::unbounded::{
-    unbounded_channel,
-    UnboundedReceiver,
-    UnboundedSender,
-};
+pub use self::unbounded::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 pub mod error {
     //! Channel error types
 
-    pub use super::bounded::{
-        SendError,
-        TrySendError,
-        RecvError,
-    };
+    pub use super::bounded::{RecvError, SendError, TrySendError};
 
-    pub use super::unbounded::{
-        UnboundedSendError,
-        UnboundedTrySendError,
-        UnboundedRecvError,
-    };
+    pub use super::unbounded::{UnboundedRecvError, UnboundedSendError, UnboundedTrySendError};
 }
 
 /// The number of values a block can contain.

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -1,7 +1,7 @@
 use super::chan;
 
-use loom::sync::atomic::AtomicUsize;
 use futures::{Poll, Sink, StartSend, Stream};
+use loom::sync::atomic::AtomicUsize;
 
 use std::fmt;
 
@@ -15,7 +15,9 @@ pub struct UnboundedSender<T> {
 
 impl<T> Clone for UnboundedSender<T> {
     fn clone(&self) -> Self {
-        UnboundedSender { chan: self.chan.clone() }
+        UnboundedSender {
+            chan: self.chan.clone(),
+        }
     }
 }
 
@@ -97,11 +99,9 @@ impl<T> Stream for UnboundedReceiver<T> {
     type Error = UnboundedRecvError;
 
     fn poll(&mut self) -> Poll<Option<T>, Self::Error> {
-        self.chan.recv()
-            .map_err(|_| UnboundedRecvError(()))
+        self.chan.recv().map_err(|_| UnboundedRecvError(()))
     }
 }
-
 
 impl<T> UnboundedSender<T> {
     pub(crate) fn new(chan: chan::Tx<T, Semaphore>) -> UnboundedSender<T> {
@@ -109,9 +109,7 @@ impl<T> UnboundedSender<T> {
     }
 
     /// Attempts to send a message on this `UnboundedSender` without blocking.
-    pub fn try_send(&mut self, message: T)
-        -> Result<(), UnboundedTrySendError<T>>
-    {
+    pub fn try_send(&mut self, message: T) -> Result<(), UnboundedTrySendError<T>> {
         self.chan.try_send(message)?;
         Ok(())
     }

--- a/tokio-sync/src/task/atomic_task.rs
+++ b/tokio-sync/src/task/atomic_task.rs
@@ -1,11 +1,11 @@
-use ::loom::{
+use loom::{
     futures::task::{self, Task},
-    sync::CausalCell,
     sync::atomic::AtomicUsize,
+    sync::CausalCell,
 };
 
 use std::fmt;
-use std::sync::atomic::Ordering::{Acquire, Release, AcqRel};
+use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 
 /// A synchronization primitive for task notification.
 ///
@@ -189,8 +189,9 @@ impl AtomicTask {
                     //
                     // Start by assuming that the state is `REGISTERING` as this
                     // is what we jut set it to.
-                    let res = self.state.compare_exchange(
-                        REGISTERING, WAITING, AcqRel, Acquire);
+                    let res = self
+                        .state
+                        .compare_exchange(REGISTERING, WAITING, AcqRel, Acquire);
 
                     match res {
                         Ok(_) => {}
@@ -230,9 +231,7 @@ impl AtomicTask {
                 //
                 // We just want to maintain memory safety. It is ok to drop the
                 // call to `register`.
-                debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | NOTIFYING);
+                debug_assert!(state == REGISTERING || state == REGISTERING | NOTIFYING);
             }
         }
     }
@@ -276,9 +275,8 @@ impl AtomicTask {
                 // not.
                 //
                 debug_assert!(
-                    state == REGISTERING ||
-                    state == REGISTERING | NOTIFYING ||
-                    state == NOTIFYING);
+                    state == REGISTERING || state == REGISTERING | NOTIFYING || state == NOTIFYING
+                );
                 None
             }
         }
@@ -309,7 +307,8 @@ struct CurrentTask;
 
 impl Register for CurrentTask {
     fn register(self, slot: &mut Option<Task>) {
-        let should_update = (&*slot).as_ref()
+        let should_update = (&*slot)
+            .as_ref()
             .map(|prev| !prev.will_notify_current())
             .unwrap_or(true);
         if should_update {

--- a/tokio-sync/tests/fuzz_atomic_task.rs
+++ b/tokio-sync/tests/fuzz_atomic_task.rs
@@ -14,11 +14,11 @@ use loom::futures::block_on;
 use loom::sync::atomic::AtomicUsize;
 use loom::thread;
 
-use futures::Async;
 use futures::future::poll_fn;
+use futures::Async;
 
-use std::sync::Arc;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Arc;
 
 struct Chan {
     num: AtomicUsize,
@@ -52,6 +52,7 @@ fn basic_notification() {
             }
 
             Ok::<_, ()>(Async::NotReady)
-        })).unwrap();
+        }))
+        .unwrap();
     });
 }

--- a/tokio-sync/tests/fuzz_mpsc.rs
+++ b/tokio-sync/tests/fuzz_mpsc.rs
@@ -16,7 +16,7 @@ mod mpsc;
 #[allow(warnings)]
 mod semaphore;
 
-use futures::{Stream, future::poll_fn};
+use futures::{future::poll_fn, Stream};
 use loom::futures::block_on;
 use loom::thread;
 

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -4,13 +4,13 @@ extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;
 
-use tokio_sync::mpsc;
 use tokio_mock_task::*;
+use tokio_sync::mpsc;
 
 use futures::prelude::*;
 
-use std::thread;
 use std::sync::Arc;
+use std::thread;
 
 trait AssertSend: Send {}
 impl AssertSend for mpsc::Sender<i32> {}
@@ -23,17 +23,17 @@ macro_rules! assert_ready {
             Ok(_) => panic!("not ready"),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
 
 macro_rules! assert_not_ready {
     ($e:expr) => {{
         match $e {
-            Ok(futures::Async::NotReady) => {},
+            Ok(futures::Async::NotReady) => {}
             Ok(futures::Async::Ready(v)) => panic!("ready; value = {:?}", v),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
 
 #[test]
@@ -212,7 +212,7 @@ fn send_recv_threads() {
     let (tx, rx) = mpsc::channel::<i32>(16);
     let mut rx = rx.wait();
 
-    thread::spawn(move|| {
+    thread::spawn(move || {
         tx.send(1).wait().unwrap();
     });
 

--- a/tokio-sync/tests/oneshot.rs
+++ b/tokio-sync/tests/oneshot.rs
@@ -4,8 +4,8 @@ extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;
 
-use tokio_sync::oneshot;
 use tokio_mock_task::*;
+use tokio_sync::oneshot;
 
 use futures::prelude::*;
 
@@ -16,19 +16,18 @@ macro_rules! assert_ready {
             Ok(_) => panic!("not ready"),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
 
 macro_rules! assert_not_ready {
     ($e:expr) => {{
         match $e {
-            Ok(futures::Async::NotReady) => {},
+            Ok(futures::Async::NotReady) => {}
             Ok(futures::Async::Ready(v)) => panic!("ready; value = {:?}", v),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
-
 
 trait AssertSend: Send {}
 impl AssertSend for oneshot::Sender<i32> {}

--- a/tokio-sync/tests/semaphore.rs
+++ b/tokio-sync/tests/semaphore.rs
@@ -4,8 +4,8 @@ extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;
 
-use tokio_sync::semaphore::{Semaphore, Permit};
 use tokio_mock_task::*;
+use tokio_sync::semaphore::{Permit, Semaphore};
 
 macro_rules! assert_ready {
     ($e:expr) => {{
@@ -14,17 +14,17 @@ macro_rules! assert_ready {
             Ok(_) => panic!("not ready"),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
 
 macro_rules! assert_not_ready {
     ($e:expr) => {{
         match $e {
-            Ok(futures::Async::NotReady) => {},
+            Ok(futures::Async::NotReady) => {}
             Ok(futures::Async::Ready(v)) => panic!("ready; value = {:?}", v),
             Err(e) => panic!("error = {:?}", e),
         }
-    }}
+    }};
 }
 
 #[test]

--- a/tokio-tcp/src/incoming.rs
+++ b/tokio-tcp/src/incoming.rs
@@ -1,9 +1,9 @@
 use super::TcpListener;
 use super::TcpStream;
 
-use std::io;
 use futures::stream::Stream;
-use futures::{Poll, Async};
+use futures::{Async, Poll};
+use std::io;
 
 /// Stream returned by the `TcpListener::incoming` function representing the
 /// stream of sockets received from a listener.

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -36,5 +36,5 @@ mod stream;
 
 pub use self::incoming::Incoming;
 pub use self::listener::TcpListener;
-pub use self::stream::TcpStream;
 pub use self::stream::ConnectFuture;
+pub use self::stream::TcpStream;

--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
 
-use futures::{Poll, Async};
+use futures::{Async, Poll};
 use mio;
 use tokio_reactor::{Handle, PollEvented};
 
@@ -235,9 +235,7 @@ impl TcpListener {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn from_std(listener: net::TcpListener, handle: &Handle)
-        -> io::Result<TcpListener>
-    {
+    pub fn from_std(listener: net::TcpListener, handle: &Handle) -> io::Result<TcpListener> {
         let io = mio::net::TcpListener::from_std(listener)?;
         let io = PollEvented::new_with_handle(io, handle)?;
         Ok(TcpListener { io })
@@ -371,8 +369,8 @@ impl fmt::Debug for TcpListener {
 
 #[cfg(unix)]
 mod sys {
-    use std::os::unix::prelude::*;
     use super::TcpListener;
+    use std::os::unix::prelude::*;
 
     impl AsRawFd for TcpListener {
         fn as_raw_fd(&self) -> RawFd {

--- a/tokio-tcp/tests/chain.rs
+++ b/tokio-tcp/tests/chain.rs
@@ -1,21 +1,23 @@
 extern crate futures;
-extern crate tokio_tcp;
 extern crate tokio_io;
+extern crate tokio_tcp;
 
+use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::thread;
-use std::io::{Write, Read};
 
-use futures::Future;
 use futures::stream::Stream;
+use futures::Future;
 use tokio_io::io::read_to_end;
 use tokio_tcp::TcpListener;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]

--- a/tokio-tcp/tests/echo.rs
+++ b/tokio-tcp/tests/echo.rs
@@ -1,23 +1,25 @@
 extern crate env_logger;
 extern crate futures;
-extern crate tokio_tcp;
 extern crate tokio_io;
+extern crate tokio_tcp;
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::thread;
 
-use futures::Future;
 use futures::stream::Stream;
-use tokio_tcp::TcpListener;
-use tokio_io::AsyncRead;
+use futures::Future;
 use tokio_io::io::copy;
+use tokio_io::AsyncRead;
+use tokio_tcp::TcpListener;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]

--- a/tokio-tcp/tests/limit.rs
+++ b/tokio-tcp/tests/limit.rs
@@ -1,21 +1,23 @@
 extern crate futures;
-extern crate tokio_tcp;
 extern crate tokio_io;
+extern crate tokio_tcp;
 
+use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::thread;
-use std::io::{Write, Read};
 
-use futures::Future;
 use futures::stream::Stream;
+use futures::Future;
 use tokio_io::io::read_to_end;
 use tokio_tcp::TcpListener;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]

--- a/tokio-tcp/tests/stream-buffered.rs
+++ b/tokio-tcp/tests/stream-buffered.rs
@@ -1,23 +1,25 @@
 extern crate env_logger;
 extern crate futures;
-extern crate tokio_tcp;
 extern crate tokio_io;
+extern crate tokio_tcp;
 
 use std::io::{Read, Write};
 use std::net::TcpStream;
 use std::thread;
 
-use futures::Future;
 use futures::stream::Stream;
+use futures::Future;
 use tokio_io::io::copy;
 use tokio_io::AsyncRead;
 use tokio_tcp::TcpListener;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
@@ -41,12 +43,13 @@ fn echo_server() {
         assert_eq!(&buf[..msg.len()], msg);
     });
 
-    let future = srv.incoming()
-                    .map(|s| s.split())
-                    .map(|(a, b)| copy(a, b).map(|_| ()))
-                    .buffered(10)
-                    .take(2)
-                    .collect();
+    let future = srv
+        .incoming()
+        .map(|s| s.split())
+        .map(|(a, b)| copy(a, b).map(|_| ()))
+        .buffered(10)
+        .take(2)
+        .collect();
 
     t!(future.wait());
 

--- a/tokio-tcp/tests/tcp.rs
+++ b/tokio-tcp/tests/tcp.rs
@@ -1,21 +1,22 @@
 extern crate env_logger;
+extern crate futures;
+extern crate mio;
 extern crate tokio_io;
 extern crate tokio_tcp;
-extern crate mio;
-extern crate futures;
 
-use std::{net, thread};
 use std::sync::mpsc::channel;
+use std::{net, thread};
 
 use futures::{Future, Stream};
 use tokio_tcp::{TcpListener, TcpStream};
 
-
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
@@ -23,9 +24,7 @@ fn connect() {
     drop(env_logger::try_init());
     let srv = t!(net::TcpListener::bind("127.0.0.1:0"));
     let addr = t!(srv.local_addr());
-    let t = thread::spawn(move || {
-        t!(srv.accept()).0
-    });
+    let t = thread::spawn(move || t!(srv.accept()).0);
 
     let stream = TcpStream::connect(&addr);
     let mine = t!(stream.wait());
@@ -42,14 +41,16 @@ fn accept() {
     let addr = t!(srv.local_addr());
 
     let (tx, rx) = channel();
-    let client = srv.incoming().map(move |t| {
-        tx.send(()).unwrap();
-        t
-    }).into_future().map_err(|e| e.0);
+    let client = srv
+        .incoming()
+        .map(move |t| {
+            tx.send(()).unwrap();
+            t
+        })
+        .into_future()
+        .map_err(|e| e.0);
     assert!(rx.try_recv().is_err());
-    let t = thread::spawn(move || {
-        net::TcpStream::connect(&addr).unwrap()
-    });
+    let t = thread::spawn(move || net::TcpStream::connect(&addr).unwrap());
 
     let (mine, _remaining) = t!(client.wait());
     let mine = mine.unwrap();
@@ -65,15 +66,17 @@ fn accept2() {
     let srv = t!(TcpListener::bind(&t!("127.0.0.1:0".parse())));
     let addr = t!(srv.local_addr());
 
-    let t = thread::spawn(move || {
-        net::TcpStream::connect(&addr).unwrap()
-    });
+    let t = thread::spawn(move || net::TcpStream::connect(&addr).unwrap());
 
     let (tx, rx) = channel();
-    let client = srv.incoming().map(move |t| {
-        tx.send(()).unwrap();
-        t
-    }).into_future().map_err(|e| e.0);
+    let client = srv
+        .incoming()
+        .map(move |t| {
+            tx.send(()).unwrap();
+            t
+        })
+        .into_future()
+        .map_err(|e| e.0);
     assert!(rx.try_recv().is_err());
 
     let (mine, _remaining) = t!(client.wait());
@@ -86,13 +89,13 @@ mod unix {
     use tokio_tcp::TcpStream;
 
     use env_logger;
-    use futures::{Future, future};
+    use futures::{future, Future};
     use mio::unix::UnixReady;
     use tokio_io::AsyncRead;
 
     use std::io::Write;
-    use std::{net, thread};
     use std::time::Duration;
+    use std::{net, thread};
 
     #[test]
     fn poll_hup() {
@@ -109,21 +112,21 @@ mod unix {
         let mut stream = t!(TcpStream::connect(&addr).wait());
 
         // Poll for HUP before reading.
-        future::poll_fn(|| {
-            stream.poll_read_ready(UnixReady::hup().into())
-        }).wait().unwrap();
+        future::poll_fn(|| stream.poll_read_ready(UnixReady::hup().into()))
+            .wait()
+            .unwrap();
 
         // Same for write half
-        future::poll_fn(|| {
-            stream.poll_write_ready()
-        }).wait().unwrap();
+        future::poll_fn(|| stream.poll_write_ready())
+            .wait()
+            .unwrap();
 
         let mut buf = vec![0; 11];
 
         // Read the data
-        future::poll_fn(|| {
-            stream.poll_read(&mut buf)
-        }).wait().unwrap();
+        future::poll_fn(|| stream.poll_read(&mut buf))
+            .wait()
+            .unwrap();
 
         assert_eq!(b"hello world", &buf[..]);
 

--- a/tokio-threadpool/benches/basic.rs
+++ b/tokio-threadpool/benches/basic.rs
@@ -1,11 +1,11 @@
 #![feature(test)]
 #![deny(warnings)]
 
-extern crate tokio_threadpool;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate num_cpus;
 extern crate test;
+extern crate tokio_threadpool;
 
 const NUM_SPAWN: usize = 10_000;
 const NUM_YIELD: usize = 1_000;
@@ -13,12 +13,12 @@ const TASKS_PER_CPU: usize = 50;
 
 mod threadpool {
     use futures::{future, task, Async};
-    use tokio_threadpool::*;
     use num_cpus;
-    use test;
-    use std::sync::{mpsc, Arc};
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering::SeqCst;
+    use std::sync::{mpsc, Arc};
+    use test;
+    use tokio_threadpool::*;
 
     #[bench]
     fn spawn_many(b: &mut test::Bencher) {
@@ -90,14 +90,14 @@ mod threadpool {
 // See rust-lang-nursery/futures-rs#617
 //
 mod cpupool {
-    use futures::{task, Async};
     use futures::future::{self, Executor};
+    use futures::{task, Async};
     use futures_cpupool::*;
     use num_cpus;
-    use test;
-    use std::sync::{mpsc, Arc};
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering::SeqCst;
+    use std::sync::{mpsc, Arc};
+    use test;
 
     #[bench]
     fn spawn_many(b: &mut test::Bencher) {
@@ -119,7 +119,9 @@ mod cpupool {
                     }
 
                     Ok(())
-                })).ok().unwrap();
+                }))
+                .ok()
+                .unwrap();
             }
 
             let _ = rx.recv().unwrap();
@@ -151,7 +153,9 @@ mod cpupool {
                         // Not ready
                         Ok(Async::NotReady)
                     }
-                })).ok().unwrap();
+                }))
+                .ok()
+                .unwrap();
             }
 
             for _ in 0..tasks {

--- a/tokio-threadpool/benches/blocking.rs
+++ b/tokio-threadpool/benches/blocking.rs
@@ -3,9 +3,9 @@
 
 extern crate futures;
 extern crate rand;
-extern crate tokio_threadpool;
-extern crate threadpool;
 extern crate test;
+extern crate threadpool;
+extern crate tokio_threadpool;
 
 const ITER: usize = 1_000;
 
@@ -13,14 +13,11 @@ mod blocking {
     use super::*;
 
     use futures::future::*;
-    use tokio_threadpool::{Builder, blocking};
+    use tokio_threadpool::{blocking, Builder};
 
     #[bench]
     fn cpu_bound(b: &mut test::Bencher) {
-        let pool = Builder::new()
-            .pool_size(2)
-            .max_blocking(20)
-            .build();
+        let pool = Builder::new().pool_size(2).max_blocking(20).build();
 
         b.iter(|| {
             let count_down = Arc::new(CountDown::new(::ITER));
@@ -29,17 +26,12 @@ mod blocking {
                 let count_down = count_down.clone();
 
                 pool.spawn(lazy(move || {
-                    poll_fn(|| {
-                        blocking(|| {
-                            perform_complex_computation()
+                    poll_fn(|| blocking(|| perform_complex_computation()).map_err(|_| panic!()))
+                        .and_then(move |_| {
+                            // Do something with the value
+                            count_down.dec();
+                            Ok(())
                         })
-                        .map_err(|_| panic!())
-                    })
-                    .and_then(move |_| {
-                        // Do something with the value
-                        count_down.dec();
-                        Ok(())
-                    })
                 }));
             }
 
@@ -57,10 +49,7 @@ mod message_passing {
 
     #[bench]
     fn cpu_bound(b: &mut test::Bencher) {
-        let pool = Builder::new()
-            .pool_size(2)
-            .max_blocking(20)
-            .build();
+        let pool = Builder::new().pool_size(2).max_blocking(20).build();
 
         let blocking = threadpool::ThreadPool::new(20);
 
@@ -85,7 +74,8 @@ mod message_passing {
                     rx.and_then(move |_| {
                         count_down.dec();
                         Ok(())
-                    }).map_err(|_| panic!())
+                    })
+                    .map_err(|_| panic!())
                 }));
             }
 
@@ -104,9 +94,9 @@ fn perform_complex_computation() -> usize {
 
 // Util for waiting until the tasks complete
 
-use std::sync::*;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::*;
+use std::sync::*;
 
 struct CountDown {
     rem: AtomicUsize,

--- a/tokio-threadpool/benches/depth.rs
+++ b/tokio-threadpool/benches/depth.rs
@@ -1,19 +1,19 @@
 #![feature(test)]
 #![deny(warnings)]
 
-extern crate tokio_threadpool;
 extern crate futures;
 extern crate futures_cpupool;
 extern crate num_cpus;
 extern crate test;
+extern crate tokio_threadpool;
 
 const ITER: usize = 20_000;
 
 mod us {
-    use tokio_threadpool::*;
     use futures::future;
-    use test;
     use std::sync::mpsc;
+    use test;
+    use tokio_threadpool::*;
 
     #[bench]
     fn chained_spawn(b: &mut test::Bencher) {
@@ -24,10 +24,12 @@ mod us {
                 res_tx.send(()).unwrap();
             } else {
                 let pool_tx2 = pool_tx.clone();
-                pool_tx.spawn(future::lazy(move || {
-                    spawn(pool_tx2, res_tx, n - 1);
-                    Ok(())
-                })).unwrap();
+                pool_tx
+                    .spawn(future::lazy(move || {
+                        spawn(pool_tx2, res_tx, n - 1);
+                        Ok(())
+                    }))
+                    .unwrap();
             }
         }
 
@@ -44,8 +46,8 @@ mod cpupool {
     use futures::future::{self, Executor};
     use futures_cpupool::*;
     use num_cpus;
-    use test;
     use std::sync::mpsc;
+    use test;
 
     #[bench]
     fn chained_spawn(b: &mut test::Bencher) {
@@ -59,7 +61,9 @@ mod cpupool {
                 pool.execute(future::lazy(move || {
                     spawn(pool2, res_tx, n - 1);
                     Ok(())
-                })).ok().unwrap();
+                }))
+                .ok()
+                .unwrap();
             }
         }
 

--- a/tokio-threadpool/examples/depth.rs
+++ b/tokio-threadpool/examples/depth.rs
@@ -1,9 +1,9 @@
+extern crate env_logger;
 extern crate futures;
 extern crate tokio_threadpool;
-extern crate env_logger;
 
-use tokio_threadpool::*;
 use futures::future::{self, Executor};
+use tokio_threadpool::*;
 
 use std::sync::mpsc;
 
@@ -22,7 +22,9 @@ fn chained_spawn() {
             tx.execute(future::lazy(move || {
                 spawn(tx2, res_tx, n - 1);
                 Ok(())
-            })).ok().unwrap();
+            }))
+            .ok()
+            .unwrap();
         }
     }
 

--- a/tokio-threadpool/examples/hello.rs
+++ b/tokio-threadpool/examples/hello.rs
@@ -1,10 +1,10 @@
+extern crate env_logger;
 extern crate futures;
 extern crate tokio_threadpool;
-extern crate env_logger;
 
-use tokio_threadpool::*;
-use futures::*;
 use futures::sync::oneshot;
+use futures::*;
+use tokio_threadpool::*;
 
 pub fn main() {
     let _ = ::env_logger::init();
@@ -12,10 +12,13 @@ pub fn main() {
     let pool = ThreadPool::new();
     let tx = pool.sender().clone();
 
-    let res = oneshot::spawn(future::lazy(|| {
-        println!("Running on the pool");
-        Ok::<_, ()>("complete")
-    }), &tx);
+    let res = oneshot::spawn(
+        future::lazy(|| {
+            println!("Running on the pool");
+            Ok::<_, ()>("complete")
+        }),
+        &tx,
+    );
 
     println!("Result: {:?}", res.wait());
 }

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -122,7 +122,8 @@ pub struct BlockingError {
 /// }
 /// ```
 pub fn blocking<F, T>(f: F) -> Poll<T, BlockingError>
-where F: FnOnce() -> T,
+where
+    F: FnOnce() -> T,
 {
     let res = Worker::with_current(|worker| {
         let worker = match worker {
@@ -148,8 +149,7 @@ where F: FnOnce() -> T,
     // back ownership of the worker if the worker handoff didn't complete yet.
     Worker::with_current(|worker| {
         // Worker must be set since it was above.
-        worker.unwrap()
-            .transition_from_blocking();
+        worker.unwrap().transition_from_blocking();
     });
 
     // Return the result

--- a/tokio-threadpool/src/callback.rs
+++ b/tokio-threadpool/src/callback.rs
@@ -12,7 +12,8 @@ pub(crate) struct Callback {
 
 impl Callback {
     pub fn new<F>(f: F) -> Self
-        where F: Fn(&Worker, &mut Enter) + Send + Sync + 'static
+    where
+        F: Fn(&Worker, &mut Enter) + Send + Sync + 'static,
     {
         Callback { f: Arc::new(f) }
     }

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -159,5 +159,5 @@ pub use blocking::{blocking, BlockingError};
 pub use builder::Builder;
 pub use sender::Sender;
 pub use shutdown::Shutdown;
-pub use thread_pool::{ThreadPool, SpawnHandle};
+pub use thread_pool::{SpawnHandle, ThreadPool};
 pub use worker::{Worker, WorkerId};

--- a/tokio-threadpool/src/park/boxed.rs
+++ b/tokio-threadpool/src/park/boxed.rs
@@ -15,7 +15,8 @@ impl<T> BoxedPark<T> {
 }
 
 impl<T: Park + Send> Park for BoxedPark<T>
-where T::Error: Error,
+where
+    T::Error: Error,
 {
     type Unpark = BoxUnpark;
     type Error = ();
@@ -25,16 +26,20 @@ where T::Error: Error,
     }
 
     fn park(&mut self) -> Result<(), Self::Error> {
-        self.0.park()
-            .map_err(|e| {
-                warn!("calling `park` on worker thread errored -- shutting down thread: {}", e);
-            })
+        self.0.park().map_err(|e| {
+            warn!(
+                "calling `park` on worker thread errored -- shutting down thread: {}",
+                e
+            );
+        })
     }
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
-        self.0.park_timeout(duration)
-            .map_err(|e| {
-                warn!("calling `park` on worker thread errored -- shutting down thread: {}", e);
-            })
+        self.0.park_timeout(duration).map_err(|e| {
+            warn!(
+                "calling `park` on worker thread errored -- shutting down thread: {}",
+                e
+            );
+        })
     }
 }

--- a/tokio-threadpool/src/pool/backup_stack.rs
+++ b/tokio-threadpool/src/pool/backup_stack.rs
@@ -1,7 +1,7 @@
 use pool::{Backup, BackupId};
 
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Acquire, AcqRel};
+use std::sync::atomic::Ordering::{AcqRel, Acquire};
 
 #[derive(Debug)]
 pub(crate) struct BackupStack {
@@ -65,8 +65,10 @@ impl BackupStack {
             entries[id.0].set_next_sleeper(head);
             next.set_head(id);
 
-            let actual = self.state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if state == actual {
                 return Ok(());
@@ -110,8 +112,10 @@ impl BackupStack {
                     return Ok(None);
                 }
 
-                let actual = self.state.compare_and_swap(
-                    state.into(), next.into(), AcqRel).into();
+                let actual = self
+                    .state
+                    .compare_and_swap(state.into(), next.into(), AcqRel)
+                    .into();
 
                 if actual != state {
                     state = actual;
@@ -138,8 +142,10 @@ impl BackupStack {
                 next.set_head(next_head);
             }
 
-            let actual = self.state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if actual == state {
                 debug_assert!(entries[head.0].is_pushed());

--- a/tokio-threadpool/src/pool/state.rs
+++ b/tokio-threadpool/src/pool/state.rs
@@ -82,8 +82,7 @@ impl State {
     }
 
     pub fn is_terminated(&self) -> bool {
-        self.lifecycle() == Lifecycle::ShutdownNow &&
-            self.num_futures() == 0
+        self.lifecycle() == Lifecycle::ShutdownNow && self.num_futures() == 0
     }
 }
 
@@ -115,9 +114,10 @@ impl From<usize> for Lifecycle {
         use self::Lifecycle::*;
 
         debug_assert!(
-            src == Running as usize ||
-            src == ShutdownOnIdle as usize ||
-            src == ShutdownNow as usize);
+            src == Running as usize
+                || src == ShutdownOnIdle as usize
+                || src == ShutdownNow as usize
+        );
 
         unsafe { ::std::mem::transmute(src) }
     }

--- a/tokio-threadpool/src/shutdown.rs
+++ b/tokio-threadpool/src/shutdown.rs
@@ -2,8 +2,8 @@ use task::Task;
 use worker;
 
 use crossbeam_deque::Injector;
-use futures::{Future, Poll, Async};
 use futures::task::AtomicTask;
+use futures::{Async, Future, Poll};
 
 use std::sync::{Arc, Mutex};
 

--- a/tokio-threadpool/src/task/state.rs
+++ b/tokio-threadpool/src/task/state.rs
@@ -41,8 +41,10 @@ impl From<usize> for State {
         use self::State::*;
 
         debug_assert!(
-            src >= Idle as usize &&
-            src <= Aborted as usize, "actual={}", src);
+            src >= Idle as usize && src <= Aborted as usize,
+            "actual={}",
+            src
+        );
 
         unsafe { ::std::mem::transmute(src) }
     }

--- a/tokio-threadpool/src/thread_pool.rs
+++ b/tokio-threadpool/src/thread_pool.rs
@@ -3,8 +3,8 @@ use pool::Pool;
 use sender::Sender;
 use shutdown::{Shutdown, ShutdownTrigger};
 
-use futures::{Future, Poll};
 use futures::sync::oneshot;
+use futures::{Future, Poll};
 
 use std::sync::Arc;
 
@@ -36,10 +36,7 @@ impl ThreadPool {
         Builder::new().build()
     }
 
-    pub(crate) fn new2(
-        pool: Arc<Pool>,
-        trigger: Arc<ShutdownTrigger>,
-    ) -> ThreadPool {
+    pub(crate) fn new2(pool: Arc<Pool>, trigger: Arc<ShutdownTrigger>) -> ThreadPool {
         ThreadPool {
             inner: Some(Inner {
                 sender: Sender { pool },
@@ -80,18 +77,19 @@ impl ThreadPool {
     /// This function panics if the spawn fails. Use [`Sender::spawn`] for a
     /// version that returns a `Result` instead of panicking.
     pub fn spawn<F>(&self, future: F)
-    where F: Future<Item = (), Error = ()> + Send + 'static,
+    where
+        F: Future<Item = (), Error = ()> + Send + 'static,
     {
         self.sender().spawn(future).unwrap();
     }
 
-    /// Spawn a future on to the thread pool, return a future representing 
+    /// Spawn a future on to the thread pool, return a future representing
     /// the produced value.
-    /// 
-    /// The SpawnHandle returned is a future that is a proxy for future itself. 
-    /// When future completes on this thread pool then the SpawnHandle will itself 
+    ///
+    /// The SpawnHandle returned is a future that is a proxy for future itself.
+    /// When future completes on this thread pool then the SpawnHandle will itself
     /// be resolved.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -105,7 +103,7 @@ impl ThreadPool {
     /// let thread_pool = ThreadPool::new();
     ///
     /// let handle = thread_pool.spawn_handle(lazy(|| Ok::<_, ()>(42)));
-    /// 
+    ///
     /// let value = handle.wait().unwrap();
     /// assert_eq!(value, 42);
     ///
@@ -116,9 +114,9 @@ impl ThreadPool {
     ///
     /// # Panics
     ///
-    /// This function panics if the spawn fails. 
+    /// This function panics if the spawn fails.
     pub fn spawn_handle<F>(&self, future: F) -> SpawnHandle<F::Item, F::Error>
-    where 
+    where
         F: Future + Send + 'static,
         F::Item: Send + 'static,
         F::Error: Send + 'static,
@@ -201,10 +199,10 @@ impl Drop for ThreadPool {
 }
 
 /// Handle returned from ThreadPool::spawn_handle.
-/// 
-/// This handle is a future representing the completion of a different future 
-/// spawned on to the thread pool. Created through the ThreadPool::spawn_handle 
-/// function this handle will resolve when the future provided resolves on the 
+///
+/// This handle is a future representing the completion of a different future
+/// spawned on to the thread pool. Created through the ThreadPool::spawn_handle
+/// function this handle will resolve when the future provided resolves on the
 /// thread pool.
 #[derive(Debug)]
 pub struct SpawnHandle<T, E>(oneshot::SpawnHandle<T, E>);

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -2,24 +2,19 @@ mod entry;
 mod stack;
 mod state;
 
-pub(crate) use self::entry::{
-    WorkerEntry as Entry,
-};
+pub(crate) use self::entry::WorkerEntry as Entry;
 pub(crate) use self::stack::Stack;
-pub(crate) use self::state::{
-    State,
-    Lifecycle,
-};
+pub(crate) use self::state::{Lifecycle, State};
 
-use pool::{self, Pool, BackupId};
 use notifier::Notifier;
+use pool::{self, BackupId, Pool};
 use sender::Sender;
 use shutdown::ShutdownTrigger;
-use task::{self, Task, CanBlock};
+use task::{self, CanBlock, Task};
 
 use tokio_executor;
 
-use futures::{Poll, Async};
+use futures::{Async, Poll};
 
 use std::cell::Cell;
 use std::marker::PhantomData;
@@ -339,8 +334,11 @@ impl Worker {
                 }
             }
 
-            let actual = self.entry().state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .entry()
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if actual == state {
                 break;
@@ -417,8 +415,11 @@ impl Worker {
 
                         self.run_task(task, notify);
 
-                        trace!("try_steal_task -- signal_work; self={}; from={}",
-                               self.id.0, idx);
+                        trace!(
+                            "try_steal_task -- signal_work; self={}; from={}",
+                            self.id.0,
+                            idx
+                        );
 
                         // Signal other workers that work is available
                         //
@@ -485,8 +486,11 @@ impl Worker {
                     let mut next = state;
                     next.dec_num_futures();
 
-                    let actual = self.pool.state.compare_and_swap(
-                        state.into(), next.into(), AcqRel).into();
+                    let actual = self
+                        .pool
+                        .state
+                        .compare_and_swap(state.into(), next.into(), AcqRel)
+                        .into();
 
                     if actual == state {
                         trace!("task complete; state={:?}", next);
@@ -526,11 +530,7 @@ impl Worker {
     ///
     /// Great care is needed to ensure that `current_task` is unset in this
     /// function.
-    fn run_task2(&self,
-                 task: &Arc<Task>,
-                 notify: &Arc<Notifier>)
-        -> task::Run
-    {
+    fn run_task2(&self, task: &Arc<Task>, notify: &Arc<Notifier>) -> task::Run {
         struct Guard<'a> {
             worker: &'a Worker,
         }
@@ -562,9 +562,7 @@ impl Worker {
 
         // Create the guard, this ensures that `current_task` is unset when the
         // function returns, even if the return is caused by a panic.
-        let _g = Guard {
-            worker: self,
-        };
+        let _g = Guard { worker: self };
 
         task.run(notify)
     }
@@ -609,8 +607,11 @@ impl Worker {
                 }
             }
 
-            let actual = self.entry().state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .entry()
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if actual == state {
                 if state.is_notified() {
@@ -668,8 +669,11 @@ impl Worker {
                         let mut next = state;
                         next.set_lifecycle(Running);
 
-                        let actual = self.entry().state.compare_and_swap(
-                            state.into(), next.into(), AcqRel).into();
+                        let actual = self
+                            .entry()
+                            .state
+                            .compare_and_swap(state.into(), next.into(), AcqRel)
+                            .into();
 
                         if actual == state {
                             return true;

--- a/tokio-threadpool/src/worker/stack.rs
+++ b/tokio-threadpool/src/worker/stack.rs
@@ -1,9 +1,9 @@
 use config::MAX_WORKERS;
 use worker;
 
-use std::{fmt, usize};
 use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Acquire, AcqRel, Relaxed};
+use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed};
+use std::{fmt, usize};
 
 /// Lock-free stack of sleeping workers.
 ///
@@ -90,8 +90,10 @@ impl Stack {
             entries[idx].set_next_sleeper(head);
             next.set_head(idx);
 
-            let actual = self.state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if state == actual {
                 return Ok(());
@@ -112,11 +114,12 @@ impl Stack {
     /// Returns the index of the popped worker and the worker's observed state.
     ///
     /// `None` if the stack is empty.
-    pub fn pop(&self, entries: &[worker::Entry],
-                  max_lifecycle: worker::Lifecycle,
-                  terminate: bool)
-        -> Option<(usize, worker::State)>
-    {
+    pub fn pop(
+        &self,
+        entries: &[worker::Entry],
+        max_lifecycle: worker::Lifecycle,
+        terminate: bool,
+    ) -> Option<(usize, worker::State)> {
         // Figure out the empty value
         let terminal = match terminate {
             true => TERMINATED,
@@ -145,8 +148,10 @@ impl Stack {
                     return None;
                 }
 
-                let actual = self.state.compare_and_swap(
-                    state.into(), next.into(), AcqRel).into();
+                let actual = self
+                    .state
+                    .compare_and_swap(state.into(), next.into(), AcqRel)
+                    .into();
 
                 if actual != state {
                     state = actual;
@@ -173,8 +178,10 @@ impl Stack {
                 next.set_head(next_head);
             }
 
-            let actual = self.state.compare_and_swap(
-                state.into(), next.into(), AcqRel).into();
+            let actual = self
+                .state
+                .compare_and_swap(state.into(), next.into(), AcqRel)
+                .into();
 
             if actual == state {
                 // Release ordering is needed to ensure that unsetting the

--- a/tokio-threadpool/src/worker/state.rs
+++ b/tokio-threadpool/src/worker/state.rs
@@ -108,11 +108,12 @@ impl From<usize> for Lifecycle {
         use self::Lifecycle::*;
 
         debug_assert!(
-            src == Shutdown as usize ||
-            src == Running as usize ||
-            src == Sleeping as usize ||
-            src == Notified as usize ||
-            src == Signaled as usize);
+            src == Shutdown as usize
+                || src == Running as usize
+                || src == Sleeping as usize
+                || src == Notified as usize
+                || src == Signaled as usize
+        );
 
         unsafe { ::std::mem::transmute(src) }
     }
@@ -128,18 +129,12 @@ impl From<Lifecycle> for usize {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use super::Lifecycle::*;
+    use super::*;
 
     #[test]
     fn lifecycle_encode() {
-        let lifecycles = &[
-            Shutdown,
-            Running,
-            Sleeping,
-            Notified,
-            Signaled,
-        ];
+        let lifecycles = &[Shutdown, Running, Sleeping, Notified, Signaled];
 
         for &lifecycle in lifecycles {
             let mut v: usize = lifecycle.into();

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -35,16 +35,16 @@ mod imp {
         }
 
         pub fn compare_and_swap(&self, old: u64, new: u64, ordering: Ordering) -> u64 {
-            self.inner.compare_and_swap(
-                old as usize, new as usize, ordering) as u64
+            self.inner
+                .compare_and_swap(old as usize, new as usize, ordering) as u64
         }
     }
 }
 
 #[cfg(not(target_pointer_width = "64"))]
 mod imp {
-    use std::sync::Mutex;
     use std::sync::atomic::Ordering;
+    use std::sync::Mutex;
 
     #[derive(Debug)]
     pub struct AtomicU64 {

--- a/tokio-timer/src/clock/clock.rs
+++ b/tokio-timer/src/clock/clock.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 ///
 /// `Clock` instances return [`Instant`] values corresponding to "now". The source
 /// of these values is configurable. The default source is [`Instant::now`].
-/// 
+///
 /// [`Instant`]: https://doc.rust-lang.org/std/time/struct.Instant.html
 /// [`Instant::now`]: https://doc.rust-lang.org/std/time/struct.Instant.html#method.now
 #[derive(Default, Clone)]
@@ -20,7 +20,7 @@ pub struct Clock {
     now: Option<Arc<Now>>,
 }
 
-thread_local!{
+thread_local! {
     /// Thread-local tracking the current clock
     static CLOCK: Cell<Option<*const Clock>> = Cell::new(None)
 }
@@ -43,13 +43,9 @@ thread_local!{
 /// let now = clock::now();
 /// ```
 pub fn now() -> Instant {
-    CLOCK.with(|current| {
-        match current.get() {
-            Some(ptr) => {
-                unsafe { (*ptr).now() }
-            }
-            None => Instant::now(),
-        }
+    CLOCK.with(|current| match current.get() {
+        Some(ptr) => unsafe { (*ptr).now() },
+        None => Instant::now(),
     })
 }
 
@@ -57,13 +53,9 @@ impl Clock {
     /// Return a new `Clock` instance that uses the current execution context's
     /// source of time.
     pub fn new() -> Clock {
-        CLOCK.with(|current| {
-            match current.get() {
-                Some(ptr) => {
-                    unsafe { (*ptr).clone() }
-                }
-                None => Clock::system(),
-            }
+        CLOCK.with(|current| match current.get() {
+            Some(ptr) => unsafe { (*ptr).clone() },
+            None => Clock::system(),
         })
     }
 
@@ -76,12 +68,10 @@ impl Clock {
 
     /// Return a new `Clock` instance that uses [`Instant::now`] as the source
     /// of time.
-    /// 
+    ///
     /// [`Instant::now`]: https://doc.rust-lang.org/std/time/struct.Instant.html#method.now
     pub fn system() -> Clock {
-        Clock {
-            now: None,
-        }
+        Clock { now: None }
     }
 
     /// Returns an instant corresponding to "now" by using the instance's source
@@ -121,10 +111,14 @@ impl fmt::Debug for Clock {
 ///
 /// This function panics if there already is a default clock set.
 pub fn with_default<F, R>(clock: &Clock, enter: &mut Enter, f: F) -> R
-where F: FnOnce(&mut Enter) -> R
+where
+    F: FnOnce(&mut Enter) -> R,
 {
     CLOCK.with(|cell| {
-        assert!(cell.get().is_none(), "default clock already set for execution context");
+        assert!(
+            cell.get().is_none(),
+            "default clock already set for execution context"
+        );
 
         // Ensure that the clock is removed from the thread-local context
         // when leaving the scope. This handles cases that involve panicking.

--- a/tokio-timer/src/clock/mod.rs
+++ b/tokio-timer/src/clock/mod.rs
@@ -19,5 +19,5 @@
 mod clock;
 mod now;
 
-pub use self::clock::{Clock, now, with_default};
+pub use self::clock::{now, with_default, Clock};
 pub use self::now::Now;

--- a/tokio-timer/src/clock/now.rs
+++ b/tokio-timer/src/clock/now.rs
@@ -7,7 +7,7 @@ use std::time::Instant;
 ///
 /// Implementations must ensure that calls to `now` return monotonically
 /// increasing [`Instant`] values.
-/// 
+///
 /// [`Instant`]: https://doc.rust-lang.org/std/time/struct.Instant.html
 pub trait Now: Send + Sync + 'static {
     /// Returns an instant corresponding to "now".

--- a/tokio-timer/src/deadline.rs
+++ b/tokio-timer/src/deadline.rs
@@ -2,7 +2,7 @@
 
 use Delay;
 
-use futures::{Future, Poll, Async};
+use futures::{Async, Future, Poll};
 
 use std::error;
 use std::fmt;
@@ -42,10 +42,7 @@ impl<T> Deadline<T> {
     }
 
     pub(crate) fn new_with_delay(future: T, delay: Delay) -> Deadline<T> {
-        Deadline {
-            future,
-            delay,
-        }
+        Deadline { future, delay }
     }
 
     /// Gets a reference to the underlying future in this deadline.
@@ -65,7 +62,8 @@ impl<T> Deadline<T> {
 }
 
 impl<T> Future for Deadline<T>
-where T: Future,
+where
+    T: Future,
 {
     type Item = T::Item;
     type Error = DeadlineError<T::Error>;
@@ -81,9 +79,7 @@ where T: Future,
         // Now check the timer
         match self.delay.poll() {
             Ok(Async::NotReady) => Ok(Async::NotReady),
-            Ok(Async::Ready(_)) => {
-                Err(DeadlineError::elapsed())
-            },
+            Ok(Async::Ready(_)) => Err(DeadlineError::elapsed()),
             Err(e) => Err(DeadlineError::timer(e)),
         }
     }

--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -1,9 +1,9 @@
+use timer::{HandlePriv, Registration};
 use Error;
-use timer::{Registration, HandlePriv};
 
 use futures::{Future, Poll};
 
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 /// A future that completes at a specified instant in time.
 ///

--- a/tokio-timer/src/interval.rs
+++ b/tokio-timer/src/interval.rs
@@ -2,9 +2,9 @@ use Delay;
 
 use clock;
 
-use futures::{Future, Stream, Poll};
+use futures::{Future, Poll, Stream};
 
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 /// A stream representing notifications at fixed interval
 #[derive(Debug)]
@@ -28,7 +28,10 @@ impl Interval {
     ///
     /// This function panics if `duration` is zero.
     pub fn new(at: Instant, duration: Duration) -> Interval {
-        assert!(duration > Duration::new(0, 0), "`duration` must be non-zero.");
+        assert!(
+            duration > Duration::new(0, 0),
+            "`duration` must be non-zero."
+        );
 
         Interval::new_with_delay(Delay::new(at), duration)
     }
@@ -47,10 +50,7 @@ impl Interval {
     }
 
     pub(crate) fn new_with_delay(delay: Delay, duration: Duration) -> Interval {
-        Interval {
-            delay,
-            duration,
-        }
+        Interval { delay, duration }
     }
 }
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -53,9 +53,9 @@ mod wheel;
 #[doc(hidden)]
 #[allow(deprecated)]
 pub use self::deadline::{Deadline, DeadlineError};
+pub use self::delay::Delay;
 #[doc(inline)]
 pub use self::delay_queue::DelayQueue;
-pub use self::delay::Delay;
 pub use self::error::Error;
 pub use self::interval::Interval;
 #[doc(inline)]
@@ -92,5 +92,8 @@ fn ms(duration: Duration, round: Round) -> u64 {
         Round::Down => duration.subsec_nanos() / NANOS_PER_MILLI,
     };
 
-    duration.as_secs().saturating_mul(MILLIS_PER_SEC).saturating_add(millis as u64)
+    duration
+        .as_secs()
+        .saturating_mul(MILLIS_PER_SEC)
+        .saturating_add(millis as u64)
 }

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -2,8 +2,8 @@
 
 use {clock, Delay, Error};
 
-use futures::{Async, Future, Poll, Stream};
 use futures::future::Either;
+use futures::{Async, Future, Poll, Stream};
 
 use std::{
     error::Error as StdError,
@@ -65,17 +65,11 @@ impl<T: Stream> Stream for Throttle<T> {
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
         if let Some(ref mut delay) = self.delay {
-            try_ready!({
-                delay.poll()
-                    .map_err(ThrottleError::from_timer_err)
-            });
+            try_ready!({ delay.poll().map_err(ThrottleError::from_timer_err) });
         }
 
         self.delay = None;
-        let value = try_ready!({
-            self.stream.poll()
-                .map_err(ThrottleError::from_stream_err)
-        });
+        let value = try_ready!({ self.stream.poll().map_err(ThrottleError::from_stream_err) });
 
         if value.is_some() {
             self.delay = Some(Delay::new(clock::now() + self.duration));

--- a/tokio-timer/src/timer/atomic_stack.rs
+++ b/tokio-timer/src/timer/atomic_stack.rs
@@ -1,10 +1,10 @@
-use Error;
 use super::Entry;
+use Error;
 
 use std::ptr;
-use std::sync::Arc;
 use std::sync::atomic::AtomicPtr;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::Arc;
 
 /// A stack of `Entry` nodes
 #[derive(Debug)]
@@ -24,7 +24,9 @@ const SHUTDOWN: *mut Entry = 1 as *mut _;
 
 impl AtomicStack {
     pub fn new() -> AtomicStack {
-        AtomicStack { head: AtomicPtr::new(ptr::null_mut()) }
+        AtomicStack {
+            head: AtomicPtr::new(ptr::null_mut()),
+        }
     }
 
     /// Push an entry onto the stack.

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -44,23 +44,23 @@ use self::atomic_stack::AtomicStack;
 use self::entry::Entry;
 use self::stack::Stack;
 
-pub use self::handle::{Handle, with_default};
 pub(crate) use self::handle::HandlePriv;
+pub use self::handle::{with_default, Handle};
 pub use self::now::{Now, SystemNow};
 pub(crate) use self::registration::Registration;
 
-use Error;
 use atomic::AtomicU64;
 use wheel;
+use Error;
 
-use tokio_executor::park::{Park, Unpark, ParkThread};
+use tokio_executor::park::{Park, ParkThread, Unpark};
 
-use std::{cmp, fmt};
-use std::time::{Duration, Instant};
-use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 use std::usize;
+use std::{cmp, fmt};
 
 /// Timer implementation that drives [`Delay`], [`Interval`], and [`Timeout`].
 ///
@@ -171,7 +171,8 @@ const MAX_TIMEOUTS: usize = usize::MAX >> 1;
 // ===== impl Timer =====
 
 impl<T> Timer<T>
-where T: Park
+where
+    T: Park,
 {
     /// Create a new `Timer` instance that uses `park` to block the current
     /// thread.
@@ -201,8 +202,9 @@ impl<T, N> Timer<T, N> {
 }
 
 impl<T, N> Timer<T, N>
-where T: Park,
-      N: Now,
+where
+    T: Park,
+    N: Now,
 {
     /// Create a new `Timer` instance that uses `park` to block the current
     /// thread and `now` to get the current `Instant`.
@@ -268,8 +270,7 @@ where T: Park,
         let mut poll = wheel::Poll::new(now);
 
         while let Some(entry) = self.wheel.poll(&mut poll, &mut ()) {
-            let when = entry.when_internal()
-                .expect("invalid internal entry state");
+            let when = entry.when_internal().expect("invalid internal entry state");
 
             // Fire the entry
             entry.fire(when);
@@ -345,8 +346,9 @@ impl Default for Timer<ParkThread, SystemNow> {
 }
 
 impl<T, N> Park for Timer<T, N>
-where T: Park,
-      N: Now,
+where
+    T: Park,
+    N: Now,
 {
     type Unpark = T::Unpark;
     type Error = T::Error;
@@ -483,7 +485,6 @@ impl Inner {
 
 impl fmt::Debug for Inner {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Inner")
-            .finish()
+        fmt.debug_struct("Inner").finish()
     }
 }

--- a/tokio-timer/src/timer/now.rs
+++ b/tokio-timer/src/timer/now.rs
@@ -7,4 +7,4 @@ pub trait Now {
     fn now(&mut self) -> Instant;
 }
 
-pub use ::clock::Clock as SystemNow;
+pub use clock::Clock as SystemNow;

--- a/tokio-timer/src/timer/registration.rs
+++ b/tokio-timer/src/timer/registration.rs
@@ -1,11 +1,11 @@
-use Error;
 use clock::now;
-use timer::{HandlePriv, Entry};
+use timer::{Entry, HandlePriv};
+use Error;
 
 use futures::Poll;
 
 use std::sync::Arc;
-use std::time::{Instant, Duration};
+use std::time::{Duration, Instant};
 
 /// Registration with a timer.
 ///
@@ -21,7 +21,9 @@ impl Registration {
         fn is_send<T: Send + Sync>() {}
         is_send::<Registration>();
 
-        Registration { entry: Arc::new(Entry::new(deadline, duration)) }
+        Registration {
+            entry: Arc::new(Entry::new(deadline, duration)),
+        }
     }
 
     pub fn deadline(&self) -> Instant {

--- a/tokio-timer/src/timer/stack.rs
+++ b/tokio-timer/src/timer/stack.rs
@@ -49,7 +49,6 @@ impl wheel::Stack for Stack {
 
             // Set this entry's next pointer
             *entry.next_stack.get() = old;
-
         }
 
         // Update the head pointer
@@ -117,7 +116,6 @@ impl wheel::Stack for Stack {
     }
 
     fn when(item: &Entry, _: &()) -> u64 {
-        item.when_internal()
-            .expect("invalid internal state")
+        item.when_internal().expect("invalid internal state")
     }
 }

--- a/tokio-timer/src/wheel/level.rs
+++ b/tokio-timer/src/wheel/level.rs
@@ -43,7 +43,9 @@ impl<T: Stack> Level<T> {
         // contained by the array be `Copy`. So, here we have to manually
         // initialize every single slot.
         macro_rules! s {
-            () => { T::default() };
+            () => {
+                T::default()
+            };
         };
 
         Level {
@@ -52,14 +54,70 @@ impl<T: Stack> Level<T> {
             slot: [
                 // It does not look like the necessary traits are
                 // derived for [T; 64].
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
-                s!(), s!(), s!(), s!(), s!(), s!(), s!(), s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
+                s!(),
             ],
         }
     }
@@ -84,8 +142,15 @@ impl<T: Stack> Level<T> {
         let level_start = now - (now % level_range);
         let deadline = level_start + slot as u64 * slot_range;
 
-        debug_assert!(deadline >= now, "deadline={}; now={}; level={}; slot={}; occupied={:b}",
-                      deadline, now, self.level, slot, self.occupied);
+        debug_assert!(
+            deadline >= now,
+            "deadline={}; now={}; level={}; slot={}; occupied={:b}",
+            deadline,
+            now,
+            self.level,
+            slot,
+            self.occupied
+        );
 
         Some(Expiration {
             level: self.level,

--- a/tokio-timer/tests/deadline.rs
+++ b/tokio-timer/tests/deadline.rs
@@ -9,8 +9,8 @@ use support::*;
 
 use tokio_timer::*;
 
-use futures::{future, Future};
 use futures::sync::oneshot;
+use futures::{future, Future};
 
 #[test]
 fn simultaneous_deadline_future_completion() {

--- a/tokio-timer/tests/delay.rs
+++ b/tokio-timer/tests/delay.rs
@@ -6,8 +6,8 @@ extern crate tokio_timer;
 mod support;
 use support::*;
 
-use tokio_timer::*;
 use tokio_timer::timer::Handle;
+use tokio_timer::*;
 
 use futures::Future;
 
@@ -52,9 +52,7 @@ fn delayed_delay_level_0() {
 fn sub_ms_delayed_delay() {
     mocked(|timer, time| {
         for _ in 0..5 {
-            let deadline = time.now()
-                + Duration::from_millis(1)
-                + Duration::new(0, 1);
+            let deadline = time.now() + Duration::from_millis(1) + Duration::new(0, 1);
 
             let mut delay = Delay::new(deadline);
 
@@ -282,11 +280,7 @@ fn sorta_long_delay() {
         // The delay has not elapsed.
         assert_not_ready!(delay);
 
-        let cascades = &[
-            262_144,
-            262_144 + 9 * 4096,
-            262_144 + 9 * 4096 + 15 * 64,
-        ];
+        let cascades = &[262_144, 262_144 + 9 * 4096, 262_144 + 9 * 4096 + 15 * 64];
 
         for &elapsed in cascades {
             turn(timer, None);

--- a/tokio-timer/tests/interval.rs
+++ b/tokio-timer/tests/interval.rs
@@ -8,7 +8,7 @@ use support::*;
 
 use tokio_timer::*;
 
-use futures::{Stream};
+use futures::Stream;
 
 #[test]
 #[should_panic]

--- a/tokio-timer/tests/queue.rs
+++ b/tokio-timer/tests/queue.rs
@@ -1,14 +1,14 @@
 extern crate futures;
 extern crate tokio_executor;
-extern crate tokio_timer;
 extern crate tokio_mock_task;
+extern crate tokio_timer;
 
 #[macro_use]
 mod support;
 use support::*;
 
-use tokio_timer::*;
 use tokio_mock_task::MockTask;
+use tokio_timer::*;
 
 use futures::Stream;
 
@@ -286,7 +286,6 @@ fn expires_before_last_insert() {
         let mut queue = DelayQueue::new();
         let mut task = MockTask::new();
 
-
         let epoch = time.now();
 
         queue.insert_at("foo", epoch + ms(10_000));
@@ -308,7 +307,6 @@ fn expires_before_last_insert() {
         assert!(task.is_notified());
         let entry = assert_ready!(queue).unwrap().into_inner();
         assert_eq!(entry, "bar");
-
     })
 }
 
@@ -382,7 +380,6 @@ fn expire_second_key_when_reset_to_expire_earlier() {
         assert_eq!(entry, "bar");
     })
 }
-
 
 #[test]
 fn reset_first_expiring_item_to_expire_later() {

--- a/tokio-timer/tests/throttle.rs
+++ b/tokio-timer/tests/throttle.rs
@@ -7,18 +7,14 @@ extern crate tokio_timer;
 mod support;
 use support::*;
 
-use futures::{
-    prelude::*,
-    sync::mpsc,
-};
+use futures::{prelude::*, sync::mpsc};
 use tokio::util::StreamExt;
 
 #[test]
 fn throttle() {
     mocked(|timer, _| {
         let (tx, rx) = mpsc::unbounded();
-        let mut stream = rx.throttle(ms(1))
-            .map_err(|e| panic!("{:?}", e));
+        let mut stream = rx.throttle(ms(1)).map_err(|e| panic!("{:?}", e));
 
         assert_not_ready!(stream);
 
@@ -40,8 +36,7 @@ fn throttle() {
 fn throttle_dur_0() {
     mocked(|_, _| {
         let (tx, rx) = mpsc::unbounded();
-        let mut stream = rx.throttle(ms(0))
-            .map_err(|e| panic!("{:?}", e));
+        let mut stream = rx.throttle(ms(0)).map_err(|e| panic!("{:?}", e));
 
         assert_not_ready!(stream);
 

--- a/tokio-timer/tests/timeout.rs
+++ b/tokio-timer/tests/timeout.rs
@@ -8,8 +8,8 @@ use support::*;
 
 use tokio_timer::*;
 
+use futures::sync::{mpsc, oneshot};
 use futures::{future, Future, Stream};
-use futures::sync::{oneshot, mpsc};
 
 #[test]
 fn simultaneous_deadline_future_completion() {

--- a/tokio-tls/examples/download-rust-lang.rs
+++ b/tokio-tls/examples/download-rust-lang.rs
@@ -14,27 +14,31 @@ use tokio::runtime::Runtime;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     let mut runtime = Runtime::new()?;
-    let addr = "www.rust-lang.org:443".to_socket_addrs()?.next().ok_or("failed to resolve www.rust-lang.org")?;
+    let addr = "www.rust-lang.org:443"
+        .to_socket_addrs()?
+        .next()
+        .ok_or("failed to resolve www.rust-lang.org")?;
 
     let socket = TcpStream::connect(&addr);
     let cx = TlsConnector::builder().build()?;
     let cx = tokio_tls::TlsConnector::from(cx);
 
     let tls_handshake = socket.and_then(move |socket| {
-        cx.connect("www.rust-lang.org", socket).map_err(|e| {
-            io::Error::new(io::ErrorKind::Other, e)
-        })
+        cx.connect("www.rust-lang.org", socket)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
     });
     let request = tls_handshake.and_then(|socket| {
-        tokio_io::io::write_all(socket, "\
-            GET / HTTP/1.0\r\n\
-            Host: www.rust-lang.org\r\n\
-            \r\n\
-        ".as_bytes())
+        tokio_io::io::write_all(
+            socket,
+            "\
+             GET / HTTP/1.0\r\n\
+             Host: www.rust-lang.org\r\n\
+             \r\n\
+             "
+            .as_bytes(),
+        )
     });
-    let response = request.and_then(|(socket, _)| {
-        tokio_io::io::read_to_end(socket, Vec::new())
-    });
+    let response = request.and_then(|(socket, _)| tokio_io::io::read_to_end(socket, Vec::new()));
 
     let (_, data) = runtime.block_on(response)?;
     println!("{}", String::from_utf8_lossy(&data));

--- a/tokio-tls/examples/echo.rs
+++ b/tokio-tls/examples/echo.rs
@@ -16,43 +16,42 @@ fn main() -> Result<(), Box<std::error::Error>> {
     // Create the TLS acceptor.
     let der = include_bytes!("identity.p12");
     let cert = Identity::from_pkcs12(der, "mypass")?;
-    let tls_acceptor = tokio_tls::TlsAcceptor::from(
-        native_tls::TlsAcceptor::builder(cert).build()?);
+    let tls_acceptor =
+        tokio_tls::TlsAcceptor::from(native_tls::TlsAcceptor::builder(cert).build()?);
 
     // Iterate incoming connections
-    let server = tcp.incoming().for_each(move |tcp| {
+    let server = tcp
+        .incoming()
+        .for_each(move |tcp| {
+            // Accept the TLS connection.
+            let tls_accept = tls_acceptor
+                .accept(tcp)
+                .and_then(move |tls| {
+                    // Split up the read and write halves
+                    let (reader, writer) = tls.split();
 
-        // Accept the TLS connection.
-        let tls_accept = tls_acceptor.accept(tcp)
-            .and_then(move |tls| {
-                // Split up the read and write halves
-                let (reader, writer) = tls.split();
+                    // Copy the data back to the client
+                    let conn = io::copy(reader, writer)
+                        // print what happened
+                        .map(|(n, _, _)| println!("wrote {} bytes", n))
+                        // Handle any errors
+                        .map_err(|err| println!("IO error {:?}", err));
 
-                // Copy the data back to the client
-                let conn = io::copy(reader, writer)
-                    // print what happened
-                    .map(|(n, _, _)| {
-                        println!("wrote {} bytes", n)
-                    })
-                    // Handle any errors
-                    .map_err(|err| {
-                        println!("IO error {:?}", err)
-                    });
+                    // Spawn the future as a concurrent task
+                    tokio::spawn(conn);
 
-                // Spawn the future as a concurrent task
-                tokio::spawn(conn);
+                    Ok(())
+                })
+                .map_err(|err| {
+                    println!("TLS accept error: {:?}", err);
+                });
+            tokio::spawn(tls_accept);
 
-                Ok(())
-            })
-            .map_err(|err| {
-                println!("TLS accept error: {:?}", err);
-            });
-        tokio::spawn(tls_accept);
-
-        Ok(())
-    }).map_err(|err| {
-        println!("server error {:?}", err);
-    });
+            Ok(())
+        })
+        .map_err(|err| {
+            println!("server error {:?}", err);
+        });
 
     // Start the runtime and spin up the server
     tokio::run(server);

--- a/tokio-tls/tests/bad.rs
+++ b/tokio-tls/tests/bad.rs
@@ -16,10 +16,12 @@ use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 cfg_if! {
@@ -100,9 +102,8 @@ fn get_host(host: &'static str) -> Error {
         let builder = TlsConnector::builder();
         let cx = builder.build().unwrap();
         let cx = tokio_tls::TlsConnector::from(cx);
-        cx.connect(host, socket).map_err(|e| {
-            Error::new(io::ErrorKind::Other, e)
-        })
+        cx.connect(host, socket)
+            .map_err(|e| Error::new(io::ErrorKind::Other, e))
     });
 
     let res = l.block_on(data);

--- a/tokio-udp/src/frame.rs
+++ b/tokio-udp/src/frame.rs
@@ -1,12 +1,12 @@
 use std::io;
-use std::net::{SocketAddr, Ipv4Addr, SocketAddrV4};
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-use futures::{Async, Poll, Stream, Sink, StartSend, AsyncSink};
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 use super::UdpSocket;
 
+use bytes::{BufMut, BytesMut};
 use tokio_codec::{Decoder, Encoder};
-use bytes::{BytesMut, BufMut};
 
 /// A unified `Stream` and `Sink` interface to an underlying `UdpSocket`, using
 /// the `Encoder` and `Decoder` traits to encode and decode frames.
@@ -67,7 +67,7 @@ impl<C: Encoder> Sink for UdpFramed<C> {
 
         if !self.flushed {
             match try!(self.poll_complete()) {
-                Async::Ready(()) => {},
+                Async::Ready(()) => {}
                 Async::NotReady => return Ok(AsyncSink::NotReady(item)),
             }
         }
@@ -83,7 +83,7 @@ impl<C: Encoder> Sink for UdpFramed<C> {
 
     fn poll_complete(&mut self) -> Poll<(), C::Error> {
         if self.flushed {
-            return Ok(Async::Ready(()))
+            return Ok(Async::Ready(()));
         }
 
         trace!("flushing frame; length={}", self.wr.len());
@@ -97,8 +97,11 @@ impl<C: Encoder> Sink for UdpFramed<C> {
         if wrote_all {
             Ok(Async::Ready(()))
         } else {
-            Err(io::Error::new(io::ErrorKind::Other,
-                               "failed to write entire datagram to socket").into())
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            )
+            .into())
         }
     }
 

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -30,11 +30,11 @@ extern crate tokio_io;
 extern crate tokio_reactor;
 
 mod frame;
-mod socket;
-mod send_dgram;
 mod recv_dgram;
+mod send_dgram;
+mod socket;
 
 pub use self::frame::UdpFramed;
-pub use self::socket::UdpSocket;
-pub use self::send_dgram::SendDgram;
 pub use self::recv_dgram::RecvDgram;
+pub use self::send_dgram::SendDgram;
+pub use self::socket::UdpSocket;

--- a/tokio-udp/src/recv_dgram.rs
+++ b/tokio-udp/src/recv_dgram.rs
@@ -12,7 +12,7 @@ use futures::{Async, Future, Poll};
 #[derive(Debug)]
 pub struct RecvDgram<T> {
     /// None means future was completed
-    state: Option<RecvDgramInner<T>>
+    state: Option<RecvDgramInner<T>>,
 }
 
 /// A struct is used to represent the full info of RecvDgram.
@@ -21,7 +21,7 @@ struct RecvDgramInner<T> {
     /// Rx socket
     socket: UdpSocket,
     /// The received data will be put in the buffer
-    buffer: T
+    buffer: T,
 }
 
 /// Components of a `RecvDgram` future, returned from `into_parts`.
@@ -32,13 +32,16 @@ pub struct Parts<T> {
     /// The buffer
     pub buffer: T,
 
-    _priv: ()
+    _priv: (),
 }
 
 impl<T> RecvDgram<T> {
     /// Create a new future to receive UDP Datagram
     pub(crate) fn new(socket: UdpSocket, buffer: T) -> RecvDgram<T> {
-        let inner = RecvDgramInner { socket: socket, buffer: buffer };
+        let inner = RecvDgramInner {
+            socket: socket,
+            buffer: buffer,
+        };
         RecvDgram { state: Some(inner) }
     }
 
@@ -69,28 +72,32 @@ impl<T> RecvDgram<T> {
     ///
     /// If called after the future has completed.
     pub fn into_parts(mut self) -> Parts<T> {
-        let state = self.state
+        let state = self
+            .state
             .take()
             .expect("into_parts called after completion");
 
         Parts {
             socket: state.socket,
             buffer: state.buffer,
-            _priv: ()
+            _priv: (),
         }
     }
 }
 
 impl<T> Future for RecvDgram<T>
-    where T: AsMut<[u8]>,
+where
+    T: AsMut<[u8]>,
 {
     type Item = (UdpSocket, T, usize, SocketAddr);
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, io::Error> {
         let (n, addr) = {
-            let ref mut inner =
-                self.state.as_mut().expect("RecvDgram polled after completion");
+            let ref mut inner = self
+                .state
+                .as_mut()
+                .expect("RecvDgram polled after completion");
 
             try_ready!(inner.socket.poll_recv_from(inner.buffer.as_mut()))
         };

--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -1,8 +1,8 @@
-use super::{SendDgram, RecvDgram};
+use super::{RecvDgram, SendDgram};
 
-use std::io;
-use std::net::{self, SocketAddr, Ipv4Addr, Ipv6Addr};
 use std::fmt;
+use std::io;
+use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use futures::{Async, Poll};
 use mio;
@@ -18,8 +18,7 @@ impl UdpSocket {
     /// This function will create a new UDP socket and attempt to bind it to
     /// the `addr` provided.
     pub fn bind(addr: &SocketAddr) -> io::Result<UdpSocket> {
-        mio::net::UdpSocket::bind(addr)
-            .map(UdpSocket::new)
+        mio::net::UdpSocket::bind(addr).map(UdpSocket::new)
     }
 
     fn new(socket: mio::net::UdpSocket) -> UdpSocket {
@@ -38,8 +37,7 @@ impl UdpSocket {
     /// `reuse_address` or binding to multiple addresses.
     ///
     /// Use `Handle::default()` to lazily bind to an event loop, just like `bind` does.
-    pub fn from_std(socket: net::UdpSocket,
-                    handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn from_std(socket: net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
         let io = PollEvented::new_with_handle(io, handle)?;
         Ok(UdpSocket { io })
@@ -196,7 +194,8 @@ impl UdpSocket {
     /// should be broadly applicable to accepting data which can be converted
     /// to a slice.
     pub fn send_dgram<T>(self, buf: T, addr: &SocketAddr) -> SendDgram<T>
-        where T: AsRef<[u8]>,
+    where
+        T: AsRef<[u8]>,
     {
         SendDgram::new(self, buf, *addr)
     }
@@ -244,7 +243,8 @@ impl UdpSocket {
     /// should be broadly applicable to accepting data which can be converted
     /// to a slice.
     pub fn recv_dgram<T>(self, buf: T) -> RecvDgram<T>
-        where T: AsMut<[u8]>,
+    where
+        T: AsMut<[u8]>,
     {
         RecvDgram::new(self, buf)
     }
@@ -389,9 +389,7 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    pub fn join_multicast_v4(&self,
-                             multiaddr: &Ipv4Addr,
-                             interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.io.get_ref().join_multicast_v4(multiaddr, interface)
     }
 
@@ -400,9 +398,7 @@ impl UdpSocket {
     /// This function specifies a new multicast group for this socket to join.
     /// The address must be a valid multicast address, and `interface` is the
     /// index of the interface to join/leave (or 0 to indicate any interface).
-    pub fn join_multicast_v6(&self,
-                             multiaddr: &Ipv6Addr,
-                             interface: u32) -> io::Result<()> {
+    pub fn join_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.get_ref().join_multicast_v6(multiaddr, interface)
     }
 
@@ -411,9 +407,7 @@ impl UdpSocket {
     /// For more information about this option, see [`join_multicast_v4`].
     ///
     /// [`join_multicast_v4`]: #method.join_multicast_v4
-    pub fn leave_multicast_v4(&self,
-                              multiaddr: &Ipv4Addr,
-                              interface: &Ipv4Addr) -> io::Result<()> {
+    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v4(multiaddr, interface)
     }
 
@@ -422,9 +416,7 @@ impl UdpSocket {
     /// For more information about this option, see [`join_multicast_v6`].
     ///
     /// [`join_multicast_v6`]: #method.join_multicast_v6
-    pub fn leave_multicast_v6(&self,
-                              multiaddr: &Ipv6Addr,
-                              interface: u32) -> io::Result<()> {
+    pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v6(multiaddr, interface)
     }
 }
@@ -437,8 +429,8 @@ impl fmt::Debug for UdpSocket {
 
 #[cfg(all(unix))]
 mod sys {
-    use std::os::unix::prelude::*;
     use super::UdpSocket;
+    use std::os::unix::prelude::*;
 
     impl AsRawFd for UdpSocket {
         fn as_raw_fd(&self) -> RawFd {

--- a/tokio-uds/src/incoming.rs
+++ b/tokio-uds/src/incoming.rs
@@ -1,6 +1,6 @@
 use {UnixListener, UnixStream};
 
-use futures::{Stream, Poll};
+use futures::{Poll, Stream};
 
 use std::io;
 
@@ -24,4 +24,3 @@ impl Stream for Incoming {
         Ok(Some(try_ready!(self.inner.poll_accept()).0).into())
     }
 }
-

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -34,5 +34,5 @@ pub use incoming::Incoming;
 pub use listener::UnixListener;
 pub use recv_dgram::RecvDgram;
 pub use send_dgram::SendDgram;
-pub use stream::{UnixStream, ConnectFuture};
+pub use stream::{ConnectFuture, UnixStream};
 pub use ucred::UCred;

--- a/tokio-uds/src/recv_dgram.rs
+++ b/tokio-uds/src/recv_dgram.rs
@@ -20,23 +20,17 @@ pub struct RecvDgram<T> {
 /// avoided.
 #[derive(Debug)]
 enum State<T> {
-    Receiving {
-        sock: UnixDatagram,
-        buf: T,
-    },
+    Receiving { sock: UnixDatagram, buf: T },
     Empty,
 }
 
 impl<T> RecvDgram<T>
 where
-    T: AsMut<[u8]>
+    T: AsMut<[u8]>,
 {
     pub(crate) fn new(sock: UnixDatagram, buf: T) -> RecvDgram<T> {
         RecvDgram {
-            st: State::Receiving {
-                sock,
-                buf,
-            },
+            st: State::Receiving { sock, buf },
         }
     }
 }
@@ -71,9 +65,7 @@ where
             panic!()
         }
 
-        if let State::Receiving { sock, buf } =
-            mem::replace(&mut self.st, State::Empty)
-        {
+        if let State::Receiving { sock, buf } = mem::replace(&mut self.st, State::Empty) {
             Ok(Async::Ready((sock, buf, received, peer)))
         } else {
             panic!()

--- a/tokio-uds/src/send_dgram.rs
+++ b/tokio-uds/src/send_dgram.rs
@@ -34,11 +34,7 @@ where
 {
     pub(crate) fn new(sock: UnixDatagram, buf: T, addr: P) -> SendDgram<T, P> {
         SendDgram {
-            st: State::Sending {
-                sock,
-                buf,
-                addr,
-            }
+            st: State::Sending { sock, buf, addr },
         }
     }
 }
@@ -70,9 +66,7 @@ where
         } else {
             panic!()
         }
-        if let State::Sending { sock, buf, addr: _ } =
-            mem::replace(&mut self.st, State::Empty)
-        {
+        if let State::Sending { sock, buf, addr: _ } = mem::replace(&mut self.st, State::Empty) {
             Ok(Async::Ready((sock, buf)))
         } else {
             panic!()

--- a/tokio-uds/src/stream.rs
+++ b/tokio-uds/src/stream.rs
@@ -50,8 +50,7 @@ impl UnixStream {
     where
         P: AsRef<Path>,
     {
-        let res = mio_uds::UnixStream::connect(path)
-            .map(UnixStream::new);
+        let res = mio_uds::UnixStream::connect(path).map(UnixStream::new);
 
         let inner = match res {
             Ok(stream) => State::Waiting(stream),
@@ -260,11 +259,11 @@ impl Future for ConnectFuture {
         match self.inner {
             State::Waiting(ref mut stream) => {
                 if let Async::NotReady = stream.io.poll_write_ready()? {
-                    return Ok(Async::NotReady)
+                    return Ok(Async::NotReady);
                 }
 
                 if let Some(e) = try!(stream.io.get_ref().take_error()) {
-                    return Err(e)
+                    return Err(e);
                 }
             }
             State::Error(_) => {
@@ -273,8 +272,8 @@ impl Future for ConnectFuture {
                     _ => unreachable!(),
                 };
 
-                return Err(e)
-            },
+                return Err(e);
+            }
             State::Empty => panic!("can't poll stream twice"),
         }
 

--- a/tokio-uds/tests/datagram.rs
+++ b/tokio-uds/tests/datagram.rs
@@ -61,12 +61,16 @@ fn framed_echo() {
 
         let (sink, stream) = server.split();
 
-        let echo_stream = stream.map(|(msg, addr)| (msg, addr.as_pathname().unwrap().to_path_buf()));
+        let echo_stream =
+            stream.map(|(msg, addr)| (msg, addr.as_pathname().unwrap().to_path_buf()));
 
         // spawn echo server
-        rt.spawn(echo_stream.forward(sink)
-                 .map_err(|e| panic!("err={:?}", e))
-                 .map(|_| ()));
+        rt.spawn(
+            echo_stream
+                .forward(sink)
+                .map_err(|e| panic!("err={:?}", e))
+                .map(|_| ()),
+        );
     }
 
     {
@@ -75,7 +79,8 @@ fn framed_echo() {
 
         let (sink, stream) = client.split();
 
-        rt.block_on(sink.send(("ECHO".to_string(), server_path))).unwrap();
+        rt.block_on(sink.send(("ECHO".to_string(), server_path)))
+            .unwrap();
 
         let response = rt.block_on(stream.take(1).collect()).unwrap();
         assert_eq!(response[0].0, "ECHO");

--- a/tokio-uds/tests/stream.rs
+++ b/tokio-uds/tests/stream.rs
@@ -11,15 +11,17 @@ use tokio_uds::*;
 use tokio::io;
 use tokio::runtime::current_thread::Runtime;
 
-use futures::{Future, Stream};
 use futures::sync::oneshot;
+use futures::{Future, Stream};
 use tempfile::Builder;
 
 macro_rules! t {
-    ($e:expr) => (match $e {
-        Ok(e) => e,
-        Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
-    })
+    ($e:expr) => {
+        match $e {
+            Ok(e) => e,
+            Err(e) => panic!("{} failed with {:?}", stringify!($e), e),
+        }
+    };
 }
 
 #[test]
@@ -33,7 +35,8 @@ fn echo() {
     let (tx, rx) = oneshot::channel();
 
     rt.spawn({
-        server.incoming()
+        server
+            .incoming()
             .into_future()
             .and_then(move |(sock, _)| {
                 tx.send(sock.unwrap()).unwrap();


### PR DESCRIPTION
## Motivation

Manually enforcing code style is annoying.

## Solution

Use `rustfmt`.
