### PR TITLE
trace:  Span API polish

### DIFF
--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -110,7 +110,7 @@ fn enter_span(b: &mut Bencher) {
 #[bench]
 fn span_repeatedly(b: &mut Bencher) {
     #[inline]
-    fn mk_span(i: u64) -> tokio_trace::Span<'static> {
+    fn mk_span(i: u64) -> tokio_trace::Span {
         span!("span", i = i)
     }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -142,11 +142,11 @@ use {
 /// span will silently do nothing. Thus, the handle can be used in the same
 /// manner regardless of whether or not the trace is currently being collected.
 #[derive(Clone, PartialEq, Hash)]
-pub struct Span<'a> {
+pub struct Span {
     /// A handle used to enter the span when it is not executing.
     ///
     /// If this is `None`, then the span has either closed or was never enabled.
-    inner: Option<Inner<'a>>,
+    inner: Option<Inner<'static>>,
 }
 
 /// A handle representing the capacity to enter a span which is known to exist.
@@ -184,7 +184,7 @@ struct Entered<'a> {
 
 // ===== impl Span =====
 
-impl<'a> Span<'a> {
+impl Span {
     /// Constructs a new `Span` with the given [metadata] and set of [field
     /// values].
     ///
@@ -199,7 +199,7 @@ impl<'a> Span<'a> {
     /// [field values]: ::field::ValueSet
     /// [`follows_from`]: ::span::Span::follows_from
     #[inline]
-    pub fn new(meta: &'a Metadata<'a>, values: &field::ValueSet) -> Span<'a> {
+    pub fn new(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
         let new_span = Attributes::new(meta, values);
         Self::make(meta, new_span)
     }
@@ -214,7 +214,7 @@ impl<'a> Span<'a> {
     /// [field values]: ::field::ValueSet
     /// [`follows_from`]: ::span::Span::follows_from
     #[inline]
-    pub fn new_root(meta: &'a Metadata<'a>, values: &field::ValueSet) -> Span<'a> {
+    pub fn new_root(meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span {
         Self::make(meta, Attributes::new_root(meta, values))
     }
 
@@ -227,7 +227,7 @@ impl<'a> Span<'a> {
     /// [metadata]: ::metadata::Metadata
     /// [field values]: ::field::ValueSet
     /// [`follows_from`]: ::span::Span::follows_from
-    pub fn child_of<I>(parent: I, meta: &'a Metadata<'a>, values: &field::ValueSet) -> Span<'a>
+    pub fn child_of<I>(parent: I, meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span
     where
         I: Into<Option<Id>>,
     {
@@ -240,15 +240,14 @@ impl<'a> Span<'a> {
 
     /// Constructs a new disabled span.
     #[inline(always)]
-    pub fn new_disabled() -> Span<'a> {
+    pub fn new_disabled() -> Span {
         Span {
             inner: None,
-            is_closed: false,
         }
     }
 
     #[inline(always)]
-    fn make(meta: &'a Metadata<'a>, new_span: Attributes) -> Span<'a> {
+    fn make(meta: &'static Metadata<'static>, new_span: Attributes) -> Span {
         let inner = dispatcher::get_default(move |dispatch| {
             let id = dispatch.new_span(&new_span);
             Some(Inner::new(id, dispatch, meta))
@@ -361,12 +360,12 @@ impl<'a> Span<'a> {
     }
 
     /// Returns this span's `Metadata`, if it is enabled.
-    pub fn metadata(&self) -> Option<&'a Metadata<'a>> {
+    pub fn metadata(&self) -> Option<&'static Metadata<'static>> {
         self.inner.as_ref().map(Inner::metadata)
     }
 }
 
-impl<'a> fmt::Debug for Span<'a> {
+impl<'a> fmt::Debug for Span {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut span = f.debug_struct("Span");
         if let Some(ref inner) = self.inner {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -37,9 +37,9 @@
 //! # extern crate tokio_trace;
 //! # extern crate futures;
 //! # use futures::{Future, Poll, Async};
-//! struct MyFuture<'a> {
+//! struct MyFuture {
 //!    // data
-//!    span: tokio_trace::Span<'a>,
+//!    span: tokio_trace::Span,
 //! }
 //!
 //! impl<'a> Future for MyFuture<'a> {

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -227,7 +227,11 @@ impl Span {
     /// [metadata]: ::metadata::Metadata
     /// [field values]: ::field::ValueSet
     /// [`follows_from`]: ::span::Span::follows_from
-    pub fn child_of<I>(parent: I, meta: &'static Metadata<'static>, values: &field::ValueSet) -> Span
+    pub fn child_of<I>(
+        parent: I,
+        meta: &'static Metadata<'static>,
+        values: &field::ValueSet,
+    ) -> Span
     where
         I: Into<Option<Id>>,
     {
@@ -241,9 +245,7 @@ impl Span {
     /// Constructs a new disabled span.
     #[inline(always)]
     pub fn new_disabled() -> Span {
-        Span {
-            inner: None,
-        }
+        Span { inner: None }
     }
 
     #[inline(always)]
@@ -252,9 +254,7 @@ impl Span {
             let id = dispatch.new_span(&new_span);
             Some(Inner::new(id, dispatch, meta))
         });
-        Self {
-            inner,
-        }
+        Self { inner }
     }
 
     /// Executes the given function in the context of this span.

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -42,7 +42,7 @@
 //!    span: tokio_trace::Span,
 //! }
 //!
-//! impl<'a> Future for MyFuture<'a> {
+//! impl Future for MyFuture {
 //!     type Item = ();
 //!     type Error = ();
 //!

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -40,7 +40,7 @@ fn handles_to_different_spans_are_not_equal() {
 fn handles_to_different_spans_with_the_same_metadata_are_not_equal() {
     // Every time time this function is called, it will return a _new
     // instance_ of a span with the same metadata, name, and fields.
-    fn make_span() -> Span<'static> {
+    fn make_span() -> Span {
         span!("foo", bar = 1u64, baz = false)
     }
 

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -11,33 +11,6 @@ use tokio_trace::{
 };
 
 #[test]
-fn closed_handle_cannot_be_entered() {
-    let subscriber = subscriber::mock()
-        .enter(span::mock().named("foo"))
-        .drop_span(span::mock().named("bar"))
-        .enter(span::mock().named("bar"))
-        .exit(span::mock().named("bar"))
-        .drop_span(span::mock().named("bar"))
-        .exit(span::mock().named("foo"))
-        .run();
-
-    with_default(subscriber, || {
-        span!("foo").enter(|| {
-            let bar = span!("bar");
-            let mut another_bar = bar.clone();
-            drop(bar);
-
-            another_bar.enter(|| {});
-
-            another_bar.close();
-            // After we close `another_bar`, it should close and not be
-            // re-entered.
-            another_bar.enter(|| {});
-        });
-    });
-}
-
-#[test]
 fn handles_to_the_same_span_are_equal() {
     // Create a mock subscriber that will return `true` on calls to
     // `Subscriber::enabled`, so that the spans will be constructed. We
@@ -272,40 +245,15 @@ fn span_closes_when_exited() {
         .run_with_handle();
     with_default(subscriber, || {
         let mut foo = span!("foo");
-        assert!(!foo.is_closed());
 
         foo.enter(|| {});
-        assert!(!foo.is_closed());
 
-        foo.close();
-        assert!(foo.is_closed());
-
-        // Now that `foo` has closed, entering it should do nothing.
-        foo.enter(|| {});
-        assert!(foo.is_closed());
+        drop(foo);
     });
 
     handle.assert_finished();
 }
 
-#[test]
-fn entering_a_closed_span_again_is_a_no_op() {
-    let (subscriber, handle) = subscriber::mock()
-        .drop_span(span::mock().named("foo"))
-        .done()
-        .run_with_handle();
-    with_default(subscriber, || {
-        let mut foo = span!("foo");
-
-        foo.close();
-        foo.enter(|| {
-            // This should do nothing.
-        });
-        assert!(foo.is_closed());
-    });
-
-    handle.assert_finished();
-}
 
 #[test]
 fn moved_field() {

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -254,7 +254,6 @@ fn span_closes_when_exited() {
     handle.assert_finished();
 }
 
-
 #[test]
 fn moved_field() {
     let (subscriber, handle) = subscriber::mock()


### PR DESCRIPTION
This branch makes the following changes to `tokio-trace`'s `Span` type:

* **Remove manual close API from spans**
  In practice, there wasn't really a use-case for this, and it 
  complicates the implementation a bit. We can always add it back later.

* **Remove generic lifetime from `Span`**
  Again, there wasn't actually a use-case for spans with metadata that
  doesn't live for the static lifetime, and it made using `Span`s in 
  other types somewhat inconvenient. It's also possible to implement an
  alternative API for non-static spans on top of the `tokio-trace-core`
  primitives.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>