### PR TITLE
trace: Add shorthand for `field::display` and `field::debug`

### DIFF
--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -94,6 +94,40 @@
 //! # }
 //!```
 //!
+//! The [`field::display`] and [`field::debug`] functions are used to record
+//! fields on spans or events using their `fmt::Display` and `fmt::Debug`
+//! implementations (rather than as typed data). This may be used in lieu of
+//! custom `Value` implementations for complex or user-defined types.
+//!
+//! In addition, the span and event macros permit the use of the `%` and `?`
+//! sigils as shorthand for `field::display` and `field::debug`, respectively.
+//! For example:
+//!
+//! ```
+//! # #[macro_use]
+//! # extern crate tokio_trace;
+//! # use tokio_trace::Level;
+//! # fn main() {
+//! #[derive(Debug)]
+//! struct MyStruct {
+//!     my_field: &'static str,
+//! }
+//!
+//! let my_struct = MyStruct {
+//!     my_field: "Hello world!"
+//! };
+//!
+//! let my_span = span!(
+//!     Level::TRACE,
+//!     "my_span",
+//!     // `my_struct` will be recorded using its `fmt::Debug` implementation.
+//!     my_struct = ?my_struct,
+//!     // `my_field` will be recorded using the implementation of `fmt::Display` for `&str`.
+//!     my_struct.my_field = %my_struct.my_field,
+//! );
+//! # }
+//!```
+//!
 //! ### When to use spans
 //!
 //! As a rule of thumb, spans should be used to represent discrete units of work
@@ -387,6 +421,8 @@
 //! [`exit`]: subscriber/trait.Subscriber.html#tymethod.exit
 //! [`enabled`]: subscriber/trait.Subscriber.html#tymethod.enabled
 //! [metadata]: struct.Metadata.html
+//! [`field::display`]: field/fn.display.html
+//! [`field::debug`]: field/fn.debug.html
 //! [`tokio-trace-nursery`]: https://github.com/tokio-rs/tokio-trace-nursery
 //! [`tokio-trace-futures`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-futures
 //! [`tokio-trace-fmt`]: https://github.com/tokio-rs/tokio-trace-nursery/tree/master/tokio-trace-fmt

--- a/tokio-trace/src/lib.rs
+++ b/tokio-trace/src/lib.rs
@@ -288,7 +288,8 @@
 //! ```rust
 //! #[macro_use]
 //! extern crate tokio_trace;
-//! use tokio_trace::{field, Level};
+//! use tokio_trace::Level;
+//!
 //! # #[derive(Debug)] pub struct Yak(String);
 //! # impl Yak { fn shave(&mut self, _: u32) {} }
 //! # fn find_a_razor() -> Result<u32, u32> { Ok(1) }
@@ -296,7 +297,7 @@
 //! pub fn shave_the_yak(yak: &mut Yak) {
 //!     // Create a new span for this invocation of `shave_the_yak`, annotated
 //!     // with  the yak being shaved as a *field* on the span.
-//!     span!(Level::TRACE, "shave_the_yak", yak = field::debug(&yak)).enter(|| {
+//!     span!(Level::TRACE, "shave_the_yak", yak = ?yak).enter(|| {
 //!         // Since the span is annotated with the yak, it is part of the context
 //!         // for everything happening inside the span. Therefore, we don't need
 //!         // to add it to the message for this event, as the `log` crate does.
@@ -308,7 +309,7 @@
 //!                     // We can add the razor as a field rather than formatting it
 //!                     // as part of the message, allowing subscribers to consume it
 //!                     // in a more structured manner:
-//!                     info!({ razor = field::display(razor) }, "Razor located");
+//!                     info!({ razor = %razor }, "Razor located");
 //!                     yak.shave(razor);
 //!                     break;
 //!                 }

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -733,52 +733,31 @@ macro_rules! event {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! trace {
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* }, $($arg)+)
+    (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* })
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::TRACE, { $($($k).+ = $val),* })
+    (target: $target:expr, $($k:ident).+ = $($field:tt)+ ) => (
+        event!(target: $target, $crate::Level::TRACE, { $($k).+ = $($field)+ })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
-        drop(event!(target: $target, $crate::Level::TRACE, {}, $($arg)+));
+        event!(target: $target, $crate::Level::TRACE, {}, $($arg)+)
     );
-    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $($k:ident).+ = $($field:tt)+ }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($($k).+ = $val),* },
+            { $($k).+ = $($field)+ },
             $($arg)+
         )
     );
-    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+    ($($k:ident).+ = $($field:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
-            { $($($k).+ = $val),* },
-            $($arg)+
+            { $($k).+ = $($field)+}
         )
     );
-    ($( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::TRACE,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($( $($k:ident).+ = $val:expr ),* ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::TRACE,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($($arg:tt)+ ) => (
+    ($($arg:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::TRACE,
@@ -811,48 +790,31 @@ macro_rules! trace {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! debug {
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
+    (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* })
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::DEBUG, { $($($k).+ = $val),* })
+    (target: $target:expr, $($k:ident).+ = $($field:tt)+ ) => (
+        event!(target: $target, $crate::Level::DEBUG, { $($k).+ = $($field)+ })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::DEBUG, {}, $($arg)+)
     );
-    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(
-            target: __tokio_trace_module_path!(), $crate::Level::DEBUG, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+    ({ $($k:ident).+ = $($field:tt)+ }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
-            { $($($k).+ = $val),* },
+            { $($k).+ = $($field)+ },
             $($arg)+
         )
     );
-    ($( $($k:ident).+ = $val:expr ),*, ) => (
+    ($($k:ident).+ = $($field:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
-            { $($($k).+ = $val),* }
+            { $($k).+ = $($field)+}
         )
     );
-    ($( $($k:ident).+ = $val:expr ),* ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::DEBUG,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($($arg:tt)+ ) => (
+    ($($arg:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::DEBUG,
@@ -892,52 +854,31 @@ macro_rules! debug {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! info {
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* }, $($arg)+)
+    (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
+        event!(target: $target, $crate::Level::INFO, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* })
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::INFO, { $($($k).+ = $val),* })
+    (target: $target:expr, $($k:ident).+ = $($field:tt)+ ) => (
+        event!(target: $target, $crate::Level::INFO, { $($k).+ = $($field)+ })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::INFO, {}, $($arg)+)
     );
-    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $($k:ident).+ = $($field:tt)+ }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($($k).+ = $val),* },
+            { $($k).+ = $($field)+ },
             $($arg)+
         )
     );
-    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+    ($($k:ident).+ = $($field:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
-            { $($($k).+ = $val),* },
-            $($arg)+
+            { $($k).+ = $($field)+}
         )
     );
-    ($( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::INFO,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($( $($k:ident).+ = $val:expr ),* ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::INFO,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($($arg:tt)+ ) => (
+    ($($arg:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::INFO,
@@ -974,51 +915,31 @@ macro_rules! info {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! warn {
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* }, $($arg)+)
+    (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
+        event!(target: $target, $crate::Level::WARN, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* })
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::WARN, { $($($k).+ = $val),* })
+    (target: $target:expr, $($k:ident).+ = $($field:tt)+ ) => (
+        event!(target: $target, $crate::Level::WARN, { $($k).+ = $($field)+ })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
-        drop(event!(target: $target, $crate::Level::WARN, {}, $($arg)+));
+        event!(target: $target, $crate::Level::WARN, {}, $($arg)+)
     );
-    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $($k:ident).+ = $($field:tt)+ }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
-            { $($($k).+ = $val),* },
+            { $($k).+ = $($field)+ },
             $($arg)+
         )
     );
-    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+    ($($k:ident).+ = $($field:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
-            { $($($k).+ = $val),* },
-            $($arg)+
+            { $($k).+ = $($field)+}
         )
     );
-    ($( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::WARN,{ $($($k).+ = $val),* }
-        )
-    );
-    ($( $($k:ident).+ = $val:expr ),* ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::WARN,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($($arg:tt)+ ) => (
+    ($($arg:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::WARN,
@@ -1050,52 +971,31 @@ macro_rules! warn {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! error {
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* }, $($arg)+)
+    (target: $target:expr, { $($field:tt)* }, $($arg:tt)* ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($field)* }, $($arg)*)
     );
-    (target: $target:expr, { $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* }, $($arg)+)
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* })
-    );
-    (target: $target:expr, $( $($k:ident).+ = $val:expr ),* ) => (
-        event!(target: $target, $crate::Level::ERROR, { $($($k).+ = $val),* })
+    (target: $target:expr, $($k:ident).+ = $($field:tt)+ ) => (
+        event!(target: $target, $crate::Level::ERROR, { $($k).+ = $($field)+ })
     );
     (target: $target:expr, $($arg:tt)+ ) => (
         event!(target: $target, $crate::Level::ERROR, {}, $($arg)+)
     );
-    ({ $( $($k:ident).+ = $val:expr ),*, }, $($arg:tt)+ ) => (
+    ({ $($k:ident).+ = $($field:tt)+ }, $($arg:tt)+ ) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($($k).+ = $val),* },
+            { $($k).+ = $($field)+ },
             $($arg)+
         )
     );
-    ({ $( $($k:ident).+ = $val:expr ),* }, $($arg:tt)+ ) => (
+    ($($k:ident).+ = $($field:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,
-            { $($($k).+ = $val),* },
-            $($arg)+
+            { $($k).+ = $($field)+}
         )
     );
-    ($( $($k:ident).+ = $val:expr ),*, ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::ERROR,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($( $($k:ident).+ = $val:expr ),* ) => (
-        event!(
-            target: __tokio_trace_module_path!(),
-            $crate::Level::ERROR,
-            { $($($k).+ = $val),* }
-        )
-    );
-    ($($arg:tt)+ ) => (
+    ($($arg:tt)+) => (
         event!(
             target: __tokio_trace_module_path!(),
             $crate::Level::ERROR,

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -249,74 +249,46 @@ macro_rules! span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! trace_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        trace_span!(
-            target: $target,
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::TRACE,
             target: $target,
             parent: $parent,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         trace_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        trace_span!(
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::TRACE,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         trace_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        trace_span!(
-            target: $target,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::TRACE,
             target: $target,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, $name:expr) => {
         trace_span!(target: $target, $name,)
     };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        trace_span!(
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    ($name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::TRACE,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     ($name:expr) => {trace_span!($name,)};
@@ -338,74 +310,46 @@ macro_rules! trace_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! debug_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        debug_span!(
-            target: $target,
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::DEBUG,
             target: $target,
             parent: $parent,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         debug_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        debug_span!(
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::DEBUG,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         debug_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        debug_span!(
-            target: $target,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::DEBUG,
             target: $target,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, $name:expr) => {
         debug_span!(target: $target, $name,)
     };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        debug_span!(
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    ($name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::DEBUG,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     ($name:expr) => {debug_span!($name,)};
@@ -427,74 +371,46 @@ macro_rules! debug_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! info_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        info_span!(
-            target: $target,
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::INFO,
             target: $target,
             parent: $parent,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         info_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        info_span!(
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         info_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        info_span!(
-            target: $target,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::INFO,
             target: $target,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, $name:expr) => {
         info_span!(target: $target, $name,)
     };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        info_span!(
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    ($name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     ($name:expr) => {info_span!($name,)};
@@ -516,74 +432,46 @@ macro_rules! info_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! warn_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        warn_span!(
-            target: $target,
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::WARN,
             target: $target,
             parent: $parent,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         warn_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        warn_span!(
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::WARN,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         warn_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        warn_span!(
-            target: $target,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::WARN,
             target: $target,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, $name:expr) => {
         warn_span!(target: $target, $name,)
     };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        warn_span!(
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    ($name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::WARN,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     ($name:expr) => {warn_span!($name,)};
@@ -604,74 +492,46 @@ macro_rules! warn_span {
 /// ```
 #[macro_export(local_inner_macros)]
 macro_rules! error_span {
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        error_span!(
-            target: $target,
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::ERROR,
             target: $target,
             parent: $parent,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, parent: $parent:expr, $name:expr) => {
         error_span!(target: $target, parent: $parent, $name,)
     };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        error_span!(
-            parent: $parent,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (parent: $parent:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (parent: $parent:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::ERROR,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (parent: $parent:expr, $name:expr) => {
         error_span!(parent: $parent, $name,)
     };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        error_span!(
-            target: $target,
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    (target: $target:expr, $name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    (target: $target:expr, $name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::ERROR,
             target: $target,
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     (target: $target:expr, $name:expr) => {
         error_span!(target: $target, $name,)
     };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*,) => {
-        error_span!(
-            $name,
-            $($($k).+ $( = $val)*),*
-        )
-    };
-    ($name:expr, $($($k:ident).+ $( = $val:expr)*),*) => {
+    ($name:expr, $($field:tt)*) => {
         span!(
             $crate::Level::ERROR,
             target: __tokio_trace_module_path!(),
             $name,
-            $($($k).+ $( = $val)*),*
+            $($field)*
         )
     };
     ($name:expr) => {error_span!($name,)};

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -88,6 +88,7 @@
 /// let my_span = span!(Level::TRACE, "my span", my_struct = ?my_struct);
 /// # }
 /// ```
+///
 /// Shorthand for `field::display`:
 /// ```
 /// # #[macro_use]

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -1112,78 +1112,49 @@ macro_rules! is_enabled {
 #[macro_export(local_inner_macros)]
 macro_rules! valueset {
 
-    // === base case (no more tts), empty out set ===
-    (@ { }, $next:expr, $($k:ident).+, $(,)*) => {
-        &[ (&$next, None),]
-    };
-    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr $(,)* ) => {
-        &[ (&$next, Some(&debug(&$val) as &Value))]
-    };
-    (@ { }, $next:expr, $($k:ident).+ = %$val:expr $(,)*) => {
-        &[ (&$next, Some(&display(&$val) as &Value))]
-    };
-    (@ { }, $next:expr, $($k:ident).+ = $val:expr $(,)*) => {
-        &[ (&$next, Some(&$val as &Value))]
-    };
-
-    // === base case (no more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ $(,)*) => {
-        &[ $($out),+, (&$next, None),]
-    };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = ?$val:expr $(,)*) => {
-        &[ $($out),*, (&$next, Some(&debug(&$val) as &Value))]
-    };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr $(,)*) => {
-        &[ $($out),+, (&$next, Some(&display(&$val) as &Value))]
-    };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr $(,)*) => {
-        &[ $($out),+, (&$next, Some(&$val as &Value))]
+    // === base case ===
+    (@ { $($val:expr),* }, $next:expr, $(,)*) => {
+        &[ $($val),* ]
     };
 
     // === recursive case (more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+, $($rest:tt)+) => {
-        valueset!(@ { $($out),+, (&$next, None) }, $next, $($rest)+)
-    };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
+    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
         valueset!(
             @ { $($out),+, (&$next, Some(&debug(&$val) as &Value)) },
             $next,
-            $($rest)+
+            $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
+    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
         valueset!(
             @ { $($out),+, (&$next, Some(&display(&$val) as &Value)) },
             $next,
-            $($rest)+
+            $($rest)*
         )
     };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
+    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
         valueset!(
             @ { $($out),+, (&$next, Some(&$val as &Value)) },
             $next,
-            $($rest)+
+            $($rest)*
         )
     };
-    (@{ $($out:expr),+ }, $next:expr, $($k:ident).+, $($rest:tt)+) => {
-        valueset!(@ { $($out),+, (&$next, None) }, $next, $($rest)+)
-    };
-    (@ { $($out:expr),+ }, $next:expr, $($k:ident).+, ) => {
-        valueset!(@ { $($out),+, (&$next, None) }, $next, $($rest)+)
+    (@{ $($out:expr),+ }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
+        valueset!(@ { $($out),+, (&$next, None) }, $next, $($rest)*)
     };
 
     // == recursive case (more tts), empty out set ===
-    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)+ ) => {
-        valueset!(@ { (&$next, Some(&debug(&$val) as &Value)) }, $next, $($rest)+ )
+    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)* ) => {
+        valueset!(@ { (&$next, Some(&debug(&$val) as &Value)) }, $next, $($rest)* )
     };
-    (@ { }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        valueset!(@ { (&$next, Some(&display(&$val) as &Value)) }, $next, $($rest)+)
+    (@ { }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        valueset!(@ { (&$next, Some(&display(&$val) as &Value)) }, $next, $($rest)*)
     };
-    (@ { }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        valueset!(@ { (&$next, Some(&$val as &Value)) }, $next, $($rest)+)
+    (@ { }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        valueset!(@ { (&$next, Some(&$val as &Value)) }, $next, $($rest)*)
     };
-    (@ { }, $next:expr, $($k:ident).+, $($rest:tt)+) => {
-        valueset!(@ { (&$next, None) }, $next, $($rest)+ )
+    (@ { }, $next:expr, $($k:ident).+, $($rest:tt)*) => {
+        valueset!(@ { (&$next, None) }, $next, $($rest)* )
     };
 
     // === entry ===
@@ -1195,7 +1166,7 @@ macro_rules! valueset {
             $fields.value_set(valueset!(
                 @ { },
                 iter.next().expect("FieldSet corrupted (this is a bug)"),
-                $($kvs)+
+                $($kvs)+,
             ))
         }
     };
@@ -1209,73 +1180,44 @@ macro_rules! valueset {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! fieldset {
-    () => {
-        &[]
+    // == base case ==
+    (@ { $($out:expr),* $(,)* } $(,)*) => {
+        &[ $($out),* ]
     };
-
-    // == empty out set, no remaining tts ===
-    (@inner { } $($k:ident).+ = ?$_val:expr $(,)*) => {
-        &[ __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner { } $($k:ident).+ = %$val:expr $(,)*) => {
-        &[ __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner { } $($k:ident).+ = $val:expr $(,)*) => {
-        &[ __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner { } $($k:ident).+ $(,)*) => {
-        &[ __tokio_trace_stringify!($($k).+) ]
-    };
-
 
     // == empty out set, remaining tts ==
-    (@inner { } $($k:ident).+ = ?$_val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { } $($k:ident).+ = ?$_val:expr, $($rest:tt)*) => {
+        fieldset!(@ { __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { } $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { } $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        fieldset!(@ { __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { } $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { } $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        fieldset!(@ { __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { } $($k:ident).+, $($rest:tt)+) => {
-        fieldset!(@inner { __tokio_trace_stringify!($($k).+) } $($rest)+)
-    };
-
-    // == non-empty out set, no remaining tts ==
-    // this needs its own set of cases (rather than using `$($rest:tt)*`) in
-    // order to gobble a potential trailing comma.
-    (@inner { $($out:expr),+ } $($k:ident).+ = ?$_val:expr $(,)*) => {
-        &[ $($out),+, __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner { $($out:expr),+} $($k:ident).+ = %$val:expr $(,)*) => {
-        &[ $($out),+, __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner {$($out:expr),+} $($k:ident).+ = $val:expr $(,)*) => {
-        &[ $($out),+, __tokio_trace_stringify!($($k).+) ]
-    };
-    (@inner { $($out:expr),+} $($k:ident).+ $(,)*) => {
-        &[ $($out),+, __tokio_trace_stringify!($($k).+) ]
+    (@ { } $($k:ident).+, $($rest:tt)*) => {
+        fieldset!(@ { __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
 
     // == non-empty out set, remaining tts ==
-    (@inner { $($out:expr),+ } $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { $($out),+,__tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { $($out:expr),+ } $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        fieldset!(@ { $($out),+,__tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { $($out:expr),+ } $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { $($out:expr),+ } $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        fieldset!(@ { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { $($out:expr),+ } $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        fieldset!(@inner { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { $($out:expr),+ } $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        fieldset!(@ { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
-    (@inner { $($out:expr),+ } $($k:ident).+, $($rest:tt)+) => {
-        fieldset!(@inner { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)+)
+    (@ { $($out:expr),+ } $($k:ident).+, $($rest:tt)*) => {
+        fieldset!(@ { $($out),+, __tokio_trace_stringify!($($k).+) } $($rest)*)
     };
 
     // == entry ==
-    ($($args:tt)+) => {
-        fieldset!(@inner { } $($args)+ )
+    ($($args:tt)*) => {
+        fieldset!(@ { } $($args)*, )
     };
+
 }
 
 // The macros above cannot invoke format_args directly because they use
@@ -1408,129 +1350,84 @@ macro_rules! __tokio_trace_disabled_span {
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __mk_format_string {
-
-    // === base case (no more tts), empty out set ===
-    (@ { }, message = $val:expr $(,)* ) => {
-        "{}"
-    };
-    (@ { }, $($k:ident).+ = ?$val:expr $(,)* ) => {
-        __tokio_trace_concat!(__tokio_trace_stringify!($($k).+), "={:?}")
-    };
-    (@ { }, $($k:ident).+ = %$val:expr $(,)*) => {
-        __tokio_trace_concat!(__tokio_trace_stringify!($($k).+), "={}")
-    };
-    (@ { }, $($k:ident).+ = $val:expr $(,)*) => {
-        __tokio_trace_concat!(__tokio_trace_stringify!($($k).+), "={:?}")
-    };
-
-    // === base case (no more tts), non-empty out set ===
-    // we have to have separate cases for empty and non-empty out sets because
-    // we need to insert a comma between out and the last value, and the
-    // `concat!` macro doesn't like its arguments to begin with a comma.
-    (@ { $($out:expr),+ }, message = $val:expr $(,)* ) => {
-        __tokio_trace_concat!( $($out),+, "{}")
-    };
-    (@ { $($out:expr),+ }, $($k:ident).+ = ?$val:expr $(,)*) => {
-        __tokio_trace_concat!( $($out),+, __tokio_trace_stringify!($($k).+), "={:?}")
-    };
-    (@ { $($out:expr),+ }, $($k:ident).+ = %$val:expr $(,)*) => {
-        __tokio_trace_concat!( $($out),+, __tokio_trace_stringify!($($k).+), "={:?}")
-    };
-    (@ { $($out:expr),+ }, $($k:ident).+ = $val:expr $(,)*) => {
-        __tokio_trace_concat!( $($out),+, __tokio_trace_stringify!($($k).+), "={:?}")
+    // === base case ===
+    (@ { $($out:expr),+ } $(,)*) => {
+        __tokio_trace_concat!( $($out),+)
     };
 
     // === recursive case (more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, message = $val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { $($out),+, "{} " }, $($rest)+)
+    (@ { $($out:expr),+ }, message = $val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { $($out),+, "{} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)+)
+    (@ { $($out:expr),+ }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={} " }, $($rest)+)
+    (@ { $($out:expr),+ }, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={} " }, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)+)
+    (@ { $($out:expr),+ }, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { $($out),+, __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
 
-    // == recursive case (more tts), empty out set ===
-    (@ { }, message = $val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { "{} " }, $($rest)+)
+    // === recursive case (more tts), empty out set ===
+    (@ { }, message = $val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { "{} " }, $($rest)*)
     };
-    (@ { }, $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)+)
+    (@ { }, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
-    (@ { }, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ {  __tokio_trace_stringify!($($k).+), "={} " }, $($rest)+)
+    (@ { }, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ {  __tokio_trace_stringify!($($k).+), "={} " }, $($rest)*)
     };
-    (@ { }, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        __mk_format_string!(@ { __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)+)
+    (@ { }, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        __mk_format_string!(@ { __tokio_trace_stringify!($($k).+), "={:?} " }, $($rest)*)
     };
 
     // === entry ===
     ($($kvs:tt)+) => {
-        __mk_format_string!(@ { }, $($kvs)+)
+        __mk_format_string!(@ { }, $($kvs)+,)
     };
+    () => {
+        ""
+    }
 }
 
 #[cfg(feature = "log")]
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __mk_format_args {
-
-    // === base case (no more tts), empty out set ===
-    (@ { }, $args:expr, $($k:ident).+ = ?$val:expr $(,)* ) => {
-        __tokio_trace_format_args!($fmt, $val)
-    };
-    (@ { }, $fmt:expr, $($k:ident).+ = %$val:expr $(,)*) => {
-        __tokio_trace_format_args!($fmt, $val)
-    };
-    (@ { }, $fmt:expr, $($k:ident).+ = $val:expr $(,)*) => {
-        __tokio_trace_format_args!($fmt, $val)
-    };
-
-    // === base case (no more tts), non-empty out set ===
-    // we have to have separate cases for empty and non-empty out sets because
-    // we need to insert a comma between out and the last value, and the
-    // `concat!` macro doesn't like its arguments to begin with a comma.
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = ?$val:expr $(,)*) => {
-        __tokio_trace_format_args!($fmt, $($out),+, $val)
-    };
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = %$val:expr $(,)*) => {
-        __tokio_trace_format_args!($fmt, $($out),+, $val)
-    };
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = $val:expr $(,)*) => {
-        __tokio_trace_format_args!($fmt, $($out),+, $val)
+    // == base case ==
+    (@ { $($out:expr),* }, $fmt:expr, $(,)*) => {
+        __tokio_trace_format_args!($fmt, $($out),*)
     };
 
     // === recursive case (more tts), non-empty out set ===
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)+)
+    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)+)
+    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)*)
     };
-    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)+)
+    (@ { $($out:expr),+ }, $fmt:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $($out),+, $val }, $fmt, $($rest)*)
     };
 
     // == recursive case (more tts), empty out set ===
-    (@ { }, $fmt:expr, message = $val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $val }, $fmt, $($rest)+)
+    (@ { }, $fmt:expr, message = $val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $val }, $fmt, $($rest)*)
     };
-    (@ { }, $fmt:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $val }, $fmt, $($rest)+)
+    (@ { }, $fmt:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $val }, $fmt, $($rest)*)
     };
-    (@ { }, $fmt:expr, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $val }, $fmt, $($rest)+)
+    (@ { }, $fmt:expr, $($k:ident).+ = %$val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $val }, $fmt, $($rest)*)
     };
-    (@ { }, $fmt:expr, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
-        __mk_format_args!(@ { $val }, $fmt, $($rest)+)
+    (@ { }, $fmt:expr, $($k:ident).+ = $val:expr, $($rest:tt)*) => {
+        __mk_format_args!(@ { $val }, $fmt, $($rest)*)
     };
 
     // === entry ===
-    ($($kv:tt)+) => {
-        __mk_format_args!(@ { }, __mk_format_string!($($kv)+), $($kv)+)
+    ($($kv:tt)*) => {
+        __mk_format_args!(@ { }, __mk_format_string!($($kv)*), $($kv)*,)
     };
 }

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -1273,10 +1273,10 @@ macro_rules! valueset {
     };
 
     // == recursive case (more tts), empty out set ===
-    (@ { }, $next:expr, ($k:ident).+ = ?$_val:expr, $($rest:tt)+ ) => {
+    (@ { }, $next:expr, $($k:ident).+ = ?$val:expr, $($rest:tt)+ ) => {
         valueset!(@ { (&$next, Some(&debug(&$val) as &Value)) }, $next, $($rest)+ )
     };
-    (@ { }, $next:expr,  $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
+    (@ { }, $next:expr, $($k:ident).+ = %$val:expr, $($rest:tt)+) => {
         valueset!(@ { (&$next, Some(&display(&$val) as &Value)) }, $next, $($rest)+)
     };
     (@ { }, $next:expr, $($k:ident).+ = $val:expr, $($rest:tt)+) => {
@@ -1293,7 +1293,7 @@ macro_rules! valueset {
             use $crate::field::{debug, display, Value};
             let mut iter = $fields.iter();
             $fields.value_set(valueset!(
-                @ {},
+                @ { },
                 iter.next().expect("FieldSet corrupted (this is a bug)"),
                 $($kvs)+
             ))

--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -1234,7 +1234,7 @@ macro_rules! valueset {
         &[ $($out),*, (&$next, Some(&debug(&$val) as &Value))]
     };
     (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = %$val:expr $(,)*) => {
-        &[ $($out),+, (&$next, Some(&display(&$val) as &$Value))]
+        &[ $($out),+, (&$next, Some(&display(&$val) as &Value))]
     };
     (@ { $($out:expr),+ }, $next:expr, $($k:ident).+ = $val:expr $(,)*) => {
         &[ $($out),+, (&$next, Some(&$val as &Value))]

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -10,6 +10,7 @@ extern crate tokio_trace;
 
 #[test]
 fn span() {
+    span!(Level::DEBUG, target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     span!(Level::DEBUG, target: "foo_events", "foo", bar.baz = 2, quux = 3);
     span!(Level::DEBUG, target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, target: "foo_events", "foo");

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -19,72 +19,90 @@ fn span() {
     span!(Level::DEBUG, "foo", bar.baz = 2, quux = 4,);
     span!(Level::TRACE, "foo", bar.baz = 2, quux = 3);
     span!(Level::TRACE, "foo", bar.baz = 2, quux = 4,);
+    span!(Level::TRACE, "foo", bar.baz = ?2);
+    span!(Level::TRACE, "foo", bar.baz = %2);
     span!(Level::TRACE, "foo");
     span!(Level::TRACE, "bar",);
 }
 
 #[test]
 fn trace_span() {
+    trace_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     trace_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     trace_span!(target: "foo_events", "foo");
     trace_span!(target: "foo_events", "bar",);
     trace_span!("foo", bar.baz = 2, quux = 3);
     trace_span!("foo", bar.baz = 2, quux = 4,);
+    trace_span!("foo", bar.baz = ?2);
+    trace_span!("foo", bar.baz = %2);
     trace_span!("bar");
     trace_span!("bar",);
 }
 
 #[test]
 fn debug_span() {
+    debug_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     debug_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     debug_span!(target: "foo_events", "foo");
     debug_span!(target: "foo_events", "bar",);
     debug_span!("foo", bar.baz = 2, quux = 3);
     debug_span!("foo", bar.baz = 2, quux = 4,);
+    debug_span!("foo", bar.baz = ?2);
+    debug_span!("foo", bar.baz = %2);
     debug_span!("bar");
     debug_span!("bar",);
 }
 
 #[test]
 fn info_span() {
+    info_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     info_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     info_span!(target: "foo_events", "foo");
     info_span!(target: "foo_events", "bar",);
     info_span!("foo", bar.baz = 2, quux = 3);
     info_span!("foo", bar.baz = 2, quux = 4,);
+    info_span!("foo", bar.baz = ?2);
+    info_span!("foo", bar.baz = %2);
     info_span!("bar");
     info_span!("bar",);
 }
 
 #[test]
 fn warn_span() {
+    warn_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     warn_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     warn_span!(target: "foo_events", "foo");
     warn_span!(target: "foo_events", "bar",);
     warn_span!("foo", bar.baz = 2, quux = 3);
     warn_span!("foo", bar.baz = 2, quux = 4,);
+    warn_span!("foo", bar.baz = ?2);
+    warn_span!("foo", bar.baz = %2);
     warn_span!("bar");
     warn_span!("bar",);
 }
 
 #[test]
 fn error_span() {
+    error_span!(target: "foo_events", "foo", bar.baz = ?2, quux = %3, quuux = 4);
     error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 3);
     error_span!(target: "foo_events", "foo", bar.baz = 2, quux = 4,);
     error_span!(target: "foo_events", "foo");
     error_span!(target: "foo_events", "bar",);
     error_span!("foo", bar.baz = 2, quux = 3);
     error_span!("foo", bar.baz = 2, quux = 4,);
+    error_span!("foo", bar.baz = ?2);
+    error_span!("foo", bar.baz = %2);
     error_span!("bar");
     error_span!("bar",);
 }
 
 #[test]
 fn span_root() {
+    span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
     span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 3);
     span!(Level::DEBUG, target: "foo_events", parent: None, "foo", bar.baz = 2, quux = 4,);
     span!(Level::DEBUG, target: "foo_events", parent: None, "foo");
@@ -247,6 +265,7 @@ fn error_span_with_parent() {
 
 #[test]
 fn event() {
+    event!(Level::DEBUG, foo = ?3, bar.baz = %2, quux = false);
     event!(Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(Level::DEBUG, "foo");
@@ -254,7 +273,7 @@ fn event() {
     event!(Level::DEBUG, { foo = 3, bar.baz = 80 }, "quux");
     event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     event!(Level::DEBUG, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    event!(Level::DEBUG, { foo = 2, bar.baz = 78, }, "quux");
+    event!(Level::DEBUG, { foo = ?2, bar.baz = %78 }, "quux");
     event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 2, quux = false);
     event!(target: "foo_events", Level::DEBUG, foo = 3, bar.baz = 3,);
     event!(target: "foo_events", Level::DEBUG, "foo");
@@ -267,6 +286,7 @@ fn event() {
 
 #[test]
 fn trace() {
+    trace!(foo = ?3, bar.baz = %2, quux = false);
     trace!(foo = 3, bar.baz = 2, quux = false);
     trace!(foo = 3, bar.baz = 3,);
     trace!("foo");
@@ -274,7 +294,8 @@ fn trace() {
     trace!({ foo = 3, bar.baz = 80 }, "quux");
     trace!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     trace!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    trace!({ foo = 2, bar.baz = 78, }, "quux");
+    trace!({ foo = 2, bar.baz = 78 }, "quux");
+    trace!({ foo = ?2, bar.baz = %78 }, "quux");
     trace!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     trace!(target: "foo_events", foo = 3, bar.baz = 3,);
     trace!(target: "foo_events", "foo");
@@ -287,6 +308,7 @@ fn trace() {
 
 #[test]
 fn debug() {
+    debug!(foo = ?3, bar.baz = %2, quux = false);
     debug!(foo = 3, bar.baz = 2, quux = false);
     debug!(foo = 3, bar.baz = 3,);
     debug!("foo");
@@ -294,7 +316,8 @@ fn debug() {
     debug!({ foo = 3, bar.baz = 80 }, "quux");
     debug!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    debug!({ foo = 2, bar.baz = 78, }, "quux");
+    debug!({ foo = 2, bar.baz = 78 }, "quux");
+    debug!({ foo = ?2, bar.baz = %78 }, "quux");
     debug!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     debug!(target: "foo_events", foo = 3, bar.baz = 3,);
     debug!(target: "foo_events", "foo");
@@ -302,12 +325,12 @@ fn debug() {
     debug!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    debug!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     debug!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn info() {
+    info!(foo = ?3, bar.baz = %2, quux = false);
     info!(foo = 3, bar.baz = 2, quux = false);
     info!(foo = 3, bar.baz = 3,);
     info!("foo");
@@ -315,7 +338,8 @@ fn info() {
     info!({ foo = 3, bar.baz = 80 }, "quux");
     info!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    info!({ foo = 2, bar.baz = 78, }, "quux");
+    info!({ foo = 2, bar.baz = 78 }, "quux");
+    info!({ foo = ?2, bar.baz = %78 }, "quux");
     info!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     info!(target: "foo_events", foo = 3, bar.baz = 3,);
     info!(target: "foo_events", "foo");
@@ -323,12 +347,12 @@ fn info() {
     info!(target: "foo_events", { foo = 3, bar.baz = 80 }, "quux");
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}", true);
     info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
-    info!(target: "foo_events", { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     info!(target: "foo_events", { foo = 2, bar.baz = 78, }, "quux");
 }
 
 #[test]
 fn warn() {
+    warn!(foo = ?3, bar.baz = %2, quux = false);
     warn!(foo = 3, bar.baz = 2, quux = false);
     warn!(foo = 3, bar.baz = 3,);
     warn!("foo");
@@ -337,6 +361,7 @@ fn warn() {
     warn!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     warn!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     warn!({ foo = 2, bar.baz = 78 }, "quux");
+    warn!({ foo = ?2, bar.baz = %78 }, "quux");
     warn!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     warn!(target: "foo_events", foo = 3, bar.baz = 3,);
     warn!(target: "foo_events", "foo");
@@ -349,6 +374,7 @@ fn warn() {
 
 #[test]
 fn error() {
+    error!(foo = ?3, bar.baz = %2, quux = false);
     error!(foo = 3, bar.baz = 2, quux = false);
     error!(foo = 3, bar.baz = 3,);
     error!("foo");
@@ -357,6 +383,7 @@ fn error() {
     error!({ foo = 2, bar.baz = 79 }, "quux {:?}", true);
     error!({ foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
     error!({ foo = 2, bar.baz = 78, }, "quux");
+    error!({ foo = ?2, bar.baz = %78 }, "quux");
     error!(target: "foo_events", foo = 3, bar.baz = 2, quux = false);
     error!(target: "foo_events", foo = 3, bar.baz = 3,);
     error!(target: "foo_events", "foo");


### PR DESCRIPTION
## Motivation

In `tokio-trace`, field values may be recorded as either a subset of
Rust primitive types or as `fmt::Display` and `fmt::Debug`
implementations. Currently, `tokio-trace` provides the `field::display`
and `field::debug` functions which wrap a type with a type that
implements `Value` using the wrapped type's `fmt::Display` or
`fmt::Debug` implementation. However, importing and using these
functions adds unnecessary boilerplate. 

In #1081, @jonhoo suggested adding shorthand syntax to the macros,
similar to that used by the `slog` crate, as a solution for the
wordiness of the current API.

## Solution

This branch adds `?` and `%` sigils to field values in the span and
event macros, which expand to the `field::debug` and `field::display`
wrappers, respectively. The shorthand sigils may be used in any position
where the macros take a field value.

For example:
```rust
trace_span!("foo", my_field = ?something, ...); // shorthand for `debug`
info!(foo = %value, bar = false, ...) // shorthand for `display`
```

Adding this shorthand required a fairly large change to how field
key-value pairs are handled by the macros --- since `%foo` and `%foo`
are not valid Rust expressions, we can no longer match repeated 
`$ident = $expr` patterns, and must now match field lists as repeated
token trees. The inner helper macros for constructing `FieldSet`s and
`ValueSet`s have to parse the token trees recursively. This added a
decent chunk of complexity, but fortunately we have a large number of
compile tests for the macros and I'm quite confident that all existing
invocations will still work.

Closes #1081

Signed-off-by: Eliza Weisman <eliza@buoyant.io>