### PR TITLE
Remove last non-dev dependency on rand crate

### DIFF
--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -32,11 +32,11 @@ crossbeam-deque = "0.7.0"
 crossbeam-queue = "0.1.0"
 crossbeam-utils = "0.6.4"
 num_cpus = "1.2"
-rand = "0.7"
 slab = "0.4.1"
 log = "0.4"
 
 [dev-dependencies]
+rand = "0.7"
 env_logger = "0.5"
 async-util = { git = "https://github.com/tokio-rs/async" }
 tokio = { version = "0.2.0", path = "../tokio" }

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -34,6 +34,7 @@ crossbeam-utils = "0.6.4"
 num_cpus = "1.2"
 slab = "0.4.1"
 log = "0.4"
+lazy_static = "1"
 
 [dev-dependencies]
 rand = "0.7"

--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -453,7 +453,6 @@ unsafe impl Sync for Pool {}
 // PRNG. This uses one libstd RandomState for a default hasher and hashes on
 // the current thread ID to obtain an unpredictable, collistion resitant seed.
 fn prng_seed() -> u32 {
-
     // This obtains a small number of random bytes from the host system (for
     // example, on unix via getrandom(2)) in order to seed an unpredictable and
     // HashDoS resistant 64-bit hash function (currently: `SipHasher13` with

--- a/tokio-threadpool/src/pool/mod.rs
+++ b/tokio-threadpool/src/pool/mod.rs
@@ -451,7 +451,7 @@ unsafe impl Sync for Pool {}
 
 // Return a thread-specific, 32-bit, non-zero seed value suitable for a 32-bit
 // PRNG. This uses one libstd RandomState for a default hasher and hashes on
-// the current thread ID to obtain an unpredictable, collistion resitant seed.
+// the current thread ID to obtain an unpredictable, collision resistant seed.
 fn prng_seed() -> u32 {
     // This obtains a small number of random bytes from the host system (for
     // example, on unix via getrandom(2)) in order to seed an unpredictable and


### PR DESCRIPTION
## Motivation

Minimizing dependencies to reduce build size and time for typical tokio applications.

## Background

In _parking_lot_ 0.9.0 (upgraded here recently in #1298) the _rand_ dependency was replaced entirely with its own private Xorshift PRNG, used for its fairness mechanism.

The _tokio-threadpool_ also has its own Xorshift PRNG for "fair" work stealing, introduced in #466 as a performance improvement. However the _rand_ dependency was kept, its use limited to producing the initial seeds for the thread local Xorshift PRNGs.  This is currently the only existing non-dev dependency on _rand_, direct or transitive, in tokio.  As mentioned, _parking_lot_ no longer depends on _rand_, and tempfile (_rand_ dep) is also only a dev dependency.

## Solution

This PR changes the seed generation to piggyback on libstd's mechanism for obtaining system randomness for the default hasher (as used by HashMap for HashDoS resistance), and hashing on the current thread id. Based on some `eprintln` testing of seeds and Xorshift output, this strategy appears more than adequate for the use case of approximating fairness.

cc: @carllerche @stjepang @Amanieu @faern
