### PR TITLE
signal: rename SignalKind methods

### DIFF
--- a/tokio-process/src/unix/mod.rs
+++ b/tokio-process/src/unix/mod.rs
@@ -102,7 +102,7 @@ pub(crate) fn spawn_child(cmd: &mut process::Command, handle: &Handle) -> io::Re
     let stdout = stdio(child.stdout.take(), handle)?;
     let stderr = stdio(child.stderr.take(), handle)?;
 
-    let signal = Signal::with_handle(SignalKind::sigchld(), handle)?;
+    let signal = Signal::with_handle(SignalKind::child(), handle)?;
 
     Ok(SpawnedChild {
         child: Child {

--- a/tokio-signal/examples/multiple.rs
+++ b/tokio-signal/examples/multiple.rs
@@ -11,8 +11,10 @@ mod platform {
 
     pub async fn main() {
         // Create a stream for each of the signals we'd like to handle.
-        let sigint = Signal::new(SignalKind::sigint()).unwrap().map(|_| "SIGINT");
-        let sigterm = Signal::new(SignalKind::sigterm())
+        let sigint = Signal::new(SignalKind::interrupt())
+            .unwrap()
+            .map(|_| "SIGINT");
+        let sigterm = Signal::new(SignalKind::terminate())
             .unwrap()
             .map(|_| "SIGTERM");
 

--- a/tokio-signal/examples/sighup-example.rs
+++ b/tokio-signal/examples/sighup-example.rs
@@ -9,7 +9,7 @@ mod platform {
 
     pub async fn main() {
         // on Unix, we can listen to whatever signal we want, in this case: SIGHUP
-        let mut stream = Signal::new(SignalKind::sighup()).unwrap();
+        let mut stream = Signal::new(SignalKind::hangup()).unwrap();
 
         println!("Waiting for SIGHUPS (Ctrl+C to quit)");
         println!(

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -77,7 +77,7 @@
 //!
 //!     // Like the previous example, this is an infinite stream of signals
 //!     // being received, and signals may be coalesced while pending.
-//!     let stream = Signal::new(SignalKind::sighup())?;
+//!     let stream = Signal::new(SignalKind::hangup())?;
 //!
 //!     // Convert out stream into a future and block the program
 //!     let (signal, _signal) = stream.into_future().await;

--- a/tokio-signal/src/unix.rs
+++ b/tokio-signal/src/unix.rs
@@ -86,7 +86,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent when a real-time timer has expired.
     /// By default, the process is terminated by this signal.
-    pub fn sigalrm() -> Self {
+    pub fn alarm() -> Self {
         Self(libc::SIGALRM)
     }
 
@@ -94,7 +94,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent when the status of a child process
     /// has changed. By default, this signal is ignored.
-    pub fn sigchld() -> Self {
+    pub fn child() -> Self {
         Self(libc::SIGCHLD)
     }
 
@@ -102,7 +102,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent when the terminal is disconnected.
     /// By default, the process is terminated by this signal.
-    pub fn sighup() -> Self {
+    pub fn hangup() -> Self {
         Self(libc::SIGHUP)
     }
 
@@ -117,7 +117,7 @@ impl SignalKind {
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    pub fn siginfo() -> Self {
+    pub fn info() -> Self {
         Self(libc::SIGINFO)
     }
 
@@ -125,7 +125,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent to interrupt a program.
     /// By default, the process is terminated by this signal.
-    pub fn sigint() -> Self {
+    pub fn interrupt() -> Self {
         Self(libc::SIGINT)
     }
 
@@ -133,7 +133,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent when I/O operations are possible
     /// on some file descriptor. By default, this signal is ignored.
-    pub fn sigio() -> Self {
+    pub fn io() -> Self {
         Self(libc::SIGIO)
     }
 
@@ -142,7 +142,7 @@ impl SignalKind {
     /// On Unix systems this signal is sent when the process attempts to write
     /// to a pipe which has no reader. By default, the process is terminated by
     /// this signal.
-    pub fn sigpipe() -> Self {
+    pub fn pipe() -> Self {
         Self(libc::SIGPIPE)
     }
 
@@ -151,7 +151,7 @@ impl SignalKind {
     /// On Unix systems this signal is sent to issue a shutdown of the
     /// process, after which the OS will dump the process core.
     /// By default, the process is terminated by this signal.
-    pub fn sigquit() -> Self {
+    pub fn quit() -> Self {
         Self(libc::SIGQUIT)
     }
 
@@ -159,7 +159,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent to issue a shutdown of the
     /// process. By default, the process is terminated by this signal.
-    pub fn sigterm() -> Self {
+    pub fn terminate() -> Self {
         Self(libc::SIGTERM)
     }
 
@@ -167,7 +167,7 @@ impl SignalKind {
     ///
     /// On Unix systems this is a user defined signal.
     /// By default, the process is terminated by this signal.
-    pub fn sigusr1() -> Self {
+    pub fn user_defined1() -> Self {
         Self(libc::SIGUSR1)
     }
 
@@ -175,7 +175,7 @@ impl SignalKind {
     ///
     /// On Unix systems this is a user defined signal.
     /// By default, the process is terminated by this signal.
-    pub fn sigusr2() -> Self {
+    pub fn user_defined2() -> Self {
         Self(libc::SIGUSR2)
     }
 
@@ -183,7 +183,7 @@ impl SignalKind {
     ///
     /// On Unix systems this signal is sent when the terminal window is resized.
     /// By default, this signal is ignored.
-    pub fn sigwinch() -> Self {
+    pub fn window_change() -> Self {
         Self(libc::SIGWINCH)
     }
 }
@@ -421,7 +421,7 @@ impl Signal {
     }
 
     pub(crate) fn ctrl_c(handle: &Handle) -> io::Result<Self> {
-        Self::with_handle(SignalKind::sigint(), handle)
+        Self::with_handle(SignalKind::interrupt(), handle)
     }
 }
 

--- a/tokio-signal/tests/drop_multi_loop.rs
+++ b/tokio-signal/tests/drop_multi_loop.rs
@@ -9,7 +9,7 @@ use crate::support::*;
 #[test]
 fn dropping_loops_does_not_cause_starvation() {
     let (mut rt, signal) = {
-        let kind = SignalKind::sigusr1();
+        let kind = SignalKind::user_defined1();
 
         let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
         let mut first_signal = Signal::new(kind).expect("failed to register first signal");

--- a/tokio-signal/tests/drop_then_get_a_signal.rs
+++ b/tokio-signal/tests/drop_then_get_a_signal.rs
@@ -9,7 +9,7 @@ use crate::support::*;
 
 #[tokio::test]
 async fn drop_then_get_a_signal() {
-    let kind = SignalKind::sigusr1();
+    let kind = SignalKind::user_defined1();
     let signal = Signal::new(kind).expect("failed to create first signal");
     drop(signal);
 

--- a/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
+++ b/tokio-signal/tests/dropping_does_not_deregister_other_instances.rs
@@ -9,7 +9,7 @@ use crate::support::*;
 
 #[tokio::test]
 async fn dropping_signal_does_not_deregister_any_other_instances() {
-    let kind = SignalKind::sigusr1();
+    let kind = SignalKind::user_defined1();
 
     // NB: Testing for issue alexcrichton/tokio-signal#38:
     // signals should not starve based on ordering

--- a/tokio-signal/tests/multi_loop.rs
+++ b/tokio-signal/tests/multi_loop.rs
@@ -20,7 +20,7 @@ fn multi_loop() {
                 let sender = sender.clone();
                 thread::spawn(move || {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
-                    let signal = Signal::new(SignalKind::sighup()).unwrap();
+                    let signal = Signal::new(SignalKind::hangup()).unwrap();
                     sender.send(()).unwrap();
                     let _ = run_with_timeout(&mut rt, signal.into_future());
                 })

--- a/tokio-signal/tests/notify_both.rs
+++ b/tokio-signal/tests/notify_both.rs
@@ -9,7 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn notify_both() {
-    let kind = SignalKind::sigusr2();
+    let kind = SignalKind::user_defined2();
     let signal1 = Signal::new(kind).expect("failed to create signal1");
 
     let signal2 = Signal::new(kind).expect("failed to create signal2");

--- a/tokio-signal/tests/simple.rs
+++ b/tokio-signal/tests/simple.rs
@@ -9,7 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn simple() {
-    let signal = Signal::new(SignalKind::sigusr1()).expect("failed to create signal");
+    let signal = Signal::new(SignalKind::user_defined1()).expect("failed to create signal");
 
     send_signal(libc::SIGUSR1);
 

--- a/tokio-signal/tests/twice.rs
+++ b/tokio-signal/tests/twice.rs
@@ -9,7 +9,7 @@ use libc;
 
 #[tokio::test]
 async fn twice() {
-    let kind = SignalKind::sigusr1();
+    let kind = SignalKind::user_defined1();
     let mut signal = Signal::new(kind).expect("failed to get signal");
 
     for _ in 0..2 {


### PR DESCRIPTION
* This renames the SignalKind constructors to be a bit more readable
instead of using the signal names themselves
* I did not go as far as naming the methods based on what the signal does/represents (some signals alike `alarm` are kinda obvious, but `pipe` isn't as much), but bikeshedding is welcome

Refs #1243 