### PR TITLE
v0.1.x: Apply `dyn` keywords to avoid fatal warnings on recent nightlies

### DIFF
--- a/tokio-buf/tests/buf_stream.rs
+++ b/tokio-buf/tests/buf_stream.rs
@@ -4,4 +4,4 @@ use tokio_buf::BufStream;
 
 // Ensures that `BufStream` can be a trait object
 #[allow(dead_code)]
-fn obj(_: &mut BufStream<Item = u32, Error = ()>) {}
+fn obj(_: &mut dyn BufStream<Item = u32, Error = ()>) {}

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -186,7 +186,11 @@ struct Borrow<'a, U: 'a> {
 }
 
 trait SpawnLocal {
-    fn spawn_local(&mut self, future: Box<dyn Future<Item = (), Error = ()>>, already_counted: bool);
+    fn spawn_local(
+        &mut self,
+        future: Box<dyn Future<Item = (), Error = ()>>,
+        already_counted: bool,
+    );
 }
 
 struct CurrentRunner {
@@ -791,7 +795,11 @@ impl<'a, U: Unpark> Borrow<'a, U> {
 }
 
 impl<'a, U: Unpark> SpawnLocal for Borrow<'a, U> {
-    fn spawn_local(&mut self, future: Box<dyn Future<Item = (), Error = ()>>, already_counted: bool) {
+    fn spawn_local(
+        &mut self,
+        future: Box<dyn Future<Item = (), Error = ()>>,
+        already_counted: bool,
+    ) {
         if !already_counted {
             // NOTE: we have a borrow of the Runtime, so we know that it isn't shut down.
             // NOTE: += 2 since LSB is the shutdown bit

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -64,7 +64,7 @@ pub struct CurrentThread<P: Park = ParkThread> {
     spawn_handle: Handle,
 
     /// Receiver for futures spawned from other threads
-    spawn_receiver: mpsc::Receiver<Box<Future<Item = (), Error = ()> + Send + 'static>>,
+    spawn_receiver: mpsc::Receiver<Box<dyn Future<Item = (), Error = ()> + Send + 'static>>,
 
     /// The thread-local ID assigned to this executor.
     id: u64,
@@ -186,11 +186,11 @@ struct Borrow<'a, U: 'a> {
 }
 
 trait SpawnLocal {
-    fn spawn_local(&mut self, future: Box<Future<Item = (), Error = ()>>, already_counted: bool);
+    fn spawn_local(&mut self, future: Box<dyn Future<Item = (), Error = ()>>, already_counted: bool);
 }
 
 struct CurrentRunner {
-    spawn: Cell<Option<*mut SpawnLocal>>,
+    spawn: Cell<Option<*mut dyn SpawnLocal>>,
     id: Cell<Option<u64>>,
 }
 
@@ -424,7 +424,7 @@ impl<P: Park> Drop for CurrentThread<P> {
 impl tokio_executor::Executor for CurrentThread {
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError> {
         self.borrow().spawn_local(future, false);
         Ok(())
@@ -629,7 +629,7 @@ impl<'a, P: Park> fmt::Debug for Entered<'a, P> {
 /// Handle to spawn a future on the corresponding `CurrentThread` instance
 #[derive(Clone)]
 pub struct Handle {
-    sender: mpsc::Sender<Box<Future<Item = (), Error = ()> + Send + 'static>>,
+    sender: mpsc::Sender<Box<dyn Future<Item = (), Error = ()> + Send + 'static>>,
     num_futures: Arc<atomic::AtomicUsize>,
     shut_down: Cell<bool>,
     notify: executor::NotifyHandle,
@@ -731,7 +731,7 @@ impl TaskExecutor {
     /// Spawn a future onto the current `CurrentThread` instance.
     pub fn spawn_local(
         &mut self,
-        future: Box<Future<Item = (), Error = ()>>,
+        future: Box<dyn Future<Item = (), Error = ()>>,
     ) -> Result<(), SpawnError> {
         CURRENT.with(|current| match current.spawn.get() {
             Some(spawn) => {
@@ -746,7 +746,7 @@ impl TaskExecutor {
 impl tokio_executor::Executor for TaskExecutor {
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError> {
         self.spawn_local(future)
     }
@@ -791,7 +791,7 @@ impl<'a, U: Unpark> Borrow<'a, U> {
 }
 
 impl<'a, U: Unpark> SpawnLocal for Borrow<'a, U> {
-    fn spawn_local(&mut self, future: Box<Future<Item = (), Error = ()>>, already_counted: bool) {
+    fn spawn_local(&mut self, future: Box<dyn Future<Item = (), Error = ()>>, already_counted: bool) {
         if !already_counted {
             // NOTE: we have a borrow of the Runtime, so we know that it isn't shut down.
             // NOTE: += 2 since LSB is the shutdown bit
@@ -804,7 +804,7 @@ impl<'a, U: Unpark> SpawnLocal for Borrow<'a, U> {
 // ===== impl CurrentRunner =====
 
 impl CurrentRunner {
-    fn set_spawn<F, R>(&self, spawn: &mut SpawnLocal, f: F) -> R
+    fn set_spawn<F, R>(&self, spawn: &mut dyn SpawnLocal, f: F) -> R
     where
         F: FnOnce() -> R,
     {
@@ -819,14 +819,14 @@ impl CurrentRunner {
 
         let _reset = Reset(self);
 
-        let spawn = unsafe { hide_lt(spawn as *mut SpawnLocal) };
+        let spawn = unsafe { hide_lt(spawn as *mut dyn SpawnLocal) };
         self.spawn.set(Some(spawn));
 
         f()
     }
 }
 
-unsafe fn hide_lt<'a>(p: *mut (SpawnLocal + 'a)) -> *mut (SpawnLocal + 'static) {
+unsafe fn hide_lt<'a>(p: *mut (dyn SpawnLocal + 'a)) -> *mut (dyn SpawnLocal + 'static) {
     use std::mem;
     mem::transmute(p)
 }

--- a/tokio-current-thread/src/scheduler.rs
+++ b/tokio-current-thread/src/scheduler.rs
@@ -125,7 +125,7 @@ enum Dequeue<U> {
 }
 
 /// Wraps a spawned boxed future
-struct Task(Spawn<Box<Future<Item = (), Error = ()>>>);
+struct Task(Spawn<Box<dyn Future<Item = (), Error = ()>>>);
 
 /// A task that is scheduled. `turn` must be called
 pub struct Scheduled<'a, U: 'a> {
@@ -171,7 +171,7 @@ where
         self.inner.clone().into()
     }
 
-    pub fn schedule(&mut self, item: Box<Future<Item = (), Error = ()>>) {
+    pub fn schedule(&mut self, item: Box<dyn Future<Item = (), Error = ()>>) {
         // Get the current scheduler tick
         let tick_num = self.inner.tick_num.load(SeqCst);
 
@@ -359,7 +359,7 @@ impl<'a, U: Unpark> Scheduled<'a, U> {
 }
 
 impl Task {
-    pub fn new(future: Box<Future<Item = (), Error = ()> + 'static>) -> Self {
+    pub fn new(future: Box<dyn Future<Item = (), Error = ()> + 'static>) -> Self {
         Task(executor::spawn(future))
     }
 }
@@ -687,8 +687,8 @@ unsafe impl<U: Unpark> UnsafeNotify for ArcNode<U> {
     }
 }
 
-unsafe fn hide_lt<U: Unpark>(p: *mut ArcNode<U>) -> *mut UnsafeNotify {
-    mem::transmute(p as *mut UnsafeNotify)
+unsafe fn hide_lt<U: Unpark>(p: *mut ArcNode<U>) -> *mut dyn UnsafeNotify {
+    mem::transmute(p as *mut dyn UnsafeNotify)
 }
 
 impl<U: Unpark> Node<U> {

--- a/tokio-current-thread/tests/current_thread.rs
+++ b/tokio-current-thread/tests/current_thread.rs
@@ -22,7 +22,7 @@ use futures::sync::oneshot;
 
 mod from_block_on_all {
     use super::*;
-    fn test<F: Fn(Box<Future<Item = (), Error = ()>>) + 'static>(spawn: F) {
+    fn test<F: Fn(Box<dyn Future<Item = (), Error = ()>>) + 'static>(spawn: F) {
         let cnt = Rc::new(Cell::new(0));
         let c = cnt.clone();
 
@@ -102,7 +102,7 @@ fn spawn_many() {
 mod does_not_set_global_executor_by_default {
     use super::*;
 
-    fn test<F: Fn(Box<Future<Item = (), Error = ()> + Send>) -> Result<(), E> + 'static, E>(
+    fn test<F: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) -> Result<(), E> + 'static, E>(
         spawn: F,
     ) {
         block_on_all(lazy(|| {
@@ -127,7 +127,7 @@ mod does_not_set_global_executor_by_default {
 mod from_block_on_future {
     use super::*;
 
-    fn test<F: Fn(Box<Future<Item = (), Error = ()>>)>(spawn: F) {
+    fn test<F: Fn(Box<dyn Future<Item = (), Error = ()>>)>(spawn: F) {
         let cnt = Rc::new(Cell::new(0));
 
         let mut tokio_current_thread = CurrentThread::new();
@@ -181,8 +181,8 @@ mod outstanding_tasks_are_dropped_when_executor_is_dropped {
 
     fn test<F, G>(spawn: F, dotspawn: G)
     where
-        F: Fn(Box<Future<Item = (), Error = ()>>) + 'static,
-        G: Fn(&mut CurrentThread, Box<Future<Item = (), Error = ()>>),
+        F: Fn(Box<dyn Future<Item = (), Error = ()>>) + 'static,
+        G: Fn(&mut CurrentThread, Box<dyn Future<Item = (), Error = ()>>),
     {
         let mut rc = Rc::new(());
 
@@ -383,8 +383,8 @@ mod and_turn {
 
     fn test<F, G>(spawn: F, dotspawn: G)
     where
-        F: Fn(Box<Future<Item = (), Error = ()>>) + 'static,
-        G: Fn(&mut CurrentThread, Box<Future<Item = (), Error = ()>>),
+        F: Fn(Box<dyn Future<Item = (), Error = ()>>) + 'static,
+        G: Fn(&mut CurrentThread, Box<dyn Future<Item = (), Error = ()>>),
     {
         let cnt = Rc::new(Cell::new(0));
         let c = cnt.clone();
@@ -459,7 +459,7 @@ mod in_drop {
     }
 
     struct MyFuture {
-        _data: Box<Any>,
+        _data: Box<dyn Any>,
     }
 
     impl Future for MyFuture {
@@ -473,8 +473,8 @@ mod in_drop {
 
     fn test<F, G>(spawn: F, dotspawn: G)
     where
-        F: Fn(Box<Future<Item = (), Error = ()>>) + 'static,
-        G: Fn(&mut CurrentThread, Box<Future<Item = (), Error = ()>>),
+        F: Fn(Box<dyn Future<Item = (), Error = ()>>) + 'static,
+        G: Fn(&mut CurrentThread, Box<dyn Future<Item = (), Error = ()>>),
     {
         let mut tokio_current_thread = CurrentThread::new();
 

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -11,7 +11,7 @@ thread_local!(static ENTERED: Cell<bool> = Cell::new(false));
 ///
 /// For more details, see [`enter` documentation](fn.enter.html)
 pub struct Enter {
-    on_exit: Vec<Box<Callback>>,
+    on_exit: Vec<Box<dyn Callback>>,
     permanent: bool,
 }
 

--- a/tokio-executor/src/executor.rs
+++ b/tokio-executor/src/executor.rs
@@ -94,7 +94,7 @@ pub trait Executor {
     /// ```
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError>;
 
     /// Provides a best effort **hint** to whether or not `spawn` will succeed.
@@ -140,7 +140,7 @@ pub trait Executor {
 impl<E: Executor + ?Sized> Executor for Box<E> {
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError> {
         (**self).spawn(future)
     }

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,7 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations, warnings)]
 #![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.8")]
-// Our MSRV doesn't allow us to fix these warnings yet
-#![allow(rust_2018_idioms)]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -128,13 +128,13 @@ pub trait Unpark: Sync + Send + 'static {
     fn unpark(&self);
 }
 
-impl Unpark for Box<Unpark> {
+impl Unpark for Box<dyn Unpark> {
     fn unpark(&self) {
         (**self).unpark()
     }
 }
 
-impl Unpark for Arc<Unpark> {
+impl Unpark for Arc<dyn Unpark> {
     fn unpark(&self) {
         (**self).unpark()
     }

--- a/tokio-executor/tests/executor.rs
+++ b/tokio-executor/tests/executor.rs
@@ -10,7 +10,7 @@ mod out_of_executor_context {
 
     fn test<F, E>(spawn: F)
     where
-        F: Fn(Box<Future<Item = (), Error = ()> + Send>) -> Result<(), E>,
+        F: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) -> Result<(), E>,
     {
         let res = spawn(Box::new(lazy(|| Ok(()))));
         assert!(res.is_err());

--- a/tokio-fs/examples/std-echo.rs
+++ b/tokio-fs/examples/std-echo.rs
@@ -14,7 +14,7 @@ use futures::{Future, Sink, Stream};
 
 use std::io;
 
-pub fn main() -> Result<(), Box<std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = Builder::new().pool_size(1).build();
 
     pool.spawn({

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -21,10 +21,10 @@ use std::io as std_io;
 use futures::{Future, Stream};
 
 /// A convenience typedef around a `Future` whose error component is `io::Error`
-pub type IoFuture<T> = Box<Future<Item = T, Error = std_io::Error> + Send>;
+pub type IoFuture<T> = Box<dyn Future<Item = T, Error = std_io::Error> + Send>;
 
 /// A convenience typedef around a `Stream` whose error component is `io::Error`
-pub type IoStream<T> = Box<Stream<Item = T, Error = std_io::Error> + Send>;
+pub type IoStream<T> = Box<dyn Stream<Item = T, Error = std_io::Error> + Send>;
 
 /// A convenience macro for working with `io::Result<T>` from the `Read` and
 /// `Write` traits.
@@ -65,6 +65,6 @@ pub use self::async_write::AsyncWrite;
 
 fn _assert_objects() {
     fn _assert<T>() {}
-    _assert::<Box<AsyncRead>>();
-    _assert::<Box<AsyncWrite>>();
+    _assert::<Box<dyn AsyncRead>>();
+    _assert::<Box<dyn AsyncWrite>>();
 }

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -652,7 +652,7 @@ impl Inner {
     /// Register an I/O resource with the reactor.
     ///
     /// The registration token is returned.
-    fn add_source(&self, source: &Evented) -> io::Result<usize> {
+    fn add_source(&self, source: &dyn Evented) -> io::Result<usize> {
         // Get an ABA guard value
         let aba_guard = self.next_aba_guard.fetch_add(1 << TOKEN_SHIFT, Relaxed);
 
@@ -690,7 +690,7 @@ impl Inner {
     }
 
     /// Deregisters an I/O resource from the reactor.
-    fn deregister_source(&self, source: &Evented) -> io::Result<()> {
+    fn deregister_source(&self, source: &dyn Evented) -> io::Result<()> {
         self.io.deregister(source)
     }
 

--- a/tokio-signal/examples/ctrl-c.rs
+++ b/tokio-signal/examples/ctrl-c.rs
@@ -7,7 +7,7 @@ use futures::{Future, Stream};
 /// how many signals to handle before exiting
 const STOP_AFTER: u64 = 10;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // tokio_signal provides a convenience builder for Ctrl+C
     // this even works cross-platform: linux and windows!
     //

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -11,7 +11,7 @@ mod platform {
     use futures::{Future, Stream};
     use tokio_signal::unix::{Signal, SIGINT, SIGTERM};
 
-    pub fn main() -> Result<(), Box<::std::error::Error>> {
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Create a stream for each of the signals we'd like to handle.
         let sigint = Signal::new(SIGINT).flatten_stream();
         let sigterm = Signal::new(SIGTERM).flatten_stream();
@@ -49,6 +49,6 @@ mod platform {
     }
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     platform::main()
 }

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -9,7 +9,7 @@ mod platform {
     use futures::{Future, Stream};
     use tokio_signal::unix::{Signal, SIGHUP};
 
-    pub fn main() -> Result<(), Box<::std::error::Error>> {
+    pub fn main() -> Result<(), Box<dyn std::error::Error>> {
         // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
         let stream = Signal::new(SIGHUP).flatten_stream();
 
@@ -48,6 +48,6 @@ mod platform {
     }
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     platform::main()
 }

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -86,9 +86,9 @@ pub mod unix;
 pub mod windows;
 
 /// A future whose error is `io::Error`
-pub type IoFuture<T> = Box<Future<Item = T, Error = io::Error> + Send>;
+pub type IoFuture<T> = Box<dyn Future<Item = T, Error = io::Error> + Send>;
 /// A stream whose error is `io::Error`
-pub type IoStream<T> = Box<Stream<Item = T, Error = io::Error> + Send>;
+pub type IoStream<T> = Box<dyn Stream<Item = T, Error = io::Error> + Send>;
 
 /// Creates a stream which receives "ctrl-c" notifications sent to a process.
 ///
@@ -125,7 +125,7 @@ pub fn ctrl_c_handle(handle: &Handle) -> IoFuture<IoStream<()>> {
         let handle = handle.clone();
         Box::new(future::lazy(move || {
             unix::Signal::with_handle(unix::libc::SIGINT, &handle)
-                .map(|x| Box::new(x.map(|_| ())) as Box<Stream<Item = _, Error = _> + Send>)
+                .map(|x| Box::new(x.map(|_| ())) as Box<dyn Stream<Item = _, Error = _> + Send>)
         }))
     }
 

--- a/tokio-threadpool/src/builder.rs
+++ b/tokio-threadpool/src/builder.rs
@@ -67,7 +67,7 @@ pub struct Builder {
     max_blocking: usize,
 
     /// Generates the `Park` instances
-    new_park: Box<Fn(&WorkerId) -> BoxPark>,
+    new_park: Box<dyn Fn(&WorkerId) -> BoxPark>,
 }
 
 impl Builder {
@@ -223,7 +223,7 @@ impl Builder {
     /// ```
     pub fn panic_handler<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(Box<Any + Send>) + Send + Sync + 'static,
+        F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,
     {
         self.config.panic_handler = Some(Arc::new(f));
         self

--- a/tokio-threadpool/src/callback.rs
+++ b/tokio-threadpool/src/callback.rs
@@ -7,7 +7,7 @@ use tokio_executor::Enter;
 
 #[derive(Clone)]
 pub(crate) struct Callback {
-    f: Arc<Fn(&Worker, &mut Enter) + Send + Sync>,
+    f: Arc<dyn Fn(&Worker, &mut Enter) + Send + Sync>,
 }
 
 impl Callback {

--- a/tokio-threadpool/src/config.rs
+++ b/tokio-threadpool/src/config.rs
@@ -13,9 +13,9 @@ pub(crate) struct Config {
     pub name_prefix: Option<String>,
     pub stack_size: Option<usize>,
     pub around_worker: Option<Callback>,
-    pub after_start: Option<Arc<Fn() + Send + Sync>>,
-    pub before_stop: Option<Arc<Fn() + Send + Sync>>,
-    pub panic_handler: Option<Arc<Fn(Box<Any + Send>) + Send + Sync>>,
+    pub after_start: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub before_stop: Option<Arc<dyn Fn() + Send + Sync>>,
+    pub panic_handler: Option<Arc<dyn Fn(Box<dyn Any + Send>) + Send + Sync>>,
 }
 
 /// Max number of workers that can be part of a pool. This is the most that can

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,7 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.15")]
 #![deny(warnings, missing_docs, missing_debug_implementations)]
-// Our MSRV doesn't allow us to fix these warnings yet
-#![allow(rust_2018_idioms)]
 
 //! A work-stealing based thread pool for executing futures.
 //!

--- a/tokio-threadpool/src/park/boxed.rs
+++ b/tokio-threadpool/src/park/boxed.rs
@@ -3,8 +3,8 @@ use tokio_executor::park::{Park, Unpark};
 use std::error::Error;
 use std::time::Duration;
 
-pub(crate) type BoxPark = Box<Park<Unpark = BoxUnpark, Error = ()> + Send>;
-pub(crate) type BoxUnpark = Box<Unpark>;
+pub(crate) type BoxPark = Box<dyn Park<Unpark = BoxUnpark, Error = ()> + Send>;
+pub(crate) type BoxUnpark = Box<dyn Unpark>;
 
 pub(crate) struct BoxedPark<T>(T);
 

--- a/tokio-threadpool/src/sender.rs
+++ b/tokio-threadpool/src/sender.rs
@@ -131,7 +131,7 @@ impl tokio_executor::Executor for Sender {
 
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError> {
         let mut s = &*self;
         tokio_executor::Executor::spawn(&mut s, future)
@@ -157,7 +157,7 @@ impl<'a> tokio_executor::Executor for &'a Sender {
 
     fn spawn(
         &mut self,
-        future: Box<Future<Item = (), Error = ()> + Send>,
+        future: Box<dyn Future<Item = (), Error = ()> + Send>,
     ) -> Result<(), SpawnError> {
         self.prepare_for_spawn()?;
 

--- a/tokio-threadpool/src/task/mod.rs
+++ b/tokio-threadpool/src/task/mod.rs
@@ -60,7 +60,7 @@ pub(crate) enum Run {
     Complete,
 }
 
-type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
+type BoxFuture = Box<dyn Future<Item = (), Error = ()> + Send + 'static>;
 
 // ===== impl Task =====
 

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -18,7 +18,9 @@ use std::time::Duration;
 
 thread_local!(static FOO: Cell<u32> = Cell::new(0));
 
-fn ignore_results<F: Future + Send + 'static>(f: F) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+fn ignore_results<F: Future + Send + 'static>(
+    f: F,
+) -> Box<dyn Future<Item = (), Error = ()> + Send> {
     Box::new(f.map(|_| ()).map_err(|_| ()))
 }
 

--- a/tokio-threadpool/tests/threadpool.rs
+++ b/tokio-threadpool/tests/threadpool.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 thread_local!(static FOO: Cell<u32> = Cell::new(0));
 
-fn ignore_results<F: Future + Send + 'static>(f: F) -> Box<Future<Item = (), Error = ()> + Send> {
+fn ignore_results<F: Future + Send + 'static>(f: F) -> Box<dyn Future<Item = (), Error = ()> + Send> {
     Box::new(f.map(|_| ()).map_err(|_| ()))
 }
 

--- a/tokio-timer/src/clock/clock.rs
+++ b/tokio-timer/src/clock/clock.rs
@@ -17,7 +17,7 @@ use std::time::Instant;
 /// [`Instant::now`]: https://doc.rust-lang.org/std/time/struct.Instant.html#method.now
 #[derive(Default, Clone)]
 pub struct Clock {
-    now: Option<Arc<Now>>,
+    now: Option<Arc<dyn Now>>,
 }
 
 thread_local! {

--- a/tokio-timer/src/throttle.rs
+++ b/tokio-timer/src/throttle.rs
@@ -158,7 +158,7 @@ impl<T: StdError + 'static> StdError for ThrottleError<T> {
     // FIXME(taiki-e): When the minimum support version of tokio reaches Rust 1.30,
     // replace this with Error::source.
     #[allow(deprecated)]
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self.0 {
             Either::A(ref err) => Some(err),
             Either::B(ref err) => Some(err),

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -162,7 +162,7 @@ pub(crate) struct Inner {
     process: AtomicStack,
 
     /// Unparks the timer thread.
-    unpark: Box<Unpark>,
+    unpark: Box<dyn Unpark>,
 }
 
 /// Maximum number of timeouts the system can handle concurrently.
@@ -426,7 +426,7 @@ impl<T, N> Drop for Timer<T, N> {
 // ===== impl Inner =====
 
 impl Inner {
-    fn new(start: Instant, unpark: Box<Unpark>) -> Inner {
+    fn new(start: Instant, unpark: Box<dyn Unpark>) -> Inner {
         Inner {
             num: AtomicUsize::new(0),
             elapsed: AtomicU64::new(0),

--- a/tokio-tls/examples/download-rust-lang.rs
+++ b/tokio-tls/examples/download-rust-lang.rs
@@ -12,7 +12,7 @@ use native_tls::TlsConnector;
 use tokio::net::TcpStream;
 use tokio::runtime::Runtime;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut runtime = Runtime::new()?;
     let addr = "www.rust-lang.org:443"
         .to_socket_addrs()?

--- a/tokio-tls/examples/echo.rs
+++ b/tokio-tls/examples/echo.rs
@@ -8,7 +8,7 @@ use tokio::io;
 use tokio::net::TcpListener;
 use tokio::prelude::*;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Bind the server's socket
     let addr = "127.0.0.1:12345".parse()?;
     let tcp = TcpListener::bind(&addr)?;

--- a/tokio/examples/chat-combinator-current-thread.rs
+++ b/tokio/examples/chat-combinator-current-thread.rs
@@ -41,7 +41,7 @@ use std::io::BufReader;
 use std::iter;
 use std::rc::Rc;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut runtime = Runtime::new().unwrap();
 
     // Create the TCP listener we'll accept connections on.

--- a/tokio/examples/chat-combinator.rs
+++ b/tokio/examples/chat-combinator.rs
@@ -34,7 +34,7 @@ use std::io::BufReader;
 use std::iter;
 use std::sync::{Arc, Mutex};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the TCP listener we'll accept connections on.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse()?;

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -422,7 +422,7 @@ fn process(socket: TcpStream, state: Arc<Mutex<Shared>>) {
     tokio::spawn(connection);
 }
 
-pub fn main() -> Result<(), Box<std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create the shared state. This is how all the peers communicate.
     //
     // The server task will hold a handle to this. For every new client, the

--- a/tokio/examples/connect.rs
+++ b/tokio/examples/connect.rs
@@ -29,7 +29,7 @@ use std::thread;
 use futures::sync::mpsc;
 use tokio::prelude::*;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Determine if we're going to run in TCP or UDP mode
     let mut args = env::args().skip(1).collect::<Vec<_>>();
     let tcp = match args.iter().position(|a| a == "--udp") {
@@ -133,8 +133,8 @@ mod tcp {
 
     pub fn connect(
         addr: &SocketAddr,
-        stdin: Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>,
-    ) -> Result<Box<Stream<Item = BytesMut, Error = io::Error> + Send>, Box<Error>> {
+        stdin: Box<dyn Stream<Item = Vec<u8>, Error = io::Error> + Send>,
+    ) -> Result<Box<dyn Stream<Item = BytesMut, Error = io::Error> + Send>, Box<dyn Error>> {
         let tcp = TcpStream::connect(addr);
 
         // After the TCP connection has been established, we set up our client
@@ -185,8 +185,8 @@ mod udp {
 
     pub fn connect(
         &addr: &SocketAddr,
-        stdin: Box<Stream<Item = Vec<u8>, Error = io::Error> + Send>,
-    ) -> Result<Box<Stream<Item = BytesMut, Error = io::Error> + Send>, Box<Error>> {
+        stdin: Box<dyn Stream<Item = Vec<u8>, Error = io::Error> + Send>,
+    ) -> Result<Box<dyn Stream<Item = BytesMut, Error = io::Error> + Send>, Box<dyn Error>> {
         // We'll bind our UDP socket to a local IP/port, but for now we
         // basically let the OS pick both of those.
         let addr_to_bind = if addr.ip().is_ipv4() {

--- a/tokio/examples/echo-udp.rs
+++ b/tokio/examples/echo-udp.rs
@@ -50,7 +50,7 @@ impl Future for Server {
     }
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
     let addr = addr.parse::<SocketAddr>()?;
 

--- a/tokio/examples/echo.rs
+++ b/tokio/examples/echo.rs
@@ -30,7 +30,7 @@ use tokio::prelude::*;
 use std::env;
 use std::net::SocketAddr;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Allow passing an address to listen on as the first argument of this
     // program, but otherwise we'll just set up our TCP listener on
     // 127.0.0.1:8080 for connections.

--- a/tokio/examples/hello_world.rs
+++ b/tokio/examples/hello_world.rs
@@ -19,7 +19,7 @@ use tokio::io;
 use tokio::net::TcpStream;
 use tokio::prelude::*;
 
-pub fn main() -> Result<(), Box<std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     let addr = "127.0.0.1:6142".parse()?;
 
     // Open a TCP stream to the socket address.

--- a/tokio/examples/manual-runtime.rs
+++ b/tokio/examples/manual-runtime.rs
@@ -60,7 +60,7 @@ fn run<F: Future<Item = (), Error = ()>>(f: F) -> Result<(), IoError> {
     Ok(())
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     run(future::lazy(|| {
         // Here comes the application logic. It can spawn further tasks by tokio_current_thread::spawn().
         // It also can use the default reactor and create timeouts.

--- a/tokio/examples/print_each_packet.rs
+++ b/tokio/examples/print_each_packet.rs
@@ -65,7 +65,7 @@ use tokio_codec::BytesCodec;
 use std::env;
 use std::net::SocketAddr;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Allow passing an address to listen on as the first argument of this
     // program, but otherwise we'll just set up our TCP listener on
     // 127.0.0.1:8080 for connections.

--- a/tokio/examples/proxy.rs
+++ b/tokio/examples/proxy.rs
@@ -33,7 +33,7 @@ use tokio::io::{copy, shutdown};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listen_addr = env::args().nth(1).unwrap_or("127.0.0.1:8081".to_string());
     let listen_addr = listen_addr.parse::<SocketAddr>()?;
 

--- a/tokio/examples/tinydb.rs
+++ b/tokio/examples/tinydb.rs
@@ -83,7 +83,7 @@ enum Response {
     },
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the address we're going to run this server on
     // and set up our TCP listener to accept connections.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());

--- a/tokio/examples/tinyhttp.rs
+++ b/tokio/examples/tinyhttp.rs
@@ -34,7 +34,7 @@ use bytes::BytesMut;
 use http::header::HeaderValue;
 use http::{Request, Response, StatusCode};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Parse the arguments, bind the TCP socket we'll be listening to, spin up
     // our worker threads, and start shipping sockets to those worker threads.
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:8080".to_string());
@@ -82,7 +82,7 @@ fn process(socket: TcpStream) {
 /// This function is a map from and HTTP request to a future of a response and
 /// represents the various handling a server might do. Currently the contents
 /// here are pretty uninteresting.
-fn respond(req: Request<()>) -> Box<Future<Item = Response<String>, Error = io::Error> + Send> {
+fn respond(req: Request<()>) -> Box<dyn Future<Item = Response<String>, Error = io::Error> + Send> {
     let f = future::lazy(move || {
         let mut response = Response::builder();
         let body = match req.uri().path() {

--- a/tokio/examples/udp-client.rs
+++ b/tokio/examples/udp-client.rs
@@ -35,13 +35,13 @@ use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 use tokio::prelude::*;
 
-fn get_stdin_data() -> Result<Vec<u8>, Box<std::error::Error>> {
+fn get_stdin_data() -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let mut buf = Vec::new();
     stdin().read_to_end(&mut buf)?;
     Ok(buf)
 }
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let remote_addr: SocketAddr = env::args()
         .nth(1)
         .unwrap_or("127.0.0.1:8080".into())

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -19,7 +19,7 @@ use tokio::net::{UdpFramed, UdpSocket};
 use tokio::prelude::*;
 use tokio_codec::BytesCodec;
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _ = env_logger::init();
 
     let addr: SocketAddr = "127.0.0.1:0".parse()?;

--- a/tokio/src/runtime/current_thread/runtime.rs
+++ b/tokio/src/runtime/current_thread/runtime.rs
@@ -105,7 +105,7 @@ impl Error for RunError {
     // FIXME(taiki-e): When the minimum support version of tokio reaches Rust 1.30,
     // replace this with Error::source.
     #[allow(deprecated)]
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         self.inner.cause()
     }
 }

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -128,7 +128,7 @@ impl Builder {
     /// ```
     pub fn panic_handler<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(Box<Any + Send>) + Send + Sync + 'static,
+        F: Fn(Box<dyn Any + Send>) + Send + Sync + 'static,
     {
         self.threadpool_builder.panic_handler(f);
         self

--- a/tokio/src/runtime/threadpool/task_executor.rs
+++ b/tokio/src/runtime/threadpool/task_executor.rs
@@ -67,7 +67,7 @@ where T: Future<Item = (), Error = ()> + Send + 'static,
 }
 
 impl ::executor::Executor for TaskExecutor {
-    fn spawn(&mut self, future: Box<Future<Item = (), Error = ()> + Send>)
+    fn spawn(&mut self, future: Box<dyn Future<Item = (), Error = ()> + Send>)
         -> Result<(), ::executor::SpawnError>
     {
         self.inner.spawn(future)

--- a/tokio/tests/reactor.rs
+++ b/tokio/tests/reactor.rs
@@ -30,7 +30,7 @@ fn test_drop_on_notify() {
 
     struct MyNotify;
 
-    type Task = Mutex<Spawn<Box<Future<Item = (), Error = ()>>>>;
+    type Task = Mutex<Spawn<Box<dyn Future<Item = (), Error = ()>>>>;
 
     impl Notify for MyNotify {
         fn notify(&self, _: usize) {
@@ -66,7 +66,7 @@ fn test_drop_on_notify() {
             .incoming()
             .for_each(|_| Ok(()))
             .map_err(|_| panic!())
-    }) as Box<Future<Item = (), Error = ()>>;
+    }) as Box<dyn Future<Item = (), Error = ()>>;
 
     let task = Arc::new(Mutex::new(spawn(task)));
     let notify = Arc::new(MyNotify);

--- a/tokio/tests/runtime.rs
+++ b/tokio/tests/runtime.rs
@@ -133,7 +133,10 @@ mod runtime_single_threaded_racy {
     use super::*;
     fn test<F>(spawn: F)
     where
-        F: Fn(tokio::runtime::current_thread::Handle, Box<dyn Future<Item = (), Error = ()> + Send>),
+        F: Fn(
+            tokio::runtime::current_thread::Handle,
+            Box<dyn Future<Item = (), Error = ()> + Send>,
+        ),
     {
         let (trigger, exit) = futures::sync::oneshot::channel();
         let (handle_tx, handle_rx) = ::std::sync::mpsc::channel();

--- a/tokio/tests/runtime.rs
+++ b/tokio/tests/runtime.rs
@@ -25,7 +25,7 @@ macro_rules! t {
     };
 }
 
-fn create_client_server_future() -> Box<Future<Item = (), Error = ()> + Send> {
+fn create_client_server_future() -> Box<dyn Future<Item = (), Error = ()> + Send> {
     let server = t!(TcpListener::bind(&"127.0.0.1:0".parse().unwrap()));
     let addr = t!(server.local_addr());
     let client = TcpStream::connect(&addr);
@@ -84,7 +84,7 @@ mod runtime_single_threaded_block_on_all {
 
     fn test<F>(spawn: F)
     where
-        F: Fn(Box<Future<Item = (), Error = ()> + Send>),
+        F: Fn(Box<dyn Future<Item = (), Error = ()> + Send>),
     {
         let cnt = Arc::new(Mutex::new(0));
         let c = cnt.clone();
@@ -133,7 +133,7 @@ mod runtime_single_threaded_racy {
     use super::*;
     fn test<F>(spawn: F)
     where
-        F: Fn(tokio::runtime::current_thread::Handle, Box<Future<Item = (), Error = ()> + Send>),
+        F: Fn(tokio::runtime::current_thread::Handle, Box<dyn Future<Item = (), Error = ()> + Send>),
     {
         let (trigger, exit) = futures::sync::oneshot::channel();
         let (handle_tx, handle_rx) = ::std::sync::mpsc::channel();
@@ -218,7 +218,7 @@ fn block_on_timer() {
     use std::time::{Duration, Instant};
     use tokio::timer::{Delay, Error};
 
-    fn after_1s<T>(x: T) -> Box<Future<Item = T, Error = Error> + Send>
+    fn after_1s<T>(x: T) -> Box<dyn Future<Item = T, Error = Error> + Send>
     where
         T: Send + 'static,
     {
@@ -235,7 +235,7 @@ mod from_block_on {
 
     fn test<F>(spawn: F)
     where
-        F: Fn(Box<Future<Item = (), Error = ()> + Send>) + Send + 'static,
+        F: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) + Send + 'static,
     {
         let cnt = Arc::new(Mutex::new(0));
         let c = cnt.clone();
@@ -317,7 +317,7 @@ mod many {
     const ITER: usize = 200;
     fn test<F>(spawn: F)
     where
-        F: Fn(&mut Runtime, Box<Future<Item = (), Error = ()> + Send>),
+        F: Fn(&mut Runtime, Box<dyn Future<Item = (), Error = ()> + Send>),
     {
         let cnt = Arc::new(Mutex::new(0));
         let mut runtime = Runtime::new().unwrap();
@@ -360,7 +360,7 @@ mod from_block_on_all {
 
     fn test<F>(spawn: F)
     where
-        F: Fn(Box<Future<Item = (), Error = ()> + Send>) + Send + 'static,
+        F: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) + Send + 'static,
     {
         let cnt = Arc::new(Mutex::new(0));
         let c = cnt.clone();
@@ -414,8 +414,8 @@ mod nested_enter {
 
     fn test<F1, F2>(first: F1, nested: F2)
     where
-        F1: Fn(Box<Future<Item = (), Error = ()> + Send>) + Send + 'static,
-        F2: Fn(Box<Future<Item = (), Error = ()> + Send>) + panic::UnwindSafe + Send + 'static,
+        F1: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) + Send + 'static,
+        F2: Fn(Box<dyn Future<Item = (), Error = ()> + Send>) + panic::UnwindSafe + Send + 'static,
     {
         let panicked = Arc::new(Mutex::new(false));
         let panicked2 = panicked.clone();


### PR DESCRIPTION
This is part (1) of proposed changes in #1348.   It may need to wait for stronger motivation, but I wanted to make the changes available.  This depends on an MSRV of at least 1.27.0.

## Motivation

On the v0.1.x branch, the use of `#[deny(warnings)]` makes the following warnings fatal on recent nighty compilers (in my case currently: rustc 1.38.0-nightly (83e4eed16 2019-07-14)), when building a local git tree.  

``` txt
error: trait objects without an explicit `dyn` are deprecated
   --> tokio-current-thread/src/scheduler.rs:128:23
    |
128 | struct Task(Spawn<Box<Future<Item = (), Error = ()>>>);
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = (), Error = ()>`
    |
note: lint level defined here
   --> tokio-current-thread/src/lib.rs:2:9
    |
2   | #![deny(warnings, missing_docs, missing_debug_implementations)]
    |         ^^^^^^^^
    = note: #[deny(bare_trait_objects)] implied by #[deny(warnings)]
```
When built as a dependency of a normal application, cargo passes `--cap-lints=allow` to rustc (or for `cargo -vv`, `--cap-lints=warn` at most), so these are not fatal in that case. The current azure-pipelines CI appears to only test with stable rust (e.g. 1.36.0) or older nightlies, so this hasn't broken CI, yet.

## Solution

I applied `cargo fix` followed by `cargo fmt` and then filtered through the changes (`git add --patch`) to isolate these `dyn` additions.   ~Also this bumps the check-minrust MSRV to 1.27.2, just to hopefully to get CI passing.~
