### PR TITLE
trace: Switch benchmarks to criterion

### DIFF
--- a/tokio-trace/Cargo.toml
+++ b/tokio-trace/Cargo.toml
@@ -30,6 +30,7 @@ ansi_term = "0.11"
 humantime = "1.1.1"
 futures = "0.1"
 log = "0.4"
+criterion = { version = "0.2", default_features = false }
 # These are used for the "basic" example from the tokio-trace-prototype repo,
 # which is currently not included as it used the `tokio-trace-log` crate, and
 # that crate is currently unstable.
@@ -51,3 +52,10 @@ release_max_level_info  = []
 release_max_level_debug = []
 release_max_level_trace = []
 
+[[bench]]
+name = "subscriber"
+harness = false
+
+[[bench]]
+name = "no_subscriber"
+harness = false

--- a/tokio-trace/benches/no_subscriber.rs
+++ b/tokio-trace/benches/no_subscriber.rs
@@ -1,46 +1,42 @@
-#![feature(test)]
 #[macro_use]
 extern crate tokio_trace;
 #[macro_use]
 extern crate log;
-extern crate test;
-use test::Bencher;
+#[macro_use]
+extern crate criterion;
+
+use criterion::Criterion;
 use tokio_trace::Level;
 
-#[bench]
-fn bench_span_no_subscriber(b: &mut Bencher) {
-    b.iter(|| {
-        span!(Level::TRACE, "span");
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("span_no_subscriber", |b| {
+        b.iter(|| {
+            span!(Level::TRACE, "span");
+        })
     });
-}
-
-#[bench]
-fn bench_log_no_logger(b: &mut Bencher) {
-    b.iter(|| {
-        log!(log::Level::Info, "log");
+    c.bench_function("bench_log_no_logger", |b| {
+        b.iter(|| {
+            log!(log::Level::Info, "log");
+        });
     });
-}
-
-#[bench]
-fn bench_costly_field_no_subscriber(b: &mut Bencher) {
-    b.iter(|| {
-        span!(
-            Level::TRACE,
-            "span",
-            foo = tokio_trace::field::display(format!("bar {:?}", 2))
-        );
+    c.bench_function("bench_costly_field_no_subscriber", |b| {
+        b.iter(|| {
+            span!(
+                Level::TRACE,
+                "span",
+                foo = tokio_trace::field::display(format!("bar {:?}", 2))
+            );
+        });
     });
-}
-
-#[bench]
-fn bench_no_span_no_subscriber(b: &mut Bencher) {
-    b.iter(|| {});
-}
-
-#[bench]
-fn bench_1_atomic_load(b: &mut Bencher) {
     // This is just included as a baseline.
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    let foo = AtomicUsize::new(1);
-    b.iter(|| foo.load(Ordering::Relaxed));
+    c.bench_function("bench_no_span_no_subscriber", |b| {
+        b.iter(|| {});
+    });
+    c.bench_function("bench_1_atomic_load", |b| {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let foo = AtomicUsize::new(1);
+        b.iter(|| foo.load(Ordering::Relaxed));
+    });
 }
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);


### PR DESCRIPTION
Extracted from #1152

This makes it possible to run benchmarks on stable + gives more statistical reliability.