### PR TITLE
Refactoring one time TLS setters

### DIFF
--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -181,7 +181,7 @@ pub fn set_current(handle: &Handle) -> CurrentReactorReset {
         assert!(
             current.is_none(),
             "default Tokio reactor already set \
-            for execution context"
+             for execution context"
         );
 
         let handle = match handle.as_priv() {
@@ -194,9 +194,7 @@ pub fn set_current(handle: &Handle) -> CurrentReactorReset {
         *current = Some(handle.clone());
     });
 
-
-    CurrentReactorReset {
-    }
+    CurrentReactorReset {}
 }
 
 impl Reactor {

--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -160,54 +160,43 @@ fn _assert_kinds() {
 
 // ===== impl Reactor =====
 
-/// Set the default reactor for the duration of the closure
-///
-/// # Panics
-///
-/// This function panics if there already is a default reactor set.
-pub fn with_default<F, R>(handle: &Handle, f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    // Ensure that the executor is removed from the thread-local context
-    // when leaving the scope. This handles cases that involve panicking.
-    struct Reset;
+#[derive(Debug)]
+///Guard that resets current reactor on drop.
+pub struct CurrentReactorReset {}
 
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            CURRENT_REACTOR.with(|current| {
-                let mut current = current.borrow_mut();
-                *current = None;
-            });
-        }
-    }
-
-    // This ensures the value for the current reactor gets reset even if there
-    // is a panic.
-    let _r = Reset;
-
-    CURRENT_REACTOR.with(|current| {
-        {
+impl Drop for CurrentReactorReset {
+    fn drop(&mut self) {
+        CURRENT_REACTOR.with(|current| {
             let mut current = current.borrow_mut();
+            *current = None;
+        });
+    }
+}
 
-            assert!(
-                current.is_none(),
-                "default Tokio reactor already set \
-                 for execution context"
-            );
+///Sets handle to current reactor, returning guard that unsets it on drop.
+pub fn set_current(handle: &Handle) -> CurrentReactorReset {
+    CURRENT_REACTOR.with(|current| {
+        let mut current = current.borrow_mut();
 
-            let handle = match handle.as_priv() {
-                Some(handle) => handle,
-                None => {
-                    panic!("`handle` does not reference a reactor");
-                }
-            };
+        assert!(
+            current.is_none(),
+            "default Tokio reactor already set \
+            for execution context"
+        );
 
-            *current = Some(handle.clone());
-        }
+        let handle = match handle.as_priv() {
+            Some(handle) => handle,
+            None => {
+                panic!("`handle` does not reference a reactor");
+            }
+        };
 
-        f()
-    })
+        *current = Some(handle.clone());
+    });
+
+
+    CurrentReactorReset {
+    }
 }
 
 impl Reactor {

--- a/tokio-test/src/clock.rs
+++ b/tokio-test/src/clock.rs
@@ -134,11 +134,10 @@ impl MockClock {
             let handle = timer.handle();
             let time = self.time.clone();
 
-            ::tokio_timer::with_default(&handle, || {
-                let mut handle = Handle::new(timer, time);
-                f(&mut handle)
-                // lazy(|| Ok::<_, ()>(f(&mut handle))).wait().unwrap()
-            })
+            let _timer = ::tokio_timer::set_default(&handle);
+            let mut handle = Handle::new(timer, time);
+            f(&mut handle)
+            // lazy(|| Ok::<_, ()>(f(&mut handle))).wait().unwrap()
         })
     }
 }

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -55,7 +55,7 @@ pub use error::Error;
 pub use interval::Interval;
 #[doc(inline)]
 pub use timeout::Timeout;
-pub use timer::{with_default, Timer};
+pub use timer::{set_default, Timer};
 
 use std::time::{Duration, Instant};
 

--- a/tokio-timer/src/timer/handle.rs
+++ b/tokio-timer/src/timer/handle.rs
@@ -49,8 +49,7 @@ thread_local! {
 
 #[derive(Debug)]
 ///Unsets default timer handler on drop.
-pub struct DefaultHandlerReset {
-}
+pub struct DefaultHandlerReset {}
 
 impl Drop for DefaultHandlerReset {
     fn drop(&mut self) {
@@ -73,7 +72,7 @@ pub fn set_default(handle: &Handle) -> DefaultHandlerReset {
         assert!(
             current.is_none(),
             "default Tokio timer already set \
-            for execution context"
+             for execution context"
         );
 
         let handle = handle
@@ -83,8 +82,7 @@ pub fn set_default(handle: &Handle) -> DefaultHandlerReset {
         *current = Some(handle.clone());
     });
 
-    DefaultHandlerReset {
-    }
+    DefaultHandlerReset {}
 }
 
 impl Handle {

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -45,7 +45,7 @@ use self::entry::Entry;
 use self::stack::Stack;
 
 pub(crate) use self::handle::HandlePriv;
-pub use self::handle::{with_default, Handle};
+pub use self::handle::{set_default, Handle};
 pub use self::now::{Now, SystemNow};
 pub(crate) use self::registration::Registration;
 

--- a/tokio-tls/tests/smoke.rs
+++ b/tokio-tls/tests/smoke.rs
@@ -265,7 +265,7 @@ cfg_if! {
 
         use std::env;
         use std::fs::File;
-        use std::io::Error;
+        use std::io;
         use std::mem;
         use std::sync::Once;
 

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -343,15 +343,13 @@ impl Builder {
             .around_worker(move |w| {
                 let index = w.id().to_usize();
 
-                tokio_net::with_default(&reactor_handles[index], || {
-                    clock::with_default(&clock, || {
-                        timer::with_default(&timer_handles[index], || {
-                            trace::dispatcher::with_default(&dispatch, || {
-                                w.run();
-                            })
-                        });
+                let _reactor = tokio_net::set_default(&reactor_handles[index]);
+                clock::with_default(&clock, || {
+                    let _timer = timer::set_default(&timer_handles[index]);
+                    trace::dispatcher::with_default(&dispatch, || {
+                        w.run();
                     })
-                });
+                })
             })
             .custom_park(move |worker_id| {
                 let index = worker_id.to_usize();

--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -173,12 +173,10 @@ impl Runtime {
         let trace = &self.inner().trace;
 
         tokio_executor::with_default(&mut self.inner().pool.sender(), || {
-            tokio_net::with_default(bg.reactor(), || {
-                timer::with_default(bg.timer(), || {
-                    trace::dispatcher::with_default(trace, || {
-                        entered.block_on(future)
-                    })
-                })
+            let _reactor = tokio_net::set_default(bg.reactor());
+            let _timer = timer::set_default(bg.timer());
+            trace::dispatcher::with_default(trace, || {
+                entered.block_on(future)
             })
         })
     }

--- a/tokio/tests/reactor.rs
+++ b/tokio/tests/reactor.rs
@@ -66,11 +66,12 @@ fn test_drop_on_notify() {
 
     let _enter = tokio_executor::enter().unwrap();
 
-    tokio_net::with_default(&reactor.handle(), || {
+    {
+        let _reactor = tokio_net::set_current(&reactor.handle());
         let waker = waker_ref(&task);
         let mut cx = Context::from_waker(&waker);
         assert_pending!(task.future.lock().unwrap().as_mut().poll(&mut cx));
-    });
+    }
 
     // Get the address
     let addr = addr_rx.recv().unwrap();

--- a/tokio/tests/reactor.rs
+++ b/tokio/tests/reactor.rs
@@ -67,7 +67,8 @@ fn test_drop_on_notify() {
     let _enter = tokio_executor::enter().unwrap();
 
     {
-        let _reactor = tokio_net::set_current(&reactor.handle());
+        let handle = reactor.handle();
+        let _reactor = tokio_net::set_default(&handle);
         let waker = waker_ref(&task);
         let mut cx = Context::from_waker(&waker);
         assert_pending!(task.future.lock().unwrap().as_mut().poll(&mut cx));


### PR DESCRIPTION
Replaces `tokio_reactor::with_default` and `tokio_timer::with_default` with methods that return guard.

There are two more similar methods, but they are not one time, and instead restore to previous value (allowing to create stack of executors/clocks)
Due to that implementing guard would mean extra access to TLS for them, I'm not sure if it is desirable in this case