### PR TITLE
sync: add async APIs to oneshot and mpsc

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -67,12 +67,14 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 
     for arg in args {
         match arg {
-            syn::NestedMeta::Meta(syn::Meta::Word(ident)) => match ident.to_string().to_lowercase().as_str() {
-                "multi_thread" => runtime = RuntimeType::Multi,
-                "single_thread" => runtime = RuntimeType::Single,
-                name => panic!("Unknown attribute {} is specified", name),
-            },
-            _ => ()
+            syn::NestedMeta::Meta(syn::Meta::Word(ident)) => {
+                match ident.to_string().to_lowercase().as_str() {
+                    "multi_thread" => runtime = RuntimeType::Multi,
+                    "single_thread" => runtime = RuntimeType::Single,
+                    name => panic!("Unknown attribute {} is specified", name),
+                }
+            }
+            _ => (),
         }
     }
 
@@ -90,7 +92,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
                 let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
                 rt.block_on(async { #body })
             }
-        }
+        },
     };
 
     result.into()

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -25,14 +25,14 @@ publish = false
 async-traits = ["async-sink", "futures-core-preview"]
 
 [dependencies]
-fnv = "1.0.6"
+async-util = { git = "https://github.com/tokio-rs/async" }
 async-sink = { git = "https://github.com/tokio-rs/async", optional = true }
+fnv = "1.0.6"
 futures-core-preview = { version = "0.3.0-alpha.16", optional = true }
 
 [dev-dependencies]
-async-util = { git = "https://github.com/tokio-rs/async" }
 env_logger = { version = "0.5", default-features = false }
 pin-utils = "0.1.0-alpha.4"
-# tokio = { version = "0.2.0", path = "../tokio" }
+tokio = { version = "*", path = "../tokio" }
 tokio-test = { version = "0.2.0", path = "../tokio-test" }
 loom = { git = "https://github.com/carllerche/loom", branch = "std-future2", features = ["futures"] }

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -7,6 +7,7 @@
 )]
 #![cfg_attr(test, deny(warnings))]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![feature(async_await)]
 
 //! Asynchronous synchronization primitives.
 //!

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -209,8 +209,7 @@ impl<T> Sender<T> {
 
         poll_fn(|cx| self.poll_ready(cx)).await?;
 
-        self.try_send(value)
-            .map_err(|_| SendError(()))
+        self.try_send(value).map_err(|_| SendError(()))
     }
 }
 

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -132,7 +132,14 @@ impl<T> Receiver<T> {
     }
 
     /// TODO: Dox
-    pub fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+    pub async fn recv(&mut self) -> Option<T> {
+        use async_util::future::poll_fn;
+
+        poll_fn(|cx| self.poll_recv(cx)).await
+    }
+
+    /// TODO: Dox
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
     }
 
@@ -150,7 +157,7 @@ impl<T> futures_core::Stream for Receiver<T> {
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        Receiver::poll_next(self.get_mut(), cx)
+        self.get_mut().poll_recv(cx)
     }
 }
 
@@ -188,6 +195,22 @@ impl<T> Sender<T> {
     pub fn try_send(&mut self, message: T) -> Result<(), TrySendError<T>> {
         self.chan.try_send(message)?;
         Ok(())
+    }
+
+    /// Send a value, waiting until there is capacity.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    pub async fn send(&mut self, value: T) -> Result<(), SendError> {
+        use async_util::future::poll_fn;
+
+        poll_fn(|cx| self.poll_ready(cx)).await?;
+
+        self.try_send(value)
+            .map_err(|_| SendError(()))
     }
 }
 

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -88,8 +88,15 @@ impl<T> UnboundedReceiver<T> {
     }
 
     /// TODO: dox
-    pub fn poll_next(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
+    }
+
+    /// TODO: Dox
+    pub async fn recv(&mut self) -> Option<T> {
+        use async_util::future::poll_fn;
+
+        poll_fn(|cx| self.poll_recv(cx)).await
     }
 
     /// Closes the receiving half of a channel, without dropping it.

--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -217,6 +217,25 @@ impl<T> Sender<T> {
         Pending
     }
 
+    /// Wait for the associated [`Receiver`] handle to drop.
+    ///
+    /// # Return
+    ///
+    /// Returns a `Future` which must be awaited on.
+    ///
+    /// [`Receiver`]: struct.Receiver.html
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    pub async fn closed(&mut self) {
+        use async_util::future::poll_fn;
+
+        poll_fn(|cx| self.poll_close(cx)).await
+    }
+
     /// Check if the associated [`Receiver`] handle has been dropped.
     ///
     /// Unlike [`poll_close`], this function does not register a task for

--- a/tokio-sync/tests/fuzz_mpsc.rs
+++ b/tokio-sync/tests/fuzz_mpsc.rs
@@ -1,4 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
+#![feature(async_await)]
 
 #[macro_use]
 extern crate loom;
@@ -32,10 +33,10 @@ fn closing_tx() {
             drop(tx);
         });
 
-        let v = block_on(poll_fn(|cx| rx.poll_next(cx)));
+        let v = block_on(poll_fn(|cx| rx.poll_recv(cx)));
         assert!(v.is_some());
 
-        let v = block_on(poll_fn(|cx| rx.poll_next(cx)));
+        let v = block_on(poll_fn(|cx| rx.poll_recv(cx)));
         assert!(v.is_none());
     });
 }

--- a/tokio-sync/tests/fuzz_oneshot.rs
+++ b/tokio-sync/tests/fuzz_oneshot.rs
@@ -1,4 +1,5 @@
 #![deny(warnings, rust_2018_idioms)]
+#![feature(async_await)]
 
 /// Unwrap a ready value or propagate `Async::Pending`.
 #[macro_export]


### PR DESCRIPTION
Adds:

- oneshot::Sender::close
- mpsc::Receiver::recv
- mpsc::Sender::send

Also renames `poll_next` to `poll_recv`.

Refs: #1210