### PR TITLE
Make default reactor guard public

### DIFF
--- a/tokio-net/src/driver/mod.rs
+++ b/tokio-net/src/driver/mod.rs
@@ -136,5 +136,5 @@ mod reactor;
 mod registration;
 mod sharded_rwlock;
 
-pub use self::reactor::{set_default, Handle, Reactor};
+pub use self::reactor::{set_default, DefaultGuard, Handle, Reactor};
 pub use self::registration::Registration;


### PR DESCRIPTION
Subj, I forgot that reactor module is private in `tokio-net` so actually now `set_default` returns private type