### PR TITLE
executor: remove unused dependency

### DIFF
--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -23,7 +23,6 @@ categories = ["concurrency", "asynchronous"]
 publish = false
 
 [dependencies]
-crossbeam-utils = { git = "https://github.com/stjepang/crossbeam", branch = "raw-parker" }
 
 [dev-dependencies]
 futures-core-preview = "=0.3.0-alpha.17"


### PR DESCRIPTION
Follow up to #1402. The code was removed, but the dependency was left.