### PR TITLE
Bump Tokio to 0.1.16.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.16 (March 1, 2019)
+
+### Fixed
+- async-await: track latest nightly changes (#940).
+
+### Added
+- `sync::Watch`, a single value broadcast channel (#922).
+- Async equivalent of read / write file helpers being added to `std` (#896).
+
 # 0.1.15 (January 24, 2019)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.15"
+version = "0.1.16"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.15/tokio/"
+documentation = "https://docs.rs/tokio/0.1.16/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.15/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.16/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 The API docs for the master branch are published [here][master-dox].

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.15")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.16")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(
     feature = "async-await-preview",

--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.5 (March 1, 2019)
+
+### Fixed
+- Documentation typos (#882).
+
 # 0.1.4 (November 21, 2018)
 
 * Fix shutdown on idle (#763).

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -3,11 +3,13 @@ name = "tokio-current-thread"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-# - Update doc URL
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.4"
-documentation = "https://docs.rs/tokio-current-thread/0.1.4/tokio_current_thread"
+version = "0.1.5"
+documentation = "https://docs.rs/tokio-current-thread/0.1.5/tokio_current_thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-current-thread/README.md
+++ b/tokio-current-thread/README.md
@@ -2,7 +2,7 @@
 
 Single threaded executor for Tokio.
 
-[Documentation](https://docs.rs/tokio-current-thread/0.1.4/tokio_current_thread/)
+[Documentation](https://docs.rs/tokio-current-thread/0.1.5/tokio_current_thread/)
 
 ## Overview
 

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.5")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A single-threaded executor which executes tasks on the same thread from which

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.6 (March 1, 2019)
+
+### Added
+- File::try_clone() (#850).
+- Async equivalent of read / write file helpers being added to `std` (#896).
+
 # 0.1.5 (January 6, 2019)
 
 * Add examples to `File` API docs (#786).

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -8,13 +8,13 @@ name = "tokio-fs"
 #   - Cargo.toml
 #   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-fs/0.1.5/tokio_fs"
+documentation = "https://docs.rs/tokio-fs/0.1.6/tokio_fs"
 description = """
 Filesystem API for Tokio.
 """

--- a/tokio-fs/README.md
+++ b/tokio-fs/README.md
@@ -2,7 +2,7 @@
 
 Asynchronous filesystem manipulation operations (and stdin, stdout, stderr).
 
-[Documentation](https://docs.rs/tokio-fs/0.1.5/tokio_fs)
+[Documentation](https://docs.rs/tokio-fs/0.1.6/tokio_fs)
 
 ## Overview
 

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.6")]
 
 //! Asynchronous file and standard stream adaptation.
 //!

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.12 (March 1, 2019)
+
+### Added
+- Add `unsplit` to join previously split `AsyncRead + AsyncWrite` (#807).
+
 # 0.1.11 (January 6, 2019)
 
 * Fix minor error in Decoder::decode API documentation (#797).

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-io"
 #   - Cargo.toml
 #   - Readme.md
 # - Create "v0.1.x" git tag.
-version = "0.1.11"
+version = "0.1.12"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.1.11/tokio_io"
+documentation = "https://docs.rs/tokio-io/0.1.12/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """

--- a/tokio-io/README.md
+++ b/tokio-io/README.md
@@ -4,7 +4,7 @@ Core I/O abstractions for the Tokio stack.
 
 [![Build Status](https://travis-ci.org/tokio-rs/tokio-io.svg?branch=master)](https://travis-ci.org/tokio-rs/tokio-io)
 
-[Documentation](https://docs.rs/tokio-io/0.1.11/tokio_io)
+[Documentation](https://docs.rs/tokio-io/0.1.12/tokio_io)
 
 ## Usage
 

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.12")]
 
 //! Core I/O traits and combinators when working with Tokio.
 //!

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.1.9 (March 1, 2019)
+
+### Added
+- impl `AsRawFd` for `Reactor` on unix platforms (#890).
+
+### Changed
+- perf: reduce unnecessary task clones (#899).
+- perf: release lock before issuing syscall (#894).
+
 # 0.1.8 (January 6, 2019)
 
 * Update to `parking_lot` 0.7 (#778).

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -8,13 +8,13 @@ name = "tokio-reactor"
 #   - Cargo.toml
 #   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1.8/tokio_reactor"
+documentation = "https://docs.rs/tokio-reactor/0.1.9/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -2,7 +2,7 @@
 
 Event loop that drives Tokio I/O resources.
 
-[Documentation](https://docs.rs/tokio-reactor/0.1.8/tokio_reactor)
+[Documentation](https://docs.rs/tokio-reactor/0.1.9/tokio_reactor)
 
 ## Overview
 
@@ -25,10 +25,10 @@ are building a custom I/O resource.
 
 [`mio`]: http://github.com/carllerche/mio
 [`futures`]: http://github.com/rust-lang-nursery/futures-rs
-[`Reactor`]: https://docs.rs/tokio-reactor/0.1.8/tokio_reactor/struct.Reactor.html
-[`Handle`]: https://docs.rs/tokio-reactor/0.1.8/tokio_reactor/struct.Handle.html
-[`Registration`]: https://docs.rs/tokio-reactor/0.1.8/tokio_reactor/struct.Registration.html
-[`PollEvented`]: https://docs.rs/tokio-reactor/0.1.8/tokio_reactor/struct.PollEvented.html
+[`Reactor`]: https://docs.rs/tokio-reactor/0.1.9/tokio_reactor/struct.Reactor.html
+[`Handle`]: https://docs.rs/tokio-reactor/0.1.9/tokio_reactor/struct.Handle.html
+[`Registration`]: https://docs.rs/tokio-reactor/0.1.9/tokio_reactor/struct.Registration.html
+[`PollEvented`]: https://docs.rs/tokio-reactor/0.1.9/tokio_reactor/struct.PollEvented.html
 [`tokio`]: ../
 
 ## License

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.9")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -24,6 +24,6 @@ futures = "0.1.19"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
-tokio = { path = ".." }
+tokio = { version = "0.1.15", path = ".." }
 tokio-mock-task = "0.1.1"
 loom = { version = "0.1.1", features = ["futures"] }

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.12 (March 1, 2019)
+
+### Fixed
+- Documentation typos (#915).
+
+### Changed
+- Update crossbeam dependencies (#874).
+
 # 0.1.11 (January 24, 2019)
 
 ### Fixed

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -7,8 +7,8 @@ name = "tokio-threadpool"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.11"
-documentation = "https://docs.rs/tokio-threadpool/0.1.11/tokio_threadpool"
+version = "0.1.12"
+documentation = "https://docs.rs/tokio-threadpool/0.1.12/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.11/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.12/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.11")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.12")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.


### PR DESCRIPTION
Also bumps:

* tokio-current-thread (0.1.5)
* tokio-fs (0.1.6)
* tokio-io (0.1.12)
* tokio-reactor (0.1.9)
* tokio-threadpool (0.1.12)