### PR TITLE
trace: Fix subscriber benchmarks panicking

### DIFF
--- a/tokio-trace/benches/subscriber.rs
+++ b/tokio-trace/benches/subscriber.rs
@@ -18,7 +18,7 @@ struct EnabledSubscriber;
 impl tokio_trace::Subscriber for EnabledSubscriber {
     fn new_span(&self, span: &span::Attributes) -> Id {
         let _ = span;
-        Id::from_u64(0)
+        Id::from_u64(0xDEADFACE)
     }
 
     fn event(&self, event: &Event) {
@@ -63,7 +63,7 @@ impl tokio_trace::Subscriber for VisitingSubscriber {
     fn new_span(&self, span: &span::Attributes) -> Id {
         let mut visitor = Visitor(self.0.lock().unwrap());
         span.record(&mut visitor);
-        Id::from_u64(0)
+        Id::from_u64(0xDEADFACE)
     }
 
     fn record(&self, _span: &Id, values: &span::Record) {


### PR DESCRIPTION
This branch fixes the `tokio-trace` Subscriber benchmarks panicking due
to constructing spans with ID 0. They will now use an arbitrary constant
instead.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
