### PR TITLE
sync: free chan Blocks when Chan is dropped

### DIFF
--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -356,7 +356,7 @@ fn dropping_rx_closes_channel_for_try() {
 }
 
 #[test]
-fn unconsumed_messagers_are_dropped() {
+fn unconsumed_messages_are_dropped() {
     let msg = Arc::new(());
 
     let (mut tx, rx) = mpsc::channel(100);


### PR DESCRIPTION
I'm not sure the best way to add a test that `Block` is actually dropped, since it's an internal type...