### PR TITLE
executor, threadpool: Patches v0.2.0 with a fix from #1155

### DIFF
--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -97,7 +97,6 @@ pub fn exit<F: FnOnce() -> R, R>(f: F) -> R {
     ret
 }
 
-
 impl Enter {
     /// Blocks the thread on the specified future, returning the value with
     /// which that future completes.

--- a/tokio-executor/src/enter.rs
+++ b/tokio-executor/src/enter.rs
@@ -61,6 +61,43 @@ pub fn enter() -> Result<Enter, EnterError> {
     })
 }
 
+// Forces the current "entered" state to be cleared while the closure
+// is executed.
+//
+// # Warning
+//
+// This is hidden for a reason. Do not use without fully understanding
+// executors. Misuing can easily cause your program to deadlock.
+#[doc(hidden)]
+pub fn exit<F: FnOnce() -> R, R>(f: F) -> R {
+    // Reset in case the closure panics
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            ENTERED.with(|c| {
+                c.set(true);
+            });
+        }
+    }
+
+    ENTERED.with(|c| {
+        debug_assert!(c.get());
+        c.set(false);
+    });
+
+    let reset = Reset;
+    let ret = f();
+    ::std::mem::forget(reset);
+
+    ENTERED.with(|c| {
+        assert!(!c.get(), "closure claimed permanent executor");
+        c.set(true);
+    });
+
+    ret
+}
+
+
 impl Enter {
     /// Blocks the thread on the specified future, returning the value with
     /// which that future completes.

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -64,7 +64,7 @@ mod global;
 pub mod park;
 mod typed;
 
-pub use crate::enter::{enter, Enter, EnterError};
+pub use crate::enter::{enter, exit, Enter, EnterError};
 pub use crate::error::SpawnError;
 pub use crate::executor::Executor;
 pub use crate::global::{spawn, with_default, DefaultExecutor};

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -1,10 +1,10 @@
 use crate::worker::Worker;
 
 use futures_core::ready;
-use tokio_executor;
 use std::error::Error;
 use std::fmt;
 use std::task::Poll;
+use tokio_executor;
 
 /// Error raised by `blocking`.
 pub struct BlockingError {

--- a/tokio-threadpool/src/blocking.rs
+++ b/tokio-threadpool/src/blocking.rs
@@ -1,6 +1,7 @@
 use crate::worker::Worker;
 
 use futures_core::ready;
+use tokio_executor;
 use std::error::Error;
 use std::fmt;
 use std::task::Poll;
@@ -140,7 +141,10 @@ where
     ready!(res)?;
 
     // Currently in blocking mode, so call the inner closure
-    let ret = f();
+    //
+    // "Exit" the current executor in case the blocking function wants
+    // to call a different executor.
+    let ret = tokio_executor::exit(move || f());
 
     // Try to transition out of blocking mode. This is a fast path that takes
     // back ownership of the worker if the worker handoff didn't complete yet.


### PR DESCRIPTION
Add `executor::exit`, allowing other executors inside threadpool::blocking

## Motivation

Blocking on a different executor inside `threadpool::blocking` doesn't work in Tokio `0.2.0-alpha.1` in contrast to `v0.1.x`. See example: https://gist.github.com/Eliah-Lakhin/9514b4798a2aed84615dbde807dbafa5

## Solution

Patch `v0.2.x` with a fix from `v0.1.x`: https://github.com/tokio-rs/tokio/pull/1155