### PR TITLE
ci: don't generate docs for deps on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ task:
   test_script:
     - . $HOME/.cargo/env
     - cargo test --all --lib && cargo test --all --tests
-    - cargo doc --all
+    - cargo doc --all --no-deps
   # TODO: Re-enable
   # i686_test_script:
   #   - . $HOME/.cargo/env


### PR DESCRIPTION
## Motivation

The FreeBSD CI generates docs for all dependent crates.

## Solution

Pass in `--no-deps` to `cargo doc` to speed up the run