### PR TITLE
tokio-sync: Add asynchronous, atomic Option type

### DIFF
--- a/tokio-sync/src/lease.rs
+++ b/tokio-sync/src/lease.rs
@@ -26,7 +26,7 @@
 //! }
 //! ```
 //!
-//! `Lease` allwos you to do this. Specifically, `poll_ready` attempts to acquire the lease using
+//! `Lease` allows you to do this. Specifically, `poll_ready` attempts to acquire the lease using
 //! `Lease::poll_acquire`, and `call` _transfers_ that lease into the returned future. When the
 //! future eventually resolves, we _restore_ the leased value so that `poll_ready` returns `Ready`
 //! again to anyone else who may want to take the value. The example above would thus look like

--- a/tokio-sync/src/lease.rs
+++ b/tokio-sync/src/lease.rs
@@ -1,0 +1,215 @@
+//! An asynchronous, atomic option type.
+//!
+//! This module provides `Lease`, a type that acts similarly to an asynchronous `Mutex`, with one
+//! major difference: it expects you to move the leased item _by value_, and then _return it_ when
+//! you are done. You can think of a `Lease` as an atomic, asynchronous `Option` type, in which we
+//! can `take` the value only if no-one else has currently taken it, and where we are notified when
+//! the value has returned so we can try to take it again.
+//!
+//! This type is intended for use with methods that take `self` by value, and _eventually_, at some
+//! later point in time, return that `Self` for future use. For example, consider the following
+//! method for a hypothetical, non-pipelined connection type:
+//!
+//! ```rust,ignore
+//! impl Connection {
+//!     fn get(self, key: i64) -> impl Future<Item = (i64, Self), Error = Error>;
+//! }
+//! ```
+//!
+//! Let's say you want to expose an interface that does _not_ consume `self`, but instead has a
+//! `poll_ready` method that checks whether the connection is ready to receive another request:
+//!
+//! ```rust,ignore
+//! impl MyConnection {
+//!     fn poll_ready(&mut self) -> Poll<(), Error = Error>;
+//!     fn call(&mut self, key: i64) -> impl Future<Item = i64, Error = Error>;
+//! }
+//! ```
+//!
+//! `Lease` allwos you to do this. Specifically, `poll_ready` attempts to acquire the lease using
+//! `Lease::poll_acquire`, and `call` _transfers_ that lease into the returned future. When the
+//! future eventually resolves, we _restore_ the leased value so that `poll_ready` returns `Ready`
+//! again to anyone else who may want to take the value. The example above would thus look like
+//! this:
+//!
+//! ```rust,ignore
+//! impl MyConnection {
+//!     fn poll_ready(&mut self) -> Poll<(), Error = Error> {
+//!         self.lease.poll_acquire()
+//!     }
+//!
+//!     fn call(&mut self, key: i64) -> impl Future<Item = i64, Error = Error> {
+//!         // We want to transfer the lease into the future
+//!         // and leave behind an unacquired lease.
+//!         let mut lease = self.lease.transfer();
+//!         lease.take().get(key).map(move |(v, connection)| {
+//!             // Give back the connection for other callers.
+//!             // After this, `poll_ready` may return `Ok(Ready)` again.
+//!             lease.restore(connection);
+//!             // And yield just the value.
+//!             v
+//!         })
+//!     }
+//! }
+//! ```
+
+use futures::Async;
+use semaphore;
+use std::cell::UnsafeCell;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+
+/// A handle to a leasable value.
+///
+/// Use `poll_acquire` to acquire the lease, `take` to grab the leased value, and `restore` to
+/// return the leased value when you're done with it.
+///
+/// The code will panic if you attempt to access the `S` behind a `Lease` through `Deref` or
+/// `DerefMut` without having acquired the lease through `poll_acquire` first, or if you have
+/// called `take`.
+///
+/// The code will also panic if you attempt to drop a `Lease` without first restoring the leased
+/// value.
+#[derive(Debug)]
+pub struct Lease<S> {
+    inner: Arc<State<S>>,
+    permit: semaphore::Permit,
+}
+
+unsafe impl<S> Send for Lease<S> where S: Send + Sync {}
+
+#[derive(Debug)]
+struct State<S> {
+    c: UnsafeCell<Option<S>>,
+    s: semaphore::Semaphore,
+}
+
+impl<S> Lease<S> {
+    fn option(&mut self) -> &mut Option<S> {
+        unsafe { &mut *self.inner.c.get() }
+    }
+
+    /// Try to acquire the lease.
+    ///
+    /// If the lease is not available, the current task is notified once it is.
+    pub fn poll_acquire(&mut self) -> Async<()> {
+        self.permit.poll_acquire(&self.inner.s).unwrap_or_else(|_| {
+            // The semaphore was closed. but, we never explicitly close it, and we have a
+            // handle to it through the Arc, which means that this can never happen.
+            unreachable!()
+        })
+    }
+
+    /// Release the lease (if it has been acquired).
+    ///
+    /// This provides a way of "undoing" a call to `poll_ready` should you decide you don't need
+    /// the lease after all, or if you only needed access by reference.
+    ///
+    /// This method will panic if you attempt to release the lease after you have called `take`.
+    pub fn release(&mut self) {
+        if self.permit.is_acquired() {
+            // We need this check in case the reason we get here is that we already hit this
+            // assertion, and `release` is being called _again_ because `self` is being dropped.
+            if !::std::thread::panicking() {
+                assert!(
+                    self.option().is_some(),
+                    "attempted to release the lease without restoring the value"
+                );
+            }
+            self.permit.release(&self.inner.s);
+        }
+    }
+
+    /// Leave behind a non-acquired lease in place of this one, and return this acquired lease.
+    ///
+    /// This allows you to move a previously acquired lease into another context (like a `Future`)
+    /// where you will later `restore` the leased value.
+    ///
+    /// This method will panic if you attempt to call it without first having acquired the lease.
+    pub fn transfer(&mut self) -> Self {
+        assert!(self.permit.is_acquired());
+        let mut transferred = self.clone();
+        ::std::mem::swap(self, &mut transferred);
+        transferred
+    }
+
+    /// Take the leased value.
+    ///
+    /// This method will panic if you attempt to call it without first having acquired the lease.
+    ///
+    /// Note that you _must_ call `restore` on this lease before you drop it to return the leased
+    /// value to other waiting clients. If you do not, dropping the lease will panic.
+    pub fn take(&mut self) -> S {
+        assert!(self.permit.is_acquired());
+        self.option()
+            .take()
+            .expect("attempted to call take(), but leased value has not been restored")
+    }
+
+    /// Restore the leased value.
+    ///
+    /// This method will panic if you attempt to call it without first having acquired the lease.
+    ///
+    /// Note that once you return the leased value, the lease is no longer considered acquired.
+    pub fn restore(&mut self, state: S) {
+        assert!(self.permit.is_acquired());
+        unsafe { *self.inner.c.get() = Some(state) };
+        // Finally, we can now release the permit since we're done with the connection
+        self.release();
+    }
+}
+
+impl<S> Drop for Lease<S> {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl<S> Deref for Lease<S> {
+    type Target = S;
+    fn deref(&self) -> &Self::Target {
+        assert!(self.permit.is_acquired());
+        let s = unsafe { &*self.inner.c.get() };
+        s.as_ref()
+            .expect("attempted to deref lease after calling take()")
+    }
+}
+
+impl<S> DerefMut for Lease<S> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        assert!(self.permit.is_acquired());
+        let s = unsafe { &mut *self.inner.c.get() };
+        s.as_mut()
+            .expect("attempted to deref_mut lease after calling take()")
+    }
+}
+
+impl<S> From<S> for Lease<S> {
+    fn from(s: S) -> Self {
+        Self {
+            inner: Arc::new(State {
+                c: UnsafeCell::new(Some(s)),
+                s: semaphore::Semaphore::new(1),
+            }),
+            permit: semaphore::Permit::new(),
+        }
+    }
+}
+
+impl<S> Clone for Lease<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            permit: semaphore::Permit::new(),
+        }
+    }
+}
+
+impl<S> Default for Lease<S>
+where
+    S: Default,
+{
+    fn default() -> Self {
+        Self::from(S::default())
+    }
+}

--- a/tokio-sync/src/lease.rs
+++ b/tokio-sync/src/lease.rs
@@ -76,7 +76,9 @@ pub struct Lease<S> {
     permit: semaphore::Permit,
 }
 
-unsafe impl<S> Send for Lease<S> where S: Send + Sync {}
+// As long as S: Send, it's fine to send Lease<S> to other threads.
+// If S was not Send, sending a Lease<S> would be bad, since you can access S through Lease<S>.
+unsafe impl<S> Send for Lease<S> where S: Send {}
 
 #[derive(Debug)]
 struct State<S> {

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -24,6 +24,7 @@ macro_rules! if_fuzz {
     }}
 }
 
+pub mod lease;
 mod loom;
 pub mod mpsc;
 pub mod oneshot;

--- a/tokio-sync/tests/lease.rs
+++ b/tokio-sync/tests/lease.rs
@@ -1,0 +1,131 @@
+#![deny(warnings)]
+
+extern crate futures;
+extern crate tokio_mock_task;
+extern crate tokio_sync;
+
+use tokio_mock_task::*;
+use tokio_sync::lease::Lease;
+
+macro_rules! assert_ready {
+    ($e:expr) => {{
+        match $e {
+            futures::Async::Ready(v) => v,
+            futures::Async::NotReady => panic!("not ready"),
+        }
+    }};
+}
+
+macro_rules! assert_not_ready {
+    ($e:expr) => {{
+        match $e {
+            futures::Async::NotReady => {}
+            futures::Async::Ready(v) => panic!("ready; value = {:?}", v),
+        }
+    }};
+}
+
+#[test]
+fn straight_execution() {
+    let mut l = Lease::from(100);
+
+    // We can immediately acquire the lease and take the value
+    assert_ready!(l.poll_acquire());
+    assert_eq!(&*l, &100);
+    assert_eq!(l.take(), 100);
+    l.restore(99);
+
+    // We can immediately acquire again since the value was returned
+    assert_ready!(l.poll_acquire());
+    assert_eq!(l.take(), 99);
+    l.restore(98);
+
+    // Dropping the lease is okay since we returned the value
+    drop(l);
+}
+
+#[test]
+fn drop_while_acquired_ok() {
+    let mut l = Lease::from(100);
+    assert_ready!(l.poll_acquire());
+
+    // Dropping the lease while it is still acquired shouldn't
+    // be an issue since we haven't taken the leased value.
+    drop(l);
+}
+
+#[test]
+#[should_panic]
+fn take_twice() {
+    let mut l = Lease::from(100);
+
+    assert_ready!(l.poll_acquire());
+    assert_eq!(l.take(), 100);
+    l.take(); // should panic
+}
+
+#[test]
+#[should_panic]
+fn take_wo_acquire() {
+    let mut l = Lease::from(100);
+    l.take(); // should panic
+}
+
+#[test]
+#[should_panic]
+fn drop_without_restore() {
+    let mut l = Lease::from(100);
+    assert_ready!(l.poll_acquire());
+    assert_eq!(l.take(), 100);
+    drop(l); // should panic
+}
+
+#[test]
+#[should_panic]
+fn release_after_take() {
+    let mut l = Lease::from(100);
+    assert_ready!(l.poll_acquire());
+    assert_eq!(l.take(), 100);
+    l.release(); // should panic
+}
+
+#[test]
+fn transfer_lease() {
+    let mut l = Lease::from(100);
+
+    assert_ready!(l.poll_acquire());
+
+    // We should be able to transfer the acquired lease
+    let mut l2 = l.transfer();
+    // And then use it as normal
+    assert_eq!(&*l2, &100);
+    assert_eq!(l2.take(), 100);
+    l2.restore(99);
+
+    // Dropping the transferred lease is okay since we returned the value
+    drop(l2);
+
+    // Once the transferred lease has been restored, we can acquire the lease again
+    assert_ready!(l.poll_acquire());
+    assert_eq!(l.take(), 99);
+    l.restore(98);
+}
+
+#[test]
+fn readiness() {
+    let mut task = MockTask::new();
+
+    let mut l = Lease::from(100);
+    assert_ready!(l.poll_acquire());
+    let mut l2 = l.transfer();
+
+    // We can't now acquire the lease since it's already held in l2
+    task.enter(|| {
+        assert_not_ready!(l.poll_acquire());
+    });
+
+    // But once l2 restores the value, we can acquire it
+    l2.restore(99);
+    assert!(task.is_notified());
+    assert_ready!(l.poll_acquire());
+}


### PR DESCRIPTION
This PR introduces `Lease`: A concurrency primitive built on top of `Semaphore` that provides a mechanism for dealing with values whose receivers consume `self` by value. Specifically, a leased value can only be "taken" by one consumer at a time, and consumers are responsible for returning the value when they are done. When the value is restored, other consumers are notified that the value is available for "taking".

The motivation for this primitive is to provide `poll_ready`-based APIs for types like [`mysql_async::Conn`](https://docs.rs/mysql_async/0.17.2/mysql_async/struct.Conn.html) and [`tiberius::SqlConnection`](https://docs.rs/tiberius/0.3.1/tiberius/struct.SqlConnection.html) where all the methods take `self` by value, and then later return `Self` in some future context. In my particular case, I want to use this to implement [`tower::Service`](https://docs.rs/tower-service/0.2.0/tower_service/trait.Service.html), but I'm sure it could also come in handy in other contexts.