### PR TITLE
signal: Change constructors to return a result instead of lazy future

### DIFF
--- a/tokio-process/tests/stdio.rs
+++ b/tokio-process/tests/stdio.rs
@@ -13,7 +13,6 @@ use std::process::{Command, ExitStatus, Stdio};
 use futures_util::future;
 use futures_util::future::FutureExt;
 use futures_util::io::AsyncBufReadExt;
-use futures_util::io::AsyncReadExt;
 use futures_util::io::AsyncWriteExt;
 use futures_util::io::BufReader;
 use futures_util::stream::{self, StreamExt};

--- a/tokio-signal/CHANGELOG.md
+++ b/tokio-signal/CHANGELOG.md
@@ -6,6 +6,7 @@ a separate `windows::CtrlBreak` struct.
 - **Breaking:** `ctrl_c{,_with_handle}` has been replaced with a `CtrlC` struct
 (which can be constructed via `CtrlC::{new, with_handle}`.
 - **Breaking:** `unix::Signal` returns `()` instead of the signal number used in registration
+- **Breaking:** `unis::Signal` constructors now return a simple result rather than a lazy future
 
 # 0.2.9
 

--- a/tokio-signal/examples/ctrl-c.rs
+++ b/tokio-signal/examples/ctrl-c.rs
@@ -10,10 +10,7 @@ const STOP_AFTER: u64 = 10;
 async fn main() {
     // tokio_signal provides a convenience builder for Ctrl+C
     // this even works cross-platform: linux and windows!
-    //
-    // `CtrlC::new()` produces a `Future` of the actual stream-initialisation
-    // so first we await until the signal is ready.
-    let endless_stream = tokio_signal::CtrlC::new().await.unwrap();
+    let endless_stream = tokio_signal::CtrlC::new().expect("failed to create CtrlC");
     // don't keep going forever: convert the endless stream to a bounded one.
     let mut limited_stream = endless_stream.take(STOP_AFTER);
 

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -11,8 +11,8 @@ mod platform {
 
     pub async fn main() {
         // Create a stream for each of the signals we'd like to handle.
-        let sigint = Signal::new(SIGINT).await.unwrap().map(|_| SIGINT);
-        let sigterm = Signal::new(SIGTERM).await.unwrap().map(|_| SIGTERM);
+        let sigint = Signal::new(SIGINT).unwrap().map(|_| SIGINT);
+        let sigterm = Signal::new(SIGTERM).unwrap().map(|_| SIGTERM);
 
         // Use the `select` combinator to merge these two streams into one
         let stream = stream::select(sigint, sigterm);

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -9,7 +9,7 @@ mod platform {
 
     pub async fn main() {
         // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
-        let mut stream = Signal::new(SIGHUP).await.unwrap();
+        let mut stream = Signal::new(SIGHUP).unwrap();
 
         println!("Waiting for SIGHUPS (Ctrl+C to quit)");
         println!(

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -33,7 +33,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create an infinite stream of "Ctrl+C" notifications. Each item received
 //!     // on this stream may represent multiple ctrl-c signals.
-//!     let ctrl_c = tokio_signal::CtrlC::new().await?;
+//!     let ctrl_c = tokio_signal::CtrlC::new()?;
 //!
 //!     // Process each ctrl-c as it comes in
 //!     let prog = ctrl_c.for_each(|_| {
@@ -60,7 +60,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create an infinite stream of "Ctrl+C" notifications. Each item received
 //!     // on this stream may represent multiple ctrl-c signals.
-//!     let ctrl_c = tokio_signal::CtrlC::new().await?;
+//!     let ctrl_c = tokio_signal::CtrlC::new()?;
 //!
 //!     // Process each ctrl-c as it comes in
 //!     let prog = ctrl_c.for_each(|_| {
@@ -72,7 +72,7 @@
 //!
 //!     // Like the previous example, this is an infinite stream of signals
 //!     // being received, and signals may be coalesced while pending.
-//!     let stream = Signal::new(SIGHUP).await?;
+//!     let stream = Signal::new(SIGHUP)?;
 //!
 //!     // Convert out stream into a future and block the program
 //!     let (signal, _signal) = stream.into_future().await;
@@ -83,10 +83,6 @@
 
 #[macro_use]
 extern crate lazy_static;
-
-use futures_core::future::Future;
-use std::io;
-use std::pin::Pin;
 
 mod ctrl_c;
 mod registry;
@@ -100,8 +96,5 @@ mod os {
 
 pub mod unix;
 pub mod windows;
-
-/// A future whose output is `io::Result<T>`
-pub type IoFuture<T> = Pin<Box<dyn Future<Output = io::Result<T>> + Send>>;
 
 pub use ctrl_c::CtrlC;

--- a/tokio-signal/tests/drop_then_get_a_signal.rs
+++ b/tokio-signal/tests/drop_then_get_a_signal.rs
@@ -9,15 +9,11 @@ use crate::support::*;
 
 #[tokio::test]
 async fn drop_then_get_a_signal() {
-    let signal = with_timeout(Signal::new(libc::SIGUSR1))
-        .await
-        .expect("failed to create first signal");
+    let signal = Signal::new(libc::SIGUSR1).expect("failed to create first signal");
     drop(signal);
 
     send_signal(libc::SIGUSR1);
-    let signal = with_timeout(Signal::new(libc::SIGUSR1))
-        .await
-        .expect("failed to create second signal");
+    let signal = Signal::new(libc::SIGUSR1).expect("failed to create second signal");
 
     let _ = with_timeout(signal.into_future()).await;
 }

--- a/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
+++ b/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
@@ -11,16 +11,13 @@ const TEST_SIGNAL: libc::c_int = libc::SIGUSR1;
 
 #[tokio::test]
 async fn dropping_signal_does_not_deregister_any_other_instances() {
-    // NB: Testing for issue #38: signals should not starve based on ordering
-    let first_duplicate_signal = with_timeout(Signal::new(TEST_SIGNAL))
-        .await
-        .expect("failed to register first duplicate signal");
-    let signal = with_timeout(Signal::new(TEST_SIGNAL))
-        .await
-        .expect("failed to register signal");
-    let second_duplicate_signal = with_timeout(Signal::new(TEST_SIGNAL))
-        .await
-        .expect("failed to register second duplicate signal");
+    // NB: Testing for issue alexcrichton/tokio-signal#38:
+    // signals should not starve based on ordering
+    let first_duplicate_signal =
+        Signal::new(TEST_SIGNAL).expect("failed to register first duplicate signal");
+    let signal = Signal::new(TEST_SIGNAL).expect("failed to register signal");
+    let second_duplicate_signal =
+        Signal::new(TEST_SIGNAL).expect("failed to register second duplicate signal");
 
     drop(first_duplicate_signal);
     drop(second_duplicate_signal);

--- a/tokio-signal/tests/multi_loop.rs
+++ b/tokio-signal/tests/multi_loop.rs
@@ -20,7 +20,7 @@ fn multi_loop() {
                 let sender = sender.clone();
                 thread::spawn(move || {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
-                    let signal = run_with_timeout(&mut rt, Signal::new(libc::SIGHUP)).unwrap();
+                    let signal = Signal::new(libc::SIGHUP).unwrap();
                     sender.send(()).unwrap();
                     let _ = run_with_timeout(&mut rt, signal.into_future());
                 })

--- a/tokio-signal/tests/notify_both.rs
+++ b/tokio-signal/tests/notify_both.rs
@@ -9,13 +9,9 @@ use libc;
 
 #[tokio::test]
 async fn notify_both() {
-    let signal1 = with_timeout(Signal::new(libc::SIGUSR2))
-        .await
-        .expect("failed to create signal1");
+    let signal1 = Signal::new(libc::SIGUSR2).expect("failed to create signal1");
 
-    let signal2 = with_timeout(Signal::new(libc::SIGUSR2))
-        .await
-        .expect("failed to create signal2");
+    let signal2 = Signal::new(libc::SIGUSR2).expect("failed to create signal2");
 
     send_signal(libc::SIGUSR2);
     let _ = with_timeout(future::join(signal1.into_future(), signal2.into_future())).await;

--- a/tokio-signal/tests/simple.rs
+++ b/tokio-signal/tests/simple.rs
@@ -9,9 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn simple() {
-    let signal = with_timeout(Signal::new(libc::SIGUSR1))
-        .await
-        .expect("failed to create signal");
+    let signal = Signal::new(libc::SIGUSR1).expect("failed to create signal");
 
     send_signal(libc::SIGUSR1);
 

--- a/tokio-signal/tests/twice.rs
+++ b/tokio-signal/tests/twice.rs
@@ -9,9 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn twice() {
-    let mut signal = with_timeout(Signal::new(libc::SIGUSR1))
-        .await
-        .expect("failed to get signal");
+    let mut signal = Signal::new(libc::SIGUSR1).expect("failed to get signal");
 
     for _ in 0..2 {
         send_signal(libc::SIGUSR1);


### PR DESCRIPTION
## Motivation

The constructors for various `tokio-signal` types return a lazy future which initializes the respective type before yielding it, which makes it awkward to work with the results directly.

## Solution

* Eagerly initialize inner types, as the restrictions which originally required lazy initialization are no longer present.
* Using `#[tokio::main]`/`#[tokio::test]` will also avoid any issues with initializing futures off-task, so this change should be safe

Refs #1243 