### PR TITLE
Fix TCP poll_hup test

### DIFF
--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -8,6 +8,9 @@ jobs:
     parameters:
       rust_version: stable
 
+  - script: sudo apt-get update
+    displayName: "apt-get update"
+
   - script: sudo apt-get install gcc-multilib
     displayName: "Install gcc-multilib"
 

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -31,4 +31,5 @@ futures = "0.1.19"
 
 [dev-dependencies]
 env_logger = { version = "0.5", default-features = false }
+net2 = "*"
 tokio = { version = "0.2.0", path = "../tokio" }

--- a/tokio-tcp/tests/tcp.rs
+++ b/tokio-tcp/tests/tcp.rs
@@ -86,8 +86,8 @@ mod linux {
 
     use env_logger;
     use futures::{future, Future};
-    use net2::TcpStreamExt;
     use mio::unix::UnixReady;
+    use net2::TcpStreamExt;
     use tokio_io::AsyncRead;
 
     use std::io::Write;

--- a/tokio-tcp/tests/tcp.rs
+++ b/tokio-tcp/tests/tcp.rs
@@ -80,12 +80,13 @@ fn accept2() {
     t.join().unwrap();
 }
 
-#[cfg(unix)]
-mod unix {
+#[cfg(target_os = "linux")]
+mod linux {
     use tokio_tcp::TcpStream;
 
     use env_logger;
     use futures::{future, Future};
+    use net2::TcpStreamExt;
     use mio::unix::UnixReady;
     use tokio_io::AsyncRead;
 
@@ -101,6 +102,7 @@ mod unix {
         let addr = t!(srv.local_addr());
         let t = thread::spawn(move || {
             let mut client = t!(srv.accept()).0;
+            client.set_linger(Some(Duration::from_millis(0))).unwrap();
             client.write(b"hello world").unwrap();
             thread::sleep(Duration::from_millis(200));
         });


### PR DESCRIPTION
This updates tests to track a fix applied in Mio. Previously, Mio
incorrectly fired HUP events. This was due to Mio mapping `RDHUP` to
HUP. The test is updated to correctly generate a HUP event.

Additionally, HUP events will be removed from all platforms except for
Linux. This is caused by the inability to reliably map kqueue events to
the epoll HUP behavior.