### PR TITLE
tokio: Bump min version of tokio-sync

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -73,7 +73,7 @@ tokio-fs = { version = "0.1.6", optional = true }
 tokio-io = { version = "0.1.6", optional = true }
 tokio-executor = { version = "0.1.7", optional = true }
 tokio-reactor = { version = "0.1.1", optional = true }
-tokio-sync = { version = "0.1.3", optional = true, path = "../tokio-sync" }
+tokio-sync = { version = "0.1.5", optional = true }
 tokio-threadpool = { version = "0.1.13", optional = true }
 tokio-tcp = { version = "0.1.0", optional = true }
 tokio-udp = { version = "0.1.0", optional = true }


### PR DESCRIPTION
It is needed for lock functionality which tokio now uses.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
