### PR TITLE
Add a block_on function to tokio-test

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -20,6 +20,7 @@ Testing utilities for Tokio- and futures-based code
 categories = ["asynchronous", "testing"]
 
 [dependencies]
+tokio = { version = "=0.2.0-alpha.1", path = "../tokio" }
 tokio-executor = { version = "=0.2.0-alpha.1", path = "../tokio-executor" }
 tokio-io = { version = "=0.2.0-alpha.1", path = "../tokio-io" }
 tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync" }
@@ -29,6 +30,4 @@ futures-core-preview = "=0.3.0-alpha.18"
 pin-convert = "0.1.0"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.1", path = "../tokio" }
-
 futures-util-preview = "=0.3.0-alpha.18"

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -14,6 +14,18 @@ pub mod io;
 mod macros;
 pub mod task;
 
+/// Runs the provided future, blocking the current thread until the
+/// future completes.
+///
+/// For more information, see the documentation for
+/// [`tokio::runtime::current_thread::Runtime::block_on`][runtime-block-on].
+///
+/// [runtime-block-on]: https://docs.rs/tokio/0.2.0-alpha.1/tokio/runtime/current_thread/struct.Runtime.html#method.block_on
+pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    let mut rt = tokio::runtime::current_thread::Runtime::new().unwrap();
+    rt.block_on(future)
+}
+
 /*
 #[doc(hidden)]
 pub mod codegen {

--- a/tokio-test/tests/block_on.rs
+++ b/tokio-test/tests/block_on.rs
@@ -1,0 +1,28 @@
+#![warn(rust_2018_idioms)]
+#![feature(async_await)]
+
+use std::time::{Duration, Instant};
+use tokio_test::block_on;
+use tokio_timer::Delay;
+
+#[test]
+fn async_block() {
+    assert_eq!(4, block_on(async { 4 }));
+}
+
+async fn five() -> u8 {
+    5
+}
+
+#[test]
+fn async_fn() {
+    assert_eq!(5, block_on(five()));
+}
+
+#[test]
+fn delay() {
+    let deadline = Instant::now() + Duration::from_millis(100);
+    let delay = Delay::new(deadline);
+
+    assert_eq!((), block_on(delay));
+}


### PR DESCRIPTION
## Motivation

Closes #1328 

## Solution

- Promote `tokio` to a non-dev dependency of `tokio-test`
- Add a `block_on` function in `tokio-test` that creates a current thread `Runtime` and runs the provided future to completion with `Runtime::block_on`.