### PR TITLE
chore: update rand dependency to 0.7

### DIFF
--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -30,7 +30,7 @@ tokio-io = { version = "0.2.0", path = "../tokio-io" }
 tokio-futures = { version = "0.2.0", path = "../tokio-futures" }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"
 tempfile = "3"
 tempdir = "0.3"
 tokio-codec = { version = "0.2.0", path = "../tokio-codec" }

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -31,7 +31,7 @@ crossbeam-deque = "0.7.0"
 crossbeam-queue = "0.1.0"
 crossbeam-utils = "0.6.4"
 num_cpus = "1.2"
-rand = "0.6"
+rand = "0.7"
 slab = "0.4.1"
 log = "0.4"
 

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -36,7 +36,7 @@ slab = "0.4.1"
 futures-core-preview = { version = "0.3.0-alpha.17", optional = true }
 
 [dev-dependencies]
-rand = "0.6"
+rand = "0.7"
 tokio = { version = "0.2.0", path = "../tokio" }
 tokio-current-thread = { version = "0.2.0", path = "../tokio-current-thread" }
 tokio-sync = { version = "0.2.0", path = "../tokio-sync", features = ["async-traits"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`rand` has removed some dependencies in version 0.7: https://github.com/rust-random/rand/blob/master/CHANGELOG.md#070---2019-06-28
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
