### PR TITLE
timer: change Into to From trait for Elpased

### DIFF
--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -221,8 +221,8 @@ impl fmt::Display for Elapsed {
 
 impl std::error::Error for Elapsed {}
 
-impl Into<std::io::Error> for Elapsed {
-    fn into(self) -> std::io::Error {
+impl From<Elapsed> for std::io::Error {
+    fn from(_err: Elapsed) -> std::io::Error {
         std::io::ErrorKind::TimedOut.into()
     }
 }


### PR DESCRIPTION
Just recognized that implementing `Into` doesn't imply `From`, and I actually can implement `From` here.
The `?` operator seems only look for `From`, not `Into`.