### PR TITLE
Add `into_mio` methods for various i/o wrappers

### DIFF
--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -2,6 +2,7 @@
 use super::incoming::Incoming;
 use super::TcpStream;
 use mio;
+use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
@@ -310,6 +311,18 @@ impl TcpListener {
     /// ```
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.io.get_ref().set_ttl(ttl)
+    }
+}
+
+impl TryFrom<TcpListener> for mio::net::TcpListener {
+    type Error = io::Error;
+
+    /// Consumes value, returning the mio I/O object.
+    ///
+    /// See [`tokio_reactor::PollEvented::into_inner`] for more details about
+    /// resource deregistration that happens during the call.
+    fn try_from(value: TcpListener) -> Result<Self, Self::Error> {
+        value.io.into_inner()
     }
 }
 

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -1,6 +1,7 @@
 use bytes::{Buf, BufMut};
 use iovec::IoVec;
 use mio;
+use std::convert::TryFrom;
 use std::fmt;
 use std::future::Future;
 use std::io;
@@ -706,6 +707,18 @@ impl TcpStream {
         // - https://github.com/tokio-rs/tokio/issues/774#issuecomment-451059317
         let msg = "`TcpStream::try_clone()` is deprecated because it doesn't work as intended";
         Err(io::Error::new(io::ErrorKind::Other, msg))
+    }
+}
+
+impl TryFrom<TcpStream> for mio::net::TcpStream {
+    type Error = io::Error;
+
+    /// Consumes value, returning the mio I/O object.
+    ///
+    /// See [`tokio_reactor::PollEvented::into_inner`] for more details about
+    /// resource deregistration that happens during the call.
+    fn try_from(value: TcpStream) -> Result<Self, Self::Error> {
+        value.io.into_inner()
     }
 }
 

--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -1,6 +1,7 @@
 use super::{RecvDgram, SendDgram};
 use futures::{try_ready, Async, Poll};
 use mio;
+use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -415,6 +416,18 @@ impl UdpSocket {
     /// [`join_multicast_v6`]: #method.join_multicast_v6
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v6(multiaddr, interface)
+    }
+}
+
+impl TryFrom<UdpSocket> for mio::net::UdpSocket {
+    type Error = io::Error;
+
+    /// Consumes value, returning the mio I/O object.
+    ///
+    /// See [`tokio_reactor::PollEvented::into_inner`] for more details about
+    /// resource deregistration that happens during the call.
+    fn try_from(value: UdpSocket) -> Result<Self, Self::Error> {
+        value.io.into_inner()
     }
 }
 

--- a/tokio-uds/src/listener.rs
+++ b/tokio-uds/src/listener.rs
@@ -2,6 +2,7 @@ use crate::{Incoming, UnixStream};
 use futures::{try_ready, Async, Poll};
 use mio::Ready;
 use mio_uds;
+use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -127,6 +128,18 @@ impl UnixListener {
     /// resolves to the sockets the are accepted on this listener.
     pub fn incoming(self) -> Incoming {
         Incoming::new(self)
+    }
+}
+
+impl TryFrom<UnixListener> for mio_uds::UnixListener {
+    type Error = io::Error;
+
+    /// Consumes value, returning the mio I/O object.
+    ///
+    /// See [`tokio_reactor::PollEvented::into_inner`] for more details about
+    /// resource deregistration that happens during the call.
+    fn try_from(value: UnixListener) -> Result<Self, Self::Error> {
+        value.io.into_inner()
     }
 }
 

--- a/tokio-uds/src/stream.rs
+++ b/tokio-uds/src/stream.rs
@@ -5,6 +5,7 @@ use iovec::{self, IoVec};
 use libc;
 use mio::Ready;
 use mio_uds;
+use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
@@ -124,6 +125,18 @@ impl UnixStream {
     /// (see the documentation of `Shutdown`).
     pub fn shutdown(&self, how: Shutdown) -> io::Result<()> {
         self.io.get_ref().shutdown(how)
+    }
+}
+
+impl TryFrom<UnixStream> for mio_uds::UnixStream {
+    type Error = io::Error;
+
+    /// Consumes value, returning the mio I/O object.
+    ///
+    /// See [`tokio_reactor::PollEvented::into_inner`] for more details about
+    /// resource deregistration that happens during the call.
+    fn try_from(value: UnixStream) -> Result<Self, Self::Error> {
+        value.io.into_inner()
     }
 }
 


### PR DESCRIPTION
## Motivation

It is sometime desired to convert `tokio::net::TcpStream` and other i/o stuff into their std counterparts. As #856 mentions, there is currently no easy way to perform that. I'd actually say there is no way at all, since one needs to somehow "deregister" the socket from the executor before converting it to an std socket via e.g. `AsRawFd`/`FromRawFd`/`mem::forget` magic.

## Solution

I understand that mio doesn't provide implementations for `AsRawSocket` and such windows-specific traits, hence it's impossible to have a cross-platform `into_std` method *yet*, but it is possible to enable at least unix users to manually convert the respective i/o primitives into their std counterparts by providing an `into_inner` method for them that returns the `mio`'s wrappers, which, in turn, already do implement `IntoRawFd`.

These method could also be used when tokio-rs/mio#859 is merged to easily implement the desired `into_std` method :)