### PR TITLE
Use ThreadPool's impl of spawn

### DIFF
--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -234,7 +234,7 @@ impl Runtime {
     pub fn spawn<F>(&mut self, future: F) -> &mut Self
     where F: Future<Item = (), Error = ()> + Send + 'static,
     {
-        self.inner_mut().pool.sender().spawn(future).unwrap();
+        self.inner_mut().pool.spawn(future);
         self
     }
 


### PR DESCRIPTION
Since spawn is implemented at struct ThreadPool, there is no need to call into its Sender.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
