### PR TITLE
sync: impl `Error` for mpsc error types

### DIFF
--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -284,3 +284,18 @@ impl<T> From<(T, chan::TrySendError)> for TrySendError<T> {
         }
     }
 }
+
+// ===== impl RecvError =====
+
+impl fmt::Display for RecvError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl ::std::error::Error for RecvError {
+    fn description(&self) -> &str {
+        "channel closed"
+    }
+}

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -180,3 +180,18 @@ impl<T> From<(T, chan::TrySendError)> for UnboundedTrySendError<T> {
         UnboundedTrySendError(value)
     }
 }
+
+// ===== impl UnboundedRecvError =====
+
+impl fmt::Display for UnboundedRecvError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        use std::error::Error;
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl ::std::error::Error for UnboundedRecvError {
+    fn description(&self) -> &str {
+        "channel closed"
+    }
+}

--- a/tokio-sync/tests/errors.rs
+++ b/tokio-sync/tests/errors.rs
@@ -1,0 +1,18 @@
+#![deny(warnings)]
+
+extern crate tokio_sync;
+
+use tokio_sync::mpsc::error;
+
+fn is_error<T: ::std::error::Error + Send + Sync>() {
+}
+
+#[test]
+fn error_bound() {
+    is_error::<error::RecvError>();
+    is_error::<error::SendError>();
+    is_error::<error::TrySendError<()>>();
+    is_error::<error::UnboundedRecvError>();
+    is_error::<error::UnboundedSendError>();
+    is_error::<error::UnboundedTrySendError<()>>();
+}

--- a/tokio-sync/tests/errors.rs
+++ b/tokio-sync/tests/errors.rs
@@ -4,8 +4,7 @@ extern crate tokio_sync;
 
 use tokio_sync::mpsc::error;
 
-fn is_error<T: ::std::error::Error + Send + Sync>() {
-}
+fn is_error<T: ::std::error::Error + Send + Sync>() {}
 
 #[test]
 fn error_bound() {


### PR DESCRIPTION
`RecvError` and `UnboundedRecvError` were missing the implementations.