### PR TITLE
Refactor tokio-timer to use std::future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
   "tokio-sync",
   "tokio-test",
   # "tokio-threadpool",
-  # "tokio-timer",
+  "tokio-timer",
   "tokio-tcp",
   # "tokio-tls",
   # "tokio-trace",

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -21,13 +21,31 @@ Timer facilities for Tokio
 """
 publish = false
 
+[features]
+# individual `Stream` impls if you so desire
+delay-queue = ["futures-core-preview"]
+interval = ["futures-core-preview"]
+timeout-stream = ["futures-core-preview"]
+throttle = ["futures-core-preview"]
+
+# easily enable all `Stream` impls
+streams = [
+    "delay-queue",
+    "interval",
+    "timeout-stream",
+    "throttle",
+]
+
 [dependencies]
-futures = "0.1.19"
 tokio-executor = { version = "0.2.0", path = "../tokio-executor" }
+tokio-sync = { version = "0.2.0", path = "../tokio-sync" }
 crossbeam-utils = "0.6.0"
 
 # Backs `DelayQueue`
 slab = "0.4.1"
+
+# optionals
+futures-core-preview = { version = "0.3.0-alpha.16", optional = true }
 
 [dev-dependencies]
 rand = "0.6"

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -31,27 +31,36 @@
 //! [`Interval`]: struct.Interval.html
 //! [`Timer`]: timer/struct.Timer.html
 
+macro_rules! ready {
+    ($e:expr) => (
+        match $e {
+            ::std::task::Poll::Ready(v) => v,
+            ::std::task::Poll::Pending => return ::std::task::Poll::Pending,
+        }
+    )
+}
+
 pub mod clock;
+#[cfg(feature = "delay-queue")]
 pub mod delay_queue;
+#[cfg(feature = "throttle")]
 pub mod throttle;
 pub mod timeout;
 pub mod timer;
 
 mod atomic;
-mod deadline;
 mod delay;
 mod error;
+#[cfg(feature = "interval")]
 mod interval;
 mod wheel;
 
-#[deprecated(since = "0.2.6", note = "use Timeout instead")]
-#[doc(hidden)]
-#[allow(deprecated)]
-pub use deadline::{Deadline, DeadlineError};
 pub use delay::Delay;
+#[cfg(feature = "delay-queue")]
 #[doc(inline)]
 pub use delay_queue::DelayQueue;
 pub use error::Error;
+#[cfg(feature = "interval")]
 pub use interval::Interval;
 #[doc(inline)]
 pub use timeout::Timeout;

--- a/tokio-timer/src/timer/handle.rs
+++ b/tokio-timer/src/timer/handle.rs
@@ -1,9 +1,9 @@
 use crate::timer::Inner;
-use crate::{Deadline, Delay, Error, Interval, Timeout};
+use crate::{Delay, Error, /*Interval,*/ Timeout};
 use std::cell::RefCell;
 use std::fmt;
 use std::sync::{Arc, Weak};
-use std::time::{Duration, Instant};
+use std::time::{/*Duration,*/ Instant};
 use tokio_executor::Enter;
 
 /// Handle to timer instance.
@@ -137,22 +137,18 @@ impl Handle {
         }
     }
 
-    #[doc(hidden)]
-    #[deprecated(since = "0.2.11", note = "use timeout instead")]
-    pub fn deadline<T>(&self, future: T, deadline: Instant) -> Deadline<T> {
-        Deadline::new_with_delay(future, self.delay(deadline))
-    }
-
     /// Create a `Timeout` driven by this handle's associated `Timer`.
     pub fn timeout<T>(&self, value: T, deadline: Instant) -> Timeout<T> {
         Timeout::new_with_delay(value, self.delay(deadline))
     }
 
+    /*
     /// Create a new `Interval` that starts at `at` and yields every `duration`
     /// interval after that.
     pub fn interval(&self, at: Instant, duration: Duration) -> Interval {
         Interval::new_with_delay(self.delay(at), duration)
     }
+    */
 
     fn as_priv(&self) -> Option<&HandlePriv> {
         self.inner.as_ref()


### PR DESCRIPTION
- Removes `Error` from `Delay` and `Interval` (see #1133 for rationale).
- Changes `Timeout` to return `Result<T::Output, Elapsed>`.
- Puts all the types that need `Stream` behind cargo features.
- Has some ugly unsafe to do pin projection 😭 

Doesn't include tests or docs, contributions welcome!