### PR TITLE
Make `tokio_current_thread::Handle` Sync

### DIFF
--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -24,6 +24,7 @@ publish = false
 
 [dependencies]
 tokio-executor = { version = "0.2.0", path = "../tokio-executor" }
+crossbeam-channel = "0.3.8"
 
 [dev-dependencies]
 tokio-sync = { version = "0.2.0", path = "../tokio-sync" }

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -702,7 +702,7 @@ impl Handle {
 
     fn is_shut_down(&self) -> bool {
         // LSB of "num_futures" is the shutdown bit
-        let num_futures = self.num_futures.fetch_add(2, atomic::Ordering::SeqCst);
+        let num_futures = self.num_futures.load(atomic::Ordering::SeqCst);
         num_futures % 2 == 1
     }
 }

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -644,7 +644,7 @@ pub struct Handle {
 impl fmt::Debug for Handle {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Handle")
-            .field("shut_down", &self.is_shutting_down())
+            .field("shut_down", &self.is_shut_down())
             .finish()
     }
 }
@@ -693,14 +693,14 @@ impl Handle {
     /// This allows a caller to avoid creating the task if the call to `spawn`
     /// has a high likelihood of failing.
     pub fn status(&self) -> Result<(), SpawnError> {
-        if self.is_shutting_down() {
+        if self.is_shut_down() {
             return Err(SpawnError::shutdown());
         }
 
         Ok(())
     }
 
-    fn is_shutting_down(&self) -> bool {
+    fn is_shut_down(&self) -> bool {
         // LSB of "num_futures" is the shutdown bit
         let num_futures = self.num_futures.fetch_add(2, atomic::Ordering::SeqCst);
         num_futures % 2 == 1

--- a/tokio-current-thread/tests/current_thread.rs
+++ b/tokio-current-thread/tests/current_thread.rs
@@ -750,6 +750,14 @@ fn spawn_from_executor_with_handle() {
     current_thread.block_on(rx).unwrap();
 }
 
+#[test]
+fn handle_is_sync() {
+    let current_thread = CurrentThread::new();
+    let handle = current_thread.handle();
+
+    let _box: Box<dyn Sync> = Box::new(handle);
+}
+
 async fn yield_once() {
     YieldOnce(false).await
 }

--- a/tokio-current-thread/tests/current_thread.rs
+++ b/tokio-current-thread/tests/current_thread.rs
@@ -751,6 +751,17 @@ fn spawn_from_executor_with_handle() {
 }
 
 #[test]
+fn handle_status() {
+    let current_thread = CurrentThread::new();
+    let handle = current_thread.handle();
+    assert!(handle.status().is_ok());
+
+    drop(current_thread);
+    assert!(handle.spawn(async { () }).is_err());
+    assert!(handle.status().is_err());
+}
+
+#[test]
 fn handle_is_sync() {
     let current_thread = CurrentThread::new();
     let handle = current_thread.handle();


### PR DESCRIPTION
## Motivation

The `dyn future::Executor` for the threadpool is `Sync` ([`tokio_threadpool::Sender`](https://docs.rs/tokio-threadpool/0.1.14/tokio_threadpool/struct.Sender.html)), but the executor for the current-thread is not ([`tokio_current_thread::Handle`](https://docs.rs/tokio/0.1.21/tokio/runtime/current_thread/struct.Handle.html)).

To use the two executors interchangeably it would better if they would both be `Sync`.

## Solution
There are two non-Sync items in the `Handle` struct:
- sender: current `mpsc::Sender` could be replaced with `crossbeam_channel::Sender`
- shut_down: `Cell<bool>` could be replaced with `Arc<atomic::AtomicBool>`

Is this a good idea?