### PR TITLE
tokio::sync::watch: A broadcast channel that only tracks the most recently sent value.

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -9,5 +9,7 @@
 //!   from one task to another.
 //! - [mpsc](mpsc/index.html), a multi-producer, single-consumer channel for
 //!   sending values between tasks.
+//! - [watch](watch/index.html), a single-producer, multi-consumer channel that
+//!   only stores the **most recently** sent value.
 
-pub use tokio_sync::{mpsc, oneshot};
+pub use tokio_sync::{mpsc, oneshot, watch};

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -19,6 +19,7 @@ Synchronization utilities.
 categories = ["asynchronous"]
 
 [dependencies]
+fnv = "1.0.6"
 futures = "0.1.19"
 
 [dev-dependencies]

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -6,6 +6,7 @@
 //!
 //! This crate provides primitives for synchronizing asynchronous tasks.
 
+extern crate fnv;
 extern crate futures;
 
 macro_rules! debug {
@@ -27,3 +28,4 @@ pub mod mpsc;
 pub mod oneshot;
 pub mod semaphore;
 pub mod task;
+pub mod watch;

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -7,6 +7,7 @@
 //! This crate provides primitives for synchronizing asynchronous tasks.
 
 extern crate fnv;
+#[macro_use]
 extern crate futures;
 
 macro_rules! debug {

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -57,13 +57,13 @@
 //! [`Receiver::poll_ref`]: struct.Receiver.html#method.poll_ref
 
 use fnv::FnvHashMap;
-use futures::{Stream, Sink, Poll, Async, AsyncSink, StartSend};
 use futures::task::AtomicTask;
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 use std::ops;
-use std::sync::{Arc, Weak, Mutex, RwLock, RwLockReadGuard};
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
 
 /// Receives values from the associated `Sender`.
 ///
@@ -188,8 +188,8 @@ pub fn channel<T>(init: T) -> (Sender<T>, Receiver<T>) {
         value: RwLock::new(init),
         version: AtomicUsize::new(2),
         watchers: Mutex::new(Watchers {
-                next_id: INIT_ID + 1,
-                watchers,
+            next_id: INIT_ID + 1,
+            watchers,
         }),
         cancel: AtomicTask::new(),
     });
@@ -287,7 +287,9 @@ impl<T> Drop for Receiver<T> {
 
 impl WatchInner {
     fn new() -> Self {
-        WatchInner { task: AtomicTask::new() }
+        WatchInner {
+            task: AtomicTask::new(),
+        }
     }
 }
 
@@ -326,9 +328,7 @@ impl<T> Sender<T> {
                 shared.cancel.register();
                 Ok(Async::NotReady)
             }
-            None => {
-                Ok(Async::Ready(()))
-            }
+            None => Ok(Async::Ready(())),
         }
     }
 }

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -1,0 +1,407 @@
+//! A multi-consumer, single producer cell that receives notifications when the inner value is
+//! changed.
+//!
+//! # Usage
+//!
+//! [`Watch::new`] returns a [`Watch`] / [`Store`] pair. These are the consumer and
+//! producer halves of the cell. The watch cell is created with an initial
+//! value. Calls to [`Watch::borrow`] will always yield the latest value.
+//!
+//! ```
+//! # use futures_watch::*;
+//! let (watch, store) = Watch::new("hello");
+//! assert_eq!(*watch.borrow(), "hello");
+//! # drop(store);
+//! ```
+//!
+//! Using the [`Store`] handle, the cell value can be updated.
+//!
+//! ```
+//! # use futures_watch::*;
+//! let (watch, mut store) = Watch::new("hello");
+//! store.store("goodbye");
+//! assert_eq!(*watch.borrow(), "goodbye");
+//! ```
+//!
+//! [`Watch`] handles are future-aware and will receive notifications whenever
+//! the inner value is changed.
+//!
+//! ```
+//! # extern crate futures;
+//! # extern crate futures_watch;
+//! # pub fn main() {
+//! # use futures::*;
+//! # use futures_watch::*;
+//! # use std::thread;
+//! # use std::time::Duration;
+//! let (watch, mut store) = Watch::new("hello");
+//!
+//! thread::spawn(move || {
+//!     thread::sleep(Duration::from_millis(100));
+//!     store.store("goodbye");
+//! });
+//!
+//! watch.into_future()
+//!     .and_then(|(_, watch)| {
+//!         assert_eq!(*watch.borrow(), "goodbye");
+//!         Ok(())
+//!     })
+//!     .wait().unwrap();
+//! # }
+//! ```
+//!
+//! [`Watch::borrow`] will yield the most recently stored value. All
+//! intermediate values are dropped.
+//!
+//! ```
+//! # use futures_watch::*;
+//! let (watch, mut store) = Watch::new("hello");
+//!
+//! store.store("two");
+//! store.store("three");
+//!
+//! assert_eq!(*watch.borrow(), "three");
+//! ```
+//!
+//! # Cancellation
+//!
+//! [`Store::poll_cancel`] allows the producer to detect when all [`Watch`]
+//! handles have been dropped. This indicates that there is no further interest
+//! in the values being produced and work can be stopped.
+//!
+//! When the [`Store`] is dropped, the watch handles will be notified and
+//! [`Watch::is_final`] will return true.
+//!
+//! # Thread safety
+//!
+//! Both [`Watch`] and [`Store`] are thread safe. They can be moved to other
+//! threads and can be used in a concurrent environment. Clones of [`Watch`]
+//! handles may be moved to separate threads and also used concurrently.
+//!
+//! [`Watch`]: struct.Watch.html
+//! [`Store`]: struct.Store.html
+//! [`Watch::new`]: struct.Watch.html#method.new
+//! [`Watch::borrow`]: struct.Watch.html#method.borrow
+//! [`Watch::is_final`]: struct.Watch.html#method.is_final
+//! [`Store::poll_cancel`]: struct.Store.html#method.poll_cancel
+
+use fnv::FnvHashMap;
+use futures::{Sink, Poll, Async, AsyncSink, StartSend};
+use futures::task::AtomicTask;
+
+use std::ops;
+use std::sync::{Arc, Weak, Mutex, RwLock, RwLockReadGuard};
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering::SeqCst;
+
+/// A future-aware cell that receives notifications when the inner value is
+/// changed.
+///
+/// `Watch` implements `Stream`, yielding `()` whenever the inner value is
+/// changed. This allows a user to monitor this stream to get notified of change
+/// events.
+///
+/// `Watch` handles may be cloned in order to create additional watchers. Each
+/// watcher operates independently and can be used to notify separate tasks.
+/// Each watcher handle must be used from only a single task.
+///
+/// See crate level documentation for more details.
+#[derive(Debug)]
+pub struct Receiver<T> {
+    /// Pointer to the shared state
+    shared: Arc<Shared<T>>,
+
+    /// Pointer to the watcher's internal state
+    inner: Arc<WatchInner>,
+
+    /// Watcher ID.
+    id: u64,
+
+    /// Last observed version
+    ver: usize,
+}
+
+/// Update the inner value of a `Watch` cell.
+///
+/// The [`store`] function sets the inner value of the cell, returning the
+/// previous value. Alternatively, `Store` implements `Sink` such that values
+/// pushed into the `Sink` are stored in the cell.
+///
+/// See crate level documentation for more details.
+///
+/// [`store`]: #method.store
+#[derive(Debug)]
+pub struct Sender<T> {
+    shared: Weak<Shared<T>>,
+}
+
+/// Borrowed reference
+///
+/// See [`Watch::borrow`] for more details.
+///
+/// [`Watch::borrow`]: struct.Watch.html#method.borrow
+#[derive(Debug)]
+pub struct Ref<'a, T: 'a> {
+    inner: RwLockReadGuard<'a, T>,
+}
+
+/// TODO: Dox
+pub mod error {
+    /// Errors produced by `Watch`.
+    #[derive(Debug)]
+    pub struct RecvError {
+        pub(crate) _p: (),
+    }
+
+    /// Errors produced by `Store`.
+    #[derive(Debug)]
+    pub struct SendError<T> {
+        pub(crate) inner: T,
+    }
+}
+
+#[derive(Debug)]
+struct Shared<T> {
+    /// The most recent value
+    value: RwLock<T>,
+
+    /// The current version
+    ///
+    /// The lowest bit represents a "closed" state. The rest of the bits
+    /// represent the current version.
+    version: AtomicUsize,
+
+    /// All watchers
+    watchers: Mutex<Watchers>,
+
+    /// Task to notify when all watchers drop
+    cancel: AtomicTask,
+}
+
+#[derive(Debug)]
+struct Watchers {
+    next_id: u64,
+    watchers: FnvHashMap<u64, Arc<WatchInner>>,
+}
+
+#[derive(Debug)]
+struct WatchInner {
+    task: AtomicTask,
+}
+
+const CLOSED: usize = 1;
+
+/// Create a new watch cell, returning the consumer / producer halves.
+///
+/// All values stored by the `Store` will become visible to the `Watch`
+/// handles. Only the last value stored is made available to the `Watch`
+/// half. All intermediate values are dropped.
+///
+/// # Examples
+///
+/// ```
+/// # use futures_watch::*;
+/// let (watch, mut store) = Watch::new("hello");
+/// store.store("goodbye");
+/// assert_eq!(*watch.borrow(), "goodbye");
+/// ```
+pub fn channel<T>(init: T) -> (Sender<T>, Receiver<T>) {
+    const INIT_ID: u64 = 0;
+
+    let inner = Arc::new(WatchInner::new());
+
+    // Insert the watcher
+    let mut watchers = FnvHashMap::with_capacity_and_hasher(0, Default::default());
+    watchers.insert(INIT_ID, inner.clone());
+
+    let shared = Arc::new(Shared {
+        value: RwLock::new(init),
+        version: AtomicUsize::new(2),
+        watchers: Mutex::new(Watchers {
+                next_id: INIT_ID + 1,
+                watchers,
+        }),
+        cancel: AtomicTask::new(),
+    });
+
+    let tx = Sender {
+        shared: Arc::downgrade(&shared),
+    };
+
+    let rx = Receiver {
+        shared,
+        inner,
+        id: INIT_ID,
+        ver: 0,
+    };
+
+    (tx, rx)
+}
+
+impl<T> Receiver<T> {
+    /// TODO: Dox
+    pub fn poll(&mut self) -> Poll<Option<Ref<T>>, error::RecvError> {
+        // Make sure the task is up to date
+        self.inner.task.register();
+
+        let version = self.shared.version.load(SeqCst);
+
+        if CLOSED == version & CLOSED {
+            // The `Store` handle has been dropped.
+            return Ok(None.into());
+        }
+
+        if self.ver == version {
+            return Ok(Async::NotReady);
+        }
+
+        // Track the latest version
+        self.ver = version;
+
+        let inner = self.shared.value.read().unwrap();
+
+        Ok(Some(Ref { inner }).into())
+    }
+}
+
+impl<T> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        let inner = Arc::new(WatchInner::new());
+        let shared = self.shared.clone();
+
+        let id = {
+            let mut watchers = shared.watchers.lock().unwrap();
+            let id = watchers.next_id;
+
+            watchers.next_id += 1;
+            watchers.watchers.insert(id, inner.clone());
+
+            id
+        };
+
+        let ver = self.ver;
+
+        Receiver {
+            shared: shared,
+            inner,
+            id,
+            ver,
+        }
+    }
+}
+
+impl<T> Drop for Receiver<T> {
+    fn drop(&mut self) {
+        let mut watchers = self.shared.watchers.lock().unwrap();
+        watchers.watchers.remove(&self.id);
+    }
+}
+
+impl WatchInner {
+    fn new() -> Self {
+        WatchInner { task: AtomicTask::new() }
+    }
+}
+
+impl<T> Sender<T> {
+    /// Store a new value in the cell, notifying all watchers. The previous
+    /// value is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use futures_watch::*;
+    /// let (watch, mut borrow) = Watch::new("hello");
+    /// assert_eq!(borrow.store("goodbye").unwrap(), "hello");
+    /// assert_eq!(*watch.borrow(), "goodbye");
+    /// ```
+    pub fn send(&mut self, value: T) -> Result<(), error::SendError<T>> {
+        let shared = match self.shared.upgrade() {
+            Some(shared) => shared,
+            // All `Watch` handles have been canceled
+            None => return Err(error::SendError { inner: value }),
+        };
+
+        // Replace the value
+        {
+            let mut lock = shared.value.write().unwrap();
+            *lock = value;
+        }
+
+        // Update the version. 2 is used so that the CLOSED bit is not set.
+        shared.version.fetch_add(2, SeqCst);
+
+        // Notify all watchers
+        notify_all(&*shared);
+
+        // Return the old value
+        Ok(())
+    }
+
+    /// Returns `Ready` when all watchers have dropped.
+    ///
+    /// This allows the producer to get notified when interest in the produced
+    /// values is canceled and immediately stop doing work.
+    pub fn poll_close(&mut self) -> Poll<(), ()> {
+        match self.shared.upgrade() {
+            Some(shared) => {
+                shared.cancel.register();
+                Ok(Async::NotReady)
+            }
+            None => {
+                Ok(Async::Ready(()))
+            }
+        }
+    }
+}
+
+impl<T> Sink for Sender<T> {
+    type SinkItem = T;
+    type SinkError = error::SendError<T>;
+
+    fn start_send(&mut self, item: T) -> StartSend<T, error::SendError<T>> {
+        let _ = self.send(item)?;
+        Ok(AsyncSink::Ready)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), error::SendError<T>> {
+        Ok(().into())
+    }
+}
+
+/// Notify all watchers of a change
+fn notify_all<T>(shared: &Shared<T>) {
+    let watchers = shared.watchers.lock().unwrap();
+
+    for watcher in watchers.watchers.values() {
+        // Notify the task
+        watcher.task.notify();
+    }
+}
+
+impl<T> Drop for Sender<T> {
+    fn drop(&mut self) {
+        if let Some(shared) = self.shared.upgrade() {
+            shared.version.fetch_or(CLOSED, SeqCst);
+            notify_all(&*shared);
+        }
+    }
+}
+
+// ===== impl Ref =====
+
+impl<'a, T: 'a> ops::Deref for Ref<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        self.inner.deref()
+    }
+}
+
+// ===== impl Shared =====
+
+impl<T> Drop for Shared<T> {
+    fn drop(&mut self) {
+        self.cancel.notify();
+    }
+}

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -209,6 +209,25 @@ pub fn channel<T>(init: T) -> (Sender<T>, Receiver<T>) {
 }
 
 impl<T> Receiver<T> {
+    /// Returns a reference to the most recently sent value
+    ///
+    /// Outstanding borrows hold a read lock. This means that long lived borrows
+    /// could cause the send half to block. It is recommended to keep the borrow
+    /// as short lived as possible.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # extern crate tokio;
+    /// # use tokio::sync::watch;
+    /// let (_, rx) = watch::channel("hello");
+    /// assert_eq!(*rx.get_ref(), "hello");
+    /// ```
+    pub fn get_ref(&self) -> Ref<T> {
+        let inner = self.shared.value.read().unwrap();
+        Ref { inner }
+    }
+
     /// Attempts to receive the latest value sent via the channel.
     ///
     /// If a new, unobserved, value has been sent, a reference to it is

--- a/tokio-sync/tests/watch.rs
+++ b/tokio-sync/tests/watch.rs
@@ -1,0 +1,85 @@
+extern crate tokio_mock_task;
+extern crate tokio_sync;
+
+use tokio_mock_task::*;
+use tokio_sync::watch;
+
+macro_rules! assert_ready {
+    ($e:expr) => {{
+        match $e {
+            Ok(futures::Async::Ready(v)) => v,
+            Ok(_) => panic!("not ready"),
+            Err(e) => panic!("error = {:?}", e),
+        }
+    }};
+}
+
+macro_rules! assert_not_ready {
+    ($e:expr) => {{
+        match $e {
+            Ok(futures::Async::NotReady) => {}
+            Ok(futures::Async::Ready(v)) => panic!("ready; value = {:?}", v),
+            Err(e) => panic!("error = {:?}", e),
+        }
+    }};
+}
+
+#[test]
+fn smoke() {
+    let (mut tx, mut rx) = watch::channel("one");
+    let mut task = MockTask::new();
+
+    task.enter(|| {
+        let v = assert_ready!(rx.poll()).unwrap();
+        assert_eq!(*v, "one");
+    });
+
+    task.enter(|| assert_not_ready!(rx.poll()));
+
+    assert!(!task.is_notified());
+
+    tx.send("two").unwrap();
+
+    assert!(task.is_notified());
+
+    task.enter(|| {
+        let v = assert_ready!(rx.poll()).unwrap();
+        assert_eq!(*v, "two");
+    });
+
+    task.enter(|| assert_not_ready!(rx.poll()));
+
+    drop(tx);
+
+    assert!(task.is_notified());
+
+    task.enter(|| {
+        let res = assert_ready!(rx.poll());
+        assert!(res.is_none());
+    });
+}
+
+/*
+#[test]
+fn multiple_watches() {
+    let (mut watch1, mut store) = Watch::new("one");
+    let mut watch2 = watch1.clone();
+
+    {
+        let mut h1 = Harness::poll_fn(|| watch1.poll());
+        let mut h2 = Harness::poll_fn(|| watch2.poll());
+
+        assert!(!h1.poll().unwrap().is_ready());
+
+        // Change the value.
+        assert_eq!(store.store("two").unwrap(), "one");
+
+        // The watch was notified
+        assert!(h1.poll().unwrap().is_ready());
+        assert!(h2.poll().unwrap().is_ready());
+    }
+
+    assert_eq!(*watch1.borrow(), "two");
+    assert_eq!(*watch2.borrow(), "two");
+}
+*/

--- a/tokio-sync/tests/watch.rs
+++ b/tokio-sync/tests/watch.rs
@@ -39,7 +39,7 @@ fn single_rx() {
 
     assert!(!task.is_notified());
 
-    tx.send("two").unwrap();
+    tx.broadcast("two").unwrap();
 
     assert!(task.is_notified());
 
@@ -76,7 +76,7 @@ fn stream_impl() {
 
     assert!(!task.is_notified());
 
-    tx.send("two").unwrap();
+    tx.broadcast("two").unwrap();
 
     assert!(task.is_notified());
 
@@ -115,7 +115,7 @@ fn multi_rx() {
         assert_eq!(*res.unwrap(), "one");
     });
 
-    tx.send("two").unwrap();
+    tx.broadcast("two").unwrap();
 
     assert!(task1.is_notified());
     assert!(task2.is_notified());
@@ -125,7 +125,7 @@ fn multi_rx() {
         assert_eq!(*res.unwrap(), "two");
     });
 
-    tx.send("three").unwrap();
+    tx.broadcast("three").unwrap();
 
     assert!(task1.is_notified());
     assert!(task2.is_notified());
@@ -140,7 +140,7 @@ fn multi_rx() {
         assert_eq!(*res.unwrap(), "three");
     });
 
-    tx.send("four").unwrap();
+    tx.broadcast("four").unwrap();
 
     task1.enter(|| {
         let res = assert_ready!(rx1.poll_ref());
@@ -190,7 +190,7 @@ fn rx_observes_final_value() {
     let (mut tx, mut rx) = watch::channel("one");
     let mut task = MockTask::new();
 
-    tx.send("two").unwrap();
+    tx.broadcast("two").unwrap();
 
     task.enter(|| {
         let res = assert_ready!(rx.poll_ref());
@@ -200,7 +200,7 @@ fn rx_observes_final_value() {
 
     task.enter(|| assert_not_ready!(rx.poll_ref()));
 
-    tx.send("three").unwrap();
+    tx.broadcast("three").unwrap();
     drop(tx);
 
     assert!(task.is_notified());
@@ -230,5 +230,5 @@ fn poll_close() {
 
     task.enter(|| assert_ready!(tx.poll_close()));
 
-    assert!(tx.send("two").is_err());
+    assert!(tx.broadcast("two").is_err());
 }

--- a/tokio-sync/tests/watch.rs
+++ b/tokio-sync/tests/watch.rs
@@ -1,3 +1,4 @@
+extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;
 
@@ -30,8 +31,45 @@ fn single_rx() {
     let mut task = MockTask::new();
 
     task.enter(|| {
-        let v = assert_ready!(rx.poll()).unwrap();
+        let v = assert_ready!(rx.poll_ref()).unwrap();
         assert_eq!(*v, "one");
+    });
+
+    task.enter(|| assert_not_ready!(rx.poll_ref()));
+
+    assert!(!task.is_notified());
+
+    tx.send("two").unwrap();
+
+    assert!(task.is_notified());
+
+    task.enter(|| {
+        let v = assert_ready!(rx.poll_ref()).unwrap();
+        assert_eq!(*v, "two");
+    });
+
+    task.enter(|| assert_not_ready!(rx.poll_ref()));
+
+    drop(tx);
+
+    assert!(task.is_notified());
+
+    task.enter(|| {
+        let res = assert_ready!(rx.poll_ref());
+        assert!(res.is_none());
+    });
+}
+
+#[test]
+fn stream_impl() {
+    use futures::Stream;
+
+    let (mut tx, mut rx) = watch::channel("one");
+    let mut task = MockTask::new();
+
+    task.enter(|| {
+        let v = assert_ready!(rx.poll()).unwrap();
+        assert_eq!(v, "one");
     });
 
     task.enter(|| assert_not_ready!(rx.poll()));
@@ -44,7 +82,7 @@ fn single_rx() {
 
     task.enter(|| {
         let v = assert_ready!(rx.poll()).unwrap();
-        assert_eq!(*v, "two");
+        assert_eq!(v, "two");
     });
 
     task.enter(|| assert_not_ready!(rx.poll()));
@@ -68,12 +106,12 @@ fn multi_rx() {
     let mut task2 = MockTask::new();
 
     task1.enter(|| {
-        let res = assert_ready!(rx1.poll());
+        let res = assert_ready!(rx1.poll_ref());
         assert_eq!(*res.unwrap(), "one");
     });
 
     task2.enter(|| {
-        let res = assert_ready!(rx2.poll());
+        let res = assert_ready!(rx2.poll_ref());
         assert_eq!(*res.unwrap(), "one");
     });
 
@@ -83,7 +121,7 @@ fn multi_rx() {
     assert!(task2.is_notified());
 
     task1.enter(|| {
-        let res = assert_ready!(rx1.poll());
+        let res = assert_ready!(rx1.poll_ref());
         assert_eq!(*res.unwrap(), "two");
     });
 
@@ -93,36 +131,36 @@ fn multi_rx() {
     assert!(task2.is_notified());
 
     task1.enter(|| {
-        let res = assert_ready!(rx1.poll());
+        let res = assert_ready!(rx1.poll_ref());
         assert_eq!(*res.unwrap(), "three");
     });
 
     task2.enter(|| {
-        let res = assert_ready!(rx2.poll());
+        let res = assert_ready!(rx2.poll_ref());
         assert_eq!(*res.unwrap(), "three");
     });
 
     tx.send("four").unwrap();
 
     task1.enter(|| {
-        let res = assert_ready!(rx1.poll());
+        let res = assert_ready!(rx1.poll_ref());
         assert_eq!(*res.unwrap(), "four");
     });
 
     drop(tx);
 
     task1.enter(|| {
-        let res = assert_ready!(rx1.poll());
+        let res = assert_ready!(rx1.poll_ref());
         assert!(res.is_none());
     });
 
     task2.enter(|| {
-        let res = assert_ready!(rx2.poll());
+        let res = assert_ready!(rx2.poll_ref());
         assert_eq!(*res.unwrap(), "four");
     });
 
     task2.enter(|| {
-        let res = assert_ready!(rx2.poll());
+        let res = assert_ready!(rx2.poll_ref());
         assert!(res.is_none());
     });
 }
@@ -137,13 +175,13 @@ fn rx_observes_final_value() {
     drop(tx);
 
     task.enter(|| {
-        let res = assert_ready!(rx.poll());
+        let res = assert_ready!(rx.poll_ref());
         assert!(res.is_some());
         assert_eq!(*res.unwrap(), "one");
     });
 
     task.enter(|| {
-        let res = assert_ready!(rx.poll());
+        let res = assert_ready!(rx.poll_ref());
         assert!(res.is_none());
     });
 
@@ -155,12 +193,12 @@ fn rx_observes_final_value() {
     tx.send("two").unwrap();
 
     task.enter(|| {
-        let res = assert_ready!(rx.poll());
+        let res = assert_ready!(rx.poll_ref());
         assert!(res.is_some());
         assert_eq!(*res.unwrap(), "two");
     });
 
-    task.enter(|| assert_not_ready!(rx.poll()));
+    task.enter(|| assert_not_ready!(rx.poll_ref()));
 
     tx.send("three").unwrap();
     drop(tx);
@@ -168,13 +206,29 @@ fn rx_observes_final_value() {
     assert!(task.is_notified());
 
     task.enter(|| {
-        let res = assert_ready!(rx.poll());
+        let res = assert_ready!(rx.poll_ref());
         assert!(res.is_some());
         assert_eq!(*res.unwrap(), "three");
     });
 
     task.enter(|| {
-        let res = assert_ready!(rx.poll());
+        let res = assert_ready!(rx.poll_ref());
         assert!(res.is_none());
     });
+}
+
+#[test]
+fn poll_close() {
+    let (mut tx, rx) = watch::channel("one");
+    let mut task = MockTask::new();
+
+    task.enter(|| assert_not_ready!(tx.poll_close()));
+
+    drop(rx);
+
+    assert!(task.is_notified());
+
+    task.enter(|| assert_ready!(tx.poll_close()));
+
+    assert!(tx.send("two").is_err());
 }


### PR DESCRIPTION
A single-producer, multi-consumer channel that only retains the *last* sent value. Values are broadcasted out.

This channel is useful for watching for changes to a value from multiple points in the code base (for example, changes to a configuration value).