### PR TITLE
Remove usage of deprecated ONCE_INIT

### DIFF
--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -10,7 +10,7 @@ pub use libc;
 use std::io::{self, Error, ErrorKind, Write};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 use crate::IoFuture;
 use futures_core::stream::Stream;
@@ -96,7 +96,7 @@ impl Default for SignalInfo {
     fn default() -> SignalInfo {
         SignalInfo {
             event_info: Default::default(),
-            init: ONCE_INIT,
+            init: Once::new(),
             initialized: AtomicBool::new(false),
         }
     }

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 use std::task::{Context, Poll};
 
 use futures_core::stream::Stream;
@@ -73,7 +73,7 @@ impl Init for OsExtraData {
     }
 }
 
-static INIT: Once = ONCE_INIT;
+static INIT: Once = Once::new();
 
 /// Stream of events discovered via `SetConsoleCtrlHandler`.
 ///

--- a/tokio-tls/tests/smoke.rs
+++ b/tokio-tls/tests/smoke.rs
@@ -32,7 +32,7 @@ struct Keys {
 
 #[allow(dead_code)]
 fn openssl_keys() -> &'static Keys {
-    static INIT: Once = ONCE_INIT;
+    static INIT: Once = Once::new();
     static mut KEYS: *mut Keys = 0 as *mut _;
 
     INIT.call_once(|| {
@@ -130,7 +130,7 @@ cfg_if! {
         use std::env;
         use std::fs::File;
         use std::process::Command;
-        use std::sync::{ONCE_INIT, Once};
+        use std::sync::Once;
 
         use untrusted::Input;
         use webpki::trust_anchor_util;
@@ -159,7 +159,7 @@ cfg_if! {
         // Right now I don't know of a way to programmatically create a
         // self-signed certificate, so we just fork out to the `openssl` binary.
         fn keys() -> (&'static [u8], &'static [u8]) {
-            static INIT: Once = ONCE_INIT;
+            static INIT: Once = Once::new();
             static mut KEYS: *mut (Vec<u8>, Vec<u8>) = 0 as *mut _;
 
             INIT.call_once(|| {
@@ -226,7 +226,7 @@ cfg_if! {
                             not(target_os = "ios"))))] {
         use std::fs::File;
         use std::env;
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         fn contexts() -> (tokio_tls::TlsAcceptor, tokio_tls::TlsConnector) {
             let keys = openssl_keys();
@@ -244,7 +244,7 @@ cfg_if! {
     } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         use std::env;
         use std::fs::File;
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         fn contexts() -> (tokio_tls::TlsAcceptor, tokio_tls::TlsConnector) {
             let keys = openssl_keys();
@@ -267,7 +267,7 @@ cfg_if! {
         use std::io::Error;
         use std::mem;
         use std::ptr;
-        use std::sync::{Once, ONCE_INIT};
+        use std::sync::Once;
 
         use schannel::cert_context::CertContext;
         use schannel::cert_store::{CertStore, CertAdd, Memory};
@@ -312,7 +312,7 @@ cfg_if! {
         // for a small period of time (e.g. 1 day).
 
         fn localhost_cert() -> CertContext {
-            static INIT: Once = ONCE_INIT;
+            static INIT: Once = Once::new();
             INIT.call_once(|| {
                 for cert in local_root_store().certs() {
                     let name = match cert.friendly_name() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`std::sync::ONCE_INIT` will be deprecated in Rust 1.38 (https://github.com/rust-lang/rust/pull/61757).
The alternative (`Once::new()`) seems to have stabilized at the same time as `AtomicUsize::new()` (https://github.com/rust-lang/rust/issues/61746#issuecomment-501077898).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
