### PR TITLE
trace: fix counters example, Span IDs must be greater than zero.

### DIFF
--- a/tokio-trace/examples/counters.rs
+++ b/tokio-trace/examples/counters.rs
@@ -113,7 +113,7 @@ impl Counters {
     fn new() -> (Self, CounterSubscriber) {
         let counters = Counters(Arc::new(RwLock::new(HashMap::new())));
         let subscriber = CounterSubscriber {
-            ids: AtomicUsize::new(0),
+            ids: AtomicUsize::new(1),
             counters: counters.clone(),
         };
         (counters, subscriber)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
tokio-trace counter example was panicking due to returning 0 as the first Span Id
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
start ID's with 1 instead
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
