### PR TITLE
Fix link to guide in runtime root docs

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -98,7 +98,7 @@
 //! ```
 //!
 //! [reactor]: ../reactor/struct.Reactor.html
-//! [executor]: https://tokio.rs/docs/getting-started/runtime-model/#executors
+//! [executor]: https://tokio.rs/docs/going-deeper/runtime-model/#executors
 //! [timer]: ../timer/index.html
 //! [`Runtime`]: struct.Runtime.html
 //! [`Reactor`]: ../reactor/struct.Reactor.html


### PR DESCRIPTION
This PR corrects the link to the tokio.rs user guide on Executors.
