### PR TITLE
fix #1153: unreachable in block_on_all

### DIFF
--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -259,7 +259,7 @@ impl Runtime {
         let mut entered = enter().expect("nested block_on");
         let (tx, rx) = futures::sync::oneshot::channel();
         self.spawn(future.then(move |r| tx.send(r).map_err(|_| unreachable!())));
-        entered.block_on(rx).unwrap()
+        entered.block_on(rx).expect("blocked on future paniced")
     }
 
     /// Run a future to completion on the Tokio runtime, then wait for all
@@ -286,7 +286,7 @@ impl Runtime {
         let (tx, rx) = futures::sync::oneshot::channel();
         self.spawn(future.then(move |r| tx.send(r).map_err(|_| unreachable!())));
         let block = rx
-            .map_err(|_| unreachable!())
+            .map_err(|_| panic!("blocked on future paniced"))
             .and_then(move |r| {
                 self.shutdown_on_idle()
                     .map(move |()| r)


### PR DESCRIPTION
## Motivation

#1153 

When the provided future in `block_on` or `block_on_all` panics, the sending part of the oneshot channel get's dropped and the `unreachable` macro is triggered.

## Solution

Replace the `unreachable` macro with a regular `panic` with an error message.