### PR TITLE
trace: fix level_span macros not propagating parents

### DIFF
--- a/tokio-trace/src/macros.rs
+++ b/tokio-trace/src/macros.rs
@@ -330,6 +330,7 @@ macro_rules! trace_span {
         span!(
             $crate::Level::TRACE,
             target: __tokio_trace_module_path!(),
+            parent: $parent,
             $name,
             $($field)*
         )
@@ -391,6 +392,7 @@ macro_rules! debug_span {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
+            parent: $parent,
             $name,
             $($field)*
         )
@@ -452,6 +454,7 @@ macro_rules! info_span {
         span!(
             $crate::Level::INFO,
             target: __tokio_trace_module_path!(),
+            parent: $parent,
             $name,
             $($field)*
         )
@@ -513,6 +516,7 @@ macro_rules! warn_span {
         span!(
             $crate::Level::WARN,
             target: __tokio_trace_module_path!(),
+            parent: $parent,
             $name,
             $($field)*
         )
@@ -573,6 +577,7 @@ macro_rules! error_span {
         span!(
             $crate::Level::ERROR,
             target: __tokio_trace_module_path!(),
+            parent: $parent,
             $name,
             $($field)*
         )

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -584,7 +584,6 @@ fn explicit_child() {
     handle.assert_finished();
 }
 
-
 #[test]
 fn explicit_child_at_levels() {
     let (subscriber, handle) = subscriber::mock()

--- a/tokio-trace/tests/span.rs
+++ b/tokio-trace/tests/span.rs
@@ -584,6 +584,31 @@ fn explicit_child() {
     handle.assert_finished();
 }
 
+
+#[test]
+fn explicit_child_at_levels() {
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(span::mock().named("foo"))
+        .new_span(span::mock().named("a").with_explicit_parent(Some("foo")))
+        .new_span(span::mock().named("b").with_explicit_parent(Some("foo")))
+        .new_span(span::mock().named("c").with_explicit_parent(Some("foo")))
+        .new_span(span::mock().named("d").with_explicit_parent(Some("foo")))
+        .new_span(span::mock().named("e").with_explicit_parent(Some("foo")))
+        .done()
+        .run_with_handle();
+
+    with_default(subscriber, || {
+        let foo = span!(Level::TRACE, "foo");
+        trace_span!(parent: foo.id(), "a");
+        debug_span!(parent: foo.id(), "b");
+        info_span!(parent: foo.id(), "c");
+        warn_span!(parent: foo.id(), "d");
+        error_span!(parent: foo.id(), "e");
+    });
+
+    handle.assert_finished();
+}
+
 #[test]
 fn explicit_child_regardless_of_ctx() {
     let (subscriber, handle) = subscriber::mock()

--- a/tokio-trace/tests/support/subscriber.rs
+++ b/tokio-trace/tests/support/subscriber.rs
@@ -220,7 +220,10 @@ where
                     Some(Parent::Explicit(expected_parent)) => {
                         let actual_parent =
                             span.parent().and_then(|id| spans.get(id)).map(|s| s.name);
-                        assert_eq!(Some(expected_parent.as_ref()), actual_parent);
+                        assert_eq!(Some(expected_parent.as_ref()), actual_parent,
+                            "expected {:?} to have explicit parent {:?}",
+                            name, expected_parent,
+                        );
                     }
                     Some(Parent::ContextualRoot) => {
                         assert!(
@@ -243,7 +246,10 @@ where
                         let stack = self.current.lock().unwrap();
                         let actual_parent =
                             stack.last().and_then(|id| spans.get(id)).map(|s| s.name);
-                        assert_eq!(Some(expected_parent.as_ref()), actual_parent);
+                        assert_eq!(Some(expected_parent.as_ref()), actual_parent,
+                            "expected {:?} to have contextual parent {:?}",
+                            name, expected_parent,
+                        );
                     }
                     None => {}
                 }

--- a/tokio-trace/tests/support/subscriber.rs
+++ b/tokio-trace/tests/support/subscriber.rs
@@ -220,9 +220,12 @@ where
                     Some(Parent::Explicit(expected_parent)) => {
                         let actual_parent =
                             span.parent().and_then(|id| spans.get(id)).map(|s| s.name);
-                        assert_eq!(Some(expected_parent.as_ref()), actual_parent,
+                        assert_eq!(
+                            Some(expected_parent.as_ref()),
+                            actual_parent,
                             "expected {:?} to have explicit parent {:?}",
-                            name, expected_parent,
+                            name,
+                            expected_parent,
                         );
                     }
                     Some(Parent::ContextualRoot) => {
@@ -246,9 +249,12 @@ where
                         let stack = self.current.lock().unwrap();
                         let actual_parent =
                             stack.last().and_then(|id| spans.get(id)).map(|s| s.name);
-                        assert_eq!(Some(expected_parent.as_ref()), actual_parent,
+                        assert_eq!(
+                            Some(expected_parent.as_ref()),
+                            actual_parent,
                             "expected {:?} to have contextual parent {:?}",
-                            name, expected_parent,
+                            name,
+                            expected_parent,
                         );
                     }
                     None => {}


### PR DESCRIPTION
## Motivation

Currently, when the `trace_span!`, `debug_span!`, `info_span!`,
`warn_span!`, and `error_span!` macros are invoked with an explicit
parent, a name, and zero or more fields (no target), the macros don't
pass along the explicitly provided parent when expanding to the `span!`
macro. This is likely due to an oversight on my part.

## Solution

This branch fixes these macros by adding the parent into the `span!`
macro expansion. I've also added a test to catch regressions

Shoutout to @jonhoo for catching this one!

Signed-off-by: Eliza Weisman <eliza@buoyant.io>