### PR TITLE
Remove `mio` dependency from `tokio`

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -41,7 +41,7 @@ default = [
 #codec = ["io", "tokio-codec"]
 #fs = ["tokio-fs"]
 io = ["bytes", "tokio-io"]
-reactor = ["io", "mio", "tokio-reactor"]
+reactor = ["io", "tokio-reactor"]
 rt-full = [
   "num_cpus",
   "reactor",
@@ -77,9 +77,6 @@ tokio-tcp = { version = "0.2.0", optional = true, path = "../tokio-tcp" }
 #tokio-udp = { version = "0.2.0", optional = true, path = "../tokio-udp" }
 #tokio-timer = { version = "0.3.0", optional = true, path = "../tokio-timer" }
 #tokio-trace-core = { version = "0.2", optional = true }
-
-# Needed until `reactor` is removed from `tokio`.
-mio = { version = "0.6.14", optional = true }
 
 # Needed for async/await preview support
 #tokio-futures = { version = "0.2.0", optional = true, path = "../tokio-futures" }


### PR DESCRIPTION
The dependency was not removed from `Cargo.toml` when the deprecated
code was removed. `tokio` no longer depends directly on `mio`. Instead,
sub crates depend on `mio` and `tokio` re-exports relevant types from
these sub crates.