### PR TITLE
trace-core: Add `'static` bound to `Subscriber`

### DIFF
--- a/tokio-trace/tests/support/subscriber.rs
+++ b/tokio-trace/tests/support/subscriber.rs
@@ -57,7 +57,10 @@ pub fn mock() -> MockSubscriber<fn(&Metadata) -> bool> {
     }
 }
 
-impl<F: Fn(&Metadata) -> bool> MockSubscriber<F> {
+impl<F> MockSubscriber<F>
+where
+    F: Fn(&Metadata) -> bool + 'static,
+{
     pub fn enter(mut self, span: MockSpan) -> Self {
         self.expected.push_back(Expect::Enter(span));
         self
@@ -106,7 +109,7 @@ impl<F: Fn(&Metadata) -> bool> MockSubscriber<F> {
 
     pub fn with_filter<G>(self, filter: G) -> MockSubscriber<G>
     where
-        G: Fn(&Metadata) -> bool,
+        G: Fn(&Metadata) -> bool + 'static,
     {
         MockSubscriber {
             filter,
@@ -133,7 +136,10 @@ impl<F: Fn(&Metadata) -> bool> MockSubscriber<F> {
     }
 }
 
-impl<F: Fn(&Metadata) -> bool> Subscriber for Running<F> {
+impl<F> Subscriber for Running<F>
+where
+    F: Fn(&Metadata) -> bool + 'static,
+{
     fn enabled(&self, meta: &Metadata) -> bool {
         (self.filter)(meta)
     }

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -33,7 +33,7 @@ use {field, span, Event, Metadata};
 ///
 /// [ID]: ::span::Span
 /// [`new_span`]: ::Span::new_span
-pub trait Subscriber {
+pub trait Subscriber: 'static {
     // === Span registry methods ==============================================
 
     /// Registers a new callsite with this subscriber, returning whether or not


### PR DESCRIPTION
This branch adds a 'static bound to the `Subscriber` trait, to enable
adding downcasting-based APIs to `Subscriber` later in a
backwards-compatible way.

This isn alternative to PR #950 that punts the actual implementation of
the downcasting API to a future version.

Signed-off-by: Eliza WEisman <eliza@buoyant.io>