### PR TITLE
Implement "split_mut" for TcpStream

### DIFF
--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -53,7 +53,9 @@ pub struct TcpStreamReadHalfMut<'a>(&'a TcpStream);
 #[derive(Debug)]
 pub struct TcpStreamWriteHalfMut<'a>(&'a TcpStream);
 
-pub(crate) fn split_mut<'a>(stream: &'a mut TcpStream) -> (TcpStreamReadHalfMut<'a>, TcpStreamWriteHalfMut<'a>) {
+pub(crate) fn split_mut<'a>(
+    stream: &'a mut TcpStream,
+) -> (TcpStreamReadHalfMut<'a>, TcpStreamWriteHalfMut<'a>) {
     (
         TcpStreamReadHalfMut(&*stream),
         TcpStreamWriteHalfMut(&*stream),

--- a/tokio-tcp/src/split.rs
+++ b/tokio-tcp/src/split.rs
@@ -42,6 +42,24 @@ pub(crate) fn split(stream: TcpStream) -> (TcpStreamReadHalf, TcpStreamWriteHalf
     )
 }
 
+/// Read half of a `TcpStream`.
+#[derive(Debug)]
+pub struct TcpStreamReadHalfMut<'a>(&'a TcpStream);
+
+/// Write half of a `TcpStream`.
+///
+/// Note that in the `AsyncWrite` implemenation of `TcpStreamWriteHalf`,
+/// `poll_shutdown` actually shuts down the TCP stream in the write direction.
+#[derive(Debug)]
+pub struct TcpStreamWriteHalfMut<'a>(&'a TcpStream);
+
+pub(crate) fn split_mut<'a>(stream: &'a mut TcpStream) -> (TcpStreamReadHalfMut<'a>, TcpStreamWriteHalfMut<'a>) {
+    (
+        TcpStreamReadHalfMut(&*stream),
+        TcpStreamWriteHalfMut(&*stream),
+    )
+}
+
 /// Error indicating two halves were not from the same stream, and thus could
 /// not be `reunite`d.
 #[derive(Debug)]
@@ -97,6 +115,18 @@ impl AsRef<TcpStream> for TcpStreamWriteHalf {
     }
 }
 
+impl AsRef<TcpStream> for TcpStreamReadHalfMut<'_> {
+    fn as_ref(&self) -> &TcpStream {
+        self.0
+    }
+}
+
+impl AsRef<TcpStream> for TcpStreamWriteHalfMut<'_> {
+    fn as_ref(&self) -> &TcpStream {
+        self.0
+    }
+}
+
 impl AsyncRead for TcpStreamReadHalf {
     unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
         false
@@ -120,6 +150,57 @@ impl AsyncRead for TcpStreamReadHalf {
 }
 
 impl AsyncWrite for TcpStreamWriteHalf {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_priv(cx, buf)
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // tcp flush is a no-op
+        Poll::Ready(Ok(()))
+    }
+
+    // `poll_shutdown` on a write half shutdowns the stream in the "write" direction.
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.0.shutdown(Shutdown::Write).into()
+    }
+
+    fn poll_write_buf<B: Buf>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_buf_priv(cx, buf)
+    }
+}
+
+impl AsyncRead for TcpStreamReadHalfMut<'_> {
+    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
+        false
+    }
+
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_read_priv(cx, buf)
+    }
+
+    fn poll_read_buf<B: BufMut>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_read_buf_priv(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpStreamWriteHalfMut<'_> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -1,4 +1,4 @@
-use crate::split::{split, TcpStreamReadHalf, TcpStreamWriteHalf};
+use crate::split::{split, split_mut, TcpStreamReadHalf, TcpStreamWriteHalf, TcpStreamReadHalfMut, TcpStreamWriteHalfMut};
 use bytes::{Buf, BufMut};
 use iovec::IoVec;
 use mio;
@@ -721,6 +721,15 @@ impl TcpStream {
     /// details.
     pub fn split(self) -> (TcpStreamReadHalf, TcpStreamWriteHalf) {
         split(self)
+    }
+
+    /// Split a `TcpStream` into a read half and a write half, which can be used
+    /// to read and write the stream concurrently.
+    ///
+    /// See the module level documenation of [`split`](super::split) for more
+    /// details.
+    pub fn split_mut<'a>(&'a mut self) -> (TcpStreamReadHalfMut<'a>, TcpStreamWriteHalfMut<'a>) {
+        split_mut(self)
     }
 
     // == Poll IO functions that takes `&self` ==

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -1,4 +1,7 @@
-use crate::split::{split, split_mut, TcpStreamReadHalf, TcpStreamWriteHalf, TcpStreamReadHalfMut, TcpStreamWriteHalfMut};
+use crate::split::{
+    split, split_mut, TcpStreamReadHalf, TcpStreamReadHalfMut, TcpStreamWriteHalf,
+    TcpStreamWriteHalfMut,
+};
 use bytes::{Buf, BufMut};
 use iovec::IoVec;
 use mio;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

See here for a longer motivation:
https://github.com/rust-lang-nursery/futures-rs/issues/1727

The TLDR is that I think a "split_mut" method on types implementing traits like `AsyncRead` could open up the possibility of the AsyncRead/AsyncWrite trait methods returning "normal-ish" futures, and eventually allow the methods on these traits to be implemented using async functions

Note: this is more useful than it might appear, because the Pin API allows the ownership of a TcpStream, *and* non-static borrows of that TcpStream to be bundled into a future without any lifetime bounds of its own.