### PR TITLE
async-await: [WIP] replace std await! macro with await syntax

### DIFF
--- a/async-await/src/chat.rs
+++ b/async-await/src/chat.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::r#await;
+use tokio::async_wait;
 use tokio::codec::{LinesCodec, Decoder};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
@@ -33,7 +33,7 @@ async fn process(stream: TcpStream, state: Arc<Mutex<Shared>>) -> io::Result<()>
     let mut lines = LinesCodec::new().framed(stream);
 
     // Extract the peer's name
-    let name = match r#await!(lines.next()) {
+    let name = match async_wait!(lines.next()) {
         Some(name) => name?,
         None => {
             // Disconnected early
@@ -56,15 +56,15 @@ async fn process(stream: TcpStream, state: Arc<Mutex<Shared>>) -> io::Result<()>
     // Spawn a task that receives all lines broadcasted to us from other peers
     // and writes it to the client.
     tokio::spawn_async(async move {
-        while let Some(line) = r#await!(rx.next()) {
+        while let Some(line) = async_wait!(rx.next()) {
             let line = line.unwrap();
-            r#await!(lines_tx.send_async(line)).unwrap();
+            async_wait!(lines_tx.send_async(line)).unwrap();
         }
     });
 
     // Use the current task to read lines from the socket and broadcast them to
     // other peers.
-    while let Some(message) = r#await!(lines_rx.next()) {
+    while let Some(message) = async_wait!(lines_rx.next()) {
         // TODO: Error handling
         let message = message.unwrap();
 
@@ -113,7 +113,7 @@ async fn main() {
     // Start the Tokio runtime.
     let mut incoming = listener.incoming();
 
-    while let Some(stream) = r#await!(incoming.next()) {
+    while let Some(stream) = async_wait!(incoming.next()) {
         let stream = match stream {
             Ok(stream) => stream,
             Err(_) => continue,
@@ -122,7 +122,7 @@ async fn main() {
         let state = state.clone();
 
         tokio::spawn_async(async move {
-            if let Err(_) = r#await!(process(stream, state)) {
+            if let Err(_) = async_wait!(process(stream, state)) {
                 eprintln!("failed to process connection");
             }
         });

--- a/async-await/src/chat.rs
+++ b/async-await/src/chat.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::await;
+use tokio::r#await;
 use tokio::codec::{LinesCodec, Decoder};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
@@ -33,7 +33,7 @@ async fn process(stream: TcpStream, state: Arc<Mutex<Shared>>) -> io::Result<()>
     let mut lines = LinesCodec::new().framed(stream);
 
     // Extract the peer's name
-    let name = match await!(lines.next()) {
+    let name = match r#await!(lines.next()) {
         Some(name) => name?,
         None => {
             // Disconnected early
@@ -56,15 +56,15 @@ async fn process(stream: TcpStream, state: Arc<Mutex<Shared>>) -> io::Result<()>
     // Spawn a task that receives all lines broadcasted to us from other peers
     // and writes it to the client.
     tokio::spawn_async(async move {
-        while let Some(line) = await!(rx.next()) {
+        while let Some(line) = r#await!(rx.next()) {
             let line = line.unwrap();
-            await!(lines_tx.send_async(line)).unwrap();
+            r#await!(lines_tx.send_async(line)).unwrap();
         }
     });
 
     // Use the current task to read lines from the socket and broadcast them to
     // other peers.
-    while let Some(message) = await!(lines_rx.next()) {
+    while let Some(message) = r#await!(lines_rx.next()) {
         // TODO: Error handling
         let message = message.unwrap();
 
@@ -113,7 +113,7 @@ async fn main() {
     // Start the Tokio runtime.
     let mut incoming = listener.incoming();
 
-    while let Some(stream) = await!(incoming.next()) {
+    while let Some(stream) = r#await!(incoming.next()) {
         let stream = match stream {
             Ok(stream) => stream,
             Err(_) => continue,
@@ -122,7 +122,7 @@ async fn main() {
         let state = state.clone();
 
         tokio::spawn_async(async move {
-            if let Err(_) = await!(process(stream, state)) {
+            if let Err(_) = r#await!(process(stream, state)) {
                 eprintln!("failed to process connection");
             }
         });

--- a/async-await/src/echo_client.rs
+++ b/async-await/src/echo_client.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::r#await;
+use tokio::async_wait;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 
@@ -14,7 +14,7 @@ const MESSAGES: &[&str] = &[
 ];
 
 async fn run_client(addr: &SocketAddr) -> io::Result<()> {
-    let mut stream = r#await!(TcpStream::connect(addr))?;
+    let mut stream = async_wait!(TcpStream::connect(addr))?;
 
     // Buffer to read into
     let mut buf = [0; 128];
@@ -23,10 +23,10 @@ async fn run_client(addr: &SocketAddr) -> io::Result<()> {
         println!(" > write = {:?}", msg);
 
         // Write the message to the server
-        r#await!(stream.write_all_async(msg.as_bytes()))?;
+        async_wait!(stream.write_all_async(msg.as_bytes()))?;
 
         // Read the message back from the server
-        r#await!(stream.read_exact_async(&mut buf[..msg.len()]))?;
+        async_wait!(stream.read_exact_async(&mut buf[..msg.len()]))?;
 
         assert_eq!(&buf[..msg.len()], msg.as_bytes());
     }
@@ -43,7 +43,7 @@ async fn main() {
 
     // Connect to the echo serveer
 
-    match r#await!(run_client(&addr)) {
+    match async_wait!(run_client(&addr)) {
         Ok(_) => println!("done."),
         Err(e) => eprintln!("echo client failed; error = {:?}", e),
     }

--- a/async-await/src/echo_client.rs
+++ b/async-await/src/echo_client.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::await;
+use tokio::r#await;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 
@@ -14,7 +14,7 @@ const MESSAGES: &[&str] = &[
 ];
 
 async fn run_client(addr: &SocketAddr) -> io::Result<()> {
-    let mut stream = await!(TcpStream::connect(addr))?;
+    let mut stream = r#await!(TcpStream::connect(addr))?;
 
     // Buffer to read into
     let mut buf = [0; 128];
@@ -23,10 +23,10 @@ async fn run_client(addr: &SocketAddr) -> io::Result<()> {
         println!(" > write = {:?}", msg);
 
         // Write the message to the server
-        await!(stream.write_all_async(msg.as_bytes()))?;
+        r#await!(stream.write_all_async(msg.as_bytes()))?;
 
         // Read the message back from the server
-        await!(stream.read_exact_async(&mut buf[..msg.len()]))?;
+        r#await!(stream.read_exact_async(&mut buf[..msg.len()]))?;
 
         assert_eq!(&buf[..msg.len()], msg.as_bytes());
     }
@@ -43,7 +43,7 @@ async fn main() {
 
     // Connect to the echo serveer
 
-    match await!(run_client(&addr)) {
+    match r#await!(run_client(&addr)) {
         Ok(_) => println!("done."),
         Err(e) => eprintln!("echo client failed; error = {:?}", e),
     }

--- a/async-await/src/echo_server.rs
+++ b/async-await/src/echo_server.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::r#await;
+use tokio::async_wait;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
@@ -11,11 +11,11 @@ fn handle(mut stream: TcpStream) {
         let mut buf = [0; 1024];
 
         loop {
-            match r#await!(stream.read_async(&mut buf)).unwrap() {
+            match async_wait!(stream.read_async(&mut buf)).unwrap() {
                 0 => break, // Socket closed
                 n => {
                     // Send the data back
-                    r#await!(stream.write_all_async(&buf[0..n])).unwrap();
+                    async_wait!(stream.write_all_async(&buf[0..n])).unwrap();
                 }
             }
         }
@@ -35,7 +35,7 @@ async fn main() {
 
     let mut incoming = listener.incoming();
 
-    while let Some(stream) = r#await!(incoming.next()) {
+    while let Some(stream) = async_wait!(incoming.next()) {
         let stream = stream.unwrap();
         handle(stream);
     }

--- a/async-await/src/echo_server.rs
+++ b/async-await/src/echo_server.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::await;
+use tokio::r#await;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
@@ -11,11 +11,11 @@ fn handle(mut stream: TcpStream) {
         let mut buf = [0; 1024];
 
         loop {
-            match await!(stream.read_async(&mut buf)).unwrap() {
+            match r#await!(stream.read_async(&mut buf)).unwrap() {
                 0 => break, // Socket closed
                 n => {
                     // Send the data back
-                    await!(stream.write_all_async(&buf[0..n])).unwrap();
+                    r#await!(stream.write_all_async(&buf[0..n])).unwrap();
                 }
             }
         }
@@ -35,7 +35,7 @@ async fn main() {
 
     let mut incoming = listener.incoming();
 
-    while let Some(stream) = await!(incoming.next()) {
+    while let Some(stream) = r#await!(incoming.next()) {
         let stream = stream.unwrap();
         handle(stream);
     }

--- a/async-await/src/hyper.rs
+++ b/async-await/src/hyper.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::r#await;
+use tokio::async_wait;
 use tokio::prelude::*;
 use hyper::Client;
 
@@ -13,7 +13,7 @@ async fn main() {
 
     let uri = "http://httpbin.org/ip".parse().unwrap();
 
-    let response = r#await!({
+    let response = async_wait!({
         client.get(uri)
             .timeout(Duration::from_secs(10))
     }).unwrap();
@@ -22,7 +22,7 @@ async fn main() {
 
     let mut body = response.into_body();
 
-    while let Some(chunk) = r#await!(body.next()) {
+    while let Some(chunk) = async_wait!(body.next()) {
         let chunk = chunk.unwrap();
         println!("chunk = {}", str::from_utf8(&chunk[..]).unwrap());
     }

--- a/async-await/src/hyper.rs
+++ b/async-await/src/hyper.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::await;
+use tokio::r#await;
 use tokio::prelude::*;
 use hyper::Client;
 
@@ -13,7 +13,7 @@ async fn main() {
 
     let uri = "http://httpbin.org/ip".parse().unwrap();
 
-    let response = await!({
+    let response = r#await!({
         client.get(uri)
             .timeout(Duration::from_secs(10))
     }).unwrap();
@@ -22,7 +22,7 @@ async fn main() {
 
     let mut body = response.into_body();
 
-    while let Some(chunk) = await!(body.next()) {
+    while let Some(chunk) = r#await!(body.next()) {
         let chunk = chunk.unwrap();
         println!("chunk = {}", str::from_utf8(&chunk[..]).unwrap());
     }

--- a/async-await/tests/macros.rs
+++ b/async-await/tests/macros.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::await;
+use tokio::r#await;
 use tokio::timer::Delay;
 use std::time::{Duration, Instant};
 
@@ -18,5 +18,5 @@ async fn fail_no_async() {
 #[tokio::test]
 async fn use_timer() {
     let when = Instant::now() + Duration::from_millis(10);
-    await!(Delay::new(when));
+    r#await!(Delay::new(when));
 }

--- a/async-await/tests/macros.rs
+++ b/async-await/tests/macros.rs
@@ -1,6 +1,6 @@
 #![feature(await_macro, async_await)]
 
-use tokio::r#await;
+use tokio::async_wait;
 use tokio::timer::Delay;
 use std::time::{Duration, Instant};
 
@@ -18,5 +18,5 @@ async fn fail_no_async() {
 #[tokio::test]
 async fn use_timer() {
     let when = Instant::now() + Duration::from_millis(10);
-    r#await!(Delay::new(when));
+    async_wait!(Delay::new(when));
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
   parameters:
     name: test_nightly
     displayName: Test Async / Await
-    rust: nightly-2019-04-25
+    rust: nightly-2019-05-09
 
 # Try cross compiling
 - template: ci/azure-cross-compile.yml

--- a/tokio-futures/README.md
+++ b/tokio-futures/README.md
@@ -25,7 +25,7 @@ Then, get started. In your application, add:
 
 ```rust
 // The nightly features that are commonly needed with async / await
-#![feature(await_macro, async_await)]
+#![feature(async_await)]
 
 // This pulls in the `tokio-futures` crate. While Rust 2018 doesn't require
 // `extern crate`, we need to pull in the macros.

--- a/tokio-futures/src/async_wait.rs
+++ b/tokio-futures/src/async_wait.rs
@@ -1,6 +1,6 @@
 /// Wait for a future to complete.
 #[macro_export]
-macro_rules! await {
+macro_rules! async_wait {
     ($e:expr) => {{
         #[allow(unused_imports)]
         use $crate::compat::backward::IntoAwaitable as IntoAwaitableBackward;

--- a/tokio-futures/src/await.rs
+++ b/tokio-futures/src/await.rs
@@ -11,6 +11,8 @@ macro_rules! await {
         #[allow(unused_mut)]
         let mut e = $e;
         let e = e.into_awaitable();
+        // TODO: The code that the macro expands inherits the edition of the crate in which the macro is defined.
+        // When this crate transitioned to 2018 edition, replace it with the `await` syntax.
         std_await!(e)
     }};
 }

--- a/tokio-futures/src/await.rs
+++ b/tokio-futures/src/await.rs
@@ -6,13 +6,10 @@ macro_rules! await {
         use $crate::compat::backward::IntoAwaitable as IntoAwaitableBackward;
         #[allow(unused_imports)]
         use $crate::compat::forward::IntoAwaitable as IntoAwaitableForward;
-        use $crate::std_await;
 
         #[allow(unused_mut)]
         let mut e = $e;
         let e = e.into_awaitable();
-        // TODO: The code that the macro expands inherits the edition of the crate in which the macro is defined.
-        // When this crate transitioned to 2018 edition, replace it with the `await` syntax.
-        std_await!(e)
+        e.await
     }};
 }

--- a/tokio-futures/src/io/mod.rs
+++ b/tokio-futures/src/io/mod.rs
@@ -25,7 +25,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -35,7 +35,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
     ///
-    /// let bytes = await!(reader.read_async(&mut output[..])).unwrap();
+    /// let bytes = reader.read_async(&mut output[..]).await.unwrap();
     ///
     /// // This is only guaranteed to be 4 because `&[u8]` is a synchronous
     /// // reader. In a real system you could get anywhere from 1 to
@@ -59,7 +59,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -69,7 +69,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 4];
     ///
-    /// await!(reader.read_exact_async(&mut output)).unwrap();
+    /// reader.read_exact_async(&mut output).await.unwrap();
     ///
     /// assert_eq!(output, [1, 2, 3, 4]);
     /// });
@@ -78,7 +78,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// ## EOF is hit before `buf` is filled
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -88,7 +88,7 @@ pub trait AsyncReadExt: AsyncRead {
     /// let mut reader = Cursor::new([1, 2, 3, 4]);
     /// let mut output = [0u8; 5];
     ///
-    /// let result = await!(reader.read_exact_async(&mut output));
+    /// let result = reader.read_exact_async(&mut output).await;
     ///
     /// assert_eq!(result.unwrap_err().kind(), io::ErrorKind::UnexpectedEof);
     /// });
@@ -110,7 +110,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -120,7 +120,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// let mut buf = [0u8; 5];
     /// let mut writer = Cursor::new(&mut buf[..]);
     ///
-    /// let n = await!(writer.write_async(&[1, 2, 3, 4])).unwrap();
+    /// let n = writer.write_async(&[1, 2, 3, 4]).await.unwrap();
     ///
     /// assert_eq!(writer.into_inner()[..n], [1, 2, 3, 4, 0][..n]);
     /// });
@@ -139,7 +139,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -149,7 +149,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// let mut buf = [0u8; 5];
     /// let mut writer = Cursor::new(&mut buf[..]);
     ///
-    /// await!(writer.write_all_async(&[1, 2, 3, 4])).unwrap();
+    /// writer.write_all_async(&[1, 2, 3, 4]).await.unwrap();
     ///
     /// assert_eq!(writer.into_inner(), [1, 2, 3, 4, 0]);
     /// });
@@ -163,7 +163,7 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(async_await, await_macro)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -175,9 +175,9 @@ pub trait AsyncWriteExt: AsyncWrite {
     /// {
     ///     let mut writer = Cursor::new(&mut output[..]);
     ///     let mut buffered = BufWriter::new(writer);
-    ///     await!(buffered.write_all_async(&[1, 2])).unwrap();
-    ///     await!(buffered.write_all_async(&[3, 4])).unwrap();
-    ///     await!(buffered.flush_async()).unwrap();
+    ///     buffered.write_all_async(&[1, 2]).await.unwrap();
+    ///     buffered.write_all_async(&[3, 4]).await.unwrap();
+    ///     buffered.flush_async().await.unwrap();
     /// }
     ///
     /// assert_eq!(output, [1, 2, 3, 4, 0]);

--- a/tokio-futures/src/lib.rs
+++ b/tokio-futures/src/lib.rs
@@ -23,7 +23,7 @@ macro_rules! try_ready {
 }
 
 #[macro_use]
-mod await;
+mod async_wait;
 pub mod compat;
 pub mod io;
 pub mod sink;

--- a/tokio-futures/src/lib.rs
+++ b/tokio-futures/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "async-await-preview")]
-#![feature(await_macro)]
+#![feature(async_await, await_macro)]
 #![doc(html_root_url = "https://docs.rs/tokio-futures/0.1.0")]
 #![deny(missing_docs, missing_debug_implementations)]
 #![cfg_attr(test, deny(warnings))]

--- a/tokio-futures/src/lib.rs
+++ b/tokio-futures/src/lib.rs
@@ -28,8 +28,3 @@ pub mod compat;
 pub mod io;
 pub mod sink;
 pub mod stream;
-
-// Rename the `await` macro in `std`. This is used by the redefined
-// `await` macro in this crate.
-#[doc(hidden)]
-pub use std::await as std_await;

--- a/tokio-futures/src/stream/mod.rs
+++ b/tokio-futures/src/stream/mod.rs
@@ -13,7 +13,7 @@ pub trait StreamExt: Stream {
     /// # Examples
     ///
     /// ```edition2018
-    /// #![feature(await_macro, async_await)]
+    /// #![feature(async_await)]
     /// tokio::run_async(async {
     /// // The extension trait can also be imported with
     /// // `use tokio::prelude::*`.
@@ -21,10 +21,10 @@ pub trait StreamExt: Stream {
     ///
     /// let mut stream = stream::iter_ok::<_, ()>(1..3);
     ///
-    /// assert_eq!(await!(stream.next()), Some(Ok(1)));
-    /// assert_eq!(await!(stream.next()), Some(Ok(2)));
-    /// assert_eq!(await!(stream.next()), Some(Ok(3)));
-    /// assert_eq!(await!(stream.next()), None);
+    /// assert_eq!(stream.next().await, Some(Ok(1)));
+    /// assert_eq!(stream.next().await, Some(Ok(2)));
+    /// assert_eq!(stream.next().await, Some(Ok(3)));
+    /// assert_eq!(stream.next().await, None);
     /// });
     /// ```
     fn next(&mut self) -> Next<Self>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`await` syntax was implemented in rust-lang/rust#60586, and nightly-2019-05-09 has been released with the changes. Also, `await!` macro will be removed in the future.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`await` syntax only works in the 2018 edition, so this PR has not replaced some std `await!` macros yet (it needs to bump the minimum support version).

This PR currently uses a way that does not bump the minimum supported version, but this is blocked by `std::r#await!` macro not working (see https://github.com/rust-lang/rust/issues/60660).

cc @carllerche @davidbarsky