### PR TITLE
Bump Tokio version to v0.1.18

### DIFF
--- a/tokio-current-thread/CHANGELOG.md
+++ b/tokio-current-thread/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.6 (March 22, 2019)
+
+### Added
+- implement `TypedExecutor` (#993).
+
 # 0.1.5 (March 1, 2019)
 
 ### Fixed

--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -8,8 +8,8 @@ name = "tokio-current-thread"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.5"
-documentation = "https://docs.rs/tokio-current-thread/0.1.5/tokio_current_thread"
+version = "0.1.6"
+documentation = "https://docs.rs/tokio-current-thread/0.1.6/tokio_current_thread"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"
@@ -21,5 +21,5 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
+tokio-executor = "0.1.6"
 futures = "0.1.19"

--- a/tokio-current-thread/README.md
+++ b/tokio-current-thread/README.md
@@ -2,7 +2,7 @@
 
 Single threaded executor for Tokio.
 
-[Documentation](https://docs.rs/tokio-current-thread/0.1.5/tokio_current_thread/)
+[Documentation](https://docs.rs/tokio-current-thread/0.1.6/tokio_current_thread/)
 
 ## Overview
 

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.6")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A single-threaded executor which executes tasks on the same thread from which

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.7 (March 22, 2019)
+
+### Added
+- `TypedExecutor` for spawning futures of a specific type (#993).
+
 # 0.1.6 (January 6, 2019)
 
 * Implement `Unpark` for `Arc<Unpark>` (#802).

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -8,8 +8,8 @@ name = "tokio-executor"
 #   - Cargo.toml
 #   - README.md
 # - Create "v0.1.x" git tag.
-version = "0.1.6"
-documentation = "https://docs.rs/tokio-executor/0.1.6/tokio_executor"
+version = "0.1.7"
+documentation = "https://docs.rs/tokio-executor/0.1.7/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"
@@ -25,4 +25,4 @@ crossbeam-utils = "0.6.2"
 futures = "0.1.19"
 
 [dev-dependencies]
-tokio = { version = "0.1.17", path = "../tokio" }
+tokio = "0.1.18"

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,7 +2,7 @@
 
 Task execution related traits and utilities.
 
-[Documentation](https://docs.rs/tokio-executor/0.1.6/tokio_executor)
+[Documentation](https://docs.rs/tokio-executor/0.1.7/tokio_executor)
 
 ## Overview
 
@@ -31,10 +31,10 @@ executor, including:
 
 * [`Park`] abstracts over blocking and unblocking the current thread.
 
-[`Executor`]: https://docs.rs/tokio-executor/0.1.6/tokio_executor/trait.Executor.html
-[`enter`]: https://docs.rs/tokio-executor/0.1.6/tokio_executor/fn.enter.html
-[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.6/tokio_executor/struct.DefaultExecutor.html
-[`Park`]: https://docs.rs/tokio-executor/0.1.6/tokio_executor/park/trait.Park.html
+[`Executor`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/trait.Executor.html
+[`enter`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/fn.enter.html
+[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/struct.DefaultExecutor.html
+[`Park`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/park/trait.Park.html
 
 ## License
 

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.7")]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.8 (March 22, 2019)
+
+### Fixed
+- remove usage of deprecated `Handle::current` (#981).
+
 ## 0.2.7 - (November 21, 2018)
 ### Changed
 * `unix::Signal` now implements `Sync`

--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -6,12 +6,12 @@ name = "tokio-signal"
 # - Update CHANGELOG.md.
 # - Update doc URL.
 # - Create "v0.2.x" git tag.
-version = "0.2.7"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.8"
+authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-signal/0.2.7/tokio_signal"
+documentation = "https://docs.rs/tokio-signal/0.2.8/tokio_signal"
 description = """
 An implementation of an asynchronous Unix signal handling backed futures.
 """

--- a/tokio-signal/README.md
+++ b/tokio-signal/README.md
@@ -1,16 +1,8 @@
 # tokio-signal
 
-An implementation of Unix signal handling for Tokio
+Unix signal handling for Tokio.
 
-[![Travis Build Status][travis-badge]][travis-url]
-[![Appveyor Build Status][appveyor-badge]][appveyor-url]
-
-[travis-badge]: https://travis-ci.org/tokio-rs/tokio.svg?branch=master
-[travis-url]: https://travis-ci.org/tokio-rs/tokio
-[appveyor-badge]: https://ci.appveyor.com/api/projects/status/s83yxhy9qeb58va7/branch/master?svg=true
-[appveyor-url]: https://ci.appveyor.com/project/carllerche/tokio/branch/master
-
-[Documentation](https://docs.rs/tokio-signal)
+[Documentation](https://docs.rs/tokio-signal/0.2.8/tokio_signal)
 
 ## Usage
 
@@ -18,7 +10,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-signal = "0.2"
+tokio-signal = "0.2.8"
 ```
 
 Next you can use this in conjunction with the `tokio` and `futures` crates:
@@ -46,10 +38,9 @@ fn main() {
 }
 ```
 
-# License
+## License
 
-This project is licensed the MIT license ([LICENSE](LICENSE) or
-http://opensource.org/licenses/MIT).
+This project is licensed under the [MIT license](./LICENSE).
 
 ### Contribution
 

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -1,3 +1,6 @@
+#![doc(html_root_url = "https://docs.rs/tokio-signal/0.2.8")]
+#![deny(missing_docs)]
+
 //! Asynchronous signal handling for Tokio
 //!
 //! This crate implements asynchronous signal handling for Tokio, an
@@ -66,9 +69,6 @@
 //! # }
 //! # fn main() {}
 //! ```
-
-#![doc(html_root_url = "https://docs.rs/tokio-signal/0.2.7")]
-#![deny(missing_docs)]
 
 extern crate futures;
 extern crate mio;

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.13 (March 22, 2019)
+
+### Added
+- `TypedExecutor` implementations (#993)
+
 # 0.1.12 (March 1, 2019)
 
 ### Fixed

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -7,8 +7,8 @@ name = "tokio-threadpool"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.12"
-documentation = "https://docs.rs/tokio-threadpool/0.1.12/tokio_threadpool"
+version = "0.1.13"
+documentation = "https://docs.rs/tokio-threadpool/0.1.13/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"
@@ -20,7 +20,7 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { version = "0.1.5", path = "../tokio-executor" }
+tokio-executor = "0.1.7"
 futures = "0.1.19"
 crossbeam-deque = "0.7.0"
 crossbeam-queue = "0.1.0"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.12/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.13/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.12")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.13")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,11 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.18 (March 22, 2019)
+
+### Added
+- `TypedExecutor` re-export and implementations (#993).
+
 # 0.1.17 (March 13, 2019)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,11 +7,11 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.17"
+version = "0.1.18"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.17/tokio/"
+documentation = "https://docs.rs/tokio/0.1.18/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -71,7 +71,7 @@ tokio-codec = { version = "0.1.0", optional = true }
 tokio-current-thread = { version = "0.1.3", optional = true }
 tokio-fs = { version = "0.1.6", optional = true }
 tokio-io = { version = "0.1.6", optional = true }
-tokio-executor = { version = "0.1.5", optional = true, path = "../tokio-executor" }
+tokio-executor = { version = "0.1.7", optional = true }
 tokio-reactor = { version = "0.1.1", optional = true }
 tokio-sync = { version = "0.1.3", optional = true }
 tokio-threadpool = { version = "0.1.8", optional = true }

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -31,10 +31,6 @@ the Rust programming language. It is:
 [API Docs](https://docs.rs/tokio/0.1.18/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
-The API docs for the master branch are published [here][master-dox].
-
-[master-dox]: https://tokio-rs.github.io/tokio/doc/tokio/
-
 ## Overview
 
 Tokio is an event-driven, non-blocking I/O platform for writing
@@ -109,63 +105,6 @@ question.  Last, if that doesn't work, try opening an [issue] with the question.
 
 [chat]: https://gitter.im/tokio-rs/tokio
 [issue]: https://github.com/tokio-rs/tokio/issues/new
-
-## Contributing
-
-:balloon: Thanks for your help improving the project! We are so happy to have
-you! We have a [contributing guide][guide] to help you get involved in the Tokio
-project.
-
-[guide]: CONTRIBUTING.md
-
-## Project layout
-
-The `tokio` crate, found at the root, is primarily intended for use by
-application developers.  Library authors should depend on the sub crates, which
-have greater guarantees of stability.
-
-The crates included as part of Tokio are:
-
-* [`tokio-async-await`]: Experimental `async` / `await` support.
-
-* [`tokio-codec`]: Utilities for encoding and decoding protocol frames.
-
-* [`tokio-current-thread`]: Schedule the execution of futures on the current
-  thread.
-
-* [`tokio-executor`]: Task execution related traits and utilities.
-
-* [`tokio-fs`]: Filesystem (and standard in / out) APIs.
-
-* [`tokio-io`]: Asynchronous I/O related traits and utilities.
-
-* [`tokio-reactor`]: Event loop that drives I/O resources (like TCP and UDP
-  sockets).
-
-* [`tokio-tcp`]: TCP bindings for use with `tokio-io` and `tokio-reactor`.
-
-* [`tokio-threadpool`]: Schedules the execution of futures across a pool of
-  threads.
-
-* [ `tokio-timer`]: Time related APIs.
-
-* [`tokio-udp`]: UDP bindings for use with `tokio-io` and `tokio-reactor`.
-
-* [`tokio-uds`]: Unix Domain Socket bindings for use with `tokio-io` and
-  `tokio-reactor`.
-
-[`tokio-async-await`]: tokio-async-await
-[`tokio-codec`]: tokio-codec
-[`tokio-current-thread`]: tokio-current-thread
-[`tokio-executor`]: tokio-executor
-[`tokio-fs`]: tokio-fs
-[`tokio-io`]: tokio-io
-[`tokio-reactor`]: tokio-reactor
-[`tokio-tcp`]: tokio-tcp
-[`tokio-threadpool`]: tokio-threadpool
-[`tokio-timer`]: tokio-timer
-[`tokio-udp`]: tokio-udp
-[`tokio-uds`]: tokio-uds
 
 ## Supported Rust Versions
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.17")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.18")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(
     feature = "async-await-preview",


### PR DESCRIPTION
Also bumps:

- tokio-signal (0.2.8)
- tokio-current-thread (0.1.6)
- tokio-executor (0.1.7)
- tokio-threadpool (0.1.13)