### PR TITLE
update udp-codec example

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,6 +87,7 @@ tracing-core = { version = "0.1", optional = true }
 tokio-uds = { version = "0.3.0", optional = true, path = "../tokio-uds" }
 
 [dev-dependencies]
+futures-preview = "0.3.0-alpha.17"
 tokio-test = { path = "../tokio-test" }
 pin-utils = "0.1.0-alpha.4"
 env_logger = { version = "0.5", default-features = false }

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -10,19 +10,19 @@
 #![deny(warnings, rust_2018_idioms)]
 
 use std::env;
-use std::error::Error as StdError;
+use std::error::Error;
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use tokio::io::Error;
+use tokio::io;
 use tokio::net::UdpSocket;
 use tokio::util::FutureExt;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
+async fn main() -> Result<(), Box<dyn Error + Send + Sync>> {
     let _ = env_logger::init();
 
-    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:0".to_string());
     let addr = addr.parse::<SocketAddr>()?;
 
     // Bind both our sockets and then figure out what ports we got.
@@ -47,7 +47,7 @@ async fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
     Ok(())
 }
 
-async fn ping(socket: &mut UdpSocket, b_addr: SocketAddr) -> Result<(), Error> {
+async fn ping(socket: &mut UdpSocket, b_addr: SocketAddr) -> Result<(), io::Error> {
     socket.send_to(b"PING", &b_addr).await?;
 
     for _ in 0..4usize {
@@ -66,7 +66,7 @@ async fn ping(socket: &mut UdpSocket, b_addr: SocketAddr) -> Result<(), Error> {
     Ok(())
 }
 
-async fn pong(socket: &mut UdpSocket) -> Result<(), Error> {
+async fn pong(socket: &mut UdpSocket) -> Result<(), io::Error> {
     let mut buffer = [0u8; 255];
 
     while let Ok(Ok((bytes_read, addr))) = socket

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -1,0 +1,84 @@
+//! This example leverages `BytesCodec` to create a UDP client and server which
+//! speak a custom protocol.
+//!
+//! Here we're using the codec from tokio-io to convert a UDP socket to a stream of
+//! client messages. These messages are then processed and returned back as a
+//! new message with a new destination. Overall, we then use this to construct a
+//! "ping pong" pair where two sockets are sending messages back and forth.
+
+#![feature(async_await)]
+#![deny(warnings, rust_2018_idioms)]
+
+use env_logger;
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use tokio;
+use tokio::io::Error;
+use tokio::net::UdpSocket;
+use tokio::util::FutureExt;
+
+#[tokio::main]
+async fn main() {
+    let _ = env_logger::init();
+
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+    // Bind both our sockets and then figure out what ports we got.
+    let a = UdpSocket::bind(&addr).expect("Failed to bind to address");
+    let b = UdpSocket::bind(&addr).expect("Failed to bind to address");
+    let b_addr = b.local_addr().expect("Failed to get address of socket B");
+
+    // Start off by sending a ping from a to b, afterwards we just print out
+    // what they send us and continually send pings
+    let a = pinger(a, b_addr);
+
+    // The second client we have will receive the pings from `a` and then send
+    // back pongs.
+    let b = ponger(b);
+
+    match futures::future::join(a, b).await {
+        (Err(e), _) | (_, Err(e)) => println!("an error occured; error = {:?}", e),
+        _ => println!("done!"),
+    }
+}
+
+// I moved the ping and pong routines into functions so I could use `?` for error handling.
+async fn pinger(mut socket: UdpSocket, b_addr: SocketAddr) -> Result<(), Error> {
+    socket.send_to(b"PING", &b_addr).await?;
+
+    for _ in 0..4usize {
+        let mut buffer = [0u8; 255];
+
+        let (bytes_read, addr) = socket.recv_from(&mut buffer).await?;
+
+        println!(
+            "[a] recv: {}",
+            String::from_utf8_lossy(&buffer[..bytes_read])
+        );
+
+        socket.send_to(b"PING", &addr).await?;
+    }
+
+    Ok(())
+}
+
+async fn ponger(mut socket: UdpSocket) -> Result<(), Error> {
+    let mut buffer = [0u8; 255];
+
+    while let Ok(Ok((bytes_read, addr))) = socket
+        .recv_from(&mut buffer)
+        .timeout(Duration::from_millis(200))
+        .await
+    {
+        println!(
+            "[b] recv: {}",
+            String::from_utf8_lossy(&buffer[..bytes_read])
+        );
+
+        socket.send_to(b"PONG", &addr).await?;
+    }
+
+    Ok(())
+}

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -16,16 +16,18 @@ use tokio::io::Error;
 use tokio::net::UdpSocket;
 use tokio::util::FutureExt;
 
+use std::error::Error as StdError;
+
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
     let _ = env_logger::init();
 
-    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    let addr: SocketAddr = "127.0.0.1:0".parse()?;
 
     // Bind both our sockets and then figure out what ports we got.
-    let mut a = UdpSocket::bind(&addr).expect("Failed to bind to address");
-    let mut b = UdpSocket::bind(&addr).expect("Failed to bind to address");
-    let b_addr = b.local_addr().expect("Failed to get address of socket B");
+    let mut a = UdpSocket::bind(&addr)?;
+    let mut b = UdpSocket::bind(&addr)?;
+    let b_addr = b.local_addr()?;
 
     // Start off by sending a ping from a to b, afterwards we just print out
     // what they send us and continually send pings
@@ -40,6 +42,8 @@ async fn main() {
         Err(e) => println!("an error occured; error = {:?}", e),
         _ => println!("done!"),
     }
+
+    Ok(())
 }
 
 async fn ping(socket: &mut UdpSocket, b_addr: SocketAddr) -> Result<(), Error> {

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -42,8 +42,6 @@ async fn main() {
     }
 }
 
-// `ping` and `pong` were originally inline but were moved into functions so that
-// `?` could be used for error handling.
 async fn ping(socket: &mut UdpSocket, b_addr: SocketAddr) -> Result<(), Error> {
     socket.send_to(b"PING", &b_addr).await?;
 

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -9,6 +9,8 @@
 #![feature(async_await)]
 #![deny(warnings, rust_2018_idioms)]
 
+use std::env;
+use std::error::Error as StdError;
 use std::net::SocketAddr;
 use std::time::Duration;
 
@@ -16,13 +18,12 @@ use tokio::io::Error;
 use tokio::net::UdpSocket;
 use tokio::util::FutureExt;
 
-use std::error::Error as StdError;
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn StdError + Send + Sync>> {
     let _ = env_logger::init();
 
-    let addr: SocketAddr = "127.0.0.1:0".parse()?;
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
+    let addr = addr.parse::<SocketAddr>()?;
 
     // Bind both our sockets and then figure out what ports we got.
     let mut a = UdpSocket::bind(&addr)?;


### PR DESCRIPTION
I've updated the udp-codec example to use the new async-await feature set and to use await wherever possible.

I wasn't able to use `Framed` with `BytesCodec` due to changes to `UdpSocket` not having an `AsyncWrite` or `AsyncRead` implementation. I have reproduced the original ping-ponging behavior of the original example using the `send` and `recv` functions just using `UdpSocket` by itself.

Maybe this example should be renamed?