### PR TITLE
fs: replace deprecated tempdir crate use in tests

### DIFF
--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -32,7 +32,6 @@ tokio-futures = { version = "0.2.0", path = "../tokio-futures" }
 [dev-dependencies]
 rand = "0.7"
 tempfile = "3"
-tempdir = "0.3"
 tokio-codec = { version = "0.2.0", path = "../tokio-codec" }
 tokio = { version = "0.2.0", path = "../tokio" }
 futures-channel-preview = "0.3.0-alpha.17"

--- a/tokio-fs/tests/dir.rs
+++ b/tokio-fs/tests/dir.rs
@@ -5,14 +5,14 @@ use futures_util::future;
 use futures_util::try_stream::TryStreamExt;
 use std::fs;
 use std::sync::{Arc, Mutex};
-use tempdir::TempDir;
+use tempfile::tempdir;
 use tokio_fs::*;
 
 mod pool;
 
 #[test]
 fn create() {
-    let base_dir = TempDir::new("base").unwrap();
+    let base_dir = tempdir().unwrap();
     let new_dir = base_dir.path().join("foo");
     let new_dir_2 = new_dir.clone();
 
@@ -26,7 +26,7 @@ fn create() {
 
 #[test]
 fn create_all() {
-    let base_dir = TempDir::new("base").unwrap();
+    let base_dir = tempdir().unwrap();
     let new_dir = base_dir.path().join("foo").join("bar");
     let new_dir_2 = new_dir.clone();
 
@@ -40,7 +40,7 @@ fn create_all() {
 
 #[test]
 fn remove() {
-    let base_dir = TempDir::new("base").unwrap();
+    let base_dir = tempdir().unwrap();
     let new_dir = base_dir.path().join("foo");
     let new_dir_2 = new_dir.clone();
 
@@ -56,7 +56,7 @@ fn remove() {
 
 #[test]
 fn read() {
-    let base_dir = TempDir::new("base").unwrap();
+    let base_dir = tempdir().unwrap();
 
     let p = base_dir.path();
     fs::create_dir(p.join("aa")).unwrap();

--- a/tokio-fs/tests/link.rs
+++ b/tokio-fs/tests/link.rs
@@ -4,14 +4,14 @@
 use std::fs;
 use std::io::prelude::*;
 use std::io::BufReader;
-use tempdir::TempDir;
+use tempfile::tempdir;
 use tokio_fs::*;
 
 mod pool;
 
 #[test]
 fn test_hard_link() {
-    let dir = TempDir::new("base").unwrap();
+    let dir = tempdir().unwrap();
     let src = dir.path().join("src.txt");
     let dst = dir.path().join("dst.txt");
 
@@ -41,7 +41,7 @@ fn test_hard_link() {
 #[cfg(unix)]
 #[test]
 fn test_symlink() {
-    let dir = TempDir::new("base").unwrap();
+    let dir = tempdir().unwrap();
     let src = dir.path().join("src.txt");
     let dst = dir.path().join("dst.txt");
 


### PR DESCRIPTION
In particular because it pulls in old rand duplicates. Replace use with `tempfile::tempdir()` which has been available since _tempfile_ 3.0.0.

The deprecated _tempdir_ crate dev  dependency was previously removed (for tokio-fs and others) in 31f71ded (#533) but was reintroduced here in 9153067d (#724).