### PR TITLE
net: switch from `log` to `tracing`.

### DIFF
--- a/tokio-net/Cargo.toml
+++ b/tokio-net/Cargo.toml
@@ -20,10 +20,12 @@ Event loop that drives Tokio I/O resources.
 """
 categories = ["asynchronous", "network-programming"]
 
+[features]
+log = ["tracing/log"]
+
 [dependencies]
 crossbeam-utils = "0.6.0"
 lazy_static = "1.0.2"
-log = "0.4.6"
 mio = "0.6.14"
 num_cpus = "1.8.0"
 parking_lot = "0.9"
@@ -31,6 +33,7 @@ slab = "0.4.0"
 tokio-executor = { version = "=0.2.0-alpha.1", path = "../tokio-executor" }
 tokio-io = { version = "=0.2.0-alpha.1", path = "../tokio-io" }
 tokio-sync = { version = "=0.2.0-alpha.1", path = "../tokio-sync" }
+tracing = "0.1.5"
 futures-core-preview = "=0.3.0-alpha.18"
 
 [dev-dependencies]

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -4,7 +4,6 @@ use super::sharded_rwlock::RwLock;
 use tokio_executor::park::{Park, Unpark};
 use tokio_sync::AtomicWaker;
 
-use log::{debug, log_enabled, trace, Level};
 use mio::event::Evented;
 use slab::Slab;
 use std::cell::RefCell;
@@ -18,6 +17,7 @@ use std::sync::{Arc, Weak};
 use std::task::Waker;
 use std::time::{Duration, Instant};
 use std::{fmt, usize};
+use tracing::{debug, trace};
 
 /// The core reactor, or event loop.
 ///
@@ -235,6 +235,7 @@ impl Reactor {
         self.inner.io_dispatch.read().is_empty()
     }
 
+    #[tracing::instrument(level = "debug")]
     fn poll(&mut self, max_wait: Option<Duration>) -> io::Result<()> {
         // Block waiting for an event to happen, peeling out how many events
         // happened.
@@ -243,18 +244,12 @@ impl Reactor {
             Err(e) => return Err(e),
         }
 
-        let start = if log_enabled!(Level::Debug) {
-            Some(Instant::now())
-        } else {
-            None
-        };
-
         // Process all the events that came in, dispatching appropriately
         let mut events = 0;
         for event in self.events.iter() {
             events += 1;
             let token = event.token();
-            trace!("event {:?} {:?}", event.readiness(), event.token());
+            trace!(event.readiness = ?event.readiness(), event.token = ?token);
 
             if token == TOKEN_WAKEUP {
                 self.inner
@@ -266,15 +261,7 @@ impl Reactor {
             }
         }
 
-        if let Some(start) = start {
-            let dur = start.elapsed();
-            trace!(
-                "loop process - {} events, {}.{:03}s",
-                events,
-                dur.as_secs(),
-                dur.subsec_millis()
-            );
-        }
+        trace!(message = "loop process", events);
 
         Ok(())
     }
@@ -465,7 +452,7 @@ impl Inner {
         };
 
         let token = aba_guard | key;
-        debug!("adding I/O source: {}", token);
+        debug!(message = "adding I/O source", token);
 
         self.io.register(
             source,
@@ -483,13 +470,13 @@ impl Inner {
     }
 
     pub(super) fn drop_source(&self, token: usize) {
-        debug!("dropping I/O source: {}", token);
+        debug!(message = "dropping I/O source", token);
         self.io_dispatch.write().remove(token);
     }
 
     /// Registers interest in the I/O resource associated with `token`.
     pub(super) fn register(&self, token: usize, dir: Direction, w: Waker) {
-        debug!("scheduling {:?} for: {}", dir, token);
+        debug!(message = "scheduling", direction = ?dir, token);
         let io_dispatch = self.io_dispatch.read();
         let sched = io_dispatch.get(token).unwrap();
 

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -1,7 +1,7 @@
 use super::platform;
 use super::reactor::{Direction, Handle, HandlePriv};
 
-use log::debug;
+use tracing::debug;
 use mio::{self, Evented};
 use std::cell::UnsafeCell;
 use std::sync::atomic::AtomicUsize;
@@ -524,7 +524,7 @@ impl Inner {
 
         if ready.is_empty() {
             if let Some(cx) = cx {
-                debug!("scheduling {:?} for: {}", direction, self.token);
+                debug!(message = "scheduling", ?direction, token = self.token);
                 // Update the task info
                 match direction {
                     Direction::Read => sched.reader.register_by_ref(cx.waker()),


### PR DESCRIPTION
## Motivation:

The `tracing` crate implements scoped, structured, context-aware
diagnostics, which can add significant debugging value over unstructured
log messages. `tracing` is part of the Tokio project. As part of the
`tokio` 0.2 changes, I thought it would be good to move over from `log`
to `tracing` in the tokio runtime.

## Solution:

This branch replaces the use of `log` in `tokio-net` with
`tracing`. I've tried to leave all the instrumentation points more or
less the same, but modified to use structured fields instead of string
interpolation.

## Notes:

I removed the timing in `Reactor::poll` in favor of simply adding a
`#[tracing::instrument]` attribute. Since the generated `tracing` span
will have enter and exit events, a `tracing::Subscriber`
implemementation can use those to record timestamps, and process that
timing data in a much more sophisticated manner than including it in a
log line.

We can add the timestamps back if they're desired.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
