### PR TITLE
Implement FusedStream and FusedFuture for Interval and Delay

### DIFF
--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -91,6 +91,13 @@ impl Delay {
     }
 }
 
+#[cfg(feature = "async-traits")]
+impl futures_core::FusedFuture for Delay {
+    fn is_terminated(&self) -> bool {
+        self.is_elapsed()
+    }
+}
+
 impl Future for Delay {
     type Output = ();
 

--- a/tokio-timer/src/interval.rs
+++ b/tokio-timer/src/interval.rs
@@ -101,6 +101,13 @@ impl Interval {
 }
 
 #[cfg(feature = "async-traits")]
+impl futures_core::FusedStream for Interval {
+    fn is_terminated(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(feature = "async-traits")]
 impl futures_core::Stream for Interval {
     type Item = Instant;
 


### PR DESCRIPTION
Implement `FusedStream` and `FusedFuture` for `Interval` and `Delay`.

To make `Delay` and `Interval` easy to use with the [`futures::select!`](https://docs.rs/futures-preview/0.3.0-alpha.18/futures/macro.select.html) macro.

These traits are required for use with `select!` to prevent completed futures from being polled in potentially invalid states. While this can be worked around by [`fusing`](https://docs.rs/futures-preview/0.3.0-alpha.18/futures/future/trait.FutureExt.html#method.fuse) them, all though this makes it harder to use methods associated with them - like if you'd want to reset a delay.

`Delay` is terminated if it is elapsed, and `Interval` simply returns `false` because it never terminates.