### PR TITLE
Replace try! macro with ? operator

### DIFF
--- a/tokio-io/src/_tokio_codec/framed_read.rs
+++ b/tokio-io/src/_tokio_codec/framed_read.rs
@@ -186,13 +186,13 @@ where
             // readable again, at which point the stream is terminated.
             if self.is_readable {
                 if self.eof {
-                    let frame = try!(self.inner.decode_eof(&mut self.buffer));
+                    let frame = self.inner.decode_eof(&mut self.buffer)?;
                     return Ok(Async::Ready(frame));
                 }
 
                 trace!("attempting to decode a frame");
 
-                if let Some(frame) = try!(self.inner.decode(&mut self.buffer)) {
+                if let Some(frame) = self.inner.decode(&mut self.buffer)? {
                     trace!("frame decoded from buffer");
                     return Ok(Async::Ready(Some(frame)));
                 }

--- a/tokio-io/src/_tokio_codec/framed_write.rs
+++ b/tokio-io/src/_tokio_codec/framed_write.rs
@@ -94,7 +94,7 @@ where
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {
-        Ok(try!(self.inner.close()))
+        Ok(self.inner.close()?)
     }
 }
 
@@ -173,14 +173,14 @@ where
         // If the buffer is already over 8KiB, then attempt to flush it. If after flushing it's
         // *still* over 8KiB, then apply backpressure (reject the send).
         if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
-            try!(self.poll_complete());
+            self.poll_complete()?;
 
             if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
                 return Ok(AsyncSink::NotReady(item));
             }
         }
 
-        try!(self.inner.encode(item, &mut self.buffer));
+        self.inner.encode(item, &mut self.buffer)?;
 
         Ok(AsyncSink::Ready)
     }
@@ -216,7 +216,7 @@ where
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {
         try_ready!(self.poll_complete());
-        Ok(try!(self.inner.shutdown()))
+        Ok(self.inner.shutdown()?)
     }
 }
 

--- a/tokio-io/src/codec/decoder.rs
+++ b/tokio-io/src/codec/decoder.rs
@@ -79,7 +79,7 @@ pub trait Decoder {
     /// frames to yield. This behavior enables returning finalization frames
     /// that may not be based on inbound data.
     fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-        match try!(self.decode(buf)) {
+        match self.decode(buf)? {
             Some(frame) => Ok(Some(frame)),
             None => {
                 if buf.is_empty() {

--- a/tokio-io/src/framed_read.rs
+++ b/tokio-io/src/framed_read.rs
@@ -190,13 +190,13 @@ where
             // readable again, at which point the stream is terminated.
             if self.is_readable {
                 if self.eof {
-                    let frame = try!(self.inner.decode_eof(&mut self.buffer));
+                    let frame = self.inner.decode_eof(&mut self.buffer)?;
                     return Ok(Async::Ready(frame));
                 }
 
                 trace!("attempting to decode a frame");
 
-                if let Some(frame) = try!(self.inner.decode(&mut self.buffer)) {
+                if let Some(frame) = self.inner.decode(&mut self.buffer)? {
                     trace!("frame decoded from buffer");
                     return Ok(Async::Ready(Some(frame)));
                 }

--- a/tokio-io/src/framed_write.rs
+++ b/tokio-io/src/framed_write.rs
@@ -98,7 +98,7 @@ where
     }
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {
-        Ok(try!(self.inner.close()))
+        Ok(self.inner.close()?)
     }
 }
 
@@ -177,14 +177,14 @@ where
         // If the buffer is already over 8KiB, then attempt to flush it. If after flushing it's
         // *still* over 8KiB, then apply backpressure (reject the send).
         if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
-            try!(self.poll_complete());
+            self.poll_complete()?;
 
             if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
                 return Ok(AsyncSink::NotReady(item));
             }
         }
 
-        try!(self.inner.encode(item, &mut self.buffer));
+        self.inner.encode(item, &mut self.buffer)?;
 
         Ok(AsyncSink::Ready)
     }
@@ -220,7 +220,7 @@ where
 
     fn close(&mut self) -> Poll<(), Self::SinkError> {
         try_ready!(self.poll_complete());
-        Ok(try!(self.inner.shutdown()))
+        Ok(self.inner.shutdown()?)
     }
 }
 

--- a/tokio-io/src/length_delimited.rs
+++ b/tokio-io/src/length_delimited.rs
@@ -368,7 +368,7 @@ impl codec::Decoder for Decoder {
 
     fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<BytesMut>> {
         let n = match self.state {
-            DecodeState::Head => match try!(self.decode_head(src)) {
+            DecodeState::Head => match self.decode_head(src)? {
                 Some(n) => {
                     self.state = DecodeState::Data(n);
                     n
@@ -378,7 +378,7 @@ impl codec::Decoder for Decoder {
             DecodeState::Data(n) => n,
         };
 
-        match try!(self.decode_data(n, src)) {
+        match self.decode_data(n, src)? {
             Some(data) => {
                 // Update the decode state
                 self.state = DecodeState::Head;
@@ -525,11 +525,11 @@ impl<T: AsyncWrite, B: IntoBuf> Sink for FramedWrite<T, B> {
     type SinkError = io::Error;
 
     fn start_send(&mut self, item: B) -> StartSend<B, io::Error> {
-        if !try!(self.do_write()).is_ready() {
+        if !self.do_write()?.is_ready() {
             return Ok(AsyncSink::NotReady(item));
         }
 
-        try!(self.set_frame(item.into_buf()));
+        self.set_frame(item.into_buf())?;
 
         Ok(AsyncSink::Ready)
     }

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -377,11 +377,11 @@ impl Signal {
         Box::new(future::lazy(move || {
             let result = (|| {
                 // Turn the signal delivery on once we are ready for it
-                try!(signal_enable(signal));
+                signal_enable(signal)?;
 
                 // Ensure there's a driver for our associated event loop processing
                 // signals.
-                let driver = try!(Driver::new(&handle));
+                let driver = Driver::new(&handle)?;
 
                 // One wakeup in a queue is enough, no need for us to buffer up any
                 // more. NB: channels always guarantee at least one slot per sender,

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -161,7 +161,7 @@ fn global_init(handle: &Handle) -> io::Result<()> {
     let reg = MyRegistration {
         inner: RefCell::new(None),
     };
-    let reg = try!(PollEvented::new_with_handle(reg, handle));
+    let reg = PollEvented::new_with_handle(reg, handle)?;
     let ready = reg.get_ref().inner.borrow().as_ref().unwrap().1.clone();
     unsafe {
         let state = Box::new(GlobalState {

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -990,7 +990,7 @@ impl ConnectFutureState {
                 return Ok(Async::NotReady);
             }
 
-            if let Some(e) = try!(stream.io.get_ref().take_error()) {
+            if let Some(e) = stream.io.get_ref().take_error()? {
                 return Err(e);
             }
         }

--- a/tokio-tls/tests/smoke.rs
+++ b/tokio-tls/tests/smoke.rs
@@ -488,7 +488,7 @@ description should mention "tokio-tls".
                 let cert_context = MyCertContext(cert_context);
                 let cert_context: CertContext = mem::transmute(cert_context);
 
-                try!(cert_context.set_friendly_name(FRIENDLY_NAME));
+                cert_context.set_friendly_name(FRIENDLY_NAME)?;
 
                 // install the certificate to the machine's local store
                 io::stdout().write_all(br#"
@@ -500,8 +500,8 @@ for one day and will be automatically deleted if you re-run the tokio-tls
 test suite later.
 
         "#).unwrap();
-                try!(local_root_store().add_cert(&cert_context,
-                                                 CertAdd::ReplaceExisting));
+                local_root_store().add_cert(&cert_context,
+                                                 CertAdd::ReplaceExisting)?;
                 Ok(cert_context)
             }
         }

--- a/tokio-udp/src/frame.rs
+++ b/tokio-udp/src/frame.rs
@@ -66,7 +66,7 @@ impl<C: Encoder> Sink for UdpFramed<C> {
         trace!("sending frame");
 
         if !self.flushed {
-            match try!(self.poll_complete()) {
+            match self.poll_complete()? {
                 Async::Ready(()) => {}
                 Async::NotReady => return Ok(AsyncSink::NotReady(item)),
             }

--- a/tokio-uds/src/frame.rs
+++ b/tokio-uds/src/frame.rs
@@ -66,7 +66,7 @@ impl<A: AsRef<Path>, C: Encoder> Sink for UnixDatagramFramed<A, C> {
         trace!("sending frame");
 
         if !self.flushed {
-            match try!(self.poll_complete()) {
+            match self.poll_complete()? {
                 Async::Ready(()) => {}
                 Async::NotReady => return Ok(AsyncSink::NotReady(item)),
             }

--- a/tokio-uds/src/stream.rs
+++ b/tokio-uds/src/stream.rs
@@ -78,7 +78,7 @@ impl UnixStream {
     /// communicating back and forth between one another. Each socket will
     /// be associated with the default event loop's handle.
     pub fn pair() -> io::Result<(UnixStream, UnixStream)> {
-        let (a, b) = try!(mio_uds::UnixStream::pair());
+        let (a, b) = mio_uds::UnixStream::pair()?;
         let a = UnixStream::new(a);
         let b = UnixStream::new(b);
 
@@ -262,7 +262,7 @@ impl Future for ConnectFuture {
                     return Ok(Async::NotReady);
                 }
 
-                if let Some(e) = try!(stream.io.get_ref().take_error()) {
+                if let Some(e) = stream.io.get_ref().take_error()? {
                     return Err(e);
                 }
             }

--- a/tokio/examples/proxy.rs
+++ b/tokio/examples/proxy.rs
@@ -124,7 +124,7 @@ impl AsyncRead for MyTcpStream {}
 
 impl AsyncWrite for MyTcpStream {
     fn shutdown(&mut self) -> Poll<(), io::Error> {
-        try!(self.0.lock().unwrap().shutdown(Shutdown::Write));
+        self.0.lock().unwrap().shutdown(Shutdown::Write)?;
         Ok(().into())
     }
 }

--- a/tokio/src/codec/length_delimited.rs
+++ b/tokio/src/codec/length_delimited.rs
@@ -530,7 +530,7 @@ impl Decoder for LengthDelimitedCodec {
 
     fn decode(&mut self, src: &mut BytesMut) -> io::Result<Option<BytesMut>> {
         let n = match self.state {
-            DecodeState::Head => match try!(self.decode_head(src)) {
+            DecodeState::Head => match self.decode_head(src)? {
                 Some(n) => {
                     self.state = DecodeState::Data(n);
                     n
@@ -540,7 +540,7 @@ impl Decoder for LengthDelimitedCodec {
             DecodeState::Data(n) => n,
         };
 
-        match try!(self.decode_data(n, src)) {
+        match self.decode_data(n, src)? {
             Some(data) => {
                 // Update the decode state
                 self.state = DecodeState::Head;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

https://doc.rust-lang.org/std/macro.try.html
> The ? operator was added to replace try! and should be used instead. Furthermore, try is a reserved word in Rust 2018, so if you must use it, you will need to use the raw-identifier syntax: r#try.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Replace try! macro with ? operator.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
