### PR TITLE
Async/await support for UdpSocket

### DIFF
--- a/async-await/Cargo.toml
+++ b/async-await/Cargo.toml
@@ -21,6 +21,14 @@ name = "echo_server"
 path = "src/echo_server.rs"
 
 [[bin]]
+name = "udp_echo_client"
+path = "src/udp_echo_client.rs"
+
+[[bin]]
+name = "udp_echo_server"
+path = "src/udp_echo_server.rs"
+
+[[bin]]
 name = "hyper"
 path = "src/hyper.rs"
 

--- a/async-await/src/udp_echo_client.rs
+++ b/async-await/src/udp_echo_client.rs
@@ -1,0 +1,35 @@
+#![feature(await_macro, async_await)]
+
+use tokio::net::UdpSocket;
+use tokio::prelude::*;
+
+use std::io;
+
+const MESSAGES: &[&str] = &["hello", "world", "one two three"];
+
+#[tokio::main]
+async fn main() -> io::Result<()> {
+    let addr = std::env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = addr.parse().unwrap();
+    let bind_addr = "127.0.0.1:0".parse().unwrap();
+    let mut socket = UdpSocket::bind(&bind_addr)?;
+    // Connect to server address.
+    socket.connect(&addr)?;
+
+    // Buffer to read into
+    let mut buf = [0; 128];
+
+    for msg in MESSAGES {
+        println!(" > write = {:?}", msg);
+
+        // Write the message to the server
+        await!(socket.send_async(msg.as_bytes()))?;
+
+        // Read the message back from the server
+        await!(socket.recv_async(&mut buf[..msg.len()]))?;
+
+        assert_eq!(&buf[..msg.len()], msg.as_bytes());
+    }
+
+    Ok(())
+}

--- a/async-await/src/udp_echo_server.rs
+++ b/async-await/src/udp_echo_server.rs
@@ -1,0 +1,20 @@
+#![feature(await_macro, async_await)]
+
+use tokio::net::UdpSocket;
+use tokio::prelude::*;
+
+#[tokio::main]
+async fn main() {
+    use std::env;
+
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = addr.parse().unwrap();
+
+    let mut socket = UdpSocket::bind(&addr).unwrap();
+
+    let mut buf = [0u8; 1500];
+    loop {
+        let (len, peer_addr) = await!(socket.recv_from_async(&mut buf)).unwrap();
+        await!(socket.send_to_async(&buf[..len], &peer_addr)).unwrap();
+    }
+}

--- a/tokio-futures/Cargo.toml
+++ b/tokio-futures/Cargo.toml
@@ -22,6 +22,7 @@ async-await-preview = ["futures/nightly"]
 [dependencies]
 futures = "0.1.23"
 tokio-io = "0.1.7"
+tokio-udp = "0.1.3"
 
 [dev-dependencies]
 bytes = "0.4.9"

--- a/tokio-futures/src/lib.rs
+++ b/tokio-futures/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate futures;
 extern crate tokio_io;
+extern crate tokio_udp;
 
 /// Extracts the successful type of a `Poll<Result<T, E>>`.
 ///
@@ -28,6 +29,7 @@ pub mod compat;
 pub mod io;
 pub mod sink;
 pub mod stream;
+pub mod udp;
 
 // Rename the `await` macro in `std`. This is used by the redefined
 // `await` macro in this crate.

--- a/tokio-futures/src/udp/mod.rs
+++ b/tokio-futures/src/udp/mod.rs
@@ -1,0 +1,60 @@
+//! Use [`UdpSocket`](tokio_udp::UdpSocket) with `async`/`await`.
+
+use std::net::SocketAddr;
+use tokio_udp::UdpSocket;
+
+mod recv_from_async;
+pub use self::recv_from_async::RecvFromAsync;
+
+mod send_to_async;
+pub use self::send_to_async::SendToAsync;
+
+mod recv_async;
+pub use self::recv_async::RecvAsync;
+
+mod send_async;
+pub use self::send_async::SendAsync;
+
+/// Extension trait that adds async/await support for [`UdpSocket`](UdpSocket).
+pub trait UdpSocketAsyncExt {
+    /// Creates a future that receives a datagram.
+    ///
+    /// See also [`poll_recv_from`](UdpSocket::poll_recv_from). The future is a simple wrapper around it.
+    fn recv_from_async<'a>(&'a mut self, buf: &'a mut [u8]) -> RecvFromAsync<'a>;
+    /// Creates a future that sends a datagram to the given address.
+    ///
+    /// See also [`poll_send_to`](UdpSocket::poll_send_to). The future is a simple wrapper around it.
+    fn send_to_async<'a>(&'a mut self, buf: &'a [u8], addr: &'a SocketAddr) -> SendToAsync<'a>;
+    /// Creates a future that sends a datagram to the connected address.
+    ///
+    /// The [`connect`](UdpSocket::connect) method must have been called,
+    /// or the returned future will resolve to an error.
+    ///
+    /// See also [`poll_send`](UdpSocket::poll_send). The future is a simple wrapper around it.
+    fn send_async<'a>(&'a mut self, buf: &'a [u8]) -> SendAsync<'a>;
+    /// Creates a future that receives a datagram from the connected address.
+    ///
+    /// The [`connect`](UdpSocket::connect) method must have been called,
+    /// or the returned future will resolve to an error.
+    ///
+    /// See also [`poll_recv`](UdpSocket::poll_recv). The future is a simple wrapper around it.
+    fn recv_async<'a>(&'a mut self, buf: &'a mut [u8]) -> RecvAsync<'a>;
+}
+
+impl UdpSocketAsyncExt for UdpSocket {
+    fn recv_from_async<'a>(&'a mut self, buf: &'a mut [u8]) -> RecvFromAsync<'a> {
+        RecvFromAsync::new(self, buf)
+    }
+
+    fn send_to_async<'a>(&'a mut self, buf: &'a [u8], addr: &'a SocketAddr) -> SendToAsync<'a> {
+        SendToAsync::new(self, buf, addr)
+    }
+
+    fn send_async<'a>(&'a mut self, buf: &'a [u8]) -> SendAsync<'a> {
+        SendAsync::new(self, buf)
+    }
+
+    fn recv_async<'a>(&'a mut self, buf: &'a mut [u8]) -> RecvAsync<'a> {
+        RecvAsync::new(self, buf)
+    }
+}

--- a/tokio-futures/src/udp/recv_async.rs
+++ b/tokio-futures/src/udp/recv_async.rs
@@ -1,0 +1,31 @@
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_udp::UdpSocket;
+
+/// A future that receives a datagram from the connected address.
+///
+/// This `struct` is created by [`recv_async`](super::UdpSocketAsyncExt::recv_async).
+#[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
+pub struct RecvAsync<'a> {
+    socket: &'a mut UdpSocket,
+    buf: &'a mut [u8],
+}
+
+impl<'a> RecvAsync<'a> {
+    pub(super) fn new(socket: &'a mut UdpSocket, buf: &'a mut [u8]) -> Self {
+        Self { socket, buf }
+    }
+}
+
+impl<'a> Future for RecvAsync<'a> {
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        use crate::compat::forward::convert_poll;
+        let _self = self.get_mut();
+        convert_poll(_self.socket.poll_recv(_self.buf))
+    }
+}

--- a/tokio-futures/src/udp/recv_from_async.rs
+++ b/tokio-futures/src/udp/recv_from_async.rs
@@ -1,0 +1,32 @@
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_udp::UdpSocket;
+
+/// A future that receives a datagram.
+///
+/// This `struct` is created by [`recv_from_async`](super::UdpSocketAsyncExt::recv_from_async).
+#[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
+pub struct RecvFromAsync<'a> {
+    socket: &'a mut UdpSocket,
+    buf: &'a mut [u8],
+}
+
+impl<'a> RecvFromAsync<'a> {
+    pub(super) fn new(socket: &'a mut UdpSocket, buf: &'a mut [u8]) -> Self {
+        Self { socket, buf }
+    }
+}
+
+impl<'a> Future for RecvFromAsync<'a> {
+    type Output = io::Result<(usize, SocketAddr)>;
+
+    fn poll(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        use crate::compat::forward::convert_poll;
+        let _self = self.get_mut();
+        convert_poll(_self.socket.poll_recv_from(_self.buf))
+    }
+}

--- a/tokio-futures/src/udp/send_async.rs
+++ b/tokio-futures/src/udp/send_async.rs
@@ -1,0 +1,31 @@
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_udp::UdpSocket;
+
+/// A future that sends a datagram to the connected address.
+///
+/// This `struct` is created by [`send_async`](super::UdpSocketAsyncExt::send_async).
+#[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
+pub struct SendAsync<'a> {
+    socket: &'a mut UdpSocket,
+    buf: &'a [u8],
+}
+
+impl<'a> SendAsync<'a> {
+    pub(super) fn new(socket: &'a mut UdpSocket, buf: &'a [u8]) -> Self {
+        Self { socket, buf }
+    }
+}
+
+impl<'a> Future for SendAsync<'a> {
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        use crate::compat::forward::convert_poll;
+        let _self = self.get_mut();
+        convert_poll(_self.socket.poll_send(_self.buf))
+    }
+}

--- a/tokio-futures/src/udp/send_to_async.rs
+++ b/tokio-futures/src/udp/send_to_async.rs
@@ -1,0 +1,33 @@
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_udp::UdpSocket;
+
+/// A future that sends a datagram to a given address.
+///
+/// This `struct` is created by [`send_to_async`](super::UdpSocketAsyncExt::send_to_async).
+#[must_use = "futures do nothing unless polled"]
+#[derive(Debug)]
+pub struct SendToAsync<'a> {
+    socket: &'a mut UdpSocket,
+    buf: &'a [u8],
+    addr: &'a SocketAddr,
+}
+
+impl<'a> SendToAsync<'a> {
+    pub(super) fn new(socket: &'a mut UdpSocket, buf: &'a [u8], addr: &'a SocketAddr) -> Self {
+        Self { socket, buf, addr }
+    }
+}
+
+impl<'a> Future for SendToAsync<'a> {
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, _ctx: &mut Context<'_>) -> Poll<Self::Output> {
+        use crate::compat::forward::convert_poll;
+        let _self = self.get_mut();
+        convert_poll(_self.socket.poll_send_to(_self.buf, _self.addr))
+    }
+}

--- a/tokio/src/prelude.rs
+++ b/tokio/src/prelude.rs
@@ -25,4 +25,5 @@ pub use tokio_futures::{
     io::{AsyncReadExt, AsyncWriteExt},
     sink::SinkExt,
     stream::StreamExt as StreamAsyncExt,
+    udp::UdpSocketAsyncExt,
 };


### PR DESCRIPTION
The implementation is straightforward, just as what @carllerche has outlined in the [comment](https://github.com/tokio-rs/tokio/issues/616#issuecomment-418822735).

Example echo server and client are also added to the async-await examples crate.

A caveat is that now the async-await-preview feature will always pull in tokio-udp through tokio-async-await. Ideally we want (async-await-preview AND udp) to pull in all these stuff, but I don't know how to specify that in `Cargo.toml`, or whether it is possible at all.