### PR TITLE
signal: change unix::Signal to return () instead of signum

### DIFF
--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Changed
 - **Breaking:** `windows::Event` has been removed in favor of `CtrlC` and
 a separate `windows::CtrlBreak` struct.
+- **Breaking:** `ctrl_c{,_with_handle}` has been replaced with a `CtrlC` struct
+(which can be constructed via `CtrlC::{new, with_handle}`.
+- **Breaking:** `unix::Signal` returns `()` instead of the signal number used in registration
 
 # 0.2.9
 

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -11,8 +11,8 @@ mod platform {
 
     pub async fn main() {
         // Create a stream for each of the signals we'd like to handle.
-        let sigint = Signal::new(SIGINT).await.unwrap();
-        let sigterm = Signal::new(SIGTERM).await.unwrap();
+        let sigint = Signal::new(SIGINT).await.unwrap().map(|_| SIGINT);
+        let sigterm = Signal::new(SIGTERM).await.unwrap().map(|_| SIGTERM);
 
         // Use the `select` combinator to merge these two streams into one
         let stream = stream::select(sigint, sigterm);

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -20,12 +20,8 @@ mod platform {
 
         // Up until now, we haven't really DONE anything, just prepared
         // our futures, now it's time to actually await the results!
-        while let Some(the_signal) = stream.next().await {
-            println!(
-                "*Got signal {:#x}* I should probably reload my config \
-                 or something",
-                the_signal
-            );
+        while let Some(_) = stream.next().await {
+            println!("*Got signal* I should probably reload my config or something");
         }
     }
 }

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -254,7 +254,6 @@ impl Driver {
 #[derive(Debug)]
 pub struct Signal {
     driver: Driver,
-    signal: c_int,
     rx: Receiver<()>,
 }
 
@@ -321,7 +320,7 @@ impl Signal {
             let (tx, rx) = channel(1);
             globals().register_listener(signal as EventId, tx);
 
-            Ok(Signal { driver, rx, signal })
+            Ok(Signal { driver, rx })
         })
         .boxed()
     }
@@ -332,12 +331,12 @@ impl Signal {
 }
 
 impl Stream for Signal {
-    type Item = c_int;
+    type Item = ();
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let _ = Pin::new(&mut self.driver).poll(cx);
 
-        self.rx.poll_recv(cx).map(|item| item.map(|()| self.signal))
+        self.rx.poll_recv(cx)
     }
 }
 

--- a/tokio-signal/tests/twice.rs
+++ b/tokio-signal/tests/twice.rs
@@ -16,8 +16,8 @@ async fn twice() {
     for _ in 0..2 {
         send_signal(libc::SIGUSR1);
 
-        let (num, sig) = with_timeout(signal.into_future()).await;
-        assert_eq!(num, Some(libc::SIGUSR1));
+        let (item, sig) = with_timeout(signal.into_future()).await;
+        assert_eq!(item, Some(()));
 
         signal = sig;
     }


### PR DESCRIPTION
* This simplifies the API surface by returning () instead of the signal
number that was used during registration. This also more closely mirrors
the cross-platform `CtrlC` event stream API
* This is a **breaking change**
* Refs #1243 