### PR TITLE
trace-core: Add  overrideable downcasting to `Subscriber`s

### DIFF
--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -267,14 +267,6 @@ pub trait Subscriber: 'static {
 
     // === Downcasting methods ================================================
 
-    /// Gets the `TypeId` of `Self`.
-    ///
-    /// Implementations of `Subscriber` are **not** expected to override this!
-    #[doc(hidden)]
-    fn type_id(&self) -> TypeId {
-        TypeId::of::<Self>()
-    }
-
     /// If `self` is the same type as the provided `TypeId`, returns an untyped
     /// `*const` pointer to that type. Otherwise, returns `None`.
     ///
@@ -292,7 +284,7 @@ pub trait Subscriber: 'static {
     /// subscribers might allow `downcast_raw` by returning references to those
     /// component if they contain components with the given `TypeId`.
     fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
-        if id == self.type_id() {
+        if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())
         } else {
             None

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -309,9 +309,8 @@ impl Subscriber {
     /// Returns some reference to this `Subscriber` value if it is of type `T`,
     /// or `None` if it isn't.
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        self.downcast_raw(TypeId::of::<T>()).map(|raw| unsafe {
-            &*(raw as *const _)
-        })
+        self.downcast_raw(TypeId::of::<T>())
+            .map(|raw| unsafe { &*(raw as *const _) })
     }
 }
 

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -283,7 +283,7 @@ pub trait Subscriber: 'static {
     /// implementations which consist of multiple composed types. Such
     /// subscribers might allow `downcast_raw` by returning references to those
     /// component if they contain components with the given `TypeId`.
-    fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())
         } else {
@@ -295,14 +295,16 @@ pub trait Subscriber: 'static {
 impl Subscriber {
     /// Returns `true` if this `Subscriber` is the same type as `T`.
     pub fn is<T: Any>(&self) -> bool {
-        self.downcast_raw(TypeId::of::<T>()).is_some()
+        unsafe { self.downcast_raw(TypeId::of::<T>()).is_some() }
     }
 
     /// Returns some reference to this `Subscriber` value if it is of type `T`,
     /// or `None` if it isn't.
     pub fn downcast_ref<T: Any>(&self) -> Option<&T> {
-        self.downcast_raw(TypeId::of::<T>())
-            .map(|raw| unsafe { &*(raw as *const _) })
+        unsafe {
+            self.downcast_raw(TypeId::of::<T>())
+                .map(|raw| &*(raw as *const _))
+        }
     }
 }
 

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -298,7 +298,7 @@ pub trait Subscriber: 'static {
 impl Subscriber {
     /// Returns `true` if this `Subscriber` is the same type as `T`.
     pub fn is<T: Any>(&self) -> bool {
-       self.downcast_ref::<T>().is_some()
+        self.downcast_ref::<T>().is_some()
     }
 
     /// Returns some reference to this `Subscriber` value if it is of type `T`,

--- a/tokio-trace/tokio-trace-core/src/subscriber.rs
+++ b/tokio-trace/tokio-trace-core/src/subscriber.rs
@@ -286,6 +286,15 @@ pub trait Subscriber: 'static {
     /// implementations which consist of multiple composed types. Such
     /// subscribers might allow `downcast_raw` by returning references to those
     /// component if they contain components with the given `TypeId`.
+    ///
+    /// # Safety
+    ///
+    /// The [`downcast_ref`] method expects that the pointer returned by
+    /// `downcast_raw` is non-null and points to a valid instance of the type
+    /// with the provided `TypeId`. Failure to ensure this will result in
+    /// undefined behaviour, so implementing `downcast_raw` is unsafe.
+    ///
+    /// [`downcast_ref`]: #method.downcast_ref
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         if id == TypeId::of::<Self>() {
             Some(self as *const Self as *const ())


### PR DESCRIPTION
## Motivation

In order to implement "out of band" `Subscriber` APIs in third-party
subscriber implementations (see [this comment]) users may want to 
downcast the current `Dispatch` to a concrete subscriber type.

For example, in a library for integrating `tokio-trace` with a fancy new
(hypothetical) distributed tracing technology "ElizaTracing", which uses
256-bit span IDs, we might expect to see a function like this:
```rust

pub fn correlate(tt: tokio_trace::span::Id, et: elizatracing::SpanId) {
    tokio_trace::dispatcher::with(|c| {
        if let Some(s) = c.downcast_ref::<elizatracing::Subscriber>() {
            s.do_elizatracing_correlation_magic(tt, et);
        }
    }); 
}
```

This allows users to correlate `tokio-trace` IDs with IDs in the
distributed tracing system without having to pass a special handle to
the subscriber through application code (as one is already present in
thread-local storage, but with its type erased).

## Solution

This branch makes the following changes:
 * Add an object-safe `downcast_raw` method to the `Subscriber` trait,
   taking a `TypeId` and returning an `*const ()` if the type ID 
   matches the subscriber's type ID, or `None` if it does not, and
 * Add `is<T>` and `downcast_ref<T>` functions to `Subscriber` 
   and `Dispatch`, using `downcast_raw`.

Unlike the approach implemented in #950, the `downcast_raw` method is
object-safe, since it takes a `TypeId` rather than a type _parameter_ 
and returns a void pointer rather than an `&T`. This means that
`Subscriber` implementations can override this method if necessary. For
example, a `Subscriber` that fans out to multiple component subscribers
can downcast to their component parts, and "chained" or "middleware"
subscribers, which wrap an inner `Subscriber` and modify its behaviour 
somehow, can downcast to the inner type if they choose to.

[this comment]: https://github.com/tokio-rs/tokio/issues/932#issuecomment-469473501
[`std::error::Error`'s]: https://doc.rust-lang.org/1.33.0/src/std/error.rs.html#204

Refs: #950, #953, https://github.com/tokio-rs/tokio/issues/948#issuecomment-469444293

Signed-off-by: Eliza Weisman <eliza@buoyant.io>