### PR TITLE
signal: fix some typos in example comments

### DIFF
--- a/tokio-signal/examples/ctrl-c.rs
+++ b/tokio-signal/examples/ctrl-c.rs
@@ -52,7 +52,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
 
     // Up until now, we haven't really DONE anything, just prepared
-    // now it's time to actually the results!
+    // now it's time to actually wait for the results!
     future.await;
 
     println!("Stream ended, quiting the program.");

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -37,7 +37,7 @@ mod platform {
         });
 
         // Up until now, we haven't really DONE anything, just prepared
-        // now it's time to actually the results!
+        // now it's time to actually wait for the results!
         future.await;
 
         Ok(())


### PR DESCRIPTION
Fix some typos in the examples, thanks @Aaron1011 for catching the mistake!