### PR TITLE
trace: Allow setting event parents explicitly

### DIFF
--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -22,7 +22,7 @@ categories = ["development-tools::debugging", "asynchronous"]
 keywords = ["logging", "tracing"]
 
 [dependencies]
-tokio-trace-core = { version = "0.2", path = "tokio-trace-core" }
+tokio-trace-core = { path = "./tokio-trace-core" }
 log = { version = "0.4", optional = true }
 cfg-if = "0.1.7"
 

--- a/tokio-trace/tests/macros.rs
+++ b/tokio-trace/tests/macros.rs
@@ -395,6 +395,280 @@ fn error() {
 }
 
 #[test]
+fn event_root() {
+    event!(Level::DEBUG, parent: None, foo = ?3, bar.baz = %2, quux = false);
+    event!(
+        Level::DEBUG,
+        parent: None,
+        foo = 3,
+        bar.baz = 2,
+        quux = false
+    );
+    event!(Level::DEBUG, parent: None, foo = 3, bar.baz = 3,);
+    event!(Level::DEBUG, parent: None, "foo");
+    event!(Level::DEBUG, parent: None, "foo: {}", 3);
+    event!(Level::DEBUG, parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    event!(Level::DEBUG, parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(Level::DEBUG, parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(Level::DEBUG, parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(target: "foo_events", Level::DEBUG, parent: None, foo = 3, bar.baz = 2, quux = false);
+    event!(target: "foo_events", Level::DEBUG, parent: None, foo = 3, bar.baz = 3,);
+    event!(target: "foo_events", Level::DEBUG, parent: None, "foo");
+    event!(target: "foo_events", Level::DEBUG, parent: None, "foo: {}", 3);
+    event!(target: "foo_events", Level::DEBUG, parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    event!(target: "foo_events", Level::DEBUG, parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(target: "foo_events", Level::DEBUG, parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", Level::DEBUG, parent: None, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn trace_root() {
+    trace!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    trace!(parent: None, foo = 3, bar.baz = 2, quux = false);
+    trace!(parent: None, foo = 3, bar.baz = 3,);
+    trace!(parent: None, "foo");
+    trace!(parent: None, "foo: {}", 3);
+    trace!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
+    trace!(parent:None, { foo = ?2, bar.baz = %78 }, "quux");
+    trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
+    trace!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
+    trace!(target: "foo_events", parent: None, "foo");
+    trace!(target: "foo_events", parent: None, "foo: {}", 3);
+    trace!(target: "foo_events", parent: None,  { foo = 3, bar.baz = 80 }, "quux");
+    trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(target: "foo_events", parent: None,  { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn debug_root() {
+    debug!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    debug!(parent: None, foo = 3, bar.baz = 2, quux = false);
+    debug!(parent: None, foo = 3, bar.baz = 3,);
+    debug!(parent: None, "foo");
+    debug!(parent: None, "foo: {}", 3);
+    debug!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
+    debug!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
+    debug!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
+    debug!(target: "foo_events", parent: None, "foo");
+    debug!(target: "foo_events", parent: None, "foo: {}", 3);
+    debug!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn info_root() {
+    info!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    info!(parent: None, foo = 3, bar.baz = 2, quux = false);
+    info!(parent: None, foo = 3, bar.baz = 3,);
+    info!(parent: None, "foo");
+    info!(parent: None, "foo: {}", 3);
+    info!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
+    info!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    info!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
+    info!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
+    info!(target: "foo_events", parent: None, "foo");
+    info!(target: "foo_events", parent: None, "foo: {}", 3);
+    info!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn warn_root() {
+    warn!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    warn!(parent: None, foo = 3, bar.baz = 2, quux = false);
+    warn!(parent: None, foo = 3, bar.baz = 3,);
+    warn!(parent: None, "foo");
+    warn!(parent: None, "foo: {}", 3);
+    warn!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
+    warn!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
+    warn!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
+    warn!(target: "foo_events", parent: None, "foo");
+    warn!(target: "foo_events", parent: None, "foo: {}", 3);
+    warn!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn error_root() {
+    error!(parent: None, foo = ?3, bar.baz = %2, quux = false);
+    error!(parent: None, foo = 3, bar.baz = 2, quux = false);
+    error!(parent: None, foo = 3, bar.baz = 3,);
+    error!(parent: None, "foo");
+    error!(parent: None, "foo: {}", 3);
+    error!(parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(parent: None, { foo = 2, bar.baz = 78 }, "quux");
+    error!(parent: None, { foo = ?2, bar.baz = %78 }, "quux");
+    error!(target: "foo_events", parent: None, foo = 3, bar.baz = 2, quux = false);
+    error!(target: "foo_events", parent: None, foo = 3, bar.baz = 3,);
+    error!(target: "foo_events", parent: None, "foo");
+    error!(target: "foo_events", parent: None, "foo: {}", 3);
+    error!(target: "foo_events", parent: None, { foo = 3, bar.baz = 80 }, "quux");
+    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(target: "foo_events", parent: None, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn event_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    event!(Level::DEBUG, parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    event!(Level::DEBUG, parent: &p, foo = 3, bar.baz = 2, quux = false);
+    event!(Level::DEBUG, parent: &p, foo = 3, bar.baz = 3,);
+    event!(Level::DEBUG, parent: &p, "foo");
+    event!(Level::DEBUG, parent: &p, "foo: {}", 3);
+    event!(Level::DEBUG, parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    event!(Level::DEBUG, parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(Level::DEBUG, parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(Level::DEBUG, parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    event!(target: "foo_events", Level::DEBUG, parent: &p, foo = 3, bar.baz = 2, quux = false);
+    event!(target: "foo_events", Level::DEBUG, parent: &p, foo = 3, bar.baz = 3,);
+    event!(target: "foo_events", Level::DEBUG, parent: &p, "foo");
+    event!(target: "foo_events", Level::DEBUG, parent: &p, "foo: {}", 3);
+    event!(target: "foo_events", Level::DEBUG, parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    event!(target: "foo_events", Level::DEBUG, parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    event!(target: "foo_events", Level::DEBUG, parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    event!(target: "foo_events", Level::DEBUG, parent: &p, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn trace_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    trace!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    trace!(parent: &p, foo = 3, bar.baz = 2, quux = false);
+    trace!(parent: &p, foo = 3, bar.baz = 3,);
+    trace!(parent: &p, "foo");
+    trace!(parent: &p, "foo: {}", 3);
+    trace!(parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    trace!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
+    trace!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    trace!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
+    trace!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
+    trace!(target: "foo_events", parent: &p, "foo");
+    trace!(target: "foo_events", parent: &p, "foo: {}", 3);
+    trace!(target: "foo_events", parent: &p,  { foo = 3, bar.baz = 80 }, "quux");
+    trace!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    trace!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    trace!(target: "foo_events", parent: &p,  { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn debug_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    debug!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    debug!(parent: &p, foo = 3, bar.baz = 2, quux = false);
+    debug!(parent: &p, foo = 3, bar.baz = 3,);
+    debug!(parent: &p, "foo");
+    debug!(parent: &p, "foo: {}", 3);
+    debug!(parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
+    debug!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    debug!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
+    debug!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
+    debug!(target: "foo_events", parent: &p, "foo");
+    debug!(target: "foo_events", parent: &p, "foo: {}", 3);
+    debug!(target: "foo_events", parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    debug!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    debug!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    debug!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn info_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    info!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    info!(parent: &p, foo = 3, bar.baz = 2, quux = false);
+    info!(parent: &p, foo = 3, bar.baz = 3,);
+    info!(parent: &p, "foo");
+    info!(parent: &p, "foo: {}", 3);
+    info!(parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    info!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
+    info!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    info!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
+    info!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
+    info!(target: "foo_events", parent: &p, "foo");
+    info!(target: "foo_events", parent: &p, "foo: {}", 3);
+    info!(target: "foo_events", parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    info!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    info!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    info!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn warn_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    warn!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    warn!(parent: &p, foo = 3, bar.baz = 2, quux = false);
+    warn!(parent: &p, foo = 3, bar.baz = 3,);
+    warn!(parent: &p, "foo");
+    warn!(parent: &p, "foo: {}", 3);
+    warn!(parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
+    warn!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    warn!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
+    warn!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
+    warn!(target: "foo_events", parent: &p, "foo");
+    warn!(target: "foo_events", parent: &p, "foo: {}", 3);
+    warn!(target: "foo_events", parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    warn!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    warn!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    warn!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
+fn error_with_parent() {
+    let p = span!(Level::TRACE, "im_a_parent!");
+    error!(parent: &p, foo = ?3, bar.baz = %2, quux = false);
+    error!(parent: &p, foo = 3, bar.baz = 2, quux = false);
+    error!(parent: &p, foo = 3, bar.baz = 3,);
+    error!(parent: &p, "foo");
+    error!(parent: &p, "foo: {}", 3);
+    error!(parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    error!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(parent: &p, { foo = 2, bar.baz = 78 }, "quux");
+    error!(parent: &p, { foo = ?2, bar.baz = %78 }, "quux");
+    error!(target: "foo_events", parent: &p, foo = 3, bar.baz = 2, quux = false);
+    error!(target: "foo_events", parent: &p, foo = 3, bar.baz = 3,);
+    error!(target: "foo_events", parent: &p, "foo");
+    error!(target: "foo_events", parent: &p, "foo: {}", 3);
+    error!(target: "foo_events", parent: &p, { foo = 3, bar.baz = 80 }, "quux");
+    error!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}", true);
+    error!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 79 }, "quux {:?}, {quux}", true, quux = false);
+    error!(target: "foo_events", parent: &p, { foo = 2, bar.baz = 78, }, "quux");
+}
+
+#[test]
 fn field_shorthand_only() {
     #[derive(Debug)]
     struct Position {

--- a/tokio-trace/tokio-trace-core/src/event.rs
+++ b/tokio-trace/tokio-trace-core/src/event.rs
@@ -1,4 +1,6 @@
 //! Events represent single points in time during the execution of a program.
+use parent::Parent;
+use span::Id;
 use {field, Metadata};
 
 /// `Event`s represent single points in time where something occurred during the
@@ -21,6 +23,7 @@ use {field, Metadata};
 pub struct Event<'a> {
     fields: &'a field::ValueSet<'a>,
     metadata: &'a Metadata<'a>,
+    parent: Parent,
 }
 
 impl<'a> Event<'a> {
@@ -28,7 +31,34 @@ impl<'a> Event<'a> {
     /// and observes it with the current subscriber.
     #[inline]
     pub fn dispatch(metadata: &'a Metadata<'a>, fields: &'a field::ValueSet) {
-        let event = Event { metadata, fields };
+        let event = Event {
+            metadata,
+            fields,
+            parent: Parent::Current,
+        };
+        ::dispatcher::get_default(|current| {
+            current.event(&event);
+        });
+    }
+
+    /// Constructs a new `Event` with the specified metadata and set of values,
+    /// and observes it with the current subscriber and an explicit parent.
+    #[inline]
+    pub fn child_of(
+        parent: impl Into<Option<Id>>,
+        metadata: &'a Metadata<'a>,
+        fields: &'a field::ValueSet,
+    ) {
+        let parent = match parent.into() {
+            Some(p) => Parent::Explicit(p),
+            None => Parent::Root,
+        };
+
+        let event = Event {
+            metadata,
+            fields,
+            parent,
+        };
         ::dispatcher::get_default(|current| {
             current.event(&event);
         });
@@ -52,5 +82,38 @@ impl<'a> Event<'a> {
     /// [metadata]: ../metadata/struct.Metadata.html
     pub fn metadata(&self) -> &Metadata {
         self.metadata
+    }
+
+    /// Returns true if the new event shoold be a root.
+    pub fn is_root(&self) -> bool {
+        match self.parent {
+            Parent::Root => true,
+            _ => false,
+        }
+    }
+
+    /// Returns true if the new event's parent should be determined based on the
+    /// current context.
+    ///
+    /// If this is true and the current thread is currently inside a span, then
+    /// that span should be the new events's parent. Otherwise, if the current
+    /// thread is _not_ inside a span, then the new event will be the root of its
+    /// own trace tree.
+    pub fn is_contextual(&self) -> bool {
+        match self.parent {
+            Parent::Current => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the new event's explicitly-specified parent, if there is one.
+    ///
+    /// Otherwise (if the new event is a root or is a child of the current span),
+    /// returns false.
+    pub fn parent(&self) -> Option<&Id> {
+        match self.parent {
+            Parent::Explicit(ref p) => Some(p),
+            _ => None,
+        }
     }
 }

--- a/tokio-trace/tokio-trace-core/src/lib.rs
+++ b/tokio-trace/tokio-trace-core/src/lib.rs
@@ -195,6 +195,7 @@ pub mod dispatcher;
 pub mod event;
 pub mod field;
 pub mod metadata;
+mod parent;
 pub mod span;
 pub mod subscriber;
 

--- a/tokio-trace/tokio-trace-core/src/parent.rs
+++ b/tokio-trace/tokio-trace-core/src/parent.rs
@@ -1,0 +1,11 @@
+use span::Id;
+
+#[derive(Debug)]
+pub(crate) enum Parent {
+    /// The new span will be a root span.
+    Root,
+    /// The new span will be rooted in the current span.
+    Current,
+    /// The new span has an explicitly-specified parent.
+    Explicit(Id),
+}

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -1,5 +1,6 @@
 //! Spans represent periods of time in the execution of a program.
 
+use parent::Parent;
 use {field, Metadata};
 
 /// Identifies a span within the context of a subscriber.
@@ -28,16 +29,6 @@ pub struct Attributes<'a> {
 #[derive(Debug)]
 pub struct Record<'a> {
     values: &'a field::ValueSet<'a>,
-}
-
-#[derive(Debug)]
-enum Parent {
-    /// The new span will be a root span.
-    Root,
-    /// The new span will be rooted in the current span.
-    Current,
-    /// The new span has an explicitly-specified parent.
-    Explicit(Id),
 }
 
 // ===== impl Span =====


### PR DESCRIPTION
Closes #1100

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>


## Motivation
As mentioned in #1100  it makes sense to be able to set the parents of events explicitly.

## Solution
For that to happen the Parent type is extracted from span.rs  and a `parent` field is added to Event. Additionally the appropriate macros arms are added with corresponding tests as described in #1100

