### PR TITLE
Allow to configure type of runtime in main macro

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,8 +48,8 @@ jobs:
       - tokio-current-thread
       - tokio-executor
       - tokio-io
-      - tokio-macros
       - tokio-sync
+      - tokio-macros
       # - tokio-threadpool
       # - tokio-timer
       # - tokio-test

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio-macros"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.0"
+version = "0.2.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 publish = false
@@ -22,3 +22,6 @@ proc-macro = true
 proc-macro2 = "0.4.27"
 quote = "0.6.11"
 syn = { version = "0.15.27", features = ["full", "extra-traits", "visit-mut"] }
+
+[dev-dependencies]
+tokio = { version = "0.2.0", path = "../tokio", default-features = false, features = ["rt-full"] }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -10,24 +10,38 @@ use proc_macro::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::spanned::Spanned;
 
-/// Define the program entry point
+/// Marks async function to be executed by selected runtime.
 ///
-/// # Examples
+/// ## Options:
 ///
-/// ```
-/// #[tokio::main]
+/// - `single_thread` - Uses `current_thread`.
+/// - `multi_thread` - Uses multi-threaded runtime. Used by default.
+///
+/// ## Usage
+///
+/// ```rust
+///#![feature(async_await)]
+///
+/// #[tokio::main(single_thread)]
 /// async fn main() {
-///     println!("Hello from Tokio!");
+///     println!("Hello world");
 /// }
 /// ```
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
-pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
+    enum RuntimeType {
+        Single,
+        Multi,
+    }
+
     let input = syn::parse_macro_input!(item as syn::ItemFn);
+    let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
     let ret = &input.decl.output;
     let name = &input.ident;
     let body = &input.block;
+    let attrs = &input.attrs;
 
     if input.asyncness.is_none() {
         let tokens = quote_spanned! { input.span() =>
@@ -37,22 +51,50 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
         return TokenStream::from(tokens);
     }
 
-    let result = quote! {
-        fn #name() #ret {
-            let mut rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(async { #body })
+    let mut runtime = RuntimeType::Multi;
+
+    for arg in args {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::Word(ident)) => match ident.to_string().to_lowercase().as_str() {
+                "multi_thread" => runtime = RuntimeType::Multi,
+                "single_thread" => runtime = RuntimeType::Single,
+                name => panic!("Unknown attribute {} is specified", name),
+            },
+            _ => ()
+        }
+    }
+
+    let result = match runtime {
+        RuntimeType::Multi => quote! {
+            #(#attrs)*
+            fn #name() #ret {
+                let mut rt = tokio::runtime::Runtime::new().unwrap();
+                rt.block_on_async(async { #body })
+            }
+        },
+        RuntimeType::Single => quote! {
+            #(#attrs)*
+            fn #name() #ret {
+                let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
+                rt.block_on(async { #body })
+            }
         }
     };
 
     result.into()
 }
 
-/// Define a Tokio aware unit test
+/// Marks async function to be executed by runtime, suitable to test enviornment
+///
+/// Uses `current_thread` runtime.
 ///
 /// # Examples
 ///
 /// ```ignore
-/// #[tokio::test]
+/// ```
+/// #![feature(async_await)]
+///
+/// #[tokio_macros::test]
 /// async fn my_test() {
 ///     assert!(true);
 /// }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -103,7 +103,6 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// # Examples
 ///
 /// ```ignore
-/// ```
 /// #![feature(async_await)]
 ///
 /// #[tokio::test]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -19,10 +19,22 @@ use syn::spanned::Spanned;
 ///
 /// ## Usage
 ///
+/// ### Select runtime
+///
 /// ```rust
 ///#![feature(async_await)]
 ///
 /// #[tokio::main(single_thread)]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+/// ### Using default
+///
+/// ```rust
+///#![feature(async_await)]
+///
+/// #[tokio::main]
 /// async fn main() {
 ///     println!("Hello world");
 /// }
@@ -69,7 +81,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
             #(#attrs)*
             fn #name() #ret {
                 let mut rt = tokio::runtime::Runtime::new().unwrap();
-                rt.block_on_async(async { #body })
+                rt.block_on(async { #body })
             }
         },
         RuntimeType::Single => quote! {
@@ -94,7 +106,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 /// #![feature(async_await)]
 ///
-/// #[tokio_macros::test]
+/// #[tokio::test]
 /// async fn my_test() {
 ///     assert!(true);
 /// }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -36,6 +36,7 @@ default = [
 #  "timer",
 #  "udp",
 #  "uds",
+  "macros",
 ]
 
 #codec = ["io", "tokio-codec"]
@@ -57,6 +58,7 @@ tcp = ["tokio-tcp"]
 #timer = ["tokio-timer"]
 #udp = ["tokio-udp"]
 #uds = ["tokio-uds"]
+macros = ["tokio-macros"]
 
 [dependencies]
 # Only non-optional dependency...
@@ -70,7 +72,7 @@ tokio-current-thread = { version = "0.2.0", optional = true, path = "../tokio-cu
 #tokio-fs = { version = "0.2.0", optional = true, path = "../tokio-fs" }
 tokio-io = { version = "0.2.0", optional = true, path = "../tokio-io" }
 tokio-executor = { version = "0.2.0", optional = true, path = "../tokio-executor" }
-tokio-macros = { version = "0.1.0", optional = true, path = "../tokio-macros" }
+tokio-macros = { version = "0.2.0", optional = true, path = "../tokio-macros" }
 tokio-reactor = { version = "0.2.0", optional = true, path = "../tokio-reactor" }
 tokio-sync = { version = "0.2.0", optional = true, path = "../tokio-sync" }
 #tokio-threadpool = { version = "0.2.0", optional = true, path = "../tokio-threadpool" }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -36,7 +36,6 @@ default = [
 #  "timer",
 #  "udp",
 #  "uds",
-  "macros",
 ]
 
 #codec = ["io", "tokio-codec"]
@@ -58,7 +57,6 @@ tcp = ["tokio-tcp"]
 #timer = ["tokio-timer"]
 #udp = ["tokio-udp"]
 #uds = ["tokio-uds"]
-macros = ["tokio-macros"]
 
 [dependencies]
 # Only non-optional dependency...

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -102,4 +102,5 @@ if_runtime! {
 
     #[cfg(not(test))] // Work around for rust-lang/rust#62127
     pub use tokio_macros::main;
+    pub use tokio_macros::test;
 }


### PR DESCRIPTION
Enables `tokio-macros` and re-exports it to root crate.

Also adds extra macro `runtime` that allows to choose type of runtime.

Also disabled `main` macros in tests because it wouldn't compile otherwise

As async is not stable yet, all examples will have enabled feature, should be removed once async fn is stable

Latest nightly compiler has troubles running tests with `main` as identifier of attribute due to compilation error. Rustc issue https://github.com/rust-lang/rust/issues/62127