### PR TITLE
trace-core: Dispatchers unset themselves

### DIFF
--- a/tokio-trace/tests/subscriber.rs
+++ b/tokio-trace/tests/subscriber.rs
@@ -1,0 +1,48 @@
+#[macro_use]
+extern crate tokio_trace;
+use tokio_trace::{
+    span,
+    subscriber::{with_default, Interest, Subscriber},
+    Event, Level, Metadata,
+};
+
+#[test]
+fn event_macros_dont_infinite_loop() {
+    // This test ensures that an event macro within a subscriber
+    // won't cause an infinite loop of events.
+    struct TestSubscriber;
+    impl Subscriber for TestSubscriber {
+        fn register_callsite(&self, _: &Metadata) -> Interest {
+            // Always return sometimes so that `enabled` will be called
+            // (which can loop).
+            Interest::sometimes()
+        }
+
+        fn enabled(&self, meta: &Metadata) -> bool {
+            assert!(meta.fields().iter().any(|f| f.name() == "foo"));
+            event!(Level::TRACE, bar = false);
+            true
+        }
+
+        fn new_span(&self, _: &span::Attributes) -> span::Id {
+            span::Id::from_u64(0xAAAA)
+        }
+
+        fn record(&self, _: &span::Id, _: &span::Record) {}
+
+        fn record_follows_from(&self, _: &span::Id, _: &span::Id) {}
+
+        fn event(&self, event: &Event) {
+            assert!(event.metadata().fields().iter().any(|f| f.name() == "foo"));
+            event!(Level::TRACE, baz = false);
+        }
+
+        fn enter(&self, _: &span::Id) {}
+
+        fn exit(&self, _: &span::Id) {}
+    }
+
+    with_default(TestSubscriber, || {
+        event!(Level::TRACE, foo = false);
+    })
+}

--- a/tokio-trace/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace/tokio-trace-core/src/dispatcher.rs
@@ -182,8 +182,7 @@ impl Dispatch {
     /// [`enabled`]: ../subscriber/trait.Subscriber.html#method.enabled
     #[inline]
     pub fn enabled(&self, metadata: &Metadata) -> bool {
-        Self::if_enabled(|| self.subscriber.enabled(metadata))
-            .unwrap_or(false)
+        Self::if_enabled(|| self.subscriber.enabled(metadata)).unwrap_or(false)
     }
 
     /// Records that an [`Event`] has occurred.
@@ -283,7 +282,6 @@ impl Dispatch {
                     return Some(f());
                 }
                 None
-
             })
             .unwrap_or(None)
     }

--- a/tokio-trace/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace/tokio-trace-core/src/dispatcher.rs
@@ -7,7 +7,7 @@ use {
 
 use std::{
     any::Any,
-    cell::RefCell,
+    cell::Cell,
     fmt,
     sync::{Arc, Weak},
 };
@@ -21,7 +21,7 @@ pub struct Dispatch {
 }
 
 thread_local! {
-    static CURRENT_DISPATCH: RefCell<Option<Dispatch>> = RefCell::new(None);
+    static CURRENT_DISPATCH: Cell<Option<Dispatch>> = Cell::new(None);
 }
 
 // A drop guard that resets CURRENT_DISPATCH to the prior dispatcher.
@@ -311,7 +311,7 @@ impl Drop for ResetGuard {
     fn drop(&mut self) {
         if let Some(dispatch) = self.0.take() {
             let _ = CURRENT_DISPATCH.try_with(|current| {
-                *current.borrow_mut() = Some(dispatch);
+                current.set(Some(dispatch));
             });
         }
     }

--- a/tokio-trace/tokio-trace-core/src/dispatcher.rs
+++ b/tokio-trace/tokio-trace-core/src/dispatcher.rs
@@ -405,7 +405,7 @@ mod test {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use {
         callsite::Callsite,
-        metadata::{Level, Metadata},
+        metadata::{Kind, Level, Metadata},
         span,
         subscriber::{Interest, Subscriber},
         Event,
@@ -431,11 +431,11 @@ mod test {
         level: Level::DEBUG,
         fields: &[],
         callsite: &TEST_CALLSITE,
+        kind: Kind::EVENT
     };
 
     impl Callsite for TestCallsite {
-        fn add_interest(&self, _: Interest) {}
-        fn clear_interest(&self) {}
+        fn set_interest(&self, _: Interest) {}
         fn metadata(&self) -> &Metadata {
             &TEST_META
         }


### PR DESCRIPTION
This branch changes `dispatcher::get_default` to unset the thread's
current dispatcher while the reference to it is held by the closure.
This prevents infinite loops if the subscriber calls code paths which
emit events or construct spans. 

Note that this also means that nested calls to `get_default` inside of a
`get_default` closure will recieve a `None` dispatcher rather than the
"actual" dispatcher. However, it was necessary to unset the default in
`get_default` rather than in dispatch methods such as `Dispatch::enter`,
as when those functions are called, the current state has already been
borrowed.

This introduces a little more overhead into span creation and events.

Before:
```

     Running target/release/deps/no_subscriber-09f0b39a00181a97

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           2 ns/iter (+/- 0)
test bench_log_no_logger              ... bench:           0 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           2 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-992535c5d1c348ad

running 5 tests
test enter_span              ... bench:           3 ns/iter (+/- 0)
test span_no_fields          ... bench:          38 ns/iter (+/- 8)
test span_repeatedly         ... bench:       4,560 ns/iter (+/- 663)
test span_with_fields        ... bench:          49 ns/iter (+/- 17)
test span_with_fields_record ... bench:         363 ns/iter (+/- 71)
```

After:
```
     Running target/release/deps/no_subscriber-09f0b39a00181a97

running 5 tests
test bench_1_atomic_load              ... bench:           0 ns/iter (+/- 0)
test bench_costly_field_no_subscriber ... bench:           2 ns/iter (+/- 0)
test bench_log_no_logger              ... bench:           0 ns/iter (+/- 0)
test bench_no_span_no_subscriber      ... bench:           0 ns/iter (+/- 0)
test bench_span_no_subscriber         ... bench:           2 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 5 measured; 0 filtered out

     Running target/release/deps/subscriber-992535c5d1c348ad

running 5 tests
test enter_span              ... bench:           3 ns/iter (+/- 0)
test span_no_fields          ... bench:          48 ns/iter (+/- 9)
test span_repeatedly         ... bench:       5,274 ns/iter (+/- 596)
test span_with_fields        ... bench:          55 ns/iter (+/- 11)
test span_with_fields_record ... bench:         346 ns/iter (+/- 71)
```

Closes #1032 

Signed-off-by: Eliza Weisman <eliza@buoyant.io>