### PR TITLE
Allow non-static futures in Runtime::block_on

### DIFF
--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -1,8 +1,8 @@
 use crate::worker::Worker;
 use futures::{try_ready, Poll};
+use std::cell::Cell;
 use std::error::Error;
 use std::fmt;
-use std::cell::Cell;
 use std::marker::PhantomData;
 
 thread_local! {
@@ -167,14 +167,14 @@ where
 }
 
 /// Registers the thread as "blockable" until the returned guard object is dropped.
-/// 
+///
 /// Calls to `blocking` made on a blockable thread will immediately run the
 /// closure. This can be used when a thread is masquerading as part of a runtime,
 /// but its associated reactor is on another thread of execution so there's no
 /// danger when running blocking tasks.
-/// 
+///
 /// # Panics
-/// 
+///
 /// Panics if the thread is already registered as blockable.
 pub fn blockable() -> Blockable {
     BLOCKABLE.with(|c| {

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -143,7 +143,7 @@ mod task;
 mod thread_pool;
 mod worker;
 
-pub use crate::blocking::{blocking, BlockingError};
+pub use crate::blocking::{blockable, blocking, Blockable, BlockingError};
 pub use crate::builder::Builder;
 pub use crate::sender::Sender;
 pub use crate::shutdown::Shutdown;

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -346,6 +346,7 @@ impl Builder {
         // subscriber for the runtime.
         let dispatch = trace::dispatcher::get_default(trace::Dispatch::clone);
 
+        let dispatch2 = dispatch.clone();
         let pool = self
             .threadpool_builder
             .around_worker(move |w, enter| {
@@ -354,7 +355,7 @@ impl Builder {
                 tokio_reactor::with_default(&reactor_handles[index], enter, |enter| {
                     clock::with_default(&clock, enter, |enter| {
                         timer::with_default(&timer_handles[index], enter, |_| {
-                            trace::dispatcher::with_default(&dispatch, || {
+                            trace::dispatcher::with_default(&dispatch2, || {
                                 w.run();
                             })
                         });
@@ -381,6 +382,8 @@ impl Builder {
                 reactor_handle,
                 reactor: Mutex::new(Some(reactor)),
                 pool,
+                clock: self.clock.clone(),
+                dispatch,
             }),
         })
     }

--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -264,6 +264,7 @@ impl Runtime {
         F: Future<Item = R, Error = E>,
     {
         let mut entered = enter().expect("nested block_on");
+        let _blockable = threadpool::blockable();
 
         let (tx, rx) = futures::sync::oneshot::channel();
         self.spawn(future::lazy(|| {

--- a/tokio/tests/runtime.rs
+++ b/tokio/tests/runtime.rs
@@ -234,6 +234,15 @@ fn block_on_timer() {
     runtime.shutdown_on_idle().wait().unwrap();
 }
 
+#[test]
+fn block_on_blocking() {
+    let mut runtime = Runtime::new().unwrap();
+    let future = future::poll_fn(|| tokio_threadpool::blocking(|| 42));
+    assert_eq!(runtime.block_on(future).unwrap(), 42);
+    runtime.shutdown_on_idle().wait().unwrap();
+}
+
+
 mod from_block_on {
     use super::*;
 

--- a/tokio/tests/runtime.rs
+++ b/tokio/tests/runtime.rs
@@ -242,7 +242,6 @@ fn block_on_blocking() {
     runtime.shutdown_on_idle().wait().unwrap();
 }
 
-
 mod from_block_on {
     use super::*;
 


### PR DESCRIPTION
Rather than just spawning the future off onto the runtime's worker
threads, we run it locally on the calling thread by setting up the
thread-local context as if we were a randomly selected worker thread.

There's currently something broken with timers - the
runtime::block_on_timer test isn't completing.