### PR TITLE
signal: remove `new()` constructors in favor of free functions

### DIFF
--- a/tokio-net/src/signal/ctrl_c.rs
+++ b/tokio-net/src/signal/ctrl_c.rs
@@ -1,8 +1,7 @@
 #[cfg(unix)]
-use super::unix::Signal as Inner;
+use super::unix::{self as os_impl, Signal as Inner};
 #[cfg(windows)]
-use super::windows::Event as Inner;
-use crate::driver::Handle;
+use super::windows::{self as os_impl, Event as Inner};
 
 use futures_core::stream::Stream;
 use std::io;
@@ -30,22 +29,12 @@ pub struct CtrlC {
     inner: Inner,
 }
 
-impl CtrlC {
-    /// Creates a new stream which receives "ctrl-c" notifications sent to the
-    /// process.
-    ///
-    /// This function binds to the default reactor.
-    pub fn new() -> io::Result<Self> {
-        Self::with_handle(&Handle::default())
-    }
-
-    /// Creates a new stream which receives "ctrl-c" notifications sent to the
-    /// process.
-    ///
-    /// This function binds to reactor specified by `handle`.
-    pub fn with_handle(handle: &Handle) -> io::Result<Self> {
-        Inner::ctrl_c(handle).map(|inner| Self { inner })
-    }
+/// Creates a new stream which receives "ctrl-c" notifications sent to the
+/// process.
+///
+/// This function binds to the default reactor.
+pub fn ctrl_c() -> io::Result<CtrlC> {
+    os_impl::ctrl_c().map(|inner| CtrlC { inner })
 }
 
 impl Stream for CtrlC {

--- a/tokio-net/src/signal/mod.rs
+++ b/tokio-net/src/signal/mod.rs
@@ -29,7 +29,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create an infinite stream of "Ctrl+C" notifications. Each item received
 //!     // on this stream may represent multiple ctrl-c signals.
-//!     let ctrl_c = signal::CtrlC::new()?;
+//!     let ctrl_c = signal::ctrl_c()?;
 //!
 //!     // Process each ctrl-c as it comes in
 //!     let prog = ctrl_c.for_each(|_| {
@@ -49,7 +49,7 @@
 //! #![feature(async_await)]
 //! # #[cfg(unix)] {
 //!
-//! use tokio_net::signal::{self, unix::{Signal, SignalKind}};
+//! use tokio_net::signal::{self, unix::{signal, SignalKind}};
 //!
 //! use futures_util::future;
 //! use futures_util::stream::StreamExt;
@@ -58,7 +58,7 @@
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create an infinite stream of "Ctrl+C" notifications. Each item received
 //!     // on this stream may represent multiple ctrl-c signals.
-//!     let ctrl_c = signal::CtrlC::new()?;
+//!     let ctrl_c = signal::ctrl_c()?;
 //!
 //!     // Process each ctrl-c as it comes in
 //!     let prog = ctrl_c.for_each(|_| {
@@ -70,10 +70,10 @@
 //!
 //!     // Like the previous example, this is an infinite stream of signals
 //!     // being received, and signals may be coalesced while pending.
-//!     let stream = Signal::new(SignalKind::hangup())?;
+//!     let stream = signal(SignalKind::hangup())?;
 //!
 //!     // Convert out stream into a future and block the program
-//!     let (signal, _signal) = stream.into_future().await;
+//!     let (signal, _stream) = stream.into_future().await;
 //!     println!("got signal {:?}", signal);
 //!     Ok(())
 //! }
@@ -93,4 +93,4 @@ mod os {
 pub mod unix;
 pub mod windows;
 
-pub use self::ctrl_c::CtrlC;
+pub use self::ctrl_c::{ctrl_c, CtrlC};

--- a/tokio-net/tests/signal_drop_multi_loop.rs
+++ b/tokio-net/tests/signal_drop_multi_loop.rs
@@ -11,10 +11,10 @@ fn dropping_loops_does_not_cause_starvation() {
         let kind = SignalKind::user_defined1();
 
         let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
-        let mut first_signal = Signal::new(kind).expect("failed to register first signal");
+        let mut first_signal = signal(kind).expect("failed to register first signal");
 
         let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
-        let mut second_signal = Signal::new(kind).expect("failed to register second signal");
+        let mut second_signal = signal(kind).expect("failed to register second signal");
 
         send_signal(libc::SIGUSR1);
 

--- a/tokio-net/tests/signal_drop_then_get_a_signal.rs
+++ b/tokio-net/tests/signal_drop_then_get_a_signal.rs
@@ -9,11 +9,11 @@ use crate::signal_support::*;
 #[tokio::test]
 async fn drop_then_get_a_signal() {
     let kind = SignalKind::user_defined1();
-    let signal = Signal::new(kind).expect("failed to create first signal");
-    drop(signal);
+    let sig = signal(kind).expect("failed to create first signal");
+    drop(sig);
 
     send_signal(libc::SIGUSR1);
-    let signal = Signal::new(kind).expect("failed to create second signal");
+    let sig = signal(kind).expect("failed to create second signal");
 
-    let _ = with_timeout(signal.into_future()).await;
+    let _ = with_timeout(sig.into_future()).await;
 }

--- a/tokio-net/tests/signal_dropping_does_not_deregister_other_instances.rs
+++ b/tokio-net/tests/signal_dropping_does_not_deregister_other_instances.rs
@@ -12,15 +12,13 @@ async fn dropping_signal_does_not_deregister_any_other_instances() {
 
     // NB: Testing for issue alexcrichton/tokio-signal#38:
     // signals should not starve based on ordering
-    let first_duplicate_signal =
-        Signal::new(kind).expect("failed to register first duplicate signal");
-    let signal = Signal::new(kind).expect("failed to register signal");
-    let second_duplicate_signal =
-        Signal::new(kind).expect("failed to register second duplicate signal");
+    let first_duplicate_signal = signal(kind).expect("failed to register first duplicate signal");
+    let sig = signal(kind).expect("failed to register signal");
+    let second_duplicate_signal = signal(kind).expect("failed to register second duplicate signal");
 
     drop(first_duplicate_signal);
     drop(second_duplicate_signal);
 
     send_signal(libc::SIGUSR1);
-    let _ = with_timeout(signal.into_future()).await;
+    let _ = with_timeout(sig.into_future()).await;
 }

--- a/tokio-net/tests/signal_multi_loop.rs
+++ b/tokio-net/tests/signal_multi_loop.rs
@@ -20,7 +20,7 @@ fn multi_loop() {
                 let sender = sender.clone();
                 thread::spawn(move || {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
-                    let signal = Signal::new(SignalKind::hangup()).unwrap();
+                    let signal = signal(SignalKind::hangup()).unwrap();
                     sender.send(()).unwrap();
                     let _ = run_with_timeout(&mut rt, signal.into_future());
                 })

--- a/tokio-net/tests/signal_notify_both.rs
+++ b/tokio-net/tests/signal_notify_both.rs
@@ -9,9 +9,9 @@ use crate::signal_support::*;
 #[tokio::test]
 async fn notify_both() {
     let kind = SignalKind::user_defined2();
-    let signal1 = Signal::new(kind).expect("failed to create signal1");
+    let signal1 = signal(kind).expect("failed to create signal1");
 
-    let signal2 = Signal::new(kind).expect("failed to create signal2");
+    let signal2 = signal(kind).expect("failed to create signal2");
 
     send_signal(libc::SIGUSR2);
     let _ = with_timeout(future::join(signal1.into_future(), signal2.into_future())).await;

--- a/tokio-net/tests/signal_simple.rs
+++ b/tokio-net/tests/signal_simple.rs
@@ -8,7 +8,7 @@ use crate::signal_support::*;
 
 #[tokio::test]
 async fn simple() {
-    let signal = Signal::new(SignalKind::user_defined1()).expect("failed to create signal");
+    let signal = signal(SignalKind::user_defined1()).expect("failed to create signal");
 
     send_signal(libc::SIGUSR1);
 
@@ -19,9 +19,9 @@ async fn simple() {
 #[cfg(unix)]
 async fn ctrl_c() {
     use tokio::sync::oneshot;
-    use tokio_net::signal::CtrlC;
+    use tokio_net::signal::ctrl_c;
 
-    let ctrl_c = CtrlC::new().expect("failed to init ctrl_c");
+    let ctrl_c = ctrl_c().expect("failed to init ctrl_c");
 
     let (fire, wait) = oneshot::channel();
 

--- a/tokio-net/tests/signal_support/mod.rs
+++ b/tokio-net/tests/signal_support/mod.rs
@@ -3,7 +3,7 @@
 
 pub use tokio::runtime::current_thread::{self, Runtime as CurrentThreadRuntime};
 use tokio::timer::Timeout;
-pub use tokio_net::signal::unix::{Signal, SignalKind};
+pub use tokio_net::signal::unix::{signal, SignalKind};
 
 pub use futures_util::future;
 use futures_util::future::FutureExt;

--- a/tokio-net/tests/signal_twice.rs
+++ b/tokio-net/tests/signal_twice.rs
@@ -9,14 +9,14 @@ use crate::signal_support::*;
 #[tokio::test]
 async fn twice() {
     let kind = SignalKind::user_defined1();
-    let mut signal = Signal::new(kind).expect("failed to get signal");
+    let mut sig = signal(kind).expect("failed to get signal");
 
     for _ in 0..2 {
         send_signal(libc::SIGUSR1);
 
-        let (item, sig) = with_timeout(signal.into_future()).await;
+        let (item, sig_next) = with_timeout(sig.into_future()).await;
         assert_eq!(item, Some(()));
 
-        signal = sig;
+        sig = sig_next;
     }
 }

--- a/tokio-process/src/windows.rs
+++ b/tokio-process/src/windows.rs
@@ -181,7 +181,7 @@ pub(crate) type ChildStdin = PollEvented<NamedPipe>;
 pub(crate) type ChildStdout = PollEvented<NamedPipe>;
 pub(crate) type ChildStderr = PollEvented<NamedPipe>;
 
-fn stdio<T>(option: Option<T>) -> io::Result<Option<PollEvented<NamedPipe>>>
+fn stdio<T>(option: Option<T>) -> Option<PollEvented<NamedPipe>>
 where
     T: IntoRawHandle,
 {

--- a/tokio-process/src/windows.rs
+++ b/tokio-process/src/windows.rs
@@ -18,7 +18,6 @@
 use super::SpawnedChild;
 use crate::kill::Kill;
 
-use tokio_net::driver::Handle;
 use tokio_net::util::PollEvented;
 use tokio_sync::oneshot;
 
@@ -69,11 +68,11 @@ struct Waiting {
 unsafe impl Sync for Waiting {}
 unsafe impl Send for Waiting {}
 
-pub(crate) fn spawn_child(cmd: &mut process::Command, handle: &Handle) -> io::Result<SpawnedChild> {
+pub(crate) fn spawn_child(cmd: &mut process::Command) -> io::Result<SpawnedChild> {
     let mut child = cmd.spawn()?;
-    let stdin = stdio(child.stdin.take(), handle)?;
-    let stdout = stdio(child.stdout.take(), handle)?;
-    let stderr = stdio(child.stderr.take(), handle)?;
+    let stdin = stdio(child.stdin.take());
+    let stdout = stdio(child.stdout.take());
+    let stderr = stdio(child.stderr.take());
 
     Ok(SpawnedChild {
         child: Child {
@@ -182,15 +181,14 @@ pub(crate) type ChildStdin = PollEvented<NamedPipe>;
 pub(crate) type ChildStdout = PollEvented<NamedPipe>;
 pub(crate) type ChildStderr = PollEvented<NamedPipe>;
 
-fn stdio<T>(option: Option<T>, handle: &Handle) -> io::Result<Option<PollEvented<NamedPipe>>>
+fn stdio<T>(option: Option<T>) -> io::Result<Option<PollEvented<NamedPipe>>>
 where
     T: IntoRawHandle,
 {
     let io = match option {
         Some(io) => io,
-        None => return Ok(None),
+        None => return None,
     };
     let pipe = unsafe { NamedPipe::from_raw_handle(io.into_raw_handle()) };
-    let io = PollEvented::new_with_handle(pipe, handle)?;
-    Ok(Some(io))
+    Some(PollEvented::new(pipe))
 }


### PR DESCRIPTION
* Also removed any `*_with_handle` related methods in favor of always
using the default reactor

Refs #1243 