### PR TITLE
trace: Add `Span::enter_unscoped`

### DIFF
--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -191,7 +191,7 @@ pub(crate) struct Inner {
 /// [`Span::enter`]: ../struct.Span.html#method.enter
 /// [`Span`]: ../struct.Span.html
 #[derive(Debug)]
-#[must_use = "once a span has been entered, it should be exited"]
+#[must_use = "dropping this guard will exit the span"]
 pub struct Entered<'a> {
     span: &'a Span,
 }
@@ -205,7 +205,7 @@ pub struct Entered<'a> {
 ///
 /// [`Span::enter_unscoped`]: ../struct.Span.html#method.enter_unscoped
 #[derive(Debug)]
-#[must_use = "dropping an EnteredUnscoped will exit the span"]
+#[must_use = "dropping this guard will exit the span"]
 pub struct EnteredUnscoped {
     span: Option<Span>,
 }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -387,6 +387,7 @@ impl Span {
     /// # use tokio_trace::Level;
     /// # fn main() {
     /// let entered = span!(Level::INFO, "my_span").enter_unscoped();
+    /// # }
     /// ```
     ///
     /// Returning an entered span guard as part of a struct:
@@ -414,11 +415,11 @@ impl Span {
     ///
     ///     pub fn new_with_span(name: &'static str) -> FooWithSpan {
     ///         let foo = Foo::new(name);
-    ///         let span = span!(Level::DEBUG, "foo", name);
+    ///         let enter = span!(Level::DEBUG, "foo", name).enter_unscoped();
     ///         // The span will remain entered until the `FooWithSpan` is dropped.
     ///         FooWithSpan {
     ///             foo,
-    ///             span,
+    ///             enter,
     ///         }
     ///     }
     /// }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -699,7 +699,16 @@ impl EnteredUnscoped {
         span
     }
 
+    /// Returns a new handle to the entered span.
+    ///
+    /// Dropping the returned handle will *not* exit the span.
+    pub fn clone_span(&self) -> Span {
+        self.span().clone()
+    }
+
     /// Borrows the entered `Span`.
+    // TODO(eliza): Consider making this pub, if we're willing to commit to
+    // `EnteredUnscoped` owning a `Span`?
     fn span(&self) -> &Span {
         self.span
             .as_ref()

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -380,6 +380,50 @@ impl Span {
     /// will call [`Subscriber::exit`]. If the span is disabled, this does
     /// nothing.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// #[macro_use] extern crate tokio_trace;
+    /// # use tokio_trace::Level;
+    /// # fn main() {
+    /// let entered = span!(Level::INFO, "my_span").enter_unscoped();
+    /// ```
+    ///
+    /// Returning an entered span guard as part of a struct:
+    /// ```
+    /// # #[macro_use] extern crate tokio_trace;
+    /// # use tokio_trace::Level;
+    /// # fn main() {
+    /// pub struct Foo {
+    ///     name: &'static str,
+    ///     // ...
+    /// }
+    ///
+    /// pub struct FooWithSpan {
+    ///     enter: tokio_trace::span::EnteredUnscoped,
+    ///     foo: Foo,
+    /// }
+    ///
+    /// impl Foo {
+    ///     pub fn new(name: &'static str) -> Self {
+    ///         Foo {
+    ///             name,
+    ///            // ...
+    ///         }
+    ///     }
+    ///
+    ///     pub fn new_with_span(name: &'static str) -> FooWithSpan {
+    ///         let foo = Foo::new(name);
+    ///         let span = span!(Level::DEBUG, "foo", name);
+    ///         // The span will remain entered until the `FooWithSpan` is dropped.
+    ///         FooWithSpan {
+    ///             foo,
+    ///             span,
+    ///         }
+    ///     }
+    /// }
+    /// # }
+    /// ```
     /// [`Subscriber::enter`]: ../subscriber/trait.Subscriber.html#method.enter
     /// [`Subscriber::exit`]: ../subscriber/trait.Subscriber.html#method.exit
     /// [`Id`]: ../struct.Id.html

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -694,7 +694,10 @@ impl EnteredUnscoped {
     /// Consumes the entered guard and exits the span, returning a handle to the
     /// previously entered `Span` that may then be entered again.
     pub fn exit(mut self) -> Span {
-        let span = self.span.take().expect("span should only be taken once");
+        let span = self
+            .span
+            .take()
+            .expect("span should only have been taken if dropped");
         span.exit_inner();
         span
     }

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -699,7 +699,7 @@ impl EnteredUnscoped {
     }
 
     /// Borrows the entered `Span`.
-    pub fn span(&self) -> &Span {
+    fn span(&self) -> &Span {
         self.span
             .as_ref()
             .expect("span only taken on exit and drop")

--- a/tokio-trace/src/span.rs
+++ b/tokio-trace/src/span.rs
@@ -878,7 +878,6 @@ impl Clone for Inner {
 
 // ===== log format helpers ======
 
-
 struct FmtValues<'a>(&'a Record<'a>);
 
 impl<'a> fmt::Display for FmtValues<'a> {

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -286,7 +286,7 @@ fn enter_unscoped() {
     with_default(subscriber, || {
         let foo = span!(Level::TRACE, "foo").enter_unscoped();
         debug!("entered");
-        foo.exit().enter_unscoped()
+        let _guard = foo.exit().enter_unscoped();
     });
 
     handle.assert_finished();

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -273,6 +273,26 @@ fn enter() {
 }
 
 #[test]
+fn enter_unscoped() {
+    let (subscriber, handle) = subscriber::mock()
+        .enter(span::mock().named("foo"))
+        .event(event::mock())
+        .exit(span::mock().named("foo"))
+        .enter(span::mock().named("foo"))
+        .exit(span::mock().named("foo"))
+        .drop_span(span::mock().named("foo"))
+        .done()
+        .run_with_handle();
+    with_default(subscriber, || {
+        let foo = span!(Level::TRACE, "foo").enter_unscoped();
+        debug!("entered");
+        foo.exit().enter_unscoped()
+    });
+
+    handle.assert_finished();
+}
+
+#[test]
 fn moved_field() {
     let (subscriber, handle) = subscriber::mock()
         .new_span(


### PR DESCRIPTION
## Motivation

The current `tokio-trace` `Span` API has an `enter` method that returns
a guard which exits the span when dropped. However, this enter method
_borrows_ the span (and is generic over the lifetime of that borrow), so
it is generally only good for entering a span for the duration of a
scope. In some cases, users may wish to enter a span for a longer period
of time than a lexical scope, or tie the duration of a span entry to
that of a heap-allocated object.

## Solution

This branch adds a new `Span::enter_unscoped` method to `Span`. Unlike
`Span::enter`, this method moves `self`, and returns a new
`EnteredUnscoped` guard type that does not have a lifetime parameter.
Dropping `EnteredUnscoped` will exit the span, similarly to `Entered`. 

Moving `self` into `enter_unscoped` means that a `Span` may be entered
without bumping its reference counts, although users who wish to enter
with an owned guard and retain the entered `Span` handle can simply use
`span.clone().enter_unscoped()`. In addition, `EnteredUnscoped` exposes
the (non-entering) methods on the inner span, and has an `exit` method
that explicitly exits it and returns the span.

Closes #1161

Signed-off-by: Eliza Weisman <eliza@buoyant.io>