### PR TITLE
timer: impl Into<std::io::Error> for Elpased

### DIFF
--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -220,3 +220,9 @@ impl fmt::Display for Elapsed {
 }
 
 impl std::error::Error for Elapsed {}
+
+impl Into<std::io::Error> for Elapsed {
+    fn into(self) -> std::io::Error {
+        std::io::ErrorKind::TimedOut.into()
+    }
+}


### PR DESCRIPTION
That converts `Elpased` into `ErrorKind::TimedOut`.