### PR TITLE
tokio: add AsyncWriteExt::write_all

### DIFF
--- a/tokio/src/io/async_write_ext.rs
+++ b/tokio/src/io/async_write_ext.rs
@@ -1,13 +1,11 @@
 use crate::io::write::{write, Write};
+use crate::io::write_all::{write_all, WriteAll};
 
 use tokio_io::AsyncWrite;
 
 /// An extension trait which adds utility methods to `AsyncWrite` types.
 pub trait AsyncWriteExt: AsyncWrite {
-    /// Write the provided data into `self`.
-    ///
-    /// The returned future will resolve to the number of bytes written once the
-    /// write operation is completed.
+    /// Write a buffer into this writter, returning how many bytes were written.
     ///
     /// # Examples
     ///
@@ -19,6 +17,20 @@ pub trait AsyncWriteExt: AsyncWrite {
         Self: Unpin,
     {
         write(self, src)
+    }
+
+    /// Attempt to write an entire buffer into this writter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    fn write_all<'a>(&'a mut self, src: &'a [u8]) -> WriteAll<'a, Self>
+    where
+        Self: Unpin,
+    {
+        write_all(self, src)
     }
 }
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -42,6 +42,7 @@ mod copy;
 mod read;
 mod read_exact;
 mod write;
+mod write_all;
 
 pub use self::async_read_ext::AsyncReadExt;
 pub use self::async_write_ext::AsyncWriteExt;

--- a/tokio/src/io/write_all.rs
+++ b/tokio/src/io/write_all.rs
@@ -1,7 +1,7 @@
 use tokio_io::AsyncWrite;
 
-use std::io;
 use std::future::Future;
+use std::io;
 use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -37,7 +37,7 @@ where
                 me.buf = rest;
             }
             if n == 0 {
-                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
             }
         }
 

--- a/tokio/src/io/write_all.rs
+++ b/tokio/src/io/write_all.rs
@@ -1,0 +1,46 @@
+use tokio_io::AsyncWrite;
+
+use std::io;
+use std::future::Future;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct WriteAll<'a, W: ?Sized> {
+    writer: &'a mut W,
+    buf: &'a [u8],
+}
+
+pub(crate) fn write_all<'a, W>(writer: &'a mut W, buf: &'a [u8]) -> WriteAll<'a, W>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    WriteAll { writer, buf }
+}
+
+impl<W: ?Sized + Unpin> Unpin for WriteAll<'_, W> {}
+
+impl<W> Future for WriteAll<'_, W>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    type Output = io::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let me = &mut *self;
+        while !me.buf.is_empty() {
+            let n = ready!(Pin::new(&mut me.writer).poll_write(cx, me.buf))?;
+            {
+                let (_, rest) = mem::replace(&mut me.buf, &[]).split_at(n);
+                me.buf = rest;
+            }
+            if n == 0 {
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()))
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}

--- a/tokio/tests/io_write_all.rs
+++ b/tokio/tests/io_write_all.rs
@@ -5,12 +5,13 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;
 
 use bytes::BytesMut;
+use std::cmp;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[tokio::test]
-async fn write() {
+async fn write_all() {
     struct Wr {
         buf: BytesMut,
         cnt: usize,
@@ -22,9 +23,12 @@ async fn write() {
             _cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
-            assert_eq!(self.cnt, 0);
-            self.buf.extend(&buf[0..4]);
-            Ok(4).into()
+            let n = cmp::min(4, buf.len());
+            let buf = &buf[0..n];
+
+            self.cnt += 1;
+            self.buf.extend(buf);
+            Ok(buf.len()).into()
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -41,7 +45,7 @@ async fn write() {
         cnt: 0,
     };
 
-    let n = assert_ok!(wr.write(b"hello world").await);
-    assert_eq!(n, 4);
-    assert_eq!(wr.buf, b"hell"[..]);
+    assert_ok!(wr.write_all(b"hello world").await);
+    assert_eq!(wr.buf, b"hello world"[..]);
+    assert_eq!(wr.cnt, 3);
 }


### PR DESCRIPTION
An async equivalent to io::Write::write_all