### PR TITLE
signal: Smaller dependency

### DIFF
--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -33,7 +33,7 @@ tokio-io = "0.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 mio-uds = "0.6"
-signal-hook = "0.1"
+signal-hook-registry = "~1"
 
 [dev-dependencies]
 tokio = "0.1.8"


### PR DESCRIPTION
The signal-hook library got split into lower-level and higher-level
parts. The tokio-signal uses only API from the lower-level one, so it
can depend on it directly.

The only effect of this change is smaller amount of compiled (and
unused) code during compilation. There's no change in the code actually used.