### PR TITLE
tokio,io: add AsyncBufRead trait and AsyncBufReadExt::{read_until, read_line, lines}

### DIFF
--- a/tokio-io/src/async_buf_read.rs
+++ b/tokio-io/src/async_buf_read.rs
@@ -1,0 +1,94 @@
+use crate::AsyncRead;
+use std::io;
+use std::ops::DerefMut;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Read bytes asynchronously.
+///
+/// This trait inherits from `std::io::BufRead` and indicates that an I/O object is
+/// **non-blocking**. All non-blocking I/O objects must return an error when
+/// bytes are unavailable instead of blocking the current thread.
+pub trait AsyncBufRead: AsyncRead {
+    /// Attempt to return the contents of the internal buffer, filling it with more data
+    /// from the inner reader if it is empty.
+    ///
+    /// On success, returns `Poll::Ready(Ok(buf))`.
+    ///
+    /// If no data is available for reading, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// readable or is closed.
+    ///
+    /// This function is a lower-level call. It needs to be paired with the
+    /// [`consume`] method to function properly. When calling this
+    /// method, none of the contents will be "read" in the sense that later
+    /// calling [`poll_read`] may return the same contents. As such, [`consume`] must
+    /// be called with the number of bytes that are consumed from this buffer to
+    /// ensure that the bytes are never returned twice.
+    ///
+    /// An empty buffer returned indicates that the stream has reached EOF.
+    ///
+    /// [`poll_read`]: AsyncRead::poll_read
+    /// [`consume`]: AsyncBufRead::consume
+    fn poll_fill_buf<'a>(
+        self: Pin<&'a mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&'a [u8]>>;
+
+    /// Tells this buffer that `amt` bytes have been consumed from the buffer,
+    /// so they should no longer be returned in calls to [`poll_read`].
+    ///
+    /// This function is a lower-level call. It needs to be paired with the
+    /// [`poll_fill_buf`] method to function properly. This function does
+    /// not perform any I/O, it simply informs this object that some amount of
+    /// its buffer, returned from [`poll_fill_buf`], has been consumed and should
+    /// no longer be returned. As such, this function may do odd things if
+    /// [`poll_fill_buf`] isn't called before calling it.
+    ///
+    /// The `amt` must be `<=` the number of bytes in the buffer returned by
+    /// [`poll_fill_buf`].
+    ///
+    /// [`poll_read`]: AsyncRead::poll_read
+    /// [`poll_fill_buf`]: AsyncBufRead::poll_fill_buf
+    fn consume(self: Pin<&mut Self>, amt: usize);
+}
+
+macro_rules! deref_async_buf_read {
+    () => {
+        fn poll_fill_buf<'a>(self: Pin<&'a mut Self>, cx: &mut Context<'_>)
+            -> Poll<io::Result<&'a [u8]>>
+        {
+            Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            Pin::new(&mut **self).consume(amt)
+        }
+    }
+}
+
+impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
+    deref_async_buf_read!();
+}
+
+impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for &mut T {
+    deref_async_buf_read!();
+}
+
+impl<P> AsyncBufRead for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: AsyncBufRead,
+{
+    fn poll_fill_buf<'a>(
+        self: Pin<&'a mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<&'a [u8]>> {
+        self.get_mut().as_mut().poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.get_mut().as_mut().consume(amt)
+    }
+}

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -12,8 +12,10 @@
 //! [found online]: https://tokio.rs/docs/
 //! [low level details]: https://tokio.rs/docs/going-deeper-tokio/core-low-level/
 
+mod async_buf_read;
 mod async_read;
 mod async_write;
 
+pub use self::async_buf_read::AsyncBufRead;
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -40,7 +40,7 @@ default = [
 
 codec = ["io", "tokio-codec"]
 fs = ["tokio-fs"]
-io = ["bytes", "tokio-io", "memchr"]
+io = ["bytes", "tokio-io", "tokio-futures", "memchr"]
 reactor = ["io", "tokio-reactor"]
 rt-full = [
   "num_cpus",
@@ -83,7 +83,7 @@ tracing-core = { version = "0.1", optional = true }
 memchr = { version = "2.2", optional = true }
 
 # Needed for async/await preview support
-#tokio-futures = { version = "0.2.0", optional = true, path = "../tokio-futures" }
+tokio-futures = { version = "0.2.0", optional = true, path = "../tokio-futures" }
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.3.0", optional = true, path = "../tokio-uds" }
@@ -102,3 +102,4 @@ num_cpus = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 time = "0.1"
+futures-util-preview = "0.3.0-alpha.17"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -40,7 +40,7 @@ default = [
 
 codec = ["io", "tokio-codec"]
 fs = ["tokio-fs"]
-io = ["bytes", "tokio-io"]
+io = ["bytes", "tokio-io", "memchr"]
 reactor = ["io", "tokio-reactor"]
 rt-full = [
   "num_cpus",
@@ -80,6 +80,7 @@ tokio-tcp = { version = "0.2.0", optional = true, path = "../tokio-tcp" }
 tokio-udp = { version = "0.2.0", optional = true, path = "../tokio-udp" }
 tokio-timer = { version = "0.3.0", optional = true, path = "../tokio-timer" }
 tracing-core = { version = "0.1", optional = true }
+memchr = { version = "2.2", optional = true }
 
 # Needed for async/await preview support
 #tokio-futures = { version = "0.2.0", optional = true, path = "../tokio-futures" }

--- a/tokio/src/io/async_buf_read_ext.rs
+++ b/tokio/src/io/async_buf_read_ext.rs
@@ -1,6 +1,34 @@
+use crate::io::read_until::{read_until, ReadUntil};
+
 use tokio_io::AsyncBufRead;
 
 /// An extension trait which adds utility methods to `AsyncBufRead` types.
-pub trait AsyncBufReadExt: AsyncBufRead {}
+pub trait AsyncBufReadExt: AsyncBufRead {
+    /// Creates a future which will read all the bytes associated with this I/O
+    /// object into `buf` until the delimiter `byte` or EOF is reached.
+    /// This method is the async equivalent to [`BufRead::read_until`](std::io::BufRead::read_until).
+    ///
+    /// This function will read bytes from the underlying stream until the
+    /// delimiter or EOF is found. Once found, all bytes up to, and including,
+    /// the delimiter (if found) will be appended to `buf`.
+    ///
+    /// The returned future will resolve to the number of bytes read once the read
+    /// operation is completed.
+    ///
+    /// In the case of an error the buffer and the object will be discarded, with
+    /// the error yielded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    fn read_until<'a>(&'a mut self, byte: u8, buf: &'a mut Vec<u8>) -> ReadUntil<'a, Self>
+    where
+        Self: Unpin,
+    {
+        read_until(self, byte, buf)
+    }
+}
 
 impl<R: AsyncBufRead + ?Sized> AsyncBufReadExt for R {}

--- a/tokio/src/io/async_buf_read_ext.rs
+++ b/tokio/src/io/async_buf_read_ext.rs
@@ -1,3 +1,4 @@
+use crate::io::lines::{lines, Lines};
 use crate::io::read_line::{read_line, ReadLine};
 use crate::io::read_until::{read_until, ReadUntil};
 
@@ -65,6 +66,34 @@ pub trait AsyncBufReadExt: AsyncBufRead {
         Self: Unpin,
     {
         read_line(self, buf)
+    }
+
+    /// Returns a stream over the lines of this reader.
+    /// This method is the async equivalent to [`BufRead::lines`](std::io::BufRead::lines).
+    ///
+    /// The stream returned from this function will yield instances of
+    /// [`io::Result`]`<`[`String`]`>`. Each string returned will *not* have a newline
+    /// byte (the 0xA byte) or CRLF (0xD, 0xA bytes) at the end.
+    ///
+    /// [`io::Result`]: std::io::Result
+    /// [`String`]: String
+    ///
+    /// # Errors
+    ///
+    /// Each line of the stream has the same error semantics as [`AsyncBufReadExt::read_line`].
+    ///
+    /// [`AsyncBufReadExt::read_line`]: AsyncBufReadExt::read_line
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    fn lines(self) -> Lines<Self>
+    where
+        Self: Sized,
+    {
+        lines(self)
     }
 }
 

--- a/tokio/src/io/async_buf_read_ext.rs
+++ b/tokio/src/io/async_buf_read_ext.rs
@@ -1,0 +1,6 @@
+use tokio_io::AsyncBufRead;
+
+/// An extension trait which adds utility methods to `AsyncBufRead` types.
+pub trait AsyncBufReadExt: AsyncBufRead {}
+
+impl<R: AsyncBufRead + ?Sized> AsyncBufReadExt for R {}

--- a/tokio/src/io/async_buf_read_ext.rs
+++ b/tokio/src/io/async_buf_read_ext.rs
@@ -1,3 +1,4 @@
+use crate::io::read_line::{read_line, ReadLine};
 use crate::io::read_until::{read_until, ReadUntil};
 
 use tokio_io::AsyncBufRead;
@@ -28,6 +29,42 @@ pub trait AsyncBufReadExt: AsyncBufRead {
         Self: Unpin,
     {
         read_until(self, byte, buf)
+    }
+
+    /// Creates a future which will read all the bytes associated with this I/O
+    /// object into `buf` until a newline (the 0xA byte) or EOF is reached,
+    /// This method is the async equivalent to [`BufRead::read_line`](std::io::BufRead::read_line).
+    ///
+    /// This function will read bytes from the underlying stream until the
+    /// newline delimiter (the 0xA byte) or EOF is found. Once found, all bytes
+    /// up to, and including, the delimiter (if found) will be appended to
+    /// `buf`.
+    ///
+    /// The returned future will resolve to the number of bytes read once the read
+    /// operation is completed.
+    ///
+    /// In the case of an error the buffer and the object will be discarded, with
+    /// the error yielded.
+    ///
+    /// # Errors
+    ///
+    /// This function has the same error semantics as [`read_until`] and will
+    /// also return an error if the read bytes are not valid UTF-8. If an I/O
+    /// error is encountered then `buf` may contain some bytes already read in
+    /// the event that all data read so far was valid UTF-8.
+    ///
+    /// [`read_until`]: AsyncBufReadExt::read_until
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// unimplemented!();
+    /// ```
+    fn read_line<'a>(&'a mut self, buf: &'a mut String) -> ReadLine<'a, Self>
+    where
+        Self: Unpin,
+    {
+        read_line(self, buf)
     }
 }
 

--- a/tokio/src/io/lines.rs
+++ b/tokio/src/io/lines.rs
@@ -1,0 +1,56 @@
+use super::read_line::read_line_internal;
+use std::io;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_futures::Stream;
+use tokio_io::AsyncBufRead;
+
+/// Stream for the [`lines`](crate::io::AsyncBufReadExt::lines) method.
+#[derive(Debug)]
+#[must_use = "streams do nothing unless polled"]
+pub struct Lines<R> {
+    reader: R,
+    buf: String,
+    bytes: Vec<u8>,
+    read: usize,
+}
+
+impl<R: Unpin> Unpin for Lines<R> {}
+
+pub(crate) fn lines<R>(reader: R) -> Lines<R>
+where
+    R: AsyncBufRead,
+{
+    Lines {
+        reader,
+        buf: String::new(),
+        bytes: Vec::new(),
+        read: 0,
+    }
+}
+
+impl<R: AsyncBufRead> Stream for Lines<R> {
+    type Item = io::Result<String>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Self {
+            reader,
+            buf,
+            bytes,
+            read,
+        } = unsafe { self.get_unchecked_mut() };
+        let reader = unsafe { Pin::new_unchecked(reader) };
+        let n = ready!(read_line_internal(reader, cx, buf, bytes, read))?;
+        if n == 0 && buf.is_empty() {
+            return Poll::Ready(None);
+        }
+        if buf.ends_with('\n') {
+            buf.pop();
+            if buf.ends_with('\r') {
+                buf.pop();
+            }
+        }
+        Poll::Ready(Some(Ok(mem::replace(buf, String::new()))))
+    }
+}

--- a/tokio/src/io/lines.rs
+++ b/tokio/src/io/lines.rs
@@ -1,4 +1,5 @@
 use super::read_line::read_line_internal;
+use futures_core::ready;
 use std::io;
 use std::mem;
 use std::pin::Pin;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -42,6 +42,7 @@ mod async_write_ext;
 mod copy;
 mod read;
 mod read_exact;
+mod read_line;
 mod read_to_end;
 mod read_until;
 mod write;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -43,6 +43,7 @@ mod copy;
 mod read;
 mod read_exact;
 mod read_to_end;
+mod read_until;
 mod write;
 mod write_all;
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -36,6 +36,7 @@
 //! [`ErrorKind`]: enum.ErrorKind.html
 //! [`Result`]: type.Result.html
 
+mod async_buf_read_ext;
 mod async_read_ext;
 mod async_write_ext;
 mod copy;
@@ -45,13 +46,14 @@ mod read_to_end;
 mod write;
 mod write_all;
 
+pub use self::async_buf_read_ext::AsyncBufReadExt;
 pub use self::async_read_ext::AsyncReadExt;
 pub use self::async_write_ext::AsyncWriteExt;
 
 // standard input, output, and error
 #[cfg(feature = "fs")]
 pub use tokio_fs::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
-pub use tokio_io::{AsyncRead, AsyncWrite};
+pub use tokio_io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
 // Re-export io::Error so that users don't have to deal
 // with conflicts when `use`ing `tokio::io` and `std::io`.

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -40,6 +40,7 @@ mod async_buf_read_ext;
 mod async_read_ext;
 mod async_write_ext;
 mod copy;
+mod lines;
 mod read;
 mod read_exact;
 mod read_line;

--- a/tokio/src/io/read_line.rs
+++ b/tokio/src/io/read_line.rs
@@ -1,0 +1,70 @@
+use super::read_until::read_until_internal;
+use std::future::Future;
+use std::io;
+use std::mem;
+use std::pin::Pin;
+use std::str;
+use std::task::{Context, Poll};
+use tokio_io::AsyncBufRead;
+
+/// Future for the [`read_line`](crate::io::AsyncBufReadExt::read_line) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ReadLine<'a, R: ?Sized + Unpin> {
+    reader: &'a mut R,
+    buf: &'a mut String,
+    bytes: Vec<u8>,
+    read: usize,
+}
+
+impl<R: ?Sized + Unpin> Unpin for ReadLine<'_, R> {}
+
+pub(crate) fn read_line<'a, R>(reader: &'a mut R, buf: &'a mut String) -> ReadLine<'a, R>
+where
+    R: AsyncBufRead + ?Sized + Unpin,
+{
+    ReadLine {
+        reader,
+        bytes: unsafe { mem::replace(buf.as_mut_vec(), Vec::new()) },
+        buf,
+        read: 0,
+    }
+}
+
+pub(super) fn read_line_internal<R: AsyncBufRead + ?Sized>(
+    reader: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    buf: &mut String,
+    bytes: &mut Vec<u8>,
+    read: &mut usize,
+) -> Poll<io::Result<usize>> {
+    let ret = ready!(read_until_internal(reader, cx, b'\n', bytes, read));
+    if str::from_utf8(&bytes).is_err() {
+        Poll::Ready(ret.and_then(|_| {
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "stream did not contain valid UTF-8",
+            ))
+        }))
+    } else {
+        debug_assert!(buf.is_empty());
+        debug_assert_eq!(*read, 0);
+        // Safety: `bytes` is a valid UTF-8 because `str::from_utf8` returned `Ok`.
+        mem::swap(unsafe { buf.as_mut_vec() }, bytes);
+        Poll::Ready(ret)
+    }
+}
+
+impl<R: AsyncBufRead + ?Sized + Unpin> Future for ReadLine<'_, R> {
+    type Output = io::Result<usize>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Self {
+            reader,
+            buf,
+            bytes,
+            read,
+        } = &mut *self;
+        read_line_internal(Pin::new(reader), cx, buf, bytes, read)
+    }
+}

--- a/tokio/src/io/read_line.rs
+++ b/tokio/src/io/read_line.rs
@@ -1,4 +1,5 @@
 use super::read_until::read_until_internal;
+use futures_core::ready;
 use std::future::Future;
 use std::io;
 use std::mem;

--- a/tokio/src/io/read_until.rs
+++ b/tokio/src/io/read_until.rs
@@ -1,3 +1,4 @@
+use futures_core::ready;
 use std::future::Future;
 use std::io;
 use std::mem;

--- a/tokio/src/io/read_until.rs
+++ b/tokio/src/io/read_until.rs
@@ -1,0 +1,74 @@
+use std::future::Future;
+use std::io;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_io::AsyncBufRead;
+
+/// Future for the [`read_until`](crate::io::AsyncBufReadExt::read_until) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct ReadUntil<'a, R: ?Sized + Unpin> {
+    reader: &'a mut R,
+    byte: u8,
+    buf: &'a mut Vec<u8>,
+    read: usize,
+}
+
+impl<R: ?Sized + Unpin> Unpin for ReadUntil<'_, R> {}
+
+pub(crate) fn read_until<'a, R>(
+    reader: &'a mut R,
+    byte: u8,
+    buf: &'a mut Vec<u8>,
+) -> ReadUntil<'a, R>
+where
+    R: AsyncBufRead + ?Sized + Unpin,
+{
+    ReadUntil {
+        reader,
+        byte,
+        buf,
+        read: 0,
+    }
+}
+
+pub(super) fn read_until_internal<R: AsyncBufRead + ?Sized>(
+    mut reader: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    byte: u8,
+    buf: &mut Vec<u8>,
+    read: &mut usize,
+) -> Poll<io::Result<usize>> {
+    loop {
+        let (done, used) = {
+            let available = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            if let Some(i) = memchr::memchr(byte, available) {
+                buf.extend_from_slice(&available[..=i]);
+                (true, i + 1)
+            } else {
+                buf.extend_from_slice(available);
+                (false, available.len())
+            }
+        };
+        reader.as_mut().consume(used);
+        *read += used;
+        if done || used == 0 {
+            return Poll::Ready(Ok(mem::replace(read, 0)));
+        }
+    }
+}
+
+impl<R: AsyncBufRead + ?Sized + Unpin> Future for ReadUntil<'_, R> {
+    type Output = io::Result<usize>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let Self {
+            reader,
+            byte,
+            buf,
+            read,
+        } = &mut *self;
+        read_until_internal(Pin::new(reader), cx, *byte, buf, read)
+    }
+}

--- a/tokio/tests/io_lines.rs
+++ b/tokio/tests/io_lines.rs
@@ -1,0 +1,53 @@
+#![deny(warnings, rust_2018_idioms)]
+#![feature(async_await)]
+
+use futures_util::StreamExt;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
+use tokio_test::assert_ok;
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[tokio::test]
+async fn lines() {
+    struct Rd {
+        val: &'static [u8],
+    }
+
+    impl AsyncRead for Rd {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            unimplemented!()
+        }
+    }
+
+    impl AsyncBufRead for Rd {
+        fn poll_fill_buf<'a>(
+            self: Pin<&'a mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<io::Result<&'a [u8]>> {
+            Poll::Ready(Ok(self.val))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            self.val = &self.val[amt..];
+        }
+    }
+
+    let rd = Rd {
+        val: b"hello\r\nworld\n\n",
+    };
+    let mut st = rd.lines();
+
+    let b = assert_ok!(st.next().await.unwrap());
+    assert_eq!(b, "hello");
+    let b = assert_ok!(st.next().await.unwrap());
+    assert_eq!(b, "world");
+    let b = assert_ok!(st.next().await.unwrap());
+    assert_eq!(b, "");
+    assert!(st.next().await.is_none());
+}

--- a/tokio/tests/io_read_line.rs
+++ b/tokio/tests/io_read_line.rs
@@ -1,0 +1,60 @@
+#![deny(warnings, rust_2018_idioms)]
+#![feature(async_await)]
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
+use tokio_test::assert_ok;
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[tokio::test]
+async fn read_line() {
+    struct Rd {
+        val: &'static [u8],
+    }
+
+    impl AsyncRead for Rd {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            unimplemented!()
+        }
+    }
+
+    impl AsyncBufRead for Rd {
+        fn poll_fill_buf<'a>(
+            self: Pin<&'a mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<io::Result<&'a [u8]>> {
+            Poll::Ready(Ok(self.val))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            self.val = &self.val[amt..];
+        }
+    }
+
+    let mut buf = String::new();
+    let mut rd = Rd {
+        val: b"hello\nworld\n\n",
+    };
+
+    let n = assert_ok!(rd.read_line(&mut buf).await);
+    assert_eq!(n, 6);
+    assert_eq!(buf, "hello\n");
+    buf.clear();
+    let n = assert_ok!(rd.read_line(&mut buf).await);
+    assert_eq!(n, 6);
+    assert_eq!(buf, "world\n");
+    buf.clear();
+    let n = assert_ok!(rd.read_line(&mut buf).await);
+    assert_eq!(n, 1);
+    assert_eq!(buf, "\n");
+    buf.clear();
+    let n = assert_ok!(rd.read_line(&mut buf).await);
+    assert_eq!(n, 0);
+    assert_eq!(buf, "");
+}

--- a/tokio/tests/io_read_until.rs
+++ b/tokio/tests/io_read_until.rs
@@ -1,0 +1,56 @@
+#![deny(warnings, rust_2018_idioms)]
+#![feature(async_await)]
+
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
+use tokio_test::assert_ok;
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[tokio::test]
+async fn read_until() {
+    struct Rd {
+        val: &'static [u8],
+    }
+
+    impl AsyncRead for Rd {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            _: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            unimplemented!()
+        }
+    }
+
+    impl AsyncBufRead for Rd {
+        fn poll_fill_buf<'a>(
+            self: Pin<&'a mut Self>,
+            _: &mut Context<'_>,
+        ) -> Poll<io::Result<&'a [u8]>> {
+            Poll::Ready(Ok(self.val))
+        }
+
+        fn consume(mut self: Pin<&mut Self>, amt: usize) {
+            self.val = &self.val[amt..];
+        }
+    }
+
+    let mut buf = vec![];
+    let mut rd = Rd {
+        val: b"hello world",
+    };
+
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 6);
+    assert_eq!(buf, b"hello ");
+    buf.clear();
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf, b"world");
+    buf.clear();
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 0);
+    assert_eq!(buf, []);
+}


### PR DESCRIPTION
This adds the following items:

* Add AsyncBufRead - An async equivalent to io::BufRead
* Add AsyncBufReadExt::read_until - An async equivalent to io::BufRead::read_until
* Add AsyncBufReadExt::read_line - An async equivalent to io::BufRead::read_line
* Add AsyncBufReadExt::lines - An async equivalent to io::BufRead::lines

The implementations are almost identical to the ones I added in futures-rs (https://github.com/rust-lang-nursery/futures-rs/pull/1552, https://github.com/rust-lang-nursery/futures-rs/pull/1556, https://github.com/rust-lang-nursery/futures-rs/pull/1585).

cc #1203

r? @carllerche 