### PR TITLE
chore: remove redundant field names in struct literals

### DIFF
--- a/tokio-codec/src/framed.rs
+++ b/tokio-codec/src/framed.rs
@@ -144,8 +144,8 @@ impl<T, U> Framed<T, U> {
         FramedParts {
             io: inner.0,
             codec: inner.1,
-            read_buf: read_buf,
-            write_buf: write_buf,
+            read_buf,
+            write_buf,
             _priv: (),
         }
     }

--- a/tokio-codec/src/framed_read.rs
+++ b/tokio-codec/src/framed_read.rs
@@ -138,7 +138,7 @@ where
 
 pub fn framed_read2<T>(inner: T) -> FramedRead2<T> {
     FramedRead2 {
-        inner: inner,
+        inner,
         eof: false,
         is_readable: false,
         buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
@@ -151,7 +151,7 @@ pub fn framed_read2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedRead2<T
         buf.reserve(bytes_to_reserve);
     }
     FramedRead2 {
-        inner: inner,
+        inner,
         eof: false,
         is_readable: buf.len() > 0,
         buffer: buf,

--- a/tokio-codec/src/framed_write.rs
+++ b/tokio-codec/src/framed_write.rs
@@ -138,7 +138,7 @@ where
 
 pub fn framed_write2<T>(inner: T) -> FramedWrite2<T> {
     FramedWrite2 {
-        inner: inner,
+        inner,
         buffer: BytesMut::with_capacity(INITIAL_CAPACITY),
     }
 }
@@ -148,10 +148,7 @@ pub fn framed_write2_with_buffer<T>(inner: T, mut buf: BytesMut) -> FramedWrite2
         let bytes_to_reserve = INITIAL_CAPACITY - buf.capacity();
         buf.reserve(bytes_to_reserve);
     }
-    FramedWrite2 {
-        inner: inner,
-        buffer: buf,
-    }
+    FramedWrite2 { inner, buffer: buf }
 }
 
 impl<T> FramedWrite2<T> {

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -268,7 +268,7 @@ impl<P: Park> CurrentThread<P> {
         let num_futures = Arc::new(atomic::AtomicUsize::new(0));
 
         CurrentThread {
-            scheduler: scheduler,
+            scheduler,
             num_futures: num_futures.clone(),
             park,
             id,
@@ -279,7 +279,7 @@ impl<P: Park> CurrentThread<P> {
                 thread,
                 id,
             },
-            spawn_receiver: spawn_receiver,
+            spawn_receiver,
         }
     }
 

--- a/tokio-current-thread/src/scheduler.rs
+++ b/tokio-current-thread/src/scheduler.rs
@@ -147,11 +147,11 @@ where
             tick_num: AtomicUsize::new(0),
             head_readiness: AtomicPtr::new(stub_ptr as *mut _),
             tail_readiness: UnsafeCell::new(stub_ptr),
-            stub: stub,
+            stub,
         });
 
         Scheduler {
-            inner: inner,
+            inner,
             nodes: List::new(),
         }
     }

--- a/tokio-fs/src/create_dir.rs
+++ b/tokio-fs/src/create_dir.rs
@@ -30,7 +30,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P) -> CreateDirFuture<P> {
-        CreateDirFuture { path: path }
+        CreateDirFuture { path }
     }
 }
 

--- a/tokio-fs/src/create_dir_all.rs
+++ b/tokio-fs/src/create_dir_all.rs
@@ -31,7 +31,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P) -> CreateDirAllFuture<P> {
-        CreateDirAllFuture { path: path }
+        CreateDirAllFuture { path }
     }
 }
 

--- a/tokio-fs/src/hard_link.rs
+++ b/tokio-fs/src/hard_link.rs
@@ -36,7 +36,7 @@ where
     Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> HardLinkFuture<P, Q> {
-        HardLinkFuture { src: src, dst: dst }
+        HardLinkFuture { src, dst }
     }
 }
 

--- a/tokio-fs/src/os/unix.rs
+++ b/tokio-fs/src/os/unix.rs
@@ -36,7 +36,7 @@ where
     Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkFuture<P, Q> {
-        SymlinkFuture { src: src, dst: dst }
+        SymlinkFuture { src, dst }
     }
 }
 

--- a/tokio-fs/src/os/windows/symlink_dir.rs
+++ b/tokio-fs/src/os/windows/symlink_dir.rs
@@ -35,7 +35,7 @@ where
     Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkDirFuture<P, Q> {
-        SymlinkDirFuture { src: src, dst: dst }
+        SymlinkDirFuture { src, dst }
     }
 }
 

--- a/tokio-fs/src/os/windows/symlink_file.rs
+++ b/tokio-fs/src/os/windows/symlink_file.rs
@@ -35,7 +35,7 @@ where
     Q: AsRef<Path>,
 {
     fn new(src: P, dst: Q) -> SymlinkFileFuture<P, Q> {
-        SymlinkFileFuture { src: src, dst: dst }
+        SymlinkFileFuture { src, dst }
     }
 }
 

--- a/tokio-fs/src/read_dir.rs
+++ b/tokio-fs/src/read_dir.rs
@@ -37,7 +37,7 @@ where
     P: AsRef<Path> + Send + 'static,
 {
     fn new(path: P) -> ReadDirFuture<P> {
-        ReadDirFuture { path: path }
+        ReadDirFuture { path }
     }
 }
 

--- a/tokio-fs/src/read_link.rs
+++ b/tokio-fs/src/read_link.rs
@@ -30,7 +30,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P) -> ReadLinkFuture<P> {
-        ReadLinkFuture { path: path }
+        ReadLinkFuture { path }
     }
 }
 

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -30,7 +30,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P) -> RemoveDirFuture<P> {
-        RemoveDirFuture { path: path }
+        RemoveDirFuture { path }
     }
 }
 

--- a/tokio-fs/src/remove_file.rs
+++ b/tokio-fs/src/remove_file.rs
@@ -34,7 +34,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P) -> RemoveFileFuture<P> {
-        RemoveFileFuture { path: path }
+        RemoveFileFuture { path }
     }
 }
 

--- a/tokio-fs/src/rename.rs
+++ b/tokio-fs/src/rename.rs
@@ -36,7 +36,7 @@ where
     Q: AsRef<Path>,
 {
     fn new(from: P, to: Q) -> RenameFuture<P, Q> {
-        RenameFuture { from: from, to: to }
+        RenameFuture { from, to }
     }
 }
 

--- a/tokio-fs/src/set_permissions.rs
+++ b/tokio-fs/src/set_permissions.rs
@@ -31,10 +31,7 @@ where
     P: AsRef<Path>,
 {
     fn new(path: P, perm: fs::Permissions) -> SetPermissionsFuture<P> {
-        SetPermissionsFuture {
-            path: path,
-            perm: perm,
-        }
+        SetPermissionsFuture { path, perm }
     }
 }
 

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -224,7 +224,7 @@ impl Reactor {
             events: mio::Events::with_capacity(1024),
             _wakeup_registration: wakeup_pair.0,
             inner: Arc::new(Inner {
-                io: io,
+                io,
                 next_aba_guard: AtomicUsize::new(0),
                 io_dispatch: RwLock::new(Slab::with_capacity(1)),
                 wakeup: wakeup_pair.1,

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -195,7 +195,7 @@ impl Driver {
         let stream = globals().receiver.try_clone()?;
         let wakeup = PollEvented::new_with_handle(stream, handle)?;
 
-        Ok(Driver { wakeup: wakeup })
+        Ok(Driver { wakeup })
     }
 
     /// Drain all data in the global receiver, ensuring we'll get woken up when
@@ -321,11 +321,7 @@ impl Signal {
             let (tx, rx) = channel(1);
             globals().register_listener(signal as EventId, tx);
 
-            Ok(Signal {
-                driver: driver,
-                rx: rx,
-                signal: signal,
-            })
+            Ok(Signal { driver, rx, signal })
         })
         .boxed()
     }

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -304,7 +304,7 @@ impl<T> Clone for Receiver<T> {
         let ver = self.ver;
 
         Receiver {
-            shared: shared,
+            shared,
             inner,
             id,
             ver,

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -154,7 +154,7 @@ impl TcpStream {
             Err(e) => Error(e),
         };
 
-        ConnectFuture { inner: inner }
+        ConnectFuture { inner }
     }
 
     /// Check the TCP stream's read readiness state.

--- a/tokio-threadpool/src/task/blocking.rs
+++ b/tokio-threadpool/src/task/blocking.rs
@@ -100,7 +100,7 @@ impl Blocking {
         Blocking {
             state: AtomicUsize::new(init.into()),
             tail: UnsafeCell::new(ptr),
-            stub: stub,
+            stub,
             lock: AtomicUsize::new(0),
         }
     }

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -27,7 +27,7 @@ impl<T> Throttle<T> {
         Self {
             delay: Delay::new_timeout(clock::now() + duration, duration),
             has_delayed: true,
-            stream: stream,
+            stream,
         }
     }
 }

--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -24,7 +24,7 @@ impl UdpSocket {
 
     fn new(socket: mio::net::UdpSocket) -> UdpSocket {
         let io = PollEvented::new(socket);
-        UdpSocket { io: io }
+        UdpSocket { io }
     }
 
     /// Creates a new `UdpSocket` from the previously bound socket provided.

--- a/tokio/benches/tcp.rs
+++ b/tokio/benches/tcp.rs
@@ -215,7 +215,7 @@ mod transfer {
                 .and_then(|sock| {
                     sock.set_linger(Some(Duration::from_secs(0))).unwrap();
                     let drain = Drain {
-                        sock: sock,
+                        sock,
                         chunk: read_size,
                     };
                     drain
@@ -226,7 +226,7 @@ mod transfer {
 
             let client = TcpStream::connect(&addr)
                 .and_then(move |sock| Transfer {
-                    sock: sock,
+                    sock,
                     rem: MB,
                     chunk: write_size,
                 })

--- a/tokio/examples/echo-udp.rs
+++ b/tokio/examples/echo-udp.rs
@@ -58,7 +58,7 @@ async fn main() {
     println!("Listening on: {}", socket.local_addr().unwrap());
 
     let server = Server {
-        socket: socket,
+        socket,
         buf: vec![0; 1024],
         to_send: None,
     };


### PR DESCRIPTION
rustfmt provides a convenient way to do this: https://github.com/rust-lang/rustfmt/blob/master/Configurations.md#use_field_init_shorthand