### PR TITLE
trace: Remove the `AsId` trait

### DIFF
--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -241,12 +241,12 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     pub fn child_of(
-        parent: impl for<'a> Into<Option<&'a Id>>,
+        parent: impl Into<Option<Id>>,
         meta: &'static Metadata<'static>,
         values: &field::ValueSet,
     ) -> Span {
         let new_span = match parent.into() {
-            Some(parent) => Attributes::child_of(parent.clone(), meta, values),
+            Some(parent) => Attributes::child_of(parent, meta, values),
             None => Attributes::new_root(meta, values),
         };
         Self::make(meta, new_span)
@@ -561,9 +561,15 @@ impl<'a> Into<Option<&'a Id>> for &'a Span {
     }
 }
 
-impl<'a> Into<Option<&'a Id>> for Span {
-    fn into(self) -> Option<&'a Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
+impl<'a> Into<Option<Id>> for &'a Span {
+    fn into(self) -> Option<Id> {
+        self.inner.as_ref().map(Inner::id)
+    }
+}
+
+impl Into<Option<Id>> for Span {
+    fn into(self) -> Option<Id> {
+        self.inner.as_ref().map(Inner::id)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -241,7 +241,7 @@ impl Span {
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
     pub fn child_of(
-        parent: impl Into<Option<&'a Id>>,
+        parent: impl for<'a> Into<Option<&'a Id>>,
         meta: &'static Metadata<'static>,
         values: &field::ValueSet,
     ) -> Span {
@@ -557,13 +557,13 @@ impl fmt::Debug for Span {
 
 impl<'a> Into<Option<&'a Id>> for &'a Span {
     fn into(self) -> Option<&'a Id> {
-        self.inner.as_ref().map(|inner| inner.id)
+        self.inner.as_ref().map(|inner| &inner.id)
     }
 }
 
 impl<'a> Into<Option<&'a Id>> for Span {
     fn into(self) -> Option<&'a Id> {
-        self.inner.as_ref().map(|inner| inner.id)
+        self.inner.as_ref().map(|inner| &inner.id)
     }
 }
 

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -467,12 +467,9 @@ impl Span {
     ///
     /// If this span is disabled, or the resulting follows-from relationship
     /// would be invalid, this function will do nothing.
-    pub fn follows_from<I>(&self, from: I) -> &Self
-    where
-        I: AsId,
-    {
+    pub fn follows_from<I>(&self, from: impl for<'a> Into<Option<&'a Id>>) -> &Self {
         if let Some(ref inner) = self.inner {
-            if let Some(from) = from.as_id() {
+            if let Some(from) = from.into() {
                 inner.follows_from(from);
             }
         }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -240,15 +240,12 @@ impl Span {
     /// [metadata]: ../metadata
     /// [field values]: ../field/struct.ValueSet.html
     /// [`follows_from`]: ../struct.Span.html#method.follows_from
-    pub fn child_of<I>(
-        parent: I,
+    pub fn child_of(
+        parent: impl Into<Option<&'a Id>>,
         meta: &'static Metadata<'static>,
         values: &field::ValueSet,
-    ) -> Span
-    where
-        I: AsId,
-    {
-        let new_span = match parent.as_id() {
+    ) -> Span {
+        let new_span = match parent.into() {
             Some(parent) => Attributes::child_of(parent.clone(), meta, values),
             None => Attributes::new_root(meta, values),
         };
@@ -467,7 +464,7 @@ impl Span {
     ///
     /// If this span is disabled, or the resulting follows-from relationship
     /// would be invalid, this function will do nothing.
-    pub fn follows_from<I>(&self, from: impl for<'a> Into<Option<&'a Id>>) -> &Self {
+    pub fn follows_from(&self, from: impl for<'a> Into<Option<&'a Id>>) -> &Self {
         if let Some(ref inner) = self.inner {
             if let Some(from) = from.into() {
                 inner.follows_from(from);
@@ -555,6 +552,18 @@ impl fmt::Debug for Span {
         }
 
         span.finish()
+    }
+}
+
+impl<'a> Into<Option<&'a Id>> for &'a Span {
+    fn into(self) -> Option<&'a Id> {
+        self.inner.as_ref().map(|inner| inner.id)
+    }
+}
+
+impl<'a> Into<Option<&'a Id>> for Span {
+    fn into(self) -> Option<&'a Id> {
+        self.inner.as_ref().map(|inner| inner.id)
     }
 }
 
@@ -661,56 +670,6 @@ impl<'a> fmt::Display for FmtAttrs<'a> {
             res = write!(f, "{}={:?} ", k, v);
         });
         res
-    }
-}
-
-// ===== impl AsId =====
-
-impl ::sealed::Sealed for Span {}
-
-impl AsId for Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Span {}
-
-impl<'a> AsId for &'a Span {
-    fn as_id(&self) -> Option<&Id> {
-        self.inner.as_ref().map(|inner| &inner.id)
-    }
-}
-
-impl ::sealed::Sealed for Id {}
-
-impl AsId for Id {
-    fn as_id(&self) -> Option<&Id> {
-        Some(self)
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Id {}
-
-impl<'a> AsId for &'a Id {
-    fn as_id(&self) -> Option<&Id> {
-        Some(self)
-    }
-}
-
-impl ::sealed::Sealed for Option<Id> {}
-
-impl AsId for Option<Id> {
-    fn as_id(&self) -> Option<&Id> {
-        self.as_ref()
-    }
-}
-
-impl<'a> ::sealed::Sealed for &'a Option<Id> {}
-
-impl<'a> AsId for &'a Option<Id> {
-    fn as_id(&self) -> Option<&Id> {
-        self.as_ref()
     }
 }
 

--- a/tokio-trace/tokio-trace-core/src/span.rs
+++ b/tokio-trace/tokio-trace-core/src/span.rs
@@ -60,6 +60,12 @@ impl Id {
     }
 }
 
+impl<'a> Into<Option<Id>> for &'a Id {
+    fn into(self) -> Option<Id> {
+        Some(self.clone())
+    }
+}
+
 // ===== impl Attributes =====
 
 impl<'a> Attributes<'a> {


### PR DESCRIPTION
## Motivation

While we're making breaking changes to `tokio-trace`, it would be good
to get rid of the `AsId` trait. The goal of span functions that are
generic over `Span`/`Id` can be achieved without the unnecessary
complexity of defining a new trait. This would also make the API added
to `tokio_trace_core::Event` in #1109 more consistent with the
`tokio-trace::Span` API.

This branch removes `AsId` from `tokio-trace` and replaces its uses with
`impl Into<Option<&'a Id>>`. Implementations of `Into<Option<&'a Id>>`
have been added for `tokio_trace::Span`.

## Solution

This is _technically_ a breaking API change, as it changes function
signatures. However, the existing macro syntax still works as-is, and
the tests which pass `&Id`, `&Span`, and `&Option<Id>` to the span
macros all still compile after this change.

Closes #1143

Signed-off-by: Eliza Weisman <eliza@buoyant.io>