### PR TITLE
trace: Make Span API functions taking IDs a little more flexible

### DIFF
--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -444,20 +444,6 @@ impl fmt::Debug for Span {
     }
 }
 
-impl ::sealed::Sealed for Span {}
-impl<'a> ::sealed::Sealed for &'a Span {}
-
-impl AsId for Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
-
-impl<'a> AsId for &'a Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
 // ===== impl Inner =====
 
 impl Inner {
@@ -572,9 +558,33 @@ impl<'a> fmt::Display for FmtAttrs<'a> {
 
 // ===== impl AsId =====
 
+impl ::sealed::Sealed for Span {}
+
+impl AsId for Span {
+    fn as_id(&self) -> Option<&Id> {
+        self.inner.as_ref().map(|inner| &inner.id)
+    }
+}
+
+impl<'a> ::sealed::Sealed for &'a Span {}
+
+impl<'a> AsId for &'a Span {
+    fn as_id(&self) -> Option<&Id> {
+        self.inner.as_ref().map(|inner| &inner.id)
+    }
+}
+
 impl ::sealed::Sealed for Id {}
 
 impl AsId for Id {
+    fn as_id(&self) -> Option<&Id> {
+        Some(self)
+    }
+}
+
+impl<'a> ::sealed::Sealed for &'a Id {}
+
+impl<'a> AsId for &'a Id {
     fn as_id(&self) -> Option<&Id> {
         Some(self)
     }
@@ -585,14 +595,6 @@ impl ::sealed::Sealed for Option<Id> {}
 impl AsId for Option<Id> {
     fn as_id(&self) -> Option<&Id> {
         self.as_ref()
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Id {}
-
-impl<'a> AsId for &'a Id {
-    fn as_id(&self) -> Option<&Id> {
-        Some(self)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -126,7 +126,6 @@
 pub use tokio_trace_core::span::{Attributes, Id, Record};
 
 use std::{
-    borrow::Borrow,
     cmp, fmt,
     hash::{Hash, Hasher},
 };
@@ -285,22 +284,21 @@ impl Span {
 
     /// Returns a [`Field`](::field::Field) for the field with the given `name`, if
     /// one exists,
-    pub fn field<Q>(&self, name: &Q) -> Option<field::Field>
+    pub fn field<Q: ?Sized>(&self, field: &Q) -> Option<field::Field>
     where
-        Q: Borrow<str>,
+        Q: field::AsField,
     {
-        self.metadata().and_then(|meta| meta.fields().field(name))
+        self.metadata().and_then(|meta| field.as_field(meta))
     }
 
     /// Returns true if this `Span` has a field for the given
     /// [`Field`](::field::Field) or field name.
+    #[inline]
     pub fn has_field<Q: ?Sized>(&self, field: &Q) -> bool
     where
         Q: field::AsField,
     {
-        self.metadata()
-            .and_then(|meta| field.as_field(meta))
-            .is_some()
+        self.field(field).is_some()
     }
 
     /// Visits that the field described by `field` has the value `value`.


### PR DESCRIPTION
This branch modifies the `tokio_trace::Span` API functions that take
span IDs (the `Span::child_of` constructor, and the `Span::follows_from`
method) so that more types bearing a span ID can be passed as an
argument. Span IDs may now be passed directly without requiring them to
be passed as `Some(id)`. This should make the API slightly more
ergonomic.

Also, it changes the `Span::field` method to take an `AsField` rather
than a `Borrow<str>`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>