### PR TITLE
Add some TryFrom/From implementations

### DIFF
--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -351,6 +351,18 @@ impl TryFrom<TcpListener> for mio::net::TcpListener {
     }
 }
 
+impl TryFrom<net::TcpListener> for TcpListener {
+    type Error = io::Error;
+
+    /// Consumes stream, returning the tokio I/O object.
+    ///
+    /// This is equivalent to
+    /// [`TcpListener::from_std(stream, &Handle::default())`](TcpListener::from_std).
+    fn try_from(stream: net::TcpListener) -> Result<Self, Self::Error> {
+        Self::from_std(stream, &Handle::default())
+    }
+}
+
 impl fmt::Debug for TcpListener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.get_ref().fmt(f)

--- a/tokio-tcp/src/stream.rs
+++ b/tokio-tcp/src/stream.rs
@@ -886,6 +886,18 @@ impl TryFrom<TcpStream> for mio::net::TcpStream {
     }
 }
 
+impl TryFrom<net::TcpStream> for TcpStream {
+    type Error = io::Error;
+
+    /// Consumes stream, returning the tokio I/O object.
+    ///
+    /// This is equivalent to
+    /// [`TcpStream::from_std(stream, &Handle::default())`](TcpStream::from_std).
+    fn try_from(stream: net::TcpStream) -> Result<Self, Self::Error> {
+        Self::from_std(stream, &Handle::default())
+    }
+}
+
 // ===== impl Read / Write =====
 
 impl AsyncRead for TcpStream {

--- a/tokio-udp/src/socket.rs
+++ b/tokio-udp/src/socket.rs
@@ -451,6 +451,18 @@ impl TryFrom<UdpSocket> for mio::net::UdpSocket {
     }
 }
 
+impl TryFrom<net::UdpSocket> for UdpSocket {
+    type Error = io::Error;
+
+    /// Consumes stream, returning the tokio I/O object.
+    ///
+    /// This is equivalent to
+    /// [`UdpSocket::from_std(stream, &Handle::default())`](UdpSocket::from_std).
+    fn try_from(stream: net::UdpSocket) -> Result<Self, Self::Error> {
+        Self::from_std(stream, &Handle::default())
+    }
+}
+
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.get_ref().fmt(f)

--- a/tokio-uds/src/listener.rs
+++ b/tokio-uds/src/listener.rs
@@ -155,6 +155,18 @@ impl TryFrom<UnixListener> for mio_uds::UnixListener {
     }
 }
 
+impl TryFrom<net::UnixListener> for UnixListener {
+    type Error = io::Error;
+
+    /// Consumes stream, returning the tokio I/O object.
+    ///
+    /// This is equivalent to
+    /// [`UnixListener::from_std(stream, &Handle::default())`](UnixListener::from_std).
+    fn try_from(stream: net::UnixListener) -> io::Result<Self> {
+        Self::from_std(stream, &Handle::default())
+    }
+}
+
 impl fmt::Debug for UnixListener {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.get_ref().fmt(f)

--- a/tokio-uds/src/stream.rs
+++ b/tokio-uds/src/stream.rs
@@ -130,6 +130,18 @@ impl TryFrom<UnixStream> for mio_uds::UnixStream {
     }
 }
 
+impl TryFrom<net::UnixStream> for UnixStream {
+    type Error = io::Error;
+
+    /// Consumes stream, returning the tokio I/O object.
+    ///
+    /// This is equivalent to
+    /// [`UnixStream::from_std(stream, &Handle::default())`](UnixStream::from_std).
+    fn try_from(stream: net::UnixStream) -> io::Result<Self> {
+        Self::from_std(stream, &Handle::default())
+    }
+}
+
 impl AsyncRead for UnixStream {
     unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
         false


### PR DESCRIPTION
This adds the following TryFrom/From implementations:

* `TryFrom<net::TcpListener> for TcpListener`
* `TryFrom<net::TcpStream> for TcpStream`
* `TryFrom<net::UdpSocket> for UdpSocket`
* `TryFrom<net::UnixDatagram> for UnixDatagram`
* `TryFrom<net::UnixListener> for UnixListener`
* `TryFrom<net::UnixStream> for UnixStream`
* `TryFrom<UnixDatagram> for mio_uds::UnixDatagram`
* `TryFrom<File> for io::File`
* `From<io::File> for File`

Closes https://github.com/tokio-rs/tokio/issues/707

Related: https://github.com/tokio-rs/tokio/pull/1158