### PR TITLE
fs: fallback implementation that doesn't rely on `blocking()`

### DIFF
--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -27,10 +27,12 @@ publish = false
 futures = "0.1.21"
 tokio-threadpool = { version = "0.2.0", path = "../tokio-threadpool" }
 tokio-io = { version = "0.2.0", path = "../tokio-io" }
+lazy_static = "1.3.0"
 
 [dev-dependencies]
 rand = "0.6"
 tempfile = "3"
 tempdir = "0.3"
 tokio-codec = { version = "0.2.0", path = "../tokio-codec" }
+tokio-current-thread = { version = "0.2.0", path = "../tokio-current-thread" }
 tokio = { version = "0.2.0", path = "../tokio" }

--- a/tokio-fs/src/blocking_pool.rs
+++ b/tokio-fs/src/blocking_pool.rs
@@ -1,10 +1,9 @@
 //! A simple thread pool for executing blocking functions.
 
-use tokio_threadpool;
-
 use futures::future;
 use futures::prelude::*;
 use futures::sync::oneshot;
+use tokio_threadpool;
 
 // TODO(stjepang): The current implementation is based on tokio-threadpool and is just a simple
 // hack that works, but doesn't deliver great performance. We'll need a custom thread pool

--- a/tokio-fs/src/blocking_pool.rs
+++ b/tokio-fs/src/blocking_pool.rs
@@ -1,0 +1,99 @@
+//! A simple thread pool for executing blocking functions.
+
+use tokio_threadpool;
+
+use futures::future;
+use futures::prelude::*;
+use futures::sync::oneshot;
+
+// TODO(stjepang): The current implementation is based on tokio-threadpool and is just a simple
+// hack that works, but doesn't deliver great performance. We'll need a custom thread pool
+// implementation here.
+
+lazy_static::lazy_static! {
+    /// A thread pool for executing blocking tasks.
+    static ref POOL: tokio_threadpool::ThreadPool = {
+        tokio_threadpool::Builder::new().pool_size(1).build()
+    };
+}
+
+/// Creates a blocking task.
+///
+/// The task will start executing the first time the returned future is polled. The first
+/// invocation of `poll()` will always return `Ok(Async::NotReady)`.
+///
+/// Dropping the returned future will cancel the task.
+pub fn blocking<T, E, F>(mut f: F) -> Blocking<T, E>
+where
+    F: Future<Item = T, Error = E> + Send + 'static,
+    T: Send + 'static,
+    E: Send + 'static,
+{
+    // Create a channel that will send back the result of `f`.
+    let (result_tx, result_rx) = oneshot::channel();
+
+    // Create a channel that will start the future.
+    let (start_tx, start_rx) = oneshot::channel();
+
+    // Always poll the future inside an invocation of `blocking()`.
+    let f = future::poll_fn(
+        move || match tokio_threadpool::blocking(|| f.poll()).unwrap() {
+            Async::Ready(v) => v,
+            Async::NotReady => Ok(Async::NotReady),
+        },
+    );
+
+    POOL.spawn(
+        // First wait for the start signal.
+        start_rx
+            // Only continue if the start signal was received.
+            // Note that if `Blocking` gets dropped, the task is cancelled.
+            .and_then(|()| {
+                // Poll `f` and then send the result through the channel.
+                f.then(|res| {
+                    let _ = result_tx.send(res);
+                    Ok(())
+                })
+            })
+            .map_err(|_| ()),
+    );
+
+    Blocking {
+        result_rx,
+        start_tx: Some(start_tx),
+    }
+}
+
+/// Future that resolves to the result of a blocking task.
+///
+/// The task will start executing the first time this future is polled. The first invocation of
+/// `poll()` will always return `Ok(Async::NotReady)`.
+///
+/// Dropping this future will cancel the task.
+#[derive(Debug)]
+pub struct Blocking<T, E> {
+    result_rx: oneshot::Receiver<Result<T, E>>,
+    start_tx: Option<oneshot::Sender<()>>,
+}
+
+impl<T, E> Future for Blocking<T, E> {
+    type Item = T;
+    type Error = E;
+
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        // If this is the first invocation of `poll()`, start the task.
+        if let Some(start_tx) = self.start_tx.take() {
+            // Poll the result so that the current task gets woken when the task completes.
+            assert!(self.result_rx.poll().unwrap().is_not_ready());
+            // Send the start signal.
+            start_tx.send(()).unwrap();
+            Ok(Async::NotReady)
+        } else {
+            match self.result_rx.poll().expect("the blocking task was lost") {
+                Async::Ready(Ok(t)) => Ok(Async::Ready(t)),
+                Async::Ready(Err(e)) => Err(e),
+                Async::NotReady => Ok(Async::NotReady),
+            }
+        }
+    }
+}

--- a/tokio-fs/src/create_dir.rs
+++ b/tokio-fs/src/create_dir.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -8,36 +9,52 @@ use std::path::Path;
 /// This is an async version of [`std::fs::create_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
-pub fn create_dir<P: AsRef<Path>>(path: P) -> CreateDirFuture<P> {
+pub fn create_dir<P>(path: P) -> CreateDirFuture<P>
+where
+    P: AsRef<Path> + Send + 'static,
+{
     CreateDirFuture::new(path)
 }
 
 /// Future returned by `create_dir`.
 #[derive(Debug)]
-pub struct CreateDirFuture<P>
+pub struct CreateDirFuture<P>(Mode<P>)
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P>
+where
+    P: AsRef<Path> + Send + 'static,
 {
-    path: P,
+    Native { path: P },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P> CreateDirFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> CreateDirFuture<P> {
-        CreateDirFuture { path: path }
+        CreateDirFuture(if tokio_threadpool::entered() {
+            Mode::Native { path }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::create_dir(&path))))
+        })
     }
 }
 
 impl<P> Future for CreateDirFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::create_dir(&self.path))
+        match &mut self.0 {
+            Mode::Native { path } => crate::blocking_io(|| fs::create_dir(path)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/create_dir_all.rs
+++ b/tokio-fs/src/create_dir_all.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -9,36 +10,52 @@ use std::path::Path;
 /// This is an async version of [`std::fs::create_dir_all`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.create_dir_all.html
-pub fn create_dir_all<P: AsRef<Path>>(path: P) -> CreateDirAllFuture<P> {
+pub fn create_dir_all<P>(path: P) -> CreateDirAllFuture<P>
+where
+    P: AsRef<Path> + Send + 'static,
+{
     CreateDirAllFuture::new(path)
 }
 
 /// Future returned by `create_dir_all`.
 #[derive(Debug)]
-pub struct CreateDirAllFuture<P>
+pub struct CreateDirAllFuture<P>(Mode<P>)
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P>
+where
+    P: AsRef<Path> + Send + 'static,
 {
-    path: P,
+    Native { path: P },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P> CreateDirAllFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> CreateDirAllFuture<P> {
-        CreateDirAllFuture { path: path }
+        CreateDirAllFuture(if tokio_threadpool::entered() {
+            Mode::Native { path }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::create_dir_all(&path))))
+        })
     }
 }
 
 impl<P> Future for CreateDirAllFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::create_dir_all(&self.path))
+        match &mut self.0 {
+            Mode::Native { path } => crate::blocking_io(|| fs::create_dir_all(path)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/file/create.rs
+++ b/tokio-fs/src/file/create.rs
@@ -12,7 +12,7 @@ pub struct CreateFuture<P>(Mode<P>);
 #[derive(Debug)]
 enum Mode<P> {
     Native { path: P },
-    Fallback(Blocking<std::fs::File, io::Error>),
+    Fallback(Blocking<StdFile, io::Error>),
 }
 
 impl<P> CreateFuture<P>

--- a/tokio-fs/src/file/create.rs
+++ b/tokio-fs/src/file/create.rs
@@ -1,13 +1,18 @@
 use super::File;
-use futures::{try_ready, Future, Poll};
+use crate::blocking_pool::{blocking, Blocking};
+use futures::{future, try_ready, Async, Future, Poll};
 use std::fs::File as StdFile;
 use std::io;
 use std::path::Path;
 
 /// Future returned by `File::create` and resolves to a `File` instance.
 #[derive(Debug)]
-pub struct CreateFuture<P> {
-    path: P,
+pub struct CreateFuture<P>(Mode<P>);
+
+#[derive(Debug)]
+enum Mode<P> {
+    Native { path: P },
+    Fallback(Blocking<std::fs::File, io::Error>),
 }
 
 impl<P> CreateFuture<P>
@@ -15,7 +20,11 @@ where
     P: AsRef<Path> + Send + 'static,
 {
     pub(crate) fn new(path: P) -> Self {
-        CreateFuture { path }
+        CreateFuture(if tokio_threadpool::entered() {
+            Mode::Native { path }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || StdFile::create(&path))))
+        })
     }
 }
 
@@ -27,9 +36,10 @@ where
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        let std = try_ready!(crate::blocking_io(|| StdFile::create(&self.path)));
-
-        let file = File::from_std(std);
-        Ok(file.into())
+        let std = match &mut self.0 {
+            Mode::Native { path } => try_ready!(crate::blocking_io(|| StdFile::create(&path))),
+            Mode::Fallback(job) => try_ready!(job.poll()),
+        };
+        Ok(Async::Ready(File::from_std(std)))
     }
 }

--- a/tokio-fs/src/file/fallback.rs
+++ b/tokio-fs/src/file/fallback.rs
@@ -1,0 +1,661 @@
+use super::File;
+use crate::blocking_pool::{blocking, Blocking};
+use futures::future;
+use futures::{Async, Future, Poll};
+use std::fs::{File as StdFile, Metadata, Permissions};
+use std::io::{self, Read, Seek, SeekFrom, Write};
+use std::mem;
+use std::sync::{Arc, Mutex};
+
+/// The fallback async file implementation.
+///
+/// This implementation spawns blocking operations onto the blocking pool instead of relying on
+/// `tokio_threadpool::blocking()`.
+#[derive(Debug)]
+pub struct Fallback {
+    /// The status of the file (idle or blocked on an async operation).
+    ///
+    /// The status is wrapped in an `Arc<Mutex<_>>` because file handles can be cloned and shared
+    /// among threads. Operating systems similarly have a lock around their internal file states.
+    status: Arc<Mutex<Status>>,
+}
+
+/// The status of a file.
+#[derive(Debug)]
+enum Status {
+    /// The file is idle and its state is readable.
+    ///
+    /// The state is set to `None` when the file is closed.
+    Idle(Option<State>),
+
+    /// The file is blocked on an async operation.
+    Blocked(Job),
+}
+
+/// The file state.
+#[derive(Debug)]
+struct State {
+    /// The file handle.
+    std: StdFile,
+
+    /// The buffer for reading or writing.
+    buffer: Buffer,
+
+    /// The current buffer kind (reader or writer).
+    kind: BufferKind,
+
+    /// The result of the last async operation.
+    last_op: Option<LastOp>,
+}
+
+/// The current buffer kind.
+#[derive(Debug, Eq, PartialEq)]
+enum BufferKind {
+    /// The buffer is used for reading bytes from the file.
+    Reader,
+
+    /// The buffer is used for writing bytes into the file.
+    Writer,
+}
+
+/// The result of the last async operation.
+#[derive(Debug)]
+enum LastOp {
+    /// A `seek` operation with the `io::SeekFrom` argument has returned the `u64` result.
+    Seek(io::SeekFrom, u64),
+
+    /// A `flush` operation has completed.
+    Flush,
+
+    /// A `sync_all` operation has completed.
+    SyncAll,
+
+    /// A `sync_data` operation has completed.
+    SyncData,
+
+    /// A `set_len` operation with the `u64` argument has completed.
+    SetLen(u64),
+
+    /// A `metadata` operation has fetched the file metadata.
+    Metadata(Metadata),
+
+    /// A `set_permissions` operation with the `Permissions` argument has completed.
+    SetPermissions(Permissions),
+
+    /// A read operation has reached the end of the file.
+    EndOfFile,
+}
+
+/// A result of the closure passed to `Fallback::update()`.
+///
+/// This result indicates how the update loop should complete or continue.
+#[derive(Debug)]
+enum Update<T> {
+    /// The loop completes with a new state and a result.
+    Done(Option<State>, T),
+
+    /// The loop completes with a new job and a result.
+    Prefetch(Job, T),
+
+    /// The loop continues with a new job.
+    Block(Job),
+}
+
+impl Fallback {
+    /// Creates a new `Fallback` from a `std::fs::File`.
+    pub fn new(std: StdFile) -> Fallback {
+        Fallback {
+            status: Arc::new(Mutex::new(Status::Idle(Some(State {
+                std,
+                buffer: Buffer::new(),
+                kind: BufferKind::Reader,
+                last_op: None,
+            })))),
+        }
+    }
+
+    /// Seek to an offset.
+    pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::Seek(last_pos, output)) = state.last_op.take() {
+                    if last_pos == pos {
+                        return Update::Done(Some(state), output);
+                    }
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else if state.kind == BufferKind::Reader && !state.buffer.is_empty() {
+                    Update::Block(Job::unread(state))
+                } else {
+                    Update::Block(Job::seek(state, pos))
+                }
+            }
+        })
+    }
+
+    /// Attempts to sync all OS-internal metadata to disk.
+    pub fn poll_sync_all(&mut self) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::SyncAll) = state.last_op.take() {
+                    return Update::Done(Some(state), ());
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else {
+                    Update::Block(Job::sync_all(state))
+                }
+            }
+        })
+    }
+
+    /// Attempts to sync OS-internal buffered data to disk.
+    pub fn poll_sync_data(&mut self) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::SyncData) = state.last_op.take() {
+                    return Update::Done(Some(state), ());
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else {
+                    Update::Block(Job::sync_data(state))
+                }
+            }
+        })
+    }
+
+    /// Truncates or extends the underlying file, updating the size of this file to become size.
+    pub fn poll_set_len(&mut self, size: u64) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::SetLen(last_size)) = state.last_op.take() {
+                    if last_size == size {
+                        return Update::Done(Some(state), ());
+                    }
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else if state.kind == BufferKind::Reader && !state.buffer.is_empty() {
+                    Update::Block(Job::unread(state))
+                } else {
+                    Update::Block(Job::set_len(state, size))
+                }
+            }
+        })
+    }
+
+    /// Queries metadata about the underlying file.
+    pub fn poll_metadata(&mut self) -> Poll<Metadata, io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::Metadata(metadata)) = state.last_op.take() {
+                    return Update::Done(Some(state), metadata);
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else {
+                    Update::Block(Job::metadata(state))
+                }
+            }
+        })
+    }
+
+    /// Create a new `File` instance that shares the same underlying file handle.
+    pub fn poll_try_clone(&mut self) -> Poll<File, io::Error> {
+        let fallback = Fallback {
+            status: self.status.clone(),
+        };
+        Ok(File::from_fallback(fallback).into())
+    }
+
+    /// Changes the permissions on the underlying file.
+    pub fn poll_set_permissions(&mut self, perms: Permissions) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::SetPermissions(last_perms)) = state.last_op.take() {
+                    if last_perms == perms {
+                        return Update::Done(Some(state), ());
+                    }
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else if state.kind == BufferKind::Reader && !state.buffer.is_empty() {
+                    Update::Block(Job::unread(state))
+                } else {
+                    let perms = perms.clone();
+                    Update::Block(Job::set_permissions(state, perms))
+                }
+            }
+        })
+    }
+
+    /// Read some bytes into the specified buffer, returning how many bytes were read.
+    pub fn poll_read(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::EndOfFile) = state.last_op.take() {
+                    if state.kind == BufferKind::Reader {
+                        let n = state.buffer.read(buf);
+                        return Update::Done(Some(state), n);
+                    }
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else if state.buffer.is_empty() {
+                    Update::Block(Job::read(state))
+                } else {
+                    let n = state.buffer.read(buf);
+
+                    if n > 0 && state.buffer.is_empty() {
+                        Update::Prefetch(Job::read(state), n)
+                    } else {
+                        Update::Done(Some(state), n)
+                    }
+                }
+            }
+        })
+    }
+
+    /// Write some bytes into this file, returning how many bytes were written.
+    pub fn poll_write(&mut self, buf: &[u8]) -> Poll<usize, io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                state.last_op.take();
+
+                if state.kind == BufferKind::Reader && !state.buffer.is_empty() {
+                    Update::Block(Job::unread(state))
+                } else if state.buffer.is_full() {
+                    Update::Block(Job::write(state))
+                } else {
+                    let n = state.buffer.write(buf);
+                    state.kind = BufferKind::Writer;
+                    Update::Done(Some(state), n)
+                }
+            }
+        })
+    }
+
+    /// Flushes the write buffer.
+    pub fn poll_flush(&mut self) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => panic!("`File` instance closed"),
+            Some(mut state) => {
+                if let Some(LastOp::Flush) = state.last_op.take() {
+                    return Update::Done(Some(state), ());
+                }
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else {
+                    Update::Block(Job::flush(state))
+                }
+            }
+        })
+    }
+
+    /// Flushes the write buffer and closes the file.
+    pub fn poll_close(&mut self) -> Poll<(), io::Error> {
+        self.update(|idle| match idle {
+            None => Update::Done(None, ()),
+            Some(mut state) => {
+                state.last_op.take();
+
+                if state.kind == BufferKind::Writer && !state.buffer.is_empty() {
+                    Update::Block(Job::write(state))
+                } else {
+                    Update::Block(Job::close(state))
+                }
+            }
+        })
+    }
+
+    /// Destructures the `Fallback` into a `std::fs::File`.
+    pub fn into_std(self) -> StdFile {
+        match Arc::try_unwrap(self.status)
+            .expect("`File` instance is not the only reference to the underlying `std::fs::File`")
+            .into_inner()
+            .unwrap_or_else(|err| err.into_inner())
+        {
+            Status::Idle(Some(State { std, .. })) => std,
+            Status::Blocked(..) => panic!("`File` instance blocked on an async operation"),
+            Status::Idle(None) => panic!("`File` instance closed"),
+        }
+    }
+
+    /// Updates the file state in a loop with a function that operates on idle state.
+    ///
+    /// If the file is blocked on a job, the job is polled. If the file is idle, the provided
+    /// function is invoked on the state and then one of the following happens:
+    ///
+    /// 1. The loop completes with a new state and a result of type `T`.
+    /// 2. The loop completes with a new job and a result of type `T`.
+    /// 3. The loop continues with a new job.
+    fn update<F, T>(&mut self, mut f: F) -> Poll<T, io::Error>
+    where
+        F: FnMut(Option<State>) -> Update<T>,
+    {
+        let status = &mut *self.status.lock().unwrap_or_else(|err| err.into_inner());
+        loop {
+            match mem::replace(status, Status::Idle(None)) {
+                Status::Idle(idle) => match f(idle) {
+                    Update::Done(idle, res) => {
+                        *status = Status::Idle(idle);
+                        return Ok(res.into());
+                    }
+                    Update::Prefetch(mut job, res) => {
+                        // Poll once in order to start the job.
+                        assert!(job.0.poll().unwrap().is_not_ready());
+                        *status = Status::Blocked(job);
+                        return Ok(res.into());
+                    }
+                    Update::Block(job) => {
+                        *status = Status::Blocked(job);
+                    }
+                },
+                Status::Blocked(mut job) => match job.0.poll() {
+                    Ok(Async::Ready(s)) => {
+                        *status = Status::Idle(s);
+                    }
+                    Ok(Async::NotReady) => {
+                        *status = Status::Blocked(job);
+                        return Ok(Async::NotReady);
+                    }
+                    Err((idle, err)) => {
+                        *status = Status::Idle(idle);
+                        return Err(err);
+                    }
+                },
+            }
+        }
+    }
+}
+
+/// An async blocking job that returns back the updated file state when finished.
+#[derive(Debug)]
+struct Job(Blocking<Option<State>, (Option<State>, io::Error)>);
+
+impl Job {
+    fn new<F>(f: F) -> Job
+    where
+        F: FnOnce() -> (Option<State>, io::Result<()>) + Send + 'static,
+    {
+        Job(blocking(future::lazy(move || match f() {
+            (idle, Ok(())) => Ok(idle),
+            (idle, Err(err)) => Err((idle, err)),
+        })))
+    }
+
+    /// Creates a job that seeks to an offset.
+    fn seek(mut state: State, pos: io::SeekFrom) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .seek(pos)
+                .map(|output| state.last_op = Some(LastOp::Seek(pos, output)));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that syncs all OS-internal metadata to disk.
+    fn sync_all(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .sync_all()
+                .map(|_| state.last_op = Some(LastOp::SyncAll));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that syncs OS-internal buffered data to disk.
+    fn sync_data(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .sync_data()
+                .map(|_| state.last_op = Some(LastOp::SyncData));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that resizes the file.
+    fn set_len(mut state: State, size: u64) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .set_len(size)
+                .map(|_| state.last_op = Some(LastOp::SetLen(size)));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that fetches the file metadata.
+    fn metadata(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .metadata()
+                .map(|metadata| state.last_op = Some(LastOp::Metadata(metadata)));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that changes the permissions on the file.
+    fn set_permissions(mut state: State, perms: Permissions) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .set_permissions(perms.clone())
+                .map(|_| state.last_op = Some(LastOp::SetPermissions(perms)));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that reads bytes from the file to refill the buffer.
+    fn read(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state.buffer.import(&mut state.std).map(|n| {
+                if n == 0 {
+                    state.last_op = Some(LastOp::EndOfFile);
+                }
+            });
+            state.kind = BufferKind::Reader;
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that clears the read buffer and seeks back to where the cursor was before
+    /// reading.
+    fn unread(mut state: State) -> Job {
+        Job::new(move || {
+            let offset = state.buffer.len() as i64;
+            let res = state
+                .std
+                .seek(SeekFrom::Current(-offset))
+                .map(|_| state.buffer.clear());
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that pulls some bytes from the buffer and writes them into the file.
+    fn write(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state.buffer.export(&mut state.std).map(drop);
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that flushes the OS-internal write buffer.
+    fn flush(mut state: State) -> Job {
+        Job::new(move || {
+            let res = state
+                .std
+                .flush()
+                .map(|_| state.last_op = Some(LastOp::Flush));
+            (Some(state), res)
+        })
+    }
+
+    /// Creates a job that closes the file.
+    fn close(state: State) -> Job {
+        Job::new(move || {
+            drop(state.std);
+            (None, Ok(()))
+        })
+    }
+}
+
+/// A byte buffer for reading/writing from/into a file.
+///
+/// The buffer contains a storage vector and numbers `pos` and `len`. The actual bytes inside the
+/// buffer are kept in slice `bytes[pos..pos + len]`. The slice is always continuous - i.e. it
+/// never wraps around past the end of the vector.
+#[derive(Debug)]
+struct Buffer {
+    /// Storage for the buffer.
+    bytes: Vec<u8>,
+    /// The start index into the storage vector.
+    pos: usize,
+    /// The number of bytes in the buffer.
+    len: usize,
+}
+
+impl Buffer {
+    /// Creates a new byte buffer.
+    fn new() -> Buffer {
+        Buffer {
+            bytes: vec![],
+            pos: 0,
+            len: 0,
+        }
+    }
+
+    /// Returns `true` if the buffer is empty.
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Returns `true` if the buffer is full.
+    fn is_full(&self) -> bool {
+        self.len == self.bytes.len()
+    }
+
+    /// Returns the number of bytes in the buffer.
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Clears the buffer.
+    fn clear(&mut self) {
+        self.pos = 0;
+        self.len = 0;
+    }
+
+    /// Reads some bytes into `buf` and returns the number of bytes transferred.
+    fn read(&mut self, buf: &mut [u8]) -> usize {
+        let count = buf.len().min(self.len).min(self.bytes.len() - self.pos);
+        buf[0..count].copy_from_slice(&self.bytes[self.pos..self.pos + count]);
+
+        self.pos += count;
+        self.len -= count;
+        if self.pos == self.bytes.len() || self.len == 0 {
+            self.pos = 0;
+        }
+
+        count
+    }
+
+    /// Writes some bytes from `buf` and returns the number of bytes transferred.
+    fn write(&mut self, buf: &[u8]) -> usize {
+        self.init();
+
+        let mut start = self.pos + self.len;
+        if start >= self.bytes.len() {
+            start -= self.bytes.len();
+        }
+
+        let count = buf
+            .len()
+            .min(self.bytes.len() - self.len)
+            .min(self.bytes.len() - start);
+        self.bytes[self.len..self.len + count].copy_from_slice(&buf[0..count]);
+
+        self.len += count;
+        count
+    }
+
+    /// Export some bytes into `writer`.
+    ///
+    /// On success, returns the number of bytes transferred.
+    ///
+    /// Note that this is a blocking operation.
+    fn export<W: Write>(&mut self, mut writer: W) -> io::Result<usize> {
+        self.init();
+
+        let start = self.pos;
+        let count = self.len.min(self.bytes.len() - start);
+        let res = writer.write(&self.bytes[start..start + count]);
+
+        if let Ok(n) = res {
+            self.len -= n;
+            self.pos += n;
+            if self.pos == self.bytes.len() || self.len == 0 {
+                self.pos = 0;
+            }
+        }
+
+        res
+    }
+
+    /// Import some bytes from `reader`.
+    ///
+    /// On success, eturns the number of bytes transferred.
+    ///
+    /// Note that this is a blocking operation.
+    fn import<R: Read>(&mut self, mut reader: R) -> io::Result<usize> {
+        self.init();
+
+        let mut start = self.pos + self.len;
+        if start >= self.bytes.len() {
+            start -= self.bytes.len();
+        }
+
+        let count = (self.bytes.len() - self.len).min(self.bytes.len() - start);
+        let res = reader.read(&mut self.bytes[start..start + count]);
+
+        if let Ok(n) = res {
+            self.len += n;
+        }
+
+        res
+    }
+
+    /// Initializes the internal byte vector.
+    fn init(&mut self) {
+        const LEN: usize = 8 * 1024; // 8 kb
+
+        if self.bytes.len() == 0 {
+            // TODO(stjepang): Maybe we should initially start with a small vector and grow it if
+            // the file turns out to be large. If we're only operating on tiny files, allocations
+            // of 4 kB are probably wasteful.
+            self.bytes = vec![0u8; LEN];
+        }
+    }
+}

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -210,11 +210,9 @@ impl File {
     /// ```
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<u64, io::Error> {
         match &mut self.0 {
-            Mode::Native(std) => crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .seek(pos)
-            }),
+            Mode::Native(std) => {
+                crate::blocking_io(|| std.as_mut().expect("`File` instance closed").seek(pos))
+            }
             Mode::Fallback(fallback) => fallback.poll_seek(pos),
         }
     }
@@ -269,11 +267,9 @@ impl File {
     /// ```
     pub fn poll_sync_all(&mut self) -> Poll<(), io::Error> {
         match &mut self.0 {
-            Mode::Native(std) => crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .sync_all()
-            }),
+            Mode::Native(std) => {
+                crate::blocking_io(|| std.as_mut().expect("`File` instance closed").sync_all())
+            }
             Mode::Fallback(fallback) => fallback.poll_sync_all(),
         }
     }
@@ -306,11 +302,9 @@ impl File {
     /// ```
     pub fn poll_sync_data(&mut self) -> Poll<(), io::Error> {
         match &mut self.0 {
-            Mode::Native(std) => crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .sync_data()
-            }),
+            Mode::Native(std) => {
+                crate::blocking_io(|| std.as_mut().expect("`File` instance closed").sync_data())
+            }
             Mode::Fallback(fallback) => fallback.poll_sync_data(),
         }
     }
@@ -345,11 +339,9 @@ impl File {
     /// ```
     pub fn poll_set_len(&mut self, size: u64) -> Poll<(), io::Error> {
         match &mut self.0 {
-            Mode::Native(std) => crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .set_len(size)
-            }),
+            Mode::Native(std) => {
+                crate::blocking_io(|| std.as_mut().expect("`File` instance closed").set_len(size))
+            }
             Mode::Fallback(fallback) => fallback.poll_set_len(size),
         }
     }
@@ -391,11 +383,9 @@ impl File {
     /// ```
     pub fn poll_metadata(&mut self) -> Poll<Metadata, io::Error> {
         match &mut self.0 {
-            Mode::Native(std) => crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .metadata()
-            }),
+            Mode::Native(std) => {
+                crate::blocking_io(|| std.as_mut().expect("`File` instance closed").metadata())
+            }
             Mode::Fallback(fallback) => fallback.poll_metadata(),
         }
     }
@@ -421,10 +411,7 @@ impl File {
     pub fn poll_try_clone(&mut self) -> Poll<File, io::Error> {
         match &mut self.0 {
             Mode::Native(std) => crate::blocking_io(|| {
-                let std = std
-                    .as_mut()
-                    .expect("`File` instance closed")
-                    .try_clone()?;
+                let std = std.as_mut().expect("`File` instance closed").try_clone()?;
                 Ok(File::from_std(std))
             }),
             Mode::Fallback(fallback) => fallback.poll_try_clone(),
@@ -540,9 +527,7 @@ impl Read for File {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match &mut self.0 {
             Mode::Native(std) => crate::would_block(crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .read(buf)
+                std.as_mut().expect("`File` instance closed").read(buf)
             })),
             Mode::Fallback(fallback) => crate::would_block(fallback.poll_read(buf)),
         }
@@ -559,9 +544,7 @@ impl Write for File {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match &mut self.0 {
             Mode::Native(std) => crate::would_block(crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .write(buf)
+                std.as_mut().expect("`File` instance closed").write(buf)
             })),
             Mode::Fallback(fallback) => crate::would_block(fallback.poll_write(buf)),
         }
@@ -570,9 +553,7 @@ impl Write for File {
     fn flush(&mut self) -> io::Result<()> {
         match &mut self.0 {
             Mode::Native(std) => crate::would_block(crate::blocking_io(|| {
-                std.as_mut()
-                    .expect("`File` instance closed")
-                    .flush()
+                std.as_mut().expect("`File` instance closed").flush()
             })),
             Mode::Fallback(fallback) => crate::would_block(fallback.poll_flush()),
         }

--- a/tokio-fs/src/file/open.rs
+++ b/tokio-fs/src/file/open.rs
@@ -1,8 +1,8 @@
 use super::File;
 use crate::blocking_pool::{blocking, Blocking};
 use futures::{future, try_ready, Async, Future, Poll};
-use std::fs::OpenOptions as StdOpenOptions;
 use std::fs::File as StdFile;
+use std::fs::OpenOptions as StdOpenOptions;
 use std::io;
 use std::path::Path;
 

--- a/tokio-fs/src/file/open.rs
+++ b/tokio-fs/src/file/open.rs
@@ -2,6 +2,7 @@ use super::File;
 use crate::blocking_pool::{blocking, Blocking};
 use futures::{future, try_ready, Async, Future, Poll};
 use std::fs::OpenOptions as StdOpenOptions;
+use std::fs::File as StdFile;
 use std::io;
 use std::path::Path;
 

--- a/tokio-fs/src/file/open.rs
+++ b/tokio-fs/src/file/open.rs
@@ -12,7 +12,7 @@ pub struct OpenFuture<P>(Mode<P>);
 #[derive(Debug)]
 enum Mode<P> {
     Native { options: StdOpenOptions, path: P },
-    Fallback(Blocking<std::fs::File, io::Error>),
+    Fallback(Blocking<StdFile, io::Error>),
 }
 
 impl<P> OpenFuture<P>

--- a/tokio-fs/src/hard_link.rs
+++ b/tokio-fs/src/hard_link.rs
@@ -3,7 +3,6 @@ use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::Path;
-use tokio_threadpool;
 
 /// Creates a new hard link on the filesystem.
 ///

--- a/tokio-fs/src/metadata.rs
+++ b/tokio-fs/src/metadata.rs
@@ -4,6 +4,7 @@ use futures::{future, Future, Poll};
 use std::fs::{self, Metadata};
 use std::io;
 use std::path::Path;
+use tokio_threadpool;
 
 /// Queries the file system metadata for a path.
 pub fn metadata<P>(path: P) -> MetadataFuture<P>

--- a/tokio-fs/src/os/unix.rs
+++ b/tokio-fs/src/os/unix.rs
@@ -1,6 +1,7 @@
 //! Unix-specific extensions to primitives in the `tokio_fs` module.
 
-use futures::{Future, Poll};
+use crate::blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::io;
 use std::os::unix::fs;
 use std::path::Path;
@@ -12,40 +13,57 @@ use std::path::Path;
 /// This is an async version of [`std::os::unix::fs::symlink`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
-pub fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkFuture<P, Q> {
+pub fn symlink<P, Q>(src: P, dst: Q) -> SymlinkFuture<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
+{
     SymlinkFuture::new(src, dst)
 }
 
 /// Future returned by `symlink`.
 #[derive(Debug)]
-pub struct SymlinkFuture<P, Q>
+pub struct SymlinkFuture<P, Q>(Mode<P, Q>)
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
-    src: P,
-    dst: Q,
+    Native { src: P, dst: Q },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P, Q> SymlinkFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     fn new(src: P, dst: Q) -> SymlinkFuture<P, Q> {
-        SymlinkFuture { src: src, dst: dst }
+        SymlinkFuture(if tokio_threadpool::entered() {
+            Mode::Native { src, dst }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::symlink(&src, &dst))))
+        })
     }
 }
 
 impl<P, Q> Future for SymlinkFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::symlink(&self.src, &self.dst))
+        match &mut self.0 {
+            Mode::Native { src, dst } => crate::blocking_io(|| fs::symlink(src, dst)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/os/windows/symlink_dir.rs
+++ b/tokio-fs/src/os/windows/symlink_dir.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::io;
 use std::os::windows::fs;
 use std::path::Path;
@@ -11,40 +12,57 @@ use std::path::Path;
 /// This is an async version of [`std::os::windows::fs::symlink_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
-pub fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkDirFuture<P, Q> {
+pub fn symlink_dir<P, Q>(src: P, dst: Q) -> SymlinkDirFuture<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
+{
     SymlinkDirFuture::new(src, dst)
 }
 
 /// Future returned by `symlink_dir`.
 #[derive(Debug)]
-pub struct SymlinkDirFuture<P, Q>
+pub struct SymlinkDirFuture<P, Q>(Mode<P, Q>)
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
-    src: P,
-    dst: Q,
+    Native { src: P, dst: Q },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P, Q> SymlinkDirFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     fn new(src: P, dst: Q) -> SymlinkDirFuture<P, Q> {
-        SymlinkDirFuture { src: src, dst: dst }
+        SymlinkDirFuture(if tokio_threadpool::entered() {
+            Mode::Native { src, dst }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::symlink_dir(&src, &dst))))
+        })
     }
 }
 
 impl<P, Q> Future for SymlinkDirFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::symlink_dir(&self.src, &self.dst))
+        match &mut self.0 {
+            Mode::Native { src, dst } => crate::blocking_io(|| fs::symlink_dir(src, dst)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/os/windows/symlink_file.rs
+++ b/tokio-fs/src/os/windows/symlink_file.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::io;
 use std::os::windows::fs;
 use std::path::Path;
@@ -11,40 +12,57 @@ use std::path::Path;
 /// This is an async version of [`std::os::windows::fs::symlink_file`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
-pub fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> SymlinkFileFuture<P, Q> {
+pub fn symlink_file<P, Q>(src: P, dst: Q) -> SymlinkFileFuture<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
+{
     SymlinkFileFuture::new(src, dst)
 }
 
 /// Future returned by `symlink_file`.
 #[derive(Debug)]
-pub struct SymlinkFileFuture<P, Q>
+pub struct SymlinkFileFuture<P, Q>(Mode<P, Q>)
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P, Q>
+where
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
-    src: P,
-    dst: Q,
+    Native { src: P, dst: Q },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P, Q> SymlinkFileFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     fn new(src: P, dst: Q) -> SymlinkFileFuture<P, Q> {
-        SymlinkFileFuture { src: src, dst: dst }
+        SymlinkFileFuture(if tokio_threadpool::entered() {
+            Mode::Native { src, dst }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::symlink_file(&src, &dst))))
+        })
     }
 }
 
 impl<P, Q> Future for SymlinkFileFuture<P, Q>
 where
-    P: AsRef<Path>,
-    Q: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
+    Q: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::symlink_file(&self.src, &self.dst))
+        match &mut self.0 {
+            Mode::Native { src, dst } => crate::blocking_io(|| fs::symlink_file(src, dst)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/read_dir.rs
+++ b/tokio-fs/src/read_dir.rs
@@ -115,7 +115,7 @@ impl Stream for ReadDir {
                         Some(Err(err)) => Err(err),
                         Some(Ok(item)) => Ok(Some(DirEntry::from_std(item))),
                         None => Ok(None),
-                    })
+                    });
                 }
                 ReadDirMode::Fallback(fallback) => match fallback.take().unwrap() {
                     ReadDirStatus::Idle(mut std) => {

--- a/tokio-fs/src/read_dir.rs
+++ b/tokio-fs/src/read_dir.rs
@@ -1,10 +1,12 @@
-use futures::{Future, Poll, Stream};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{future, try_ready, Async, Future, Poll, Stream};
 use std::ffi::OsString;
 use std::fs::{self, DirEntry as StdDirEntry, FileType, Metadata, ReadDir as StdReadDir};
 use std::io;
 #[cfg(unix)]
 use std::os::unix::fs::DirEntryExt;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
 
 /// Returns a stream over the entries within a directory.
 ///
@@ -20,11 +22,17 @@ where
 
 /// Future returned by `read_dir`.
 #[derive(Debug)]
-pub struct ReadDirFuture<P>
+pub struct ReadDirFuture<P>(ReadDirFutureMode<P>)
+where
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum ReadDirFutureMode<P>
 where
     P: AsRef<Path> + Send + 'static,
 {
-    path: P,
+    Native { path: P },
+    Fallback(Blocking<StdReadDir, io::Error>),
 }
 
 impl<P> ReadDirFuture<P>
@@ -32,7 +40,11 @@ where
     P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> ReadDirFuture<P> {
-        ReadDirFuture { path: path }
+        ReadDirFuture(if tokio_threadpool::entered() {
+            ReadDirFutureMode::Native { path }
+        } else {
+            ReadDirFutureMode::Fallback(blocking(future::lazy(move || fs::read_dir(&path))))
+        })
     }
 }
 
@@ -44,7 +56,19 @@ where
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, io::Error> {
-        crate::blocking_io(|| Ok(ReadDir(fs::read_dir(&self.path)?)))
+        let std = match &mut self.0 {
+            ReadDirFutureMode::Native { path } => {
+                try_ready!(crate::blocking_io(|| fs::read_dir(path)))
+            }
+            ReadDirFutureMode::Fallback(job) => try_ready!(job.poll()),
+        };
+
+        let read_dir = ReadDir(if tokio_threadpool::entered() {
+            ReadDirMode::Native(std)
+        } else {
+            ReadDirMode::Fallback(Some(ReadDirStatus::Idle(std)))
+        });
+        Ok(read_dir.into())
     }
 }
 
@@ -65,18 +89,62 @@ where
 /// [`Stream`]: ../futures/stream/trait.Stream.html
 /// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
 #[derive(Debug)]
-pub struct ReadDir(StdReadDir);
+pub struct ReadDir(ReadDirMode);
+
+#[derive(Debug)]
+enum ReadDirMode {
+    Native(StdReadDir),
+    Fallback(Option<ReadDirStatus>),
+}
+
+#[derive(Debug)]
+enum ReadDirStatus {
+    Idle(StdReadDir),
+    Blocked(Blocking<(StdReadDir, Option<StdDirEntry>), (StdReadDir, io::Error)>),
+}
 
 impl Stream for ReadDir {
     type Item = DirEntry;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        crate::blocking_io(|| match self.0.next() {
-            Some(Err(err)) => Err(err),
-            Some(Ok(item)) => Ok(Some(DirEntry(item))),
-            None => Ok(None),
-        })
+        loop {
+            match &mut self.0 {
+                ReadDirMode::Native(std) => {
+                    return crate::blocking_io(|| match std.next() {
+                        Some(Err(err)) => Err(err),
+                        Some(Ok(item)) => Ok(Some(DirEntry::from_std(item))),
+                        None => Ok(None),
+                    })
+                }
+                ReadDirMode::Fallback(fallback) => match fallback.take().unwrap() {
+                    ReadDirStatus::Idle(mut std) => {
+                        // Start a new blocking task that fetches the next `DirEntry`.
+                        *fallback = Some(ReadDirStatus::Blocked(blocking(future::lazy(
+                            move || match std.next() {
+                                Some(Err(err)) => Err((std, err)),
+                                Some(Ok(item)) => Ok((std, Some(item))),
+                                None => Ok((std, None)),
+                            },
+                        ))));
+                    }
+                    ReadDirStatus::Blocked(mut job) => match job.poll() {
+                        Ok(Async::Ready((std, item))) => {
+                            *fallback = Some(ReadDirStatus::Idle(std));
+                            return Ok(Async::Ready(item.map(DirEntry::from_std)));
+                        }
+                        Ok(Async::NotReady) => {
+                            *fallback = Some(ReadDirStatus::Blocked(job));
+                            return Ok(Async::NotReady);
+                        }
+                        Err((std, err)) => {
+                            *fallback = Some(ReadDirStatus::Idle(std));
+                            return Err(err);
+                        }
+                    },
+                },
+            }
+        }
     }
 }
 
@@ -93,14 +161,48 @@ impl Stream for ReadDir {
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html
 #[derive(Debug)]
-pub struct DirEntry(StdDirEntry);
+pub struct DirEntry(DirEntryMode);
+
+#[derive(Debug)]
+enum DirEntryMode {
+    Native(StdDirEntry),
+    Fallback(Mutex<Option<DirEntryStatus>>),
+}
+
+#[derive(Debug)]
+enum DirEntryStatus {
+    Idle(StdDirEntry),
+    Blocked(Blocking<(StdDirEntry, Operation), (StdDirEntry, io::Error)>),
+}
+
+#[derive(Debug)]
+enum Operation {
+    Metadata(Metadata),
+    FileType(FileType),
+}
 
 impl DirEntry {
+    fn from_std(std: StdDirEntry) -> DirEntry {
+        DirEntry(if tokio_threadpool::entered() {
+            DirEntryMode::Native(std)
+        } else {
+            DirEntryMode::Fallback(Mutex::new(Some(DirEntryStatus::Idle(std))))
+        })
+    }
+
     /// Destructures the `tokio_fs::DirEntry` into a [`std::fs::DirEntry`][std].
     ///
     /// [std]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html
     pub fn into_std(self) -> StdDirEntry {
-        self.0
+        match self.0 {
+            DirEntryMode::Native(std) => std,
+            DirEntryMode::Fallback(fallback) => match fallback.into_inner().unwrap().unwrap() {
+                DirEntryStatus::Idle(std) => std,
+                DirEntryStatus::Blocked(..) => {
+                    panic!("`DirEntry` instance blocked on an async operation")
+                }
+            },
+        }
     }
 
     /// Returns the full path to the file that this entry represents.
@@ -131,7 +233,19 @@ impl DirEntry {
     ///
     /// The exact text, of course, depends on what files you have in `.`.
     pub fn path(&self) -> PathBuf {
-        self.0.path()
+        match &self.0 {
+            DirEntryMode::Native(std) => std.path(),
+            DirEntryMode::Fallback(fallback) => {
+                let fallback = &*fallback.lock().unwrap_or_else(|err| err.into_inner());
+
+                match fallback.as_ref().unwrap() {
+                    DirEntryStatus::Idle(std) => std.path(),
+                    DirEntryStatus::Blocked(..) => {
+                        panic!("`DirEntry` instance blocked on an async operation")
+                    }
+                }
+            }
+        }
     }
 
     /// Returns the bare file name of this directory entry without any other
@@ -151,7 +265,19 @@ impl DirEntry {
     /// tokio::run(fut);
     /// ```
     pub fn file_name(&self) -> OsString {
-        self.0.file_name()
+        match &self.0 {
+            DirEntryMode::Native(std) => std.file_name(),
+            DirEntryMode::Fallback(fallback) => {
+                let fallback = &*fallback.lock().unwrap_or_else(|err| err.into_inner());
+
+                match fallback.as_ref().unwrap() {
+                    DirEntryStatus::Idle(std) => std.file_name(),
+                    DirEntryStatus::Blocked(..) => {
+                        panic!("`DirEntry` instance blocked on an async operation")
+                    }
+                }
+            }
+        }
     }
 
     /// Return the metadata for the file that this entry points at.
@@ -182,7 +308,40 @@ impl DirEntry {
     /// tokio::run(fut);
     /// ```
     pub fn poll_metadata(&self) -> Poll<Metadata, io::Error> {
-        crate::blocking_io(|| self.0.metadata())
+        match &self.0 {
+            DirEntryMode::Native(std) => crate::blocking_io(|| std.metadata()),
+            DirEntryMode::Fallback(fallback) => {
+                let fallback = &mut *fallback.lock().unwrap_or_else(|err| err.into_inner());
+                loop {
+                    match fallback.take().unwrap() {
+                        DirEntryStatus::Idle(std) => {
+                            // Start a new blocking task that fetches the metadata.
+                            *fallback = Some(DirEntryStatus::Blocked(blocking(future::lazy(
+                                move || match std.metadata() {
+                                    Ok(md) => Ok((std, Operation::Metadata(md))),
+                                    Err(err) => Err((std, err)),
+                                },
+                            ))));
+                        }
+                        DirEntryStatus::Blocked(mut job) => match job.poll() {
+                            Ok(Async::Ready((std, oper))) => {
+                                *fallback = Some(DirEntryStatus::Idle(std));
+
+                                // If the last operation was `MetaData`, returns its result.
+                                if let Operation::Metadata(md) = oper {
+                                    return Ok(md.into());
+                                }
+                            }
+                            Ok(Async::NotReady) => {
+                                *fallback = Some(DirEntryStatus::Blocked(job));
+                                return Ok(Async::NotReady);
+                            }
+                            Err(..) => unreachable!(),
+                        },
+                    }
+                }
+            }
+        }
     }
 
     /// Return the file type for the file that this entry points at.
@@ -214,13 +373,59 @@ impl DirEntry {
     /// tokio::run(fut);
     /// ```
     pub fn poll_file_type(&self) -> Poll<FileType, io::Error> {
-        crate::blocking_io(|| self.0.file_type())
+        match &self.0 {
+            DirEntryMode::Native(std) => crate::blocking_io(|| std.file_type()),
+            DirEntryMode::Fallback(fallback) => {
+                let fallback = &mut *fallback.lock().unwrap_or_else(|err| err.into_inner());
+
+                loop {
+                    match fallback.take().unwrap() {
+                        DirEntryStatus::Idle(std) => {
+                            // Start a new blocking task that fetches the file type.
+                            *fallback = Some(DirEntryStatus::Blocked(blocking(future::lazy(
+                                move || match std.file_type() {
+                                    Ok(ft) => Ok((std, Operation::FileType(ft))),
+                                    Err(err) => Err((std, err)),
+                                },
+                            ))));
+                        }
+                        DirEntryStatus::Blocked(mut job) => match job.poll() {
+                            Ok(Async::Ready((std, oper))) => {
+                                *fallback = Some(DirEntryStatus::Idle(std));
+
+                                // If the last operation was `FileType`, returns its result.
+                                if let Operation::FileType(ft) = oper {
+                                    return Ok(ft.into());
+                                }
+                            }
+                            Ok(Async::NotReady) => {
+                                *fallback = Some(DirEntryStatus::Blocked(job));
+                                return Ok(Async::NotReady);
+                            }
+                            Err(..) => unreachable!(),
+                        },
+                    }
+                }
+            }
+        }
     }
 }
 
 #[cfg(unix)]
 impl DirEntryExt for DirEntry {
     fn ino(&self) -> u64 {
-        self.0.ino()
+        match &self.0 {
+            DirEntryMode::Native(std) => std.ino(),
+            DirEntryMode::Fallback(fallback) => {
+                let fallback = &*fallback.lock().unwrap_or_else(|err| err.into_inner());
+
+                match fallback.as_ref().unwrap() {
+                    DirEntryStatus::Idle(std) => std.ino(),
+                    DirEntryStatus::Blocked(..) => {
+                        panic!("`DirEntry` instance blocked on an async operation")
+                    }
+                }
+            }
+        }
     }
 }

--- a/tokio-fs/src/read_link.rs
+++ b/tokio-fs/src/read_link.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
@@ -8,36 +9,52 @@ use std::path::{Path, PathBuf};
 /// This is an async version of [`std::fs::read_link`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.read_link.html
-pub fn read_link<P: AsRef<Path>>(path: P) -> ReadLinkFuture<P> {
+pub fn read_link<P>(path: P) -> ReadLinkFuture<P>
+where
+    P: AsRef<Path> + Send + 'static,
+{
     ReadLinkFuture::new(path)
 }
 
 /// Future returned by `read_link`.
 #[derive(Debug)]
-pub struct ReadLinkFuture<P>
+pub struct ReadLinkFuture<P>(Mode<P>)
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P>
+where
+    P: AsRef<Path> + Send + 'static,
 {
-    path: P,
+    Native { path: P },
+    Fallback(Blocking<PathBuf, io::Error>),
 }
 
 impl<P> ReadLinkFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> ReadLinkFuture<P> {
-        ReadLinkFuture { path: path }
+        ReadLinkFuture(if tokio_threadpool::entered() {
+            Mode::Native { path }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::read_link(path))))
+        })
     }
 }
 
 impl<P> Future for ReadLinkFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = PathBuf;
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::read_link(&self.path))
+        match &mut self.0 {
+            Mode::Native { path } => crate::blocking_io(|| fs::read_link(path)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -1,5 +1,5 @@
 use super::blocking_pool::{blocking, Blocking};
-use futures::{future, Future, Poll, future};
+use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -1,5 +1,5 @@
 use super::blocking_pool::{blocking, Blocking};
-use futures::{Future, Poll, future};
+use futures::{future, Future, Poll, future};
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{Future, Poll, future};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -8,36 +9,52 @@ use std::path::Path;
 /// This is an async version of [`std::fs::remove_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir.html
-pub fn remove_dir<P: AsRef<Path>>(path: P) -> RemoveDirFuture<P> {
+pub fn remove_dir<P>(path: P) -> RemoveDirFuture<P>
+where
+    P: AsRef<Path> + Send + 'static,
+{
     RemoveDirFuture::new(path)
 }
 
 /// Future returned by `remove_dir`.
 #[derive(Debug)]
-pub struct RemoveDirFuture<P>
+pub struct RemoveDirFuture<P>(Mode<P>)
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P>
+where
+    P: AsRef<Path> + Send + 'static,
 {
-    path: P,
+    Native { path: P },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P> RemoveDirFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> RemoveDirFuture<P> {
-        RemoveDirFuture { path: path }
+        RemoveDirFuture(if tokio_threadpool::entered() {
+            Mode::Native { path }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || fs::remove_dir(&path))))
+        })
     }
 }
 
 impl<P> Future for RemoveDirFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::remove_dir(&self.path))
+        match &mut self.0 {
+            Mode::Native { path } => crate::blocking_io(|| fs::remove_dir(path)),
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/rename.rs
+++ b/tokio-fs/src/rename.rs
@@ -46,9 +46,7 @@ where
         RenameFuture(if tokio_threadpool::entered() {
             Mode::Native { from, to }
         } else {
-            Mode::Fallback(blocking(future::lazy(move || {
-                fs::rename(&from, &to)
-            })))
+            Mode::Fallback(blocking(future::lazy(move || fs::rename(&from, &to))))
         })
     }
 }

--- a/tokio-fs/src/set_permissions.rs
+++ b/tokio-fs/src/set_permissions.rs
@@ -1,4 +1,5 @@
-use futures::{Future, Poll};
+use super::blocking_pool::{blocking, Blocking};
+use futures::{future, Future, Poll};
 use std::fs;
 use std::io;
 use std::path::Path;
@@ -8,40 +9,56 @@ use std::path::Path;
 /// This is an async version of [`std::fs::set_permissions`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
-pub fn set_permissions<P: AsRef<Path>>(path: P, perm: fs::Permissions) -> SetPermissionsFuture<P> {
+pub fn set_permissions<P>(path: P, perm: fs::Permissions) -> SetPermissionsFuture<P>
+where
+    P: AsRef<Path> + Send + 'static,
+{
     SetPermissionsFuture::new(path, perm)
 }
 
 /// Future returned by `set_permissions`.
 #[derive(Debug)]
-pub struct SetPermissionsFuture<P>
+pub struct SetPermissionsFuture<P>(Mode<P>)
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static;
+
+#[derive(Debug)]
+enum Mode<P>
+where
+    P: AsRef<Path> + Send + 'static,
 {
-    path: P,
-    perm: fs::Permissions,
+    Native { path: P, perm: fs::Permissions },
+    Fallback(Blocking<(), io::Error>),
 }
 
 impl<P> SetPermissionsFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P, perm: fs::Permissions) -> SetPermissionsFuture<P> {
-        SetPermissionsFuture {
-            path: path,
-            perm: perm,
-        }
+        SetPermissionsFuture(if tokio_threadpool::entered() {
+            Mode::Native { path, perm }
+        } else {
+            Mode::Fallback(blocking(future::lazy(move || {
+                fs::set_permissions(&path, perm)
+            })))
+        })
     }
 }
 
 impl<P> Future for SetPermissionsFuture<P>
 where
-    P: AsRef<Path>,
+    P: AsRef<Path> + Send + 'static,
 {
     type Item = ();
     type Error = io::Error;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        crate::blocking_io(|| fs::set_permissions(&self.path, self.perm.clone()))
+        match &mut self.0 {
+            Mode::Native { path, perm } => {
+                crate::blocking_io(|| fs::set_permissions(path, perm.clone()))
+            }
+            Mode::Fallback(job) => job.poll(),
+        }
     }
 }

--- a/tokio-fs/src/stderr.rs
+++ b/tokio-fs/src/stderr.rs
@@ -2,6 +2,8 @@ use futures::Poll;
 use std::io::{self, Stderr as StdStderr, Write};
 use tokio_io::AsyncWrite;
 
+// TODO(stjepang): Implement support for single-threaded runtimes.
+
 /// A handle to the standard error stream of a process.
 ///
 /// The handle implements the [`AsyncWrite`] trait, but beware that concurrent
@@ -27,11 +29,11 @@ pub fn stderr() -> Stderr {
 
 impl Write for Stderr {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        crate::would_block(|| self.std.write(buf))
+        crate::would_block(crate::blocking_io(|| self.std.write(buf)))
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        crate::would_block(|| self.std.flush())
+        crate::would_block(crate::blocking_io(|| self.std.flush()))
     }
 }
 

--- a/tokio-fs/src/stdin.rs
+++ b/tokio-fs/src/stdin.rs
@@ -1,6 +1,8 @@
 use std::io::{self, Read, Stdin as StdStdin};
 use tokio_io::AsyncRead;
 
+// TODO(stjepang): Implement support for single-threaded runtimes.
+
 /// A handle to the standard input stream of a process.
 ///
 /// The handle implements the [`AsyncRead`] trait, but beware that concurrent
@@ -32,7 +34,7 @@ pub fn stdin() -> Stdin {
 
 impl Read for Stdin {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        crate::would_block(|| self.std.read(buf))
+        crate::would_block(crate::blocking_io(|| self.std.read(buf)))
     }
 }
 

--- a/tokio-fs/src/stdout.rs
+++ b/tokio-fs/src/stdout.rs
@@ -2,6 +2,8 @@ use futures::Poll;
 use std::io::{self, Stdout as StdStdout, Write};
 use tokio_io::AsyncWrite;
 
+// TODO(stjepang): Implement support for single-threaded runtimes.
+
 /// A handle to the standard output stream of a process.
 ///
 /// The handle implements the [`AsyncWrite`] trait, but beware that concurrent
@@ -27,11 +29,11 @@ pub fn stdout() -> Stdout {
 
 impl Write for Stdout {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        crate::would_block(|| self.std.write(buf))
+        crate::would_block(crate::blocking_io(|| self.std.write(buf)))
     }
 
     fn flush(&mut self) -> io::Result<()> {
-        crate::would_block(|| self.std.flush())
+        crate::would_block(crate::blocking_io(|| self.std.flush()))
     }
 }
 

--- a/tokio-fs/tests/common/dir.rs
+++ b/tokio-fs/tests/common/dir.rs
@@ -1,19 +1,18 @@
 #![deny(warnings, rust_2018_idioms)]
 
+use crate::run;
 use futures::{Future, Stream};
 use std::fs;
 use std::sync::{Arc, Mutex};
 use tempdir::TempDir;
 use tokio_fs::*;
 
-mod pool;
-
 #[test]
 fn create() {
     let base_dir = TempDir::new("base").unwrap();
     let new_dir = base_dir.path().join("foo");
 
-    pool::run({ create_dir(new_dir.clone()) });
+    run({ create_dir(new_dir.clone()) });
 
     assert!(new_dir.is_dir());
 }
@@ -23,7 +22,7 @@ fn create_all() {
     let base_dir = TempDir::new("base").unwrap();
     let new_dir = base_dir.path().join("foo").join("bar");
 
-    pool::run({ create_dir_all(new_dir.clone()) });
+    run({ create_dir_all(new_dir.clone()) });
 
     assert!(new_dir.is_dir());
 }
@@ -35,7 +34,7 @@ fn remove() {
 
     fs::create_dir(new_dir.clone()).unwrap();
 
-    pool::run({ remove_dir(new_dir.clone()) });
+    run({ remove_dir(new_dir.clone()) });
 
     assert!(!new_dir.exists());
 }
@@ -53,7 +52,7 @@ fn read() {
 
     let f = files.clone();
     let p = p.to_path_buf();
-    pool::run({
+    run({
         read_dir(p).flatten_stream().for_each(move |e| {
             let s = e.file_name().to_str().unwrap().to_string();
             f.lock().unwrap().push(s);

--- a/tokio-fs/tests/common/link.rs
+++ b/tokio-fs/tests/common/link.rs
@@ -1,12 +1,12 @@
 #![deny(warnings, rust_2018_idioms)]
 
+use crate::run;
+use futures::Future;
 use std::fs;
 use std::io::prelude::*;
 use std::io::BufReader;
 use tempdir::TempDir;
 use tokio_fs::*;
-
-mod pool;
 
 #[test]
 fn test_hard_link() {
@@ -19,7 +19,7 @@ fn test_hard_link() {
         file.write_all(b"hello").unwrap();
     }
 
-    pool::run({ hard_link(src, dst.clone()) });
+    run({ hard_link(src, dst.clone()) });
 
     let mut content = String::new();
 
@@ -35,8 +35,6 @@ fn test_hard_link() {
 #[cfg(unix)]
 #[test]
 fn test_symlink() {
-    use futures::Future;
-
     let dir = TempDir::new("base").unwrap();
     let src = dir.path().join("src.txt");
     let dst = dir.path().join("dst.txt");
@@ -46,7 +44,7 @@ fn test_symlink() {
         file.write_all(b"hello").unwrap();
     }
 
-    pool::run({ os::unix::symlink(src.clone(), dst.clone()) });
+    run({ os::unix::symlink(src.clone(), dst.clone()) });
 
     let mut content = String::new();
 
@@ -58,6 +56,6 @@ fn test_symlink() {
 
     assert!(content == "hello");
 
-    pool::run({ read_link(dst.clone()).map(move |x| assert!(x == src)) });
-    pool::run({ symlink_metadata(dst.clone()).map(move |x| assert!(x.file_type().is_symlink())) });
+    run({ read_link(dst.clone()).map(move |x| assert!(x == src)) });
+    run({ symlink_metadata(dst.clone()).map(move |x| assert!(x.file_type().is_symlink())) });
 }

--- a/tokio-fs/tests/common/mod.rs
+++ b/tokio-fs/tests/common/mod.rs
@@ -1,0 +1,3 @@
+mod dir;
+mod file;
+mod link;

--- a/tokio-fs/tests/current_thread.rs
+++ b/tokio-fs/tests/current_thread.rs
@@ -1,0 +1,12 @@
+mod common;
+
+use futures::Future;
+use std::io;
+use tokio_current_thread::CurrentThread;
+
+pub fn run<F>(f: F)
+where
+    F: Future<Item = (), Error = io::Error> + Send + 'static,
+{
+    CurrentThread::new().block_on(f).unwrap();
+}

--- a/tokio-fs/tests/threadpool.rs
+++ b/tokio-fs/tests/threadpool.rs
@@ -1,10 +1,11 @@
-use futures;
-use tokio_threadpool;
-
 use self::tokio_threadpool::Builder;
+use futures;
 use futures::sync::oneshot;
 use futures::Future;
 use std::io;
+use tokio_threadpool;
+
+mod common;
 
 pub fn run<F>(f: F)
 where

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -148,4 +148,4 @@ pub use crate::builder::Builder;
 pub use crate::sender::Sender;
 pub use crate::shutdown::Shutdown;
 pub use crate::thread_pool::{SpawnHandle, ThreadPool};
-pub use crate::worker::{Worker, WorkerId};
+pub use crate::worker::{entered, Worker, WorkerId};

--- a/tokio-threadpool/src/worker/mod.rs
+++ b/tokio-threadpool/src/worker/mod.rs
@@ -82,6 +82,11 @@ pub struct WorkerId(pub(crate) usize);
 // Pointer to the current worker info
 thread_local!(static CURRENT_WORKER: Cell<*const Worker> = Cell::new(0 as *const _));
 
+/// Returns `true` when inside a `tokio-threadpool`.
+pub fn entered() -> bool {
+    CURRENT_WORKER.with(|worker| !worker.get().is_null())
+}
+
 impl Worker {
     pub(crate) fn new(
         id: WorkerId,


### PR DESCRIPTION
## Summary

Make `tokio-fs` work on runtimes that don't have `tokio-threadpool`.

Apologies for the big PR. :( While the total diff is pretty large, half of it
is just boring boilerplate. You can find the most interesting code in these
files:

* `fallback.rs`
* `blocking_pool.rs`

## Motivation

When using the `curent-thread` runtime, the `tokio_threadpool::blocking()`
function is not available, which is currently a requirement for `tokio-fs` to
to run blocking filesystem operations.

Note that `tokio-current-thread` cannot implement a function equivalent to
`tokio_threadpool::blocking()` because futures in this single-threaded
executor are not necessarily `Send`. That means we cannot start executing
the blocking function on the current thread and move the event loop onto a
new thread.

Blocking filesystem operations therefore *must* be run on a thread different
from the current one. Still, the solution to this problem is not as easy as
"just" spawning blocking operations onto a different thread.

## Naive solutions and why they don't work

Consider this function that reads bytes from a file asynchronously:

```rust
pub fn poll_read(&mut self, buf: &mut [u8]) -> Poll<usize, io::Error> {
    // ...
}
```

Suppose now that the file is not ready for reading and spawns a blocking
operation onto a different thread. Where should the read bytes be written? We
can't write them into `buf` because this reference is not available after
`poll_read()` returns `Ok(Async::NotReady)`.

A solution might be to change the signature of the function so that it gives
the `poll_read()` function a buffer, moves it into the spawned blocking task,
and finally returns it back when ready:

```rust
pub fn poll_read(&mut self, buf: Vec<u8>) -> Poll<Vec<u8>, io::Error> {
    // ...
}
```

This would work just fine at the expense of having a more cumbersome interface
and not being able to implement the `AsyncRead` trait.

## The right solution

Fortunately, there is a way out of this mess. We can create a hidden internal
byte buffer inside our file implementation. When `poll_read()` gets called,
we transfer bytes from the internal buffer into `buf`. And if the buffer is
empty, we spawn a blocking operation that reads from the file and refills
the internal buffer.

This is a neat solution, but note that it complicates other operations, too.
For example, if we want to seek inside the file 100 bytes forward but the
buffer is 10 bytes long, that means we *actually* need to seek 90 bytes forward
only because the cursor has already been moved 10 bytes forward by the last
async read operation.

Long story short, if we keep building the whole set of async file operations
this way, we'll essentially reimplement the same file abstraction that exists
inside the OS when a file is opened. There will be a read/write buffer, some
sort of state like the current position inside the file, whether there is data
that needs to be flushed to disk, etc.

## What's in this PR?

First, function `entered()` that returns a `bool` is added to
`tokio-threadpool` so that we can check whether `blocking()` is available or
not.

Then, there is a very simple "blocking pool" implementation that is able to
spawn tasks that execute blocking functions. It is currently just a hack on
top of a dedicated `tokio-threadpool` instance and will need a better
implementation in the future. See #588.

Simple filesystem operations like `remove_file()` just call `entered()` and
then call the blocking operation inside `blocking()` if available, or else
spawn the operation onto the blocking pool and await its result.

The whole `tokio-fs` crate besides stdin/stdout/stderr is covered by this PR.

Implementing `tokio_fs::File` was the biggest challenge by far because we
need to keep a pretty complex state of the file and make transitions through
its state machine when async operations get polled.

The fallback implementation of `File` is inside `fallback.rs`. The general
idea behind its design is that there is an `Option<State>` (set to `None` when
the file is closed) containing the state of the file, which consists of:

1. The file handle of type `std::fs::File`.
2. The byte buffer - essentially a `Vec<u8>` and a slice inside it.
3. Whether the buffer is currently used for reading or writing.
4. The result of the last async operation.

The file is either idle and contains the state, or blocked on an async
operation and contains just an awaitable handle to the operation. When the
async operation is completed, it returns back the state and the file becomes
idle again. There can be only one async operation in progress at a time.

As an example, function `poll_read()` will do the following:

1. If the last operation was read and resulted in EOF, return.
2. If the buffer is currently used for writing, spawn an operation flushing it.
3. If the buffer is empty, spawn an operation that reads from the file and
   refills the buffer.
4. Otherwise, the buffer is ready for reading so we can just pull some bytes
   from it.

## Backwards compatibility

Unfortunately, we have to break compatibility in a few cases. Consider this
function:

```rust
pub fn create_dir<P: AsRef<Path>>(path: P) -> CreateDirFuture<P> {
    // ...
}
```

We cannot spawn a blocking task that runs `std::fs::create_dir(path)` onto a
different thread because `P` is not `Send + 'static`. Therefore, we need
this signature instead:

```rust
pub fn create_dir(path: P) -> CreateDirFuture<P>
where
    P: AsRef<Path> + Send + 'static,
{
    // ...
}
```

Here's a complete list of functions that break compatibility in the same
manner:

- `create_dir(path)`
- `create_dir_all(path)`
- `hard_link(src, dist)`
- `symlink(src, dist)`
- `symlink_dir(src, dist)`
- `symlink_file(src, dist)`
- `read_link(path)`
- `remove_dir(path)`
- `remove_file(path)`
- `rename(from, to)`
- `set_permissions(path, perm)`

## Additional notes and caveats

* The fallback `File` implementation wraps its inner representation into an
  `Arc<Mutex<_>>` and every operation on the file locks the mutex. The reason
  why we do that is because `File` handles can be cloned and shared among
  threads. But that's totally okay - OS-level file descriptors can be cloned
  (aka "duped") as well so the OS will protect the internal file state by
  its equivalent of `Arc<Mutex<_>>` too.

* If you don't flush or close the file manually, the contents written into the
  file might be lost! Unfortunately, we cannot (actually, *can* but probably
  *shouldn't*) flush the contents when `File` gets dropped because flushing is
  a blocking operation.

* Functions [`poll_metadata()`] and [`poll_file_type()`] should've taken
  `&mut self` rather than `&self`. We could switch to `&mut self` and break
  compatibility, but I decided to just wrap the inner state of `DirEntry`
  inside a mutex instead.

* The async function `write(path, contents)` will now also flush after writing
  into the file. I figured it'd be too easy to make mistakes without
  automatic flushing and in fact, without flushing one of the tests was
  failing.

* Performance is not good right now. For example, reading a 10 Gb file
  currently takes ~10 times longer using the fallback method. But don't worry,
  there is a way to bring the implementation on par with blocking file reads
  (or maybe make it even faster?). See below under "remaining work".

* In #954, @carllerche asked about unnecessary allocations during blocking
  task spawning. The current blocking pool based on `tokio-threadpool` is
  very simple and not really designed for performance. Once we build a proper
  `tokio-blocking` pool, spawning will incur a single allocation only.

* Since `tokio-fs` expects `tokio_threadpool::entered()`, we'll temporarily
  need a `[patch.crates-io]` section inside `Cargo.toml` to use the local
  version of `tokio-threadpool` rather than the latest published one.

[`poll_metadata()`]: https://docs.rs/tokio-fs/0.1.6/tokio_fs/struct.DirEntry.html#method.poll_metadata
[`poll_file_type()`]: https://docs.rs/tokio-fs/0.1.6/tokio_fs/struct.DirEntry.html#method.poll_file_type

## Tests

The test suite has been refactored so that all unit tests get run on both
runtimes (the one based on `tokio-threadpool` and the one based on
`tokio-current-thread`).

All tests seem to be passing, but note that the test suite is not as
extensive at the moment as we would like it to be. There's a lot of functions
that are simply not covered by tests.

## Remaining work

There is some remaining work, but I'd like to address it in seprate PRs:

* The test suite needs higher coverage. Nothing besides the most important
  filesystem operations is currently tested.

* Instead of the simple blocking pool hack inside `blocking_pool.rs`, we'll
  need a real thread pool for executing blocking functions. This issue is
  tracked in #588.

* Support for stdin/stdout/stderr will come later. Reading/writing from/into
  these files is a slightly different problem because operations on them
  might block for a longer time than typical filesystem operations, or might
  even block indefinitely waiting for user input.

* Performance improvements. Increasing the size of the internal buffer seems
  to make huge reads much faster, so we probably just need to tweak the buffer
  growth or prefetching strategy. There is an [article] on readahead logic in
  the Linux kernel we might want to steal ideas from.

[article]: https://lwn.net/Articles/372384/

Refs: #1178