### PR TITLE
remove async-traits feature from tcp/uds/timer

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,11 +51,9 @@ jobs:
       tokio-process: []
       tokio-reactor: []
       tokio-signal: []
-      tokio-tcp:
-        - async-traits
+      tokio-tcp: []
       tokio-udp: []
-      tokio-uds:
-        - async-traits
+      tokio-uds: []
 
 # Test crates that are NOT platform specific
 - template: ci/azure-test-stable.yml
@@ -74,8 +72,7 @@ jobs:
         - async-traits
       tokio-macros: []
       # - tokio-threadpool
-      tokio-timer:
-        - async-traits
+      tokio-timer: []
       tokio-test: []
 
 # - template: ci/azure-cargo-check.yml

--- a/tokio-tcp/Cargo.toml
+++ b/tokio-tcp/Cargo.toml
@@ -19,9 +19,6 @@ TCP bindings for tokio.
 """
 categories = ["asynchronous"]
 
-[features]
-async-traits = []
-
 [dependencies]
 tokio-io = { version = "=0.2.0-alpha.1", path = "../tokio-io" }
 tokio-reactor = { version = "=0.2.0-alpha.1", path = "../tokio-reactor" }

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -27,7 +27,6 @@
 //! [incoming_method]: struct.TcpListener.html#method.incoming
 //! [`Incoming`]: struct.Incoming.html
 
-#[cfg(feature = "async-traits")]
 mod incoming;
 mod listener;
 pub mod split;

--- a/tokio-tcp/src/listener.rs
+++ b/tokio-tcp/src/listener.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "async-traits")]
 use super::incoming::Incoming;
 use super::TcpStream;
 use futures_core::ready;
@@ -203,7 +202,6 @@ impl TcpListener {
     /// necessarily fatal ‒ for example having too many open file descriptors or the other side
     /// closing the connection while it waits in an accept queue. These would terminate the stream
     /// if not handled in any way.
-    #[cfg(feature = "async-traits")]
     pub fn incoming(self) -> Incoming {
         Incoming::new(self)
     }

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -20,15 +20,11 @@ description = """
 Timer facilities for Tokio
 """
 
-[features]
-async-traits = []
-
 [dependencies]
 tokio-executor = { version = "=0.2.0-alpha.1", path = "../tokio-executor" }
 tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync" }
 
 futures-core-preview = "=0.3.0-alpha.18"
-futures-util-preview = "=0.3.0-alpha.18"
 
 crossbeam-utils = "0.6.0"
 # Backs `DelayQueue`

--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -79,7 +79,6 @@ impl Delay {
     }
 
     // Used by `Timeout<Stream>`
-    #[cfg(feature = "async-traits")]
     pub(crate) fn reset_timeout(&mut self) {
         self.registration.reset_timeout();
     }

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -72,8 +72,9 @@ use std::time::{Duration, Instant};
 /// ```rust,no_run
 /// use tokio::timer::{delay_queue, DelayQueue, Error};
 ///
-/// use futures_core::ready;
+/// use futures_core::{ready, Stream};
 /// use std::collections::HashMap;
+/// use std::pin::Pin;
 /// use std::task::{Context, Poll};
 /// use std::time::Duration;
 /// # type CacheKey = String;
@@ -106,7 +107,7 @@ use std::time::{Duration, Instant};
 ///     }
 ///
 ///     fn poll_purge(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
-///         while let Some(res) = ready!(self.expirations.poll_next(cx)) {
+///         while let Some(res) = ready!(Pin::new(&mut self.expirations).poll_next(cx)) {
 ///             let entry = res?;
 ///             self.entries.remove(entry.get_ref());
 ///         }

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -9,7 +9,7 @@ use crate::timer::Handle;
 use crate::wheel::{self, Wheel};
 use crate::{Delay, Error};
 
-use futures_core::ready;
+use futures_core::{ready, Stream};
 use slab::Slab;
 use std::cmp;
 use std::future::Future;
@@ -701,7 +701,7 @@ impl<T> DelayQueue<T> {
 // We never put `T` in a `Pin`...
 impl<T> Unpin for DelayQueue<T> {}
 
-impl<T> futures_core::Stream for DelayQueue<T> {
+impl<T> Stream for DelayQueue<T> {
     // DelayQueue seems much more specific, where a user may care that it
     // has reached capacity, so return those errors instead of panicking.
     type Item = Result<Expired<T>, Error>;

--- a/tokio-timer/src/interval.rs
+++ b/tokio-timer/src/interval.rs
@@ -1,7 +1,7 @@
 use crate::clock;
 use crate::Delay;
 
-use futures_core::ready;
+use futures_core::{ready, Stream};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{self, Poll};
@@ -55,7 +55,7 @@ impl Interval {
     }
 }
 
-impl futures_core::Stream for Interval {
+impl Stream for Interval {
     type Item = Instant;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -38,7 +38,6 @@
 
 pub mod clock;
 pub mod delay_queue;
-#[cfg(feature = "async-traits")]
 pub mod throttle;
 pub mod timeout;
 pub mod timer;

--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -6,7 +6,7 @@
 
 use crate::clock::now;
 use crate::Delay;
-use futures_core::ready;
+use futures_core::{ready, Stream};
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
@@ -181,9 +181,9 @@ where
     }
 }
 
-impl<T> futures_core::Stream for Timeout<T>
+impl<T> Stream for Timeout<T>
 where
-    T: futures_core::Stream,
+    T: Stream,
 {
     type Item = Result<T::Item, Elapsed>;
 

--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -6,7 +6,6 @@
 
 use crate::clock::now;
 use crate::Delay;
-#[cfg(feature = "async-traits")]
 use futures_core::ready;
 use std::fmt;
 use std::future::Future;
@@ -182,7 +181,6 @@ where
     }
 }
 
-#[cfg(feature = "async-traits")]
 impl<T> futures_core::Stream for Timeout<T>
 where
     T: futures_core::Stream,

--- a/tokio-timer/src/timer/registration.rs
+++ b/tokio-timer/src/timer/registration.rs
@@ -45,7 +45,6 @@ impl Registration {
     }
 
     // Used by `Timeout<Stream>`
-    #[cfg(feature = "async-traits")]
     pub(crate) fn reset_timeout(&mut self) {
         let deadline = crate::clock::now() + self.entry.time_ref().duration;
         unsafe {

--- a/tokio-timer/tests/interval.rs
+++ b/tokio-timer/tests/interval.rs
@@ -7,6 +7,7 @@ use tokio_timer::*;
 
 use futures_core::Stream;
 use std::time::Duration;
+use std::pin::Pin;
 
 #[test]
 #[should_panic]
@@ -26,7 +27,7 @@ fn usage() {
 
         macro_rules! poll {
             () => {
-                task.enter(|cx| int.poll_next(cx))
+                task.enter(|cx| Pin::new(&mut int).poll_next(cx))
             };
         }
 

--- a/tokio-timer/tests/interval.rs
+++ b/tokio-timer/tests/interval.rs
@@ -5,6 +5,7 @@ use tokio_test::task::MockTask;
 use tokio_test::{assert_pending, assert_ready_eq, clock};
 use tokio_timer::*;
 
+use futures_core::Stream;
 use std::time::Duration;
 
 #[test]

--- a/tokio-timer/tests/interval.rs
+++ b/tokio-timer/tests/interval.rs
@@ -6,8 +6,8 @@ use tokio_test::{assert_pending, assert_ready_eq, clock};
 use tokio_timer::*;
 
 use futures_core::Stream;
-use std::time::Duration;
 use std::pin::Pin;
+use std::time::Duration;
 
 #[test]
 #[should_panic]

--- a/tokio-timer/tests/queue.rs
+++ b/tokio-timer/tests/queue.rs
@@ -4,6 +4,7 @@ use tokio_test::task::MockTask;
 use tokio_test::{assert_ok, assert_pending, assert_ready, clock};
 use tokio_timer::*;
 
+use futures_core::Stream;
 use std::time::Duration;
 
 macro_rules! poll {

--- a/tokio-timer/tests/queue.rs
+++ b/tokio-timer/tests/queue.rs
@@ -6,10 +6,11 @@ use tokio_timer::*;
 
 use futures_core::Stream;
 use std::time::Duration;
+use std::pin::Pin;
 
 macro_rules! poll {
     ($task:ident, $queue:ident) => {
-        $task.enter(|cx| $queue.poll_next(cx))
+        $task.enter(|cx| Pin::new(&mut $queue).poll_next(cx))
     };
 }
 

--- a/tokio-timer/tests/queue.rs
+++ b/tokio-timer/tests/queue.rs
@@ -5,8 +5,8 @@ use tokio_test::{assert_ok, assert_pending, assert_ready, clock};
 use tokio_timer::*;
 
 use futures_core::Stream;
-use std::time::Duration;
 use std::pin::Pin;
+use std::time::Duration;
 
 macro_rules! poll {
     ($task:ident, $queue:ident) => {

--- a/tokio-timer/tests/throttle.rs
+++ b/tokio-timer/tests/throttle.rs
@@ -1,5 +1,4 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "async-traits")]
 
 use tokio_sync::mpsc;
 use tokio_test::task::MockTask;

--- a/tokio-timer/tests/timeout.rs
+++ b/tokio-timer/tests/timeout.rs
@@ -8,6 +8,7 @@ use tokio_test::{
 };
 use tokio_timer::*;
 
+use futures_core::Stream;
 use std::time::Duration;
 
 #[test]
@@ -132,7 +133,6 @@ fn deadline_future_elapses() {
 
 macro_rules! poll {
     ($task:ident, $stream:ident) => {{
-        use futures_core::Stream;
         $task.enter(|cx| Pin::new(&mut $stream).poll_next(cx))
     }};
 }

--- a/tokio-timer/tests/timeout.rs
+++ b/tokio-timer/tests/timeout.rs
@@ -130,7 +130,6 @@ fn deadline_future_elapses() {
     });
 }
 
-#[cfg(feature = "async-traits")]
 macro_rules! poll {
     ($task:ident, $stream:ident) => {{
         use futures_core::Stream;
@@ -139,7 +138,6 @@ macro_rules! poll {
 }
 
 #[test]
-#[cfg(feature = "async-traits")]
 fn stream_and_timeout_in_future() {
     use tokio_sync::mpsc;
 
@@ -169,7 +167,6 @@ fn stream_and_timeout_in_future() {
 }
 
 #[test]
-#[cfg(feature = "async-traits")]
 fn idle_stream_timesout_periodically() {
     use tokio_sync::mpsc;
 

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -30,7 +30,7 @@ tokio-io = { version = "=0.2.0-alpha.1", path = "../tokio-io" }
 
 [dev-dependencies]
 tokio = { version = "=0.2.0-alpha.1", path = "../tokio" }
-tokio-tcp = { version = "=0.2.0-alpha.1", path = "../tokio-tcp", features = ["async-traits"] }
+tokio-tcp = { version = "=0.2.0-alpha.1", path = "../tokio-tcp" }
 
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -19,9 +19,6 @@ Unix Domain sockets for Tokio
 """
 categories = ["asynchronous"]
 
-[features]
-async-traits = []
-
 [dependencies]
 tokio-codec = { version = "=0.2.0-alpha.1", path = "../tokio-codec" }
 tokio-reactor = { version = "=0.2.0-alpha.1", path = "../tokio-reactor" }

--- a/tokio-uds/src/incoming.rs
+++ b/tokio-uds/src/incoming.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "async-traits")]
-
 use crate::{UnixListener, UnixStream};
 use futures_core::ready;
 use futures_core::stream::Stream;

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -22,7 +22,6 @@ mod stream;
 mod ucred;
 
 pub use crate::datagram::UnixDatagram;
-#[cfg(feature = "async-traits")]
 pub use crate::incoming::Incoming;
 pub use crate::listener::UnixListener;
 pub use crate::stream::UnixStream;

--- a/tokio-uds/src/listener.rs
+++ b/tokio-uds/src/listener.rs
@@ -1,4 +1,4 @@
-use crate::UnixStream;
+use crate::{Incoming, UnixStream};
 
 use tokio_reactor::{Handle, PollEvented};
 
@@ -91,9 +91,8 @@ impl UnixListener {
     ///
     /// This method returns an implementation of the `Stream` trait which
     /// resolves to the sockets the are accepted on this listener.
-    #[cfg(feature = "async-traits")]
-    pub fn incoming(self) -> crate::Incoming {
-        crate::Incoming::new(self)
+    pub fn incoming(self) -> Incoming {
+        Incoming::new(self)
     }
 }
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -74,13 +74,13 @@ tokio-macros = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-m
 tokio-reactor = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-reactor" }
 tokio-sync = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-sync", features = ["async-traits"] }
 tokio-threadpool = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-threadpool" }
-tokio-tcp = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-tcp", features = ["async-traits"] }
+tokio-tcp = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-tcp" }
 tokio-udp = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-udp" }
-tokio-timer = { version = "=0.3.0-alpha.1", optional = true, path = "../tokio-timer", features = ["async-traits"] }
+tokio-timer = { version = "=0.3.0-alpha.1", optional = true, path = "../tokio-timer" }
 tracing-core = { version = "0.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "=0.3.0-alpha.1", optional = true, path = "../tokio-uds", features = ["async-traits"] }
+tokio-uds = { version = "=0.3.0-alpha.1", optional = true, path = "../tokio-uds" }
 
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.1", path = "../tokio-test" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`futures-core` is no longer an optional dependency in these crates.

This also removes the `futures-util` dependency from timer.

cc #1209 #1261 #1263

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
