### PR TITLE
trace: prepare tokio-trace for release

### DIFF
--- a/tokio-trace/CHANGELOG.md
+++ b/tokio-trace/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 0.1.0 (April 15, 2019)
+
+- Initial release

--- a/tokio-trace/CHANGELOG.md
+++ b/tokio-trace/CHANGELOG.md
@@ -1,3 +1,3 @@
-# 0.1.0 (April 15, 2019)
+# 0.1.0 (April 22, 2019)
 
 - Initial release

--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -1,21 +1,26 @@
 [package]
 name = "tokio-trace"
-version = "0.0.1"
-authors = ["Eliza Weisman <eliza@buoyant.io>"]
+# When releasing to crates.io:
+# - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag
+version = "0.1.0"
+authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
+documentation = "https://docs.rs/tokio-trace/0.1.0/tokio_trace"
 description = """
 A scoped, structured logging and diagnostics system.
 """
 categories = ["development-tools::debugging", "asynchronous"]
 keywords = ["logging", "tracing"]
 
-# Not yet ready for production.
-publish = false
-
 [dependencies]
-tokio-trace-core = { path = "./tokio-trace-core" }
+tokio-trace-core = "0.2"
 log = { version = "0.4", optional = true }
 cfg-if = "0.1.7"
 

--- a/tokio-trace/README.md
+++ b/tokio-trace/README.md
@@ -2,7 +2,7 @@
 
 A scoped, structured logging and diagnostics system.
 
-[Documentation](https://tokio-rs.github.io/tokio/doc/tokio_trace/)
+[Documentation](https://docs.rs/tokio-trace/0.1.0/tokio_trace/index.html)
 
 ## Overview
 
@@ -29,7 +29,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+tokio-trace = "0.1"
 ```
 
 Next, add this to your crate:

--- a/tokio-trace/src/field.rs
+++ b/tokio-trace/src/field.rs
@@ -10,6 +10,8 @@ use Metadata;
 /// Indexing a field with a string results in an iterative search that performs
 /// string comparisons. Thus, if possible, once the key for a field is known, it
 /// should be used whenever possible.
+///
+/// [`Field`]: ../struct.Field.html
 pub trait AsField: ::sealed::Sealed {
     /// Attempts to convert `&self` into a `Field` with the specified `metadata`.
     ///

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -1,4 +1,6 @@
 #![doc(html_root_url = "https://docs.rs/tokio-trace/0.1.0")]
+#![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
+#![cfg_attr(test, deny(warnings))]
 //! A scoped, structured logging and diagnostics system.
 //!
 //! # Overview
@@ -33,6 +35,20 @@
 //! another context. The span in which a thread is currently executing is
 //! referred to as the _current_ span.
 //!
+//! For example:
+//! ```
+//! #[macro_use]
+//! extern crate tokio_trace;
+//!
+//! use tokio_trace::Level;
+//!
+//! # fn main() {
+//! span!(Level::TRACE, "my_span").enter(|| {
+//!     // perform some work in the context of `my_span`...
+//! });
+//! # }
+//!```
+//!
 //! Spans form a tree structure — unless it is a root span, all spans have a
 //! _parent_, and may have one or more _children_. When a new span is created,
 //! the current span becomes the new span's parent. The total execution time of
@@ -40,10 +56,43 @@
 //! represented by its children. Thus, a parent span always lasts for at least
 //! as long as the longest-executing span in its subtree.
 //!
+//! ```
+//! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
+//! # fn main() {
+//! // this span is considered the "root" of a new trace tree:
+//! span!(Level::INFO, "root").enter(|| {
+//!     // since we are now inside "root", this span is considered a child
+//!     // of "root":
+//!     span!(Level::DEBUG, "outer_child").enter(|| {
+//!         // this span is a child of "outer_child", which is in turn a
+//!         // child of "root":
+//!         span!(Level::TRACE, "inner_child").enter(|| {
+//!             // and so on...
+//!         });
+//!     });
+//! });
+//! # }
+//!```
+//!
 //! In addition, data may be associated with spans. A span may have _fields_ —
 //! a set of key-value pairs describing the state of the program during that
 //! span; an optional name, and metadata describing the source code location
 //! where the span was originally entered.
+//! ```
+//! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
+//! # fn main() {
+//! // construct a new span with three fields:
+//! //  - "foo", with a value of 42,
+//! //  - "bar", with the value "false"
+//! //  - "baz", with no initial value
+//! let my_span = span!(Level::INFO, "my_span", foo = 42, bar = false, baz);
+//!
+//! // record a value for the field "baz" declared above:
+//! my_span.record("baz", &"hello world");
+//! # }
+//!```
 //!
 //! ### When to use spans
 //!
@@ -96,9 +145,22 @@
 //! records emitted by unstructured logging code, but unlike a typical log line,
 //! an `Event` may occur within the context of a `Span`. Like a `Span`, it
 //! may have fields, and implicitly inherits any of the fields present on its
-//! parent span, and it may be linked with one or more additional
-//! spans that are not its parent; in this case, the event is said to _follow
-//! from_ those spans.
+//! parent span.
+//!
+//! For example:
+//! ```
+//! # #[macro_use] extern crate tokio_trace;
+//! # use tokio_trace::Level;
+//! # fn main() {
+//! // records an event outside of any span context:
+//! event!(Level::INFO, "something happened");
+//!
+//! span!(Level::INFO, "my_span").enter(|| {
+//!     // records an event within "my_span".
+//!     event!(Level::DEBUG, "something happened inside my_span");
+//! });
+//! # }
+//!```
 //!
 //! Essentially, `Event`s exist to bridge the gap between traditional
 //! unstructured logging and span-based tracing. Similar to log records, they
@@ -231,13 +293,13 @@
 //! You can find examples showing how to use this crate in the examples
 //! directory.
 //!
-//! ### In libraries
+//! ## In libraries
 //!
 //! Libraries should link only to the `tokio-trace` crate, and use the provided
 //! macros to record whatever information will be useful to downstream
 //! consumers.
 //!
-//! ### In executables
+//! ## In executables
 //!
 //! In order to record trace events, executables have to use a `Subscriber`
 //! implementation compatible with `tokio-trace`. A `Subscriber` implements a
@@ -265,6 +327,7 @@
 //! #   fn new() -> Self { FooSubscriber }
 //! # }
 //! # fn main() {
+//!
 //! let my_subscriber = FooSubscriber::new();
 //!
 //! tokio_trace::subscriber::with_default(my_subscriber, || {
@@ -300,6 +363,21 @@
 //!   trace tree. This is useful when a project using `tokio-trace` have
 //!   dependencies which use `log`.
 //!
+//!
+//! ##  Crate Feature Flags
+//!
+//! The following crate feature flags are available:
+//!
+//! * A set of features controlling the [static verbosity level].
+//! * `log` causes trace instrumentation points to emit [`log`] records as well
+//!   as trace events. This is inteded for use in libraries whose users may be
+//!   using either `tokio-trace` or `log`.
+//!
+//! ```toml
+//! [dependencies]
+//! tokio-trace = { version = "0.1", features = ["log"] }
+//! ```
+//!
 //! [`log`]: https://docs.rs/log/0.4.6/log/
 //! [`Span`]: span/struct.Span
 //! [`Event`]: struct.Event.html
@@ -313,6 +391,7 @@
 //! [`tokio-trace-futures`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-futures
 //! [`tokio-trace-fmt`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-fmt
 //! [`tokio-trace-log`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-log
+//! [static verbosity level]: level_filters/index.html#compile-time-filters
 #[macro_use]
 extern crate cfg_if;
 extern crate tokio_trace_core;

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_root_url = "https://docs.rs/tokio-trace/0.1.0")]
 //! A scoped, structured logging and diagnostics system.
 //!
 //! # Overview
@@ -139,7 +140,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! tokio-trace = { git = "https://github.com/tokio-rs/tokio" }
+//! tokio-trace = "0.1"
 //! ```
 //!
 //! Next, add this to your crate:

--- a/tokio-trace/src/subscriber.rs
+++ b/tokio-trace/src/subscriber.rs
@@ -8,9 +8,9 @@ pub use tokio_trace_core::subscriber::*;
 /// executing, new spans or events are dispatched to the subscriber that
 /// tagged that span, instead.
 ///
-/// [`Span`]: ::span::Span
-/// [`Subscriber`]: ::Subscriber
-/// [`Event`]: ::Event
+/// [`Span`]: ../span/struct.Span.html
+/// [`Subscriber`]: ../subscriber/trait.Subscriber.html
+/// [`Event`]: :../event/struct.Event.html
 pub fn with_default<T, S>(subscriber: S, f: impl FnOnce() -> T) -> T
 where
     S: Subscriber + Send + Sync + 'static,


### PR DESCRIPTION
This branch prepares `tokio-trace` for an 0.1 release on crates.io.

It also makes some last minute documentation improvements 
(including fixing broken links in RustDoc).