### PR TITLE
- remove default trace level and make log lvl mandatory on span! macro

### DIFF
--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -5,11 +5,12 @@ extern crate tokio_trace;
 extern crate log;
 extern crate test;
 use test::Bencher;
+use tokio_trace::Level;
 
 #[bench]
 fn bench_span_no_subscriber(b: &mut Bencher) {
     b.iter(|| {
-        span!("span");
+        span!(Level::TRACE, "span");
     });
 }
 
@@ -24,6 +25,7 @@ fn bench_log_no_logger(b: &mut Bencher) {
 fn bench_costly_field_no_subscriber(b: &mut Bencher) {
     b.iter(|| {
         span!(
+            Level::TRACE,
             "span",
             foo = tokio_trace::field::display(format!("bar {:?}", 2))
         );

--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -4,6 +4,7 @@
 extern crate tokio_trace;
 extern crate test;
 use test::Bencher;
+use tokio_trace::Level;
 
 use std::{
     fmt,
@@ -97,13 +98,15 @@ const N_SPANS: usize = 100;
 
 #[bench]
 fn span_no_fields(b: &mut Bencher) {
-    tokio_trace::subscriber::with_default(EnabledSubscriber, || b.iter(|| span!("span")));
+    tokio_trace::subscriber::with_default(EnabledSubscriber, || {
+        b.iter(|| span!(Level::TRACE, "span"))
+    });
 }
 
 #[bench]
 fn enter_span(b: &mut Bencher) {
     tokio_trace::subscriber::with_default(EnabledSubscriber, || {
-        b.iter(|| test::black_box(span!("span").enter(|| {})))
+        b.iter(|| test::black_box(span!(Level::TRACE, "span").enter(|| {})))
     });
 }
 
@@ -111,7 +114,7 @@ fn enter_span(b: &mut Bencher) {
 fn span_repeatedly(b: &mut Bencher) {
     #[inline]
     fn mk_span(i: u64) -> tokio_trace::Span {
-        span!("span", i = i)
+        span!(Level::TRACE, "span", i = i)
     }
 
     let n = test::black_box(N_SPANS);
@@ -125,6 +128,7 @@ fn span_with_fields(b: &mut Bencher) {
     tokio_trace::subscriber::with_default(EnabledSubscriber, || {
         b.iter(|| {
             span!(
+                Level::TRACE,
                 "span",
                 foo = "foo",
                 bar = "bar",
@@ -141,6 +145,7 @@ fn span_with_fields_record(b: &mut Bencher) {
     tokio_trace::subscriber::with_default(subscriber, || {
         b.iter(|| {
             span!(
+                Level::TRACE,
                 "span",
                 foo = "foo",
                 bar = "bar",

--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -5,7 +5,7 @@ use tokio_trace::{
     field::{Field, Visit},
     span,
     subscriber::{self, Subscriber},
-    Event, Id, Metadata,
+    Event, Id, Level, Metadata,
 };
 
 use std::{
@@ -125,10 +125,16 @@ fn main() {
 
     tokio_trace::subscriber::with_default(subscriber, || {
         let mut foo: u64 = 2;
-        span!("my_great_span", foo_count = &foo).enter(|| {
+        span!(Level::TRACE, "my_great_span", foo_count = &foo).enter(|| {
             foo += 1;
             info!({ yak_shaved = true, yak_count = 1 }, "hi from inside my span");
-            span!("my other span", foo_count = &foo, baz_count = 5).enter(|| {
+            span!(
+                Level::TRACE,
+                "my other span",
+                foo_count = &foo,
+                baz_count = 5
+            )
+            .enter(|| {
                 warn!({ yak_shaved = false, yak_count = -1 }, "failed to shave yak");
             });
         });

--- a/tokio-trace/examples/sloggish/main.rs
+++ b/tokio-trace/examples/sloggish/main.rs
@@ -13,7 +13,7 @@
 #[macro_use]
 extern crate tokio_trace;
 
-use tokio_trace::field;
+use tokio_trace::{field, Level};
 
 mod sloggish_subscriber;
 use self::sloggish_subscriber::SloggishSubscriber;
@@ -22,16 +22,16 @@ fn main() {
     let subscriber = SloggishSubscriber::new(2);
 
     tokio_trace::subscriber::with_default(subscriber, || {
-        span!("", version = &field::display(5.0)).enter(|| {
-            span!("server", host = "localhost", port = 8080).enter(|| {
+        span!(Level::TRACE, "", version = &field::display(5.0)).enter(|| {
+            span!(Level::TRACE, "server", host = "localhost", port = 8080).enter(|| {
                 info!("starting");
                 info!("listening");
-                let mut peer1 = span!("conn", peer_addr = "82.9.9.9", port = 42381);
+                let mut peer1 = span!(Level::TRACE, "conn", peer_addr = "82.9.9.9", port = 42381);
                 peer1.enter(|| {
                     debug!("connected");
                     debug!({ length = 2 }, "message received");
                 });
-                let mut peer2 = span!("conn", peer_addr = "8.8.8.8", port = 18230);
+                let mut peer2 = span!(Level::TRACE, "conn", peer_addr = "8.8.8.8", port = 18230);
                 peer2.enter(|| {
                     debug!("connected");
                 });

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -56,9 +56,10 @@
 //! construct one span and perform the entire loop inside of that span, like:
 //! ```rust
 //! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
 //! # let n = 1;
-//! span!("my loop").enter(|| {
+//! span!(Level::TRACE, "my loop").enter(|| {
 //!     for i in 0..n {
 //!         # let _ = i;
 //!         // ...
@@ -69,11 +70,12 @@
 //! Or, should we create a new span for each iteration of the loop, as in:
 //! ```rust
 //! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
 //! # let n = 1u64;
 //! for i in 0..n {
 //!     # let _ = i;
-//!     span!("my loop", iteration = i).enter(|| {
+//!     span!(Level::TRACE, "my loop", iteration = i).enter(|| {
 //!         // ...
 //!     })
 //! }
@@ -154,9 +156,10 @@
 //! ```rust
 //! # #[macro_use]
 //! # extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
-//! // Construct a new span named "my span".
-//! let mut span = span!("my span");
+//! // Construct a new span named "my span" with trace log level.
+//! let mut span = span!(Level::TRACE, "my span");
 //! span.enter(|| {
 //!     // Any trace events in this closure or code called by it will occur within
 //!     // the span.
@@ -188,7 +191,7 @@
 //! ```rust
 //! #[macro_use]
 //! extern crate tokio_trace;
-//! use tokio_trace::field;
+//! use tokio_trace::{field, Level};
 //! # #[derive(Debug)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, u32> { Ok(1) }
@@ -196,7 +199,7 @@
 //! pub fn shave_the_yak(yak: &mut Yak) {
 //!     // Create a new span for this invocation of `shave_the_yak`, annotated
 //!     // with  the yak being shaved as a *field* on the span.
-//!     span!("shave_the_yak", yak = field::debug(&yak)).enter(|| {
+//!     span!(Level::TRACE, "shave_the_yak", yak = field::debug(&yak)).enter(|| {
 //!         // Since the span is annotated with the yak, it is part of the context
 //!         // for everything happening inside the span. Therefore, we don't need
 //!         // to add it to the message for this event, as the `log` crate does.

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -12,9 +12,10 @@
 //! if the span exists:
 //! ```
 //! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
 //! let my_var: u64 = 5;
-//! let mut my_span = span!("my_span", my_var = &my_var);
+//! let mut my_span = span!(Level::TRACE, "my_span", my_var = &my_var);
 //!
 //! my_span.enter(|| {
 //!     // perform some work in the context of `my_span`...
@@ -78,9 +79,10 @@
 //! exists. For example:
 //! ```
 //! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
 //! {
-//!     span!("my_span").enter(|| {
+//!     span!(Level::TRACE, "my_span").enter(|| {
 //!         // perform some work in the context of `my_span`...
 //!     }); // --> Subscriber::exit(my_span)
 //!
@@ -96,10 +98,11 @@
 //! time it is exited. For example:
 //! ```
 //! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
 //! # fn main() {
 //! use tokio_trace::Span;
 //!
-//! let my_span = span!("my_span");
+//! let my_span = span!(Level::TRACE, "my_span");
 //! // Drop the handle to the span.
 //! drop(my_span); // --> Subscriber::drop_span(my_span)
 //! # }

--- a/tokio-trace/test-log-support/tests/log_no_trace.rs
+++ b/tokio-trace/test-log-support/tests/log_no_trace.rs
@@ -4,6 +4,7 @@ extern crate tokio_trace;
 
 use log::{LevelFilter, Log, Metadata, Record};
 use std::sync::{Arc, Mutex};
+use tokio_trace::Level;
 
 struct State {
     last_log: Mutex<Option<String>>,
@@ -41,7 +42,7 @@ fn test_always_log() {
     info!(message = "hello world;", thingy = 42, other_thingy = 666);
     last(&a, "hello world; thingy=42 other_thingy=666");
 
-    let mut foo = span!("foo");
+    let mut foo = span!(Level::TRACE, "foo");
     last(&a, "foo;");
     foo.enter(|| {
         last(&a, "-> foo");
@@ -51,10 +52,10 @@ fn test_always_log() {
     });
     last(&a, "<- foo");
 
-    span!("foo", bar = 3, baz = false);
+    span!(Level::TRACE, "foo", bar = 3, baz = false);
     last(&a, "foo; bar=3 baz=false");
 
-    let mut span = span!("foo", bar, baz);
+    let mut span = span!(Level::TRACE, "foo", bar, baz);
     span.record("bar", &3);
     last(&a, "foo; bar=3");
     span.record("baz", &"a string");

--- a/tokio-trace/test_static_max_level_features/tests/test.rs
+++ b/tokio-trace/test_static_max_level_features/tests/test.rs
@@ -51,15 +51,15 @@ fn test_static_max_level_features() {
         trace!("");
         last(&a, None);
 
-        span!(level: Level::ERROR, "");
+        span!(Level::ERROR, "");
         last(&a, None);
-        span!(level: Level::WARN, "");
+        span!(Level::WARN, "");
         last(&a, None);
-        span!(level: Level::INFO, "");
+        span!(Level::INFO, "");
         last(&a, None);
-        span!(level: Level::DEBUG, "");
+        span!(Level::DEBUG, "");
         last(&a, None);
-        span!(level: Level::TRACE, "");
+        span!(Level::TRACE, "");
         last(&a, None);
     });
 }

--- a/tokio-trace/tests/event.rs
+++ b/tokio-trace/tests/event.rs
@@ -68,7 +68,7 @@ fn one_with_everything() {
                         .and(field::mock("bar").with_value(&false))
                         .only(),
                 )
-                .at_level(tokio_trace::Level::ERROR)
+                .at_level(Level::ERROR)
                 .with_target("whatever"),
         )
         .done()
@@ -77,7 +77,7 @@ fn one_with_everything() {
     with_default(subscriber, || {
         event!(
             target: "whatever",
-            tokio_trace::Level::ERROR,
+            Level::ERROR,
             { foo = 666, bar = false },
              "{:#x} make me one with{what:.>20}", 4277009102u64, what = "everything"
         );

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -1,3 +1,5 @@
+use tokio_trace::Level;
+
 #[macro_use]
 extern crate tokio_trace;
 // Tests that macros work across various invocation syntax.
@@ -8,95 +10,258 @@ extern crate tokio_trace;
 
 #[test]
 fn span() {
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 3);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 4,);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "foo");
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, "bar",);
-    span!(level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 3);
-    span!(level: tokio_trace::Level::DEBUG, "foo", bar = 2, baz = 4,);
-    span!(level: tokio_trace::Level::DEBUG, "foo");
-    span!(level: tokio_trace::Level::DEBUG, "bar",);
-    span!("foo", bar = 2, baz = 3);
-    span!("foo", bar = 2, baz = 4,);
-    span!("foo");
-    span!("bar",);
+    span!(Level::DEBUG, target: "foo_events", "foo", bar = 2, baz = 3);
+    span!(Level::DEBUG, target: "foo_events", "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", "foo");
+    span!(Level::DEBUG, target: "foo_events", "bar",);
+    span!(Level::DEBUG, "foo", bar = 2, baz = 3);
+    span!(Level::DEBUG, "foo", bar = 2, baz = 4,);
+    span!(Level::TRACE, "foo", bar = 2, baz = 3);
+    span!(Level::TRACE, "foo", bar = 2, baz = 4,);
+    span!(Level::TRACE, "foo");
+    span!(Level::TRACE, "bar",);
+}
+
+#[test]
+fn trace_span() {
+    trace_span!(target: "foo_events", "foo", bar = 2, baz = 3);
+    trace_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", "foo");
+    trace_span!(target: "foo_events", "bar",);
+    trace_span!("foo", bar = 2, baz = 3);
+    trace_span!("foo", bar = 2, baz = 4,);
+    trace_span!("bar");
+    trace_span!("bar",);
+}
+
+#[test]
+fn debug_span() {
+    debug_span!(target: "foo_events", "foo", bar = 2, baz = 3);
+    debug_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", "foo");
+    debug_span!(target: "foo_events", "bar",);
+    debug_span!("foo", bar = 2, baz = 3);
+    debug_span!("foo", bar = 2, baz = 4,);
+    debug_span!("bar");
+    debug_span!("bar",);
+}
+
+#[test]
+fn info_span() {
+    info_span!(target: "foo_events", "foo", bar = 2, baz = 3);
+    info_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", "foo");
+    info_span!(target: "foo_events", "bar",);
+    info_span!("foo", bar = 2, baz = 3);
+    info_span!("foo", bar = 2, baz = 4,);
+    info_span!("bar");
+    info_span!("bar",);
+}
+
+#[test]
+fn warn_span() {
+    warn_span!(target: "foo_events", "foo", bar = 2, baz = 3);
+    warn_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", "foo");
+    warn_span!(target: "foo_events", "bar",);
+    warn_span!("foo", bar = 2, baz = 3);
+    warn_span!("foo", bar = 2, baz = 4,);
+    warn_span!("bar");
+    warn_span!("bar",);
+}
+
+#[test]
+fn error_span() {
+    error_span!(target: "foo_events", "foo", bar = 2, baz = 3);
+    error_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", "foo");
+    error_span!(target: "foo_events", "bar",);
+    error_span!("foo", bar = 2, baz = 3);
+    error_span!("foo", bar = 2, baz = 4,);
+    error_span!("bar");
+    error_span!("bar",);
 }
 
 #[test]
 fn span_root() {
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: None, "foo", bar = 2, baz = 3);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: None, "foo", bar = 2, baz = 4,);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: None, "foo");
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: None, "bar",);
-    span!(
-        level: tokio_trace::Level::DEBUG,
-        parent: None,
-        "foo",
-        bar = 2,
-        baz = 3
-    );
-    span!(
-        level: tokio_trace::Level::DEBUG,
-        parent: None,
-        "foo",
-        bar = 2,
-        baz = 4,
-    );
-    span!(level: tokio_trace::Level::DEBUG, parent: None, "foo");
-    span!(level: tokio_trace::Level::DEBUG, parent: None, "bar",);
-    span!(parent: None, "foo", bar = 2, baz = 3);
-    span!(parent: None, "foo", bar = 2, baz = 4,);
-    span!(parent: None, "foo");
-    span!(parent: None, "bar",);
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo");
+    span!(Level::DEBUG, target: "foo_events", parent: None, "bar",);
+    span!(Level::TRACE, parent: None, "foo", bar = 2, baz = 3);
+    span!(Level::TRACE, parent: None, "foo", bar = 2, baz = 4,);
+    span!(Level::TRACE, parent: None, "foo");
+    span!(Level::TRACE, parent: None, "bar",);
+}
+
+#[test]
+fn trace_span_root() {
+    trace_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    trace_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", parent: None, "foo");
+    trace_span!(target: "foo_events", parent: None, "bar",);
+    trace_span!(parent: None, "foo", bar = 2, baz = 3);
+    trace_span!(parent: None, "foo", bar = 2, baz = 4,);
+    trace_span!(parent: None, "foo");
+    trace_span!(parent: None, "bar",);
+}
+
+#[test]
+fn debug_span_root() {
+    debug_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    debug_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", parent: None, "foo");
+    debug_span!(target: "foo_events", parent: None, "bar",);
+    debug_span!(parent: None, "foo", bar = 2, baz = 3);
+    debug_span!(parent: None, "foo", bar = 2, baz = 4,);
+    debug_span!(parent: None, "foo");
+    debug_span!(parent: None, "bar",);
+}
+
+#[test]
+fn info_span_root() {
+    info_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    info_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", parent: None, "foo");
+    info_span!(target: "foo_events", parent: None, "bar",);
+    info_span!(parent: None, "foo", bar = 2, baz = 3);
+    info_span!(parent: None, "foo", bar = 2, baz = 4,);
+    info_span!(parent: None, "foo");
+    info_span!(parent: None, "bar",);
+}
+
+#[test]
+fn warn_span_root() {
+    warn_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    warn_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", parent: None, "foo");
+    warn_span!(target: "foo_events", parent: None, "bar",);
+    warn_span!(parent: None, "foo", bar = 2, baz = 3);
+    warn_span!(parent: None, "foo", bar = 2, baz = 4,);
+    warn_span!(parent: None, "foo");
+    warn_span!(parent: None, "bar",);
+}
+
+#[test]
+fn error_span_root() {
+    error_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
+    error_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", parent: None, "foo");
+    error_span!(target: "foo_events", parent: None, "bar",);
+    error_span!(parent: None, "foo", bar = 2, baz = 3);
+    error_span!(parent: None, "foo", bar = 2, baz = 4,);
+    error_span!(parent: None, "foo");
+    error_span!(parent: None, "bar",);
 }
 
 #[test]
 fn span_with_parent() {
-    let p = span!("im_a_parent!");
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: &p, "foo", bar = 2, baz = 3);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: &p, "foo", bar = 2, baz = 4,);
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: &p, "foo");
-    span!(target: "foo_events", level: tokio_trace::Level::DEBUG, parent: &p, "bar",);
-    span!(
-        level: tokio_trace::Level::DEBUG,
-        parent: &p,
-        "foo",
-        bar = 2,
-        baz = 3
-    );
-    span!(
-        level: tokio_trace::Level::DEBUG,
-        parent: &p,
-        "foo",
-        bar = 2,
-        baz = 4,
-    );
-    span!(level: tokio_trace::Level::DEBUG, parent: &p, "foo");
-    span!(level: tokio_trace::Level::DEBUG, parent: &p, "bar",);
-    span!(parent: &p, "foo", bar = 2, baz = 3);
-    span!(parent: &p, "foo", bar = 2, baz = 4,);
-    span!(parent: &p, "foo");
-    span!(parent: &p, "bar",);
+    let p = span!(Level::TRACE, "im_a_parent!");
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo");
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "bar",);
+
+    span!(Level::DEBUG, parent: &p, "foo", bar = 2, baz = 3);
+    span!(Level::DEBUG, parent: &p, "foo", bar = 2, baz = 4,);
+
+    span!(Level::DEBUG, parent: &p, "foo");
+    span!(Level::DEBUG, parent: &p, "bar",);
+}
+
+#[test]
+fn trace_span_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    trace_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    trace_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", parent: &p, "foo");
+    trace_span!(target: "foo_events", parent: &p, "bar",);
+
+    trace_span!(parent: &p, "foo", bar = 2, baz = 3);
+    trace_span!(parent: &p, "foo", bar = 2, baz = 4,);
+
+    trace_span!(parent: &p, "foo");
+    trace_span!(parent: &p, "bar",);
+}
+
+#[test]
+fn debug_span_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    debug_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    debug_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", parent: &p, "foo");
+    debug_span!(target: "foo_events", parent: &p, "bar",);
+
+    debug_span!(parent: &p, "foo", bar = 2, baz = 3);
+    debug_span!(parent: &p, "foo", bar = 2, baz = 4,);
+
+    debug_span!(parent: &p, "foo");
+    debug_span!(parent: &p, "bar",);
+}
+
+#[test]
+fn info_span_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    info_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    info_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", parent: &p, "foo");
+    info_span!(target: "foo_events", parent: &p, "bar",);
+
+    info_span!(parent: &p, "foo", bar = 2, baz = 3);
+    info_span!(parent: &p, "foo", bar = 2, baz = 4,);
+
+    info_span!(parent: &p, "foo");
+    info_span!(parent: &p, "bar",);
+}
+
+#[test]
+fn warn_span_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    warn_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    warn_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", parent: &p, "foo");
+    warn_span!(target: "foo_events", parent: &p, "bar",);
+
+    warn_span!(parent: &p, "foo", bar = 2, baz = 3);
+    warn_span!(parent: &p, "foo", bar = 2, baz = 4,);
+
+    warn_span!(parent: &p, "foo");
+    warn_span!(parent: &p, "bar",);
+}
+
+#[test]
+fn error_span_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    error_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
+    error_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", parent: &p, "foo");
+    error_span!(target: "foo_events", parent: &p, "bar",);
+
+    error_span!(parent: &p, "foo", bar = 2, baz = 3);
+    error_span!(parent: &p, "foo", bar = 2, baz = 4,);
+
+    error_span!(parent: &p, "foo");
+    error_span!(parent: &p, "bar",);
 }
 
 #[test]
 fn event() {
-    event!(tokio_trace::Level::DEBUG, foo = 3, bar = 2, baz = false);
-    event!(tokio_trace::Level::DEBUG, foo = 3, bar = 3,);
-    event!(tokio_trace::Level::DEBUG, "foo");
-    event!(tokio_trace::Level::DEBUG, "foo: {}", 3);
-    event!(tokio_trace::Level::DEBUG, { foo = 3, bar = 80 }, "baz");
-    event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
-    event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    event!(tokio_trace::Level::DEBUG, { foo = 2, bar = 78, }, "baz");
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, foo = 3, bar = 2, baz = false);
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, foo = 3, bar = 3,);
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, "foo");
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, "foo: {}", 3);
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 3, bar = 80 }, "baz");
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    event!(target: "foo_events", tokio_trace::Level::DEBUG, { foo = 2, bar = 78, }, "baz");
+    event!(Level::DEBUG, foo = 3, bar = 2, baz = false);
+    event!(Level::DEBUG, foo = 3, bar = 3,);
+    event!(Level::DEBUG, "foo");
+    event!(Level::DEBUG, "foo: {}", 3);
+    event!(Level::DEBUG, { foo = 3, bar = 80 }, "baz");
+    event!(Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
+    event!(Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    event!(Level::DEBUG, { foo = 2, bar = 78, }, "baz");
+    event!(target: "foo_events", Level::DEBUG, foo = 3, bar = 2, baz = false);
+    event!(target: "foo_events", Level::DEBUG, foo = 3, bar = 3,);
+    event!(target: "foo_events", Level::DEBUG, "foo");
+    event!(target: "foo_events", Level::DEBUG, "foo: {}", 3);
+    event!(target: "foo_events", Level::DEBUG, { foo = 3, bar = 80 }, "baz");
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 78, }, "baz");
 }
 
 #[test]


### PR DESCRIPTION
## Motivation
Was determined that having the span! macro default to the TRACE level is probably not ideal (see discussion on #952).
closes #1013 

## Solution
remove default trace level and make log lvl mandatory on span! macro, and add the respective 
`trace_span!`, `debug_span!`, `info_span!`, `warn_span!` and `error_span!` macros that behave as span! macro, but with defined log levels

## Notes
I think this is it, also removed some captures that were repeated, and some testcases that also seemed repeated after adding the mandatory log level, but please review it, if more tests or examples are needed happy to provide (tried to find a way to get the generated macros log level, but didn't find one, if there is a way i can add tests to assert that the generated macro has the matching log level ).
thanks