### PR TITLE
signal: replace `windows::Event` with `windows::CtrlBreak`

### DIFF
--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0
+
+### Changed
+- **Breaking:** `windows::Event` has been removed in favor of `CtrlC` and
+a separate `windows::CtrlBreak` struct.
+
 # 0.2.9
 
 ### Fixed

--- a/tokio-signal/src/ctrl_c.rs
+++ b/tokio-signal/src/ctrl_c.rs
@@ -20,6 +20,11 @@ use tokio_reactor::Handle;
 /// Note that there are a number of caveats listening for signals, and you may
 /// wish to read up on the documentation in the `unix` or `windows` module to
 /// take a peek.
+///
+/// Notably, a notification to this process notifies *all* streams listening to
+/// this event. Moreover, the notifications **are coalesced** if they aren't processed
+/// quickly enough. This means that if two notifications are received back-to-back,
+/// then the stream may only receive one item about the two notifications.
 #[must_use = "streams do nothing unless polled"]
 #[derive(Debug)]
 pub struct CtrlC {
@@ -39,7 +44,7 @@ impl CtrlC {
     /// process.
     ///
     /// This function binds to reactor specified by `handle`.
-    pub fn with_handle(handle: &Handle) -> IoFuture<CtrlC> {
+    pub fn with_handle(handle: &Handle) -> IoFuture<Self> {
         Inner::ctrl_c(handle).map_ok(|inner| Self { inner }).boxed()
     }
 }

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -85,7 +85,6 @@
 extern crate lazy_static;
 
 use futures_core::future::Future;
-use futures_core::stream::Stream;
 use std::io;
 use std::pin::Pin;
 
@@ -104,7 +103,5 @@ pub mod windows;
 
 /// A future whose output is `io::Result<T>`
 pub type IoFuture<T> = Pin<Box<dyn Future<Output = io::Result<T>> + Send>>;
-/// A stream whose item is `io::Result<T>`
-pub type IoStream<T> = Pin<Box<dyn Stream<Item = io::Result<T>> + Send>>;
 
 pub use ctrl_c::CtrlC;


### PR DESCRIPTION
* Add a new `windows::CtrlBreak` struct which wil represent a stream of
CTRL_BREAK_EVENT signals on Windows systems
* The `windows::Event` type is no longer publicly accessible and is
replaced by using `CtrlC` or `windows::CtrlBreak`.
* This is a **breaking change**
* Refs #1243 