### PR TITLE
Bump tokio-sync version to v0.1.3

### DIFF
--- a/tokio-sync/CHANGELOG.md
+++ b/tokio-sync/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.3 (March 1, 2019)
+
+### Added
+- `Watch`, a single value broadcast channel (#922).
+- `std::error::Error` implementation for more `mpsc` types (#937).
+
 # 0.1.2 (February 20, 2019)
 
 ### Fixes

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -7,12 +7,12 @@ name = "tokio-sync"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-sync/0.1.2/tokio_sync"
+documentation = "https://docs.rs/tokio-sync/0.1.3/tokio_sync"
 description = """
 Synchronization utilities.
 """

--- a/tokio-sync/README.md
+++ b/tokio-sync/README.md
@@ -2,7 +2,7 @@
 
 Synchronization utilities
 
-[Documentation](https://docs.rs/tokio-sync/0.1.2/tokio_sync/)
+[Documentation](https://docs.rs/tokio-sync/0.1.3/tokio_sync/)
 
 ## Overview
 

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-sync/0.1.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-sync/0.1.3")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
### Added
- `Watch`, a single value broadcast channel (#922).
- `std::error::Error` implementation for more `mpsc` types (#937).