### PR TITLE
sync: rename async-traits feature to sink

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ jobs:
       tokio-io:
         - util
       tokio-sync:
-        - async-traits
+        - sink
       tokio-macros: []
       # - tokio-threadpool
       tokio-timer:

--- a/tokio-signal/Cargo.toml
+++ b/tokio-signal/Cargo.toml
@@ -36,7 +36,7 @@ signal-hook-registry = "~1"
 [dev-dependencies]
 tokio = { version = "=0.2.0-alpha.1", path = "../tokio" }
 tokio-timer = { version = "=0.3.0-alpha.1", path = "../tokio-timer" }
-tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync", features = ["async-traits"]}
+tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync", features = ["sink"]}
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -20,7 +20,7 @@ Synchronization utilities.
 categories = ["asynchronous"]
 
 [features]
-async-traits = ["futures-sink-preview"]
+sink = ["futures-sink-preview"]
 
 [dependencies]
 fnv = "1.0.6"

--- a/tokio-sync/src/mpsc/bounded.rs
+++ b/tokio-sync/src/mpsc/bounded.rs
@@ -1,10 +1,8 @@
 use super::chan;
 
 use std::fmt;
-use std::task::{Context, Poll};
-
-#[cfg(feature = "async-traits")]
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// Send values to the associated `Receiver`.
 ///
@@ -187,7 +185,6 @@ impl<T> Receiver<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
 impl<T> futures_core::Stream for Receiver<T> {
     type Item = T;
 
@@ -252,7 +249,7 @@ impl<T> Sender<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
+#[cfg(feature = "sink")]
 impl<T> futures_sink::Sink<T> for Sender<T> {
     type Error = SendError;
 

--- a/tokio-sync/src/mpsc/unbounded.rs
+++ b/tokio-sync/src/mpsc/unbounded.rs
@@ -2,10 +2,8 @@ use super::chan;
 use crate::loom::sync::atomic::AtomicUsize;
 
 use std::fmt;
-use std::task::{Context, Poll};
-
-#[cfg(feature = "async-traits")]
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 /// Send values to the associated `UnboundedReceiver`.
 ///
@@ -150,7 +148,6 @@ impl<T> UnboundedReceiver<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
 impl<T> futures_core::Stream for UnboundedReceiver<T> {
     type Item = T;
 
@@ -171,7 +168,7 @@ impl<T> UnboundedSender<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
+#[cfg(feature = "sink")]
 impl<T> futures_sink::Sink<T> for UnboundedSender<T> {
     type Error = UnboundedSendError;
 

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -60,18 +60,14 @@ use crate::task::AtomicWaker;
 use core::task::Poll::{Pending, Ready};
 use core::task::{Context, Poll};
 use fnv::FnvHashMap;
+use futures_core::ready;
 use futures_util::future::poll_fn;
+use futures_util::pin_mut;
 use std::ops;
+use std::pin::Pin;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
-
-#[cfg(feature = "async-traits")]
-use futures_core::ready;
-#[cfg(feature = "async-traits")]
-use futures_util::pin_mut;
-#[cfg(feature = "async-traits")]
-use std::pin::Pin;
 
 /// Receives values from the associated `Sender`.
 ///
@@ -301,7 +297,6 @@ impl<T: Clone> Receiver<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
 impl<T: Clone> futures_core::Stream for Receiver<T> {
     type Item = T;
 
@@ -402,7 +397,7 @@ impl<T> Sender<T> {
     }
 }
 
-#[cfg(feature = "async-traits")]
+#[cfg(feature = "sink")]
 impl<T> futures_sink::Sink<T> for Sender<T> {
     type Error = error::SendError<T>;
 

--- a/tokio-sync/tests/mpsc.rs
+++ b/tokio-sync/tests/mpsc.rs
@@ -54,7 +54,7 @@ async fn async_send_recv_with_buffer() {
 }
 
 #[test]
-#[cfg(feature = "async-traits")]
+#[cfg(feature = "sink")]
 fn send_sink_recv_with_buffer() {
     use futures_core::Stream;
     use futures_sink::Sink;
@@ -167,7 +167,7 @@ async fn async_send_recv_unbounded() {
 }
 
 #[test]
-#[cfg(feature = "async-traits")]
+#[cfg(feature = "sink")]
 fn sink_send_recv_unbounded() {
     use futures_core::Stream;
     use futures_sink::Sink;

--- a/tokio-sync/tests/watch.rs
+++ b/tokio-sync/tests/watch.rs
@@ -97,7 +97,6 @@ fn single_rx_recv() {
 }
 
 #[test]
-#[cfg(feature = "async-traits")]
 fn stream_impl() {
     use tokio::prelude::*;
 

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -38,7 +38,7 @@ slab = "0.4.1"
 [dev-dependencies]
 tokio = { version = "=0.2.0-alpha.1", path = "../tokio" }
 tokio-current-thread = { version = "=0.2.0-alpha.1", path = "../tokio-current-thread" }
-tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync", features = ["async-traits"] }
+tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync", features = ["sink"] }
 tokio-test = { version = "=0.2.0-alpha.1", path = "../tokio-test" }
 
 rand = "0.7"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -72,7 +72,7 @@ tokio-io = { version = "=0.2.0-alpha.1", optional = true, features = ["util"], p
 tokio-executor = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-executor" }
 tokio-macros = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-macros" }
 tokio-reactor = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-reactor" }
-tokio-sync = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-sync", features = ["async-traits"] }
+tokio-sync = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-sync", features = ["sink"] }
 tokio-threadpool = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-threadpool" }
 tokio-tcp = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-tcp", features = ["async-traits"] }
 tokio-udp = { version = "=0.2.0-alpha.1", optional = true, path = "../tokio-udp" }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This feature is currently only relevant for futures-sink dependency, so it is probably clearer to use this name.

cc #1210
Related: #1439

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
