### PR TITLE
Bump `tokio` to 0.1.19.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.18/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.19/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 The API docs for the master branch are published [here][master-dox].
@@ -49,9 +49,9 @@ level, it provides a few major components:
 These components provide the runtime components necessary for building
 an asynchronous application.
 
-[net]: https://docs.rs/tokio/0.1.18/tokio/net/index.html
-[reactor]: https://docs.rs/tokio/0.1.18/tokio/reactor/index.html
-[scheduler]: https://docs.rs/tokio/0.1.18/tokio/runtime/index.html
+[net]: https://docs.rs/tokio/0.1.19/tokio/net/index.html
+[reactor]: https://docs.rs/tokio/0.1.19/tokio/reactor/index.html
+[scheduler]: https://docs.rs/tokio/0.1.19/tokio/runtime/index.html
 
 ## Example
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,7 +75,7 @@ jobs:
   parameters:
     name: async_await
     displayName: Async / Await
-    rust: nightly-2019-04-13
+    rust: nightly-2019-04-22
     noDefaultFeatures: ''
     benches: true
     crates:

--- a/tokio-async-await/Cargo.toml
+++ b/tokio-async-await/Cargo.toml
@@ -3,12 +3,12 @@ name = "tokio-async-await"
 
 # When releasing to crates.io:
 # - Update html_root_url.
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-async-await/0.1.6"
+documentation = "https://docs.rs/tokio-async-await/0.1.7"
 description = """
 Experimental async/await support for Tokio
 """

--- a/tokio-async-await/src/lib.rs
+++ b/tokio-async-await/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "async-await-preview")]
 #![feature(rust_2018_preview, async_await, await_macro, futures_api)]
-#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-async-await/0.1.7")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/tokio-buf/CHANGELOG.md
+++ b/tokio-buf/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.1.1 (April 22, 2019)
+
+### Added
+- Utilities for creating a `BufStream` from iterators and streams (#1011).
+- Add `BufStream::into_stream` (#1048).
+- Implement `FromBufStream` for `Bytes` (#1009).
+- Implement `Error` for `CollectVecError` (#1010).
+
+### Fixed
+- Implement `size_hint` for string types (#1012).
+
 # 0.1.0 (February 23, 2019)
 
 * Initial release

--- a/tokio-buf/Cargo.toml
+++ b/tokio-buf/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-buf"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-buf/0.1.0/tokio_buf"
+documentation = "https://docs.rs/tokio-buf/0.1.1/tokio_buf"
 description = """
 Asynchronous stream of byte buffers
 """

--- a/tokio-buf/README.md
+++ b/tokio-buf/README.md
@@ -10,7 +10,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-tokio-buf = "0.1.0"
+tokio-buf = "0.1.1"
 ```
 
 Next, add this to your crate:

--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-buf/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-buf/0.1.1")]
 #![deny(missing_docs, missing_debug_implementations, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/tokio-sync/CHANGELOG.md
+++ b/tokio-sync/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.5 (April 22, 2019)
+
+### Added
+- Add asynchronous mutual exclusion primitive (#964).
+
 # 0.1.4 (March 13, 2019)
 
 ### Fixed

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -7,12 +7,12 @@ name = "tokio-sync"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-sync/0.1.4/tokio_sync"
+documentation = "https://docs.rs/tokio-sync/0.1.5/tokio_sync"
 description = """
 Synchronization utilities.
 """

--- a/tokio-sync/README.md
+++ b/tokio-sync/README.md
@@ -2,7 +2,7 @@
 
 Synchronization utilities
 
-[Documentation](https://docs.rs/tokio-sync/0.1.4/tokio_sync/)
+[Documentation](https://docs.rs/tokio-sync/0.1.5/tokio_sync/)
 
 ## Overview
 

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-sync/0.1.4")]
+#![doc(html_root_url = "https://docs.rs/tokio-sync/0.1.5")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
 

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.14 (April 22, 2019)
+
+### Added
+- Add `panic_handler` for customizing action taken on panic (#1052).
+
 # 0.1.13 (March 22, 2019)
 
 ### Added

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -7,8 +7,8 @@ name = "tokio-threadpool"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.13"
-documentation = "https://docs.rs/tokio-threadpool/0.1.13/tokio_threadpool"
+version = "0.1.14"
+documentation = "https://docs.rs/tokio-threadpool/0.1.14/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.13/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.14/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.13")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.14")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,11 +7,11 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.18/tokio/"
+documentation = "https://docs.rs/tokio/0.1.19/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -28,7 +28,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.18/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.19/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 ## Overview
@@ -45,9 +45,9 @@ level, it provides a few major components:
 These components provide the runtime components necessary for building
 an asynchronous application.
 
-[net]: https://docs.rs/tokio/0.1.18/tokio/net/index.html
-[reactor]: https://docs.rs/tokio/0.1.18/tokio/reactor/index.html
-[scheduler]: https://docs.rs/tokio/0.1.18/tokio/runtime/index.html
+[net]: https://docs.rs/tokio/0.1.19/tokio/net/index.html
+[reactor]: https://docs.rs/tokio/0.1.19/tokio/reactor/index.html
+[scheduler]: https://docs.rs/tokio/0.1.19/tokio/runtime/index.html
 
 ## Example
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.18")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.19")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 #![cfg_attr(
     feature = "async-await-preview",


### PR DESCRIPTION
This also bumps:

- tokio-async-await (0.1.7)
- tokio-buf (0.1.1)
- tokio-sync (0.1.5)
- tokio-threadpool (0.1.14)