### PR TITLE
Refactor tokio-tcp to use std::future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
   "tokio-test",
   # "tokio-threadpool",
   # "tokio-timer",
-  # "tokio-tcp",
+  "tokio-tcp",
   # "tokio-tls",
   # "tokio-trace",
   # "tokio-trace/tokio-trace-core",

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -21,15 +21,20 @@ TCP bindings for tokio.
 categories = ["asynchronous"]
 publish = false
 
+[features]
+incoming = ["futures-core-preview"]
+
 [dependencies]
 tokio-io = { version = "0.2.0", path = "../tokio-io" }
 tokio-reactor = { version = "0.2.0", path = "../tokio-reactor" }
 bytes = "0.4"
 mio = "0.6.14"
 iovec = "0.1"
-futures = "0.1.19"
+
+# optionals
+futures-core-preview = { version = "0.3.0-alpha.16", optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.5", default-features = false }
-net2 = "*"
-tokio = { version = "0.2.0", path = "../tokio" }
+#env_logger = { version = "0.5", default-features = false }
+#net2 = "*"
+#tokio = { version = "0.2.0", path = "../tokio" }

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -9,8 +9,7 @@
 //! library, which can be used to implement networking protocols.
 //!
 //! Connecting to an address, via TCP, can be done using [`TcpStream`]'s
-//! [`connect`] method, which returns [`ConnectFuture`]. `ConnectFuture`
-//! implements a future which returns a `TcpStream`.
+//! [`connect`] method, which returns a future which returns a `TcpStream`.
 //!
 //! To listen on an address [`TcpListener`] can be used. `TcpListener`'s
 //! [`incoming`][incoming_method] method can be used to accept new connections.
@@ -19,16 +18,23 @@
 //!
 //! [`TcpStream`]: struct.TcpStream.html
 //! [`connect`]: struct.TcpStream.html#method.connect
-//! [`ConnectFuture`]: struct.ConnectFuture.html
 //! [`TcpListener`]: struct.TcpListener.html
 //! [incoming_method]: struct.TcpListener.html#method.incoming
 //! [`Incoming`]: struct.Incoming.html
 
+macro_rules! ready {
+    ($e:expr) => {
+        match $e {
+            ::std::task::Poll::Ready(t) => t,
+            ::std::task::Poll::Pending => return ::std::task::Poll::Pending,
+        }
+    };
+}
+
+#[cfg(feature = "incoming")]
 mod incoming;
 mod listener;
 mod stream;
 
-pub use self::incoming::Incoming;
 pub use self::listener::TcpListener;
-pub use self::stream::ConnectFuture;
 pub use self::stream::TcpStream;


### PR DESCRIPTION
- Removes several deprecated functions.
- Hides `ConnectFuture` as just an `impl Future`.
- Exposes `TcpListener::incoming()` optionally via the cargo feature `incoming`.

And doesn't fix any of the tests, because I'm tired...