### PR TITLE
sync: impl `Error` for oneshot and watch error types

### DIFF
--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -32,6 +32,8 @@ pub struct Receiver<T> {
 pub mod error {
     //! Oneshot error types
 
+    use std::fmt;
+
     /// Error returned by the `Future` implementation for `Receiver`.
     #[derive(Debug)]
     pub struct RecvError(pub(super) ());
@@ -39,6 +41,36 @@ pub mod error {
     /// Error returned by the `try_recv` function on `Receiver`.
     #[derive(Debug)]
     pub struct TryRecvError(pub(super) ());
+
+    // ===== impl RecvError =====
+
+    impl fmt::Display for RecvError {
+        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            use std::error::Error;
+            write!(fmt, "{}", self.description())
+        }
+    }
+
+    impl ::std::error::Error for RecvError {
+        fn description(&self) -> &str {
+            "channel closed"
+        }
+    }
+
+    // ===== impl TryRecvError =====
+
+    impl fmt::Display for TryRecvError {
+        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            use std::error::Error;
+            write!(fmt, "{}", self.description())
+        }
+    }
+
+    impl ::std::error::Error for TryRecvError {
+        fn description(&self) -> &str {
+            "channel closed"
+        }
+    }
 }
 
 use self::error::*;

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -104,6 +104,8 @@ pub struct Ref<'a, T: 'a> {
 pub mod error {
     //! Watch error types
 
+    use std::fmt;
+
     /// Error produced when receiving a value fails.
     #[derive(Debug)]
     pub struct RecvError {
@@ -114,6 +116,36 @@ pub mod error {
     #[derive(Debug)]
     pub struct SendError<T> {
         pub(crate) inner: T,
+    }
+
+    // ===== impl RecvError =====
+
+    impl fmt::Display for RecvError {
+        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            use std::error::Error;
+            write!(fmt, "{}", self.description())
+        }
+    }
+
+    impl ::std::error::Error for RecvError {
+        fn description(&self) -> &str {
+            "channel closed"
+        }
+    }
+
+    // ===== impl SendError =====
+
+    impl<T: fmt::Debug> fmt::Display for SendError<T> {
+        fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+            use std::error::Error;
+            write!(fmt, "{}", self.description())
+        }
+    }
+
+    impl<T: fmt::Debug> ::std::error::Error for SendError<T> {
+        fn description(&self) -> &str {
+            "channel closed"
+        }
     }
 }
 

--- a/tokio-sync/tests/errors.rs
+++ b/tokio-sync/tests/errors.rs
@@ -2,16 +2,32 @@
 
 extern crate tokio_sync;
 
-use tokio_sync::mpsc::error;
-
 fn is_error<T: ::std::error::Error + Send + Sync>() {}
 
 #[test]
-fn error_bound() {
+fn mpsc_error_bound() {
+    use tokio_sync::mpsc::error;
+
     is_error::<error::RecvError>();
     is_error::<error::SendError>();
     is_error::<error::TrySendError<()>>();
     is_error::<error::UnboundedRecvError>();
     is_error::<error::UnboundedSendError>();
     is_error::<error::UnboundedTrySendError<()>>();
+}
+
+#[test]
+fn oneshot_error_bound() {
+    use tokio_sync::oneshot::error;
+
+    is_error::<error::RecvError>();
+    is_error::<error::TryRecvError>();
+}
+
+#[test]
+fn watch_error_bound() {
+    use tokio_sync::watch::error;
+
+    is_error::<error::RecvError>();
+    is_error::<error::SendError<()>>();
 }


### PR DESCRIPTION
Implementation of `std::error::Error` for `oneshot` and `watch`.

Refs: #937