### PR TITLE
tokio: re-export correct tokio-uds version

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -84,7 +84,7 @@ tracing-core = { version = "0.1", optional = true }
 #tokio-futures = { version = "0.2.0", optional = true, path = "../tokio-futures" }
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "0.2.1", optional = true }
+tokio-uds = { version = "0.3.0", optional = true, path = "../tokio-uds" }
 
 [dev-dependencies]
 tokio-test = { path = "../tokio-test" }

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -67,10 +67,7 @@ pub use self::udp::UdpSocket;
 pub mod unix {
     //! Unix domain socket bindings for `tokio` (only available on unix systems).
 
-    pub use tokio_uds::{
-        ConnectFuture, Incoming, RecvDgram, SendDgram, UCred, UnixDatagram, UnixDatagramFramed,
-        UnixListener, UnixStream,
-    };
+    pub use tokio_uds::{UCred, UnixDatagram, UnixListener, UnixStream};
 }
 #[cfg(all(unix, feature = "uds"))]
-pub use self::unix::{UnixDatagram, UnixDatagramFramed, UnixListener, UnixStream};
+pub use self::unix::{UnixDatagram, UnixListener, UnixStream};


### PR DESCRIPTION
An earlier PR (#1282) re-exported the version from crates.io and not git
master.