### PR TITLE
Replace (some) std::mem::uninitialized usage with MaybeUninit

### DIFF
--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -4,7 +4,7 @@ use crate::loom::{sync::atomic::AtomicUsize, sync::CausalCell};
 
 use std::fmt;
 use std::future::Future;
-use std::mem::{self, ManuallyDrop};
+use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::{self, AcqRel, Acquire};
 use std::sync::Arc;
@@ -72,10 +72,10 @@ struct Inner<T> {
     value: CausalCell<Option<T>>,
 
     /// The task to notify when the receiver drops without consuming the value.
-    tx_task: CausalCell<ManuallyDrop<Waker>>,
+    tx_task: CausalCell<MaybeUninit<Waker>>,
 
     /// The task to notify when the value is sent.
-    rx_task: CausalCell<ManuallyDrop<Waker>>,
+    rx_task: CausalCell<MaybeUninit<Waker>>,
 }
 
 #[derive(Clone, Copy)]
@@ -116,8 +116,8 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let inner = Arc::new(Inner {
         state: AtomicUsize::new(State::new().as_usize()),
         value: CausalCell::new(None),
-        tx_task: CausalCell::new(ManuallyDrop::new(unsafe { mem::uninitialized() })),
-        rx_task: CausalCell::new(ManuallyDrop::new(unsafe { mem::uninitialized() })),
+        tx_task: CausalCell::new(MaybeUninit::uninit()),
+        rx_task: CausalCell::new(MaybeUninit::uninit()),
     });
 
     let tx = Sender {
@@ -176,9 +176,7 @@ impl<T> Sender<T> {
         }
 
         if state.is_tx_task_set() {
-            let will_notify = inner
-                .tx_task
-                .with(|ptr| unsafe { (&*ptr).will_wake(cx.waker()) });
+            let will_notify = unsafe { inner.with_tx_task(|w| w.will_wake(cx.waker())) };
 
             if !will_notify {
                 state = State::unset_tx_task(&inner.state);
@@ -332,7 +330,9 @@ impl<T> Inner<T> {
 
         if prev.is_rx_task_set() {
             // TODO: Consume waker?
-            self.rx_task.with(|ptr| unsafe { (&*ptr).wake_by_ref() });
+            unsafe {
+                self.with_rx_task(Waker::wake_by_ref);
+            }
         }
 
         true
@@ -351,9 +351,7 @@ impl<T> Inner<T> {
             Ready(Err(RecvError(())))
         } else {
             if state.is_rx_task_set() {
-                let will_notify = self
-                    .rx_task
-                    .with(|ptr| unsafe { (&*ptr).will_wake(cx.waker()) });
+                let will_notify = unsafe { self.with_rx_task(|w| w.will_wake(cx.waker())) };
 
                 // Check if the task is still the same
                 if !will_notify {
@@ -398,7 +396,9 @@ impl<T> Inner<T> {
         let prev = State::set_closed(&self.state);
 
         if prev.is_tx_task_set() && !prev.is_complete() {
-            self.tx_task.with(|ptr| unsafe { (&*ptr).wake_by_ref() });
+            unsafe {
+                self.with_tx_task(Waker::wake_by_ref);
+            }
         }
     }
 
@@ -407,22 +407,52 @@ impl<T> Inner<T> {
         self.value.with_mut(|ptr| (*ptr).take())
     }
 
+    unsafe fn with_rx_task<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Waker) -> R,
+    {
+        self.rx_task.with(|ptr| {
+            let waker: *const Waker = (&*ptr).as_ptr();
+            f(&*waker)
+        })
+    }
+
+    unsafe fn with_tx_task<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&Waker) -> R,
+    {
+        self.tx_task.with(|ptr| {
+            let waker: *const Waker = (&*ptr).as_ptr();
+            f(&*waker)
+        })
+    }
+
     unsafe fn drop_rx_task(&self) {
-        self.rx_task.with_mut(|ptr| ManuallyDrop::drop(&mut *ptr))
+        self.rx_task.with_mut(|ptr| {
+            let ptr: *mut Waker = (&mut *ptr).as_mut_ptr();
+            ptr.drop_in_place();
+        });
     }
 
     unsafe fn drop_tx_task(&self) {
-        self.tx_task.with_mut(|ptr| ManuallyDrop::drop(&mut *ptr))
+        self.tx_task.with_mut(|ptr| {
+            let ptr: *mut Waker = (&mut *ptr).as_mut_ptr();
+            ptr.drop_in_place();
+        });
     }
 
     unsafe fn set_rx_task(&self, cx: &mut Context<'_>) {
-        self.rx_task
-            .with_mut(|ptr| *ptr = ManuallyDrop::new(cx.waker().clone()));
+        self.rx_task.with_mut(|ptr| {
+            let ptr: *mut Waker = (&mut *ptr).as_mut_ptr();
+            ptr.write(cx.waker().clone());
+        });
     }
 
     unsafe fn set_tx_task(&self, cx: &mut Context<'_>) {
-        self.tx_task
-            .with_mut(|ptr| *ptr = ManuallyDrop::new(cx.waker().clone()));
+        self.tx_task.with_mut(|ptr| {
+            let ptr: *mut Waker = (&mut *ptr).as_mut_ptr();
+            ptr.write(cx.waker().clone());
+        });
     }
 }
 
@@ -434,15 +464,15 @@ impl<T> Drop for Inner<T> {
         let state = State(*self.state.get_mut());
 
         if state.is_rx_task_set() {
-            self.rx_task.with_mut(|ptr| unsafe {
-                ManuallyDrop::drop(&mut *ptr);
-            });
+            unsafe {
+                self.drop_rx_task();
+            }
         }
 
         if state.is_tx_task_set() {
-            self.tx_task.with_mut(|ptr| unsafe {
-                ManuallyDrop::drop(&mut *ptr);
-            });
+            unsafe {
+                self.drop_tx_task();
+            }
         }
     }
 }


### PR DESCRIPTION
[`MaybeUninit`](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html) is stable in rust 1.36 and `std::mem::uninitialized` will be [deprecated](https://doc.rust-lang.org/nightly/std/mem/fn.uninitialized.html) in 1.38. Tokio v0.2 is targeting at least rust 1.36 and probably 1.38 or newer, so usage of `uninitialized` should be replaced with `MaybeUninit`.

Changes:

* In `tokio-uds/src/ucred.rs`: this is a straightforward change following the [out pointer pattern](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#out-pointers).

* In `tokio-sync/src/oneshot.rs`: `ManuallyDrop` is replaced with `MaybeUninit`. This is recommended in the doc of [`ManuallyDrop`](https://doc.rust-lang.org/std/mem/struct.ManuallyDrop.html). I also made some small refactoring to abstract the pointer to reference dances.

There is still `uninitialized` in `tokio-sync/src/mpsc/block.rs`. This one is a bit more tricky. Blindly using `MaybeUninit::uninit().assume_init()` is still not correct. This [technique](https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element) does not work because you cannot transmute an array of unknown size. Left for future work.