### PR TITLE
udp: add `try_clone` to `UdpSocket` (#1307)

### DIFF
--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -436,6 +436,15 @@ impl UdpSocket {
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v6(multiaddr, interface)
     }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// The returned `UdpSocket` is a reference to the same socket that this
+    /// object references. Both handles will read and write the same port, and
+    /// options set on one socket will be propagated to the other.
+    pub fn try_clone(&self) -> io::Result<UdpSocket> {
+        self.io.get_ref().try_clone().map(UdpSocket::new)
+    }
 }
 
 impl TryFrom<UdpSocket> for mio::net::UdpSocket {


### PR DESCRIPTION
Adding implementation of `try_clone` that just uses the existing
`mio::net::UdpSocket`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
