### PR TITLE
Remove usage of deprecated std::error::Error methods (#1206)

### DIFF
--- a/tokio-buf/src/never.rs
+++ b/tokio-buf/src/never.rs
@@ -15,8 +15,4 @@ impl fmt::Display for Never {
     }
 }
 
-impl error::Error for Never {
-    fn description(&self) -> &str {
-        match *self {}
-    }
-}
+impl error::Error for Never {}

--- a/tokio-buf/src/util/from.rs
+++ b/tokio-buf/src/util/from.rs
@@ -143,11 +143,7 @@ impl fmt::Display for CollectVecError {
     }
 }
 
-impl Error for CollectVecError {
-    fn description(&self) -> &str {
-        "BufStream too big"
-    }
-}
+impl Error for CollectVecError {}
 
 impl fmt::Display for CollectBytesError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -155,8 +151,4 @@ impl fmt::Display for CollectBytesError {
     }
 }
 
-impl Error for CollectBytesError {
-    fn description(&self) -> &str {
-        "BufStream too big"
-    }
-}
+impl Error for CollectBytesError {}

--- a/tokio-buf/src/util/iter.rs
+++ b/tokio-buf/src/util/iter.rs
@@ -47,8 +47,4 @@ impl fmt::Display for Never {
     }
 }
 
-impl Error for Never {
-    fn description(&self) -> &str {
-        unreachable!();
-    }
-}
+impl Error for Never {}

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -107,15 +107,11 @@ pub struct RunError {
 
 impl fmt::Display for RunError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        write!(fmt, "Run error")
     }
 }
 
-impl Error for RunError {
-    fn description(&self) -> &str {
-        "Run error"
-    }
-}
+impl Error for RunError {}
 
 /// Error returned by the `run_timeout` function.
 #[derive(Debug)]
@@ -125,19 +121,16 @@ pub struct RunTimeoutError {
 
 impl fmt::Display for RunTimeoutError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.description())
-    }
-}
-
-impl Error for RunTimeoutError {
-    fn description(&self) -> &str {
-        if self.timeout {
+        let descr = if self.timeout {
             "Run timeout error (timeout)"
         } else {
             "Run timeout error (not timeout)"
-        }
+        };
+        write!(fmt, "{}", descr)
     }
 }
+
+impl Error for RunTimeoutError {}
 
 /// Error returned by the `turn` function.
 #[derive(Debug)]
@@ -147,15 +140,11 @@ pub struct TurnError {
 
 impl fmt::Display for TurnError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        write!(fmt, "Turn error")
     }
 }
 
-impl Error for TurnError {
-    fn description(&self) -> &str {
-        "Turn error"
-    }
-}
+impl Error for TurnError {}
 
 /// Error returned by the `block_on` function.
 #[derive(Debug)]
@@ -169,11 +158,7 @@ impl<T> fmt::Display for BlockError<T> {
     }
 }
 
-impl<T: fmt::Debug> Error for BlockError<T> {
-    fn description(&self) -> &str {
-        "Block error"
-    }
-}
+impl<T: fmt::Debug> Error for BlockError<T> {}
 
 /// This is mostly split out to make the borrow checker happy.
 struct Borrow<'a, U> {

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -22,7 +22,7 @@ pub struct EnterError {
 impl fmt::Debug for EnterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EnterError")
-            .field("reason", &self.description())
+            .field("reason", &format!("{}", self))
             .finish()
     }
 }

--- a/tokio-executor/src/error.rs
+++ b/tokio-executor/src/error.rs
@@ -39,12 +39,11 @@ impl SpawnError {
 
 impl fmt::Display for SpawnError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        write!(
+            fmt,
+            "attempted to spawn task while the executor is at capacity or shut down"
+        )
     }
 }
 
-impl Error for SpawnError {
-    fn description(&self) -> &str {
-        "attempted to spawn task while the executor is at capacity or shut down"
-    }
-}
+impl Error for SpawnError {}

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -241,16 +241,11 @@ impl<T> async_sink::Sink<T> for Sender<T> {
 
 impl fmt::Display for SendError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "channel closed")
     }
 }
 
-impl ::std::error::Error for SendError {
-    fn description(&self) -> &str {
-        "channel closed"
-    }
-}
+impl ::std::error::Error for SendError {}
 
 // ===== impl TrySendError =====
 
@@ -281,19 +276,15 @@ impl<T> TrySendError<T> {
 
 impl<T: fmt::Debug> fmt::Display for TrySendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        let descr = match self.kind {
+            ErrorKind::Closed => "channel closed",
+            ErrorKind::NoCapacity => "no available capacity",
+        };
+        write!(fmt, "{}", descr)
     }
 }
 
-impl<T: fmt::Debug> ::std::error::Error for TrySendError<T> {
-    fn description(&self) -> &str {
-        match self.kind {
-            ErrorKind::Closed => "channel closed",
-            ErrorKind::NoCapacity => "no available capacity",
-        }
-    }
-}
+impl<T: fmt::Debug> ::std::error::Error for TrySendError<T> {}
 
 impl<T> From<(T, chan::TrySendError)> for TrySendError<T> {
     fn from((value, err): (T, chan::TrySendError)) -> TrySendError<T> {
@@ -311,13 +302,8 @@ impl<T> From<(T, chan::TrySendError)> for TrySendError<T> {
 
 impl fmt::Display for RecvError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "channel closed")
     }
 }
 
-impl ::std::error::Error for RecvError {
-    fn description(&self) -> &str {
-        "channel closed"
-    }
-}
+impl ::std::error::Error for RecvError {}

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -154,16 +154,11 @@ impl<T> async_sink::Sink<T> for UnboundedSender<T> {
 
 impl fmt::Display for UnboundedSendError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "channel closed")
     }
 }
 
-impl ::std::error::Error for UnboundedSendError {
-    fn description(&self) -> &str {
-        "channel closed"
-    }
-}
+impl ::std::error::Error for UnboundedSendError {}
 
 // ===== impl TrySendError =====
 
@@ -176,16 +171,11 @@ impl<T> UnboundedTrySendError<T> {
 
 impl<T: fmt::Debug> fmt::Display for UnboundedTrySendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "channel closed")
     }
 }
 
-impl<T: fmt::Debug> ::std::error::Error for UnboundedTrySendError<T> {
-    fn description(&self) -> &str {
-        "channel closed"
-    }
-}
+impl<T: fmt::Debug> ::std::error::Error for UnboundedTrySendError<T> {}
 
 impl<T> From<(T, chan::TrySendError)> for UnboundedTrySendError<T> {
     fn from((value, err): (T, chan::TrySendError)) -> UnboundedTrySendError<T> {
@@ -198,13 +188,8 @@ impl<T> From<(T, chan::TrySendError)> for UnboundedTrySendError<T> {
 
 impl fmt::Display for UnboundedRecvError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "channel closed")
     }
 }
 
-impl ::std::error::Error for UnboundedRecvError {
-    fn description(&self) -> &str {
-        "channel closed"
-    }
-}
+impl ::std::error::Error for UnboundedRecvError {}

--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -44,31 +44,21 @@ pub mod error {
 
     impl fmt::Display for RecvError {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-            use std::error::Error;
-            write!(fmt, "{}", self.description())
+            write!(fmt, "channel closed")
         }
     }
 
-    impl ::std::error::Error for RecvError {
-        fn description(&self) -> &str {
-            "channel closed"
-        }
-    }
+    impl ::std::error::Error for RecvError {}
 
     // ===== impl TryRecvError =====
 
     impl fmt::Display for TryRecvError {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-            use std::error::Error;
-            write!(fmt, "{}", self.description())
+            write!(fmt, "channel closed")
         }
     }
 
-    impl ::std::error::Error for TryRecvError {
-        fn description(&self) -> &str {
-            "channel closed"
-        }
-    }
+    impl ::std::error::Error for TryRecvError {}
 }
 
 use self::error::*;

--- a/tokio-sync/src/semaphore.rs
+++ b/tokio-sync/src/semaphore.rs
@@ -685,16 +685,11 @@ fn to_try_acquire(_: AcquireError) -> TryAcquireError {
 
 impl fmt::Display for AcquireError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        write!(fmt, "semaphore closed")
     }
 }
 
-impl ::std::error::Error for AcquireError {
-    fn description(&self) -> &str {
-        "semaphore closed"
-    }
-}
+impl ::std::error::Error for AcquireError {}
 
 // ===== impl TryAcquireError =====
 
@@ -731,19 +726,15 @@ impl TryAcquireError {
 
 impl fmt::Display for TryAcquireError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        write!(fmt, "{}", self.description())
+        let descr = match self.kind {
+            ErrorKind::Closed => "semaphore closed",
+            ErrorKind::NoPermits => "no permits available",
+        };
+        write!(fmt, "{}", descr)
     }
 }
 
-impl ::std::error::Error for TryAcquireError {
-    fn description(&self) -> &str {
-        match self.kind {
-            ErrorKind::Closed => "semaphore closed",
-            ErrorKind::NoPermits => "no permits available",
-        }
-    }
-}
+impl ::std::error::Error for TryAcquireError {}
 
 // ===== impl WaiterNode =====
 

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -117,16 +117,11 @@ pub mod error {
 
     impl<T: fmt::Debug> fmt::Display for SendError<T> {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-            use std::error::Error;
-            write!(fmt, "{}", self.description())
+            write!(fmt, "channel closed")
         }
     }
 
-    impl<T: fmt::Debug> ::std::error::Error for SendError<T> {
-        fn description(&self) -> &str {
-            "channel closed"
-        }
-    }
+    impl<T: fmt::Debug> ::std::error::Error for SendError<T> {}
 }
 
 #[derive(Debug)]

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -154,20 +154,19 @@ where
 
 impl fmt::Display for BlockingError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "{}", self.description())
+        write!(
+            fmt,
+            "`blocking` annotation used from outside the context of a thread pool"
+        )
     }
 }
 
 impl fmt::Debug for BlockingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BlockingError")
-            .field("reason", &self.description())
+            .field("reason", &format!("{}", self))
             .finish()
     }
 }
 
-impl Error for BlockingError {
-    fn description(&self) -> &str {
-        "`blocking` annotation used from outside the context of a thread pool"
-    }
-}
+impl Error for BlockingError {}

--- a/tokio-threadpool/src/park/default_park.rs
+++ b/tokio-threadpool/src/park/default_park.rs
@@ -84,12 +84,8 @@ impl Unpark for DefaultUnpark {
 
 impl fmt::Display for ParkError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.description().fmt(fmt)
+        write!(fmt, "unknown park error")
     }
 }
 
-impl Error for ParkError {
-    fn description(&self) -> &str {
-        "unknown park error"
-    }
-}
+impl Error for ParkError {}

--- a/tokio-timer/src/deadline.rs
+++ b/tokio-timer/src/deadline.rs
@@ -147,17 +147,7 @@ impl<T> DeadlineError<T> {
     }
 }
 
-impl<T: error::Error> error::Error for DeadlineError<T> {
-    fn description(&self) -> &str {
-        use self::Kind::*;
-
-        match self.0 {
-            Inner(ref e) => e.description(),
-            Elapsed => "deadline has elapsed",
-            Timer(ref e) => e.description(),
-        }
-    }
-}
+impl<T: error::Error> error::Error for DeadlineError<T> {}
 
 impl<T: fmt::Display> fmt::Display for DeadlineError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio-timer/src/error.rs
+++ b/tokio-timer/src/error.rs
@@ -58,20 +58,15 @@ impl Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        use self::Kind::*;
-
-        match self.0 {
-            Shutdown => "timer is shutdown",
-            AtCapacity => "timer is at capacity and cannot create a new entry",
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use std::error::Error;
-        self.description().fmt(fmt)
+        use self::Kind::*;
+        let descr = match self.0 {
+            Shutdown => "timer is shutdown",
+            AtCapacity => "timer is at capacity and cannot create a new entry",
+        };
+        write!(fmt, "{}", descr)
     }
 }

--- a/tokio/src/codec/length_delimited.rs
+++ b/tokio/src/codec/length_delimited.rs
@@ -940,12 +940,8 @@ impl fmt::Debug for FrameTooBig {
 
 impl fmt::Display for FrameTooBig {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.description())
+        f.write_str("frame size too big")
     }
 }
 
-impl StdError for FrameTooBig {
-    fn description(&self) -> &str {
-        "frame size too big"
-    }
-}
+impl StdError for FrameTooBig {}

--- a/tokio/src/runtime/current_thread/runtime.rs
+++ b/tokio/src/runtime/current_thread/runtime.rs
@@ -80,15 +80,8 @@ impl fmt::Display for RunError {
 }
 
 impl Error for RunError {
-    fn description(&self) -> &str {
-        self.inner.description()
-    }
-
-    // FIXME(taiki-e): When the minimum support version of tokio reaches Rust 1.30,
-    // replace this with Error::source.
-    #[allow(deprecated)]
-    fn cause(&self) -> Option<&dyn Error> {
-        self.inner.cause()
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.inner.source()
     }
 }
 


### PR DESCRIPTION
Removes:
- deprecated implementations of std::error::Error::{cause, description}, since they are deprecated and we do not have to keep BC in a new 0.2 release.
- calls to those deprecated methods, since they are problematic.

References #1206