### PR TITLE
trace-core: Make `Dispatch` downcasty

### DIFF
--- a/tokio-trace/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace/tokio-trace-core/src/dispatcher.rs
@@ -14,7 +14,7 @@ use std::{
 /// `Dispatch` trace data to a [`Subscriber`](::Subscriber).
 #[derive(Clone)]
 pub struct Dispatch {
-    subscriber: Arc<Subscriber + Send + Sync>,
+    subscriber: Arc<Subscriber + Send + Sync + 'static>,
 }
 
 thread_local! {
@@ -61,7 +61,7 @@ where
         .unwrap_or_else(|_| f(&Dispatch::none()))
 }
 
-pub(crate) struct Registrar(Weak<Subscriber + Send + Sync>);
+pub(crate) struct Registrar(Weak<Subscriber + Send + Sync + 'static>);
 
 impl Dispatch {
     /// Returns a new `Dispatch` that discards events and spans.

--- a/tokio-trace/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace/tokio-trace-core/src/dispatcher.rs
@@ -196,6 +196,32 @@ impl Dispatch {
     pub fn drop_span(&self, id: span::Id) {
         self.subscriber.drop_span(id)
     }
+
+    /// Returns `true` if this `Dispatch` forwards to a subscriber of type `T`
+    #[inline]
+    pub fn is<T>(&self) -> bool
+    where
+        T: Subscriber + Send + Sync + 'static,
+    {
+        use std::any::TypeId;
+
+        TypeId::of::<T>() == self.subscriber.type_id()
+    }
+
+    /// Returns a reference to the `Subscriber` this `Dispatch` forwards to if
+    /// it is of type `T`, or `None` if it isn't.
+    #[inline]
+    pub fn downcast_ref<T>(&self) -> Option<&T>
+    where
+        T: Subscriber + Send + Sync + 'static,
+    {
+        if self.is::<T>() {
+            let inner = self.subscriber.as_ref();
+            unsafe { Some(&*(inner as *const Subscriber as *const T)) }
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Debug for Dispatch {

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -1,4 +1,5 @@
 //! Subscribers collect and record trace data.
+use std::any::TypeId;
 use {field, span, Event, Metadata};
 
 /// Trait representing the functions required to collect trace data.
@@ -239,6 +240,15 @@ pub trait Subscriber {
     /// [`drop_span`]: ::subscriber::Subscriber::drop_span
     fn drop_span(&self, id: span::Id) {
         let _ = id;
+    }
+
+    /// Gets the `TypeId` of `self`
+    #[doc(hidden)]
+    fn type_id(&self) -> TypeId
+    where
+        Self: 'static,
+    {
+        TypeId::of::<Self>()
     }
 }
 


### PR DESCRIPTION
## Motivation

In order to implement "out of band" `Subscriber` APIs in third-party
subscriber implementations (see [this comment]) users may want to 
downcast the current `Dispatch` to a concrete subscriber type.

For example, in a library for integrating `tokio-trace` with a fancy new
(hypothetical) distributed tracing technology "ElizaTracing", which uses
256-bit span IDs, we might expect to see a function like this:
```rust

pub fn correlate(tt: tokio_trace::span::Id, et: elizatracing::SpanId) {
    tokio_trace::dispatcher::with(|c| {
        if let Some(s) = c.downcast_ref::<elizatracing::Subscriber>() {
            s.do_elizatracing_correlation_magic(tt, et);
        }
    }); 
}
```

This allows users to correlate `tokio-trace` IDs with IDs in the
distributed tracing system without having to pass a special handle to
the subscriber through application code (as one is already present in
thread-local storage, but with its type erased).

## Solution

This branch makes the following changes:
 * Change the `Dispatch` type to add a `'static` bound on the 
   subscriber trait object so that it can be downcast,
 * Add a hidden `type_id` function to the `Subscriber` trait, similarly
   to [`std::error::Error`'s], and
 * Add a `is<T>` and `downcast_ref<T>` functions to `Dispatch`, again
   based on `std::error::Error`.

[this comment]: https://github.com/tokio-rs/tokio/issues/932#issuecomment-469473501
[`std::error::Error`'s]: https://doc.rust-lang.org/1.33.0/src/std/error.rs.html#204

Signed-off-by: Eliza Weisman <eliza@buoyant.io>