### PR TITLE
v0.1.x:  Don't deny warnings

### DIFF
--- a/benches/latency.rs
+++ b/benches/latency.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate test;
 #[macro_use]

--- a/benches/mio-ops.rs
+++ b/benches/mio-ops.rs
@@ -1,7 +1,6 @@
 // Measure cost of different operations
 // to get a sense of performance tradeoffs
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate mio;
 extern crate test;

--- a/benches/tcp.rs
+++ b/benches/tcp.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate futures;
 extern crate tokio;

--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-buf/0.1.1")]
 #![deny(missing_docs, missing_debug_implementations, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
 
 //! Asynchronous stream of bytes.
 //!

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/tokio-codec/0.1.1")]
 
 //! Utilities for encoding and decoding frames.

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-current-thread/0.1.6")]
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! A single-threaded executor which executes tasks on the same thread from which
 //! they are spawned.

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.8")]
 
 //! Task execution related traits and utilities.

--- a/tokio-fs/examples/std-echo.rs
+++ b/tokio-fs/examples/std-echo.rs
@@ -1,5 +1,5 @@
 //! Echo everything received on STDIN to STDOUT.
-#![deny(deprecated, warnings)]
+#![deny(deprecated)]
 
 extern crate futures;
 extern crate tokio_codec;

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/tokio-fs/0.1.6")]
 
 //! Asynchronous file and standard stream adaptation.

--- a/tokio-futures/src/lib.rs
+++ b/tokio-futures/src/lib.rs
@@ -2,7 +2,6 @@
 #![feature(await_macro)]
 #![doc(html_root_url = "https://docs.rs/tokio-futures/0.1.0")]
 #![deny(missing_docs, missing_debug_implementations)]
-#![cfg_attr(test, deny(warnings))]
 
 //! A preview of Tokio w/ `async` / `await` support.
 

--- a/tokio-io/src/_tokio_codec/mod.rs
+++ b/tokio-io/src/_tokio_codec/mod.rs
@@ -10,7 +10,7 @@
 //! [`Stream`]: #
 //! [transports]: #
 
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(hidden, html_root_url = "https://docs.rs/tokio-codec/0.1.0")]
 
 // _tokio_codec are the items that belong in the `tokio_codec` crate. However, because we need to

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs, missing_debug_implementations, warnings)]
+#![deny(missing_docs, missing_debug_implementations)]
 #![doc(html_root_url = "https://docs.rs/tokio-io/0.1.12")]
 
 //! Core I/O traits and combinators when working with Tokio.

--- a/tokio-reactor/benches/basic.rs
+++ b/tokio-reactor/benches/basic.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate futures;
 extern crate mio;

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.9")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.
 //!

--- a/tokio-sync/benches/mpsc.rs
+++ b/tokio-sync/benches/mpsc.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![cfg_attr(test, deny(warnings))]
 
 extern crate futures;
 extern crate test;

--- a/tokio-sync/benches/oneshot.rs
+++ b/tokio-sync/benches/oneshot.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![cfg_attr(test, deny(warnings))]
 
 extern crate futures;
 extern crate test;

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-sync/0.1.6")]
 #![deny(missing_debug_implementations, missing_docs, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
 
 //! Asynchronous synchronization primitives.
 //!

--- a/tokio-sync/tests/atomic_task.rs
+++ b/tokio-sync/tests/atomic_task.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;

--- a/tokio-sync/tests/errors.rs
+++ b/tokio-sync/tests/errors.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate tokio_sync;
 
 fn is_error<T: ::std::error::Error + Send + Sync>() {}

--- a/tokio-sync/tests/fuzz_list.rs
+++ b/tokio-sync/tests/fuzz_list.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 #[macro_use]
 extern crate loom;

--- a/tokio-sync/tests/fuzz_oneshot.rs
+++ b/tokio-sync/tests/fuzz_oneshot.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate loom;
 

--- a/tokio-sync/tests/fuzz_semaphore.rs
+++ b/tokio-sync/tests/fuzz_semaphore.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 #[macro_use]
 extern crate futures;
 #[macro_use]

--- a/tokio-sync/tests/lock.rs
+++ b/tokio-sync/tests/lock.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;

--- a/tokio-sync/tests/oneshot.rs
+++ b/tokio-sync/tests/oneshot.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;

--- a/tokio-sync/tests/semaphore.rs
+++ b/tokio-sync/tests/semaphore.rs
@@ -1,5 +1,3 @@
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio_mock_task;
 extern crate tokio_sync;

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.3")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! TCP bindings for `tokio`.
 //!

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-test/0.1.0")]
 #![deny(missing_docs, missing_debug_implementations, unreachable_pub)]
-#![cfg_attr(test, deny(warnings))]
 
 //! Tokio and Futures based testing utilites
 //!

--- a/tokio-threadpool/benches/basic.rs
+++ b/tokio-threadpool/benches/basic.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate futures;
 extern crate futures_cpupool;

--- a/tokio-threadpool/benches/blocking.rs
+++ b/tokio-threadpool/benches/blocking.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate futures;
 extern crate rand;

--- a/tokio-threadpool/benches/depth.rs
+++ b/tokio-threadpool/benches/depth.rs
@@ -1,5 +1,4 @@
 #![feature(test)]
-#![deny(warnings)]
 
 extern crate futures;
 extern crate futures_cpupool;

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.15")]
-#![deny(warnings, missing_docs, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.
 //!

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.11")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! Utilities for tracking time.
 //!

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio-tcp/0.1.3")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! UDP bindings for `tokio`.
 //!

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 #![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.5")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! Unix Domain Sockets for Tokio.
 //!

--- a/tokio/examples/chat-combinator-current-thread.rs
+++ b/tokio/examples/chat-combinator-current-thread.rs
@@ -24,8 +24,6 @@
 //! connected clients they'll all join the same room and see everyone else's
 //! messages.
 
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio;
 

--- a/tokio/examples/chat-combinator.rs
+++ b/tokio/examples/chat-combinator.rs
@@ -19,8 +19,6 @@
 //! connected clients they'll all join the same room and see everyone else's
 //! messages.
 
-#![deny(warnings)]
-
 extern crate futures;
 extern crate tokio;
 

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -24,8 +24,6 @@
 //! connected clients they'll all join the same room and see everyone else's
 //! messages.
 
-#![deny(warnings)]
-
 extern crate tokio;
 #[macro_use]
 extern crate futures;

--- a/tokio/examples/connect.rs
+++ b/tokio/examples/connect.rs
@@ -14,8 +14,6 @@
 //! this repository! Many of them recommend running this as a simple "hook up
 //! stdin/stdout to a server" to get up and running.
 
-#![deny(warnings)]
-
 extern crate bytes;
 extern crate futures;
 extern crate tokio;

--- a/tokio/examples/echo-udp.rs
+++ b/tokio/examples/echo-udp.rs
@@ -10,8 +10,6 @@
 //!
 //! Each line you type in to the `nc` terminal should be echo'd back to you!
 
-#![deny(warnings)]
-
 #[macro_use]
 extern crate futures;
 extern crate tokio;

--- a/tokio/examples/echo.rs
+++ b/tokio/examples/echo.rs
@@ -19,8 +19,6 @@
 //! you! If you open up multiple terminals running the `connect` example you
 //! should be able to see them all make progress simultaneously.
 
-#![deny(warnings)]
-
 extern crate tokio;
 
 use tokio::io;

--- a/tokio/examples/hello_world.rs
+++ b/tokio/examples/hello_world.rs
@@ -11,8 +11,6 @@
 //!
 //!     cargo run --example hello_world
 
-#![deny(warnings)]
-
 extern crate tokio;
 
 use tokio::io;

--- a/tokio/examples/print_each_packet.rs
+++ b/tokio/examples/print_each_packet.rs
@@ -52,8 +52,6 @@
 //! ```
 //!
 
-#![deny(warnings)]
-
 extern crate tokio;
 extern crate tokio_codec;
 

--- a/tokio/examples/proxy.rs
+++ b/tokio/examples/proxy.rs
@@ -20,8 +20,6 @@
 //! This final terminal will connect to our proxy, which will in turn connect to
 //! the echo server, and you'll be able to see data flowing between them.
 
-#![deny(warnings)]
-
 extern crate tokio;
 
 use std::env;

--- a/tokio/examples/tinydb.rs
+++ b/tokio/examples/tinydb.rs
@@ -39,8 +39,6 @@
 //! * `SET $key $value` - this will set the value of `$key` to `$value`,
 //!   returning the previous value, if any.
 
-#![deny(warnings)]
-
 extern crate tokio;
 
 use std::collections::HashMap;

--- a/tokio/examples/tinyhttp.rs
+++ b/tokio/examples/tinyhttp.rs
@@ -11,8 +11,6 @@
 //! respectively. By default this will run I/O on all the cores your system has
 //! available, and it doesn't support HTTP request bodies.
 
-#![deny(warnings)]
-
 extern crate bytes;
 extern crate http;
 extern crate httparse;

--- a/tokio/examples/udp-codec.rs
+++ b/tokio/examples/udp-codec.rs
@@ -6,8 +6,6 @@
 //! new message with a new destination. Overall, we then use this to construct a
 //! "ping pong" pair where two sockets are sending messages back and forth.
 
-#![deny(warnings)]
-
 extern crate env_logger;
 extern crate tokio;
 extern crate tokio_codec;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc(html_root_url = "https://docs.rs/tokio/0.1.22")]
-#![deny(missing_docs, warnings, missing_debug_implementations)]
+#![deny(missing_docs, missing_debug_implementations)]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!


### PR DESCRIPTION
This is minimally, an alternative solution to #1351, and for maximum future-proofing, could be applied _in addition to_ #1351.   Note that #1351 greatly reduces build warning noise for the common missing `dyn` issue, while this PR just preserves the warnings. 

## Motivation

While there are tradeoffs and some open questions regarding using `#![deny(warnings)]` on tokio's master branch, its harder to justify keeping this setting on the v0.1.x stable maintenance branch where new features aren't being added, and as in #1351, subsequent rust stable releases can introduce new warnings that `deny` makes fatal errors (at least with a local dev tree or CI).

## Solution

Remove `deny(warnings)` everywhere on v0.1.x branch (crate root modules, examples, tests, benches, etc.)! Also drop the explicit `allow(rust_2018_idioms)` (in d6dcaea) which was only selectively applied and caused a build failure on 1.27.2 (see https://github.com/tokio-rs/tokio/pull/1351#issuecomment-514838709).