### PR TITLE
sync: change oneshot poll_close to poll_closed

### DIFF
--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -175,7 +175,7 @@ impl<T> Sender<T> {
     /// registered to receive a notification if the `Receiver` handle goes away.
     ///
     /// [`Receiver`]: struct.Receiver.html
-    pub fn poll_close(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         let inner = self.inner.as_ref().unwrap();
 
         let mut state = State::load(&inner.state, Acquire);
@@ -233,16 +233,16 @@ impl<T> Sender<T> {
     pub async fn closed(&mut self) {
         use async_util::future::poll_fn;
 
-        poll_fn(|cx| self.poll_close(cx)).await
+        poll_fn(|cx| self.poll_closed(cx)).await
     }
 
     /// Check if the associated [`Receiver`] handle has been dropped.
     ///
-    /// Unlike [`poll_close`], this function does not register a task for
+    /// Unlike [`poll_closed`], this function does not register a task for
     /// wakeup upon close.
     ///
     /// [`Receiver`]: struct.Receiver.html
-    /// [`poll_close`]: struct.Sender.html#method.poll_close
+    /// [`poll_closed`]: struct.Sender.html#method.poll_closed
     pub fn is_closed(&self) -> bool {
         let inner = self.inner.as_ref().unwrap();
 

--- a/tokio-sync/tests/fuzz_oneshot.rs
+++ b/tokio-sync/tests/fuzz_oneshot.rs
@@ -90,7 +90,7 @@ impl<'a> Future for OnClose<'a> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        self.get_mut().tx.poll_close(cx)
+        self.get_mut().tx.poll_closed(cx)
     }
 }
 

--- a/tokio-sync/tests/oneshot.rs
+++ b/tokio-sync/tests/oneshot.rs
@@ -47,24 +47,24 @@ fn close_tx() {
 
 #[test]
 fn close_rx() {
-    // First, without checking poll_close()
+    // First, without checking poll_closed()
     //
     let (tx, _) = oneshot::channel();
 
     assert_err!(tx.send(1));
 
-    // Second, via poll_close();
+    // Second, via poll_closed();
 
     let (mut tx, rx) = oneshot::channel();
     let mut task = MockTask::new();
 
-    assert_pending!(task.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task.enter(|cx| tx.poll_closed(cx)));
 
     drop(rx);
 
     assert!(task.is_woken());
     assert!(tx.is_closed());
-    assert_ready!(task.enter(|cx| tx.poll_close(cx)));
+    assert_ready!(task.enter(|cx| tx.poll_closed(cx)));
 
     assert_err!(tx.send(1));
 }
@@ -96,13 +96,13 @@ fn explicit_close_poll() {
     // Second, without the message sent
     let (mut tx, mut rx) = oneshot::channel::<i32>();
 
-    assert_pending!(task.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task.enter(|cx| tx.poll_closed(cx)));
 
     rx.close();
 
     assert!(task.is_woken());
     assert!(tx.is_closed());
-    assert_ready!(task.enter(|cx| tx.poll_close(cx)));
+    assert_ready!(task.enter(|cx| tx.poll_closed(cx)));
 
     assert_err!(tx.send(1));
     assert_ready_err!(task.poll(&mut rx));
@@ -111,13 +111,13 @@ fn explicit_close_poll() {
     let (mut tx, mut rx) = oneshot::channel::<i32>();
     let mut task = MockTask::new();
 
-    assert_pending!(task.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task.enter(|cx| tx.poll_closed(cx)));
 
     rx.close();
 
     assert!(task.is_woken());
     assert!(tx.is_closed());
-    assert_ready!(task.enter(|cx| tx.poll_close(cx)));
+    assert_ready!(task.enter(|cx| tx.poll_closed(cx)));
 
     assert_ready_err!(task.poll(&mut rx));
 }
@@ -138,13 +138,13 @@ fn explicit_close_try_recv() {
     let (mut tx, mut rx) = oneshot::channel::<i32>();
     let mut task = MockTask::new();
 
-    assert_pending!(task.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task.enter(|cx| tx.poll_closed(cx)));
 
     rx.close();
 
     assert!(task.is_woken());
     assert!(tx.is_closed());
-    assert_ready!(task.enter(|cx| tx.poll_close(cx)));
+    assert_ready!(task.enter(|cx| tx.poll_closed(cx)));
 
     assert_err!(rx.try_recv());
 }
@@ -168,7 +168,7 @@ fn drops_tasks() {
     let mut tx_task = MockTask::new();
     let mut rx_task = MockTask::new();
 
-    assert_pending!(tx_task.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(tx_task.enter(|cx| tx.poll_closed(cx)));
     assert_pending!(rx_task.poll(&mut rx));
 
     drop(tx);
@@ -210,12 +210,12 @@ fn sender_changes_task() {
     let mut task1 = MockTask::new();
     let mut task2 = MockTask::new();
 
-    assert_pending!(task1.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task1.enter(|cx| tx.poll_closed(cx)));
 
     assert_eq!(2, task1.waker_ref_count());
     assert_eq!(1, task2.waker_ref_count());
 
-    assert_pending!(task2.enter(|cx| tx.poll_close(cx)));
+    assert_pending!(task2.enter(|cx| tx.poll_closed(cx)));
 
     assert_eq!(1, task1.waker_ref_count());
     assert_eq!(2, task2.waker_ref_count());
@@ -225,5 +225,5 @@ fn sender_changes_task() {
     assert!(!task1.is_woken());
     assert!(task2.is_woken());
 
-    assert_ready!(task2.enter(|cx| tx.poll_close(cx)));
+    assert_ready!(task2.enter(|cx| tx.poll_closed(cx)));
 }


### PR DESCRIPTION
The action of `Sender::poll_close` is to check if the receiver has been closed, not to try to close the sender itself. So change to `poll_closed`.
