### PR TITLE
tokio: re-export tokio-uds

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -35,7 +35,7 @@ default = [
   "tcp",
   "timer",
   "udp",
-#  "uds",
+  "uds",
 ]
 
 codec = ["io", "tokio-codec"]
@@ -56,7 +56,7 @@ sync = ["tokio-sync"]
 tcp = ["tokio-tcp"]
 timer = ["tokio-timer"]
 udp = ["tokio-udp"]
-#uds = ["tokio-uds"]
+uds = ["tokio-uds"]
 
 [dependencies]
 # Only non-optional dependency...


### PR DESCRIPTION
The tokio-uds crate has been previously updated to std::future. This
commit enables the re-export in the tokio facade crate.