### PR TITLE
Release tokio v0.1.20, tokio-timer v0.2.21, and remove async-await-preview feature.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.19/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.20/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 The API docs for the master branch are published [here][master-dox].
@@ -49,9 +49,9 @@ level, it provides a few major components:
 These components provide the runtime components necessary for building
 an asynchronous application.
 
-[net]: https://docs.rs/tokio/0.1.19/tokio/net/index.html
-[reactor]: https://docs.rs/tokio/0.1.19/tokio/reactor/index.html
-[scheduler]: https://docs.rs/tokio/0.1.19/tokio/runtime/index.html
+[net]: https://docs.rs/tokio/0.1.20/tokio/net/index.html
+[reactor]: https://docs.rs/tokio/0.1.20/tokio/reactor/index.html
+[scheduler]: https://docs.rs/tokio/0.1.20/tokio/runtime/index.html
 
 ## Example
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
-trigger: ["master"]
-pr: ["master"]
+trigger: ["master", "v0.1.x"]
+pr: ["master", "v0.1.x"]
 
 jobs:
 # Check formatting

--- a/ci/azure-test-nightly.yml
+++ b/ci/azure-test-nightly.yml
@@ -11,10 +11,6 @@ jobs:
 
   - template: azure-patch-crates.yml
 
-  - script: cargo test
-    displayName: cargo +nightly test -p async-await
-    workingDirectory: $(Build.SourcesDirectory)/async-await
-
   - script: cargo check --all
     displayName: cargo +nightly check --all
 

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -1,5 +1,13 @@
 [package]
 name = "tokio-macros"
+# When releasing to crates.io:
+# - Remove path dependencies
+# - Update html_root_url.
+# - Update doc url
+#   - Cargo.toml
+#   - README.md
+# - Update CHANGELOG.md.
+# - Create "v0.1.x" git tag.
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2018"

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.11 (May 14, 2019)
+
+### Added
+- `Handle::timeout` API, replacing the deprecated `Handle::deadline` (#1074).
+
 # 0.2.10 (February 4, 2019)
 
 ### Fixed

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -8,11 +8,11 @@ name = "tokio-timer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.10"
+version = "0.2.11"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.10/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.11/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,7 +2,7 @@
 
 Timer facilities for Tokio
 
-[Documentation](https://docs.rs/tokio-timer/0.2.10/tokio_timer/)
+[Documentation](https://docs.rs/tokio-timer/0.2.11/tokio_timer/)
 
 ## Overview
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.10")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.11")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! Utilities for tracking time.

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,17 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.20 (May 14, 2019)
+
+### Added
+- `tokio::runtime::Builder::panic_handler` allows configuring handling
+  panics on the runtime (#1055).
+
+# 0.1.19 (April 22, 2019)
+
+### Added
+- Re-export `tokio::sync::Mutex` primitive (#964).
+
 # 0.1.18 (March 22, 2019)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,11 +8,11 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.1.19/tokio/"
+documentation = "https://docs.rs/tokio/0.1.20/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -55,13 +55,6 @@ timer = ["tokio-timer"]
 udp = ["tokio-udp"]
 uds = ["tokio-uds"]
 
-# This feature comes with no promise of stability. Things will
-# break with each patch release. Use at your own risk.
-async-await-preview = [
-  "tokio-futures/async-await-preview",
-  "tokio-macros/async-await-preview",
-]
-
 [dependencies]
 # Only non-optional dependency...
 futures = "0.1.20"
@@ -74,7 +67,6 @@ tokio-current-thread = { version = "0.1.6", optional = true }
 tokio-fs = { version = "0.1.6", optional = true }
 tokio-io = { version = "0.1.6", optional = true }
 tokio-executor = { version = "0.1.7", optional = true }
-tokio-macros = { version = "0.1.0", optional = true, path = "../tokio-macros" }
 tokio-reactor = { version = "0.1.1", optional = true }
 tokio-sync = { version = "0.1.5", optional = true }
 tokio-threadpool = { version = "0.1.14", optional = true }
@@ -85,9 +77,6 @@ tokio-trace-core = { version = "0.1", optional = true }
 
 # Needed until `reactor` is removed from `tokio`.
 mio = { version = "0.6.14", optional = true }
-
-# Needed for async/await preview support
-tokio-futures = { version = "0.1.0", optional = true, path = "../tokio-futures" }
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.2.1", optional = true }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,6 +1,5 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.19")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.20")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
-#![cfg_attr(feature = "async-await-preview", feature(async_await, await_macro))]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!
@@ -136,23 +135,3 @@ if_runtime! {
     pub use executor::spawn;
     pub use runtime::run;
 }
-
-// ===== Experimental async/await support =====
-
-#[cfg(feature = "async-await-preview")]
-extern crate tokio_futures;
-
-#[cfg(feature = "async-await-preview")]
-extern crate tokio_macros;
-
-#[cfg(feature = "async-await-preview")]
-mod async_await;
-
-#[cfg(feature = "async-await-preview")]
-pub use async_await::{run_async, spawn_async};
-
-#[cfg(feature = "async-await-preview")]
-pub use tokio_futures::await;
-
-#[cfg(feature = "async-await-preview")]
-pub use tokio_macros::{main, test};


### PR DESCRIPTION
The `async-await-preview` feature is removed as 0.1 will no longer track
Rust nightly.

This also bumps:
- tokio-timer (0.2.11).