### PR TITLE
Trace static level filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ members = [
   "tokio-tcp",
   "tokio-tls",
   "tokio-trace",
+  "tokio-trace/test_static_max_level_features",
   "tokio-trace/tokio-trace-core",
   "tokio-udp",
   "tokio-uds",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ jobs:
       - tokio-timer
       - tokio-trace
       - tokio-trace/tokio-trace-core
-      - tokio-trace/tokio-trace-core
+      - tokio-trace/test_static_max_level_features
 
 - template: ci/azure-cargo-check.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,7 @@ jobs:
       - tokio-timer
       - tokio-trace
       - tokio-trace/tokio-trace-core
+      - tokio-trace/tokio-trace-core
 
 - template: ci/azure-cargo-check.yml
   parameters:

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["logging", "tracing"]
 publish = false
 
 [dependencies]
-tokio-trace-core = { path = "tokio-trace-core" }
+tokio-trace-core = "0.1"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -24,6 +24,21 @@ humantime = "1.1.1"
 futures = "0.1"
 log = "0.4"
 
+[features]
+max_level_off   = []
+max_level_error = []
+max_level_warn  = []
+max_level_info  = []
+max_level_debug = []
+max_level_trace = []
+
+release_max_level_off   = []
+release_max_level_error = []
+release_max_level_warn  = []
+release_max_level_info  = []
+release_max_level_debug = []
+release_max_level_trace = []
+
 # These are used for the "basic" example from the tokio-trace-prototype repo,
 # which is currently not included as it used the `tokio-trace-log` crate, and
 # that crate is currently unstable.

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -16,7 +16,6 @@ publish = false
 
 [dependencies]
 tokio-trace-core = "0.1"
-cfg-if = "0.1.7"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 
 [dependencies]
 tokio-trace-core = "0.1"
+cfg-if = "0.1.7"
 
 [dev-dependencies]
 ansi_term = "0.11"

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -1,7 +1,8 @@
 use std::cmp::Ordering;
 use tokio_trace_core::Level;
 
-/// Describes the level of verbosity of a span or event.
+/// `LevelFilter` is used to statistically filter the logging messages based on its `Level`.
+/// Logging messages will be discarded if its `Level` is greater than `LevelFilter`.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LevelFilter(Option<Level>);
 

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -56,40 +56,30 @@ impl PartialOrd<LevelFilter> for Level {
 ///
 /// This value is checked by the `event` macro. Code that manually calls functions on that value
 /// should compare the level against this value.
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
-
-#[cfg(feature = "max_level_off")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
-
-#[cfg(feature = "max_level_error")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
-
-#[cfg(feature = "max_level_warn")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
-
-#[cfg(feature = "max_level_info")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
-
-#[cfg(feature = "max_level_debug")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
-
-#[cfg(feature = "max_level_trace")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_off"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_info"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+cfg_if! {
+    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+    } else if #[cfg(feature = "max_level_off")] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
+    } else if #[cfg(feature = "max_level_error")] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+    } else if #[cfg(feature = "max_level_warn")] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+    } else if #[cfg(feature = "max_level_info")] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+    } else if #[cfg(feature = "max_level_debug")] {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+    } else {
+        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+    }
+}

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -8,7 +8,7 @@ pub struct LevelFilter(Option<Level>);
 impl LevelFilter {
     /// The "off" level.
     ///
-    /// Designates to turn off logging.
+    /// Designates that logging should be to turned off.
     pub const OFF: LevelFilter = LevelFilter(None);
     /// The "error" level.
     ///

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -3,64 +3,38 @@ use tokio_trace_core::Level;
 
 /// Describes the level of verbosity of a span or event.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct LevelFilter(LevelFilterInner, Option<Level>);
+pub struct LevelFilter(Option<Level>);
 
 impl LevelFilter {
-    /// The "zero" level.
+    /// The "off" level.
     ///
-    /// Designates no logging.
-    pub const ZERO: LevelFilter = LevelFilter(LevelFilterInner::Zero, None);
+    /// Designates to turn off logging.
+    pub const OFF: LevelFilter = LevelFilter(None);
     /// The "error" level.
     ///
     /// Designates very serious errors.
-    pub const ERROR: LevelFilter = LevelFilter(LevelFilterInner::Error, Some(Level::ERROR));
+    pub const ERROR: LevelFilter = LevelFilter(Some(Level::ERROR));
     /// The "warn" level.
     ///
     /// Designates hazardous situations.
-    pub const WARN: LevelFilter = LevelFilter(LevelFilterInner::Warn, Some(Level::WARN));
+    pub const WARN: LevelFilter = LevelFilter(Some(Level::WARN));
     /// The "info" level.
     ///
     /// Designates useful information.
-    pub const INFO: LevelFilter = LevelFilter(LevelFilterInner::Info, Some(Level::INFO));
+    pub const INFO: LevelFilter = LevelFilter(Some(Level::INFO));
     /// The "debug" level.
     ///
     /// Designates lower priority information.
-    pub const DEBUG: LevelFilter = LevelFilter(LevelFilterInner::Debug, Some(Level::DEBUG));
+    pub const DEBUG: LevelFilter = LevelFilter(Some(Level::DEBUG));
     /// The "trace" level.
     ///
     /// Designates very low priority, often extremely verbose, information.
-    pub const TRACE: LevelFilter = LevelFilter(LevelFilterInner::Trace, Some(Level::TRACE));
-}
-
-#[repr(usize)]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
-enum LevelFilterInner {
-    Zero = 0,
-    /// The "error" level.
-    ///
-    /// Designates very serious errors.
-    Error,
-    /// The "warn" level.
-    ///
-    /// Designates hazardous situations.
-    Warn,
-    /// The "info" level.
-    ///
-    /// Designates useful information.
-    Info,
-    /// The "debug" level.
-    ///
-    /// Designates lower priority information.
-    Debug,
-    /// The "trace" level.
-    ///
-    /// Designates very low priority, often extremely verbose, information.
-    Trace,
+    pub const TRACE: LevelFilter = LevelFilter(Some(Level::TRACE));
 }
 
 impl PartialEq<LevelFilter> for Level {
     fn eq(&self, other: &LevelFilter) -> bool {
-        match other.1 {
+        match other.0 {
             None => false,
             Some(ref level) => self.eq(level),
         }
@@ -69,7 +43,7 @@ impl PartialEq<LevelFilter> for Level {
 
 impl PartialOrd<LevelFilter> for Level {
     fn partial_cmp(&self, other: &LevelFilter) -> Option<Ordering> {
-        match other.1 {
+        match other.0 {
             None => Some(Ordering::Less),
             Some(ref level) => self.partial_cmp(level),
         }
@@ -82,10 +56,10 @@ impl PartialOrd<LevelFilter> for Level {
 ///
 /// This value is checked by the `event` macro. Code that manually calls functions on that value
 /// should compare the level against this value.
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
 
-#[cfg(feature = "max_level_zero")]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+#[cfg(feature = "max_level_off")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
 
 #[cfg(feature = "max_level_error")]
 pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
@@ -102,8 +76,8 @@ pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
 #[cfg(feature = "max_level_trace")]
 pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
 
-#[cfg(all(not(debug_assertions), feature = "release_max_level_zero"))]
-pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+#[cfg(all(not(debug_assertions), feature = "release_max_level_off"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
 
 #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
 pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -57,30 +57,32 @@ impl PartialOrd<LevelFilter> for Level {
 ///
 /// This value is checked by the `event` macro. Code that manually calls functions on that value
 /// should compare the level against this value.
+pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL;
+
 cfg_if! {
     if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
+        const MAX_LEVEL: LevelFilter = LevelFilter::OFF;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+        const MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+        const MAX_LEVEL: LevelFilter = LevelFilter::WARN;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+        const MAX_LEVEL: LevelFilter = LevelFilter::INFO;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+        const MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
     } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+        const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
     } else if #[cfg(feature = "max_level_off")] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::OFF;
+        const MAX_LEVEL: LevelFilter = LevelFilter::OFF;
     } else if #[cfg(feature = "max_level_error")] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+        const MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
     } else if #[cfg(feature = "max_level_warn")] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+        const MAX_LEVEL: LevelFilter = LevelFilter::WARN;
     } else if #[cfg(feature = "max_level_info")] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+        const MAX_LEVEL: LevelFilter = LevelFilter::INFO;
     } else if #[cfg(feature = "max_level_debug")] {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+        const MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
     } else {
-        pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+        const MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
     }
 }

--- a/tokio-trace/src/level_filters.rs
+++ b/tokio-trace/src/level_filters.rs
@@ -1,0 +1,121 @@
+use std::cmp::Ordering;
+use tokio_trace_core::Level;
+
+/// Describes the level of verbosity of a span or event.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct LevelFilter(LevelFilterInner, Option<Level>);
+
+impl LevelFilter {
+    /// The "zero" level.
+    ///
+    /// Designates no logging.
+    pub const ZERO: LevelFilter = LevelFilter(LevelFilterInner::Zero, None);
+    /// The "error" level.
+    ///
+    /// Designates very serious errors.
+    pub const ERROR: LevelFilter = LevelFilter(LevelFilterInner::Error, Some(Level::ERROR));
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    pub const WARN: LevelFilter = LevelFilter(LevelFilterInner::Warn, Some(Level::WARN));
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    pub const INFO: LevelFilter = LevelFilter(LevelFilterInner::Info, Some(Level::INFO));
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    pub const DEBUG: LevelFilter = LevelFilter(LevelFilterInner::Debug, Some(Level::DEBUG));
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    pub const TRACE: LevelFilter = LevelFilter(LevelFilterInner::Trace, Some(Level::TRACE));
+}
+
+#[repr(usize)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
+enum LevelFilterInner {
+    Zero = 0,
+    /// The "error" level.
+    ///
+    /// Designates very serious errors.
+    Error,
+    /// The "warn" level.
+    ///
+    /// Designates hazardous situations.
+    Warn,
+    /// The "info" level.
+    ///
+    /// Designates useful information.
+    Info,
+    /// The "debug" level.
+    ///
+    /// Designates lower priority information.
+    Debug,
+    /// The "trace" level.
+    ///
+    /// Designates very low priority, often extremely verbose, information.
+    Trace,
+}
+
+impl PartialEq<LevelFilter> for Level {
+    fn eq(&self, other: &LevelFilter) -> bool {
+        match other.1 {
+            None => false,
+            Some(ref level) => self.eq(level),
+        }
+    }
+}
+
+impl PartialOrd<LevelFilter> for Level {
+    fn partial_cmp(&self, other: &LevelFilter) -> Option<Ordering> {
+        match other.1 {
+            None => Some(Ordering::Less),
+            Some(ref level) => self.partial_cmp(level),
+        }
+    }
+}
+
+/// The statically resolved maximum trace level.
+///
+/// See the crate level documentation for information on how to configure this.
+///
+/// This value is checked by the `event` macro. Code that manually calls functions on that value
+/// should compare the level against this value.
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+
+#[cfg(feature = "max_level_zero")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+
+#[cfg(feature = "max_level_error")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+
+#[cfg(feature = "max_level_warn")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+
+#[cfg(feature = "max_level_info")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+
+#[cfg(feature = "max_level_debug")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+
+#[cfg(feature = "max_level_trace")]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_zero"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ZERO;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::ERROR;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::WARN;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_info"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::INFO;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::DEBUG;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))]
+pub const STATIC_MAX_LEVEL: LevelFilter = LevelFilter::TRACE;

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -309,10 +309,12 @@
 //! [`tokio-trace-futures`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-futures
 //! [`tokio-trace-fmt`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-fmt
 //! [`tokio-trace-log`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-log
+extern crate cfg_if;
 extern crate tokio_trace_core;
 
 // Somehow this `use` statement is necessary for us to re-export the `core`
 // macros on Rust 1.26.0. I'm not sure how this makes it work, but it does.
+use cfg_if::cfg_if;
 #[allow(unused_imports)]
 #[doc(hidden)]
 use tokio_trace_core::*;
@@ -344,4 +346,59 @@ pub mod subscriber;
 
 mod sealed {
     pub trait Sealed {}
+}
+
+/// An enum representing the available verbosity level filters of the logger.
+#[repr(usize)]
+#[derive(Copy, Clone, Debug, Hash)]
+pub enum LevelFilter {
+    /// A level lower than all log levels.
+    Off,
+    /// Corresponds to the `Error` log level.
+    Error,
+    /// Corresponds to the `Warn` log level.
+    Warn,
+    /// Corresponds to the `Info` log level.
+    Info,
+    /// Corresponds to the `Debug` log level.
+    Debug,
+    /// Corresponds to the `Trace` log level.
+    Trace,
+}
+
+/// The statically resolved maximum trace level.
+///
+/// See the crate level documentation for information on how to configure this.
+///
+/// This value is checked by the `event` macro. Code that manually calls functions on that value
+/// should compare the level against this value.
+///
+pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL_INNER;
+
+cfg_if! {
+    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
+    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
+    } else if #[cfg(feature = "max_level_off")] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
+    } else if #[cfg(feature = "max_level_error")] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
+    } else if #[cfg(feature = "max_level_warn")] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
+    } else if #[cfg(feature = "max_level_info")] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
+    } else if #[cfg(feature = "max_level_debug")] {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
+    } else {
+        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
+    }
 }

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -309,6 +309,8 @@
 //! [`tokio-trace-futures`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-futures
 //! [`tokio-trace-fmt`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-fmt
 //! [`tokio-trace-log`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-log
+#[macro_use]
+extern crate cfg_if;
 extern crate tokio_trace_core;
 
 // Somehow this `use` statement is necessary for us to re-export the `core`

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -339,44 +339,10 @@ pub use self::{
 mod macros;
 
 pub mod field;
+pub mod level_filters;
 pub mod span;
 pub mod subscriber;
 
 mod sealed {
     pub trait Sealed {}
 }
-
-/// The statically resolved maximum trace level.
-///
-/// See the crate level documentation for information on how to configure this.
-///
-/// This value is checked by the `event` macro. Code that manually calls functions on that value
-/// should compare the level against this value.
-pub const STATIC_MAX_LEVEL: Level = Level::TRACE;
-
-#[cfg(feature = "max_level_error")]
-pub const STATIC_MAX_LEVEL: Level = Level::ERROR;
-
-#[cfg(feature = "max_level_warn")]
-pub const STATIC_MAX_LEVEL: Level = Level::WARN;
-
-#[cfg(feature = "max_level_info")]
-pub const STATIC_MAX_LEVEL: Level = Level::INFO;
-
-#[cfg(feature = "max_level_debug")]
-pub const STATIC_MAX_LEVEL: Level = Level::DEBUG;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
-pub const STATIC_MAX_LEVEL: Level = Level::ERROR;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))]
-pub const STATIC_MAX_LEVEL: Level = Level::WARN;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_info"))]
-pub const STATIC_MAX_LEVEL: Level = Level::INFO;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))]
-pub const STATIC_MAX_LEVEL: Level = Level::DEBUG;
-
-#[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))]
-pub const STATIC_MAX_LEVEL: Level = Level::TRACE;

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -309,12 +309,10 @@
 //! [`tokio-trace-futures`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-futures
 //! [`tokio-trace-fmt`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-fmt
 //! [`tokio-trace-log`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-log
-extern crate cfg_if;
 extern crate tokio_trace_core;
 
 // Somehow this `use` statement is necessary for us to re-export the `core`
 // macros on Rust 1.26.0. I'm not sure how this makes it work, but it does.
-use cfg_if::cfg_if;
 #[allow(unused_imports)]
 #[doc(hidden)]
 use tokio_trace_core::*;
@@ -348,57 +346,37 @@ mod sealed {
     pub trait Sealed {}
 }
 
-/// An enum representing the available verbosity level filters of the logger.
-#[repr(usize)]
-#[derive(Copy, Clone, Debug, Hash)]
-pub enum LevelFilter {
-    /// A level lower than all log levels.
-    Off,
-    /// Corresponds to the `Error` log level.
-    Error,
-    /// Corresponds to the `Warn` log level.
-    Warn,
-    /// Corresponds to the `Info` log level.
-    Info,
-    /// Corresponds to the `Debug` log level.
-    Debug,
-    /// Corresponds to the `Trace` log level.
-    Trace,
-}
-
 /// The statically resolved maximum trace level.
 ///
 /// See the crate level documentation for information on how to configure this.
 ///
 /// This value is checked by the `event` macro. Code that manually calls functions on that value
 /// should compare the level against this value.
-///
-pub const STATIC_MAX_LEVEL: LevelFilter = MAX_LEVEL_INNER;
+pub const STATIC_MAX_LEVEL: Level = Level::TRACE;
 
-cfg_if! {
-    if #[cfg(all(not(debug_assertions), feature = "release_max_level_off"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_error"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_info"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
-    } else if #[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
-    } else if #[cfg(feature = "max_level_off")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Off;
-    } else if #[cfg(feature = "max_level_error")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Error;
-    } else if #[cfg(feature = "max_level_warn")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Warn;
-    } else if #[cfg(feature = "max_level_info")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Info;
-    } else if #[cfg(feature = "max_level_debug")] {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Debug;
-    } else {
-        const MAX_LEVEL_INNER: LevelFilter = LevelFilter::Trace;
-    }
-}
+#[cfg(feature = "max_level_error")]
+pub const STATIC_MAX_LEVEL: Level = Level::ERROR;
+
+#[cfg(feature = "max_level_warn")]
+pub const STATIC_MAX_LEVEL: Level = Level::WARN;
+
+#[cfg(feature = "max_level_info")]
+pub const STATIC_MAX_LEVEL: Level = Level::INFO;
+
+#[cfg(feature = "max_level_debug")]
+pub const STATIC_MAX_LEVEL: Level = Level::DEBUG;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_error"))]
+pub const STATIC_MAX_LEVEL: Level = Level::ERROR;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_warn"))]
+pub const STATIC_MAX_LEVEL: Level = Level::WARN;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_info"))]
+pub const STATIC_MAX_LEVEL: Level = Level::INFO;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_debug"))]
+pub const STATIC_MAX_LEVEL: Level = Level::DEBUG;
+
+#[cfg(all(not(debug_assertions), feature = "release_max_level_trace"))]
+pub const STATIC_MAX_LEVEL: Level = Level::TRACE;

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -101,7 +101,7 @@ macro_rules! span {
         $name:expr,
         $($k:ident $( = $val:expr )* ),*
     ) => {
-        if $lvl <= $crate::STATIC_MAX_LEVEL {
+        if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
             use $crate::callsite;
             use $crate::callsite::Callsite;
             let callsite = callsite! {
@@ -130,7 +130,7 @@ macro_rules! span {
         $name:expr,
         $($k:ident $( = $val:expr )* ),*
     ) => {
-        if $lvl <= $crate::STATIC_MAX_LEVEL {
+        if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
             use $crate::callsite;
             use $crate::callsite::Callsite;
             let callsite = callsite! {
@@ -338,7 +338,7 @@ macro_rules! span {
 #[macro_export(local_inner_macros)]
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident = $val:expr ),* $(,)*} )=> ({
-        if $lvl <= $crate::STATIC_MAX_LEVEL {
+        if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
             #[allow(unused_imports)]
             use $crate::{callsite, dispatcher, Event, field::{Value, ValueSet}};
             use $crate::callsite::Callsite;

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -101,7 +101,7 @@ macro_rules! span {
         $name:expr,
         $($k:ident $( = $val:expr )* ),*
     ) => {
-        {
+        if $lvl <= $crate::STATIC_MAX_LEVEL {
             use $crate::callsite;
             use $crate::callsite::Callsite;
             let callsite = callsite! {
@@ -120,6 +120,8 @@ macro_rules! span {
             } else {
                 $crate::Span::new_disabled()
             }
+        } else {
+            $crate::Span::new_disabled()
         }
     };
     (
@@ -128,7 +130,7 @@ macro_rules! span {
         $name:expr,
         $($k:ident $( = $val:expr )* ),*
     ) => {
-        {
+        if $lvl <= $crate::STATIC_MAX_LEVEL {
             use $crate::callsite;
             use $crate::callsite::Callsite;
             let callsite = callsite! {
@@ -146,6 +148,8 @@ macro_rules! span {
             } else {
                 $crate::Span::new_disabled()
             }
+        } else {
+            $crate::Span::new_disabled()
         }
     };
     (target: $target:expr, level: $lvl:expr, parent: $parent:expr, $name:expr) => {
@@ -334,7 +338,7 @@ macro_rules! span {
 #[macro_export(local_inner_macros)]
 macro_rules! event {
     (target: $target:expr, $lvl:expr, { $( $k:ident = $val:expr ),* $(,)*} )=> ({
-        {
+        if $lvl <= $crate::STATIC_MAX_LEVEL {
             #[allow(unused_imports)]
             use $crate::{callsite, dispatcher, Event, field::{Value, ValueSet}};
             use $crate::callsite::Callsite;

--- a/tokio-trace/test_static_max_level_features/Cargo.toml
+++ b/tokio-trace/test_static_max_level_features/Cargo.toml
@@ -3,10 +3,6 @@ name = "test_cargo_max_level_features"
 version = "0.1.0"
 publish = false
 
-[[bin]]
-name = "main"
-path = "main.rs"
-
 [dependencies.tokio-trace]
 path = ".."
 features = ["max_level_debug", "release_max_level_info"]

--- a/tokio-trace/test_static_max_level_features/Cargo.toml
+++ b/tokio-trace/test_static_max_level_features/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test_cargo_max_level_features"
+version = "0.1.0"
+publish = false
+
+[[bin]]
+name = "main"
+path = "main.rs"
+
+[dependencies.tokio-trace]
+path = ".."
+features = ["max_level_debug", "release_max_level_info"]

--- a/tokio-trace/test_static_max_level_features/main.rs
+++ b/tokio-trace/test_static_max_level_features/main.rs
@@ -1,0 +1,75 @@
+#[macro_use]
+extern crate log;
+
+use std::sync::{Arc, Mutex};
+use log::{Level, LevelFilter, Log, Record, Metadata};
+
+#[cfg(feature = "std")]
+use log::set_boxed_logger;
+#[cfg(not(feature = "std"))]
+fn set_boxed_logger(logger: Box<Log>) -> Result<(), log::SetLoggerError> {
+    unsafe {
+        log::set_logger(&*Box::into_raw(logger))
+    }
+}
+
+struct State {
+    last_log: Mutex<Option<Level>>,
+}
+
+struct Logger(Arc<State>);
+
+impl Log for Logger {
+    fn enabled(&self, _: &Metadata) -> bool {
+        true
+    }
+
+    fn log(&self, record: &Record) {
+        *self.0.last_log.lock().unwrap() = Some(record.level());
+    }
+
+    fn flush(&self) {}
+}
+
+fn main() {
+    let me = Arc::new(State { last_log: Mutex::new(None) });
+    let a = me.clone();
+    set_boxed_logger(Box::new(Logger(me))).unwrap();
+
+    test(&a, LevelFilter::Off);
+    test(&a, LevelFilter::Error);
+    test(&a, LevelFilter::Warn);
+    test(&a, LevelFilter::Info);
+    test(&a, LevelFilter::Debug);
+    test(&a, LevelFilter::Trace);
+}
+
+fn test(a: &State, filter: LevelFilter) {
+    log::set_max_level(filter);
+    error!("");
+    last(&a, t(Level::Error, filter));
+    warn!("");
+    last(&a, t(Level::Warn, filter));
+    info!("");
+    last(&a, t(Level::Info, filter));
+
+    debug!("");
+    if cfg!(debug_assertions) {
+        last(&a, t(Level::Debug, filter));
+    } else {
+        last(&a, None);
+    }
+
+    trace!("");
+    last(&a, None);
+
+    fn t(lvl: Level, filter: LevelFilter) -> Option<Level> {
+        if lvl <= filter {Some(lvl)} else {None}
+    }
+}
+
+fn last(state: &State, expected: Option<Level>) {
+    let mut lvl = state.last_log.lock().unwrap();
+    assert_eq!(*lvl, expected);
+    *lvl = None;
+}

--- a/tokio-trace/test_static_max_level_features/tests/test.rs
+++ b/tokio-trace/test_static_max_level_features/tests/test.rs
@@ -33,7 +33,8 @@ impl Subscriber for TestSubscriber {
     fn exit(&self, _span: &Id) {}
 }
 
-fn main() {
+#[cfg(test)]
+fn test_static_max_level_features() {
     let me = Arc::new(State {
         last_level: Mutex::new(None),
     });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`tokio-trace` should have static verbosity level filtering, like the `log` crate. The static max verbosity level should be controlled at compile time with a set of features. It should be possible to set a separate max level for release and debug mode builds.

https://github.com/tokio-rs/tokio/issues/959

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

We can do this fairly similarly to how the `log` crate does it: `tokio-trace` should export a constant whose value is set based on the static max level feature flags. Then, we can add an if statement to the `span!` and `event!` macros, like

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
