### PR TITLE
sync: Add Sync impl for Lock

### DIFF
--- a/tokio-sync/src/lock.rs
+++ b/tokio-sync/src/lock.rs
@@ -72,9 +72,11 @@ pub struct Lock<T> {
 #[derive(Debug)]
 pub struct LockGuard<T>(Lock<T>);
 
-// As long as T: Send, it's fine to send Lock<T> to other threads.
-// If T was not Send, sending a Lock<T> would be bad, since you can access T through Lock<T>.
+// As long as T: Send, it's fine to send and share Lock<T> between threads.
+// If T was not Send, sending and sharing a Lock<T> would be bad, since you can access T through
+// Lock<T>.
 unsafe impl<T> Send for Lock<T> where T: Send {}
+unsafe impl<T> Sync for Lock<T> where T: Send {}
 unsafe impl<T> Sync for LockGuard<T> where T: Send + Sync {}
 
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation

I am using `Lock` so that I can get `Sync` for a sendable type. It appears that
the `Sync` impl is missing for `Lock` though, so the underlying `UnsafeCell`'s
`!Sync` is causing an issue.

## Solution

I have added a `Sync` impl for `Lock`. The only bound required is `T: Send`,
which is the same for the `Send` impl for `Lock`.

Signed-off-by: Kevin Leimkuhler <kevinl@buoyant.io>
