### PR TITLE
signal: finish the driver task (on Windows) if there are no sub-tasks

### DIFF
--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -201,8 +201,11 @@ impl Future for DriverTask {
         self.check_messages();
         self.check_events().unwrap();
 
-        // TODO: when to finish this task?
-        Ok(Async::NotReady)
+        if self.ctrl_c.tasks.is_empty() && self.ctrl_break.tasks.is_empty() {
+            Ok(Async::Ready(()))
+        } else {
+            Ok(Async::NotReady)
+        }
     }
 }
 
@@ -397,5 +400,7 @@ mod tests {
         rt.block_on(with_timeout(event_ctrl_break.into_future()))
             .ok()
             .expect("failed to run event");
+
+        let _ = rt.run();
     }
 }


### PR DESCRIPTION
Fixes: #1000

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Keep the event loop from being stuck open by the `DriverTask`.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Check if there are no more sub-tasks (`ctrl_c.tasks` and `ctrl_break.tasks`) and if so, finish out the `DriverTask` `Future`.


One remaining question I have is concerning the test case. The change I made to the test will make the test hang infinitely in the case of a regression. Is this a suitable solution or should this be handled some other way?
