### PR TITLE
tokio: re-enable timer in runtimes

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -33,7 +33,7 @@ default = [
   "rt-full",
   "sync",
   "tcp",
-#  "timer",
+  "timer",
   "udp",
 #  "uds",
 ]
@@ -45,7 +45,7 @@ reactor = ["io", "tokio-reactor"]
 rt-full = [
   "num_cpus",
   "reactor",
-#  "timer",
+  "timer",
   "tokio-current-thread",
   "tokio-executor",
   "tokio-macros",
@@ -54,7 +54,7 @@ rt-full = [
 ]
 sync = ["tokio-sync"]
 tcp = ["tokio-tcp"]
-#timer = ["tokio-timer"]
+timer = ["tokio-timer"]
 udp = ["tokio-udp"]
 #uds = ["tokio-uds"]
 
@@ -76,7 +76,7 @@ tokio-sync = { version = "0.2.0", optional = true, path = "../tokio-sync" }
 #tokio-threadpool = { version = "0.2.0", optional = true, path = "../tokio-threadpool" }
 tokio-tcp = { version = "0.2.0", optional = true, path = "../tokio-tcp" }
 tokio-udp = { version = "0.2.0", optional = true, path = "../tokio-udp" }
-#tokio-timer = { version = "0.3.0", optional = true, path = "../tokio-timer" }
+tokio-timer = { version = "0.3.0", optional = true, path = "../tokio-timer" }
 tracing-core = { version = "0.1", optional = true }
 
 # Needed for async/await preview support

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -100,7 +100,7 @@ pub mod reactor;
 pub mod sync;
 #[cfg(feature = "timer")]
 pub mod timer;
-//pub mod util;
+pub mod util;
 
 if_runtime! {
     pub mod executor;

--- a/tokio/src/prelude.rs
+++ b/tokio/src/prelude.rs
@@ -12,6 +12,6 @@
 
 pub use std::future::Future;
 pub use std::task::{self, Poll};
-//pub use crate::util::{FutureExt, StreamExt};
+pub use crate::util::{FutureExt /*, StreamExt*/};
 #[cfg(feature = "io")]
 pub use tokio_io::{AsyncRead, AsyncWrite};

--- a/tokio/src/prelude.rs
+++ b/tokio/src/prelude.rs
@@ -10,8 +10,8 @@
 //!
 //! The prelude may grow over time as additional items see ubiquitous use.
 
+pub use crate::util::FutureExt;
 pub use std::future::Future;
 pub use std::task::{self, Poll};
-pub use crate::util::{FutureExt /*, StreamExt*/};
 #[cfg(feature = "io")]
 pub use tokio_io::{AsyncRead, AsyncWrite};

--- a/tokio/src/runtime/current_thread/builder.rs
+++ b/tokio/src/runtime/current_thread/builder.rs
@@ -1,8 +1,8 @@
 use crate::runtime::current_thread::Runtime;
 use tokio_current_thread::CurrentThread;
 use tokio_reactor::Reactor;
-//use tokio_timer::clock::Clock;
-//use tokio_timer::timer::Timer;
+use tokio_timer::clock::Clock;
+use tokio_timer::timer::Timer;
 use std::io;
 
 /// Builds a Single-threaded runtime with custom configuration values.
@@ -35,8 +35,8 @@ use std::io;
 /// ```
 #[derive(Debug)]
 pub struct Builder {
-    // /// The clock to use
-//clock: Clock,
+    /// The clock to use
+    clock: Clock,
 }
 
 impl Builder {
@@ -46,17 +46,15 @@ impl Builder {
     /// Configuration methods can be chained on the return value.
     pub fn new() -> Builder {
         Builder {
-            //clock: Clock::new(),
+            clock: Clock::new(),
         }
     }
 
-    /*
     /// Set the `Clock` instance that will be used by the runtime.
     pub fn clock(&mut self, clock: Clock) -> &mut Self {
         self.clock = clock;
         self
     }
-    */
 
     /// Create the configured `Runtime`.
     pub fn build(&mut self) -> io::Result<Runtime> {
@@ -66,18 +64,18 @@ impl Builder {
 
         // Place a timer wheel on top of the reactor. If there are no timeouts to fire, it'll let the
         // reactor pick up some new external events.
-        //let timer = Timer::new_with_now(reactor, self.clock.clone());
-        //let timer_handle = timer.handle();
+        let timer = Timer::new_with_now(reactor, self.clock.clone());
+        let timer_handle = timer.handle();
 
         // And now put a single-threaded executor on top of the timer. When there are no futures ready
         // to do something, it'll let the timer or the reactor to generate some new stimuli for the
         // futures to continue in their life.
-        let executor = CurrentThread::new_with_park(reactor /*timer*/);
+        let executor = CurrentThread::new_with_park(timer);
 
         let runtime = Runtime::new2(
             reactor_handle,
-            //timer_handle,
-            //self.clock.clone(),
+            timer_handle,
+            self.clock.clone(),
             executor,
         );
 

--- a/tokio/src/timer.rs
+++ b/tokio/src/timer.rs
@@ -81,12 +81,3 @@
 //! [`DelayQueue`]: struct.DelayQueue.html
 
 pub use tokio_timer::{delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout};
-
-#[deprecated(since = "0.1.8", note = "use Timeout instead")]
-#[allow(deprecated)]
-#[doc(hidden)]
-pub type Deadline<T> = ::tokio_timer::Deadline<T>;
-#[deprecated(since = "0.1.8", note = "use Timeout instead")]
-#[allow(deprecated)]
-#[doc(hidden)]
-pub type DeadlineError<T> = ::tokio_timer::DeadlineError<T>;

--- a/tokio/src/util/future.rs
+++ b/tokio/src/util/future.rs
@@ -1,14 +1,10 @@
-use futures::Future;
-
-#[cfg(feature = "timer")]
-#[allow(deprecated)]
-use tokio_timer::Deadline;
-
 #[cfg(feature = "timer")]
 use tokio_timer::Timeout;
 
 #[cfg(feature = "timer")]
 use std::time::{Duration, Instant};
+
+use std::future::Future;
 
 /// An extension trait for `Future` that provides a variety of convenient
 /// combinator functions.
@@ -62,31 +58,6 @@ pub trait FutureExt: Future {
     {
         Timeout::new(self, timeout)
     }
-
-    #[cfg(feature = "timer")]
-    #[deprecated(since = "0.1.8", note = "use `timeout` instead")]
-    #[allow(deprecated)]
-    #[doc(hidden)]
-    fn deadline(self, deadline: Instant) -> Deadline<Self>
-    where
-        Self: Sized,
-    {
-        Deadline::new(self, deadline)
-    }
 }
 
 impl<T: ?Sized> FutureExt for T where T: Future {}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::prelude::future;
-
-    #[cfg(feature = "timer")]
-    #[test]
-    fn timeout_polls_at_least_once() {
-        let base_future = future::result::<(), ()>(Ok(()));
-        let timeouted_future = base_future.timeout(Duration::new(0, 0));
-        assert!(timeouted_future.wait().is_ok());
-    }
-}

--- a/tokio/src/util/future.rs
+++ b/tokio/src/util/future.rs
@@ -2,7 +2,7 @@
 use tokio_timer::Timeout;
 
 #[cfg(feature = "timer")]
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use std::future::Future;
 

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -7,9 +7,9 @@
 //! [`FutureExt`]: trait.FutureExt.html
 //! [`StreamExt`]: trait.StreamExt.html
 
-mod enumerate;
+// mod enumerate;
 mod future;
-mod stream;
+// mod stream;
 
 pub use self::future::FutureExt;
-pub use self::stream::StreamExt;
+// pub use self::stream::StreamExt;

--- a/tokio/src/util/stream.rs
+++ b/tokio/src/util/stream.rs
@@ -1,8 +1,8 @@
 pub use crate::util::enumerate::Enumerate;
 
-use futures::Stream;
 #[cfg(feature = "timer")]
 use std::time::Duration;
+
 #[cfg(feature = "timer")]
 use tokio_timer::{throttle::Throttle, Timeout};
 


### PR DESCRIPTION
This also brings back the timer tests in the tokio crate.