### PR TITLE
Fix TcpStream::try_clone error message

### DIFF
--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -785,7 +785,7 @@ impl TcpStream {
         // Rationale for deprecation:
         // - https://github.com/tokio-rs/tokio/pull/824
         // - https://github.com/tokio-rs/tokio/issues/774#issuecomment-451059317
-        let msg = "`TcpStream::split()` is deprecated because it doesn't work as intended";
+        let msg = "`TcpStream::try_clone()` is deprecated because it doesn't work as intended";
         Err(io::Error::new(io::ErrorKind::Other, msg))
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

I began using rust nightly, and started getting errors with my code that uses `TcpStream::try_clone`. I was confused by the error message: it told me `split` was deprecated, but I think it meant to say `try_clone` is deprecated. I think this is just a simple typo fix.

## Solution

Update the error message to reference `try_clone` instead of `split`. Updated my code to use `Framed::into_inner` to get at the underlying stream inside my `Framed` object.
