### PR TITLE
trace: Allow field names to be separated by `.`s

### DIFF
--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -1438,10 +1438,10 @@ macro_rules! __tokio_trace_log {
                     .metadata(log_meta)
                     .args(__tokio_trace_format_args!(
                         __tokio_trace_concat!(
-                            $(__tokio_trace_log!(@key $key)),*
+                            $(__tokio_trace_log!(@key $($k).+)),*
                         ),
                         $(
-                            __tokio_trace_log!(@val_or $key $( = $val)* )
+                            __tokio_trace_log!(@val_or $($k).+ $( = $val)* )
                         ),*
                     ))
                     .build());
@@ -1449,7 +1449,7 @@ macro_rules! __tokio_trace_log {
         }
     };
     (@key message) => { "{} " };
-    (@key $($k:ident).+) => { __tokio_trace_concat!(__tokio_trace_stringify!( $key ), "={:?} ") };
+    (@key $($k:ident).+) => { __tokio_trace_concat!(__tokio_trace_stringify!( $($k).+ ), "={:?} ") };
     (@val_or $($k:ident).+ = $v:expr) => { $v };
     (@val_or $($k:ident).+ ) => { __tokio_trace_format_args!("?") };
 }

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -87,16 +87,16 @@
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! span {
-    ($lvl:expr, target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr )* ),*,) => {
+    ($lvl:expr, target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr )* ),*,) => {
         span!(
             $lvl,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($lvl:expr, target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr )* ),*) => {
+    ($lvl:expr, target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr )* ),*) => {
         {
             use $crate::callsite;
             use $crate::callsite::Callsite;
@@ -104,7 +104,7 @@ macro_rules! span {
                 name: $name,
                 target: $target,
                 level: $lvl,
-                fields: $($k),*
+                fields: $($($k).+),*
             };
             let meta = callsite.metadata();
 
@@ -112,17 +112,17 @@ macro_rules! span {
                 $crate::Span::child_of(
                     $parent,
                     meta,
-                    &valueset!(meta.fields(), $($k $( = $val)*),*),
+                    &valueset!(meta.fields(), $($($k).+ $( = $val)*),*),
                 )
             } else {
                  __tokio_trace_disabled_span!(
                     meta,
-                    &valueset!(meta.fields(), $($k $( = $val)*),*)
+                    &valueset!(meta.fields(), $($($k).+ $( = $val)*),*)
                 )
             }
         }
     };
-    ($lvl:expr, target: $target:expr, $name:expr,$($k:ident $( = $val:expr )* ),*) => {
+    ($lvl:expr, target: $target:expr, $name:expr,$($($k:ident).+ $( = $val:expr )* ),*) => {
         {
             use $crate::callsite;
             use $crate::callsite::Callsite;
@@ -130,19 +130,19 @@ macro_rules! span {
                 name: $name,
                 target: $target,
                 level: $lvl,
-                fields: $($k),*
+                fields: $( $($k).+ ),*
             };
             let meta = callsite.metadata();
 
             if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL && is_enabled!(callsite) {
                 $crate::Span::new(
                     meta,
-                    &valueset!(meta.fields(), $($k $( = $val)*),*),
+                    &valueset!(meta.fields(), $($($k).+ $( = $val)*),*),
                 )
             } else {
                 __tokio_trace_disabled_span!(
                     meta,
-                    &valueset!(meta.fields(), $($k $( = $val)*),*)
+                    &valueset!(meta.fields(), $($($k).+ $( = $val)*),*)
                 )
             }
         }
@@ -151,22 +151,22 @@ macro_rules! span {
     ($lvl:expr, target: $target:expr, parent: $parent:expr, $name:expr) => {
         span!($lvl, target: $target, parent: $parent, $name,)
     };
-    ($lvl:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($lvl:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         span!(
             $lvl,
             target: __tokio_trace_module_path!(),
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($lvl:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($lvl:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $lvl,
             target: __tokio_trace_module_path!(),
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($lvl:expr, parent: $parent:expr, $name:expr) => {
@@ -177,40 +177,40 @@ macro_rules! span {
             $name,
         )
     };
-    ($lvl:expr, target: $target:expr, $name:expr, $($k:ident $( = $val:expr )* ),*,
+    ($lvl:expr, target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr )* ),*,
     ) => {
         span!(
             $lvl,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($lvl:expr, target: $target:expr, $name:expr, $($k:ident $( = $val:expr )* ),*) => {
+    ($lvl:expr, target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr )* ),*) => {
         span!(
             $lvl,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($lvl:expr, target: $target:expr, $name:expr) => {
         span!($lvl, target: $target, $name,)
     };
-    ($lvl:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($lvl:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         span!(
             $lvl,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($lvl:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($lvl:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $lvl,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($lvl:expr, $name:expr) => {
@@ -238,74 +238,74 @@ macro_rules! span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! trace_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         trace_span!(
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::TRACE,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         trace_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         trace_span!(
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::TRACE,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         trace_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         trace_span!(
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::TRACE,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, $name:expr) => {
         trace_span!(target: $target, $name,)
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         trace_span!(
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::TRACE,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($name:expr) => {trace_span!($name,)};
@@ -327,74 +327,74 @@ macro_rules! trace_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! debug_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         debug_span!(
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::DEBUG,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         debug_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         debug_span!(
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::DEBUG,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         debug_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         debug_span!(
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::DEBUG,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, $name:expr) => {
         debug_span!(target: $target, $name,)
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         debug_span!(
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::DEBUG,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($name:expr) => {debug_span!($name,)};
@@ -416,74 +416,74 @@ macro_rules! debug_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! info_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         info_span!(
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::INFO,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         info_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         info_span!(
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         info_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         info_span!(
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::INFO,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, $name:expr) => {
         info_span!(target: $target, $name,)
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         info_span!(
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($name:expr) => {info_span!($name,)};
@@ -505,74 +505,74 @@ macro_rules! info_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! warn_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         warn_span!(
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::WARN,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         warn_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         warn_span!(
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::WARN,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         warn_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         warn_span!(
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::WARN,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, $name:expr) => {
         warn_span!(target: $target, $name,)
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         warn_span!(
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::WARN,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($name:expr) => {warn_span!($name,)};
@@ -593,74 +593,74 @@ macro_rules! warn_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! error_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         error_span!(
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::ERROR,
             target: $target,
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         error_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         error_span!(
             parent: $parent,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (parent: $parent:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::ERROR,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         error_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         error_span!(
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    (target: $target:expr, $name:expr, $($k:ident $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::ERROR,
             target: $target,
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     (target: $target:expr, $name:expr) => {
         error_span!(target: $target, $name,)
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*,) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
         error_span!(
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
-    ($name:expr, $($k:ident $( = $val:expr)*),*) => {
+    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
         span!(
             $crate::Level::ERROR,
             target: __tokio_trace_module_path!(),
             $name,
-            $($k $( = $val)*),*
+            $($($k).+ $( = $val)*),*
         )
     };
     ($name:expr) => {error_span!($name,)};
@@ -723,12 +723,12 @@ macro_rules! error_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! event {
-    (target: $target:expr, $lvl:expr, { $( $k:ident = $val:expr ),* $(,)*} )=> ({
+    (target: $target:expr, $lvl:expr, { $( $($k:ident).+ = $val:expr ),* $(,)*} )=> ({
         {
             __tokio_trace_log!(
                 target: $target,
                 $lvl,
-                $( $k = $val ),*
+                $( $($k).+ = $val ),*
             );
 
             if $lvl <= $crate::level_filters::STATIC_MAX_LEVEL {
@@ -744,11 +744,11 @@ macro_rules! event {
                     ),
                     target: $target,
                     level: $lvl,
-                    fields: $( $k ),*
+                    fields: $( $($k).+ ),*
                 };
                 if is_enabled!(callsite) {
                     let meta = callsite.metadata();
-                    Event::dispatch(meta, &valueset!(meta.fields(), $( $k = $val),* ));
+                    Event::dispatch(meta, &valueset!(meta.fields(), $( $($k).+ = $val),* ));
                 }
             }
         }
@@ -756,55 +756,55 @@ macro_rules! event {
     (
         target: $target:expr,
         $lvl:expr,
-        { $( $k:ident = $val:expr ),*, },
+        { $( $($k:ident).+ = $val:expr ),*, },
         $($arg:tt)+
     ) => ({
         event!(
             target: $target,
             $lvl,
-            { message = __tokio_trace_format_args!($($arg)+), $( $k = $val ),* }
+            { message = __tokio_trace_format_args!($($arg)+), $( $($k).+ = $val ),* }
         )
     });
     (
         target: $target:expr,
         $lvl:expr,
-        { $( $k:ident = $val:expr ),* },
+        { $( $($k:ident).+ = $val:expr ),* },
         $($arg:tt)+
     ) => ({
         event!(
             target: $target,
             $lvl,
-            { message = __tokio_trace_format_args!($($arg)+), $( $k = $val ),* }
+            { message = __tokio_trace_format_args!($($arg)+), $( $($k).+ = $val ),* }
         )
     });
-    (target: $target:expr, $lvl:expr, $( $k:ident = $val:expr ),+, ) => (
-        event!(target: $target, $lvl, { $($k = $val),+ })
+    (target: $target:expr, $lvl:expr, $( $($k:ident).+ = $val:expr ),+, ) => (
+        event!(target: $target, $lvl, { $($($k).+ = $val),+ })
     );
-    (target: $target:expr, $lvl:expr, $( $k:ident = $val:expr ),+ ) => (
-        event!(target: $target, $lvl, { $($k = $val),+ })
+    (target: $target:expr, $lvl:expr, $( $($k:ident).+ = $val:expr ),+ ) => (
+        event!(target: $target, $lvl, { $($($k).+ = $val),+ })
     );
     (target: $target:expr, $lvl:expr, $($arg:tt)+ ) => (
         event!(target: $target, $lvl, { }, $($arg)+)
     );
-    ( $lvl:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ( $lvl:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $lvl,
-            { message = __tokio_trace_format_args!($($arg)+), $($k = $val),* }
+            { message = __tokio_trace_format_args!($($arg)+), $($($k).+ = $val),* }
         )
     );
-    ( $lvl:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ( $lvl:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $lvl,
-            { message = __tokio_trace_format_args!($($arg)+), $($k = $val),* }
+            { message = __tokio_trace_format_args!($($arg)+), $($($k).+ = $val),* }
         )
     );
-    ( $lvl:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: __tokio_trace_module_path!(), $lvl, { $($k = $val),* })
+    ( $lvl:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: __tokio_trace_module_path!(), $lvl, { $($($k).+ = $val),* })
     );
-    ( $lvl:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: __tokio_trace_module_path!(), $lvl, { $($k = $val),* })
+    ( $lvl:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: __tokio_trace_module_path!(), $lvl, { $($($k).+ = $val),* })
     );
     ( $lvl:expr, $($arg:tt)+ ) => (
         event!(target: __tokio_trace_module_path!(), $lvl, { }, $($arg)+)
@@ -847,49 +847,49 @@ macro_rules! event {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! trace {
-    (target: $target:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* })
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::TRACE, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ($( $k:ident = $val:expr ),*, ) => (
+    ($( $($k:ident).+ = $val:expr ),*, ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $($k:ident).+ = $val:expr ),* ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
     ($($arg:tt)+ ) => (
@@ -925,45 +925,45 @@ macro_rules! trace {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
-    (target: $target:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* })
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::DEBUG, {}, $($arg)+)
     );
-    ({ $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
-            target: __tokio_trace_module_path!(), $crate::Level::DEBUG, { $($k = $val),* }, $($arg)+)
+            target: __tokio_trace_module_path!(), $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ($( $k:ident = $val:expr ),*, ) => (
+    ($( $($k:ident).+ = $val:expr ),*, ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $($k:ident).+ = $val:expr ),* ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
     ($($arg:tt)+ ) => (
@@ -1006,49 +1006,49 @@ macro_rules! debug {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! info {
-    (target: $target:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::INFO, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::INFO, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::INFO, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* })
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::INFO, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::INFO, {}, $($arg)+)
     );
-    ({ $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ($( $k:ident = $val:expr ),*, ) => (
+    ($( $($k:ident).+ = $val:expr ),*, ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $($k:ident).+ = $val:expr ),* ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
     ($($arg:tt)+ ) => (
@@ -1088,48 +1088,48 @@ macro_rules! info {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
-    (target: $target:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::WARN, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::WARN, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::WARN, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* })
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::WARN, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         drop(event!(target: $target, $crate::Level::WARN, {}, $($arg)+));
     );
-    ({ $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ($( $k:ident = $val:expr ),*, ) => (
+    ($( $($k:ident).+ = $val:expr ),*, ) => (
         event!(
             target: __tokio_trace_module_path!(),
-            $crate::Level::WARN,{ $($k = $val),* }
+            $crate::Level::WARN,{ $($($k).+ = $val),* }
         )
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $($k:ident).+ = $val:expr ),* ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
     ($($arg:tt)+ ) => (
@@ -1164,49 +1164,49 @@ macro_rules! warn {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! error {
-    (target: $target:expr, { $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, { $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($k = $val),* }, $($arg)+)
+    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* }, $($arg)+)
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* })
     );
-    (target: $target:expr, $( $k:ident = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($k = $val),* })
+    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::ERROR, {}, $($arg)+)
     );
-    ({ $( $k:ident = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ({ $( $k:ident = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($k = $val),* },
+            { $($($k).+ = $val),* },
             $($arg)+
         )
     );
-    ($( $k:ident = $val:expr ),*, ) => (
+    ($( $($k:ident).+ = $val:expr ),*, ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
-    ($( $k:ident = $val:expr ),* ) => (
+    ($( $($k:ident).+ = $val:expr ),* ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($k = $val),* }
+            { $($($k).+ = $val),* }
         )
     );
     ($($arg:tt)+ ) => (
@@ -1327,21 +1327,21 @@ macro_rules! is_enabled {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! valueset {
-    ($fields:expr, $($k:ident $( = $val:expr )* ) ,*) => {
+    ($fields:expr, $($($k:ident).+ $( = $val:expr )* ) ,*) => {
         {
             let mut iter = $fields.iter();
             $fields.value_set(&[
                 $((
                     &iter.next().expect("FieldSet corrupted (this is a bug)"),
-                    valueset!(@val $k $(= $val)*)
+                    valueset!(@val $($k).+ $(= $val)*)
                 )),*
             ])
         }
     };
-    (@val $k:ident = $val:expr) => {
+    (@val $($k:ident).+ = $val:expr) => {
         Some(&$val as &$crate::field::Value)
     };
-    (@val $k:ident) => { None };
+    (@val $($k:ident).+) => { None };
 }
 
 // The macros above cannot invoke format_args directly because they use
@@ -1421,7 +1421,7 @@ macro_rules! level_to_log {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __tokio_trace_log {
-    (target: $target:expr, $level:expr, $( $key:ident $( = $val:expr )* ),* $(,)* ) => {
+    (target: $target:expr, $level:expr, $( $($k:ident).+ $( = $val:expr )* ),* $(,)* ) => {
         use $crate::log;
         let level = level_to_log!($level);
         if level <= log::STATIC_MAX_LEVEL {
@@ -1449,16 +1449,16 @@ macro_rules! __tokio_trace_log {
         }
     };
     (@key message) => { "{} " };
-    (@key $key:ident) => { __tokio_trace_concat!(__tokio_trace_stringify!( $key ), "={:?} ") };
-    (@val_or $k:ident = $v:expr) => { $v };
-    (@val_or $k:ident ) => { __tokio_trace_format_args!("?") };
+    (@key $($k:ident).+) => { __tokio_trace_concat!(__tokio_trace_stringify!( $key ), "={:?} ") };
+    (@val_or $($k:ident).+ = $v:expr) => { $v };
+    (@val_or $($k:ident).+ ) => { __tokio_trace_format_args!("?") };
 }
 
 #[cfg(not(feature = "log"))]
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __tokio_trace_log {
-    (target: $target:expr, $level:expr, $( $key:ident $( = $val:expr )* ),* $(,)* ) => {};
+    (target: $target:expr, $level:expr, $( $($k:ident).+ $( = $val:expr )* ),* $(,)* ) => {};
 }
 
 #[cfg(feature = "log")]

--- a/tokio-trace/tests/event.rs
+++ b/tokio-trace/tests/event.rs
@@ -107,6 +107,26 @@ fn moved_field() {
 }
 
 #[test]
+fn dotted_field_name() {
+    let (subscriber, handle) = subscriber::mock()
+        .event(
+            event::mock().with_fields(
+                field::mock("foo.bar")
+                    .with_value(&true)
+                    .and(field::mock("foo.baz").with_value(&false))
+                    .only(),
+            ),
+        )
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || {
+        event!(Level::INFO, foo.bar = true, foo.baz = false);
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
 fn borrowed_field() {
     let (subscriber, handle) = subscriber::mock()
         .event(

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -10,146 +10,146 @@ extern crate tokio_trace;
 
 #[test]
 fn span() {
-    span!(Level::DEBUG, target: "foo_events", "foo", bar = 2, baz = 3);
-    span!(Level::DEBUG, target: "foo_events", "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, target: "foo_events", "foo");
     span!(Level::DEBUG, target: "foo_events", "bar",);
-    span!(Level::DEBUG, "foo", bar = 2, baz = 3);
-    span!(Level::DEBUG, "foo", bar = 2, baz = 4,);
-    span!(Level::TRACE, "foo", bar = 2, baz = 3);
-    span!(Level::TRACE, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
+    span!(Level::TRACE, "foo", bar.baz = 2, quux = 3);
+    span!(Level::TRACE, "foo", bar.baz = 2, quux = 4,);
     span!(Level::TRACE, "foo");
     span!(Level::TRACE, "bar",);
 }
 
 #[test]
 fn trace_span() {
-    trace_span!(target: "foo_events", "foo", bar = 2, baz = 3);
-    trace_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     trace_span!(target: "foo_events", "foo");
     trace_span!(target: "foo_events", "bar",);
-    trace_span!("foo", bar = 2, baz = 3);
-    trace_span!("foo", bar = 2, baz = 4,);
+    trace_span!("foo", bar.baz = 2, quux = 3);
+    trace_span!("foo", bar.baz = 2, quux = 4,);
     trace_span!("bar");
     trace_span!("bar",);
 }
 
 #[test]
 fn debug_span() {
-    debug_span!(target: "foo_events", "foo", bar = 2, baz = 3);
-    debug_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     debug_span!(target: "foo_events", "foo");
     debug_span!(target: "foo_events", "bar",);
-    debug_span!("foo", bar = 2, baz = 3);
-    debug_span!("foo", bar = 2, baz = 4,);
+    debug_span!("foo", bar.baz = 2, quux = 3);
+    debug_span!("foo", bar.baz = 2, quux = 4,);
     debug_span!("bar");
     debug_span!("bar",);
 }
 
 #[test]
 fn info_span() {
-    info_span!(target: "foo_events", "foo", bar = 2, baz = 3);
-    info_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     info_span!(target: "foo_events", "foo");
     info_span!(target: "foo_events", "bar",);
-    info_span!("foo", bar = 2, baz = 3);
-    info_span!("foo", bar = 2, baz = 4,);
+    info_span!("foo", bar.baz = 2, quux = 3);
+    info_span!("foo", bar.baz = 2, quux = 4,);
     info_span!("bar");
     info_span!("bar",);
 }
 
 #[test]
 fn warn_span() {
-    warn_span!(target: "foo_events", "foo", bar = 2, baz = 3);
-    warn_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     warn_span!(target: "foo_events", "foo");
     warn_span!(target: "foo_events", "bar",);
-    warn_span!("foo", bar = 2, baz = 3);
-    warn_span!("foo", bar = 2, baz = 4,);
+    warn_span!("foo", bar.baz = 2, quux = 3);
+    warn_span!("foo", bar.baz = 2, quux = 4,);
     warn_span!("bar");
     warn_span!("bar",);
 }
 
 #[test]
 fn error_span() {
-    error_span!(target: "foo_events", "foo", bar = 2, baz = 3);
-    error_span!(target: "foo_events", "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
+    error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     error_span!(target: "foo_events", "foo");
     error_span!(target: "foo_events", "bar",);
-    error_span!("foo", bar = 2, baz = 3);
-    error_span!("foo", bar = 2, baz = 4,);
+    error_span!("foo", bar.baz = 2, quux = 3);
+    error_span!("foo", bar.baz = 2, quux = 4,);
     error_span!("bar");
     error_span!("bar",);
 }
 
 #[test]
 fn span_root() {
-    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, target: "foo_events", parent: None, "foo");
     span!(Level::DEBUG, target: "foo_events", parent: None, "bar",);
-    span!(Level::TRACE, parent: None, "foo", bar = 2, baz = 3);
-    span!(Level::TRACE, parent: None, "foo", bar = 2, baz = 4,);
+    span!(Level::TRACE, parent: None, "foo", bar.baz = 2, quux = 3);
+    span!(Level::TRACE, parent: None, "foo", bar.baz = 2, quux = 4,);
     span!(Level::TRACE, parent: None, "foo");
     span!(Level::TRACE, parent: None, "bar",);
 }
 
 #[test]
 fn trace_span_root() {
-    trace_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    trace_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    trace_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     trace_span!(target: "foo_events", parent: None, "foo");
     trace_span!(target: "foo_events", parent: None, "bar",);
-    trace_span!(parent: None, "foo", bar = 2, baz = 3);
-    trace_span!(parent: None, "foo", bar = 2, baz = 4,);
+    trace_span!(parent: None, "foo", bar.baz = 2, quux = 3);
+    trace_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
     trace_span!(parent: None, "foo");
     trace_span!(parent: None, "bar",);
 }
 
 #[test]
 fn debug_span_root() {
-    debug_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    debug_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    debug_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     debug_span!(target: "foo_events", parent: None, "foo");
     debug_span!(target: "foo_events", parent: None, "bar",);
-    debug_span!(parent: None, "foo", bar = 2, baz = 3);
-    debug_span!(parent: None, "foo", bar = 2, baz = 4,);
+    debug_span!(parent: None, "foo", bar.baz = 2, quux = 3);
+    debug_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
     debug_span!(parent: None, "foo");
     debug_span!(parent: None, "bar",);
 }
 
 #[test]
 fn info_span_root() {
-    info_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    info_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    info_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     info_span!(target: "foo_events", parent: None, "foo");
     info_span!(target: "foo_events", parent: None, "bar",);
-    info_span!(parent: None, "foo", bar = 2, baz = 3);
-    info_span!(parent: None, "foo", bar = 2, baz = 4,);
+    info_span!(parent: None, "foo", bar.baz = 2, quux = 3);
+    info_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
     info_span!(parent: None, "foo");
     info_span!(parent: None, "bar",);
 }
 
 #[test]
 fn warn_span_root() {
-    warn_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    warn_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    warn_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     warn_span!(target: "foo_events", parent: None, "foo");
     warn_span!(target: "foo_events", parent: None, "bar",);
-    warn_span!(parent: None, "foo", bar = 2, baz = 3);
-    warn_span!(parent: None, "foo", bar = 2, baz = 4,);
+    warn_span!(parent: None, "foo", bar.baz = 2, quux = 3);
+    warn_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
     warn_span!(parent: None, "foo");
     warn_span!(parent: None, "bar",);
 }
 
 #[test]
 fn error_span_root() {
-    error_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 3);
-    error_span!(target: "foo_events", parent: None, "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
+    error_span!(target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     error_span!(target: "foo_events", parent: None, "foo");
     error_span!(target: "foo_events", parent: None, "bar",);
-    error_span!(parent: None, "foo", bar = 2, baz = 3);
-    error_span!(parent: None, "foo", bar = 2, baz = 4,);
+    error_span!(parent: None, "foo", bar.baz = 2, quux = 3);
+    error_span!(parent: None, "foo", bar.baz = 2, quux = 4,);
     error_span!(parent: None, "foo");
     error_span!(parent: None, "bar",);
 }
@@ -157,13 +157,13 @@ fn error_span_root() {
 #[test]
 fn span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, target: "foo_events", parent: &p, "foo");
     span!(Level::DEBUG, target: "foo_events", parent: &p, "bar",);
 
-    span!(Level::DEBUG, parent: &p, "foo", bar = 2, baz = 3);
-    span!(Level::DEBUG, parent: &p, "foo", bar = 2, baz = 4,);
+    span!(Level::DEBUG, parent: &p, "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     span!(Level::DEBUG, parent: &p, "foo");
     span!(Level::DEBUG, parent: &p, "bar",);
@@ -172,13 +172,13 @@ fn span_with_parent() {
 #[test]
 fn trace_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    trace_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    trace_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    trace_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    trace_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     trace_span!(target: "foo_events", parent: &p, "foo");
     trace_span!(target: "foo_events", parent: &p, "bar",);
 
-    trace_span!(parent: &p, "foo", bar = 2, baz = 3);
-    trace_span!(parent: &p, "foo", bar = 2, baz = 4,);
+    trace_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
+    trace_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     trace_span!(parent: &p, "foo");
     trace_span!(parent: &p, "bar",);
@@ -187,13 +187,13 @@ fn trace_span_with_parent() {
 #[test]
 fn debug_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    debug_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    debug_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    debug_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    debug_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     debug_span!(target: "foo_events", parent: &p, "foo");
     debug_span!(target: "foo_events", parent: &p, "bar",);
 
-    debug_span!(parent: &p, "foo", bar = 2, baz = 3);
-    debug_span!(parent: &p, "foo", bar = 2, baz = 4,);
+    debug_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
+    debug_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     debug_span!(parent: &p, "foo");
     debug_span!(parent: &p, "bar",);
@@ -202,13 +202,13 @@ fn debug_span_with_parent() {
 #[test]
 fn info_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    info_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    info_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    info_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    info_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     info_span!(target: "foo_events", parent: &p, "foo");
     info_span!(target: "foo_events", parent: &p, "bar",);
 
-    info_span!(parent: &p, "foo", bar = 2, baz = 3);
-    info_span!(parent: &p, "foo", bar = 2, baz = 4,);
+    info_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
+    info_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     info_span!(parent: &p, "foo");
     info_span!(parent: &p, "bar",);
@@ -217,13 +217,13 @@ fn info_span_with_parent() {
 #[test]
 fn warn_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    warn_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    warn_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    warn_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    warn_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     warn_span!(target: "foo_events", parent: &p, "foo");
     warn_span!(target: "foo_events", parent: &p, "bar",);
 
-    warn_span!(parent: &p, "foo", bar = 2, baz = 3);
-    warn_span!(parent: &p, "foo", bar = 2, baz = 4,);
+    warn_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
+    warn_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     warn_span!(parent: &p, "foo");
     warn_span!(parent: &p, "bar",);
@@ -232,13 +232,13 @@ fn warn_span_with_parent() {
 #[test]
 fn error_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    error_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 3);
-    error_span!(target: "foo_events", parent: &p, "foo", bar = 2, baz = 4,);
+    error_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
+    error_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
     error_span!(target: "foo_events", parent: &p, "foo");
     error_span!(target: "foo_events", parent: &p, "bar",);
 
-    error_span!(parent: &p, "foo", bar = 2, baz = 3);
-    error_span!(parent: &p, "foo", bar = 2, baz = 4,);
+    error_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
+    error_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
 
     error_span!(parent: &p, "foo");
     error_span!(parent: &p, "bar",);
@@ -246,122 +246,122 @@ fn error_span_with_parent() {
 
 #[test]
 fn event() {
-    event!(Level::DEBUG, foo = 3, bar = 2, baz = false);
-    event!(Level::DEBUG, foo = 3, bar = 3,);
+    event!(Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
+    event!(Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(Level::DEBUG, "foo");
     event!(Level::DEBUG, "foo: {}", 3);
-    event!(Level::DEBUG, { foo = 3, bar = 80 }, "baz");
-    event!(Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
-    event!(Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    event!(Level::DEBUG, { foo = 2, bar = 78, }, "baz");
-    event!(target: "foo_events", Level::DEBUG, foo = 3, bar = 2, baz = false);
-    event!(target: "foo_events", Level::DEBUG, foo = 3, bar = 3,);
+    event!(Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
+    event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
+    event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
+    event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(target: "foo_events", Level::DEBUG, "foo");
     event!(target: "foo_events", Level::DEBUG, "foo: {}", 3);
-    event!(target: "foo_events", Level::DEBUG, { foo = 3, bar = 80 }, "baz");
-    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}", true);
-    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar = 78, }, "baz");
+    event!(target: "foo_events", Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn trace() {
-    trace!(foo = 3, bar = 2, baz = false);
-    trace!(foo = 3, bar = 3,);
+    trace!(foo = 3, bar.baz = 2, quux = false);
+    trace!(foo = 3, bar.baz = 3,);
     trace!("foo");
     trace!("foo: {}", 3);
-    trace!({ foo = 3, bar = 80 }, "baz");
-    trace!({ foo = 2, bar = 79 }, "baz {:?}", true);
-    trace!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    trace!({ foo = 2, bar = 78, }, "baz");
-    trace!(target: "foo_events", foo = 3, bar = 2, baz = false);
-    trace!(target: "foo_events", foo = 3, bar = 3,);
+    trace!({ foo = 3, bar.baz = 80 }, "quux");
+    trace!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!({ foo = 2, bar.baz = 78, }, "quux");
+    trace!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    trace!(target: "foo_events", foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", "foo");
     trace!(target: "foo_events", "foo: {}", 3);
-    trace!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
-    trace!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
-    trace!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    trace!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
+    trace!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
+    trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn debug() {
-    debug!(foo = 3, bar = 2, baz = false);
-    debug!(foo = 3, bar = 3,);
+    debug!(foo = 3, bar.baz = 2, quux = false);
+    debug!(foo = 3, bar.baz = 3,);
     debug!("foo");
     debug!("foo: {}", 3);
-    debug!({ foo = 3, bar = 80 }, "baz");
-    debug!({ foo = 2, bar = 79 }, "baz {:?}", true);
-    debug!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    debug!({ foo = 2, bar = 78, }, "baz");
-    debug!(target: "foo_events", foo = 3, bar = 2, baz = false);
-    debug!(target: "foo_events", foo = 3, bar = 3,);
+    debug!({ foo = 3, bar.baz = 80 }, "quux");
+    debug!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!({ foo = 2, bar.baz = 78, }, "quux");
+    debug!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    debug!(target: "foo_events", foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", "foo");
     debug!(target: "foo_events", "foo: {}", 3);
-    debug!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
-    debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
-    debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    debug!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    debug!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
+    debug!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
+    debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn info() {
-    info!(foo = 3, bar = 2, baz = false);
-    info!(foo = 3, bar = 3,);
+    info!(foo = 3, bar.baz = 2, quux = false);
+    info!(foo = 3, bar.baz = 3,);
     info!("foo");
     info!("foo: {}", 3);
-    info!({ foo = 3, bar = 80 }, "baz");
-    info!({ foo = 2, bar = 79 }, "baz {:?}", true);
-    info!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    info!({ foo = 2, bar = 78, }, "baz");
-    info!(target: "foo_events", foo = 3, bar = 2, baz = false);
-    info!(target: "foo_events", foo = 3, bar = 3,);
+    info!({ foo = 3, bar.baz = 80 }, "quux");
+    info!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!({ foo = 2, bar.baz = 78, }, "quux");
+    info!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    info!(target: "foo_events", foo = 3, bar.baz = 3,);
     info!(target: "foo_events", "foo");
     info!(target: "foo_events", "foo: {}", 3);
-    info!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
-    info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
-    info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    info!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    info!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
+    info!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
+    info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn warn() {
-    warn!(foo = 3, bar = 2, baz = false);
-    warn!(foo = 3, bar = 3,);
+    warn!(foo = 3, bar.baz = 2, quux = false);
+    warn!(foo = 3, bar.baz = 3,);
     warn!("foo");
     warn!("foo: {}", 3);
-    warn!({ foo = 3, bar = 80 }, "baz");
-    warn!({ foo = 2, bar = 79 }, "baz {:?}", true);
-    warn!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    warn!({ foo = 2, bar = 78 }, "baz");
-    warn!(target: "foo_events", foo = 3, bar = 2, baz = false);
-    warn!(target: "foo_events", foo = 3, bar = 3,);
+    warn!({ foo = 3, bar.baz = 80 }, "quux");
+    warn!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!({ foo = 2, bar.baz = 78 }, "quux");
+    warn!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    warn!(target: "foo_events", foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", "foo");
     warn!(target: "foo_events", "foo: {}", 3);
-    warn!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
-    warn!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
-    warn!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    warn!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
+    warn!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
+    warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn error() {
-    error!(foo = 3, bar = 2, baz = false);
-    error!(foo = 3, bar = 3,);
+    error!(foo = 3, bar.baz = 2, quux = false);
+    error!(foo = 3, bar.baz = 3,);
     error!("foo");
     error!("foo: {}", 3);
-    error!({ foo = 3, bar = 80 }, "baz");
-    error!({ foo = 2, bar = 79 }, "baz {:?}", true);
-    error!({ foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    error!({ foo = 2, bar = 78, }, "baz");
-    error!(target: "foo_events", foo = 3, bar = 2, baz = false);
-    error!(target: "foo_events", foo = 3, bar = 3,);
+    error!({ foo = 3, bar.baz = 80 }, "quux");
+    error!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!({ foo = 2, bar.baz = 78, }, "quux");
+    error!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
+    error!(target: "foo_events", foo = 3, bar.baz = 3,);
     error!(target: "foo_events", "foo");
     error!(target: "foo_events", "foo: {}", 3);
-    error!(target: "foo_events", { foo = 3, bar = 80 }, "baz");
-    error!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}", true);
-    error!(target: "foo_events", { foo = 2, bar = 79 }, "baz {:?}, {quux}", true, quux = false);
-    error!(target: "foo_events", { foo = 2, bar = 78, }, "baz");
+    error!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
+    error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -279,6 +279,23 @@ fn moved_field() {
 }
 
 #[test]
+fn dotted_field_name() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(
+            span::mock()
+                .named("foo")
+                .with_field(field::mock("fields.bar").with_value(&true).only()),
+        )
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || {
+        span!(Level::TRACE, "foo", fields.bar = true);
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
 fn borrowed_field() {
     let (subscriber, handle) = subscriber::mock()
         .new_span(


### PR DESCRIPTION
## Motivation

In order to support conventions that add namespacing to `tokio-trace`
field names, it's necessary to accept at least one type of separator
character. Currently, the `tokio-trace` macros only accept valid Rust
identifiers, so there is no clear separator character for namespaced
conventions. See also #1018.

## Solution

This branch changes the single `ident` fragment matcher for field names
to match *one or more* `ident` fragments separated by `.` characters.

## Notes

The resulting key is still exposed to `tokio-trace-core` as a string
constant created by stringifying the dotted expression. However, if
`tokio-trace-core` were later to adopt a first class notion of
hierarchical field keys, we would be able to track that change in
`tokio-trace` as an implementation detail.

Closes #1018.
Closes #1022.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>