### PR TITLE
v0.1.x: Fix `UdpFramed` with regards to `Decode`

### DIFF
--- a/tokio-udp/src/frame.rs
+++ b/tokio-udp/src/frame.rs
@@ -49,7 +49,7 @@ impl<C: Decoder> Stream for UdpFramed<C> {
             if self.is_readable {
                 if let Some(frame) = self.codec.decode(&mut self.rd)? {
                     trace!("frame decoded from buffer");
-                    
+
                     let current_addr = self
                         .current_addr
                         .expect("will always be set before this line is called");

--- a/tokio-udp/tests/udp.rs
+++ b/tokio-udp/tests/udp.rs
@@ -293,24 +293,22 @@ fn send_framed_byte_codec() {
 fn send_framed_lines_codec() {
     drop(env_logger::try_init());
 
-    let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
-    let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
     let a_addr = t!(a_soc.local_addr());
     let b_addr = t!(b_soc.local_addr());
-    
+
     let a = UdpFramed::new(a_soc, ByteCodec);
     let b = UdpFramed::new(b_soc, LinesCodec::new());
 
-    let msg = b"1\r\n2\r\n3\r\nLet's go!\r\n".to_vec();
+    let msg = b"1\r\n2\r\n3\r\n".to_vec();
 
     let send = a.send((msg.clone(), b_addr));
     t!(send.wait());
-    
-    let mut recv = Stream::wait(b);
-    let mut recv = recv.map(|e| e.unwrap());
+
+    let mut recv = Stream::wait(b).map(|e| e.unwrap());
 
     assert_eq!(recv.next(), Some(("1".to_string(), a_addr)));
     assert_eq!(recv.next(), Some(("2".to_string(), a_addr)));
     assert_eq!(recv.next(), Some(("3".to_string(), a_addr)));
-    assert_eq!(recv.next(), Some(("Let's go!".to_string(), a_addr)));
 }

--- a/tokio-udp/tests/udp.rs
+++ b/tokio-udp/tests/udp.rs
@@ -12,7 +12,7 @@ use std::net::SocketAddr;
 use futures::{Future, Poll, Sink, Stream};
 
 use bytes::{BufMut, BytesMut};
-use tokio_codec::{Decoder, Encoder};
+use tokio_codec::{Decoder, Encoder, LinesCodec};
 use tokio_udp::{UdpFramed, UdpSocket};
 
 macro_rules! t {
@@ -247,7 +247,7 @@ impl Encoder for ByteCodec {
 }
 
 #[test]
-fn send_framed() {
+fn send_framed_byte_codec() {
     drop(env_logger::try_init());
 
     let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
@@ -287,4 +287,30 @@ fn send_framed() {
         assert_eq!(msg, data);
         assert_eq!(a_addr, addr);
     }
+}
+
+#[test]
+fn send_framed_lines_codec() {
+    drop(env_logger::try_init());
+
+    let mut a_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let mut b_soc = t!(UdpSocket::bind(&t!("127.0.0.1:0".parse())));
+    let a_addr = t!(a_soc.local_addr());
+    let b_addr = t!(b_soc.local_addr());
+    
+    let a = UdpFramed::new(a_soc, ByteCodec);
+    let b = UdpFramed::new(b_soc, LinesCodec::new());
+
+    let msg = b"1\r\n2\r\n3\r\nLet's go!\r\n".to_vec();
+
+    let send = a.send((msg.clone(), b_addr));
+    t!(send.wait());
+    
+    let mut recv = Stream::wait(b);
+    let mut recv = recv.map(|e| e.unwrap());
+
+    assert_eq!(recv.next(), Some(("1".to_string(), a_addr)));
+    assert_eq!(recv.next(), Some(("2".to_string(), a_addr)));
+    assert_eq!(recv.next(), Some(("3".to_string(), a_addr)));
+    assert_eq!(recv.next(), Some(("Let's go!".to_string(), a_addr)));
 }


### PR DESCRIPTION
Should (fix) #1443 in the v0.1.x branch.

`UdpFramed` now attempts to continue decoding past the first discrete item if there is more data in the read buffer. I added a test for this that sends a packet with 3 lines and tests for the successful decoding of each item in turn.