### PR TITLE
Fix an error in the mit-url in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the Rust programming language. It is:
 [crates-badge]: https://img.shields.io/crates/v/tokio.svg
 [crates-url]: https://crates.io/crates/tokio
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
-[mit-url]: LICENSE-MIT
+[mit-url]: LICENSE
 [azure-badge]: https://dev.azure.com/tokio-rs/Tokio/_apis/build/status/tokio-rs.tokio?branchName=master
 [azure-url]: https://dev.azure.com/tokio-rs/Tokio/_build/latest?definitionId=1&branchName=master
 [gitter-badge]: https://img.shields.io/gitter/room/tokio-rs/tokio.svg


### PR DESCRIPTION
The URL for the licence badge points to the wrong place.

## Motivation

Point the URL to the correct place.

## Solution

Remove the -MIT from the end of the current file name.