### PR TITLE
sync: fix fuzz_oneshot test by using instrumented `loom::sync::Arc`

### DIFF
--- a/tokio-sync/src/oneshot.rs
+++ b/tokio-sync/src/oneshot.rs
@@ -1,6 +1,6 @@
 //! A channel for sending a single message between asynchronous tasks.
 
-use crate::loom::{sync::atomic::AtomicUsize, sync::CausalCell};
+use crate::loom::sync::{atomic::AtomicUsize, Arc, CausalCell};
 
 use futures_core::ready;
 use std::fmt;
@@ -8,7 +8,6 @@ use std::future::Future;
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::{self, AcqRel, Acquire};
-use std::sync::Arc;
 use std::task::Poll::{Pending, Ready};
 use std::task::{Context, Poll, Waker};
 


### PR DESCRIPTION
Since `tokio_sync::oneshot` makes a `CausalCell::with_mut()` mutable
access in the `Inner::drop()`, we must use the instrumented
`loom::sync::Arc`.

To be clear, there is no issue with the underlying `tokio_sync::oneshot`.
This change just fixes the test so that it no longer reports a false negative
test output.

Uncovered by carllerche/loom#42