### PR TITLE
async-await: fix build for latest nightly

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,7 @@ jobs:
   parameters:
     name: async_await
     displayName: Async / Await
-    rust: nightly-2019-02-22
+    rust: nightly-2019-02-28
     noDefaultFeatures: ''
     benches: true
     crates:

--- a/src/async_await.rs
+++ b/src/async_await.rs
@@ -1,8 +1,32 @@
 use std::future::Future as StdFuture;
+use std::pin::Pin;
+use std::task::{Poll, Waker};
 
-async fn map_ok<T: StdFuture>(future: T) -> Result<(), ()> {
-    let _ = await!(future);
-    Ok(())
+fn map_ok<T: StdFuture>(future: T) -> impl StdFuture<Output = Result<(), ()>> {
+    MapOk(future)
+}
+
+struct MapOk<T>(T);
+
+impl<T> MapOk<T> {
+    fn future<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
+        unsafe {
+            Pin::map_unchecked_mut(
+                self, |x| &mut x.0
+            )
+        }
+    }
+}
+
+impl<T: StdFuture> StdFuture for MapOk<T> {
+    type Output = Result<(), ()>;
+
+    fn poll(self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
+        match self.future().poll(waker) {
+            Poll::Ready(_) => Poll::Ready(Ok(())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 /// Like `tokio::run`, but takes an `async` block

--- a/src/async_await.rs
+++ b/src/async_await.rs
@@ -10,11 +10,7 @@ struct MapOk<T>(T);
 
 impl<T> MapOk<T> {
     fn future<'a>(self: Pin<&'a mut Self>) -> Pin<&'a mut T> {
-        unsafe {
-            Pin::map_unchecked_mut(
-                self, |x| &mut x.0
-            )
-        }
+        unsafe { Pin::map_unchecked_mut(self, |x| &mut x.0) }
     }
 }
 

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -29,77 +29,7 @@ pub mod io;
 pub mod sink;
 pub mod stream;
 
-/*
-pub mod prelude {
-    //! A "prelude" for users of the `tokio` crate.
-    //!
-    //! This prelude is similar to the standard library's prelude in that you'll
-    //! almost always want to import its entire contents, but unlike the standard
-    //! library's prelude you'll have to do so manually:
-    //!
-    //! ```
-    //! use tokio::prelude::*;
-    //! ```
-    //!
-    //! The prelude may grow over time as additional items see ubiquitous use.
-
-    pub use tokio_main::prelude::*;
-
-    #[doc(inline)]
-    pub use crate::async_await::{
-        io::{
-            AsyncReadExt,
-            AsyncWriteExt,
-        },
-        sink::{
-            SinkExt,
-        },
-        stream::{
-            StreamExt,
-        },
-    };
-}
-*/
-
 // Rename the `await` macro in `std`. This is used by the redefined
 // `await` macro in this crate.
 #[doc(hidden)]
 pub use std::await as std_await;
-
-/*
-use std::future::{Future as StdFuture};
-
-fn run<T: futures::Future<Item = (), Error = ()>>(t: T) {
-    drop(t);
-}
-
-async fn map_ok<T: StdFuture>(future: T) -> Result<(), ()> {
-    let _ = await!(future);
-    Ok(())
-}
-
-/// Like `tokio::run`, but takes an `async` block
-pub fn run_async<F>(future: F)
-where F: StdFuture<Output = ()> + Send + 'static,
-{
-    use async_await::compat::backward;
-    let future = backward::Compat::new(map_ok(future));
-
-    run(future);
-    unimplemented!();
-}
-*/
-
-/*
-/// Like `tokio::spawn`, but takes an `async` block
-pub fn spawn_async<F>(future: F)
-where F: StdFuture<Output = ()> + Send + 'static,
-{
-    use crate::async_await::compat::backward;
-
-    spawn(backward::Compat::new(async || {
-        let _ = await!(future);
-        Ok(())
-    }));
-}
-*/


### PR DESCRIPTION
Rust 2015 no longer supports the `async fn` syntax. However, we cannot update to Rust 2018
and remain backwards compatible.

To work around this, `async fn` is removed in favor of manually implementing futures.

Supersedes #935