### PR TITLE
tokio: Enable trace subscriber propagation in the runtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ rt-full = [
   "tokio-current-thread",
   "tokio-executor",
   "tokio-threadpool",
+  "tokio-trace-core",
 ]
 sync = ["tokio-sync"]
 tcp = ["tokio-tcp"]
@@ -105,6 +106,7 @@ tokio-threadpool = { version = "0.1.8", path = "tokio-threadpool", optional = tr
 tokio-tcp = { version = "0.1.0", path = "tokio-tcp", optional = true }
 tokio-udp = { version = "0.1.0", path = "tokio-udp", optional = true }
 tokio-timer = { version = "0.2.8", path = "tokio-timer", optional = true }
+tokio-trace-core = { version = "0.1", path = "tokio-trace/tokio-trace-core", optional = true }
 
 # Needed until `reactor` is removed from `tokio`.
 mio = { version = "0.6.14", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,7 @@ pub mod util;
 
 if_runtime! {
     extern crate tokio_executor;
+    extern crate tokio_trace_core;
     pub mod executor;
     pub mod runtime;
 

--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -11,6 +11,7 @@ use tokio_reactor;
 use tokio_threadpool::Builder as ThreadPoolBuilder;
 use tokio_timer::clock::{self, Clock};
 use tokio_timer::timer::{self, Timer};
+use tokio_trace_core::dispatcher::{self, Dispatch};
 
 /// Builds Tokio Runtime with custom configuration values.
 ///
@@ -90,10 +91,10 @@ impl Builder {
 
     /// Set builder to set up the thread pool instance.
     #[deprecated(
-        since="0.1.9",
-        note="use the `core_threads`, `blocking_threads`, `name_prefix`, \
-              `keep_alive`, and `stack_size` functions on `runtime::Builder`, \
-              instead")]
+        since = "0.1.9",
+        note = "use the `core_threads`, `blocking_threads`, `name_prefix`, \
+                `keep_alive`, and `stack_size` functions on `runtime::Builder`, \
+                instead")]
     #[doc(hidden)]
     pub fn threadpool_builder(&mut self, val: ThreadPoolBuilder) -> &mut Self {
         self.threadpool_builder = val;
@@ -330,14 +331,24 @@ impl Builder {
         // Get a handle to the clock for the runtime.
         let clock = self.clock.clone();
 
-        let pool = self.threadpool_builder
+        // Get the current trace dispatcher.
+        // TODO(eliza): when `tokio-trace-core` is stable enough to take a
+        // public API dependency, we should allow users to set a custom
+        // subscriber for the runtime.
+        let dispatch = dispatcher::get_default(Dispatch::clone);
+
+        let pool = self
+            .threadpool_builder
             .around_worker(move |w, enter| {
                 let index = w.id().to_usize();
+                let dispatch = dispatch.clone();
 
                 tokio_reactor::with_default(&reactor_handles[index], enter, |enter| {
                     clock::with_default(&clock, enter, |enter| {
                         timer::with_default(&timer_handles[index], enter, |_| {
-                            w.run();
+                            dispatcher::with_default(dispatch, || {
+                                w.run();
+                            })
                         });
                     })
                 });

--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -11,7 +11,7 @@ use tokio_reactor;
 use tokio_threadpool::Builder as ThreadPoolBuilder;
 use tokio_timer::clock::{self, Clock};
 use tokio_timer::timer::{self, Timer};
-use tokio_trace_core::dispatcher::{self, Dispatch};
+use tokio_trace_core as trace;
 
 /// Builds Tokio Runtime with custom configuration values.
 ///
@@ -335,7 +335,7 @@ impl Builder {
         // TODO(eliza): when `tokio-trace-core` is stable enough to take a
         // public API dependency, we should allow users to set a custom
         // subscriber for the runtime.
-        let dispatch = dispatcher::get_default(Dispatch::clone);
+        let dispatch = trace::dispatcher::get_default(trace::Dispatch::clone);
 
         let pool = self
             .threadpool_builder
@@ -345,7 +345,7 @@ impl Builder {
                 tokio_reactor::with_default(&reactor_handles[index], enter, |enter| {
                     clock::with_default(&clock, enter, |enter| {
                         timer::with_default(&timer_handles[index], enter, |_| {
-                            dispatcher::with_default(&dispatch, || {
+                            trace::dispatcher::with_default(&dispatch, || {
                                 w.run();
                             })
                         });

--- a/src/runtime/threadpool/builder.rs
+++ b/src/runtime/threadpool/builder.rs
@@ -341,12 +341,11 @@ impl Builder {
             .threadpool_builder
             .around_worker(move |w, enter| {
                 let index = w.id().to_usize();
-                let dispatch = dispatch.clone();
 
                 tokio_reactor::with_default(&reactor_handles[index], enter, |enter| {
                     clock::with_default(&clock, enter, |enter| {
                         timer::with_default(&timer_handles[index], enter, |_| {
-                            dispatcher::with_default(dispatch, || {
+                            dispatcher::with_default(&dispatch, || {
                                 w.run();
                             })
                         });


### PR DESCRIPTION

## Motivation

One of the biggest pain points in the current `tokio-trace` API is that
the subscriber context must be propagated manually. For example, if a
user `tokio::spawn`s a future, the spawning thread's subscriber will not
be propagated to the worker thread the spawned future actually executes
on. 

Users can currently get around this one of two ways:
- Instrument the future with a span:
  ```rust
   use tokio_trace_futures::Instrument;

   let fut = do_stuff()
       .instrument(span!("do stuff"));
   tokio::spawn(Box::new(fut));
  ```
   Since entering a span sets the dispatcher to that span's dispatcher
   while inside the span, this will both propagate the dispatcher
   context and create a span for the future. However, if the span is
   disabled, then the dispatcher will not be set, which can lead to
   surprising and unexpected behavior.
- Explicitly attach a subscriber context to the future:
   ```rust
   use tokio_trace_futures::WithSubscriber;
   let dispatch = tokio_trace::dispatcher::with(|current| current.clone());

   let fut = do_stuff()
       .instrument(span!("do stuff")) // optionally
       .with_subscriber(dispatch);
   tokio::spawn(Box::new(fut));
   ```
   This will work regardless of whether or not the future is
   instrumented with a span, and regardless of whether or not any spans
   are enabled. However, it requires some extra noise and is perhaps
   non-obvious.

Additionally, the following issues apply to both of these approaches:
- They both require the `tokio-trace-futures` crate, which is in the
  nursery and thus less stable than the core `tokio-trace` crates.
- If library code also uses `tokio::spawn` or similar functions (a 
  reasonably common pattern!) there is nothing that user code can do 
  to ensure that futures spawned by libraries also propagate the 
  subscriber context correctly.

## Solution

This branch modifies `runtime::Builder::build` so that the current
trace subscriber context is captured, and adds a call to 
`tokio_trace_core::dispatcher::with_default` in the closure passed
to `around_worker` in the runtime builder's threadpool builder. This
results in the dispatcher context being propagated to all of the worker
threads in the runtime.

## Notes

- This branch requires `tokio` to depend on `tokio-trace-core`. 
  Therefore, we should not merge this branch until a 0.1 release of
  `tokio-trace-core` is published to crates.io.
- Currently, the user cannot explicitly configure the runtime to use a
  provided dispatcher. Adding a function to allow this would require a 
  dependency on `tokio-trace-core` in `tokio`'s _public_ API surface,
  and I believe that we haven't yet decided that `tokio-trace-core` is 
  stable enough for that. This can be added later.

Fixes: #947 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>