### PR TITLE
signal: Add SignalKind for registering signals more easily

### DIFF
--- a/tokio-process/src/unix/mod.rs
+++ b/tokio-process/src/unix/mod.rs
@@ -40,7 +40,7 @@ use std::process::{self, ExitStatus};
 use std::task::Context;
 use std::task::Poll;
 use tokio_reactor::{Handle, PollEvented};
-use tokio_signal::unix::Signal;
+use tokio_signal::unix::{Signal, SignalKind};
 
 impl Wait for process::Child {
     fn id(&self) -> u32 {
@@ -99,7 +99,7 @@ pub(crate) fn spawn_child(cmd: &mut process::Command, handle: &Handle) -> io::Re
     let stdout = stdio(child.stdout.take(), handle)?;
     let stderr = stdio(child.stderr.take(), handle)?;
 
-    let signal = Signal::with_handle(libc::SIGCHLD, handle)?;
+    let signal = Signal::with_handle(SignalKind::sigchld(), handle)?;
 
     Ok(SpawnedChild {
         child: Child {

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -7,12 +7,14 @@
 #[cfg(unix)]
 mod platform {
     use futures_util::stream::{self, StreamExt};
-    use tokio_signal::unix::{Signal, SIGINT, SIGTERM};
+    use tokio_signal::unix::{Signal, SignalKind};
 
     pub async fn main() {
         // Create a stream for each of the signals we'd like to handle.
-        let sigint = Signal::new(SIGINT).unwrap().map(|_| SIGINT);
-        let sigterm = Signal::new(SIGTERM).unwrap().map(|_| SIGTERM);
+        let sigint = Signal::new(SignalKind::sigint()).unwrap().map(|_| "SIGINT");
+        let sigterm = Signal::new(SignalKind::sigterm())
+            .unwrap()
+            .map(|_| "SIGTERM");
 
         // Use the `select` combinator to merge these two streams into one
         let stream = stream::select(sigint, sigterm);
@@ -27,13 +29,8 @@ mod platform {
         let (item, _rest) = stream.into_future().await;
 
         // Figure out which signal we received
-        let item = item.ok_or("received no signal").unwrap();
-        if item == SIGINT {
-            println!("received SIGINT");
-        } else {
-            assert_eq!(item, SIGTERM);
-            println!("received SIGTERM");
-        }
+        let msg = item.ok_or("received no signal").unwrap();
+        println!("received {}", msg);
     }
 }
 

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -5,11 +5,11 @@
 #[cfg(unix)]
 mod platform {
     use futures_util::stream::StreamExt;
-    use tokio_signal::unix::{Signal, SIGHUP};
+    use tokio_signal::unix::{Signal, SignalKind};
 
     pub async fn main() {
         // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
-        let mut stream = Signal::new(SIGHUP).unwrap();
+        let mut stream = Signal::new(SignalKind::sighup()).unwrap();
 
         println!("Waiting for SIGHUPS (Ctrl+C to quit)");
         println!(

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -59,7 +59,7 @@
 //!
 //! use futures_util::future;
 //! use futures_util::stream::StreamExt;
-//! use tokio_signal::unix::{Signal, SIGHUP};
+//! use tokio_signal::unix::{Signal, SignalKind};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -77,7 +77,7 @@
 //!
 //!     // Like the previous example, this is an infinite stream of signals
 //!     // being received, and signals may be coalesced while pending.
-//!     let stream = Signal::new(SIGHUP)?;
+//!     let stream = Signal::new(SignalKind::sighup())?;
 //!
 //!     // Convert out stream into a future and block the program
 //!     let (signal, _signal) = stream.into_future().await;

--- a/tokio-signal/tests/drop_multi_loop.rs
+++ b/tokio-signal/tests/drop_multi_loop.rs
@@ -6,18 +6,18 @@ use libc;
 pub mod support;
 use crate::support::*;
 
-const TEST_SIGNAL: libc::c_int = libc::SIGUSR1;
-
 #[test]
 fn dropping_loops_does_not_cause_starvation() {
     let (mut rt, signal) = {
+        let kind = SignalKind::sigusr1();
+
         let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
-        let mut first_signal = Signal::new(TEST_SIGNAL).expect("failed to register first signal");
+        let mut first_signal = Signal::new(kind).expect("failed to register first signal");
 
         let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
-        let mut second_signal = Signal::new(TEST_SIGNAL).expect("failed to register second signal");
+        let mut second_signal = Signal::new(kind).expect("failed to register second signal");
 
-        send_signal(TEST_SIGNAL);
+        send_signal(libc::SIGUSR1);
 
         let _ = run_with_timeout(&mut first_rt, first_signal.next())
             .expect("failed to await first signal");
@@ -31,7 +31,7 @@ fn dropping_loops_does_not_cause_starvation() {
         (second_rt, second_signal)
     };
 
-    send_signal(TEST_SIGNAL);
+    send_signal(libc::SIGUSR1);
 
     let _ = run_with_timeout(&mut rt, signal.into_future());
 }

--- a/tokio-signal/tests/drop_then_get_a_signal.rs
+++ b/tokio-signal/tests/drop_then_get_a_signal.rs
@@ -9,11 +9,12 @@ use crate::support::*;
 
 #[tokio::test]
 async fn drop_then_get_a_signal() {
-    let signal = Signal::new(libc::SIGUSR1).expect("failed to create first signal");
+    let kind = SignalKind::sigusr1();
+    let signal = Signal::new(kind).expect("failed to create first signal");
     drop(signal);
 
     send_signal(libc::SIGUSR1);
-    let signal = Signal::new(libc::SIGUSR1).expect("failed to create second signal");
+    let signal = Signal::new(kind).expect("failed to create second signal");
 
     let _ = with_timeout(signal.into_future()).await;
 }

--- a/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
+++ b/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
@@ -7,21 +7,21 @@ use libc;
 pub mod support;
 use crate::support::*;
 
-const TEST_SIGNAL: libc::c_int = libc::SIGUSR1;
-
 #[tokio::test]
 async fn dropping_signal_does_not_deregister_any_other_instances() {
+    let kind = SignalKind::sigusr1();
+
     // NB: Testing for issue alexcrichton/tokio-signal#38:
     // signals should not starve based on ordering
     let first_duplicate_signal =
-        Signal::new(TEST_SIGNAL).expect("failed to register first duplicate signal");
-    let signal = Signal::new(TEST_SIGNAL).expect("failed to register signal");
+        Signal::new(kind).expect("failed to register first duplicate signal");
+    let signal = Signal::new(kind).expect("failed to register signal");
     let second_duplicate_signal =
-        Signal::new(TEST_SIGNAL).expect("failed to register second duplicate signal");
+        Signal::new(kind).expect("failed to register second duplicate signal");
 
     drop(first_duplicate_signal);
     drop(second_duplicate_signal);
 
-    send_signal(TEST_SIGNAL);
+    send_signal(libc::SIGUSR1);
     let _ = with_timeout(signal.into_future()).await;
 }

--- a/tokio-signal/tests/multi_loop.rs
+++ b/tokio-signal/tests/multi_loop.rs
@@ -20,7 +20,7 @@ fn multi_loop() {
                 let sender = sender.clone();
                 thread::spawn(move || {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
-                    let signal = Signal::new(libc::SIGHUP).unwrap();
+                    let signal = Signal::new(SignalKind::sighup()).unwrap();
                     sender.send(()).unwrap();
                     let _ = run_with_timeout(&mut rt, signal.into_future());
                 })

--- a/tokio-signal/tests/notify_both.rs
+++ b/tokio-signal/tests/notify_both.rs
@@ -9,9 +9,10 @@ use libc;
 
 #[tokio::test]
 async fn notify_both() {
-    let signal1 = Signal::new(libc::SIGUSR2).expect("failed to create signal1");
+    let kind = SignalKind::sigusr2();
+    let signal1 = Signal::new(kind).expect("failed to create signal1");
 
-    let signal2 = Signal::new(libc::SIGUSR2).expect("failed to create signal2");
+    let signal2 = Signal::new(kind).expect("failed to create signal2");
 
     send_signal(libc::SIGUSR2);
     let _ = with_timeout(future::join(signal1.into_future(), signal2.into_future())).await;

--- a/tokio-signal/tests/simple.rs
+++ b/tokio-signal/tests/simple.rs
@@ -9,7 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn simple() {
-    let signal = Signal::new(libc::SIGUSR1).expect("failed to create signal");
+    let signal = Signal::new(SignalKind::sigusr1()).expect("failed to create signal");
 
     send_signal(libc::SIGUSR1);
 

--- a/tokio-signal/tests/support.rs
+++ b/tokio-signal/tests/support.rs
@@ -10,7 +10,7 @@ use tokio_timer::Timeout;
 pub use futures_util::future;
 pub use futures_util::stream::StreamExt;
 pub use tokio::runtime::current_thread::{self, Runtime as CurrentThreadRuntime};
-pub use tokio_signal::unix::Signal;
+pub use tokio_signal::unix::{Signal, SignalKind};
 
 pub fn with_timeout<F: Future>(future: F) -> impl Future<Output = F::Output> {
     Timeout::new(future, Duration::from_secs(1)).map(Result::unwrap)

--- a/tokio-signal/tests/twice.rs
+++ b/tokio-signal/tests/twice.rs
@@ -9,7 +9,8 @@ use libc;
 
 #[tokio::test]
 async fn twice() {
-    let mut signal = Signal::new(libc::SIGUSR1).expect("failed to get signal");
+    let kind = SignalKind::sigusr1();
+    let mut signal = Signal::new(kind).expect("failed to get signal");
 
     for _ in 0..2 {
         send_signal(libc::SIGUSR1);


### PR DESCRIPTION
* This avoids having consumers import libc for common signals, and it
improves discoverability since users need not be aware that libc
contains all supported constants
* I had originally considered using a public enum, but given that `#[non_exaustive]` is not yet stable, I opted for a private enum with public constructors to give us maximum flexibility for adding new convenience constructors without technically breaking changes
* We also allow for an escape hatch via `from_raw` which allows for users to specify platform-specific signals (or any other signals which may or may not be a good idea to capture) without forcing us to support those definitions publicly

Refs #1243 

cc @carllerche in case you have any API related feedback