### PR TITLE
Support UnixDatagram framed transport and dgram futures on connected …

### DIFF
--- a/tokio-uds/src/datagram.rs
+++ b/tokio-uds/src/datagram.rs
@@ -1,4 +1,4 @@
-use {RecvDgram, SendDgram};
+use {RecvDgramFrom, RecvDgram2, RecvDgram, SendDgramTo, SendDgram, SendDgram2};
 
 use tokio_reactor::{Handle, PollEvented};
 
@@ -126,12 +126,31 @@ impl UnixDatagram {
         }
     }
 
-    /// Returns a future for receiving a datagram. See the documentation on RecvDgram for details.
+    #[deprecated(since = "0.2.6", note = "use recv_dgram_from instead")]
+    #[doc(hidden)]
     pub fn recv_dgram<T>(self, buf: T) -> RecvDgram<T>
     where
         T: AsMut<[u8]>,
     {
-        RecvDgram::new(self, buf)
+        self.recv_dgram_from(buf)
+    }
+
+    /// A future for receiving datagrams through a Unix datagram socket. See the documentation on RecvDgramFrom
+    /// for details.
+    pub fn recv_dgram_from<T>(self, buf: T) -> RecvDgramFrom<T>
+    where
+        T: AsMut<[u8]>,
+    {
+        RecvDgramFrom::new(self, buf)
+    }
+
+    /// A future for receiving datagrams from the previously connected peer through a Unix datagram socket.
+    /// See the documentation on RecvDgramFrom for details.
+    pub fn recv_dgram2<T>(self, buf: T) -> RecvDgram2<T>
+    where
+        T: AsMut<[u8]>,
+    {
+        RecvDgram2::new(self, buf)
     }
 
     /// Sends data on the socket to the specified address.
@@ -172,13 +191,31 @@ impl UnixDatagram {
         }
     }
 
-    /// Returns a future sending the data in buf to the socket at path.
+    #[deprecated(since = "0.2.6", note = "use send_dgram_to instead")]
+    #[doc(hidden)]
     pub fn send_dgram<T, P>(self, buf: T, path: P) -> SendDgram<T, P>
     where
         T: AsRef<[u8]>,
         P: AsRef<Path>,
     {
-        SendDgram::new(self, buf, path)
+        self.send_dgram_to(buf, path)
+    }
+
+    /// Returns a future for sending datagrams to a previously connected peer through a Unix datagram socket.
+    pub fn send_dgram2<T>(self, buf: T) -> SendDgram2<T>
+    where
+        T: AsRef<[u8]>,
+    {
+        SendDgram2::new(self, buf)
+    }
+
+    /// Returns a future for sending datagram through a Unix datagram socket.
+    pub fn send_dgram_to<T, P>(self, buf: T, path: P) -> SendDgramTo<T, P>
+    where
+        T: AsRef<[u8]>,
+        P: AsRef<Path>,
+    {
+        SendDgramTo::new(self, buf, path)
     }
 
     /// Returns the value of the `SO_ERROR` option.

--- a/tokio-uds/src/datagram.rs
+++ b/tokio-uds/src/datagram.rs
@@ -1,4 +1,4 @@
-use {RecvDgramFrom, RecvDgram2, RecvDgram, SendDgramTo, SendDgram, SendDgram2};
+use {RecvDgram, RecvDgram2, RecvDgramFrom, SendDgram, SendDgram2, SendDgramTo};
 
 use tokio_reactor::{Handle, PollEvented};
 

--- a/tokio-uds/src/frame_connected.rs
+++ b/tokio-uds/src/frame_connected.rs
@@ -34,7 +34,7 @@ use tokio_codec::{Decoder, Encoder};
 /// [unnamed pair]: struct.UnixDatagram.html#method.pair
 #[must_use = "sinks do nothing unless polled"]
 #[derive(Debug)]
-pub struct UnixDatagramPeerFramed<C> {
+pub struct UnixDatagramConnectedFramed<C> {
     socket: UnixDatagram,
     codec: C,
     rd: BytesMut,
@@ -42,7 +42,7 @@ pub struct UnixDatagramPeerFramed<C> {
     flushed: bool,
 }
 
-impl<C: Decoder> Stream for UnixDatagramPeerFramed<C> {
+impl<C: Decoder> Stream for UnixDatagramConnectedFramed<C> {
     type Item = C::Item;
     type Error = C::Error;
 
@@ -63,7 +63,7 @@ impl<C: Decoder> Stream for UnixDatagramPeerFramed<C> {
     }
 }
 
-impl<C: Encoder> Sink for UnixDatagramPeerFramed<C> {
+impl<C: Encoder> Sink for UnixDatagramConnectedFramed<C> {
     type SinkItem = C::Item;
     type SinkError = C::Error;
 
@@ -119,12 +119,12 @@ impl<C: Encoder> Sink for UnixDatagramPeerFramed<C> {
 const INITIAL_RD_CAPACITY: usize = 64 * 1024;
 const INITIAL_WR_CAPACITY: usize = 8 * 1024;
 
-impl<C> UnixDatagramPeerFramed<C> {
+impl<C> UnixDatagramConnectedFramed<C> {
     /// Create a new `UnixDatagramFramed` backed by the given socket and codec.
     ///
     /// See struct level documentation for more details.
-    pub fn new(socket: UnixDatagram, codec: C) -> UnixDatagramPeerFramed<C> {
-        UnixDatagramPeerFramed {
+    pub fn new(socket: UnixDatagram, codec: C) -> UnixDatagramConnectedFramed<C> {
+        UnixDatagramConnectedFramed {
             socket: socket,
             codec: codec,
             rd: BytesMut::with_capacity(INITIAL_RD_CAPACITY),

--- a/tokio-uds/src/frame_peer.rs
+++ b/tokio-uds/src/frame_peer.rs
@@ -1,0 +1,158 @@
+use std::io;
+
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
+
+use super::UnixDatagram;
+
+use bytes::{BufMut, BytesMut};
+use tokio_codec::{Decoder, Encoder};
+
+/// A unified `Stream` and `Sink` interface to an underlying connected `UnixDatagram`,
+/// using the `Encoder` and `Decoder` traits to encode and decode frames.
+///
+/// This version differs from `UnixDatagramFramed`. It communicates with `connected`
+/// peer, and doesn't deal with the remote addr in both `Stream` and `Sink` interfaces.
+/// See [`connect`] for details)
+///
+/// This is especially useful with [unnamed pair] of `UnixDatagram`
+///
+/// Unix datagram sockets work with datagrams, but higher-level code may wants to
+/// batch these into meaningful chunks, called "frames". This method layers
+/// framing on top of this socket by using the `Encoder` and `Decoder` traits to
+/// handle encoding and decoding of messages frames. Note that the incoming and
+/// outgoing frame types may be distinct.
+///
+/// This function returns a *single* object that is both `Stream` and `Sink`;
+/// grouping this into a single object is often useful for layering things which
+/// require both read and write access to the underlying object.
+///
+/// If you want to work more directly with the streams and sink, consider
+/// calling `split` on the `UnixDatagramFramed` returned by this method, which will break
+/// them into separate objects, allowing them to interact more easily.
+///
+/// [`connect`]: struct.UnixDatagram.html#method.connect
+/// [unnamed pair]: struct.UnixDatagram.html#method.pair
+#[must_use = "sinks do nothing unless polled"]
+#[derive(Debug)]
+pub struct UnixDatagramPeerFramed<C> {
+    socket: UnixDatagram,
+    codec: C,
+    rd: BytesMut,
+    wr: BytesMut,
+    flushed: bool,
+}
+
+impl<C: Decoder> Stream for UnixDatagramPeerFramed<C> {
+    type Item = C::Item;
+    type Error = C::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.rd.reserve(INITIAL_RD_CAPACITY);
+
+        let n = unsafe {
+            let n = try_ready!(self.socket.poll_recv(self.rd.bytes_mut()));
+            self.rd.advance_mut(n);
+            n
+        };
+        trace!("received {} bytes, decoding", n);
+        let frame_res = self.codec.decode(&mut self.rd);
+        self.rd.clear();
+        let frame = frame_res?;
+        trace!("frame decoded from buffer");
+        Ok(Async::Ready(frame))
+    }
+}
+
+impl<C: Encoder> Sink for UnixDatagramPeerFramed<C> {
+    type SinkItem = C::Item;
+    type SinkError = C::Error;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        trace!("sending frame");
+
+        if !self.flushed {
+            match try!(self.poll_complete()) {
+                Async::Ready(()) => {}
+                Async::NotReady => return Ok(AsyncSink::NotReady(item)),
+            }
+        }
+
+        self.codec.encode(item, &mut self.wr)?;
+        self.flushed = false;
+        trace!("frame encoded; length={}", self.wr.len());
+
+        Ok(AsyncSink::Ready)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), C::Error> {
+        if self.flushed {
+            return Ok(Async::Ready(()));
+        }
+
+        let n = {
+            trace!("flushing frame; length={}", self.wr.len());
+            try_ready!(self.socket.poll_send(&self.wr))
+        };
+
+        trace!("written {}", n);
+
+        let wrote_all = n == self.wr.len();
+        self.wr.clear();
+        self.flushed = true;
+
+        if wrote_all {
+            Ok(Async::Ready(()))
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            )
+            .into())
+        }
+    }
+
+    fn close(&mut self) -> Poll<(), C::Error> {
+        self.poll_complete()
+    }
+}
+
+const INITIAL_RD_CAPACITY: usize = 64 * 1024;
+const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+
+impl<C> UnixDatagramPeerFramed<C> {
+    /// Create a new `UnixDatagramFramed` backed by the given socket and codec.
+    ///
+    /// See struct level documentation for more details.
+    pub fn new(socket: UnixDatagram, codec: C) -> UnixDatagramPeerFramed<C> {
+        UnixDatagramPeerFramed {
+            socket: socket,
+            codec: codec,
+            rd: BytesMut::with_capacity(INITIAL_RD_CAPACITY),
+            wr: BytesMut::with_capacity(INITIAL_WR_CAPACITY),
+            flushed: true,
+        }
+    }
+
+    /// Returns a reference to the underlying I/O stream wrapped by `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_ref(&self) -> &UnixDatagram {
+        &self.socket
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_mut(&mut self) -> &mut UnixDatagram {
+        &mut self.socket
+    }
+}

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -21,18 +21,30 @@ extern crate tokio_reactor;
 
 mod datagram;
 mod frame;
+mod frame_peer;
 mod incoming;
 mod listener;
-mod recv_dgram;
-mod send_dgram;
+mod recv_dgram2;
+mod send_dgram2;
+mod recv_dgram_from;
+mod send_dgram_to;
 mod stream;
 mod ucred;
 
 pub use datagram::UnixDatagram;
 pub use frame::UnixDatagramFramed;
+pub use frame_peer::UnixDatagramPeerFramed;
 pub use incoming::Incoming;
 pub use listener::UnixListener;
-pub use recv_dgram::RecvDgram;
-pub use send_dgram::SendDgram;
+pub use recv_dgram_from::RecvDgramFrom;
+pub use send_dgram_to::SendDgramTo;
+#[deprecated(since = "0.2.6", note = "use RecvDgramFrom instead")]
+#[doc(hidden)]
+pub use recv_dgram_from::RecvDgramFrom as RecvDgram;
+#[deprecated(since = "0.2.6", note = "use SendDgramTo instead")]
+#[doc(hidden)]
+pub use send_dgram_to::SendDgramTo as SendDgram;
+pub use recv_dgram2::RecvDgram2;
+pub use send_dgram2::SendDgram2;
 pub use stream::{ConnectFuture, UnixStream};
 pub use ucred::UCred;

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -21,7 +21,7 @@ extern crate tokio_reactor;
 
 mod datagram;
 mod frame;
-mod frame_peer;
+mod frame_connected;
 mod incoming;
 mod listener;
 mod recv_dgram2;
@@ -33,7 +33,7 @@ mod ucred;
 
 pub use datagram::UnixDatagram;
 pub use frame::UnixDatagramFramed;
-pub use frame_peer::UnixDatagramPeerFramed;
+pub use frame_connected::UnixDatagramConnectedFramed;
 pub use incoming::Incoming;
 pub use listener::UnixListener;
 pub use recv_dgram_from::RecvDgramFrom;

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -25,8 +25,8 @@ mod frame_connected;
 mod incoming;
 mod listener;
 mod recv_dgram2;
-mod send_dgram2;
 mod recv_dgram_from;
+mod send_dgram2;
 mod send_dgram_to;
 mod stream;
 mod ucred;
@@ -36,15 +36,15 @@ pub use frame::UnixDatagramFramed;
 pub use frame_connected::UnixDatagramConnectedFramed;
 pub use incoming::Incoming;
 pub use listener::UnixListener;
+pub use recv_dgram2::RecvDgram2;
 pub use recv_dgram_from::RecvDgramFrom;
-pub use send_dgram_to::SendDgramTo;
 #[deprecated(since = "0.2.6", note = "use RecvDgramFrom instead")]
 #[doc(hidden)]
 pub use recv_dgram_from::RecvDgramFrom as RecvDgram;
+pub use send_dgram2::SendDgram2;
+pub use send_dgram_to::SendDgramTo;
 #[deprecated(since = "0.2.6", note = "use SendDgramTo instead")]
 #[doc(hidden)]
 pub use send_dgram_to::SendDgramTo as SendDgram;
-pub use recv_dgram2::RecvDgram2;
-pub use send_dgram2::SendDgram2;
 pub use stream::{ConnectFuture, UnixStream};
 pub use ucred::UCred;

--- a/tokio-uds/src/recv_dgram2.rs
+++ b/tokio-uds/src/recv_dgram2.rs
@@ -5,68 +5,56 @@ use futures::{Async, Future, Poll};
 use std::io;
 use std::mem;
 
-/// A future for receiving datagrams from a Unix datagram socket.
-///
-/// An example that uses UDP sockets but is still applicable can be found at
-/// https://gist.github.com/dermesser/e331094c2ab28fc7f6ba8a16183fe4d5.
+/// A future for receiving datagrams from the previously connected peer through a Unix datagram socket.
 #[derive(Debug)]
-pub struct RecvDgram<T> {
+pub struct RecvDgram2<T> {
     st: State<T>,
 }
 
-/// A future similar to RecvDgram, but without allocating and returning the peer's address.
-///
-/// This can be used if the peer's address is of no interest, so the allocation overhead can be
-/// avoided.
 #[derive(Debug)]
 enum State<T> {
     Receiving { sock: UnixDatagram, buf: T },
     Empty,
 }
 
-impl<T> RecvDgram<T>
+impl<T> RecvDgram2<T>
 where
     T: AsMut<[u8]>,
 {
-    pub(crate) fn new(sock: UnixDatagram, buf: T) -> RecvDgram<T> {
-        RecvDgram {
+    pub(crate) fn new(sock: UnixDatagram, buf: T) -> RecvDgram2<T> {
+        RecvDgram2 {
             st: State::Receiving { sock, buf },
         }
     }
 }
 
-impl<T> Future for RecvDgram<T>
+impl<T> Future for RecvDgram2<T>
 where
     T: AsMut<[u8]>,
 {
     /// RecvDgram yields a tuple of the underlying socket, the receive buffer, how many bytes were
     /// received, and the address (path) of the peer sending the datagram. If the buffer is too small, the
     /// datagram is truncated.
-    type Item = (UnixDatagram, T, usize, String);
+    type Item = (UnixDatagram, T, usize);
     /// This future yields io::Error if an error occurred.
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         let received;
-        let peer;
 
         if let State::Receiving {
             ref mut sock,
             ref mut buf,
         } = self.st
         {
-            let (n, p) = try_ready!(sock.poll_recv_from(buf.as_mut()));
+            let n = try_ready!(sock.poll_recv(buf.as_mut()));
             received = n;
-
-            peer = p.as_pathname().map_or(String::new(), |p| {
-                p.to_str().map_or(String::new(), |s| s.to_string())
-            });
         } else {
             panic!()
         }
 
         if let State::Receiving { sock, buf } = mem::replace(&mut self.st, State::Empty) {
-            Ok(Async::Ready((sock, buf, received, peer)))
+            Ok(Async::Ready((sock, buf, received)))
         } else {
             panic!()
         }

--- a/tokio-uds/src/recv_dgram_from.rs
+++ b/tokio-uds/src/recv_dgram_from.rs
@@ -1,0 +1,70 @@
+use UnixDatagram;
+
+use futures::{Async, Future, Poll};
+
+use std::io;
+use std::mem;
+
+/// A future for receiving datagrams through a Unix datagram socket.
+///
+/// An example that uses UDP sockets but is still applicable can be found at
+/// https://gist.github.com/dermesser/e331094c2ab28fc7f6ba8a16183fe4d5.
+#[derive(Debug)]
+pub struct RecvDgramFrom<T> {
+    st: State<T>,
+}
+
+#[derive(Debug)]
+enum State<T> {
+    Receiving { sock: UnixDatagram, buf: T },
+    Empty,
+}
+
+impl<T> RecvDgramFrom<T>
+where
+    T: AsMut<[u8]>,
+{
+    pub(crate) fn new(sock: UnixDatagram, buf: T) -> RecvDgramFrom<T> {
+        RecvDgramFrom {
+            st: State::Receiving { sock, buf },
+        }
+    }
+}
+
+impl<T> Future for RecvDgramFrom<T>
+where
+    T: AsMut<[u8]>,
+{
+    /// RecvDgram yields a tuple of the underlying socket, the receive buffer, how many bytes were
+    /// received, and the address (path) of the peer sending the datagram. If the buffer is too small, the
+    /// datagram is truncated.
+    type Item = (UnixDatagram, T, usize, String);
+    /// This future yields io::Error if an error occurred.
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let received;
+        let peer;
+
+        if let State::Receiving {
+            ref mut sock,
+            ref mut buf,
+        } = self.st
+        {
+            let (n, p) = try_ready!(sock.poll_recv_from(buf.as_mut()));
+            received = n;
+
+            peer = p.as_pathname().map_or(String::new(), |p| {
+                p.to_str().map_or(String::new(), |s| s.to_string())
+            });
+        } else {
+            panic!()
+        }
+
+        if let State::Receiving { sock, buf } = mem::replace(&mut self.st, State::Empty) {
+            Ok(Async::Ready((sock, buf, received, peer)))
+        } else {
+            panic!()
+        }
+    }
+}

--- a/tokio-uds/src/send_dgram2.rs
+++ b/tokio-uds/src/send_dgram2.rs
@@ -1,0 +1,69 @@
+use UnixDatagram;
+
+use futures::{Async, Future, Poll};
+
+use std::io;
+use std::mem;
+
+/// A future for sending datagrams to a previously connected peer through a Unix datagram socket.
+#[derive(Debug)]
+pub struct SendDgram2<T> {
+    st: State<T>,
+}
+
+#[derive(Debug)]
+enum State<T> {
+    /// current state is Sending
+    Sending {
+        /// the underlying socket
+        sock: UnixDatagram,
+        /// the buffer to send
+        buf: T,
+    },
+    /// neutral state
+    Empty,
+}
+
+impl<T> SendDgram2<T>
+where
+    T: AsRef<[u8]>
+{
+    pub(crate) fn new(sock: UnixDatagram, buf: T) -> SendDgram2<T> {
+        SendDgram2 {
+            st: State::Sending { sock, buf },
+        }
+    }
+}
+
+impl<T> Future for SendDgram2<T>
+where
+    T: AsRef<[u8]>,
+{
+    /// Returns the underlying socket and the buffer that was sent.
+    type Item = (UnixDatagram, T);
+    /// The error that is returned when sending failed.
+    type Error = io::Error;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        if let State::Sending {
+            ref mut sock,
+            ref buf,
+        } = self.st
+        {
+            let n = try_ready!(sock.poll_send(buf.as_ref()));
+            if n < buf.as_ref().len() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "Couldn't send whole buffer".to_string(),
+                ));
+            }
+        } else {
+            panic!()
+        }
+        if let State::Sending { sock, buf } = mem::replace(&mut self.st, State::Empty) {
+            Ok(Async::Ready((sock, buf)))
+        } else {
+            panic!()
+        }
+    }
+}

--- a/tokio-uds/src/send_dgram2.rs
+++ b/tokio-uds/src/send_dgram2.rs
@@ -26,7 +26,7 @@ enum State<T> {
 
 impl<T> SendDgram2<T>
 where
-    T: AsRef<[u8]>
+    T: AsRef<[u8]>,
 {
     pub(crate) fn new(sock: UnixDatagram, buf: T) -> SendDgram2<T> {
         SendDgram2 {

--- a/tokio-uds/src/send_dgram_to.rs
+++ b/tokio-uds/src/send_dgram_to.rs
@@ -6,9 +6,9 @@ use std::io;
 use std::mem;
 use std::path::Path;
 
-/// A future for writing a buffer to a Unix datagram socket.
+/// Future for sending datagram through a Unix datagram socket.
 #[derive(Debug)]
-pub struct SendDgram<T, P> {
+pub struct SendDgramTo<T, P> {
     st: State<T, P>,
 }
 
@@ -27,19 +27,19 @@ enum State<T, P> {
     Empty,
 }
 
-impl<T, P> SendDgram<T, P>
+impl<T, P> SendDgramTo<T, P>
 where
     T: AsRef<[u8]>,
     P: AsRef<Path>,
 {
-    pub(crate) fn new(sock: UnixDatagram, buf: T, addr: P) -> SendDgram<T, P> {
-        SendDgram {
+    pub(crate) fn new(sock: UnixDatagram, buf: T, addr: P) -> SendDgramTo<T, P> {
+        SendDgramTo {
             st: State::Sending { sock, buf, addr },
         }
     }
 }
 
-impl<T, P> Future for SendDgram<T, P>
+impl<T, P> Future for SendDgramTo<T, P>
 where
     T: AsRef<[u8]>,
     P: AsRef<Path>,

--- a/tokio-uds/tests/datagram.rs
+++ b/tokio-uds/tests/datagram.rs
@@ -95,7 +95,7 @@ fn unnamed_pair_peer_framed_echo() {
     let (s1, s2) = UnixDatagram::pair().unwrap();
 
     {
-        let server = UnixDatagramPeerFramed::new(s1, StringDatagramCodec);
+        let server = UnixDatagramConnectedFramed::new(s1, StringDatagramCodec);
 
         let (sink, stream) = server.split();
 
@@ -109,7 +109,7 @@ fn unnamed_pair_peer_framed_echo() {
     }
 
     {
-        let client = UnixDatagramPeerFramed::new(s2, StringDatagramCodec);
+        let client = UnixDatagramConnectedFramed::new(s2, StringDatagramCodec);
 
         let (sink, stream) = client.split();
 

--- a/tokio-uds/tests/datagram.rs
+++ b/tokio-uds/tests/datagram.rs
@@ -89,7 +89,6 @@ fn framed_echo() {
 
 #[test]
 fn unnamed_pair_peer_framed_echo() {
-
     let mut rt = Runtime::new().unwrap();
 
     let (s1, s2) = UnixDatagram::pair().unwrap();
@@ -113,8 +112,7 @@ fn unnamed_pair_peer_framed_echo() {
 
         let (sink, stream) = client.split();
 
-        rt.block_on(sink.send("ECHO".to_string()))
-            .unwrap();
+        rt.block_on(sink.send("ECHO".to_string())).unwrap();
 
         let response = rt.block_on(stream.take(1).collect()).unwrap();
         assert_eq!(response[0], "ECHO");


### PR DESCRIPTION
## Motivation

`UnixDatagram` supports `connect` and `pair` methods, which are used to define the remote address explicitly, and avoid sending/receiving the remote address. Currently, there are no `Framed` and `send_dgram`/`recv_dgram` methods, which work with the connected `UnixDatagram`s. This is especially a problem with `unnamed` pair, where the remote address is generally not available.  

## Solution

This PR adds new `framed` implementation: `UnixDatagramConnectedFramed`. It works with connected `UnixDatagram` and doesn't deal with a remote address. 
Also, two new methods are added: `recv_dgram_from` and `send_dgram_to`. They behave the same as `recv_dgram` and `send_dgram`, which are now deprecated. `rust` std lib defines the naming for datagram protocols, and it should be preserved for futures. Unfortunately, previously the naming was confusing.
Two additional new methods were introduced for connected variants: `recv_dgram2` and `send_dgram2`.