### PR TITLE
Fix Handle::timeout

### DIFF
--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -42,8 +42,12 @@ impl Delay {
         Delay { registration }
     }
 
-    pub(crate) fn new_with_handle(deadline: Instant, handle: HandlePriv) -> Delay {
-        let mut registration = Registration::new(deadline, Duration::from_millis(0));
+    pub(crate) fn new_with_handle(
+        deadline: Instant,
+        duration: Duration,
+        handle: HandlePriv,
+    ) -> Delay {
+        let mut registration = Registration::new(deadline, duration);
         registration.register_with(handle);
 
         Delay { registration }

--- a/tokio-timer/src/timer/handle.rs
+++ b/tokio-timer/src/timer/handle.rs
@@ -1,3 +1,4 @@
+use crate::clock::now;
 use crate::timer::Inner;
 use crate::{Deadline, Delay, Error, Interval, Timeout};
 use std::cell::RefCell;
@@ -131,9 +132,15 @@ impl Handle {
 
     /// Create a `Delay` driven by this handle's associated `Timer`.
     pub fn delay(&self, deadline: Instant) -> Delay {
+        self.delay_timeout(deadline, Duration::from_secs(0))
+    }
+
+    fn delay_timeout(&self, deadline: Instant, duration: Duration) -> Delay {
         match self.inner {
-            Some(ref handle_priv) => Delay::new_with_handle(deadline, handle_priv.clone()),
-            None => Delay::new(deadline),
+            Some(ref handle_priv) => {
+                Delay::new_with_handle(deadline, Duration::from_secs(0), handle_priv.clone())
+            }
+            None => Delay::new_timeout(deadline, duration),
         }
     }
 
@@ -144,8 +151,8 @@ impl Handle {
     }
 
     /// Create a `Timeout` driven by this handle's associated `Timer`.
-    pub fn timeout<T>(&self, value: T, deadline: Instant) -> Timeout<T> {
-        Timeout::new_with_delay(value, self.delay(deadline))
+    pub fn timeout<T>(&self, value: T, timeout: Duration) -> Timeout<T> {
+        Timeout::new_with_delay(value, self.delay_timeout(now() + timeout, timeout))
     }
 
     /// Create a new `Interval` that starts at `at` and yields every `duration`

--- a/tokio-timer/tests/hammer.rs
+++ b/tokio-timer/tests/hammer.rs
@@ -105,16 +105,13 @@ fn hammer_cancel() {
                 barrier.wait();
 
                 for _ in 0..PER_THREAD {
-                    let deadline1 =
-                        Instant::now() + Duration::from_millis(rng.gen_range(MIN_DELAY, MAX_DELAY));
+                    let timeout1 = Duration::from_millis(rng.gen_range(MIN_DELAY, MAX_DELAY));
+                    let timeout2 = Duration::from_millis(rng.gen_range(MIN_DELAY, MAX_DELAY));
 
-                    let deadline2 =
-                        Instant::now() + Duration::from_millis(rng.gen_range(MIN_DELAY, MAX_DELAY));
+                    let deadline = Instant::now() + cmp::min(timeout1, timeout2);
 
-                    let deadline = cmp::min(deadline1, deadline2);
-
-                    let delay = handle.delay(deadline1);
-                    let join = handle.timeout(delay, deadline2);
+                    let delay = handle.delay(Instant::now() + timeout1);
+                    let join = handle.timeout(delay, timeout2);
 
                     exec.push({
                         join.and_then(move |_| {


### PR DESCRIPTION
## Motivation

The old implementation didn't work for Timeout<Stream>, since the method
took a deadline rather than a timeout.

## Solution

`timeout` now takes a `Duration` rather than `Instant`, and plumbs things through so that the inner Delay will be reset appropriately. This is a breaking change, so it shouldn't be backported to 1.x