### PR TITLE
macros: Detect double test attribute

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -121,6 +121,16 @@ pub fn test(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let body = &input.block;
     let attrs = &input.attrs;
 
+    for attr in attrs {
+        if attr.path.is_ident("test") {
+            let tokens = quote_spanned! { input.span() =>
+                compile_error!("second test attribute is supplied");
+            };
+
+            return TokenStream::from(tokens);
+        }
+    }
+
     if input.asyncness.is_none() {
         let tokens = quote_spanned! { input.span() =>
           compile_error!("the async keyword is missing from the function declaration");


### PR DESCRIPTION
 Just in case adds compile error if user try to supply `test` attribute, as it would lead to confusing output in `cargo test`

I made such mistake myself actually, so thought it would be nice to throw error to notify user