### PR TITLE
async-await: fix examples

### DIFF
--- a/tokio-async-await/examples/Cargo.toml
+++ b/tokio-async-await/examples/Cargo.toml
@@ -25,14 +25,14 @@ name = "hyper"
 path = "src/hyper.rs"
 
 [dependencies]
-tokio = { version = "0.1.0", path = "../..", features = ["async-await-preview"] }
+tokio = { version = "0.1.18", features = ["async-await-preview"] }
 futures = "0.1.23"
 bytes = "0.4.9"
 hyper = "0.12.8"
 
 # Avoid using crates.io for Tokio dependencies
 [patch.crates-io]
-tokio = { path = "../.." }
+tokio = { path = "../../tokio" }
 tokio-async-await  = { path = "../" }
 tokio-codec = { path = "../../tokio-codec" }
 tokio-current-thread = { path = "../../tokio-current-thread" }

--- a/tokio-async-await/src/io/mod.rs
+++ b/tokio-async-await/src/io/mod.rs
@@ -24,7 +24,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
@@ -58,7 +58,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
@@ -77,7 +77,7 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// ## EOF is hit before `buf` is filled
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
@@ -109,7 +109,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
@@ -138,7 +138,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
@@ -162,7 +162,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```edition2018
     /// #![feature(async_await, await_macro, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with

--- a/tokio-async-await/src/stream/mod.rs
+++ b/tokio-async-await/src/stream/mod.rs
@@ -12,12 +12,12 @@ pub trait StreamExt: Stream {
     ///
     /// # Examples
     ///
-    /// ```
-    /// #![feature(await_macro, async_await)]
+    /// ```edition2018
+    /// #![feature(await_macro, async_await, futures_api)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
-    /// use tokio::prelude::{stream, StreamExt};
+    /// use tokio::prelude::{stream, StreamAsyncExt};
     ///
     /// let mut stream = stream::iter_ok::<_, ()>(1..3);
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Some examples in async-await fail to compile (even if updated to the new API by https://github.com/tokio-rs/tokio/pull/1049).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

* Fix crate path in `Cargo.toml` of examples
* Add `edition2018` to examples in the documentation to make it compiled on Rust 2018
* Fix an example in the documentation

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
