### PR TITLE
io: Move io helpers back into `tokio-io`

### DIFF
--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -25,10 +25,14 @@ publish = false
 bytes = "0.4.7"
 log = "0.4"
 futures-core-preview = "0.3.0-alpha.17"
-memchr = "2.2"
+memchr = { version = "2.2", optional = true }
 
 [dev-dependencies]
 pin-utils = "0.1.0-alpha.4"
 tokio = { version = "0.2.0", path = "../tokio" }
 futures-util-preview = "0.3.0-alpha.17"
 tokio-test = { version = "0.2.0", path = "../tokio-test" }
+
+[features]
+default = ["util"]
+util = ["memchr"]

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -25,7 +25,10 @@ publish = false
 bytes = "0.4.7"
 log = "0.4"
 futures-core-preview = "0.3.0-alpha.17"
+memchr = "2.2"
 
 [dev-dependencies]
 pin-utils = "0.1.0-alpha.4"
+tokio = { version = "0.2.0", path = "../tokio" }
+futures-util-preview = "0.3.0-alpha.17"
 tokio-test = { version = "0.2.0", path = "../tokio-test" }

--- a/tokio-io/src/io/async_buf_read_ext.rs
+++ b/tokio-io/src/io/async_buf_read_ext.rs
@@ -1,8 +1,7 @@
 use crate::io::lines::{lines, Lines};
 use crate::io::read_line::{read_line, ReadLine};
 use crate::io::read_until::{read_until, ReadUntil};
-
-use tokio_io::AsyncBufRead;
+use crate::AsyncBufRead;
 
 /// An extension trait which adds utility methods to `AsyncBufRead` types.
 pub trait AsyncBufReadExt: AsyncBufRead {

--- a/tokio-io/src/io/async_buf_read_ext.rs
+++ b/tokio-io/src/io/async_buf_read_ext.rs
@@ -18,12 +18,6 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     ///
     /// In the case of an error the buffer and the object will be discarded, with
     /// the error yielded.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read_until<'a>(&'a mut self, byte: u8, buf: &'a mut Vec<u8>) -> ReadUntil<'a, Self>
     where
         Self: Unpin,
@@ -54,12 +48,6 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// the event that all data read so far was valid UTF-8.
     ///
     /// [`read_until`]: AsyncBufReadExt::read_until
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read_line<'a>(&'a mut self, buf: &'a mut String) -> ReadLine<'a, Self>
     where
         Self: Unpin,
@@ -82,12 +70,6 @@ pub trait AsyncBufReadExt: AsyncBufRead {
     /// Each line of the stream has the same error semantics as [`AsyncBufReadExt::read_line`].
     ///
     /// [`AsyncBufReadExt::read_line`]: AsyncBufReadExt::read_line
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn lines(self) -> Lines<Self>
     where
         Self: Sized,

--- a/tokio-io/src/io/async_read_ext.rs
+++ b/tokio-io/src/io/async_read_ext.rs
@@ -17,12 +17,6 @@ pub trait AsyncReadExt: AsyncRead {
     /// On success the number of bytes is returned and the `reader` and `writer`
     /// are consumed. On error the error is returned and the I/O objects are
     /// consumed as well.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn copy<'a, W>(&'a mut self, dst: &'a mut W) -> Copy<'a, Self, W>
     where
         Self: Unpin,
@@ -35,12 +29,6 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// The returned future will resolve to the number of bytes read once the
     /// read operation is completed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read<'a>(&'a mut self, dst: &'a mut [u8]) -> Read<'a, Self>
     where
         Self: Unpin,
@@ -49,12 +37,6 @@ pub trait AsyncReadExt: AsyncRead {
     }
 
     /// Read exactly the amount of data needed to fill the provided buffer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read_exact<'a>(&'a mut self, dst: &'a mut [u8]) -> ReadExact<'a, Self>
     where
         Self: Unpin,
@@ -65,12 +47,6 @@ pub trait AsyncReadExt: AsyncRead {
     /// Read all bytes until EOF in this source, placing them into `dst`.
     ///
     /// On success the total number of bytes read is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read_to_end<'a>(&'a mut self, dst: &'a mut Vec<u8>) -> ReadToEnd<'a, Self>
     where
         Self: Unpin,
@@ -81,12 +57,6 @@ pub trait AsyncReadExt: AsyncRead {
     /// Read all bytes until EOF in this source, placing them into `dst`.
     ///
     /// On success the total number of bytes read is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn read_to_string<'a>(&'a mut self, dst: &'a mut String) -> ReadToString<'a, Self>
     where
         Self: Unpin,

--- a/tokio-io/src/io/async_read_ext.rs
+++ b/tokio-io/src/io/async_read_ext.rs
@@ -3,8 +3,7 @@ use crate::io::read::{read, Read};
 use crate::io::read_exact::{read_exact, ReadExact};
 use crate::io::read_to_end::{read_to_end, ReadToEnd};
 use crate::io::read_to_string::{read_to_string, ReadToString};
-
-use tokio_io::{AsyncRead, AsyncWrite};
+use crate::{AsyncRead, AsyncWrite};
 
 /// An extension trait which adds utility methods to `AsyncRead` types.
 pub trait AsyncReadExt: AsyncRead {

--- a/tokio-io/src/io/async_write_ext.rs
+++ b/tokio-io/src/io/async_write_ext.rs
@@ -1,8 +1,7 @@
 use crate::io::flush::{flush, Flush};
 use crate::io::write::{write, Write};
 use crate::io::write_all::{write_all, WriteAll};
-
-use tokio_io::AsyncWrite;
+use crate::AsyncWrite;
 
 /// An extension trait which adds utility methods to `AsyncWrite` types.
 pub trait AsyncWriteExt: AsyncWrite {

--- a/tokio-io/src/io/async_write_ext.rs
+++ b/tokio-io/src/io/async_write_ext.rs
@@ -6,12 +6,6 @@ use crate::AsyncWrite;
 /// An extension trait which adds utility methods to `AsyncWrite` types.
 pub trait AsyncWriteExt: AsyncWrite {
     /// Write a buffer into this writter, returning how many bytes were written.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ````
     fn write<'a>(&'a mut self, src: &'a [u8]) -> Write<'a, Self>
     where
         Self: Unpin,
@@ -20,12 +14,6 @@ pub trait AsyncWriteExt: AsyncWrite {
     }
 
     /// Attempt to write an entire buffer into this writter.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn write_all<'a>(&'a mut self, src: &'a [u8]) -> WriteAll<'a, Self>
     where
         Self: Unpin,
@@ -34,12 +22,6 @@ pub trait AsyncWriteExt: AsyncWrite {
     }
 
     /// Flush the contents of this writer.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// unimplemented!();
-    /// ```
     fn flush(&mut self) -> Flush<'_, Self>
     where
         Self: Unpin,

--- a/tokio-io/src/io/copy.rs
+++ b/tokio-io/src/io/copy.rs
@@ -1,9 +1,9 @@
+use crate::{AsyncRead, AsyncWrite};
 use futures_core::ready;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_io::{AsyncRead, AsyncWrite};
 
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]

--- a/tokio-io/src/io/flush.rs
+++ b/tokio-io/src/io/flush.rs
@@ -1,9 +1,8 @@
+use crate::AsyncWrite;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-
-use tokio_io::AsyncWrite;
 
 /// A future used to fully flush an I/O object.
 ///

--- a/tokio-io/src/io/lines.rs
+++ b/tokio-io/src/io/lines.rs
@@ -1,6 +1,5 @@
 use super::read_line::read_line_internal;
-
-use tokio_io::AsyncBufRead;
+use crate::AsyncBufRead;
 
 use futures_core::{ready, Stream};
 use std::io;

--- a/tokio-io/src/io/mod.rs
+++ b/tokio-io/src/io/mod.rs
@@ -1,0 +1,56 @@
+//! Asynchronous I/O.
+//!
+//! This module is the asynchronous version of `std::io`. Primarily, it
+//! defines two traits, [`AsyncRead`] and [`AsyncWrite`], which extend the
+//! `Read` and `Write` traits of the standard library.
+//!
+//! # AsyncRead and AsyncWrite
+//!
+//! [`AsyncRead`] and [`AsyncWrite`] must only be implemented for
+//! non-blocking I/O types that integrate with the futures type system. In
+//! other words, these types must never block the thread, and instead the
+//! current task is notified when the I/O resource is ready.
+//!
+//! # Standard input and output
+//!
+//! Tokio provides asynchronous APIs to standard [input], [output], and [error].
+//! These APIs are very similar to the ones provided by `std`, but they also
+//! implement [`AsyncRead`] and [`AsyncWrite`].
+//!
+//! Unlike *most* other Tokio APIs, the standard input / output APIs
+//! **must** be used from the context of the Tokio runtime as they require
+//! Tokio specific features to function.
+//!
+//! [input]: fn.stdin.html
+//! [output]: fn.stdout.html
+//! [error]: fn.stderr.html
+//!
+//! # `std` re-exports
+//!
+//! Additionally, [`Error`], [`ErrorKind`], and [`Result`] are re-exported
+//! from `std::io` for ease of use.
+//!
+//! [`AsyncRead`]: trait.AsyncRead.html
+//! [`AsyncWrite`]: trait.AsyncWrite.html
+//! [`Error`]: struct.Error.html
+//! [`ErrorKind`]: enum.ErrorKind.html
+//! [`Result`]: type.Result.html
+
+mod async_buf_read_ext;
+mod async_read_ext;
+mod async_write_ext;
+mod copy;
+mod flush;
+mod lines;
+mod read;
+mod read_exact;
+mod read_line;
+mod read_to_end;
+mod read_to_string;
+mod read_until;
+mod write;
+mod write_all;
+
+pub use self::async_buf_read_ext::AsyncBufReadExt;
+pub use self::async_read_ext::AsyncReadExt;
+pub use self::async_write_ext::AsyncWriteExt;

--- a/tokio-io/src/io/read.rs
+++ b/tokio-io/src/io/read.rs
@@ -1,9 +1,9 @@
+use crate::AsyncRead;
 use std::future::Future;
 use std::io;
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_io::AsyncRead;
 
 /// Tries to read some bytes directly into the given `buf` in asynchronous
 /// manner, returning a future type.

--- a/tokio-io/src/io/read_exact.rs
+++ b/tokio-io/src/io/read_exact.rs
@@ -1,10 +1,10 @@
+use crate::AsyncRead;
 use futures_core::ready;
 use std::future::Future;
 use std::io;
 use std::marker::Unpin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_io::AsyncRead;
 
 /// A future which can be used to easily read exactly enough bytes to fill
 /// a buffer.

--- a/tokio-io/src/io/read_to_end.rs
+++ b/tokio-io/src/io/read_to_end.rs
@@ -1,5 +1,4 @@
-use tokio_io::AsyncRead;
-
+use crate::AsyncRead;
 use futures_core::ready;
 use std::future::Future;
 use std::io;

--- a/tokio-io/src/io/read_until.rs
+++ b/tokio-io/src/io/read_until.rs
@@ -1,10 +1,10 @@
+use crate::AsyncBufRead;
 use futures_core::ready;
 use std::future::Future;
 use std::io;
 use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_io::AsyncBufRead;
 
 /// Future for the [`read_until`](crate::io::AsyncBufReadExt::read_until) method.
 #[derive(Debug)]

--- a/tokio-io/src/io/write.rs
+++ b/tokio-io/src/io/write.rs
@@ -1,8 +1,8 @@
+use crate::AsyncWrite;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_io::AsyncWrite;
 
 /// A future to write some of the buffer to an `AsyncWrite`.
 #[derive(Debug)]

--- a/tokio-io/src/io/write_all.rs
+++ b/tokio-io/src/io/write_all.rs
@@ -1,5 +1,4 @@
-use tokio_io::AsyncWrite;
-
+use crate::AsyncWrite;
 use futures_core::ready;
 use std::future::Future;
 use std::io;

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.1.12")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.2.0")]
 #![deny(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![cfg_attr(test, deny(warnings))]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
@@ -14,11 +14,15 @@
 mod async_buf_read;
 mod async_read;
 mod async_write;
+
+#[cfg(feature = "util")]
 mod io;
 
 pub use self::async_buf_read::AsyncBufRead;
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;
+
+#[cfg(feature = "util")]
 pub use self::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 
 // Re-export `Buf` and `BufMut` since they are part of the API

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -14,10 +14,12 @@
 mod async_buf_read;
 mod async_read;
 mod async_write;
+mod io;
 
 pub use self::async_buf_read::AsyncBufRead;
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;
+pub use self::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 
 // Re-export `Buf` and `BufMut` since they are part of the API
 pub use bytes::{Buf, BufMut};

--- a/tokio-io/tests/copy.rs
+++ b/tokio-io/tests/copy.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use tokio_io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use tokio_test::assert_ok;
 
 use bytes::BytesMut;

--- a/tokio-io/tests/read.rs
+++ b/tokio-io/tests/read.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_io::{AsyncRead, AsyncReadExt};
 use tokio_test::assert_ok;
 
 use std::io;

--- a/tokio-io/tests/read_line.rs
+++ b/tokio-io/tests/read_line.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
+use tokio_io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
 use tokio_test::assert_ok;
 
 use std::io;

--- a/tokio-io/tests/read_to_string.rs
+++ b/tokio-io/tests/read_to_string.rs
@@ -1,7 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncRead, AsyncReadExt};
+use tokio_io::{AsyncRead, AsyncReadExt};
 use tokio_test::assert_ok;
 
 use std::pin::Pin;
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 use std::{cmp, io};
 
 #[tokio::test]
-async fn read_to_end() {
+async fn read_to_string() {
     struct Rd {
         val: &'static [u8],
     }
@@ -29,12 +29,12 @@ async fn read_to_end() {
         }
     }
 
-    let mut buf = vec![];
+    let mut buf = String::new();
     let mut rd = Rd {
         val: b"hello world",
     };
 
-    let n = assert_ok!(rd.read_to_end(&mut buf).await);
+    let n = assert_ok!(rd.read_to_string(&mut buf).await);
     assert_eq!(n, 11);
-    assert_eq!(buf[..], b"hello world"[..]);
+    assert_eq!(buf[..], "hello world"[..]);
 }

--- a/tokio-io/tests/read_until.rs
+++ b/tokio-io/tests/read_until.rs
@@ -1,8 +1,7 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use futures_util::StreamExt;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
+use tokio_io::{AsyncBufRead, AsyncBufReadExt, AsyncRead};
 use tokio_test::assert_ok;
 
 use std::io;
@@ -10,7 +9,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[tokio::test]
-async fn lines() {
+async fn read_until() {
     struct Rd {
         val: &'static [u8],
     }
@@ -38,16 +37,20 @@ async fn lines() {
         }
     }
 
-    let rd = Rd {
-        val: b"hello\r\nworld\n\n",
+    let mut buf = vec![];
+    let mut rd = Rd {
+        val: b"hello world",
     };
-    let mut st = rd.lines();
 
-    let b = assert_ok!(st.next().await.unwrap());
-    assert_eq!(b, "hello");
-    let b = assert_ok!(st.next().await.unwrap());
-    assert_eq!(b, "world");
-    let b = assert_ok!(st.next().await.unwrap());
-    assert_eq!(b, "");
-    assert!(st.next().await.is_none());
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 6);
+    assert_eq!(buf, b"hello ");
+    buf.clear();
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf, b"world");
+    buf.clear();
+    let n = assert_ok!(rd.read_until(b' ', &mut buf).await);
+    assert_eq!(n, 0);
+    assert_eq!(buf, []);
 }

--- a/tokio-io/tests/write.rs
+++ b/tokio-io/tests/write.rs
@@ -1,17 +1,16 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio_io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;
 
 use bytes::BytesMut;
-use std::cmp;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[tokio::test]
-async fn write_all() {
+async fn write() {
     struct Wr {
         buf: BytesMut,
         cnt: usize,
@@ -23,12 +22,9 @@ async fn write_all() {
             _cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
-            let n = cmp::min(4, buf.len());
-            let buf = &buf[0..n];
-
-            self.cnt += 1;
-            self.buf.extend(buf);
-            Ok(buf.len()).into()
+            assert_eq!(self.cnt, 0);
+            self.buf.extend(&buf[0..4]);
+            Ok(4).into()
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -45,7 +41,7 @@ async fn write_all() {
         cnt: 0,
     };
 
-    assert_ok!(wr.write_all(b"hello world").await);
-    assert_eq!(wr.buf, b"hello world"[..]);
-    assert_eq!(wr.cnt, 3);
+    let n = assert_ok!(wr.write(b"hello world").await);
+    assert_eq!(n, 4);
+    assert_eq!(wr.buf, b"hell"[..]);
 }

--- a/tokio-io/tests/write_all.rs
+++ b/tokio-io/tests/write_all.rs
@@ -1,16 +1,17 @@
 #![deny(warnings, rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio_io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;
 
 use bytes::BytesMut;
+use std::cmp;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
 #[tokio::test]
-async fn write() {
+async fn write_all() {
     struct Wr {
         buf: BytesMut,
         cnt: usize,
@@ -22,9 +23,12 @@ async fn write() {
             _cx: &mut Context<'_>,
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
-            assert_eq!(self.cnt, 0);
-            self.buf.extend(&buf[0..4]);
-            Ok(4).into()
+            let n = cmp::min(4, buf.len());
+            let buf = &buf[0..n];
+
+            self.cnt += 1;
+            self.buf.extend(buf);
+            Ok(buf.len()).into()
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
@@ -41,7 +45,7 @@ async fn write() {
         cnt: 0,
     };
 
-    let n = assert_ok!(wr.write(b"hello world").await);
-    assert_eq!(n, 4);
-    assert_eq!(wr.buf, b"hell"[..]);
+    assert_ok!(wr.write_all(b"hello world").await);
+    assert_eq!(wr.buf, b"hello world"[..]);
+    assert_eq!(wr.cnt, 3);
 }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -38,9 +38,9 @@ default = [
   "uds",
 ]
 
-codec = ["io", "tokio-codec"]
+codec = ["io", "tokio-codec", "bytes"]
 fs = ["tokio-fs"]
-io = ["bytes", "tokio-io", "memchr"]
+io = ["tokio-io"]
 reactor = ["io", "tokio-reactor"]
 rt-full = [
   "num_cpus",
@@ -80,7 +80,6 @@ tokio-tcp = { version = "0.2.0", optional = true, path = "../tokio-tcp", feature
 tokio-udp = { version = "0.2.0", optional = true, path = "../tokio-udp" }
 tokio-timer = { version = "0.3.0", optional = true, path = "../tokio-timer", features = ["async-traits"] }
 tracing-core = { version = "0.1", optional = true }
-memchr = { version = "2.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 tokio-uds = { version = "0.3.0", optional = true, path = "../tokio-uds", features = ["async-traits"] }

--- a/tokio/src/io.rs
+++ b/tokio/src/io.rs
@@ -36,29 +36,12 @@
 //! [`ErrorKind`]: enum.ErrorKind.html
 //! [`Result`]: type.Result.html
 
-mod async_buf_read_ext;
-mod async_read_ext;
-mod async_write_ext;
-mod copy;
-mod flush;
-mod lines;
-mod read;
-mod read_exact;
-mod read_line;
-mod read_to_end;
-mod read_to_string;
-mod read_until;
-mod write;
-mod write_all;
-
-pub use self::async_buf_read_ext::AsyncBufReadExt;
-pub use self::async_read_ext::AsyncReadExt;
-pub use self::async_write_ext::AsyncWriteExt;
-
 // standard input, output, and error
 #[cfg(feature = "fs")]
 pub use tokio_fs::{stderr, stdin, stdout, Stderr, Stdin, Stdout};
-pub use tokio_io::{AsyncBufRead, AsyncRead, AsyncWrite};
+pub use tokio_io::{
+    AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+};
 
 // Re-export io::Error so that users don't have to deal
 // with conflicts when `use`ing `tokio::io` and `std::io`.


### PR DESCRIPTION
Closes #1203

Related to #1264