### PR TITLE
Add edition = "2018" to tokio-async-await

### DIFF
--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -13,6 +13,7 @@ description = """
 Experimental async/await support for Tokio
 """
 categories = ["asynchronous"]
+edition = "2018"
 
 [features]
 # This feature comes with no promise of stability. Things will


### PR DESCRIPTION
## Motivation

Recently some of our builds started to fail with error in tokio-async-await (i suspect fresh nightly came out):

> error[E0670]: `async fn` is not permitted in the 2015 edition

turns out this crate does not have 2018 edition requirement

## Solution

add edition="2018"