### PR TITLE
Update chat example

### DIFF
--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -172,8 +172,14 @@ async fn process(
     // Read the first line from the `LineCodec` stream to get the username.
     let username = match lines.next().await {
         Some(Ok(line)) => line,
-        // We didn't get a line so we return here.
-        _ => return Ok(()),
+        // We didn't get a line so we return early here.
+        _ => {
+            println!(
+                "Failed to get username from {}. Client disconnected.",
+                addr
+            );
+            return Ok(());
+        }
     };
 
     // Register our peer with state which internally sets up some channels.

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -165,7 +165,7 @@ async fn process(
 ) -> Result<(), Box<dyn Error>> {
     let mut lines = Framed::new(stream, LinesCodec::new());
 
-    // Send a prompt to the client to let them know to enter their username.
+    // Send a prompt to the client to enter their username.
     lines
         .send(String::from("Please enter your username:"))
         .await?;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -27,10 +27,10 @@
 #![feature(async_await)]
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::{lock::Mutex, Poll, SinkExt, Stream, StreamExt};
+use futures::{Poll, SinkExt, Stream, StreamExt};
 
 use std::{
-    collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin, sync::Arc,
+    collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin,
     task::Context,
 };
 
@@ -38,7 +38,7 @@ use tokio::{
     self,
     codec::{Framed, LinesCodec, LinesCodecError},
     net::{TcpListener, TcpStream},
-    sync::mpsc,
+    sync::{mpsc, lock::Lock},
 };
 
 /// Shorthand for the transmit half of the message channel.
@@ -101,7 +101,7 @@ impl Shared {
 impl Peer {
     /// Create a new instance of `Peer`.
     async fn new(
-        state: Arc<Mutex<Shared>>,
+        mut state: Lock<Shared>,
         lines: Framed<TcpStream, LinesCodec>,
     ) -> io::Result<Peer> {
         // Get the client socket address
@@ -156,7 +156,7 @@ impl Stream for Peer {
 
 /// Process an individual chat client
 async fn process(
-    state: Arc<Mutex<Shared>>,
+    mut state: Lock<Shared>,
     stream: TcpStream,
     addr: SocketAddr,
 ) -> Result<(), Box<dyn Error>> {
@@ -234,7 +234,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // The server task will hold a handle to this. For every new client, the
     // `state` handle is cloned and passed into the task that processes the
     // client connection.
-    let state = Arc::new(Mutex::new(Shared::new()));
+    let state = Lock::new(Shared::new());
 
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:6142".to_string());
     let addr = addr.parse::<SocketAddr>()?;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -41,7 +41,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use tokio;
-use tokio::codec::{Framed, LinesCodec};
+use tokio::codec::{Framed, LinesCodec, LinesCodecError};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
@@ -123,7 +123,7 @@ enum Message {
 }
 
 impl Stream for Peer {
-    type Item = Result<Message, ()>; // #TODO LinesCodecError
+    type Item = Result<Message, LinesCodecError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         while let Poll::Ready(Some(v)) = self.rx.poll_next_unpin(cx) {
@@ -132,14 +132,11 @@ impl Stream for Peer {
 
         match self.lines.poll_next_unpin(cx) {
             Poll::Ready(Some(v)) => {
-                // #TODO LinesCodecError
-                /*let res = match v {
+                let res = match v {
                     Ok(msg) => Ok(Message::MessageToSend(msg)),
                     Err(e) => Err(e),
                 };
-                return Poll::Ready(Some(res));*/
-
-                return Poll::Ready(Some(Ok(Message::MessageToSend(v.unwrap()))));
+                return Poll::Ready(Some(res));
             }
             Poll::Ready(None) => {
                 return Poll::Ready(None);

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -102,10 +102,7 @@ impl Shared {
 
 impl Peer {
     /// Create a new instance of `Peer`.
-    async fn new(
-        state: Arc<Mutex<Shared>>,
-        lines: Framed<TcpStream, LinesCodec>,
-    ) -> Peer {
+    async fn new(state: Arc<Mutex<Shared>>, lines: Framed<TcpStream, LinesCodec>) -> Peer {
         // Get the client socket address
         let addr = lines.get_ref().peer_addr().unwrap();
 
@@ -115,10 +112,7 @@ impl Peer {
         // Add an entry for this `Peer` in the shared state map.
         state.lock().await.peers.insert(addr, tx);
 
-        Peer {
-            lines,
-            rx,
-        }
+        Peer { lines, rx }
     }
 }
 
@@ -138,7 +132,6 @@ impl Stream for Peer {
 
         match self.lines.poll_next_unpin(cx) {
             Poll::Ready(Some(v)) => {
-
                 // #TODO LinesCodecError
                 /*let res = match v {
                     Ok(msg) => Ok(Message::MessageToSend(msg)),
@@ -158,8 +151,11 @@ impl Stream for Peer {
     }
 }
 
-async fn process(state: Arc<Mutex<Shared>>, stream: TcpStream, addr: SocketAddr) -> Result<(), Box<dyn Error>> {
-    
+async fn process(
+    state: Arc<Mutex<Shared>>,
+    stream: TcpStream,
+    addr: SocketAddr,
+) -> Result<(), Box<dyn Error>> {
     let mut lines = Framed::new(stream, LinesCodec::new());
     let username = lines.next().await?.unwrap();
     let mut peer = Peer::new(state.clone(), lines).await;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -165,6 +165,11 @@ async fn process(
 ) -> Result<(), Box<dyn Error>> {
     let mut lines = Framed::new(stream, LinesCodec::new());
 
+    // Send a prompt to the client to let them know to enter their username.
+    lines
+        .send(String::from("Please enter your username:"))
+        .await?;
+
     // Read the first line from the `LineCodec` stream to get the username.
     let username = match lines.next().await {
         Some(Ok(line)) => line,

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -43,7 +43,6 @@ use tokio;
 use tokio::codec::{Framed, LinesCodec, LinesCodecError};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
-//use tokio::sync::lock::Lock;
 
 /// Shorthand for the transmit half of the message channel.
 type Tx = mpsc::UnboundedSender<String>;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -1,0 +1,229 @@
+//! A chat server that broadcasts a message to all connections.
+//!
+//! This example is explicitly more verbose than it has to be. This is to
+//! illustrate more concepts.
+//!
+//! A chat server for telnet clients. After a telnet client connects, the first
+//! line should contain the client's name. After that, all lines sent by a
+//! client are broadcasted to all other connected clients.
+//!
+//! Because the client is telnet, lines are delimited by "\r\n".
+//!
+//! You can test this out by running:
+//!
+//!     cargo run --example chat
+//!
+//! And then in another terminal run:
+//!
+//!     telnet localhost 6142
+//!
+//! You can run the `telnet` command in any number of additional windows.
+//!
+//! You can run the second command in multiple windows and then chat between the
+//! two, seeing the messages from the other client as they're received. For all
+//! connected clients they'll all join the same room and see everyone else's
+//! messages.
+
+#![feature(async_await)]
+#![deny(warnings, rust_2018_idioms)]
+
+use futures::channel::mpsc;
+use futures::lock::Mutex;
+use futures::task::Context;
+use futures::Stream;
+use futures::{SinkExt, StreamExt};
+
+use std::collections::HashMap;
+use std::env;
+use std::error::Error;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio;
+use tokio::codec::{Framed, LinesCodec};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::*;
+
+/// Shorthand for the transmit half of the message channel.
+type Tx = mpsc::UnboundedSender<String>;
+
+/// Shorthand for the receive half of the message channel.
+type Rx = mpsc::UnboundedReceiver<String>;
+
+/// Data that is shared between all peers in the chat server.
+///
+/// This is the set of `Tx` handles for all connected clients. Whenever a
+/// message is received from a client, it is broadcasted to all peers by
+/// iterating over the `peers` entries and sending a copy of the message on each
+/// `Tx`.
+struct Shared {
+    peers: HashMap<SocketAddr, Tx>,
+}
+
+/// The state for each connected client.
+struct Peer {
+    /// The TCP socket wrapped with the `Lines` codec, defined below.
+    ///
+    /// This handles sending and receiving data on the socket. When using
+    /// `Lines`, we can work at the line level instead of having to manage the
+    /// raw byte operations.
+    lines: Framed<TcpStream, LinesCodec>,
+
+    /// Receive half of the message channel.
+    ///
+    /// This is used to receive messages from peers. When a message is received
+    /// off of this `Rx`, it will be written to the socket.
+    rx: Rx,
+}
+
+impl Shared {
+    /// Create a new, empty, instance of `Shared`.
+    fn new() -> Self {
+        Shared {
+            peers: HashMap::new(),
+        }
+    }
+
+    async fn broadcast(
+        &mut self,
+        sender: SocketAddr,
+        message: &str,
+    ) -> Result<(), futures::channel::mpsc::SendError> {
+        for peer in self.peers.iter_mut() {
+            if *peer.0 != sender {
+                peer.1.send(message.into()).await?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Peer {
+    /// Create a new instance of `Peer`.
+    async fn new(
+        state: Arc<Mutex<Shared>>,
+        lines: Framed<TcpStream, LinesCodec>,
+    ) -> Peer {
+        // Get the client socket address
+        let addr = lines.get_ref().peer_addr().unwrap();
+
+        // Create a channel for this peer
+        let (tx, rx) = mpsc::unbounded();
+
+        // Add an entry for this `Peer` in the shared state map.
+        state.lock().await.peers.insert(addr, tx);
+
+        Peer {
+            lines,
+            rx,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Message {
+    MessageToSend(String),
+    MessageToReceieve(String),
+}
+
+impl Stream for Peer {
+    type Item = Result<Message, ()>; // #TODO LinesCodecError
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        while let Poll::Ready(Some(v)) = self.rx.poll_next_unpin(cx) {
+            return Poll::Ready(Some(Ok(Message::MessageToReceieve(v))));
+        }
+
+        match self.lines.poll_next_unpin(cx) {
+            Poll::Ready(Some(v)) => {
+
+                // #TODO LinesCodecError
+                /*let res = match v {
+                    Ok(msg) => Ok(Message::MessageToSend(msg)),
+                    Err(e) => Err(e),
+                };
+                return Poll::Ready(Some(res));*/
+
+                return Poll::Ready(Some(Ok(Message::MessageToSend(v.unwrap()))));
+            }
+            Poll::Ready(None) => {
+                return Poll::Ready(None);
+            }
+            _ => {}
+        }
+
+        Poll::Pending
+    }
+}
+
+async fn process(state: Arc<Mutex<Shared>>, stream: TcpStream, addr: SocketAddr) -> Result<(), Box<dyn Error>> {
+    
+    let mut lines = Framed::new(stream, LinesCodec::new());
+    let username = lines.next().await?.unwrap();
+    let mut peer = Peer::new(state.clone(), lines).await;
+
+    {
+        let mut state = state.lock().await;
+        let msg = format!("{} has joined the chat", username);
+        state.broadcast(addr, &msg).await?;
+    }
+
+    while let Ok(msg) = peer.next().await.unwrap() {
+        match msg {
+            Message::MessageToSend(msg) => {
+                let mut state = state.lock().await;
+                let msg = format!("{}: {}", username, msg);
+
+                state.broadcast(addr, &msg).await?;
+            }
+            Message::MessageToReceieve(msg) => {
+                peer.lines.send(msg).await?;
+            }
+        }
+    }
+
+    {
+        let mut state = state.lock().await;
+        state.peers.remove(&addr);
+
+        let msg = format!("{} has left the chat", username);
+        state.broadcast(addr, &msg).await?;
+    }
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Create the shared state. This is how all the peers communicate.
+    //
+    // The server task will hold a handle to this. For every new client, the
+    // `state` handle is cloned and passed into the task that processes the
+    // client connection.
+    let state = Arc::new(Mutex::new(Shared::new()));
+
+    let addr = env::args().nth(1).unwrap_or("127.0.0.1:6142".to_string());
+    let addr = addr.parse::<SocketAddr>()?;
+
+    // Bind a TCP listener to the socket address.
+    //
+    // Note that this is the Tokio TcpListener, which is fully async.
+    let mut listener = TcpListener::bind(&addr)?;
+
+    println!("server running on {}", addr);
+
+    loop {
+        // Asynchronously wait for an inbound TcpStream.
+        let (stream, addr) = listener.accept().await?;
+
+        let state = state.clone();
+
+        tokio::spawn(async move {
+            if let Err(e) = process(state, stream, addr).await {
+                println!("an error occured; error = {:?}", e);
+            }
+        });
+    }
+}

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -29,16 +29,13 @@
 
 use futures::{Poll, SinkExt, Stream, StreamExt};
 
-use std::{
-    collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin,
-    task::Context,
-};
+use std::{collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin, task::Context};
 
 use tokio::{
     self,
     codec::{Framed, LinesCodec, LinesCodecError},
     net::{TcpListener, TcpStream},
-    sync::{mpsc, lock::Lock},
+    sync::{lock::Lock, mpsc},
 };
 
 /// Shorthand for the transmit half of the message channel.

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -89,7 +89,7 @@ impl Shared {
         &mut self,
         sender: SocketAddr,
         message: &str,
-    ) -> Result<(), futures::channel::mpsc::SendError> {
+    ) -> Result<(), mpsc::SendError> {
         for peer in self.peers.iter_mut() {
             if *peer.0 != sender {
                 peer.1.send(message.into()).await?;
@@ -162,10 +162,11 @@ async fn process(
     {
         let mut state = state.lock().await;
         let msg = format!("{} has joined the chat", username);
+        println!("{}", msg);
         state.broadcast(addr, &msg).await?;
     }
 
-    while let Ok(msg) = peer.next().await.unwrap() {
+    while let Some(Ok(msg)) = peer.next().await {
         match msg {
             Message::MessageToSend(msg) => {
                 let mut state = state.lock().await;
@@ -184,6 +185,7 @@ async fn process(
         state.peers.remove(&addr);
 
         let msg = format!("{} has left the chat", username);
+        println!("{}", msg);
         state.broadcast(addr, &msg).await?;
     }
 

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -157,7 +157,9 @@ async fn process(
     addr: SocketAddr,
 ) -> Result<(), Box<dyn Error>> {
     let mut lines = Framed::new(stream, LinesCodec::new());
-    let username = lines.next().await?.unwrap();
+
+    let username = lines.next().await.unwrap()?;
+
     let mut peer = Peer::new(state.clone(), lines).await;
 
     {

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -27,22 +27,19 @@
 #![feature(async_await)]
 #![deny(warnings, rust_2018_idioms)]
 
-use futures::lock::Mutex;
-use futures::{Poll, SinkExt, Stream, StreamExt};
+use futures::{lock::Mutex, Poll, SinkExt, Stream, StreamExt};
 
-use std::collections::HashMap;
-use std::env;
-use std::error::Error;
-use std::io;
-use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::Context;
+use std::{
+    collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin, sync::Arc,
+    task::Context,
+};
 
-use tokio;
-use tokio::codec::{Framed, LinesCodec, LinesCodecError};
-use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::{
+    self,
+    codec::{Framed, LinesCodec, LinesCodecError},
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+};
 
 /// Shorthand for the transmit half of the message channel.
 type Tx = mpsc::UnboundedSender<String>;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -111,8 +111,8 @@ impl Shared {
         }
     }
 
-    /// Send a `LineCodec` encoded message to every peer, without
-    /// including the sender.
+    /// Send a `LineCodec` encoded message to every peer, except
+    /// for the sender.
     async fn broadcast(
         &mut self,
         sender: SocketAddr,


### PR DESCRIPTION
I've updated the chat example to use the new async-await feature set and to use await wherever possible. 

Some changes still need to be made:
- [x] Error handling with regards to `LinesCodecError`.
- [x] Comments / Documentation
- [x] Make the code more idiomatic. (Could still be improved probably)
