### PR TITLE
Implement Default for tokio_timer::DelayQueue

### DIFF
--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -711,6 +711,12 @@ impl<T> Stream for DelayQueue<T> {
     }
 }
 
+impl<T> Default for DelayQueue<T> {
+    fn default() -> DelayQueue<T> {
+        DelayQueue::new()
+    }
+}
+
 impl<T> wheel::Stack for Stack<T> {
     type Owned = usize;
     type Borrowed = usize;


### PR DESCRIPTION
## Motivation

```rust
#[derive(Default)] // To derive Default
struct Cache {
    entries: HashMap<CacheKey, (Value, delay_queue::Key)>,
    expirations: DelayQueue<CacheKey>,
}
```

## Solution

Implement `Default` for `tokio_timer::DelayQueue`.
