### PR TITLE
timer: introduce delay function shortcut

### DIFF
--- a/tokio-test/src/clock.rs
+++ b/tokio-test/src/clock.rs
@@ -7,14 +7,13 @@
 //!
 //! use tokio::clock;
 //! use tokio_test::{assert_ready, assert_pending, task};
-//! use tokio_timer::Delay;
+//! use tokio_timer::delay;
 //!
 //! use std::time::Duration;
 //!
 //! tokio_test::clock::mock(|handle| {
 //!     let mut task = task::spawn(async {
-//!         let delay = Delay::new(clock::now() + Duration::from_secs(1));
-//!         delay.await
+//!         delay(clock::now() + Duration::from_secs(1)).await
 //!     });
 //!
 //!     assert_pending!(task.poll());

--- a/tokio-test/tests/block_on.rs
+++ b/tokio-test/tests/block_on.rs
@@ -3,7 +3,7 @@
 
 use std::time::{Duration, Instant};
 use tokio_test::block_on;
-use tokio_timer::Delay;
+use tokio_timer::delay;
 
 #[test]
 fn async_block() {
@@ -20,9 +20,7 @@ fn async_fn() {
 }
 
 #[test]
-fn delay() {
+fn test_delay() {
     let deadline = Instant::now() + Duration::from_millis(100);
-    let delay = Delay::new(deadline);
-
-    assert_eq!((), block_on(delay));
+    assert_eq!((), block_on(delay(deadline)));
 }

--- a/tokio-test/tests/clock.rs
+++ b/tokio-test/tests/clock.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 use tokio_test::clock::MockClock;
 use tokio_test::task::MockTask;
 use tokio_test::{assert_not_ready, assert_ready};
-use tokio_timer::Delay;
+use tokio_timer::delay;
 
 #[test]
 fn clock() {
@@ -14,7 +14,7 @@ fn clock() {
 
     mock.enter(|handle| {
         let deadline = Instant::now() + Duration::from_secs(1);
-        let mut delay = Delay::new(deadline);
+        let mut delay = delay(deadline);
 
         assert_not_ready!(delay.poll());
 
@@ -31,7 +31,7 @@ fn notify() {
     let mut task = MockTask::new();
 
     mock.enter(|handle| {
-        let mut delay = Delay::new(deadline);
+        let mut delay = delay(deadline);
 
         task.enter(|| assert_not_ready!(delay.poll()));
 

--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -33,7 +33,7 @@ impl Delay {
     /// Only millisecond level resolution is guaranteed. There is no guarantee
     /// as to how the sub-millisecond portion of `deadline` will be handled.
     /// `Delay` should not be used for high-resolution timer use cases.
-    pub fn new(deadline: Instant) -> Delay {
+    pub(crate) fn new(deadline: Instant) -> Delay {
         let registration = Registration::new(deadline, Duration::from_millis(0));
 
         Delay { registration }

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -59,9 +59,14 @@ pub use timer::{set_default, Timer};
 
 use std::time::{Duration, Instant};
 
+/// Create a Future that completes at `deadline`.
+pub fn delay(deadline: Instant) -> Delay {
+    Delay::new(deadline)
+}
+
 /// Create a Future that completes in `duration` from now.
 pub fn sleep(duration: Duration) -> Delay {
-    Delay::new(Instant::now() + duration)
+    delay(Instant::now() + duration)
 }
 
 // ===== Internal utils =====

--- a/tokio/src/timer.rs
+++ b/tokio/src/timer.rs
@@ -33,7 +33,7 @@
 //! #![feature(async_await)]
 //!
 //! use tokio::prelude::*;
-//! use tokio::timer::Delay;
+//! use tokio::timer::delay;
 //!
 //! use std::time::{Duration, Instant};
 //!
@@ -41,7 +41,7 @@
 //! #[tokio::main]
 //! async fn main() {
 //!     let when = tokio::clock::now() + Duration::from_millis(100);
-//!     Delay::new(when).await;
+//!     delay(when).await;
 //!     println!("100 ms have elapsed");
 //! }
 //! ```
@@ -79,4 +79,4 @@
 //! [Interval]: struct.Interval.html
 //! [`DelayQueue`]: struct.DelayQueue.html
 
-pub use tokio_timer::{delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout};
+pub use tokio_timer::{delay, delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout};

--- a/tokio/tests/clock.rs
+++ b/tokio/tests/clock.rs
@@ -28,7 +28,7 @@ fn clock_and_timer_concurrent() {
     let (tx, rx) = mpsc::channel();
 
     rt.spawn(async move {
-        Delay::new(when).await;
+        delay(when).await;
         assert!(Instant::now() < when);
         tx.send(()).unwrap();
     });
@@ -44,7 +44,7 @@ fn clock_and_timer_single_threaded() {
     let mut rt = current_thread::Builder::new().clock(clock).build().unwrap();
 
     rt.block_on(async move {
-        Delay::new(when).await;
+        delay(when).await;
         assert!(Instant::now() < when);
     });
 }

--- a/tokio/tests/runtime_current_thread.rs
+++ b/tokio/tests/runtime_current_thread.rs
@@ -6,12 +6,12 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::current_thread::Runtime;
 use tokio::sync::oneshot;
-use tokio::timer::Delay;
 use tokio_test::{assert_err, assert_ok};
 
 use env_logger;
 use std::sync::mpsc;
 use std::time::{Duration, Instant};
+use tokio::timer::delay;
 
 async fn client_server(tx: mpsc::Sender<()>) {
     let addr = assert_ok!("127.0.0.1:0".parse());
@@ -47,7 +47,7 @@ fn spawn_run_spawn_root() {
 
     let tx2 = tx.clone();
     rt.spawn(async move {
-        Delay::new(Instant::now() + Duration::from_millis(1000)).await;
+        delay(Instant::now() + Duration::from_millis(1000)).await;
         tx2.send(()).unwrap();
     });
 
@@ -68,7 +68,7 @@ fn spawn_run_nested_spawn() {
     let tx2 = tx.clone();
     rt.spawn(async move {
         tokio::spawn(async move {
-            Delay::new(Instant::now() + Duration::from_millis(1000)).await;
+            delay(Instant::now() + Duration::from_millis(1000)).await;
             tx2.send(()).unwrap();
         });
     });
@@ -89,7 +89,7 @@ fn block_on() {
 
     let tx2 = tx.clone();
     rt.spawn(async move {
-        Delay::new(Instant::now() + Duration::from_millis(1000)).await;
+        delay(Instant::now() + Duration::from_millis(1000)).await;
         tx2.send(()).unwrap();
     });
 

--- a/tokio/tests/runtime_threaded.rs
+++ b/tokio/tests/runtime_threaded.rs
@@ -7,7 +7,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
-use tokio::timer::Delay;
+use tokio::timer::delay;
 use tokio_test::{assert_err, assert_ok};
 
 use env_logger;
@@ -65,8 +65,7 @@ fn block_on_timer() {
     let rt = Runtime::new().unwrap();
 
     let v = rt.block_on(async move {
-        let delay = Delay::new(Instant::now() + Duration::from_millis(100));
-        delay.await;
+        delay(Instant::now() + Duration::from_millis(100)).await;
         42
     });
 


### PR DESCRIPTION
This PR adds a simple delay shortcut to avoid writing `Delay::new` everywhere.

I noticed that the `sleep` shortcut defined above my addition is not used anywhere in the repository,  should I at least use it in tests (i.e. `delay(now() + n)` -> `sleep(n)`)?

Suggested by: #1261