### PR TITLE
ci: scope each tests/examples invocation to a specific crate

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,14 +32,11 @@ jobs:
     crates:
 #       - tokio-fs
       tokio-reactor:
-        - ''
 #       - tokio-signal
       tokio-tcp:
-        - ''
         - incoming
 #       - tokio-tls
       tokio-udp:
-        - ''
 #       - tokio-uds
 
 # Test crates that are NOT platform specific
@@ -51,24 +48,16 @@ jobs:
     crates:
       # - tokio-buf
       tokio-codec:
-        - ''
       tokio-current-thread:
-        - ''
       tokio-executor:
-        - ''
       tokio-io:
-        - ''
       tokio-sync:
-        - ''
         - async-traits
       tokio-macros:
-        - ''
       # - tokio-threadpool
       tokio-timer:
-        - ''
         - async-traits
       tokio-test:
-        - ''
 
 # - template: ci/azure-cargo-check.yml
 #   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,12 +31,12 @@ jobs:
     rust: $(nightly)
     crates:
 #       - tokio-fs
-      tokio-reactor:
+      tokio-reactor: []
 #       - tokio-signal
-      tokio-tcp:
+      tokio-tcp: []
         - incoming
 #       - tokio-tls
-      tokio-udp:
+      tokio-udp: []
 #       - tokio-uds
 
 # Test crates that are NOT platform specific
@@ -47,17 +47,17 @@ jobs:
     rust: $(nightly)
     crates:
       # - tokio-buf
-      tokio-codec:
-      tokio-current-thread:
-      tokio-executor:
-      tokio-io:
+      tokio-codec: []
+      tokio-current-thread: []
+      tokio-executor: []
+      tokio-io: []
       tokio-sync:
         - async-traits
-      tokio-macros:
+      tokio-macros: []
       # - tokio-threadpool
       tokio-timer:
         - async-traits
-      tokio-test:
+      tokio-test: []
 
 # - template: ci/azure-cargo-check.yml
 #   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,13 +32,14 @@ jobs:
     crates:
 #       - tokio-fs
       tokio-reactor:
-        - default
+        - ''
 #       - tokio-signal
       tokio-tcp:
-        - default
+        - ''
+        - incoming
 #       - tokio-tls
       tokio-udp:
-        - default
+        - ''
 #       - tokio-uds
 
 # Test crates that are NOT platform specific
@@ -50,23 +51,24 @@ jobs:
     crates:
       # - tokio-buf
       tokio-codec:
-        - default
+        - ''
       tokio-current-thread:
-        - default
+        - ''
       tokio-executor:
-        - default
+        - ''
       tokio-io:
-        - default
+        - ''
       tokio-sync:
-        - default
+        - ''
+        - async-traits
       tokio-macros:
-        - default
+        - ''
       # - tokio-threadpool
       tokio-timer:
-        - default
+        - ''
         - async-traits
       tokio-test:
-        - default
+        - ''
 
 # - template: ci/azure-cargo-check.yml
 #   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
 #       - tokio-fs
       tokio-reactor: []
 #       - tokio-signal
-      tokio-tcp: []
+      tokio-tcp:
         - incoming
 #       - tokio-tls
       tokio-udp: []

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -42,7 +42,7 @@ jobs:
       displayName: cargo test --tests
       workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
     - script: cargo test --examples
-      displayName: cargo test --examples --features ${{ feature }}
+      displayName: cargo test --examples
       workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
     # Run with each specified feature

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -34,13 +34,14 @@ jobs:
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
-    workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
     - ${{ each feature in crate.value }}:
       - script: cargo test --tests --no-default-features --features ${{ feature }}
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: cargo test --tests --features ${{ feature }}
+        displayName: ${{ crate.key }}: cargo test --tests --features ${{ feature }}
+        workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
-        displayName: cargo test --examples --features ${{ feature }}
+        displayName: ${{ crate.key }}: cargo test --examples --features ${{ feature }}
+        workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -39,9 +39,9 @@ jobs:
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: ${{ crate }}: cargo test --tests --features ${{ feature }}
+        displayName: ${{ crate }} -- cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
-        displayName: ${{ crate }}: cargo test --examples --features ${{ feature }}
+        displayName: ${{ crate }} -- cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -39,9 +39,9 @@ jobs:
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: ${{ crate.key }}: cargo test --tests --features ${{ feature }}
+        displayName: cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
-        displayName: ${{ crate.key }}: cargo test --examples --features ${{ feature }}
+        displayName: cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -34,14 +34,26 @@ jobs:
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
+    # Run with default crate features
+    - script: cargo test --tests
+      env:
+        LOOM_MAX_DURATION: 10
+        CI: 'True'
+      displayName: cargo test --tests
+      workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
+    - script: cargo test --examples
+      displayName: cargo test --examples --features ${{ feature }}
+      workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
+
+    # Run with each specified feature
     - ${{ each feature in crate.value }}:
-      - script: cargo test --tests --no-default-features --features "$(feature)"
+      - script: cargo test --tests --no-default-features --features ${{ feature }}
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
         displayName: cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
-      - script: cargo test --examples --no-default-features --features "$(feature)"
+      - script: cargo test --examples --no-default-features --features ${{ feature }}
         displayName: cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -39,7 +39,9 @@ jobs:
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: cargo test --tests --features ${{ feature }}
+        displayName: ${{ crate }}: cargo test --tests --features ${{ feature }}
+        workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
-        displayName: cargo test --examples --features ${{ feature }}
+        displayName: ${{ crate }}: cargo test --examples --features ${{ feature }}
+        workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -39,9 +39,9 @@ jobs:
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: ${{ crate }} -- cargo test --tests --features ${{ feature }}
+        displayName: cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
-        displayName: ${{ crate }} -- cargo test --examples --features ${{ feature }}
+        displayName: cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -35,13 +35,13 @@ jobs:
 
   - ${{ each crate in parameters.crates }}:
     - ${{ each feature in crate.value }}:
-      - script: cargo test --tests --no-default-features --features $(feature)
+      - script: cargo test --tests --no-default-features --features "$(feature)"
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
         displayName: cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
-      - script: cargo test --examples --no-default-features --features $(feature)
+      - script: cargo test --examples --no-default-features --features "$(feature)"
         displayName: cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -39,9 +39,9 @@ jobs:
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: cargo test --tests --features ${{ feature }}
+        displayName: cargo test --tests --features $(feature)
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
-      - script: cargo test --examples --no-default-features --features ${{ feature }}
+      - script: cargo test --examples --no-default-features --features $(feature)
         displayName: cargo test --examples --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -34,14 +34,13 @@ jobs:
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
+    workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
     - ${{ each feature in crate.value }}:
       - script: cargo test --tests --no-default-features --features ${{ feature }}
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
         displayName: cargo test --tests --features ${{ feature }}
-        workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
       - script: cargo test --examples --no-default-features --features ${{ feature }}
         displayName: cargo test --examples --features ${{ feature }}
-        workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -35,11 +35,11 @@ jobs:
 
   - ${{ each crate in parameters.crates }}:
     - ${{ each feature in crate.value }}:
-      - script: cargo test --tests --no-default-features --features ${{ feature }}
+      - script: cargo test --tests --no-default-features --features $(feature)
         env:
           LOOM_MAX_DURATION: 10
           CI: 'True'
-        displayName: cargo test --tests --features $(feature)
+        displayName: cargo test --tests --features ${{ feature }}
         workingDirectory: $(Build.SourcesDirectory)/${{ crate.key }}
 
       - script: cargo test --examples --no-default-features --features $(feature)


### PR DESCRIPTION
## Motivation
For each cross product of a crate and it's features, the CI is running all tests for all crates.

## Solution
Scope each test invocation to a specific crate's directory, so only its tests run.
