### PR TITLE
macros: re-export `main` macro from `tokio`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
   # "tokio-fs",
   "tokio-futures",
   "tokio-io",
-  # "tokio-macros",
+  "tokio-macros",
   "tokio-reactor",
   # "tokio-signal",
   "tokio-sync",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,6 +48,7 @@ jobs:
       - tokio-current-thread
       - tokio-executor
       - tokio-io
+      - tokio-macros
       - tokio-sync
       # - tokio-threadpool
       # - tokio-timer

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -34,7 +34,7 @@ jobs:
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
-    - script: cargo test --lib && cargo test --tests
+    - script: cargo test --lib && cargo test --tests && cargo test --examples
       env:
         LOOM_MAX_DURATION: 10
         CI: 'True'

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -17,9 +17,11 @@ use syn::spanned::Spanned;
 /// ```
 /// #[tokio::main]
 /// async fn main() {
-///     println!("Hello world");
+///     println!("Hello from Tokio!");
 /// }
+/// ```
 #[proc_macro_attribute]
+#[cfg(not(test))]
 pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 
@@ -38,7 +40,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let result = quote! {
         fn #name() #ret {
             let mut rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on_async(async { #body })
+            rt.block_on(async { #body })
         }
     };
 
@@ -49,7 +51,7 @@ pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore
 /// #[tokio::test]
 /// async fn my_test() {
 ///     assert!(true);

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -21,7 +21,7 @@ use syn::spanned::Spanned;
 /// }
 /// ```
 #[proc_macro_attribute]
-#[cfg(not(test))]
+#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -48,6 +48,7 @@ rt-full = [
 #  "timer",
   "tokio-current-thread",
   "tokio-executor",
+  "tokio-macros",
 #  "tokio-threadpool",
 #  "tokio-trace-core",
 ]
@@ -69,7 +70,7 @@ tokio-current-thread = { version = "0.2.0", optional = true, path = "../tokio-cu
 #tokio-fs = { version = "0.2.0", optional = true, path = "../tokio-fs" }
 tokio-io = { version = "0.2.0", optional = true, path = "../tokio-io" }
 tokio-executor = { version = "0.2.0", optional = true, path = "../tokio-executor" }
-#tokio-macros = { version = "0.1.0", optional = true, path = "../tokio-macros" }
+tokio-macros = { version = "0.1.0", optional = true, path = "../tokio-macros" }
 tokio-reactor = { version = "0.2.0", optional = true, path = "../tokio-reactor" }
 tokio-sync = { version = "0.2.0", optional = true, path = "../tokio-sync" }
 #tokio-threadpool = { version = "0.2.0", optional = true, path = "../tokio-threadpool" }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -99,4 +99,6 @@ if_runtime! {
 
     pub use crate::executor::spawn;
     pub use crate::runtime::run;
+
+    pub use tokio_macros::main;
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -100,5 +100,6 @@ if_runtime! {
     pub use crate::executor::spawn;
     pub use crate::runtime::run;
 
+    #[cfg(not(test))] // Work around for rust-lang/rust#62127
     pub use tokio_macros::main;
 }


### PR DESCRIPTION
Includes minor fixes and a very basic example.

Fixes #1183 
Refs: #1185