### PR TITLE
tokio-process: change CommandExt to a fully asynchronous Command struct

### DIFF
--- a/tokio-process/tests/issue_42.rs
+++ b/tokio-process/tests/issue_42.rs
@@ -4,13 +4,13 @@
 use futures_util::future::FutureExt;
 use futures_util::stream::FuturesOrdered;
 use futures_util::stream::StreamExt;
-use std::process::{Command, Stdio};
+use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use tokio::runtime::current_thread;
-use tokio_process::CommandExt;
+use tokio_process::Command;
 
 mod support;
 
@@ -27,7 +27,7 @@ fn run_test() {
                     .stdin(Stdio::null())
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())
-                    .spawn_async()
+                    .spawn()
                     .unwrap()
                     .boxed(),
             )

--- a/tokio-process/tests/smoke.rs
+++ b/tokio-process/tests/smoke.rs
@@ -1,8 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![feature(async_await)]
 
-use tokio_process::CommandExt;
-
 mod support;
 
 #[tokio::test]
@@ -10,7 +8,7 @@ async fn simple() {
     let mut cmd = support::cmd("exit");
     cmd.arg("2");
 
-    let mut child = cmd.spawn_async().unwrap();
+    let mut child = cmd.spawn().unwrap();
 
     let id = child.id();
     assert!(id > 0);

--- a/tokio-process/tests/support/mod.rs
+++ b/tokio-process/tests/support/mod.rs
@@ -4,9 +4,9 @@ use futures_util::future;
 use futures_util::future::FutureExt;
 use std::env;
 use std::future::Future;
-use std::process::Command;
 use std::time::Duration;
 use tokio::timer::Timeout;
+use tokio_process::Command;
 
 #[allow(dead_code)]
 pub fn cmd(s: &str) -> Command {


### PR DESCRIPTION
https://github.com/tokio-rs/tokio/issues/1371 suggested to rewrite `CommandExt` in a way similar to `tokio-fs` (wrap the `std` struct and expose only asynchronous functions). I started rewriting Command in such a way.

Documentation and doctests are not updated yet, I just transformed the minimum amount of code to make tests pass. Please let me know if it's OK and if I shall continue :)

Refs: #1371