### PR TITLE
docs: update API documentation for some crates

### DIFF
--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -53,21 +53,22 @@ pub trait BufStream {
     /// There are several possible return values, each indicating a distinct
     /// stream state:
     ///
-    /// - `Ok(Async::NotReady)` means that this stream's next value is not ready
-    /// yet. Implementations will ensure that the current task will be notified
-    /// when the next value may be ready.
+    /// - `Poll::Pending` means that this stream's next value is not ready yet.
+    ///    Implementations will ensure that the current task will be notified
+    ///    when the next value may be ready.
     ///
-    /// - `Ok(Async::Ready(Some(buf)))` means that the stream has successfully
-    /// produced a value, `buf`, and may produce further values on subsequent
-    /// `poll_buf` calls.
+    /// - `Poll::Ready(Some(Ok(buf)))` means that the stream has successfully
+    ///    produced a value, `buf`, and may produce further values on subsequent
+    ///    `poll_buf` calls.
     ///
-    /// - `Ok(Async::Ready(None))` means that the stream has terminated, and
-    /// `poll_buf` should not be invoked again.
+    /// - `Poll::Ready(None)` means that the stream has terminated, and
+    ///   `poll_buf` should not be invoked again.
     ///
     /// # Panics
     ///
-    /// Once a stream is finished, i.e. `Ready(None)` has been returned, further
-    /// calls to `poll_buf` may result in a panic or other "bad behavior".
+    /// Once a stream is finished, i.e. `Poll::Ready(None)` has been returned,
+    /// further calls to `poll_buf` may result in a panic or other "bad
+    /// behavior".
     fn poll_buf(&mut self, cx: &mut Context<'_>) -> Poll<Option<Result<Self::Item, Self::Error>>>;
 
     /// Returns the bounds on the remaining length of the stream.

--- a/tokio-codec/src/encoder.rs
+++ b/tokio-codec/src/encoder.rs
@@ -3,9 +3,6 @@ use std::io;
 
 /// Trait of helper objects to write out messages as bytes, for use with
 /// `FramedWrite`.
-
-// Note: We can't deprecate this trait, because the deprecation carries through to tokio-codec, and
-// there doesn't seem to be a way to un-deprecate the re-export.
 pub trait Encoder {
     /// The type of items consumed by the `Encoder`
     type Item;

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -7,13 +7,12 @@
 //!
 //! Contains adapters to go from streams of bytes, [`AsyncRead`] and
 //! [`AsyncWrite`], to framed streams implementing [`Sink`] and [`Stream`].
-//! Framed streams are also known as [transports].
+//! Framed streams are also known as transports.
 //!
-//! [`AsyncRead`]: #
-//! [`AsyncWrite`]: #
-//! [`Sink`]: #
-//! [`Stream`]: #
-//! [transports]: #
+//! [`AsyncRead`]: https://docs.rs/tokio/*/tokio/io/trait.AsyncRead.html
+//! [`AsyncWrite`]: https://docs.rs/tokio/*/tokio/io/trait.AsyncWrite.html
+//! [`Sink`]: https://docs.rs/futures-sink-preview/*/futures_sink/trait.Sink.html
+//! [`Stream`]: https://docs.rs/futures-core-preview/*/futures_core/stream/trait.Stream.html
 
 #[macro_use]
 mod macros;

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -6,26 +6,19 @@
 //! A single-threaded executor which executes tasks on the same thread from which
 //! they are spawned.
 //!
+//! [`CurrentThread`] is the main type of this crate. It executes tasks on the
+//! current thread.  The easiest way to start a new [`CurrentThread`] executor
+//! is to call [`block_on_all`] with an initial task to seed the executor.  All
+//! tasks that are being managed by a [`CurrentThread`] executor are able to
+//! spawn additional tasks by calling [`spawn`].
 //!
-//! The crate provides:
-//!
-//! * [`CurrentThread`] is the main type of this crate. It executes tasks on the current thread.
-//!   The easiest way to start a new [`CurrentThread`] executor is to call
-//!   [`block_on_all`] with an initial task to seed the executor.
-//!   All tasks that are being managed by a [`CurrentThread`] executor are able to
-//!   spawn additional tasks by calling [`spawn`].
-//!
-//!
-//! Application authors will not use this crate directly. Instead, they will use the
-//! `tokio` crate. Library authors should only depend on `tokio-current-thread` if they
-//! are building a custom task executor.
-//!
-//! For more details, see [executor module] documentation in the Tokio crate.
+//! Application authors will not use this crate directly. Instead, they will use
+//! the `tokio` crate. Library authors should only depend on
+//! `tokio-current-thread` if they are building a custom task executor.
 //!
 //! [`CurrentThread`]: struct.CurrentThread.html
 //! [`spawn`]: fn.spawn.html
 //! [`block_on_all`]: fn.block_on_all.html
-//! [executor module]: https://docs.rs/tokio/0.1/tokio/executor/index.html
 
 mod scheduler;
 

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -26,5 +26,5 @@ publish = false
 crossbeam-utils = { git = "https://github.com/stjepang/crossbeam", branch = "raw-parker" }
 
 [dev-dependencies]
-futures-core-preview = "0.3.0-alpha.17"
+futures-core-preview = "=0.3.0-alpha.17"
 tokio = { version = "*", path = "../tokio" }

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -23,8 +23,8 @@ categories = ["concurrency", "asynchronous"]
 publish = false
 
 [dependencies]
-# crossbeam-utils = "0.6.2"
 crossbeam-utils = { git = "https://github.com/stjepang/crossbeam", branch = "raw-parker" }
 
 [dev-dependencies]
-# tokio = { version = "0.2.0", path = "../tokio" }
+futures-core-preview = "0.3.0-alpha.17"
+tokio = { version = "*", path = "../tokio" }

--- a/tokio-executor/src/executor.rs
+++ b/tokio-executor/src/executor.rs
@@ -48,20 +48,20 @@ use std::pin::Pin;
 ///
 /// # Examples
 ///
-/// ```rust
+/// ```
+/// #![feature(async_await)]
+///
 /// use tokio_executor::Executor;
-/// use futures::future::lazy;
 ///
 /// # fn docs(my_executor: &mut dyn Executor) {
-/// my_executor.spawn(Box::new(lazy(|| {
+/// my_executor.spawn(Box::pin(async {
 ///     println!("running on the executor");
-///     Ok(())
-/// }))).unwrap();
+/// })).unwrap();
 /// # }
 /// ```
 ///
 /// [`spawn`]: #tymethod.spawn
-/// [`poll`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#tymethod.poll
+/// [`poll`]: https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll
 /// [`TypedExecutor`]: ../trait.TypedExecutor.html
 pub trait Executor {
     /// Spawns a future object to run on this executor.
@@ -78,15 +78,15 @@ pub trait Executor {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
+    /// #![feature(async_await)]
+    ///
     /// use tokio_executor::Executor;
-    /// use futures::future::lazy;
     ///
     /// # fn docs(my_executor: &mut dyn Executor) {
-    /// my_executor.spawn(Box::pin(lazy(|| {
+    /// my_executor.spawn(Box::pin(async {
     ///     println!("running on the executor");
-    ///     Ok(())
-    /// }))).unwrap();
+    /// })).unwrap();
     /// # }
     /// ```
     fn spawn(&mut self, future: Pin<Box<dyn Future<Output = ()> + Send>>)
@@ -109,16 +109,16 @@ pub trait Executor {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```
+    /// #![feature(async_await)]
+    ///
     /// use tokio_executor::Executor;
-    /// use futures::future::lazy;
     ///
     /// # fn docs(my_executor: &mut dyn Executor) {
     /// if my_executor.status().is_ok() {
-    ///     my_executor.spawn(Box::pin(lazy(|| {
+    ///     my_executor.spawn(Box::pin(async {
     ///         println!("running on the executor");
-    ///         Ok(())
-    ///     }))).unwrap();
+    ///     })).unwrap();
     /// } else {
     ///     println!("the executor is not in a good state");
     /// }

--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -124,13 +124,11 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// use tokio_executor::spawn;
-/// use futures::future::lazy;
+/// #![feature(async_await)]
 ///
-/// spawn(lazy(|| {
+/// tokio::spawn(async {
 ///     println!("running on the default executor");
-///     Ok(())
-/// }));
+/// });
 /// ```
 pub fn spawn<T>(future: T)
 where

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -51,7 +51,7 @@
 //! [`enter`]: fn.enter.html
 //! [`DefaultExecutor`]: struct.DefaultExecutor.html
 //! [`Park`]: park/index.html
-//! [`Future::poll`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#tymethod.poll
+//! [`Future::poll`]: https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll
 
 mod enter;
 mod error;

--- a/tokio-executor/src/park.rs
+++ b/tokio-executor/src/park.rs
@@ -28,7 +28,7 @@
 //! Some things to note:
 //!
 //! * If [`unpark`] is called before [`park`], the next call to [`park`] will
-//! **not** block the thread.
+//!   **not** block the thread.
 //! * **Spurious** wakeups are permitted, i.e., the [`park`] method may unblock
 //!   even if [`unpark`] was not called.
 //! * [`park_timeout`] does the same as [`park`] but allows specifying a maximum

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -44,15 +44,15 @@ use std::task::Poll;
 /// Create a new file and asynchronously write bytes to it:
 ///
 /// ```no_run
-/// use tokio::prelude::{AsyncWrite, Future};
+/// #![feature(async_await)]
 ///
-/// let task = tokio::fs::File::create("foo.txt")
-///     .and_then(|mut file| file.poll_write(b"hello, world!"))
-///     .map(|res| {
-///         println!("{:?}", res);
-///     }).map_err(|err| eprintln!("IO error: {:?}", err));
+/// use tokio::fs::File;
 ///
-/// tokio::run(task);
+/// # async fn dox() -> std::io::Result<()> {
+/// let file = File::create("foo.txt").await?;
+/// file.write_all(b"hello, world!").await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Read the contents of a file into a buffer
@@ -93,17 +93,17 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio::prelude::Future;
+    /// #![feature(async_await)]
     ///
-    /// let task = tokio::fs::File::open("foo.txt").and_then(|file| {
-    ///     // do something with the file ...
-    ///     file.metadata().map(|md| println!("{:?}", md))
-    /// }).map_err(|e| {
-    ///     // handle errors
-    ///     eprintln!("IO error: {:?}", e);
-    /// });
+    /// use tokio::fs::File;
     ///
-    /// tokio::run(task);
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let file = File::open("foo.txt").await?;
+    /// let metadata = file.metadata().await?;
+    ///
+    /// println!("metadata = {:?}", metadata);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn open<P>(path: P) -> OpenFuture<P>
     where

--- a/tokio-fs/src/file/mod.rs
+++ b/tokio-fs/src/file/mod.rs
@@ -47,9 +47,10 @@ use std::task::Poll;
 /// #![feature(async_await)]
 ///
 /// use tokio::fs::File;
+/// use tokio::prelude::*;
 ///
 /// # async fn dox() -> std::io::Result<()> {
-/// let file = File::create("foo.txt").await?;
+/// let mut file = File::create("foo.txt").await?;
 /// file.write_all(b"hello, world!").await?;
 /// # Ok(())
 /// # }
@@ -58,18 +59,20 @@ use std::task::Poll;
 /// Read the contents of a file into a buffer
 ///
 /// ```no_run
-/// use tokio::prelude::{AsyncRead, Future};
+/// #![feature(async_await)]
 ///
-/// let task = tokio::fs::File::open("foo.txt")
-///     .and_then(|mut file| {
-///         let mut contents = vec![];
-///         file.read_buf(&mut contents)
-///             .map(|res| {
-///                 println!("{:?}", res);
-///             })
-///     }).map_err(|err| eprintln!("IO error: {:?}", err));
+/// use tokio::fs::File;
+/// use tokio::prelude::*;
 ///
-/// tokio::run(task);
+/// # async fn dox() -> std::io::Result<()> {
+/// let mut file = File::open("foo.txt").await?;
+///
+/// let mut contents = vec![];
+/// file.read_to_end(&mut contents).await?;
+///
+/// println!("len = {}", contents.len());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug)]
 pub struct File {
@@ -96,12 +99,15 @@ impl File {
     /// #![feature(async_await)]
     ///
     /// use tokio::fs::File;
+    /// use tokio::prelude::*;
     ///
     /// # async fn dox() -> std::io::Result<()> {
-    /// let file = File::open("foo.txt").await?;
-    /// let metadata = file.metadata().await?;
+    /// let mut file = File::open("foo.txt").await?;
     ///
-    /// println!("metadata = {:?}", metadata);
+    /// let mut contents = vec![];
+    /// file.read_to_end(&mut contents).await?;
+    ///
+    /// println!("len = {}", contents.len());
     /// # Ok(())
     /// # }
     /// ```
@@ -131,18 +137,16 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio::prelude::Future;
+    /// #![feature(async_await)]
     ///
-    /// let task = tokio::fs::File::create("foo.txt")
-    ///     .and_then(|file| {
-    ///         // do something with the created file ...
-    ///         file.metadata().map(|md| println!("{:?}", md))
-    ///     }).map_err(|e| {
-    ///         // handle errors
-    ///         eprintln!("IO error: {:?}", e);
-    /// });
+    /// use tokio::fs::File;
+    /// use tokio::prelude::*;
     ///
-    /// tokio::run(task);
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let mut file = File::create("foo.txt").await?;
+    /// file.write_all(b"hello, world!").await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn create<P>(path: P) -> CreateFuture<P>
     where
@@ -156,11 +160,12 @@ impl File {
     /// [std]: https://doc.rust-lang.org/std/fs/struct.File.html
     /// [file]: struct.File.html
     ///
-    /// Examples
-    /// ```no_run
-    /// use std::fs::File;
+    /// # Examples
     ///
-    /// let std_file = File::open("foo.txt").unwrap();
+    /// ```no_run
+    /// // This line could block. It is not recommended to do this on the Tokio
+    /// // runtime.
+    /// let std_file = std::fs::File::open("foo.txt").unwrap();
     /// let file = tokio::fs::File::from_std(std_file);
     /// ```
     pub fn from_std(std: StdFile) -> File {
@@ -179,22 +184,6 @@ impl File {
     /// # Errors
     ///
     /// Seeking to a negative offset is considered an error.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::prelude::Future;
-    /// use std::io::SeekFrom;
-    ///
-    /// let task = tokio::fs::File::open("foo.txt")
-    ///     // move cursor 6 bytes from the start of the file
-    ///     .and_then(|mut file| file.poll_seek(SeekFrom::Start(6)))
-    ///     .map(|res| {
-    ///         println!("{:?}", res);
-    ///     }).map_err(|err| eprintln!("IO error: {:?}", err));
-    ///
-    /// tokio::run(task);
-    /// ```
     pub fn poll_seek(&mut self, pos: io::SeekFrom) -> Poll<io::Result<u64>> {
         crate::blocking_io(|| self.std().seek(pos))
     }
@@ -209,17 +198,21 @@ impl File {
     /// # Examples
     ///
     /// ```no_run
-    /// use tokio::prelude::Future;
+    /// #![feature(async_await)]
+    ///
+    /// use tokio::fs::File;
+    /// use tokio::prelude::*;
+    ///
     /// use std::io::SeekFrom;
     ///
-    /// let task = tokio::fs::File::create("foo.txt")
-    ///     .and_then(|file| file.seek(SeekFrom::Start(6)))
-    ///     .map(|file| {
-    ///         // handle returned file ..
-    ///         # println!("{:?}", file);
-    ///     }).map_err(|err| eprintln!("IO error: {:?}", err));
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let mut file = File::open("foo.txt").await?;
+    /// file.seek(SeekFrom::Start(6)).await?;
     ///
-    /// tokio::run(task);
+    /// let mut contents = vec![0u8; 10];
+    /// file.read_exact(&mut contents).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn seek(self, pos: io::SeekFrom) -> SeekFuture {
         SeekFuture::new(self, pos)


### PR DESCRIPTION
Updates API documentation for

- tokio-buf
- tokio-codec
- tokio-current-thread
- tokio-executor