### PR TITLE
threadpool: add panic_handler

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -36,7 +36,3 @@ env_logger = "0.5"
 # For comparison benchmarks
 futures-cpupool = "0.1.7"
 threadpool = "1.7.1"
-
-[features]
-default = []
-no_catch_panic = []

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -36,3 +36,7 @@ env_logger = "0.5"
 # For comparison benchmarks
 futures-cpupool = "0.1.7"
 threadpool = "1.7.1"
+
+[features]
+default = []
+no_catch_panic = []

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -106,6 +106,7 @@ impl Builder {
                 around_worker: None,
                 after_start: None,
                 before_stop: None,
+                catch_panics: true,
             },
             new_park,
         }
@@ -196,6 +197,13 @@ impl Builder {
     /// ```
     pub fn keep_alive(&mut self, val: Option<Duration>) -> &mut Self {
         self.config.keep_alive = val;
+        self
+    }
+
+    /// Sets whether Tokio should catch panics (and print them to stderr) from
+    /// tasks. The default value is `false`.
+    pub fn catch_panics(&mut self, val: bool) -> &mut Self {
+        self.config.catch_panics = val;
         self
     }
 

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -107,7 +107,7 @@ impl Builder {
                 around_worker: None,
                 after_start: None,
                 before_stop: None,
-                catch_panics: None,
+                panic_handler: None,
             },
             new_park,
         }
@@ -217,15 +217,15 @@ impl Builder {
     ///
     /// # pub fn main() {
     /// let thread_pool = Builder::new()
-    ///     .catch_panics(|err| std::panic::resume_unwind(err))
+    ///     .panic_handler(|err| std::panic::resume_unwind(err))
     ///     .build();
     /// # }
     /// ```
-    pub fn catch_panics<F>(&mut self, f: F) -> &mut Self
+    pub fn panic_handler<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(Box<Any + Send>) + Send + Sync + 'static,
     {
-        self.config.catch_panics = Some(Arc::new(f));
+        self.config.panic_handler = Some(Arc::new(f));
         self
     }
 

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -6,6 +6,7 @@ use shutdown::ShutdownTrigger;
 use thread_pool::ThreadPool;
 use worker::{self, Worker, WorkerId};
 
+use std::any::Any;
 use std::cmp::max;
 use std::error::Error;
 use std::fmt;
@@ -222,7 +223,7 @@ impl Builder {
     /// ```
     pub fn catch_panics<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(Box<dyn std::any::Any + Send>) + Send + Sync + 'static,
+        F: Fn(Box<Any + Send>) + Send + Sync + 'static,
     {
         self.config.catch_panics = Some(Arc::new(f));
         self

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -203,8 +203,9 @@ impl Builder {
     /// Sets a callback to be triggered when a panic during a future bubbles up
     /// to Tokio. By default Tokio catches these panics, and they will be
     /// ignored. The parameter passed to this callback is the same error value
-    /// returned from std::panic::catch_unwind(). To crash on panics, use
-    /// std::panic::resume_unwind() in this callback.
+    /// returned from std::panic::catch_unwind(). To abort the process on
+    /// panics, use std::panic::resume_unwind() in this callback as shown
+    /// below.
     ///
     /// # Examples
     ///
@@ -215,9 +216,7 @@ impl Builder {
     ///
     /// # pub fn main() {
     /// let thread_pool = Builder::new()
-    ///     .catch_panics(|err| {
-    ///         std::panic::resume_unwind(err)
-    ///     })
+    ///     .catch_panics(|err| std::panic::resume_unwind(err))
     ///     .build();
     /// # }
     /// ```

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -1,5 +1,6 @@
 use callback::Callback;
 
+use std::any::Any;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,7 +15,7 @@ pub(crate) struct Config {
     pub around_worker: Option<Callback>,
     pub after_start: Option<Arc<Fn() + Send + Sync>>,
     pub before_stop: Option<Arc<Fn() + Send + Sync>>,
-    pub catch_panics: Option<Arc<Fn(Box<dyn std::any::Any + Send>) + Send + Sync>>,
+    pub catch_panics: Option<Arc<Fn(Box<Any + Send>) + Send + Sync>>,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -14,6 +14,7 @@ pub(crate) struct Config {
     pub around_worker: Option<Callback>,
     pub after_start: Option<Arc<Fn() + Send + Sync>>,
     pub before_stop: Option<Arc<Fn() + Send + Sync>>,
+    pub catch_panics: bool,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can
@@ -27,6 +28,7 @@ impl fmt::Debug for Config {
             .field("keep_alive", &self.keep_alive)
             .field("name_prefix", &self.name_prefix)
             .field("stack_size", &self.stack_size)
+            .field("catch_panics", &self.catch_panics)
             .finish()
     }
 }

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -15,7 +15,7 @@ pub(crate) struct Config {
     pub around_worker: Option<Callback>,
     pub after_start: Option<Arc<Fn() + Send + Sync>>,
     pub before_stop: Option<Arc<Fn() + Send + Sync>>,
-    pub catch_panics: Option<Arc<Fn(Box<Any + Send>) + Send + Sync>>,
+    pub panic_handler: Option<Arc<Fn(Box<Any + Send>) + Send + Sync>>,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -14,7 +14,7 @@ pub(crate) struct Config {
     pub around_worker: Option<Callback>,
     pub after_start: Option<Arc<Fn() + Send + Sync>>,
     pub before_stop: Option<Arc<Fn() + Send + Sync>>,
-    pub catch_panics: bool,
+    pub catch_panics: Option<Arc<Fn(Box<dyn std::any::Any + Send>) + Send + Sync>>,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can
@@ -28,7 +28,6 @@ impl fmt::Debug for Config {
             .field("keep_alive", &self.keep_alive)
             .field("name_prefix", &self.name_prefix)
             .field("stack_size", &self.stack_size)
-            .field("catch_panics", &self.catch_panics)
             .finish()
     }
 }

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -166,7 +166,7 @@ impl Task {
                 self.state.store(State::Complete.into(), Release);
 
                 if let Err(panic_err) = res {
-                    if let Some(ref f) = unpark.pool.config.catch_panics {
+                    if let Some(ref f) = unpark.pool.config.panic_handler {
                         f(panic_err);
                     }
                 }

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -151,6 +151,13 @@ impl Task {
             ret
         }));
 
+        #[cfg(feature = "no_catch_panic")]
+        {
+            if let Err(err) = res {
+                panic::resume_unwind(err);
+            }
+        }
+
         match res {
             Ok(Ok(Async::Ready(_))) | Ok(Err(_)) | Err(_) => {
                 trace!("    -> task complete");

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -151,8 +151,7 @@ impl Task {
             ret
         }));
 
-        #[cfg(feature = "no_catch_panic")]
-        {
+        if !unpark.pool.config.catch_panics {
             if let Err(err) = res {
                 panic::resume_unwind(err);
             }

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -400,11 +400,11 @@ fn panic_in_task() {
 }
 
 #[test]
-fn count_catch_panics() {
+fn count_panics() {
     let counter = Arc::new(AtomicUsize::new(0));
     let counter_ = counter.clone();
     let pool = tokio_threadpool::Builder::new()
-        .catch_panics(move |_err| {
+        .panic_handler(move |_err| {
             // We caught a panic.
             counter_.fetch_add(1, Relaxed);
         })

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -372,6 +372,7 @@ fn busy_threadpool_is_not_idle() {
     idle.wait().unwrap();
 }
 
+#[cfg(not(feature = "no_catch_panic"))]
 #[test]
 fn panic_in_task() {
     let pool = ThreadPool::new();

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -372,7 +372,6 @@ fn busy_threadpool_is_not_idle() {
     idle.wait().unwrap();
 }
 
-#[cfg(not(feature = "no_catch_panic"))]
 #[test]
 fn panic_in_task() {
     let pool = ThreadPool::new();
@@ -399,6 +398,37 @@ fn panic_in_task() {
 
     pool.shutdown_on_idle().wait().unwrap();
 }
+
+/* WIP...
+
+#[test]
+fn no_catch_panics() {
+    use std::panic;
+
+    struct Boom;
+
+    impl Future for Boom {
+        type Item = ();
+        type Error = ();
+
+        fn poll(&mut self) -> Poll<(), ()> {
+            panic!();
+        }
+    }
+
+    let pool = tokio_threadpool::Builder::new()
+        .catch_panics(false)
+        .around_worker(move |w, _| {
+            let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                w.run();
+            }));
+            assert!(res.is_err());
+        })
+        .build();
+
+    pool.spawn_handle(Boom).wait();
+}
+*/
 
 #[test]
 fn multi_threadpool() {


### PR DESCRIPTION


## Motivation

tokio-threadpool currently catches panics that happen inside the thread pool. This can cause silent failures. 

## Solution

This patch adds a feature `no_catch_panic` to tokio-threadpool to `resume_unwind()` after the catch happens. This does not actually forward the panics back to `tokio::run()`, that will be left for later work.

Ref https://github.com/tokio-rs/tokio/issues/495
https://github.com/tokio-rs/tokio/issues/209
https://github.com/denoland/deno/issues/1311
https://github.com/denoland/deno/issues/2097
