### PR TITLE
Update tokio-codec to use std-future

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 members = [
   "tokio",
   # "tokio-buf",
-  # "tokio-codec",
+  "tokio-codec",
   "tokio-current-thread",
   "tokio-executor",
   # "tokio-fs",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -45,7 +45,7 @@ jobs:
     rust: $(nightly)
     crates:
       # - tokio-buf
-      # - tokio-codec
+      - tokio-codec
       - tokio-current-thread
       - tokio-executor
       - tokio-io

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -25,3 +25,4 @@ publish = false
 tokio-io = { version = "0.2.0", path = "../tokio-io" }
 bytes = "0.4.7"
 futures = "0.1.18"
+log = "0.4"

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -24,5 +24,5 @@ publish = false
 [dependencies]
 tokio-io = { version = "0.2.0", path = "../tokio-io" }
 bytes = "0.4.7"
-# futures = "0.1.18"
+tokio-futures = { version = "0.2.0", path = "../tokio-futures" }
 log = "0.4"

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -24,5 +24,5 @@ publish = false
 [dependencies]
 tokio-io = { version = "0.2.0", path = "../tokio-io" }
 bytes = "0.4.7"
-futures = "0.1.18"
+# futures = "0.1.18"
 log = "0.4"

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -26,3 +26,8 @@ tokio-io = { version = "0.2.0", path = "../tokio-io" }
 bytes = "0.4.7"
 tokio-futures = { version = "0.2.0", path = "../tokio-futures" }
 log = "0.4"
+
+[dev-dependencies]
+futures-preview = "0.3.0-alpha.16"
+tokio-current-thread = { version = "0.2.0", path = "../tokio-current-thread" }
+tokio-test = { version = "0.2.0", path = "../tokio-test" }

--- a/tokio-codec/src/bytes_codec.rs
+++ b/tokio-codec/src/bytes_codec.rs
@@ -1,7 +1,7 @@
-use bytes::{BufMut, Bytes, BytesMut};
-use std::io;
 use crate::decoder::Decoder;
 use crate::encoder::Encoder;
+use bytes::{BufMut, Bytes, BytesMut};
+use std::io;
 
 /// A simple `Codec` implementation that just ships bytes around.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/tokio-codec/src/bytes_codec.rs
+++ b/tokio-codec/src/bytes_codec.rs
@@ -1,6 +1,7 @@
 use bytes::{BufMut, Bytes, BytesMut};
 use std::io;
-use tokio_io::_tokio_codec::{Decoder, Encoder};
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
 
 /// A simple `Codec` implementation that just ships bytes around.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/tokio-codec/src/decoder.rs
+++ b/tokio-codec/src/decoder.rs
@@ -1,0 +1,117 @@
+use bytes::BytesMut;
+use std::io;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use super::encoder::Encoder;
+
+use super::Framed;
+
+/// Decoding of frames via buffers.
+///
+/// This trait is used when constructing an instance of `Framed` or
+/// `FramedRead`. An implementation of `Decoder` takes a byte stream that has
+/// already been buffered in `src` and decodes the data into a stream of
+/// `Self::Item` frames.
+///
+/// Implementations are able to track state on `self`, which enables
+/// implementing stateful streaming parsers. In many cases, though, this type
+/// will simply be a unit struct (e.g. `struct HttpDecoder`).
+
+// Note: We can't deprecate this trait, because the deprecation carries through to tokio-codec, and
+// there doesn't seem to be a way to un-deprecate the re-export.
+pub trait Decoder {
+    /// The type of decoded frames.
+    type Item;
+
+    /// The type of unrecoverable frame decoding errors.
+    ///
+    /// If an individual message is ill-formed but can be ignored without
+    /// interfering with the processing of future messages, it may be more
+    /// useful to report the failure as an `Item`.
+    ///
+    /// `From<io::Error>` is required in the interest of making `Error` suitable
+    /// for returning directly from a `FramedRead`, and to enable the default
+    /// implementation of `decode_eof` to yield an `io::Error` when the decoder
+    /// fails to consume all available data.
+    ///
+    /// Note that implementors of this trait can simply indicate `type Error =
+    /// io::Error` to use I/O errors as this type.
+    type Error: From<io::Error>;
+
+    /// Attempts to decode a frame from the provided buffer of bytes.
+    ///
+    /// This method is called by `FramedRead` whenever bytes are ready to be
+    /// parsed.  The provided buffer of bytes is what's been read so far, and
+    /// this instance of `Decode` can determine whether an entire frame is in
+    /// the buffer and is ready to be returned.
+    ///
+    /// If an entire frame is available, then this instance will remove those
+    /// bytes from the buffer provided and return them as a decoded
+    /// frame. Note that removing bytes from the provided buffer doesn't always
+    /// necessarily copy the bytes, so this should be an efficient operation in
+    /// most circumstances.
+    ///
+    /// If the bytes look valid, but a frame isn't fully available yet, then
+    /// `Ok(None)` is returned. This indicates to the `Framed` instance that
+    /// it needs to read some more bytes before calling this method again.
+    ///
+    /// Note that the bytes provided may be empty. If a previous call to
+    /// `decode` consumed all the bytes in the buffer then `decode` will be
+    /// called again until it returns `Ok(None)`, indicating that more bytes need to
+    /// be read.
+    ///
+    /// Finally, if the bytes in the buffer are malformed then an error is
+    /// returned indicating why. This informs `Framed` that the stream is now
+    /// corrupt and should be terminated.
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error>;
+
+    /// A default method available to be called when there are no more bytes
+    /// available to be read from the underlying I/O.
+    ///
+    /// This method defaults to calling `decode` and returns an error if
+    /// `Ok(None)` is returned while there is unconsumed data in `buf`.
+    /// Typically this doesn't need to be implemented unless the framing
+    /// protocol differs near the end of the stream.
+    ///
+    /// Note that the `buf` argument may be empty. If a previous call to
+    /// `decode_eof` consumed all the bytes in the buffer, `decode_eof` will be
+    /// called again until it returns `None`, indicating that there are no more
+    /// frames to yield. This behavior enables returning finalization frames
+    /// that may not be based on inbound data.
+    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match self.decode(buf)? {
+            Some(frame) => Ok(Some(frame)),
+            None => {
+                if buf.is_empty() {
+                    Ok(None)
+                } else {
+                    Err(io::Error::new(io::ErrorKind::Other, "bytes remaining on stream").into())
+                }
+            }
+        }
+    }
+
+    /// Provides a `Stream` and `Sink` interface for reading and writing to this
+    /// `Io` object, using `Decode` and `Encode` to read and write the raw data.
+    ///
+    /// Raw I/O objects work with byte sequences, but higher-level code usually
+    /// wants to batch these into meaningful chunks, called "frames". This
+    /// method layers framing on top of an I/O object, by using the `Codec`
+    /// traits to handle encoding and decoding of messages frames. Note that
+    /// the incoming and outgoing frame types may be distinct.
+    ///
+    /// This function returns a *single* object that is both `Stream` and
+    /// `Sink`; grouping this into a single object is often useful for layering
+    /// things like gzip or TLS, which require both read and write access to the
+    /// underlying object.
+    ///
+    /// If you want to work more directly with the streams and sink, consider
+    /// calling `split` on the `Framed` returned by this method, which will
+    /// break them into separate objects, allowing them to interact more easily.
+    fn framed<T: AsyncRead + AsyncWrite + Sized>(self, io: T) -> Framed<T, Self>
+    where
+        Self: Encoder + Sized,
+    {
+        Framed::new(io, self)
+    }
+}

--- a/tokio-codec/src/encoder.rs
+++ b/tokio-codec/src/encoder.rs
@@ -1,0 +1,25 @@
+use bytes::BytesMut;
+use std::io;
+
+/// Trait of helper objects to write out messages as bytes, for use with
+/// `FramedWrite`.
+
+// Note: We can't deprecate this trait, because the deprecation carries through to tokio-codec, and
+// there doesn't seem to be a way to un-deprecate the re-export.
+pub trait Encoder {
+    /// The type of items consumed by the `Encoder`
+    type Item;
+
+    /// The type of encoding errors.
+    ///
+    /// `FramedWrite` requires `Encoder`s errors to implement `From<io::Error>`
+    /// in the interest letting it return `Error`s directly.
+    type Error: From<io::Error>;
+
+    /// Encodes a frame into the buffer provided.
+    ///
+    /// This method will encode `item` into the byte buffer provided by `dst`.
+    /// The `dst` provided is an internal buffer of the `Framed` instance and
+    /// will be written out when possible.
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
+}

--- a/tokio-codec/src/framed.rs
+++ b/tokio-codec/src/framed.rs
@@ -1,0 +1,284 @@
+#![allow(deprecated)]
+
+use std::fmt;
+use std::io::{self, Read, Write};
+
+use crate::framed_read::{framed_read2, framed_read2_with_buffer, FramedRead2};
+use crate::framed_write::{framed_write2, framed_write2_with_buffer, FramedWrite2};
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use bytes::BytesMut;
+use futures::{Poll, Sink, StartSend, Stream};
+
+/// A unified `Stream` and `Sink` interface to an underlying I/O object, using
+/// the `Encoder` and `Decoder` traits to encode and decode frames.
+///
+/// You can create a `Framed` instance by using the `AsyncRead::framed` adapter.
+pub struct Framed<T, U> {
+    inner: FramedRead2<FramedWrite2<Fuse<T, U>>>,
+}
+
+pub struct Fuse<T, U>(pub T, pub U);
+
+impl<T, U> Framed<T, U>
+where
+    T: AsyncRead + AsyncWrite,
+    U: Decoder + Encoder,
+{
+    /// Provides a `Stream` and `Sink` interface for reading and writing to this
+    /// `Io` object, using `Decode` and `Encode` to read and write the raw data.
+    ///
+    /// Raw I/O objects work with byte sequences, but higher-level code usually
+    /// wants to batch these into meaningful chunks, called "frames". This
+    /// method layers framing on top of an I/O object, by using the `Codec`
+    /// traits to handle encoding and decoding of messages frames. Note that
+    /// the incoming and outgoing frame types may be distinct.
+    ///
+    /// This function returns a *single* object that is both `Stream` and
+    /// `Sink`; grouping this into a single object is often useful for layering
+    /// things like gzip or TLS, which require both read and write access to the
+    /// underlying object.
+    ///
+    /// If you want to work more directly with the streams and sink, consider
+    /// calling `split` on the `Framed` returned by this method, which will
+    /// break them into separate objects, allowing them to interact more easily.
+    pub fn new(inner: T, codec: U) -> Framed<T, U> {
+        Framed {
+            inner: framed_read2(framed_write2(Fuse(inner, codec))),
+        }
+    }
+}
+
+impl<T, U> Framed<T, U> {
+    /// Provides a `Stream` and `Sink` interface for reading and writing to this
+    /// `Io` object, using `Decode` and `Encode` to read and write the raw data.
+    ///
+    /// Raw I/O objects work with byte sequences, but higher-level code usually
+    /// wants to batch these into meaningful chunks, called "frames". This
+    /// method layers framing on top of an I/O object, by using the `Codec`
+    /// traits to handle encoding and decoding of messages frames. Note that
+    /// the incoming and outgoing frame types may be distinct.
+    ///
+    /// This function returns a *single* object that is both `Stream` and
+    /// `Sink`; grouping this into a single object is often useful for layering
+    /// things like gzip or TLS, which require both read and write access to the
+    /// underlying object.
+    ///
+    /// This objects takes a stream and a readbuffer and a writebuffer. These field
+    /// can be obtained from an existing `Framed` with the `into_parts` method.
+    ///
+    /// If you want to work more directly with the streams and sink, consider
+    /// calling `split` on the `Framed` returned by this method, which will
+    /// break them into separate objects, allowing them to interact more easily.
+    pub fn from_parts(parts: FramedParts<T, U>) -> Framed<T, U> {
+        Framed {
+            inner: framed_read2_with_buffer(
+                framed_write2_with_buffer(Fuse(parts.io, parts.codec), parts.write_buf),
+                parts.read_buf,
+            ),
+        }
+    }
+
+    /// Returns a reference to the underlying I/O stream wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_ref(&self) -> &T {
+        &self.inner.get_ref().get_ref().0
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner.get_mut().get_mut().0
+    }
+
+    /// Returns a reference to the underlying codec wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec(&self) -> &U {
+        &self.inner.get_ref().get_ref().1
+    }
+
+    /// Returns a mutable reference to the underlying codec wrapped by
+    /// `Frame`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec_mut(&mut self) -> &mut U {
+        &mut self.inner.get_mut().get_mut().1
+    }
+
+    /// Consumes the `Frame`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.inner.into_inner().into_inner().0
+    }
+
+    /// Consumes the `Frame`, returning its underlying I/O stream, the buffer
+    /// with unprocessed data, and the codec.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_parts(self) -> FramedParts<T, U> {
+        let (inner, read_buf) = self.inner.into_parts();
+        let (inner, write_buf) = inner.into_parts();
+
+        FramedParts {
+            io: inner.0,
+            codec: inner.1,
+            read_buf: read_buf,
+            write_buf: write_buf,
+            _priv: (),
+        }
+    }
+}
+
+impl<T, U> Stream for Framed<T, U>
+where
+    T: AsyncRead,
+    U: Decoder,
+{
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<T, U> Sink for Framed<T, U>
+where
+    T: AsyncWrite,
+    U: Encoder,
+    U::Error: From<io::Error>,
+{
+    type SinkItem = U::Item;
+    type SinkError = U::Error;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        self.inner.get_mut().start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.get_mut().poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.get_mut().close()
+    }
+}
+
+impl<T, U> fmt::Debug for Framed<T, U>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Framed")
+            .field("io", &self.inner.get_ref().get_ref().0)
+            .field("codec", &self.inner.get_ref().get_ref().1)
+            .finish()
+    }
+}
+
+// ===== impl Fuse =====
+
+impl<T: Read, U> Read for Fuse<T, U> {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        self.0.read(dst)
+    }
+}
+
+impl<T: AsyncRead, U> AsyncRead for Fuse<T, U> {
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.0.prepare_uninitialized_buffer(buf)
+    }
+}
+
+impl<T: Write, U> Write for Fuse<T, U> {
+    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+        self.0.write(src)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.0.flush()
+    }
+}
+
+impl<T: AsyncWrite, U> AsyncWrite for Fuse<T, U> {
+    fn shutdown(&mut self) -> Poll<(), io::Error> {
+        self.0.shutdown()
+    }
+}
+
+impl<T, U: Decoder> Decoder for Fuse<T, U> {
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn decode(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.1.decode(buffer)
+    }
+
+    fn decode_eof(&mut self, buffer: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        self.1.decode_eof(buffer)
+    }
+}
+
+impl<T, U: Encoder> Encoder for Fuse<T, U> {
+    type Item = U::Item;
+    type Error = U::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        self.1.encode(item, dst)
+    }
+}
+
+/// `FramedParts` contains an export of the data of a Framed transport.
+/// It can be used to construct a new `Framed` with a different codec.
+/// It contains all current buffers and the inner transport.
+#[derive(Debug)]
+pub struct FramedParts<T, U> {
+    /// The inner transport used to read bytes to and write bytes to
+    pub io: T,
+
+    /// The codec
+    pub codec: U,
+
+    /// The buffer with read but unprocessed data.
+    pub read_buf: BytesMut,
+
+    /// A buffer with unprocessed data which are not written yet.
+    pub write_buf: BytesMut,
+
+    /// This private field allows us to add additional fields in the future in a
+    /// backwards compatible way.
+    _priv: (),
+}
+
+impl<T, U> FramedParts<T, U> {
+    /// Create a new, default, `FramedParts`
+    pub fn new(io: T, codec: U) -> FramedParts<T, U> {
+        FramedParts {
+            io,
+            codec,
+            read_buf: BytesMut::new(),
+            write_buf: BytesMut::new(),
+            _priv: (),
+        }
+    }
+}

--- a/tokio-codec/src/framed.rs
+++ b/tokio-codec/src/framed.rs
@@ -158,7 +158,7 @@ where
     type Item = Result<U::Item, U::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().inner).poll_next(cx)
+        pin!(self.get_mut().inner).poll_next(cx)
     }
 }
 
@@ -218,7 +218,7 @@ impl<T: AsyncRead + Unpin, U: Unpin> AsyncRead for Fuse<T, U> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<Result<usize, io::Error>> {
-        Pin::new(&mut self.get_mut().0).poll_read(cx, buf)
+        pin!(self.get_mut().0).poll_read(cx, buf)
     }
 }
 
@@ -238,15 +238,15 @@ impl<T: AsyncWrite + Unpin, U: Unpin> AsyncWrite for Fuse<T, U> {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        Pin::new(&mut self.get_mut().0).poll_write(cx, buf)
+        pin!(self.get_mut().0).poll_write(cx, buf)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+        pin!(self.get_mut().0).poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+        pin!(self.get_mut().0).poll_shutdown(cx)
     }
 }
 

--- a/tokio-codec/src/framed_read.rs
+++ b/tokio-codec/src/framed_read.rs
@@ -1,0 +1,217 @@
+#![allow(deprecated)]
+
+use std::fmt;
+
+use super::framed::Fuse;
+use super::Decoder;
+use tokio_io::AsyncRead;
+use log::trace;
+
+use bytes::BytesMut;
+use futures::{Async, Poll, Sink, StartSend, Stream};
+
+/// A `Stream` of messages decoded from an `AsyncRead`.
+pub struct FramedRead<T, D> {
+    inner: FramedRead2<Fuse<T, D>>,
+}
+
+pub struct FramedRead2<T> {
+    inner: T,
+    eof: bool,
+    is_readable: bool,
+    buffer: BytesMut,
+}
+
+const INITIAL_CAPACITY: usize = 8 * 1024;
+
+// ===== impl FramedRead =====
+
+impl<T, D> FramedRead<T, D>
+where
+    T: AsyncRead,
+    D: Decoder,
+{
+    /// Creates a new `FramedRead` with the given `decoder`.
+    pub fn new(inner: T, decoder: D) -> FramedRead<T, D> {
+        FramedRead {
+            inner: framed_read2(Fuse(inner, decoder)),
+        }
+    }
+}
+
+impl<T, D> FramedRead<T, D> {
+    /// Returns a reference to the underlying I/O stream wrapped by
+    /// `FramedRead`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_ref(&self) -> &T {
+        &self.inner.inner.0
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `FramedRead`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner.inner.0
+    }
+
+    /// Consumes the `FramedRead`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.inner.inner.0
+    }
+
+    /// Returns a reference to the underlying decoder.
+    pub fn decoder(&self) -> &D {
+        &self.inner.inner.1
+    }
+
+    /// Returns a mutable reference to the underlying decoder.
+    pub fn decoder_mut(&mut self) -> &mut D {
+        &mut self.inner.inner.1
+    }
+}
+
+impl<T, D> Stream for FramedRead<T, D>
+where
+    T: AsyncRead,
+    D: Decoder,
+{
+    type Item = D::Item;
+    type Error = D::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.poll()
+    }
+}
+
+impl<T, D> Sink for FramedRead<T, D>
+where
+    T: Sink,
+{
+    type SinkItem = T::SinkItem;
+    type SinkError = T::SinkError;
+
+    fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Self::SinkError> {
+        self.inner.inner.0.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.inner.0.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.inner.0.close()
+    }
+}
+
+impl<T, D> fmt::Debug for FramedRead<T, D>
+where
+    T: fmt::Debug,
+    D: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FramedRead")
+            .field("inner", &self.inner.inner.0)
+            .field("decoder", &self.inner.inner.1)
+            .field("eof", &self.inner.eof)
+            .field("is_readable", &self.inner.is_readable)
+            .field("buffer", &self.inner.buffer)
+            .finish()
+    }
+}
+
+// ===== impl FramedRead2 =====
+
+pub fn framed_read2<T>(inner: T) -> FramedRead2<T> {
+    FramedRead2 {
+        inner: inner,
+        eof: false,
+        is_readable: false,
+        buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
+    }
+}
+
+pub fn framed_read2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedRead2<T> {
+    if buf.capacity() < INITIAL_CAPACITY {
+        let bytes_to_reserve = INITIAL_CAPACITY - buf.capacity();
+        buf.reserve(bytes_to_reserve);
+    }
+    FramedRead2 {
+        inner: inner,
+        eof: false,
+        is_readable: buf.len() > 0,
+        buffer: buf,
+    }
+}
+
+impl<T> FramedRead2<T> {
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn into_parts(self) -> (T, BytesMut) {
+        (self.inner, self.buffer)
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> Stream for FramedRead2<T>
+where
+    T: AsyncRead + Decoder,
+{
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        loop {
+            // Repeatedly call `decode` or `decode_eof` as long as it is
+            // "readable". Readable is defined as not having returned `None`. If
+            // the upstream has returned EOF, and the decoder is no longer
+            // readable, it can be assumed that the decoder will never become
+            // readable again, at which point the stream is terminated.
+            if self.is_readable {
+                if self.eof {
+                    let frame = self.inner.decode_eof(&mut self.buffer)?;
+                    return Ok(Async::Ready(frame));
+                }
+
+                trace!("attempting to decode a frame");
+
+                if let Some(frame) = self.inner.decode(&mut self.buffer)? {
+                    trace!("frame decoded from buffer");
+                    return Ok(Async::Ready(Some(frame)));
+                }
+
+                self.is_readable = false;
+            }
+
+            assert!(!self.eof);
+
+            // Otherwise, try to read more data and try again. Make sure we've
+            // got room for at least one byte to read to ensure that we don't
+            // get a spurious 0 that looks like EOF
+            self.buffer.reserve(1);
+            if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
+                self.eof = true;
+            }
+
+            self.is_readable = true;
+        }
+    }
+}

--- a/tokio-codec/src/framed_read.rs
+++ b/tokio-codec/src/framed_read.rs
@@ -1,15 +1,15 @@
-#![allow(deprecated)]
-
 use std::fmt;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
 
 use super::framed::Fuse;
 use super::Decoder;
+use tokio_futures::Stream;
 use tokio_io::AsyncRead;
-use log::trace;
 
 use bytes::BytesMut;
-use std::task::Poll;
-// use futures::{Async, Poll, Sink, StartSend, Stream};
+use log::trace;
 
 /// A `Stream` of messages decoded from an `AsyncRead`.
 pub struct FramedRead<T, D> {
@@ -81,20 +81,19 @@ impl<T, D> FramedRead<T, D> {
     }
 }
 
-// TODO update stream and sink impls
-// impl<T, D> Stream for FramedRead<T, D>
-// where
-//     T: AsyncRead,
-//     D: Decoder,
-// {
-//     type Item = D::Item;
-//     type Error = D::Error;
+impl<T, D> Stream for FramedRead<T, D>
+where
+    T: AsyncRead,
+    D: Decoder,
+{
+    type Item = Result<D::Item, D::Error>;
 
-//     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-//         self.inner.poll()
-//     }
-// }
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.map_unchecked_mut(|fr| &mut fr.inner).poll_next(cx)
+    }
+}
 
+// TODO update sink impls
 // impl<T, D> Sink for FramedRead<T, D>
 // where
 //     T: Sink,
@@ -173,48 +172,48 @@ impl<T> FramedRead2<T> {
     }
 }
 
-// TODO update Stream impl
-// impl<T> Stream for FramedRead2<T>
-// where
-//     T: AsyncRead + Decoder,
-// {
-//     type Item = T::Item;
-//     type Error = T::Error;
+impl<T> Stream for FramedRead2<T>
+where
+    T: AsyncRead + Decoder,
+{
+    type Item = Result<T::Item, T::Error>;
 
-//     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-//         loop {
-//             // Repeatedly call `decode` or `decode_eof` as long as it is
-//             // "readable". Readable is defined as not having returned `None`. If
-//             // the upstream has returned EOF, and the decoder is no longer
-//             // readable, it can be assumed that the decoder will never become
-//             // readable again, at which point the stream is terminated.
-//             if self.is_readable {
-//                 if self.eof {
-//                     let frame = self.inner.decode_eof(&mut self.buffer)?;
-//                     return Ok(Async::Ready(frame));
-//                 }
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // TODO update Stream impl
+        // loop {
+        //     // Repeatedly call `decode` or `decode_eof` as long as it is
+        //     // "readable". Readable is defined as not having returned `None`. If
+        //     // the upstream has returned EOF, and the decoder is no longer
+        //     // readable, it can be assumed that the decoder will never become
+        //     // readable again, at which point the stream is terminated.
+        //     if self.is_readable {
+        //         if self.eof {
+        //             let frame = self.inner.decode_eof(&mut self.buffer)?;
+        //             return Ok(Async::Ready(frame));
+        //         }
 
-//                 trace!("attempting to decode a frame");
+        //         trace!("attempting to decode a frame");
 
-//                 if let Some(frame) = self.inner.decode(&mut self.buffer)? {
-//                     trace!("frame decoded from buffer");
-//                     return Ok(Async::Ready(Some(frame)));
-//                 }
+        //         if let Some(frame) = self.inner.decode(&mut self.buffer)? {
+        //             trace!("frame decoded from buffer");
+        //             return Ok(Async::Ready(Some(frame)));
+        //         }
 
-//                 self.is_readable = false;
-//             }
+        //         self.is_readable = false;
+        //     }
 
-//             assert!(!self.eof);
+        //     assert!(!self.eof);
 
-//             // Otherwise, try to read more data and try again. Make sure we've
-//             // got room for at least one byte to read to ensure that we don't
-//             // get a spurious 0 that looks like EOF
-//             self.buffer.reserve(1);
-//             if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
-//                 self.eof = true;
-//             }
+        //     // Otherwise, try to read more data and try again. Make sure we've
+        //     // got room for at least one byte to read to ensure that we don't
+        //     // get a spurious 0 that looks like EOF
+        //     self.buffer.reserve(1);
+        //     if 0 == try_ready!(self.inner.read_buf(&mut self.buffer)) {
+        //         self.eof = true;
+        //     }
 
-//             self.is_readable = true;
-//         }
-//     }
-// }
+        //     self.is_readable = true;
+        // }
+        unimplemented!()
+    }
+}

--- a/tokio-codec/src/framed_read.rs
+++ b/tokio-codec/src/framed_read.rs
@@ -88,7 +88,7 @@ where
     type Item = Result<D::Item, D::Error>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        Pin::new(&mut self.get_mut().inner).poll_next(cx)
+        pin!(self.get_mut().inner).poll_next(cx)
     }
 }
 
@@ -101,19 +101,19 @@ where
     type Error = T::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut Pin::get_mut(self).inner.inner.0).poll_ready(cx)
+        pin!(Pin::get_mut(self).inner.inner.0).poll_ready(cx)
     }
 
     fn start_send(self: Pin<&mut Self>, item: I) -> Result<(), Self::Error> {
-        Pin::new(&mut Pin::get_mut(self).inner.inner.0).start_send(item)
+        pin!(Pin::get_mut(self).inner.inner.0).start_send(item)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut Pin::get_mut(self).inner.inner.0).poll_flush(cx)
+        pin!(Pin::get_mut(self).inner.inner.0).poll_flush(cx)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Pin::new(&mut Pin::get_mut(self).inner.inner.0).poll_close(cx)
+        pin!(Pin::get_mut(self).inner.inner.0).poll_close(cx)
     }
 }
 
@@ -211,7 +211,7 @@ where
             // got room for at least one byte to read to ensure that we don't
             // get a spurious 0 that looks like EOF
             pinned.buffer.reserve(1);
-            let bytect = match Pin::new(&mut pinned.inner).poll_read_buf(cx, &mut pinned.buffer)? {
+            let bytect = match pin!(pinned.inner).poll_read_buf(cx, &mut pinned.buffer)? {
                 Poll::Ready(ct) => ct,
                 Poll::Pending => return Poll::Pending,
             };

--- a/tokio-codec/src/framed_read.rs
+++ b/tokio-codec/src/framed_read.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
+use std::task::{Context, Poll};
 
 use super::framed::Fuse;
 use super::Decoder;
@@ -117,6 +116,7 @@ where
         Pin::new(&mut Pin::get_mut(self).inner.inner.0).poll_close(cx)
     }
 }
+
 impl<T, D> fmt::Debug for FramedRead<T, D>
 where
     T: fmt::Debug,

--- a/tokio-codec/src/framed_write.rs
+++ b/tokio-codec/src/framed_write.rs
@@ -220,8 +220,7 @@ where
                 .into()));
             }
 
-            // TODO: Add a way to `bytes` to do this w/o returning the drained
-            // data.
+            // TODO: Add a way to `bytes` to do this w/o returning the drained data.
             let _ = pinned.buffer.split_to(n);
         }
 
@@ -268,6 +267,7 @@ impl<T: AsyncRead + Unpin> AsyncRead for FramedWrite2<T> {
         cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<Result<usize, io::Error>> {
+        // TODO use pin! macros
         Pin::new(&mut Pin::get_mut(self).inner).poll_read(cx, buf)
     }
 }

--- a/tokio-codec/src/framed_write.rs
+++ b/tokio-codec/src/framed_write.rs
@@ -1,0 +1,248 @@
+#![allow(deprecated)]
+
+use std::fmt;
+use std::io::{self, Read};
+use log::trace;
+
+use super::framed::Fuse;
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
+use tokio_io::{AsyncRead, AsyncWrite};
+
+use bytes::BytesMut;
+use futures::{try_ready, Async, AsyncSink, Poll, Sink, StartSend, Stream};
+
+/// A `Sink` of frames encoded to an `AsyncWrite`.
+pub struct FramedWrite<T, E> {
+    inner: FramedWrite2<Fuse<T, E>>,
+}
+
+pub struct FramedWrite2<T> {
+    inner: T,
+    buffer: BytesMut,
+}
+
+const INITIAL_CAPACITY: usize = 8 * 1024;
+const BACKPRESSURE_BOUNDARY: usize = INITIAL_CAPACITY;
+
+impl<T, E> FramedWrite<T, E>
+where
+    T: AsyncWrite,
+    E: Encoder,
+{
+    /// Creates a new `FramedWrite` with the given `encoder`.
+    pub fn new(inner: T, encoder: E) -> FramedWrite<T, E> {
+        FramedWrite {
+            inner: framed_write2(Fuse(inner, encoder)),
+        }
+    }
+}
+
+impl<T, E> FramedWrite<T, E> {
+    /// Returns a reference to the underlying I/O stream wrapped by
+    /// `FramedWrite`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_ref(&self) -> &T {
+        &self.inner.inner.0
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `FramedWrite`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner.inner.0
+    }
+
+    /// Consumes the `FramedWrite`, returning its underlying I/O stream.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn into_inner(self) -> T {
+        self.inner.inner.0
+    }
+
+    /// Returns a reference to the underlying decoder.
+    pub fn encoder(&self) -> &E {
+        &self.inner.inner.1
+    }
+
+    /// Returns a mutable reference to the underlying decoder.
+    pub fn encoder_mut(&mut self) -> &mut E {
+        &mut self.inner.inner.1
+    }
+}
+
+impl<T, E> Sink for FramedWrite<T, E>
+where
+    T: AsyncWrite,
+    E: Encoder,
+{
+    type SinkItem = E::Item;
+    type SinkError = E::Error;
+
+    fn start_send(&mut self, item: E::Item) -> StartSend<E::Item, E::Error> {
+        self.inner.start_send(item)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        self.inner.poll_complete()
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        Ok(self.inner.close()?)
+    }
+}
+
+impl<T, D> Stream for FramedWrite<T, D>
+where
+    T: Stream,
+{
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+        self.inner.inner.0.poll()
+    }
+}
+
+impl<T, U> fmt::Debug for FramedWrite<T, U>
+where
+    T: fmt::Debug,
+    U: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("FramedWrite")
+            .field("inner", &self.inner.get_ref().0)
+            .field("encoder", &self.inner.get_ref().1)
+            .field("buffer", &self.inner.buffer)
+            .finish()
+    }
+}
+
+// ===== impl FramedWrite2 =====
+
+pub fn framed_write2<T>(inner: T) -> FramedWrite2<T> {
+    FramedWrite2 {
+        inner: inner,
+        buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
+    }
+}
+
+pub fn framed_write2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedWrite2<T> {
+    if buf.capacity() < INITIAL_CAPACITY {
+        let bytes_to_reserve = INITIAL_CAPACITY - buf.capacity();
+        buf.reserve(bytes_to_reserve);
+    }
+    FramedWrite2 {
+        inner: inner,
+        buffer: buf,
+    }
+}
+
+impl<T> FramedWrite2<T> {
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    pub fn into_parts(self) -> (T, BytesMut) {
+        (self.inner, self.buffer)
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+}
+
+impl<T> Sink for FramedWrite2<T>
+where
+    T: AsyncWrite + Encoder,
+{
+    type SinkItem = T::Item;
+    type SinkError = T::Error;
+
+    fn start_send(&mut self, item: T::Item) -> StartSend<T::Item, T::Error> {
+        // If the buffer is already over 8KiB, then attempt to flush it. If after flushing it's
+        // *still* over 8KiB, then apply backpressure (reject the send).
+        if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
+            self.poll_complete()?;
+
+            if self.buffer.len() >= BACKPRESSURE_BOUNDARY {
+                return Ok(AsyncSink::NotReady(item));
+            }
+        }
+
+        self.inner.encode(item, &mut self.buffer)?;
+
+        Ok(AsyncSink::Ready)
+    }
+
+    fn poll_complete(&mut self) -> Poll<(), Self::SinkError> {
+        trace!("flushing framed transport");
+
+        while !self.buffer.is_empty() {
+            trace!("writing; remaining={}", self.buffer.len());
+
+            let n = try_ready!(self.inner.poll_write(&self.buffer));
+
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to \
+                     write frame to transport",
+                )
+                .into());
+            }
+
+            // TODO: Add a way to `bytes` to do this w/o returning the drained
+            // data.
+            let _ = self.buffer.split_to(n);
+        }
+
+        // Try flushing the underlying IO
+        try_ready!(self.inner.poll_flush());
+
+        trace!("framed transport flushed");
+        return Ok(Async::Ready(()));
+    }
+
+    fn close(&mut self) -> Poll<(), Self::SinkError> {
+        try_ready!(self.poll_complete());
+        Ok(self.inner.shutdown()?)
+    }
+}
+
+impl<T: Decoder> Decoder for FramedWrite2<T> {
+    type Item = T::Item;
+    type Error = T::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
+        self.inner.decode(src)
+    }
+
+    fn decode_eof(&mut self, src: &mut BytesMut) -> Result<Option<T::Item>, T::Error> {
+        self.inner.decode_eof(src)
+    }
+}
+
+impl<T: Read> Read for FramedWrite2<T> {
+    fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(dst)
+    }
+}
+
+impl<T: AsyncRead> AsyncRead for FramedWrite2<T> {
+    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
+        self.inner.prepare_uninitialized_buffer(buf)
+    }
+}

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -24,9 +24,9 @@ mod framed_write;
 mod lines_codec;
 
 pub use crate::bytes_codec::BytesCodec;
-pub use crate::lines_codec::LinesCodec;
 pub use crate::decoder::Decoder;
 pub use crate::encoder::Encoder;
 pub use crate::framed::{Framed, FramedParts};
 pub use crate::framed_read::FramedRead;
 pub use crate::framed_write::FramedWrite;
+pub use crate::lines_codec::LinesCodec;

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -15,6 +15,9 @@
 //! [`Stream`]: #
 //! [transports]: #
 
+#[macro_use]
+mod macros;
+
 mod bytes_codec;
 mod decoder;
 mod encoder;
@@ -30,19 +33,3 @@ pub use crate::framed::{Framed, FramedParts};
 pub use crate::framed_read::FramedRead;
 pub use crate::framed_write::FramedWrite;
 pub use crate::lines_codec::LinesCodec;
-
-/// A macro for extracting the successful type of a `Poll<T, E>`.
-///
-/// This macro bakes propagation of both errors and `Pending` signals by
-/// returning early.
-// TODO this should probably be in tokio-futures
-#[macro_export]
-macro_rules! try_ready {
-    ($e:expr) => {
-        match $e {
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-            std::task::Poll::Ready(Err(e)) => return std::task::Poll::Ready(Err(From::from(e))),
-            std::task::Poll::Ready(Ok(t)) => t,
-        }
-    };
-}

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -30,3 +30,19 @@ pub use crate::framed::{Framed, FramedParts};
 pub use crate::framed_read::FramedRead;
 pub use crate::framed_write::FramedWrite;
 pub use crate::lines_codec::LinesCodec;
+
+/// A macro for extracting the successful type of a `Poll<T, E>`.
+///
+/// This macro bakes propagation of both errors and `Pending` signals by
+/// returning early.
+// TODO this should probably be in tokio-futures
+#[macro_export]
+macro_rules! try_ready {
+    ($e:expr) => {
+        match $e {
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+            std::task::Poll::Ready(Err(e)) => return std::task::Poll::Ready(Err(From::from(e))),
+            std::task::Poll::Ready(Ok(t)) => t,
+        }
+    };
+}

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -16,8 +16,17 @@
 //! [transports]: #
 
 mod bytes_codec;
+mod decoder;
+mod encoder;
+mod framed;
+mod framed_read;
+mod framed_write;
 mod lines_codec;
 
 pub use crate::bytes_codec::BytesCodec;
 pub use crate::lines_codec::LinesCodec;
-pub use tokio_io::_tokio_codec::{Decoder, Encoder, Framed, FramedParts, FramedRead, FramedWrite};
+pub use crate::decoder::Decoder;
+pub use crate::encoder::Encoder;
+pub use crate::framed::{Framed, FramedParts};
+pub use crate::framed_read::FramedRead;
+pub use crate::framed_write::FramedWrite;

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -1,7 +1,7 @@
 use crate::decoder::Decoder;
 use crate::encoder::Encoder;
 use bytes::{BufMut, BytesMut};
-use std::{cmp, io, str, usize};
+use std::{cmp, fmt, io, str, usize};
 
 /// A simple `Codec` implementation that splits up data into lines.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
@@ -118,11 +118,9 @@ fn without_carriage_return(s: &[u8]) -> &[u8] {
 
 impl Decoder for LinesCodec {
     type Item = String;
-    // TODO: in the next breaking change, this should be changed to a custom
-    // error type that indicates the "max length exceeded" condition better.
-    type Error = io::Error;
+    type Error = LinesCodecError;
 
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<String>, LinesCodecError> {
         loop {
             // Determine how far into the buffer we'll search for a newline. If
             // there's no max_length set, we'll read to the end of the buffer.
@@ -150,10 +148,7 @@ impl Decoder for LinesCodec {
                     // newline, return an error and start discarding on the
                     // next call.
                     self.is_discarding = true;
-                    Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        "line length limit exceeded",
-                    ))
+                    Err(LinesCodecError::MaxLineLengthExceeded)
                 } else {
                     // We didn't find a line or reach the length limit, so the next
                     // call will resume searching at the current offset.
@@ -164,7 +159,7 @@ impl Decoder for LinesCodec {
         }
     }
 
-    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<String>, io::Error> {
+    fn decode_eof(&mut self, buf: &mut BytesMut) -> Result<Option<String>, LinesCodecError> {
         Ok(match self.decode(buf)? {
             Some(frame) => Some(frame),
             None => {
@@ -185,12 +180,35 @@ impl Decoder for LinesCodec {
 
 impl Encoder for LinesCodec {
     type Item = String;
-    type Error = io::Error;
+    type Error = LinesCodecError;
 
-    fn encode(&mut self, line: String, buf: &mut BytesMut) -> Result<(), io::Error> {
+    fn encode(&mut self, line: String, buf: &mut BytesMut) -> Result<(), LinesCodecError> {
         buf.reserve(line.len() + 1);
         buf.put(line);
         buf.put_u8(b'\n');
         Ok(())
     }
 }
+
+#[derive(Debug)]
+pub enum LinesCodecError {
+    MaxLineLengthExceeded,
+    Io(io::Error),
+}
+
+impl fmt::Display for LinesCodecError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LinesCodecError::MaxLineLengthExceeded => write!(f, "max line length exceeded"),
+            LinesCodecError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl From<io::Error> for LinesCodecError {
+    fn from(e: io::Error) -> LinesCodecError {
+        LinesCodecError::Io(e)
+    }
+}
+
+impl std::error::Error for LinesCodecError {}

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -1,6 +1,7 @@
 use bytes::{BufMut, BytesMut};
 use std::{cmp, io, str, usize};
-use tokio_io::_tokio_codec::{Decoder, Encoder};
+use crate::decoder::Decoder;
+use crate::encoder::Encoder;
 
 /// A simple `Codec` implementation that splits up data into lines.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/tokio-codec/src/lines_codec.rs
+++ b/tokio-codec/src/lines_codec.rs
@@ -1,7 +1,7 @@
-use bytes::{BufMut, BytesMut};
-use std::{cmp, io, str, usize};
 use crate::decoder::Decoder;
 use crate::encoder::Encoder;
+use bytes::{BufMut, BytesMut};
+use std::{cmp, io, str, usize};
 
 /// A simple `Codec` implementation that splits up data into lines.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/tokio-codec/src/macros.rs
+++ b/tokio-codec/src/macros.rs
@@ -1,0 +1,22 @@
+// TODO this macro should probably be somewhere in tokio-futures
+/// A macro for extracting the successful type of a `Poll<T, E>`.
+///
+/// This macro bakes propagation of both errors and `Pending` signals by
+/// returning early.
+macro_rules! try_ready {
+    ($e:expr) => {
+        match $e {
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+            std::task::Poll::Ready(Err(e)) => return std::task::Poll::Ready(Err(From::from(e))),
+            std::task::Poll::Ready(Ok(t)) => t,
+        }
+    };
+}
+
+/// A macro to reduce some of the boilerplate for projecting from
+/// `Pin<&mut T>` to `Pin<&mut T.field>`
+macro_rules! pin {
+    ($e:expr) => {
+        std::pin::Pin::new(&mut $e)
+    };
+}

--- a/tokio-codec/tests/codecs.rs
+++ b/tokio-codec/tests/codecs.rs
@@ -118,8 +118,8 @@ fn lines_decoder_max_length() {
 
     // Line that's one character too long. This could cause an out of bounds
     // error if we peek at the next characters using slice indexing.
-    // buf.put("aaabbbc");
-    // assert!(codec.decode(buf).is_err());
+    buf.put("aaabbbc");
+    assert!(codec.decode(buf).is_err());
 }
 
 #[test]

--- a/tokio-codec/tests/framed_read.rs
+++ b/tokio-codec/tests/framed_read.rs
@@ -1,18 +1,31 @@
-#![deny(warnings, rust_2018_idioms)]
+// #![deny(warnings, rust_2018_idioms)]
 
-use bytes::{Buf, BytesMut, IntoBuf};
-use futures::Async::{NotReady, Ready};
-use futures::Stream;
 use std::collections::VecDeque;
 use std::io::{self, Read};
+use std::pin::Pin;
+use std::task::Poll::{Pending, Ready};
+use std::task::{Context, Poll};
+
+use bytes::{Buf, BytesMut, IntoBuf};
+use futures::Stream;
+
 use tokio_codec::{Decoder, FramedRead};
 use tokio_io::AsyncRead;
+use tokio_test::assert_ready;
+use tokio_test::task::MockTask;
 
 macro_rules! mock {
     ($($x:expr,)*) => {{
         let mut v = VecDeque::new();
         v.extend(vec![$($x),*]);
         Mock { calls: v }
+    }};
+}
+
+macro_rules! assert_read {
+    ($e:expr, $n:expr) => {{
+        let val = assert_ready!($e);
+        assert_eq!(val.unwrap().unwrap(), $n);
     }};
 }
 
@@ -34,158 +47,162 @@ impl Decoder for U32Decoder {
 
 #[test]
 fn read_multi_frame_in_packet() {
+    let mut task = MockTask::new();
+
     let mock = mock! {
         Ok(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
     };
 
     let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
+    task.enter(|cx| {
+        assert_read!(Pin::new(&mut framed).poll_next(cx), 0);
+        assert_read!(Pin::new(&mut framed).poll_next(cx), 1);
+        assert_read!(Pin::new(&mut framed).poll_next(cx), 2);
+        assert!(assert_ready!(Pin::new(&mut framed).poll_next(cx)).is_none());
+    });
 }
 
-#[test]
-fn read_multi_frame_across_packets() {
-    let mock = mock! {
-        Ok(b"\x00\x00\x00\x00".to_vec()),
-        Ok(b"\x00\x00\x00\x01".to_vec()),
-        Ok(b"\x00\x00\x00\x02".to_vec()),
-    };
+// #[test]
+// fn read_multi_frame_across_packets() {
+//     let mock = mock! {
+//         Ok(b"\x00\x00\x00\x00".to_vec()),
+//         Ok(b"\x00\x00\x00\x01".to_vec()),
+//         Ok(b"\x00\x00\x00\x02".to_vec()),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
+//     assert_eq!(Ready(None), framed.poll().unwrap());
+// }
 
-#[test]
-fn read_not_ready() {
-    let mock = mock! {
-        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-        Ok(b"\x00\x00\x00\x00".to_vec()),
-        Ok(b"\x00\x00\x00\x01".to_vec()),
-    };
+// #[test]
+// fn read_not_ready() {
+//     let mock = mock! {
+//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+//         Ok(b"\x00\x00\x00\x00".to_vec()),
+//         Ok(b"\x00\x00\x00\x01".to_vec()),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(NotReady, framed.poll().unwrap());
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(NotReady, framed.poll().unwrap());
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
+//     assert_eq!(Ready(None), framed.poll().unwrap());
+// }
 
-#[test]
-fn read_partial_then_not_ready() {
-    let mock = mock! {
-        Ok(b"\x00\x00".to_vec()),
-        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-        Ok(b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
-    };
+// #[test]
+// fn read_partial_then_not_ready() {
+//     let mock = mock! {
+//         Ok(b"\x00\x00".to_vec()),
+//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+//         Ok(b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(NotReady, framed.poll().unwrap());
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(NotReady, framed.poll().unwrap());
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
+//     assert_eq!(Ready(None), framed.poll().unwrap());
+// }
 
-#[test]
-fn read_err() {
-    let mock = mock! {
-        Err(io::Error::new(io::ErrorKind::Other, "")),
-    };
+// #[test]
+// fn read_err() {
+//     let mock = mock! {
+//         Err(io::Error::new(io::ErrorKind::Other, "")),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
+// }
 
-#[test]
-fn read_partial_then_err() {
-    let mock = mock! {
-        Ok(b"\x00\x00".to_vec()),
-        Err(io::Error::new(io::ErrorKind::Other, "")),
-    };
+// #[test]
+// fn read_partial_then_err() {
+//     let mock = mock! {
+//         Ok(b"\x00\x00".to_vec()),
+//         Err(io::Error::new(io::ErrorKind::Other, "")),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
+// }
 
-#[test]
-fn read_partial_would_block_then_err() {
-    let mock = mock! {
-        Ok(b"\x00\x00".to_vec()),
-        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-        Err(io::Error::new(io::ErrorKind::Other, "")),
-    };
+// #[test]
+// fn read_partial_would_block_then_err() {
+//     let mock = mock! {
+//         Ok(b"\x00\x00".to_vec()),
+//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+//         Err(io::Error::new(io::ErrorKind::Other, "")),
+//     };
 
-    let mut framed = FramedRead::new(mock, U32Decoder);
-    assert_eq!(NotReady, framed.poll().unwrap());
-    assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-}
+//     let mut framed = FramedRead::new(mock, U32Decoder);
+//     assert_eq!(NotReady, framed.poll().unwrap());
+//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
+// }
 
-#[test]
-fn huge_size() {
-    let data = [0; 32 * 1024];
+// #[test]
+// fn huge_size() {
+//     let data = [0; 32 * 1024];
 
-    let mut framed = FramedRead::new(&data[..], BigDecoder);
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
+//     let mut framed = FramedRead::new(&data[..], BigDecoder);
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert_eq!(Ready(None), framed.poll().unwrap());
 
-    struct BigDecoder;
+//     struct BigDecoder;
 
-    impl Decoder for BigDecoder {
-        type Item = u32;
-        type Error = io::Error;
+//     impl Decoder for BigDecoder {
+//         type Item = u32;
+//         type Error = io::Error;
 
-        fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
-            if buf.len() < 32 * 1024 {
-                return Ok(None);
-            }
-            buf.split_to(32 * 1024);
-            Ok(Some(0))
-        }
-    }
-}
+//         fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
+//             if buf.len() < 32 * 1024 {
+//                 return Ok(None);
+//             }
+//             buf.split_to(32 * 1024);
+//             Ok(Some(0))
+//         }
+//     }
+// }
 
-#[test]
-fn data_remaining_is_error() {
-    let data = [0; 5];
+// #[test]
+// fn data_remaining_is_error() {
+//     let data = [0; 5];
 
-    let mut framed = FramedRead::new(&data[..], U32Decoder);
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert!(framed.poll().is_err());
-}
+//     let mut framed = FramedRead::new(&data[..], U32Decoder);
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert!(framed.poll().is_err());
+// }
 
-#[test]
-fn multi_frames_on_eof() {
-    struct MyDecoder(Vec<u32>);
+// #[test]
+// fn multi_frames_on_eof() {
+//     struct MyDecoder(Vec<u32>);
 
-    impl Decoder for MyDecoder {
-        type Item = u32;
-        type Error = io::Error;
+//     impl Decoder for MyDecoder {
+//         type Item = u32;
+//         type Error = io::Error;
 
-        fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
-            unreachable!();
-        }
+//         fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+//             unreachable!();
+//         }
 
-        fn decode_eof(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
-            if self.0.is_empty() {
-                return Ok(None);
-            }
+//         fn decode_eof(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+//             if self.0.is_empty() {
+//                 return Ok(None);
+//             }
 
-            Ok(Some(self.0.remove(0)))
-        }
-    }
+//             Ok(Some(self.0.remove(0)))
+//         }
+//     }
 
-    let mut framed = FramedRead::new(mock!(), MyDecoder(vec![0, 1, 2, 3]));
-    assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-    assert_eq!(Ready(Some(3)), framed.poll().unwrap());
-    assert_eq!(Ready(None), framed.poll().unwrap());
-}
+//     let mut framed = FramedRead::new(mock!(), MyDecoder(vec![0, 1, 2, 3]));
+//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
+//     assert_eq!(Ready(Some(3)), framed.poll().unwrap());
+//     assert_eq!(Ready(None), framed.poll().unwrap());
+// }
 
 // ===== Mock ======
 
@@ -207,4 +224,12 @@ impl Read for Mock {
     }
 }
 
-impl AsyncRead for Mock {}
+impl AsyncRead for Mock {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Ready(Pin::get_mut(self).read(buf))
+    }
+}

--- a/tokio-codec/tests/framed_read.rs
+++ b/tokio-codec/tests/framed_read.rs
@@ -29,6 +29,12 @@ macro_rules! assert_read {
     }};
 }
 
+macro_rules! pin {
+    ($id:ident) => {
+        Pin::new(&mut $id)
+    };
+}
+
 struct U32Decoder;
 
 impl Decoder for U32Decoder {
@@ -48,161 +54,206 @@ impl Decoder for U32Decoder {
 #[test]
 fn read_multi_frame_in_packet() {
     let mut task = MockTask::new();
-
     let mock = mock! {
         Ok(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
     };
-
     let mut framed = FramedRead::new(mock, U32Decoder);
+
     task.enter(|cx| {
-        assert_read!(Pin::new(&mut framed).poll_next(cx), 0);
-        assert_read!(Pin::new(&mut framed).poll_next(cx), 1);
-        assert_read!(Pin::new(&mut framed).poll_next(cx), 2);
-        assert!(assert_ready!(Pin::new(&mut framed).poll_next(cx)).is_none());
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert_read!(pin!(framed).poll_next(cx), 1);
+        assert_read!(pin!(framed).poll_next(cx), 2);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
     });
 }
 
-// #[test]
-// fn read_multi_frame_across_packets() {
-//     let mock = mock! {
-//         Ok(b"\x00\x00\x00\x00".to_vec()),
-//         Ok(b"\x00\x00\x00\x01".to_vec()),
-//         Ok(b"\x00\x00\x00\x02".to_vec()),
-//     };
+#[test]
+fn read_multi_frame_across_packets() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Ok(b"\x00\x00\x00\x00".to_vec()),
+        Ok(b"\x00\x00\x00\x01".to_vec()),
+        Ok(b"\x00\x00\x00\x02".to_vec()),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-//     assert_eq!(Ready(None), framed.poll().unwrap());
-// }
+    task.enter(|cx| {
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert_read!(pin!(framed).poll_next(cx), 1);
+        assert_read!(pin!(framed).poll_next(cx), 2);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
+    });
+}
 
-// #[test]
-// fn read_not_ready() {
-//     let mock = mock! {
-//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-//         Ok(b"\x00\x00\x00\x00".to_vec()),
-//         Ok(b"\x00\x00\x00\x01".to_vec()),
-//     };
+#[test]
+fn read_not_ready() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+        Ok(b"\x00\x00\x00\x00".to_vec()),
+        Ok(b"\x00\x00\x00\x01".to_vec()),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(NotReady, framed.poll().unwrap());
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-//     assert_eq!(Ready(None), framed.poll().unwrap());
-// }
+    task.enter(|cx| {
+        assert!(pin!(framed).poll_next(cx).is_pending());
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert_read!(pin!(framed).poll_next(cx), 1);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
+    });
+}
 
-// #[test]
-// fn read_partial_then_not_ready() {
-//     let mock = mock! {
-//         Ok(b"\x00\x00".to_vec()),
-//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-//         Ok(b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
-//     };
+#[test]
+fn read_partial_then_not_ready() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Ok(b"\x00\x00".to_vec()),
+        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+        Ok(b"\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(NotReady, framed.poll().unwrap());
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-//     assert_eq!(Ready(None), framed.poll().unwrap());
-// }
+    task.enter(|cx| {
+        assert!(pin!(framed).poll_next(cx).is_pending());
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert_read!(pin!(framed).poll_next(cx), 1);
+        assert_read!(pin!(framed).poll_next(cx), 2);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
+    });
+}
 
-// #[test]
-// fn read_err() {
-//     let mock = mock! {
-//         Err(io::Error::new(io::ErrorKind::Other, "")),
-//     };
+#[test]
+fn read_err() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-// }
+    task.enter(|cx| {
+        assert_eq!(
+            io::ErrorKind::Other,
+            assert_ready!(pin!(framed).poll_next(cx))
+                .unwrap()
+                .unwrap_err()
+                .kind()
+        )
+    });
+}
 
-// #[test]
-// fn read_partial_then_err() {
-//     let mock = mock! {
-//         Ok(b"\x00\x00".to_vec()),
-//         Err(io::Error::new(io::ErrorKind::Other, "")),
-//     };
+#[test]
+fn read_partial_then_err() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Ok(b"\x00\x00".to_vec()),
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-// }
+    task.enter(|cx| {
+        assert_eq!(
+            io::ErrorKind::Other,
+            assert_ready!(pin!(framed).poll_next(cx))
+                .unwrap()
+                .unwrap_err()
+                .kind()
+        )
+    });
+}
 
-// #[test]
-// fn read_partial_would_block_then_err() {
-//     let mock = mock! {
-//         Ok(b"\x00\x00".to_vec()),
-//         Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
-//         Err(io::Error::new(io::ErrorKind::Other, "")),
-//     };
+#[test]
+fn read_partial_would_block_then_err() {
+    let mut task = MockTask::new();
+    let mock = mock! {
+        Ok(b"\x00\x00".to_vec()),
+        Err(io::Error::new(io::ErrorKind::WouldBlock, "")),
+        Err(io::Error::new(io::ErrorKind::Other, "")),
+    };
+    let mut framed = FramedRead::new(mock, U32Decoder);
 
-//     let mut framed = FramedRead::new(mock, U32Decoder);
-//     assert_eq!(NotReady, framed.poll().unwrap());
-//     assert_eq!(io::ErrorKind::Other, framed.poll().unwrap_err().kind());
-// }
+    task.enter(|cx| {
+        assert!(pin!(framed).poll_next(cx).is_pending());
+        assert_eq!(
+            io::ErrorKind::Other,
+            assert_ready!(pin!(framed).poll_next(cx))
+                .unwrap()
+                .unwrap_err()
+                .kind()
+        )
+    });
+}
 
-// #[test]
-// fn huge_size() {
-//     let data = [0; 32 * 1024];
+#[test]
+fn huge_size() {
+    let mut task = MockTask::new();
+    let data = [0; 32 * 1024];
+    let mut framed = FramedRead::new(Slice(&data[..]), BigDecoder);
 
-//     let mut framed = FramedRead::new(&data[..], BigDecoder);
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert_eq!(Ready(None), framed.poll().unwrap());
+    task.enter(|cx| {
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
+    });
 
-//     struct BigDecoder;
+    struct BigDecoder;
 
-//     impl Decoder for BigDecoder {
-//         type Item = u32;
-//         type Error = io::Error;
+    impl Decoder for BigDecoder {
+        type Item = u32;
+        type Error = io::Error;
 
-//         fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
-//             if buf.len() < 32 * 1024 {
-//                 return Ok(None);
-//             }
-//             buf.split_to(32 * 1024);
-//             Ok(Some(0))
-//         }
-//     }
-// }
+        fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            if buf.len() < 32 * 1024 {
+                return Ok(None);
+            }
+            buf.split_to(32 * 1024);
+            Ok(Some(0))
+        }
+    }
+}
 
-// #[test]
-// fn data_remaining_is_error() {
-//     let data = [0; 5];
+#[test]
+fn data_remaining_is_error() {
+    let mut task = MockTask::new();
+    let slice = Slice(&[0; 5]);
+    let mut framed = FramedRead::new(slice, U32Decoder);
 
-//     let mut framed = FramedRead::new(&data[..], U32Decoder);
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert!(framed.poll().is_err());
-// }
+    task.enter(|cx| {
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).unwrap().is_err());
+    });
+}
 
-// #[test]
-// fn multi_frames_on_eof() {
-//     struct MyDecoder(Vec<u32>);
+#[test]
+fn multi_frames_on_eof() {
+    let mut task = MockTask::new();
+    struct MyDecoder(Vec<u32>);
 
-//     impl Decoder for MyDecoder {
-//         type Item = u32;
-//         type Error = io::Error;
+    impl Decoder for MyDecoder {
+        type Item = u32;
+        type Error = io::Error;
 
-//         fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
-//             unreachable!();
-//         }
+        fn decode(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            unreachable!();
+        }
 
-//         fn decode_eof(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
-//             if self.0.is_empty() {
-//                 return Ok(None);
-//             }
+        fn decode_eof(&mut self, _buf: &mut BytesMut) -> io::Result<Option<u32>> {
+            if self.0.is_empty() {
+                return Ok(None);
+            }
 
-//             Ok(Some(self.0.remove(0)))
-//         }
-//     }
+            Ok(Some(self.0.remove(0)))
+        }
+    }
 
-//     let mut framed = FramedRead::new(mock!(), MyDecoder(vec![0, 1, 2, 3]));
-//     assert_eq!(Ready(Some(0)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(1)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(2)), framed.poll().unwrap());
-//     assert_eq!(Ready(Some(3)), framed.poll().unwrap());
-//     assert_eq!(Ready(None), framed.poll().unwrap());
-// }
+    let mut framed = FramedRead::new(mock!(), MyDecoder(vec![0, 1, 2, 3]));
+
+    task.enter(|cx| {
+        assert_read!(pin!(framed).poll_next(cx), 0);
+        assert_read!(pin!(framed).poll_next(cx), 1);
+        assert_read!(pin!(framed).poll_next(cx), 2);
+        assert_read!(pin!(framed).poll_next(cx), 3);
+        assert!(assert_ready!(pin!(framed).poll_next(cx)).is_none());
+    });
+}
 
 // ===== Mock ======
 
@@ -230,6 +281,22 @@ impl AsyncRead for Mock {
         _cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
-        Ready(Pin::get_mut(self).read(buf))
+        match Pin::get_mut(self).read(buf) {
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => Pending,
+            other => Ready(other),
+        }
+    }
+}
+
+// TODO this newtype is necessary because `&[u8]` does not implement `AsyncRead`
+struct Slice<'a>(&'a [u8]);
+
+impl<'a> AsyncRead for Slice<'a> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Ready(Pin::get_mut(self).0.read(buf))
     }
 }

--- a/tokio-codec/tests/framed_read.rs
+++ b/tokio-codec/tests/framed_read.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings, rust_2018_idioms)]
+#![deny(warnings, rust_2018_idioms)]
 
 use std::collections::VecDeque;
 use std::io::{self, Read};

--- a/tokio-codec/tests/framed_read.rs
+++ b/tokio-codec/tests/framed_read.rs
@@ -288,7 +288,7 @@ impl AsyncRead for Mock {
     }
 }
 
-// TODO this newtype is necessary because `&[u8]` does not implement `AsyncRead`
+// TODO this newtype is necessary because `&[u8]` does not currently implement `AsyncRead`
 struct Slice<'a>(&'a [u8]);
 
 impl<'a> AsyncRead for Slice<'a> {

--- a/tokio-codec/tests/framed_write.rs
+++ b/tokio-codec/tests/framed_write.rs
@@ -1,129 +1,129 @@
 #![deny(warnings, rust_2018_idioms)]
 
-use bytes::{BufMut, BytesMut};
-use futures::{Poll, Sink};
-use std::collections::VecDeque;
-use std::io::{self, Write};
-use tokio_codec::{Encoder, FramedWrite};
-use tokio_io::AsyncWrite;
+// use bytes::{BufMut, BytesMut};
+// use futures::{Poll, Sink};
+// use std::collections::VecDeque;
+// use std::io::{self, Write};
+// use tokio_codec::{Encoder, FramedWrite};
+// use tokio_io::AsyncWrite;
 
-macro_rules! mock {
-    ($($x:expr,)*) => {{
-        let mut v = VecDeque::new();
-        v.extend(vec![$($x),*]);
-        Mock { calls: v }
-    }};
-}
+// macro_rules! mock {
+//     ($($x:expr,)*) => {{
+//         let mut v = VecDeque::new();
+//         v.extend(vec![$($x),*]);
+//         Mock { calls: v }
+//     }};
+// }
 
-struct U32Encoder;
+// struct U32Encoder;
 
-impl Encoder for U32Encoder {
-    type Item = u32;
-    type Error = io::Error;
+// impl Encoder for U32Encoder {
+//     type Item = u32;
+//     type Error = io::Error;
 
-    fn encode(&mut self, item: u32, dst: &mut BytesMut) -> io::Result<()> {
-        // Reserve space
-        dst.reserve(4);
-        dst.put_u32_be(item);
-        Ok(())
-    }
-}
+//     fn encode(&mut self, item: u32, dst: &mut BytesMut) -> io::Result<()> {
+//         // Reserve space
+//         dst.reserve(4);
+//         dst.put_u32_be(item);
+//         Ok(())
+//     }
+// }
 
-#[test]
-fn write_multi_frame_in_packet() {
-    let mock = mock! {
-        Ok(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
-    };
+// #[test]
+// fn write_multi_frame_in_packet() {
+//     let mock = mock! {
+//         Ok(b"\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02".to_vec()),
+//     };
 
-    let mut framed = FramedWrite::new(mock, U32Encoder);
-    assert!(framed.start_send(0).unwrap().is_ready());
-    assert!(framed.start_send(1).unwrap().is_ready());
-    assert!(framed.start_send(2).unwrap().is_ready());
+//     let mut framed = FramedWrite::new(mock, U32Encoder);
+//     assert!(framed.start_send(0).unwrap().is_ready());
+//     assert!(framed.start_send(1).unwrap().is_ready());
+//     assert!(framed.start_send(2).unwrap().is_ready());
 
-    // Nothing written yet
-    assert_eq!(1, framed.get_ref().calls.len());
+//     // Nothing written yet
+//     assert_eq!(1, framed.get_ref().calls.len());
 
-    // Flush the writes
-    assert!(framed.poll_complete().unwrap().is_ready());
+//     // Flush the writes
+//     assert!(framed.poll_complete().unwrap().is_ready());
 
-    assert_eq!(0, framed.get_ref().calls.len());
-}
+//     assert_eq!(0, framed.get_ref().calls.len());
+// }
 
-#[test]
-fn write_hits_backpressure() {
-    const ITER: usize = 2 * 1024;
+// #[test]
+// fn write_hits_backpressure() {
+//     const ITER: usize = 2 * 1024;
 
-    let mut mock = mock! {
-        // Block the `ITER`th write
-        Err(io::Error::new(io::ErrorKind::WouldBlock, "not ready")),
-        Ok(b"".to_vec()),
-    };
+//     let mut mock = mock! {
+//         // Block the `ITER`th write
+//         Err(io::Error::new(io::ErrorKind::WouldBlock, "not ready")),
+//         Ok(b"".to_vec()),
+//     };
 
-    for i in 0..(ITER + 1) {
-        let mut b = BytesMut::with_capacity(4);
-        b.put_u32_be(i as u32);
+//     for i in 0..(ITER + 1) {
+//         let mut b = BytesMut::with_capacity(4);
+//         b.put_u32_be(i as u32);
 
-        // Append to the end
-        match mock.calls.back_mut().unwrap() {
-            &mut Ok(ref mut data) => {
-                // Write in 2kb chunks
-                if data.len() < ITER {
-                    data.extend_from_slice(&b[..]);
-                    continue;
-                }
-            }
-            _ => unreachable!(),
-        }
+//         // Append to the end
+//         match mock.calls.back_mut().unwrap() {
+//             &mut Ok(ref mut data) => {
+//                 // Write in 2kb chunks
+//                 if data.len() < ITER {
+//                     data.extend_from_slice(&b[..]);
+//                     continue;
+//                 }
+//             }
+//             _ => unreachable!(),
+//         }
 
-        // Push a new new chunk
-        mock.calls.push_back(Ok(b[..].to_vec()));
-    }
+//         // Push a new new chunk
+//         mock.calls.push_back(Ok(b[..].to_vec()));
+//     }
 
-    let mut framed = FramedWrite::new(mock, U32Encoder);
+//     let mut framed = FramedWrite::new(mock, U32Encoder);
 
-    for i in 0..ITER {
-        assert!(framed.start_send(i as u32).unwrap().is_ready());
-    }
+//     for i in 0..ITER {
+//         assert!(framed.start_send(i as u32).unwrap().is_ready());
+//     }
 
-    // This should reject
-    assert!(!framed.start_send(ITER as u32).unwrap().is_ready());
+//     // This should reject
+//     assert!(!framed.start_send(ITER as u32).unwrap().is_ready());
 
-    // This should succeed and start flushing the buffer.
-    assert!(framed.start_send(ITER as u32).unwrap().is_ready());
+//     // This should succeed and start flushing the buffer.
+//     assert!(framed.start_send(ITER as u32).unwrap().is_ready());
 
-    // Flush the rest of the buffer
-    assert!(framed.poll_complete().unwrap().is_ready());
+//     // Flush the rest of the buffer
+//     assert!(framed.poll_complete().unwrap().is_ready());
 
-    // Ensure the mock is empty
-    assert_eq!(0, framed.get_ref().calls.len());
-}
+//     // Ensure the mock is empty
+//     assert_eq!(0, framed.get_ref().calls.len());
+// }
 
-// ===== Mock ======
+// // ===== Mock ======
 
-struct Mock {
-    calls: VecDeque<io::Result<Vec<u8>>>,
-}
+// struct Mock {
+//     calls: VecDeque<io::Result<Vec<u8>>>,
+// }
 
-impl Write for Mock {
-    fn write(&mut self, src: &[u8]) -> io::Result<usize> {
-        match self.calls.pop_front() {
-            Some(Ok(data)) => {
-                assert!(src.len() >= data.len());
-                assert_eq!(&data[..], &src[..data.len()]);
-                Ok(data.len())
-            }
-            Some(Err(e)) => Err(e),
-            None => panic!("unexpected write; {:?}", src),
-        }
-    }
+// impl Write for Mock {
+//     fn write(&mut self, src: &[u8]) -> io::Result<usize> {
+//         match self.calls.pop_front() {
+//             Some(Ok(data)) => {
+//                 assert!(src.len() >= data.len());
+//                 assert_eq!(&data[..], &src[..data.len()]);
+//                 Ok(data.len())
+//             }
+//             Some(Err(e)) => Err(e),
+//             None => panic!("unexpected write; {:?}", src),
+//         }
+//     }
 
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
+//     fn flush(&mut self) -> io::Result<()> {
+//         Ok(())
+//     }
+// }
 
-impl AsyncWrite for Mock {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        Ok(().into())
-    }
-}
+// impl AsyncWrite for Mock {
+//     fn shutdown(&mut self) -> Poll<(), io::Error> {
+//         Ok(().into())
+//     }
+// }

--- a/tokio-codec/tests/framed_write.rs
+++ b/tokio-codec/tests/framed_write.rs
@@ -3,8 +3,8 @@
 use bytes::{BufMut, BytesMut};
 use std::collections::VecDeque;
 use tokio_codec::{Encoder, FramedWrite};
-use tokio_io::AsyncWrite;
 use tokio_futures::Sink;
+use tokio_io::AsyncWrite;
 use tokio_test::assert_ready;
 use tokio_test::task::MockTask;
 
@@ -77,7 +77,7 @@ fn write_hits_backpressure() {
         Ok(b"".to_vec()),
     };
 
-    for i in 0 ..= ITER {
+    for i in 0..=ITER {
         let mut b = BytesMut::with_capacity(4);
         b.put_u32_be(i as u32);
 
@@ -102,7 +102,6 @@ fn write_hits_backpressure() {
     let mut task = MockTask::new();
     let mut framed = FramedWrite::new(mock, U32Encoder);
     task.enter(|cx| {
-
         // Send 8KB. This fills up FramedWrite2 buffer
         for i in 0..ITER {
             assert!(assert_ready!(pin!(framed).poll_ready(cx)).is_ok());


### PR DESCRIPTION
Strategy was to

* copy the old codec code that was temporarily being stashed in `tokio-io`
* modify all the type signatures to use Pin, as literal a translation as possible
* fix up the tests likewise

This is intended just to get things compiling and passing tests. Beyond that there is surely lots of refactoring that can be done to make things more idiomatic. The docs are unchanged.

Closes #1189 