### PR TITLE
tokio-uds: Expose clear_{read,write}_ready.

### DIFF
--- a/tokio-uds/src/stream.rs
+++ b/tokio-uds/src/stream.rs
@@ -95,9 +95,19 @@ impl UnixStream {
         self.io.poll_read_ready(ready)
     }
 
+    /// Clear read ready state.
+    pub fn clear_read_ready(&self, ready: Ready) -> io::Result<()> {
+        self.io.clear_read_ready(ready)
+    }
+
     /// Test whether this socket is ready to be written to or not.
     pub fn poll_write_ready(&self) -> Poll<Ready, io::Error> {
         self.io.poll_write_ready()
+    }
+
+    /// Clear read ready state.
+    pub fn clear_write_ready(&self) -> io::Result<()> {
+        self.io.clear_write_ready()
     }
 
     /// Returns the socket address of the local half of this connection.
@@ -195,7 +205,7 @@ impl<'a> AsyncRead for &'a UnixStream {
             if r == -1 {
                 let e = io::Error::last_os_error();
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_read_ready(Ready::readable())?;
+                    <UnixStream>::clear_read_ready(self, Ready::readable())?;
                     Ok(Async::NotReady)
                 } else {
                     Err(e)
@@ -223,7 +233,7 @@ impl<'a> AsyncWrite for &'a UnixStream {
             if r == -1 {
                 let e = io::Error::last_os_error();
                 if e.kind() == io::ErrorKind::WouldBlock {
-                    self.io.clear_write_ready()?;
+                    <UnixStream>::clear_write_ready(self)?;
                     Ok(Async::NotReady)
                 } else {
                     Err(e)


### PR DESCRIPTION
While migrating a project from tokio-core to tokio 0.1, I found `need_read`/`need_write` on tokio-uds's UnixStream were removed and the newer `clear_read_ready` and `clear_write_ready` replacement API wasn't exposed.

The project I'm migrating to tokio 0.1 extends AsyncRead/AsyncWrite with new traits that support file descriptor passing over the UnixStream using libc::recvmsg/libc::sendmsg, so we need the ability to clear the read/write ready state on the UnixStream's PollEvented.

Note: this PR is against v0.1.x but I'm happy to submit another for master if this PR is approved.