### PR TITLE
trace-core: prepare for 0.2 release

### DIFF
--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.0 (April 11, 2019)
+# 0.2.0 (April 21, 2019)
 
 ### Breaking Changes
 - Remove `Callsite::clear_interest` and `Callsite::add_interest` (#1039)

--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Fixed
 - `fmt::Debug` impls for `field::Display` and `field::Debug` not passing through
   to the inner value (#992)
+- Entering a `Dispatch` function unsets the default dispatcher for the duration
+  of the function (so that events inside the subscriber cannot cause infinite
+  loops) (#1033)
 
 # 0.1.0 (March 13, 2019)
 

--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Next Release
+
+### Breaking Change
+- Removed `Callsite::clear_interest` and `Callsite::add_interest`.
+
+### Added
+- `Callsite::set_interest`
+
 # 0.1.0 (March 13, 2019)
 
 - Initial release

--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -1,10 +1,16 @@
 # Next Release
 
 ### Breaking Change
-- Removed `Callsite::clear_interest` and `Callsite::add_interest`.
+- Removed `Callsite::clear_interest` and `Callsite::add_interest` (#1039)
 
 ### Added
-- `Callsite::set_interest`
+- Add a function to rebuild cached interest (#1039)
+- Add overrideable downcasting to `Subscriber`s (#974)
+- Add slightly more useful debug impls (#1014)
+
+### Fixed
+- `fmt::Debug` impls for `field::Display` and `field::Debug` not passing through
+  to the inner value (#992)
 
 # 0.1.0 (March 13, 2019)
 

--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next Release
+# 0.2.0 (April 11, 2019)
 
 ### Breaking Changes
 - Remove `Callsite::clear_interest` and `Callsite::add_interest` (#1039)

--- a/tokio-trace/tokio-trace-core/CHANGELOG.md
+++ b/tokio-trace/tokio-trace-core/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Next Release
 
-### Breaking Change
-- Removed `Callsite::clear_interest` and `Callsite::add_interest` (#1039)
+### Breaking Changes
+- Remove `Callsite::clear_interest` and `Callsite::add_interest` (#1039)
+- `metadata!` macro now requires a `Kind` field (#1046)
 
 ### Added
 - Add a function to rebuild cached interest (#1039)
 - Add overrideable downcasting to `Subscriber`s (#974)
 - Add slightly more useful debug impls (#1014)
+- Introduce callsite classification in metadata (#1046)
 
 ### Fixed
 - `fmt::Debug` impls for `field::Display` and `field::Debug` not passing through

--- a/tokio-trace/tokio-trace-core/Cargo.toml
+++ b/tokio-trace/tokio-trace-core/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-trace-core"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
+# - Create "v0.2.x" git tag.
 version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio-trace/tokio-trace-core/Cargo.toml
+++ b/tokio-trace/tokio-trace-core/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core"
+documentation = "https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core"
 description = """
 Core primitives for tokio-trace.
 """

--- a/tokio-trace/tokio-trace-core/README.md
+++ b/tokio-trace/tokio-trace-core/README.md
@@ -2,7 +2,7 @@
 
 Core primitives for `tokio-trace`.
 
-[Documentation](https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/index.html)
+[Documentation](https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/index.html)
 
 ## Overview
 
@@ -34,16 +34,16 @@ API. However, this crate's API will change very infrequently, so it may be used
 when dependencies must be very stable.
 
 [`tokio-trace`]: ../
-[`Span`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/span/struct.Span.html
-[`Event`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/event/struct.Event.html
-[`Subscriber`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/subscriber/trait.Subscriber.html
-[`Metadata`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/metadata/struct.Metadata.html
-[`Callsite`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/callsite/trait.Callsite.html
-[`Field`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/field/struct.Field.html
-[`FieldSet`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/field/struct.FieldSet.html
-[`Value`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/field/trait.Value.html
-[`ValueSet`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/field/struct.ValueSet.html
-[`Dispatch`]: https://docs.rs/tokio-trace-core/0.1.0/tokio_trace_core/dispatcher/struct.Dispatch.html
+[`Span`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/span/struct.Span.html
+[`Event`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/event/struct.Event.html
+[`Subscriber`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/subscriber/trait.Subscriber.html
+[`Metadata`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/metadata/struct.Metadata.html
+[`Callsite`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/callsite/trait.Callsite.html
+[`Field`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/field/struct.Field.html
+[`FieldSet`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/field/struct.FieldSet.html
+[`Value`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/field/trait.Value.html
+[`ValueSet`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/field/struct.ValueSet.html
+[`Dispatch`]: https://docs.rs/tokio-trace-core/0.2.0/tokio_trace_core/dispatcher/struct.Dispatch.html
 
 ## License
 

--- a/tokio-trace/tokio-trace-core/src/lib.rs
+++ b/tokio-trace/tokio-trace-core/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-trace-core/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-trace-core/0.2.0")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 


### PR DESCRIPTION
This branch prepares `tokio-trace-core` to release version 0.2. It
updates the changelog, including a note on breaking changes; and bumps
the docs.rs version linked in Cargo.toml & in the README.