### PR TITLE
io: remove `util` from default features

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,8 @@ jobs:
       tokio-codec: []
       tokio-current-thread: []
       tokio-executor: []
-      tokio-io: []
+      tokio-io:
+        - util
       tokio-sync:
         - async-traits
       tokio-macros: []

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -34,5 +34,4 @@ futures-util-preview = "0.3.0-alpha.17"
 tokio-test = { version = "0.2.0", path = "../tokio-test" }
 
 [features]
-default = ["util"]
 util = ["memchr"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -70,7 +70,7 @@ num_cpus = { version = "1.8.0", optional = true }
 tokio-codec = { version = "0.2.0", optional = true, path = "../tokio-codec" }
 tokio-current-thread = { version = "0.2.0", optional = true, path = "../tokio-current-thread" }
 tokio-fs = { version = "0.2.0", optional = true, path = "../tokio-fs" }
-tokio-io = { version = "0.2.0", optional = true, path = "../tokio-io" }
+tokio-io = { version = "0.2.0", optional = true, features = ["util"], path = "../tokio-io" }
 tokio-executor = { version = "0.2.0", optional = true, path = "../tokio-executor" }
 tokio-macros = { version = "0.2.0", optional = true, path = "../tokio-macros" }
 tokio-reactor = { version = "0.2.0", optional = true, path = "../tokio-reactor" }


### PR DESCRIPTION
Sub-crates should require opting into features. This will make it harder to include more than needed.

The facade crate (`tokio`) will pull in all the features by default.