### PR TITLE
Update link to existing (old) examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ fn main() {
 }
 ```
 
-More examples can be found [here](tokio/examples).
+More examples can be found [here](tokio/examples_old).
 
 ## Getting Help
 


### PR DESCRIPTION
## Motivation
The current link to the examples is dead. This change changes the link for the examples to https://github.com/tokio-rs/tokio/tree/master/tokio/examples_old.

## Solution
The example link now points to tokio/examples_old instead of tokio/examples which does not exist anymore.
