### PR TITLE
Remove driver task for Windows event implementation

### DIFF
--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -24,7 +24,6 @@ futures-core-preview = "=0.3.0-alpha.18"
 futures-util-preview = "=0.3.0-alpha.18"
 lazy_static = "1"
 tokio-reactor = { version = "=0.2.0-alpha.1", path = "../tokio-reactor" }
-tokio-executor = { version = "=0.2.0-alpha.1", path = "../tokio-executor" }
 tokio-io = { version = "=0.2.0-alpha.1", path = "../tokio-io" }
 tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync" }
 

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -8,7 +8,6 @@
 #![cfg(windows)]
 
 use std::convert::TryFrom;
-use std::future::Future;
 use std::io;
 use std::pin::Pin;
 use std::sync::Once;
@@ -16,7 +15,7 @@ use std::task::{Context, Poll};
 
 use futures_core::stream::Stream;
 use tokio_reactor::Handle;
-use tokio_sync::mpsc::{channel, Receiver, Sender};
+use tokio_sync::mpsc::{channel, Receiver};
 use winapi::shared::minwindef::*;
 use winapi::um::consoleapi::SetConsoleCtrlHandler;
 use winapi::um::wincon::*;

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -219,12 +219,12 @@ mod tests {
             super::handler(CTRL_C_EVENT);
         }
 
-        with_timeout(event_ctrl_c.into_future()).await;
+        with_timeout(ctrl_c.into_future()).await;
     }
 
     #[tokio::test]
     async fn ctrl_break() {
-        let ctrl_c = crate::CtrlBreak::new().expect("failed to create CtrlC");
+        let ctrl_break = crate::CtrlBreak::new().expect("failed to create CtrlC");
 
         // Windows doesn't have a good programmatic way of sending events
         // like sending signals on Unix, so we'll stub out the actual OS
@@ -233,6 +233,6 @@ mod tests {
             super::handler(CTRL_BREAK_EVENT);
         }
 
-        with_timeout(event_ctrl_c.into_future()).await;
+        with_timeout(ctrl_break.into_future()).await;
     }
 }

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -219,7 +219,7 @@ mod tests {
             super::handler(CTRL_C_EVENT);
         }
 
-        with_timeout(ctrl_c.into_future()).await;
+        let _ = with_timeout(ctrl_c.into_future()).await;
     }
 
     #[tokio::test]
@@ -233,6 +233,6 @@ mod tests {
             super::handler(CTRL_BREAK_EVENT);
         }
 
-        with_timeout(ctrl_break.into_future()).await;
+        let _ = with_timeout(ctrl_break.into_future()).await;
     }
 }

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -198,10 +198,10 @@ impl Stream for CtrlBreak {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use futures_util::future::{self, FutureExt};
+    use futures_util::future::FutureExt;
     use futures_util::stream::StreamExt;
+    use std::future::Future;
     use std::time::Duration;
-    use tokio::runtime::current_thread;
     use tokio_timer::Timeout;
 
     fn with_timeout<F: Future>(future: F) -> impl Future<Output = F::Output> {

--- a/tokio-signal/src/windows.rs
+++ b/tokio-signal/src/windows.rs
@@ -224,7 +224,7 @@ mod tests {
 
     #[tokio::test]
     async fn ctrl_break() {
-        let ctrl_break = crate::CtrlBreak::new().expect("failed to create CtrlC");
+        let ctrl_break = super::CtrlBreak::new().expect("failed to create CtrlC");
 
         // Windows doesn't have a good programmatic way of sending events
         // like sending signals on Unix, so we'll stub out the actual OS


### PR DESCRIPTION
* Windows guarantees handler routines are always invoked in a new thread
(https://docs.microsoft.com/en-us/windows/console/handlerroutine), so we
don't need to use the handler-wake-another-driver technique used in the
Unix implementation
* By broadcasting the event notifications from the handler, we no longer
need the Driver task to be spawned, which fixes the starvation issue if
the executor which runs the Driver task goes away
* Also changed the behavior so that the default event handler runs if
all listeners for CTRL_{C, BREAK} events go away

Fixes #1000 