### PR TITLE
trace: Deprecate Id::clone, remove AsId

### DIFF
--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio-trace"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
@@ -19,6 +19,7 @@ A scoped, structured logging and diagnostics system.
 """
 categories = ["development-tools::debugging", "asynchronous"]
 keywords = ["logging", "tracing"]
+publish = false
 
 [dependencies]
 tokio-trace-core = "0.2"

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -143,6 +143,11 @@ use std::{
 use {dispatcher::Dispatch, field, Metadata};
 
 /// Trait implemented by types which have a span `Id`.
+#[deprecated(
+    since = "0.2.0",
+    note = "this is no longer necessary, use `Into<Option<&Id>>` instead"
+)]
+#[doc(hidden)]
 pub trait AsId: ::sealed::Sealed {
     /// Returns the `Id` of the span that `self` corresponds to, or `None` if
     /// this corresponds to a disabled span.
@@ -464,12 +469,9 @@ impl Span {
     ///
     /// If this span is disabled, or the resulting follows-from relationship
     /// would be invalid, this function will do nothing.
-    pub fn follows_from<I>(&self, from: I) -> &Self
-    where
-        I: AsId,
-    {
+    pub fn follows_from<I>(&self, from: impl for<'a> Into<Option<&'a Id>>) -> &Self {
         if let Some(ref inner) = self.inner {
-            if let Some(from) = from.as_id() {
+            if let Some(from) = from.into() {
                 inner.follows_from(from);
             }
         }
@@ -555,6 +557,12 @@ impl fmt::Debug for Span {
         }
 
         span.finish()
+    }
+}
+
+impl<'a> Into<Option<&'a Id>> for &'a Span {
+    fn into(self) -> Option<&'a Id> {
+        self.inner.as_ref().map(|inner| &inner.id)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -655,7 +655,6 @@ impl Drop for Inner {
         if let Some(id) = self.id.take() {
             self.subscriber.drop_span(id);
         }
-
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -142,18 +142,6 @@ use std::{
 };
 use {dispatcher::Dispatch, field, Metadata};
 
-/// Trait implemented by types which have a span `Id`.
-#[deprecated(
-    since = "0.2.0",
-    note = "this is no longer necessary, use `Into<Option<&Id>>` instead"
-)]
-#[doc(hidden)]
-pub trait AsId: ::sealed::Sealed {
-    /// Returns the `Id` of the span that `self` corresponds to, or `None` if
-    /// this corresponds to a disabled span.
-    fn as_id(&self) -> Option<&Id>;
-}
-
 /// A handle representing a span, with the capability to enter the span if it
 /// exists.
 ///
@@ -685,56 +673,6 @@ impl<'a> fmt::Display for FmtAttrs<'a> {
             res = write!(f, "{}={:?} ", k, v);
         });
         res
-    }
-}
-
-// ===== impl AsId =====
-
-impl ::sealed::Sealed for Span {}
-
-impl AsId for Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Span {}
-
-impl<'a> AsId for &'a Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
-
-impl ::sealed::Sealed for Id {}
-
-impl AsId for Id {
-    fn as_id(&self) -> Option<&Id> {
-        Some(self)
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Id {}
-
-impl<'a> AsId for &'a Id {
-    fn as_id(&self) -> Option<&Id> {
-        Some(self)
-    }
-}
-
-impl ::sealed::Sealed for Option<Id> {}
-
-impl AsId for Option<Id> {
-    fn as_id(&self) -> Option<&Id> {
-        self.as_ref()
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Option<Id> {}
-
-impl<'a> AsId for &'a Option<Id> {
-    fn as_id(&self) -> Option<&Id> {
-        self.as_ref()
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -476,7 +476,7 @@ impl Span {
     }
 
     /// Returns this span's `Id`, if it is enabled.
-    pub fn id(&self) -> Option<Id> {
+    pub fn id(&self) -> Option<&Id> {
         self.inner.as_ref().map(Inner::id)
     }
 
@@ -560,12 +560,6 @@ impl fmt::Debug for Span {
 impl<'a> Into<Option<&'a Id>> for &'a Span {
     fn into(self) -> Option<&'a Id> {
         self.inner.as_ref().map(Inner::id)
-    }
-}
-
-impl<'a> Into<Option<Id>> for &'a Span {
-    fn into(self) -> Option<Id> {
-        self.id()
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -245,8 +245,8 @@ impl Span {
         meta: &'static Metadata<'static>,
         values: &field::ValueSet,
     ) -> Span {
-        let new_span = match parent.as_id() {
-            Some(parent) => Attributes::child_of(parent.clone(), meta, values),
+        let new_span = match parent.into() {
+            Some(parent) => Attributes::child_of(parent, meta, values),
             None => Attributes::new_root(meta, values),
         };
         Self::make(meta, new_span)
@@ -537,7 +537,7 @@ impl fmt::Debug for Span {
             .field("target", &self.meta.target());
 
         if let Some(ref inner) = self.inner {
-            span.field("id", &inner.id());
+            span.field("id", &inner.id);
         } else {
             span.field("disabled", &true);
         }
@@ -565,10 +565,18 @@ impl<'a> Into<Option<Id>> for &'a Span {
 }
 
 impl Into<Option<Id>> for Span {
-    fn into(self) -> Option<Id> {
+    fn into(mut self) -> Option<Id> {
         // since we're moving the span, it's not necessary to clone the ref
         // count.
         self.inner.take().map(|inner| inner.id)
+    }
+}
+
+impl Drop for Span {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner.take() {
+            inner.subscriber.drop_span(inner.id);
+        }
     }
 }
 
@@ -620,12 +628,6 @@ impl cmp::PartialEq for Inner {
 impl Hash for Inner {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state);
-    }
-}
-
-impl Drop for Inner {
-    fn drop(&mut self) {
-        self.subscriber.drop_span(self.id.clone());
     }
 }
 

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -176,91 +176,91 @@ fn error_span_root() {
 #[test]
 fn span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "foo");
-    span!(Level::DEBUG, target: "foo_events", parent: &p, "bar",);
+    span!(Level::DEBUG, target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    span!(Level::DEBUG, target: "foo_events", parent: p.clone(), "foo");
+    span!(Level::DEBUG, target: "foo_events", parent: p.clone(), "bar",);
 
-    span!(Level::DEBUG, parent: &p, "foo", bar.baz = 2, quux = 3);
-    span!(Level::DEBUG, parent: &p, "foo", bar.baz = 2, quux = 4,);
+    span!(Level::DEBUG, parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    span!(Level::DEBUG, parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    span!(Level::DEBUG, parent: &p, "foo");
-    span!(Level::DEBUG, parent: &p, "bar",);
+    span!(Level::DEBUG, parent: p.clone(), "foo");
+    span!(Level::DEBUG, parent: p.clone(), "bar",);
 }
 
 #[test]
 fn trace_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    trace_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    trace_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    trace_span!(target: "foo_events", parent: &p, "foo");
-    trace_span!(target: "foo_events", parent: &p, "bar",);
+    trace_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    trace_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    trace_span!(target: "foo_events", parent: p.clone(), "foo");
+    trace_span!(target: "foo_events", parent: p.clone(), "bar",);
 
-    trace_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
-    trace_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
+    trace_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    trace_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    trace_span!(parent: &p, "foo");
-    trace_span!(parent: &p, "bar",);
+    trace_span!(parent: p.clone(), "foo");
+    trace_span!(parent: p.clone(), "bar",);
 }
 
 #[test]
 fn debug_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    debug_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    debug_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    debug_span!(target: "foo_events", parent: &p, "foo");
-    debug_span!(target: "foo_events", parent: &p, "bar",);
+    debug_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    debug_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    debug_span!(target: "foo_events", parent: p.clone(), "foo");
+    debug_span!(target: "foo_events", parent: p.clone(), "bar",);
 
-    debug_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
-    debug_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
+    debug_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    debug_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    debug_span!(parent: &p, "foo");
-    debug_span!(parent: &p, "bar",);
+    debug_span!(parent: p.clone(), "foo");
+    debug_span!(parent: p.clone(), "bar",);
 }
 
 #[test]
 fn info_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    info_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    info_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    info_span!(target: "foo_events", parent: &p, "foo");
-    info_span!(target: "foo_events", parent: &p, "bar",);
+    info_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    info_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    info_span!(target: "foo_events", parent: p.clone(), "foo");
+    info_span!(target: "foo_events", parent: p.clone(), "bar",);
 
-    info_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
-    info_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
+    info_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    info_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    info_span!(parent: &p, "foo");
-    info_span!(parent: &p, "bar",);
+    info_span!(parent: p.clone(), "foo");
+    info_span!(parent: p.clone(), "bar",);
 }
 
 #[test]
 fn warn_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    warn_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    warn_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    warn_span!(target: "foo_events", parent: &p, "foo");
-    warn_span!(target: "foo_events", parent: &p, "bar",);
+    warn_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    warn_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    warn_span!(target: "foo_events", parent: p.clone(), "foo");
+    warn_span!(target: "foo_events", parent: p.clone(), "bar",);
 
-    warn_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
-    warn_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
+    warn_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    warn_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    warn_span!(parent: &p, "foo");
-    warn_span!(parent: &p, "bar",);
+    warn_span!(parent: p.clone(), "foo");
+    warn_span!(parent: p.clone(), "bar",);
 }
 
 #[test]
 fn error_span_with_parent() {
     let p = span!(Level::TRACE, "im_a_parent!");
-    error_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 3);
-    error_span!(target: "foo_events", parent: &p, "foo", bar.baz = 2, quux = 4,);
-    error_span!(target: "foo_events", parent: &p, "foo");
-    error_span!(target: "foo_events", parent: &p, "bar",);
+    error_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    error_span!(target: "foo_events", parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
+    error_span!(target: "foo_events", parent: p.clone(), "foo");
+    error_span!(target: "foo_events", parent: p.clone(), "bar",);
 
-    error_span!(parent: &p, "foo", bar.baz = 2, quux = 3);
-    error_span!(parent: &p, "foo", bar.baz = 2, quux = 4,);
+    error_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 3);
+    error_span!(parent: p.clone(), "foo", bar.baz = 2, quux = 4,);
 
-    error_span!(parent: &p, "foo");
-    error_span!(parent: &p, "bar",);
+    error_span!(parent: p.clone(), "foo");
+    error_span!(parent: p.clone(), "bar",);
 }
 
 #[test]

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -515,6 +515,23 @@ fn explicit_child() {
 }
 
 #[test]
+fn explicit_child_from_ref_clones_id() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("foo"))
+        .clone_span(span::mock().named("foo"))
+        .new_span(span::mock().named("bar").with_explicit_parent(Some("foo")))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let foo = span!(Level::TRACE, "foo");
+        span!(Level::TRACE, parent: &foo, "bar");
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
 fn explicit_child_regardless_of_ctx() {
     let (subscriber, handle) = subscriber::mock()
         .new_span(span::mock().named("foo"))

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -508,24 +508,7 @@ fn explicit_child() {
 
     with_default(subscriber, || {
         let foo = span!(Level::TRACE, "foo");
-        span!(Level::TRACE, parent: foo.id(), "bar");
-    });
-
-    handle.assert_finished();
-}
-
-#[test]
-fn explicit_child_from_ref_clones_id() {
-    let (subscriber, handle) = subscriber::mock()
-        .new_span(span::mock().named("foo"))
-        .clone_span(span::mock().named("foo"))
-        .new_span(span::mock().named("bar").with_explicit_parent(Some("foo")))
-        .done()
-        .run_with_handle();
-
-    with_default(subscriber, || {
-        let foo = span!(Level::TRACE, "foo");
-        span!(Level::TRACE, parent: &foo, "bar");
+        span!(Level::TRACE, parent: foo, "bar");
     });
 
     handle.assert_finished();
@@ -544,7 +527,7 @@ fn explicit_child_regardless_of_ctx() {
 
     with_default(subscriber, || {
         let foo = span!(Level::TRACE, "foo");
-        span!(Level::TRACE, "bar").in_scope(|| span!(Level::TRACE, parent: foo.id(), "baz"))
+        span!(Level::TRACE, "bar").in_scope(|| span!(Level::TRACE, parent: foo, "baz"))
     });
 
     handle.assert_finished();

--- a/tokio-trace/tests/support/subscriber.rs
+++ b/tokio-trace/tests/support/subscriber.rs
@@ -217,8 +217,10 @@ where
                         );
                     }
                     Some(Parent::Explicit(expected_parent)) => {
-                        let actual_parent =
-                            span.parent().and_then(|id| spans.get(&id.into_u64())).map(|s| s.name);
+                        let actual_parent = span
+                            .parent()
+                            .and_then(|id| spans.get(&id.into_u64()))
+                            .map(|s| s.name);
                         assert_eq!(Some(expected_parent.as_ref()), actual_parent);
                     }
                     Some(Parent::ContextualRoot) => {
@@ -240,8 +242,10 @@ where
                             name
                         );
                         let stack = self.current.lock().unwrap();
-                        let actual_parent =
-                            stack.last().and_then(|id| spans.get(&id.into_u64())).map(|s| s.name);
+                        let actual_parent = stack
+                            .last()
+                            .and_then(|id| spans.get(&id.into_u64()))
+                            .map(|s| s.name);
                         assert_eq!(Some(expected_parent.as_ref()), actual_parent);
                     }
                     None => {}
@@ -296,7 +300,9 @@ where
                     curr.as_ref(),
                     "exited span {:?}, but the current span was {:?}",
                     span.name,
-                    curr.as_ref().and_then(|id| spans.get(&id.into_u64())).map(|s| s.name)
+                    curr.as_ref()
+                        .and_then(|id| spans.get(&id.into_u64()))
+                        .map(|s| s.name)
                 );
             }
             Some(ex) => ex.bad(format_args!("exited span {:?}", span.name)),
@@ -304,12 +310,17 @@ where
     }
 
     fn clone_span(&self, id: &Id) -> Id {
-        let name = self.spans.lock().unwrap().get_mut(&id.into_u64()).map(|span| {
-            let name = span.name;
-            println!("clone_span: {}; id={:?}; refs={:?};", name, id, span.refs);
-            span.refs += 1;
-            name
-        });
+        let name = self
+            .spans
+            .lock()
+            .unwrap()
+            .get_mut(&id.into_u64())
+            .map(|span| {
+                let name = span.name;
+                println!("clone_span: {}; id={:?}; refs={:?};", name, id, span.refs);
+                span.refs += 1;
+                name
+            });
         if name.is_none() {
             println!("clone_span: id={:?};", id);
         }

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -63,14 +63,14 @@ impl Id {
 #[deprecated(
     since = "0.2.1",
     note = "cloning span IDs can cause incorrect reference counts, use \
-           `Subscriber::clone_span` instead"
+            `Subscriber::clone_span` instead"
 )]
 #[doc(hidden)]
 impl Clone for Id {
     fn clone(&self) -> Self {
         panic!(
             "cloning span IDs can cause incorrect reference counts, use \
-            `Subscriber::clone_span` instead"
+             `Subscriber::clone_span` instead"
         )
     }
 }

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -60,11 +60,18 @@ impl Id {
     }
 }
 
-#[deprecated(since = "0.2.1", note = "please use `Subscriber::clone_span` instead")]
+#[deprecated(
+    since = "0.2.1",
+    note = "cloning span IDs can cause incorrect reference counts, use \
+           `Subscriber::clone_span` instead"
+)]
 #[doc(hidden)]
 impl Clone for Id {
     fn clone(&self) -> Self {
-        Id::from_u64(self.into_u64())
+        panic!(
+            "cloning span IDs can cause incorrect reference counts, use \
+            `Subscriber::clone_span` instead"
+        )
     }
 }
 

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -10,7 +10,7 @@ use {field, Metadata};
 ///
 /// [`Subscriber`]: ../subscriber/trait.Subscriber.html
 /// [`new_span`]: ../subscriber/trait.Subscriber.html#method.new_span
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 // TODO(eliza): when Tokio's minimum Rust version is >= 1.28, change the
 // internal representation to a `NonZeroU64`.
 pub struct Id(u64);
@@ -57,6 +57,14 @@ impl Id {
     /// Returns the span's ID as a  `u64`.
     pub fn into_u64(&self) -> u64 {
         self.0
+    }
+}
+
+#[deprecated(since = "0.2.1", note = "please use `Subscriber::clone_span` instead")]
+#[doc(hidden)]
+impl Clone for Id {
+    fn clone(&self) -> Self {
+        Id::from_u64(self.into_u64())
     }
 }
 

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -138,13 +138,25 @@ impl<'a> Attributes<'a> {
         }
     }
 
+    /// Returns a reference to the new span's explicitly-specified parent, if
+    /// there is one.
+    ///
+    /// Otherwise (if the new span is a root or is a child of the current span),
+    /// returns none.
+    pub fn parent(&self) -> Option<&Id> {
+        match self.parent {
+            Parent::Explicit(ref p) => Some(p),
+            _ => None,
+        }
+    }
+
     /// Returns the new span's explicitly-specified parent, if there is one.
     ///
     /// Otherwise (if the new span is a root or is a child of the current span),
     /// returns false.
-    pub fn parent(&self) -> Option<&Id> {
+    pub fn take_parent(self) -> Option<Id> {
         match self.parent {
-            Parent::Explicit(ref p) => Some(p),
+            Parent::Explicit(p) => Some(p),
             _ => None,
         }
     }


### PR DESCRIPTION
## Motivation

Currently, the `tokio_trace_core::span::Id` type implements `Clone`. The
`Clone` implementation will return a copy of the `Id` _without_ calling
`Subscriber::clone_span` to increment the reference count for that ID.
However, _dropping_ the `Id` _will_ call `Subscriber::drop_span`. 

This means that if users call `clone` on an `Id`, span reference counts
will become incorrect. `Clone` is particularly dangerous because it can
be derived; if user code stores an `Id` as a field on a struct deriving
`Clone`, the derived implementation will lead to incorrect reference
counts. Additionally, many APIs in `tokio_trace` expose functions
returning `&Id`, which may be `clone`d without going through
`Subscriber::clone_span`.

Additionally, the `AsId` type in `tokio_trace` is unnecessary, as it 
was primarily used in conjunction with `Id::clone`, and all its 
use-cases could have used `Into` conversions instead. 

## Solution

This branch deprecates the `Clone` implementation for
`tokio_trace_core::span::Id` and hides it from documentation. In
addition, it removes the `tokio_trace::span::AsId` trait, and replaces
uses of it with `Into` conversions. Finally, a new method was added to
`tokio_trace_core::span::Attributes` to allow subscribers to consume
parent IDs without cloning them.

This branch is a breaking change for `tokio-trace`, but *not* a breaking
change for `tokio-trace-core`. Ideally, we would remove the `Clone`
implementation for `Id`, as when it is deprecated, it may still be used
by derived `Clone` impls. However, while there is an upcoming
breaking-change release scheduled for `tokio-trace`, there isn't
currently one for `-core`, so I chose to deprecate the `Clone`
implementation until we're ready to make a breaking release of `-core`.

Closes #1101

Signed-off-by: Eliza Weisman <eliza@buoyant.io>