### PR TITLE
Bump 0.1 versions for latest changes

### DIFF
--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.8 (June 2, 2019)
+
+### Added
+- Add `executor::exit` to allow other executors inside `threadpool::blocking` (#1155).
+
 # 0.1.7 (March 22, 2019)
 
 ### Added

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio-executor"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.7"
+version = "0.1.8"
 documentation = "https://docs.rs/tokio-executor/0.1.7/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,7 +2,7 @@
 
 Task execution related traits and utilities.
 
-[Documentation](https://docs.rs/tokio-executor/0.1.7/tokio_executor)
+[Documentation](https://docs.rs/tokio-executor/0.1.8/tokio_executor)
 
 ## Overview
 
@@ -31,10 +31,10 @@ executor, including:
 
 * [`Park`] abstracts over blocking and unblocking the current thread.
 
-[`Executor`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/trait.Executor.html
-[`enter`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/fn.enter.html
-[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/struct.DefaultExecutor.html
-[`Park`]: https://docs.rs/tokio-executor/0.1.7/tokio_executor/park/trait.Park.html
+[`Executor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/trait.Executor.html
+[`enter`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/fn.enter.html
+[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/struct.DefaultExecutor.html
+[`Park`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/park/trait.Park.html
 
 ## License
 

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.7")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.8")]
 // Our MSRV doesn't allow us to fix these warnings yet
 #![allow(rust_2018_idioms)]
 

--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.15 (June 2, 2019)
+
+### Changed
+- Allow other executors inside `threadpool::blocking` (#1155).
+
 # 0.1.14 (April 22, 2019)
 
 ### Added

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio-threadpool"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.14"
+version = "0.1.15"
 documentation = "https://docs.rs/tokio-threadpool/0.1.14/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
@@ -21,7 +21,7 @@ keywords = ["futures", "tokio"]
 categories = ["concurrency", "asynchronous"]
 
 [dependencies]
-tokio-executor = { path = "../tokio-executor", version = "0.1.7" }
+tokio-executor = "0.1.8"
 futures = "0.1.19"
 crossbeam-deque = "0.7.0"
 crossbeam-queue = "0.1.0"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.14/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.15/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.14")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.15")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
 // Our MSRV doesn't allow us to fix these warnings yet
 #![allow(rust_2018_idioms)]

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,11 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.1.22 (June 2, 2019)
+
+### Changed
+- Moved from `tokio-trace-core` to `tracing-core` (#1223).
+
 # 0.1.21 (May 30, 2019)
 
 ### Changed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -28,7 +28,7 @@ the Rust programming language. It is:
 
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/docs/getting-started/hello-world/) |
-[API Docs](https://docs.rs/tokio/0.1.21/tokio) |
+[API Docs](https://docs.rs/tokio/0.1.22/tokio) |
 [Chat](https://gitter.im/tokio-rs/tokio)
 
 ## Overview
@@ -45,9 +45,9 @@ level, it provides a few major components:
 These components provide the runtime components necessary for building
 an asynchronous application.
 
-[net]: https://docs.rs/tokio/0.1.21/tokio/net/index.html
-[reactor]: https://docs.rs/tokio/0.1.21/tokio/reactor/index.html
-[scheduler]: https://docs.rs/tokio/0.1.21/tokio/runtime/index.html
+[net]: https://docs.rs/tokio/0.1.22/tokio/net/index.html
+[reactor]: https://docs.rs/tokio/0.1.22/tokio/reactor/index.html
+[scheduler]: https://docs.rs/tokio/0.1.22/tokio/runtime/index.html
 
 ## Example
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.1.21")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.1.22")]
 #![deny(missing_docs, warnings, missing_debug_implementations)]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.


### PR DESCRIPTION
This bumps the minor version for `threadpool` and `executor` for #1155, and `tokio` itself for #1223.