### PR TITLE
async-await: update to new future/task API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
     script: |
       cd tokio-async-await
       cargo check --all
+      cargo check --features async-await-preview
 
   # This runs TSAN against nightly and allows failures to propagate up.
   - rust: nightly-2018-11-18

--- a/tokio-async-await/README.md
+++ b/tokio-async-await/README.md
@@ -9,7 +9,7 @@ guarantees. You are living on the edge here.**
 ## Usage
 
 To use this crate, you need to start with a Rust 2018 edition crate, with rustc
-1.33.0-nightly or later.
+1.34.0-nightly or later.
 
 Add this to your `Cargo.toml`:
 

--- a/tokio-async-await/src/compat/forward.rs
+++ b/tokio-async-await/src/compat/forward.rs
@@ -3,7 +3,7 @@ use futures::{Async, Future};
 use std::future::Future as StdFuture;
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::{LocalWaker, Poll as StdPoll};
+use std::task::{Poll as StdPoll, Waker};
 
 /// Converts an 0.1 `Future` into an 0.3 `Future`.
 #[derive(Debug)]
@@ -54,7 +54,7 @@ where
 {
     type Output = Result<T::Item, T::Error>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &LocalWaker) -> StdPoll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &Waker) -> StdPoll<Self::Output> {
         use futures::Async::{NotReady, Ready};
 
         // TODO: wire in cx

--- a/tokio-async-await/src/compat/forward.rs
+++ b/tokio-async-await/src/compat/forward.rs
@@ -1,7 +1,6 @@
 use futures::{Async, Future};
 
 use std::future::Future as StdFuture;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Poll as StdPoll, Waker};
 

--- a/tokio-async-await/src/io/flush.rs
+++ b/tokio-async-await/src/io/flush.rs
@@ -2,7 +2,6 @@ use tokio_io::AsyncWrite;
 
 use std::future::Future;
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Poll, Waker};
 

--- a/tokio-async-await/src/io/flush.rs
+++ b/tokio-async-await/src/io/flush.rs
@@ -4,7 +4,7 @@ use std::future::Future;
 use std::io;
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::{LocalWaker, Poll};
+use std::task::{Poll, Waker};
 
 /// A future used to fully flush an I/O object.
 #[derive(Debug)]
@@ -24,7 +24,7 @@ impl<'a, T: AsyncWrite + ?Sized> Flush<'a, T> {
 impl<'a, T: AsyncWrite + ?Sized> Future for Flush<'a, T> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, _wx: &LocalWaker) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _wx: &Waker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll;
         convert_poll(self.writer.poll_flush())
     }

--- a/tokio-async-await/src/io/read.rs
+++ b/tokio-async-await/src/io/read.rs
@@ -26,7 +26,7 @@ impl<'a, T: AsyncRead + ?Sized> Read<'a, T> {
 impl<'a, T: AsyncRead + ?Sized> Future for Read<'a, T> {
     type Output = io::Result<usize>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &task::Waker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll;
 
         let this = &mut *self;

--- a/tokio-async-await/src/io/read.rs
+++ b/tokio-async-await/src/io/read.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::task::{self, Poll};
 
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A future which can be used to read bytes.

--- a/tokio-async-await/src/io/read_exact.rs
+++ b/tokio-async-await/src/io/read_exact.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::task::{self, Poll};
 
 use std::io;
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 

--- a/tokio-async-await/src/io/read_exact.rs
+++ b/tokio-async-await/src/io/read_exact.rs
@@ -31,7 +31,7 @@ fn eof() -> io::Error {
 impl<'a, T: AsyncRead + ?Sized> Future for ReadExact<'a, T> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &task::Waker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll;
 
         let this = &mut *self;

--- a/tokio-async-await/src/io/write.rs
+++ b/tokio-async-await/src/io/write.rs
@@ -26,7 +26,7 @@ impl<'a, T: AsyncWrite + ?Sized> Write<'a, T> {
 impl<'a, T: AsyncWrite + ?Sized> Future for Write<'a, T> {
     type Output = io::Result<usize>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<io::Result<usize>> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &task::Waker) -> Poll<io::Result<usize>> {
         use crate::compat::forward::convert_poll;
 
         let this = &mut *self;

--- a/tokio-async-await/src/io/write.rs
+++ b/tokio-async-await/src/io/write.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::task::{self, Poll};
 
 use std::io;
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// A future used to write data.

--- a/tokio-async-await/src/io/write_all.rs
+++ b/tokio-async-await/src/io/write_all.rs
@@ -4,7 +4,6 @@ use std::future::Future;
 use std::task::{self, Poll};
 
 use std::io;
-use std::marker::Unpin;
 use std::mem;
 use std::pin::Pin;
 

--- a/tokio-async-await/src/io/write_all.rs
+++ b/tokio-async-await/src/io/write_all.rs
@@ -31,7 +31,7 @@ fn zero_write() -> io::Error {
 impl<'a, T: AsyncWrite + ?Sized> Future for WriteAll<'a, T> {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<io::Result<()>> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &task::Waker) -> Poll<io::Result<()>> {
         use crate::compat::forward::convert_poll;
 
         let this = &mut *self;

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -1,11 +1,5 @@
 #![cfg(feature = "async-await-preview")]
-#![feature(
-    rust_2018_preview,
-    arbitrary_self_types,
-    async_await,
-    await_macro,
-    futures_api
-)]
+#![feature(rust_2018_preview, async_await, await_macro, futures_api)]
 #![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.5")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]

--- a/tokio-async-await/src/sink/mod.rs
+++ b/tokio-async-await/src/sink/mod.rs
@@ -6,8 +6,6 @@ pub use self::send::Send;
 
 use futures::Sink;
 
-use std::marker::Unpin;
-
 /// An extension trait which adds utility methods to `Sink` types.
 pub trait SinkExt: Sink {
     /// Send an item into the sink.

--- a/tokio-async-await/src/sink/send.rs
+++ b/tokio-async-await/src/sink/send.rs
@@ -3,7 +3,6 @@ use futures::Sink;
 use std::future::Future;
 use std::task::{self, Poll};
 
-use std::marker::Unpin;
 use std::pin::Pin;
 
 /// Future for the `SinkExt::send_async` combinator, which sends a value to a

--- a/tokio-async-await/src/sink/send.rs
+++ b/tokio-async-await/src/sink/send.rs
@@ -28,7 +28,7 @@ impl<'a, T: Sink + Unpin + ?Sized> Send<'a, T> {
 impl<T: Sink + Unpin + ?Sized> Future for Send<'_, T> {
     type Output = Result<(), T::SinkError>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &task::LocalWaker) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &task::Waker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll;
         use futures::AsyncSink::{NotReady, Ready};
 

--- a/tokio-async-await/src/stream/mod.rs
+++ b/tokio-async-await/src/stream/mod.rs
@@ -6,8 +6,6 @@ pub use self::next::Next;
 
 use futures::Stream;
 
-use std::marker::Unpin;
-
 /// An extension trait which adds utility methods to `Stream` types.
 pub trait StreamExt: Stream {
     /// Creates a future that resolves to the next item in the stream.

--- a/tokio-async-await/src/stream/next.rs
+++ b/tokio-async-await/src/stream/next.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use std::future::Future;
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::{LocalWaker, Poll};
+use std::task::{Poll, Waker};
 
 /// A future of the next element of a stream.
 #[derive(Debug)]
@@ -22,7 +22,7 @@ impl<'a, T: Stream + Unpin> Next<'a, T> {
 impl<'a, T: Stream + Unpin> Future for Next<'a, T> {
     type Output = Option<Result<T::Item, T::Error>>;
 
-    fn poll(mut self: Pin<&mut Self>, _lw: &LocalWaker) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _waker: &Waker) -> Poll<Self::Output> {
         use crate::compat::forward::convert_poll_stream;
 
         convert_poll_stream(self.stream.poll())

--- a/tokio-async-await/src/stream/next.rs
+++ b/tokio-async-await/src/stream/next.rs
@@ -1,7 +1,6 @@
 use futures::Stream;
 
 use std::future::Future;
-use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Poll, Waker};
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

future/task API updated in rust-lang/rust#57992.
## Solution

Rewrites the noop_waker with items from the new API and replaces LocalWaker with Waker.

This also bumps the minimum required version of tokio-async-await to 1.34.0-nightly.

Fixes: #908
