### PR TITLE
Add tokio::spawn_lazy and supporting methods

### DIFF
--- a/examples/echo_lazy.rs
+++ b/examples/echo_lazy.rs
@@ -1,0 +1,137 @@
+//! A "hello world" echo server with Tokio
+//!
+//! This server will create a TCP listener, accept connections in a loop, and
+//! write back everything that's read off of each TCP connection.
+//!
+//! Because the Tokio runtime uses a thread pool, each TCP connection is
+//! processed concurrently with all other TCP connections across multiple
+//! threads.
+//!
+//! To see this server in action, you can run this in one terminal:
+//!
+//!     cargo run --example echo_lazy
+//!
+//! and in another terminal you can run:
+//!
+//!     cargo run --example connect 127.0.0.1:8080
+//!
+//! Each line you type in to the `connect` terminal should be echo'd back to
+//! you! If you open up multiple terminals running the `connect` example you
+//! should be able to see them all make progress simultaneously.
+
+#![deny(warnings)]
+
+extern crate tokio;
+extern crate env_logger;
+
+use tokio::io;
+use tokio::net::TcpListener;
+use tokio::prelude::*;
+
+use std::env;
+use std::net::SocketAddr;
+use std::rc::Rc;
+use std::cell::Cell;
+
+fn main() -> Result<(), Box<std::error::Error>> {
+    env_logger::init();
+    // Allow passing an address to listen on as the first argument of this
+    // program, but otherwise we'll just set up our TCP listener on
+    // 127.0.0.1:8080 for connections.
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = addr.parse::<SocketAddr>()?;
+
+    // Next up we create a TCP listener which will listen for incoming
+    // connections. This TCP listener is bound to the address we determined
+    // above and must be associated with an event loop, so we pass in a handle
+    // to our event loop. After the socket's created we inform that we're ready
+    // to go and start accepting connections.
+    let socket = TcpListener::bind(&addr)?;
+    println!("Listening on: {}", addr);
+
+    // Here we convert the `TcpListener` to a stream of incoming connections
+    // with the `incoming` method. We then define how to process each element in
+    // the stream with the `for_each` method.
+    //
+    // This combinator, defined on the `Stream` trait, will allow us to define a
+    // computation to happen for all items on the stream (in this case TCP
+    // connections made to the server).  The return value of the `for_each`
+    // method is itself a future representing processing the entire stream of
+    // connections, and ends up being our server.
+    let done = socket
+        .incoming()
+        .map_err(|e| println!("failed to accept socket; error = {:?}", e))
+        .for_each(move |socket| {
+
+            tokio::spawn_lazy(|| {
+                // Once we're inside this closure this represents an accepted client
+                // from our server. The `socket` is the client connection (similar to
+                // how the standard library operates).
+                //
+                // We just want to copy all data read from the socket back onto the
+                // socket itself (e.g. "echo"). We can use the standard `io::copy`
+                // combinator in the `tokio-core` crate to do precisely this!
+                //
+                // The `copy` function takes two arguments, where to read from and where
+                // to write to. We only have one argument, though, with `socket`.
+                // Luckily there's a method, `Io::split`, which will split an Read/Write
+                // stream into its two halves. This operation allows us to work with
+                // each stream independently, such as pass them as two arguments to the
+                // `copy` function.
+                //
+                // The `copy` function then returns a future, and this future will be
+                // resolved when the copying operation is complete, resolving to the
+                // amount of data that was copied.
+                let (reader, writer) = socket.split();
+                let amt = io::copy(reader, writer);
+
+                // Since we're using 'tokio::spawn_lazy', we're able to use an Rc here.
+                // If we were using 'tokio::spawn' instead, we would be unable to do so,
+                // due to the 'Send' boound on its argument. However, `tokio::spawn_lazy`
+                // will work perfectly well with a non-Send future - only the outer
+                // closure must be Send.
+                let amount = Rc::new(Cell::new(0));
+
+                // We make two copies of 'amount' - one for each of the closures below.
+                // This allows each closure to take owernship of its own copy of the
+                // original Rc, since the closures might live longer than the original
+                // 'amount' variable
+                let amount_one = amount.clone();
+                let amount_two = amount.clone();
+
+                // After our copy operation is complete we just print out some helpful
+                // information.
+                let msg = amt.then(move |result| {
+                    match result {
+                        Ok((amt, _, _)) => {
+                            println!("wrote {} bytes", amt);
+
+                            amount_one.set(amt);
+                        },
+                        Err(e) => println!("error: {}", e),
+                    }
+
+                    Ok(())
+                }).map(move |_| {
+                    // In a larger program, we might make use of this Cell
+                    // in a different part of program.
+                    println!("Read amount from Cell: {:?}", amount_two.get());
+                });
+
+                // We return our created future from
+                // the closure we provide to spawn_lazy
+                // This closure will be called just before
+                // execution of the task starts.
+                Box::new(msg)
+            })
+        });
+
+    // And finally now that we've define what our server is, we run it!
+    //
+    // This starts the Tokio runtime, spawns the server task, and blocks the
+    // current thread until all tasks complete execution. Since the `done` task
+    // never completes (it just keeps accepting sockets), `tokio::run` blocks
+    // forever (until ctrl-c is pressed).
+    tokio::run(done);
+    Ok(())
+}

--- a/examples/echo_lazy.rs
+++ b/examples/echo_lazy.rs
@@ -21,17 +21,17 @@
 
 #![deny(warnings)]
 
-extern crate tokio;
 extern crate env_logger;
+extern crate tokio;
 
 use tokio::io;
 use tokio::net::TcpListener;
 use tokio::prelude::*;
 
+use std::cell::Cell;
 use std::env;
 use std::net::SocketAddr;
 use std::rc::Rc;
-use std::cell::Cell;
 
 fn main() -> Result<(), Box<std::error::Error>> {
     env_logger::init();
@@ -62,7 +62,6 @@ fn main() -> Result<(), Box<std::error::Error>> {
         .incoming()
         .map_err(|e| println!("failed to accept socket; error = {:?}", e))
         .for_each(move |socket| {
-
             tokio::spawn_lazy(|| {
                 // Once we're inside this closure this represents an accepted client
                 // from our server. The `socket` is the client connection (similar to
@@ -101,22 +100,24 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
                 // After our copy operation is complete we just print out some helpful
                 // information.
-                let msg = amt.then(move |result| {
-                    match result {
-                        Ok((amt, _, _)) => {
-                            println!("wrote {} bytes", amt);
+                let msg = amt
+                    .then(move |result| {
+                        match result {
+                            Ok((amt, _, _)) => {
+                                println!("wrote {} bytes", amt);
 
-                            amount_one.set(amt);
-                        },
-                        Err(e) => println!("error: {}", e),
-                    }
+                                amount_one.set(amt);
+                            }
+                            Err(e) => println!("error: {}", e),
+                        }
 
-                    Ok(())
-                }).map(move |_| {
-                    // In a larger program, we might make use of this Cell
-                    // in a different part of program.
-                    println!("Read amount from Cell: {:?}", amount_two.get());
-                });
+                        Ok(())
+                    })
+                    .map(move |_| {
+                        // In a larger program, we might make use of this Cell
+                        // in a different part of program.
+                        println!("Read amount from Cell: {:?}", amount_two.get());
+                    });
 
                 // We return our created future from
                 // the closure we provide to spawn_lazy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,7 @@ if_runtime! {
     pub mod runtime;
 
     pub use executor::spawn;
+    pub use executor::spawn_lazy;
     pub use runtime::run;
 }
 

--- a/src/runtime/threadpool/task_executor.rs
+++ b/src/runtime/threadpool/task_executor.rs
@@ -1,5 +1,6 @@
 
 use tokio_threadpool::Sender;
+use tokio_executor::LazyFn;
 
 use futures::future::{self, Future};
 
@@ -71,5 +72,11 @@ impl ::executor::Executor for TaskExecutor {
         -> Result<(), ::executor::SpawnError>
     {
         self.inner.spawn(future)
+    }
+
+    fn spawn_lazy(&mut self, lazy: LazyFn)
+        -> Result<(), ::executor::SpawnError>
+    {
+        self.inner.spawn_lazy(lazy)
     }
 }

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -33,7 +33,7 @@ mod scheduler;
 use self::scheduler::Scheduler;
 
 use tokio_executor::park::{Park, ParkThread, Unpark};
-use tokio_executor::{Enter, SpawnError, LazyFn};
+use tokio_executor::{Enter, LazyFn, SpawnError};
 
 use futures::future::{ExecuteError, ExecuteErrorKind, Executor};
 use futures::{executor, Async, Future};
@@ -430,10 +430,7 @@ impl tokio_executor::Executor for CurrentThread {
         Ok(())
     }
 
-    fn spawn_lazy(
-        &mut self,
-        lazy: LazyFn,
-    ) -> Result<(), SpawnError> {
+    fn spawn_lazy(&mut self, lazy: LazyFn) -> Result<(), SpawnError> {
         // We're already on the proper thread by definition,
         // so go ahead and create the future.
         let future: Box<Future<Item = (), Error = ()>> = lazy.call();
@@ -752,10 +749,7 @@ impl tokio_executor::Executor for TaskExecutor {
         self.spawn_local(future)
     }
 
-    fn spawn_lazy(
-        &mut self,
-        lazy: LazyFn
-    ) -> Result<(), SpawnError> {
+    fn spawn_lazy(&mut self, lazy: LazyFn) -> Result<(), SpawnError> {
         // We're already on the proper thread by definition,
         // so go ahead and create the future.
 

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -23,3 +23,4 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 crossbeam-utils = "0.6.2"
 futures = "0.1.19"
+log = "0.4.6"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -37,7 +37,8 @@
 
 extern crate crossbeam_utils;
 extern crate futures;
-#[macro_use] extern crate log;
+#[macro_use]
+extern crate log;
 
 mod enter;
 mod global;
@@ -60,7 +61,7 @@ use std::fmt;
 ///
 /// [`spawn_lazy`] takes a LazyFn as it argument
 pub struct LazyFn {
-    inner: Box<FnBox<Box<Future<Item = (), Error = ()>>> + Send>
+    inner: Box<FnBox<Box<Future<Item = (), Error = ()>>> + Send>,
 }
 
 impl fmt::Debug for LazyFn {
@@ -70,7 +71,6 @@ impl fmt::Debug for LazyFn {
 }
 
 impl LazyFn {
-
     /// Invokes the boxed closure, returning its result
     pub fn call(self) -> Box<Future<Item = (), Error = ()>> {
         self.inner.call()
@@ -79,9 +79,7 @@ impl LazyFn {
 
 impl<F: Send + 'static + FnOnce() -> Box<Future<Item = (), Error = ()>>> From<F> for LazyFn {
     fn from(f: F) -> LazyFn {
-        LazyFn {
-            inner: Box::new(f)
-        }
+        LazyFn { inner: Box::new(f) }
     }
 }
 
@@ -232,10 +230,7 @@ pub trait Executor {
     /// # }
     /// # fn main() {}
     /// ```
-    fn spawn_lazy(
-        &mut self,
-        lazy: LazyFn
-    ) -> Result<(), SpawnError>;
+    fn spawn_lazy(&mut self, lazy: LazyFn) -> Result<(), SpawnError>;
 
     /// Provides a best effort **hint** to whether or not `spawn` will succeed.
     ///
@@ -285,13 +280,9 @@ impl<E: Executor + ?Sized> Executor for Box<E> {
         (**self).spawn(future)
     }
 
-    fn spawn_lazy(
-        &mut self,
-        lazy: LazyFn
-    ) -> Result<(), SpawnError> {
+    fn spawn_lazy(&mut self, lazy: LazyFn) -> Result<(), SpawnError> {
         (**self).spawn_lazy(lazy)
     }
-
 
     fn status(&self) -> Result<(), SpawnError> {
         (**self).status()

--- a/tokio-executor/tests/executor.rs
+++ b/tokio-executor/tests/executor.rs
@@ -2,6 +2,7 @@ extern crate futures;
 extern crate tokio_executor;
 
 use futures::{future::lazy, Future};
+use futures::future::ok;
 use tokio_executor::*;
 
 mod out_of_executor_context {
@@ -18,6 +19,12 @@ mod out_of_executor_context {
     #[test]
     fn spawn() {
         test(|f| DefaultExecutor::current().spawn(f));
+    }
+
+    #[test]
+    fn spawn_lazy() {
+        let res = DefaultExecutor::current().spawn_lazy((move || Box::new(ok(())) as Box<Future<Item = (), Error = ()>>).into());
+        assert!(res.is_err());
     }
 
     #[test]

--- a/tokio-executor/tests/executor.rs
+++ b/tokio-executor/tests/executor.rs
@@ -1,8 +1,8 @@
 extern crate futures;
 extern crate tokio_executor;
 
-use futures::{future::lazy, Future};
 use futures::future::ok;
+use futures::{future::lazy, Future};
 use tokio_executor::*;
 
 mod out_of_executor_context {
@@ -23,7 +23,8 @@ mod out_of_executor_context {
 
     #[test]
     fn spawn_lazy() {
-        let res = DefaultExecutor::current().spawn_lazy((move || Box::new(ok(())) as Box<Future<Item = (), Error = ()>>).into());
+        let res = DefaultExecutor::current()
+            .spawn_lazy((move || Box::new(ok(())) as Box<Future<Item = (), Error = ()>>).into());
         assert!(res.is_err());
     }
 

--- a/tokio-threadpool/src/sender.rs
+++ b/tokio-threadpool/src/sender.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::Ordering::{AcqRel, Acquire};
 use std::sync::Arc;
 
 use futures::{future, Future};
-use tokio_executor::{self, SpawnError, LazyFn};
+use tokio_executor::{self, LazyFn, SpawnError};
 
 /// Submit futures to the associated thread pool for execution.
 ///
@@ -138,14 +138,10 @@ impl tokio_executor::Executor for Sender {
         tokio_executor::Executor::spawn(&mut s, future)
     }
 
-    fn spawn_lazy(
-        &mut self,
-        lazy: LazyFn
-    ) -> Result<(), SpawnError> {
+    fn spawn_lazy(&mut self, lazy: LazyFn) -> Result<(), SpawnError> {
         let mut s = &*self;
         tokio_executor::Executor::spawn_lazy(&mut s, lazy)
     }
-
 }
 
 impl<'a> tokio_executor::Executor for &'a Sender {
@@ -185,10 +181,7 @@ impl<'a> tokio_executor::Executor for &'a Sender {
         Ok(())
     }
 
-    fn spawn_lazy(
-        &mut self,
-        future: LazyFn,
-    ) -> Result<(), SpawnError> {
+    fn spawn_lazy(&mut self, future: LazyFn) -> Result<(), SpawnError> {
         self.prepare_for_spawn()?;
         // At this point, the pool has accepted the future, so schedule it for
         // execution.

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -16,6 +16,7 @@ use tokio_executor::LazyFn;
 
 use std::cell::Cell;
 use std::cell::RefCell;
+use std::mem;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 use std::sync::atomic::{AtomicPtr, AtomicUsize};
 use std::sync::Arc;
@@ -163,7 +164,7 @@ impl Task {
                     _ => unreachable!(),
                 }
             } else {
-                let inner = std::mem::replace(ref_mut, MaybeFuture::Future(None));
+                let inner = mem::replace(ref_mut, MaybeFuture::Future(None));
                 let lazy = match inner {
                     MaybeFuture::Lazy(f) => f.call(),
                     _ => unreachable!(),


### PR DESCRIPTION
`tokio::spawn_lazy` allows the actual creation of a future
to be deferred to the thread that will actually be executing it. This
allows non-Send futures to be spawned onto an executor, as long as the
closure that creates it is itself Send.

## Motivation

When using `tokio` to write a TCP server, it's common to spawn a new future for each incoming client. For example, the [echo server example](https://github.com/tokio-rs/tokio/blob/85487727d41574020793fbe0025a9dafc4890a70/examples/echo.rs#L104) spawns a new future to handle incoming messages for each client.

Since `tokio::spawn` may end up running the future on a different thread, it requires that the future be `Send`. In many cases, however, the future is never polled before being passed to `spawn`. This makes the `Send` bound overly restrictive, since the future will only ever be run on a single thread.

Consider the following future:

```rust
let my_rc: Rc<Cell<bool>> = some_rc.clone();
let my_fut = futures::future::lazy(move || {
    println!("Value from rc: {:?}", my_rc.get());
    futures::future::ok(());
})
```

The future `my_fut` is not `Send`, becaues it owns a non-`Send` type (`Rc`). Thus, Rust prevents us from passing it to `tokio::spawn`.

However, it would actually be fine to run this future on an executor thread. Even though it's not `Send`, there's no issue with *running* it on a different thread - the issue is *getting* it to another thread. Since `tokio::send` takes a `Future` as its argument, the future must necessarily already exist on a different thread, which requires it to be `Send`.

It would be useful to be able to spawn this kind of future. In the case of a TCP server, it's useful to be to be able to create a separate task for each incoming connection. We don't actually need the ability to send each client's future between threads - we simply want each future to (potentially) run on a different thread.

## Solution

This PR introduces `tokio::spawn_lazy`, along with a corresponding method in `Executor`. This method has the following signature:

```rust
pub fn spawn_lazy<F>(f: F) -> Spawn
where F: FnOnce() -> Box<Future<Item = (), Error = ()>> + Send + 'static
```

The key part of this signature is the `FnOnce`. `tokio::spawn_lazy` take a closure which *returns* a `Future`, rather than directly taking a `Future`.

This closure will be called just before the future is initially run. Crucially, it will be called on the 'target' thread - e.g. a threadpool thread if a threadpool executor is in use. This means that while the closure itself must be `Send`, the future it returns need not be.

This allows using non-send types like `Rc` within the returned future. For example, a closure returning the `my_fut` variable (in the 'Motivation' section) could be passed to `spawn_lazy`, even though `my_fut` cannot be passed to `pawn`.

## Implementation notes

### LazyFn

Most of the changes in this PR should be fairly straightforward. The two most significant changes are the introduction of the `LazyFn` type, and some internal refactoring of `tokio-threadpool`.

The freestanding `tokio::spawn_lazy` function is able to take a `FnOnce` directly, via a generic parameter. However, this is not possible in the `Executor` trait, due to the need to maintain object-safety.

The most obvious solution would be for `Executor::spawn_lazy` to take a `Box<FnOnce>`. Unfortunately, due to [a longstanding Rust issue](https://github.com/rust-lang/rust/issues/28796), it's not possible to actually invoke a `Box<FnOnce>`.

My solution is to essentially reimplement a minimal subset of the [boxfnonce](https://crates.io/crates/boxfnonce) crate. `tokio-executor` now exposes an opaque `LazyFn` type, which implements `From<FnOnce>`. This type is consumed by `Executor::spawn_lazy`, allowing it to remain object safe.

While introducing a new public type is unfortunate, its impact should be minimal. Most consumers of `tokio` will likely use the top-level `tokio::spawn_lazy` function, which can directly take a `FnOnce` as its argument. Consumers that directly call `Executor::spawn_lazy` can simply call `into()` on their closure before passing it to `spawn_lazy`.

Since this type is completely opaque to external crates, I've only implemented the internal `FnBox` trait for the zero-argument case. Since the trait is private, it's always possible to modify or completely replace it without breaking backwards compatibility.

In the future, it may become possible to directly call a `Box<FnOnce>` from Rust, without any indirection. In that case, we could change `LazyFn` to directly contain a `Box<FnOnce>`, or remove it entirely. While the latter case would be a breaking change, its impact should be minimal. Most users will likely never name `LazyFn` directly - instead, they'll call `into` on a closure. Since the impl `From<T> for Box<T>` exists, the call to `into()` would simply change to construct a `Box` insted of a `LazyFn`, with no changes needed by users.

### tokio-threadpool changes

Previously, `tokio_threadpool::task::Task` directly stored a `Spawn<BoxFuture>`. To support `spawn_lazy`, I've modified it to store a new enum `MaybeFuture`. `MaybeFuture` represents an already spawned future as passed by `tokio::spawn`, or a `LazyFn` as passed by `tokio::spawn_lazy`.

Where the future would be previously be polled, the `MaybeFuture` instance is now checked. If it contains a `LazyFn`, the `LazyFn` is called, and the returned future is stored in a new `MaybeFuture` instance. The future (whether pre-existing or stored) is then polled as usual.

Previously, an `UnsafeCell` was used to store the `Spawn<BoxFuture>`. As far as I could tell, this was just to avoid dealing with the lifetime constraints imposed by `RefCell` - there was nothing that specifically required an `UnsafeCell`. It wasn't at all obvious to me how to handle the required enum manipulation, while guaranteeing that I didn't cause insta-UB by making aliased mutable references. Instead, I replaced the `UnsafeCell` by a `RefCell`. While the enum-manipulation code is a little tricky, any mistakes will result in a panic rather than UB.