### PR TITLE
TcpSocket specialized split

### DIFF
--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -37,4 +37,4 @@ futures-core-preview = { version = "0.3.0-alpha.16", optional = true }
 [dev-dependencies]
 #env_logger = { version = "0.5", default-features = false }
 #net2 = "*"
-#tokio = { version = "0.2.0", path = "../tokio" }
+tokio = { version = "0.2.0", path = "../tokio" }

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -34,6 +34,7 @@ macro_rules! ready {
 #[cfg(feature = "incoming")]
 mod incoming;
 mod listener;
+pub mod split;
 mod stream;
 
 pub use self::listener::TcpListener;

--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -28,6 +28,9 @@ use tokio_io::{AsyncRead, AsyncWrite};
 pub struct TcpStreamReadHalf(Arc<TcpStream>);
 
 /// Write half of a `TcpStream`.
+///
+/// Note that in the `AsyncWrite` implemenation of `TcpStreamWriteHalf`,
+/// `poll_shutdown` actually shuts down the TCP stream in the write direction.
 #[derive(Debug)]
 pub struct TcpStreamWriteHalf(Arc<TcpStream>);
 

--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -1,0 +1,142 @@
+//! `TcpStream` split support.
+//!
+//! A `TcpStream` can be split into a `TcpStreamReadHalf` and a
+//! `TcpStreamWriteHalf` with the `TcpStream::split` method. `TcpStreamReadHalf`
+//! implements `AsyncRead` while `TcpStreamWriteHalf` implements `AsyncWrite`.
+//! The two halves can be used concurrently, even from multiple tasks.
+//!
+//! Compared to the generic split of `AsyncRead + AsyncWrite`, this specialized
+//! split gives read and write halves that are faster and smaller, because they
+//! do not use locks. They also provide access to the underlying `TcpStream`
+//! after split, implementing `AsRef<TcpStream>`. This allows you to call
+//! `TcpStream` methods that takes `&self`, e.g., to get local and peer
+//! addresses, to get and set socket options, and to shutdown the sockets.
+
+use super::TcpStream;
+use bytes::{Buf, BufMut};
+use std::error::Error;
+use std::fmt;
+use std::io;
+use std::net::Shutdown;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio_io::{AsyncRead, AsyncWrite};
+
+/// Read half of a `TcpStream`.
+#[derive(Debug)]
+pub struct TcpStreamReadHalf(Arc<TcpStream>);
+
+/// Write half of a `TcpStream`.
+#[derive(Debug)]
+pub struct TcpStreamWriteHalf(Arc<TcpStream>);
+
+pub(crate) fn split(stream: TcpStream) -> (TcpStreamReadHalf, TcpStreamWriteHalf) {
+    let shared = Arc::new(stream);
+    (
+        TcpStreamReadHalf(shared.clone()),
+        TcpStreamWriteHalf(shared),
+    )
+}
+
+/// Error indicating two halves were not from the same stream, and thus could
+/// not be `reunite`d.
+#[derive(Debug)]
+pub struct ReuniteError(pub TcpStreamReadHalf, pub TcpStreamWriteHalf);
+
+impl fmt::Display for ReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same stream"
+        )
+    }
+}
+
+impl Error for ReuniteError {}
+
+impl TcpStreamReadHalf {
+    /// Attempts to put the two "halves" of a `TcpStream` back together and
+    /// recover the original stream. Succeeds only if the two "halves"
+    /// originated from the same call to `TcpStream::split`.
+    pub fn reunite(self, other: TcpStreamWriteHalf) -> Result<TcpStream, ReuniteError> {
+        if Arc::ptr_eq(&self.0, &other.0) {
+            drop(other);
+            Ok(Arc::try_unwrap(self.0).unwrap())
+        } else {
+            Err(ReuniteError(self, other))
+        }
+    }
+}
+
+impl TcpStreamWriteHalf {
+    /// Attempts to put the two "halves" of a `TcpStream` back together and
+    /// recover the original stream. Succeeds only if the two "halves"
+    /// originated from the same call to `TcpStream::split`.
+    pub fn reunite(self, other: TcpStreamReadHalf) -> Result<TcpStream, ReuniteError> {
+        other.reunite(self)
+    }
+}
+
+impl AsRef<TcpStream> for TcpStreamReadHalf {
+    fn as_ref(&self) -> &TcpStream {
+        &self.0
+    }
+}
+
+impl AsRef<TcpStream> for TcpStreamWriteHalf {
+    fn as_ref(&self) -> &TcpStream {
+        &self.0
+    }
+}
+
+impl AsyncRead for TcpStreamReadHalf {
+    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
+        false
+    }
+
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_read_priv(cx, buf)
+    }
+
+    fn poll_read_buf<B: BufMut>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_read_buf_priv(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpStreamWriteHalf {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_priv(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // tcp flush is a no-op
+        Poll::Ready(Ok(()))
+    }
+
+    // `poll_shutdown` on a write half shutdowns the stream in the "write" direction.
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.0.shutdown(Shutdown::Write).into()
+    }
+
+    fn poll_write_buf<B: Buf>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_buf_priv(cx, buf)
+    }
+}

--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -65,6 +65,10 @@ impl TcpStreamReadHalf {
     pub fn reunite(self, other: TcpStreamWriteHalf) -> Result<TcpStream, ReuniteError> {
         if Arc::ptr_eq(&self.0, &other.0) {
             drop(other);
+            // Only two instances of the `Arc` are ever created, one for the
+            // reader and one for the writer, and those `Arc`s are never exposed
+            // externally. And so when we drop one here, the other one must be
+            // the only remaining one.
             Ok(Arc::try_unwrap(self.0).expect("tokio_tcp: try_unwrap failed in reunite"))
         } else {
             Err(ReuniteError(self, other))

--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -65,7 +65,7 @@ impl TcpStreamReadHalf {
     pub fn reunite(self, other: TcpStreamWriteHalf) -> Result<TcpStream, ReuniteError> {
         if Arc::ptr_eq(&self.0, &other.0) {
             drop(other);
-            Ok(Arc::try_unwrap(self.0).unwrap())
+            Ok(Arc::try_unwrap(self.0).expect("tokio_tcp: try_unwrap failed in reunite"))
         } else {
             Err(ReuniteError(self, other))
         }

--- a/tokio-tcp/tests/split.rs
+++ b/tokio-tcp/tests/split.rs
@@ -1,0 +1,25 @@
+#![feature(async_await)]
+
+use tokio_tcp::{TcpListener, TcpStream};
+
+#[tokio::test]
+async fn split_reunite() -> std::io::Result<()> {
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap())?;
+    let stream = TcpStream::connect(&listener.local_addr()?).await?;
+
+    let (r, w) = stream.split();
+    assert!(r.reunite(w).is_ok());
+    Ok(())
+}
+
+#[tokio::test]
+async fn split_reunite_error() -> std::io::Result<()> {
+    let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap())?;
+    let stream = TcpStream::connect(&listener.local_addr()?).await?;
+    let stream1 = TcpStream::connect(&listener.local_addr()?).await?;
+
+    let (r, _) = stream.split();
+    let (_, w) = stream1.split();
+    assert!(r.reunite(w).is_err());
+    Ok(())
+}

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -40,7 +40,7 @@ pub mod tcp {
     //! [`TcpListener`]: struct.TcpListener.html
     //! [incoming_method]: struct.TcpListener.html#method.incoming
     //! [`Incoming`]: struct.Incoming.html
-    pub use tokio_tcp::{TcpListener, TcpStream};
+    pub use tokio_tcp::{split, TcpListener, TcpStream};
 }
 #[cfg(feature = "tcp")]
 pub use self::tcp::{TcpListener, TcpStream};


### PR DESCRIPTION
A specialized split is implemented for `TcpStream`(close #174, related: #1108).

Compared to the generic `AsyncRead::split`, the specialized split gives handles (halves) that are faster and smaller, because they do not use locks.

The write half handle properly implements the shutdown operation, by shutting down the underlying stream in the "write" direction (close #852).

The handles also implement `AsRef<TcpStream>`, allowing access to methods of the `TcpStream` that takes `&self`: to get local and peer addresses, to get/set various socket options, to shutdown the socket, etc. (Close #852 even if write half shutdown does not call stream shutdown.)

## Future Work

Other IO resources should have similar specialized split support as well.