### PR TITLE
timer: Replace Handle::deadline with Handle::timeout

### DIFF
--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -126,7 +126,10 @@ impl<T> Timeout<T> {
     /// ```
     pub fn new(value: T, timeout: Duration) -> Timeout<T> {
         let delay = Delay::new_timeout(now() + timeout, timeout);
+        Timeout::new_with_delay(value, delay)
+    }
 
+    pub(crate) fn new_with_delay(value: T, delay: Delay) -> Timeout<T> {
         Timeout { value, delay }
     }
 

--- a/tokio-timer/src/timer/handle.rs
+++ b/tokio-timer/src/timer/handle.rs
@@ -1,5 +1,5 @@
 use timer::Inner;
-use {Deadline, Delay, Error, Interval};
+use {Deadline, Delay, Error, Interval, Timeout};
 
 use tokio_executor::Enter;
 
@@ -139,9 +139,15 @@ impl Handle {
         }
     }
 
-    /// Create a `Deadline` driven by this handle's associated `Timer`.
+    #[doc(hidden)]
+    #[deprecated(since = "0.2.11", note = "use timeout instead")]
     pub fn deadline<T>(&self, future: T, deadline: Instant) -> Deadline<T> {
         Deadline::new_with_delay(future, self.delay(deadline))
+    }
+
+    /// Create a `Timeout` driven by this handle's associated `Timer`.
+    pub fn timeout<T>(&self, value: T, deadline: Instant) -> Timeout<T> {
+        Timeout::new_with_delay(value, self.delay(deadline))
     }
 
     /// Create a new `Interval` that starts at `at` and yields every `duration`

--- a/tokio-timer/tests/hammer.rs
+++ b/tokio-timer/tests/hammer.rs
@@ -118,7 +118,7 @@ fn hammer_cancel() {
                     let deadline = cmp::min(deadline1, deadline2);
 
                     let delay = handle.delay(deadline1);
-                    let join = handle.deadline(delay, deadline2);
+                    let join = handle.timeout(delay, deadline2);
 
                     exec.push({
                         join.and_then(move |_| {


### PR DESCRIPTION
Deadline was deprecated a while ago and replaced with Timeout, but the
methods on Handle got missed.

Fixes #1071