### PR TITLE
net, codec: Extract a Datagram framed implementation for UDP and UDS

### DIFF
--- a/tokio-codec/src/datagram.rs
+++ b/tokio-codec/src/datagram.rs
@@ -1,0 +1,179 @@
+use crate::{Decoder, Encoder};
+
+use bytes::{BufMut, BytesMut};
+use core::task::{Context, Poll};
+use futures_core::{ready, Stream};
+use futures_sink::Sink;
+use log::trace;
+use std::io;
+use std::pin::Pin;
+
+/// A unified `Stream` and `Sink` interface to an underlying datagram socket, using
+/// the `Encoder` and `Decoder` traits to encode and decode frames.
+///
+/// Even for datagram-based sockets, higher-level code usually wants to
+/// batch these into meaningful chunks, called "frames". This method layers
+/// framing on top of this socket by using the `Encoder` and `Decoder` traits to
+/// handle encoding and decoding of messages frames. Note that the incoming and
+/// outgoing frame types may be distinct.
+///
+/// This function returns a *single* object that is both `Stream` and `Sink`;
+/// grouping this into a single object is often useful for layering things which
+/// require both read and write access to the underlying object.
+#[must_use = "sinks do nothing unless polled"]
+#[derive(Debug)]
+pub struct DatagramFramed<C, S, A> {
+    socket: S,
+    codec: C,
+    rd: BytesMut,
+    wr: BytesMut,
+    out_addr: Option<A>,
+    flushed: bool,
+}
+
+pub trait DatagramSocket<A> {
+    fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, A), io::Error>>;
+    fn poll_datagram_send(&self, cx: &mut Context<'_>, buf: &mut [u8], target: &A) -> Poll<io::Result<usize>>;
+}
+
+impl<C: Decoder + Unpin, S: DatagramSocket<A> + Unpin, A: Unpin> Stream for DatagramFramed<C, S, A> {
+    type Item = Result<(C::Item, A), C::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let pin = self.get_mut();
+
+        pin.rd.reserve(INITIAL_RD_CAPACITY);
+
+        let (n, addr) = unsafe {
+            // Read into the buffer without having to initialize the memory.
+            let res = ready!(Pin::new(&mut pin.socket).poll_datagram_recv(cx, pin.rd.bytes_mut()));
+            let (n, addr) = res?;
+            pin.rd.advance_mut(n);
+            (n, addr)
+        };
+        trace!("received {} bytes, decoding", n);
+        let frame_res = pin.codec.decode(&mut pin.rd);
+        pin.rd.clear();
+        let frame = frame_res?;
+        let result = frame.map(|frame| Ok((frame, addr))); // frame -> (frame, addr)
+
+        trace!("frame decoded from buffer");
+        Poll::Ready(result)
+    }
+}
+
+impl<C: Encoder + Unpin, S: DatagramSocket<A> + Unpin, A: Unpin> Sink<(C::Item, A)> for DatagramFramed<C, S, A> {
+    type Error = C::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if !self.flushed {
+            match self.poll_flush(cx)? {
+                Poll::Ready(()) => {}
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: (C::Item, A)) -> Result<(), Self::Error> {
+        trace!("sending frame");
+
+        let (frame, out_addr) = item;
+
+        let pin = self.get_mut();
+
+        pin.codec.encode(frame, &mut pin.wr)?;
+        pin.out_addr = Some(out_addr);
+        pin.flushed = false;
+        trace!("frame encoded; length={}", pin.wr.len());
+
+        Ok(())
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if self.flushed {
+            return Poll::Ready(Ok(()));
+        }
+
+        trace!("flushing frame; length={}", self.wr.len());
+
+        let Self {
+            ref mut socket,
+            ref mut out_addr,
+            ref mut wr,
+            ..
+        } = *self;
+
+        let n = ready!(socket.poll_datagram_send(cx, wr, out_addr.as_ref().unwrap()))?;
+        trace!("written {}", n);
+
+        let wrote_all = n == self.wr.len();
+        self.wr.clear();
+        self.flushed = true;
+
+        let res = if wrote_all {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            )
+                .into())
+        };
+
+        Poll::Ready(res)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_flush(cx))?;
+        Poll::Ready(Ok(()))
+    }
+}
+
+const INITIAL_RD_CAPACITY: usize = 64 * 1024;
+const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+
+impl<C, S, A> DatagramFramed<C, S, A> {
+    /// Create a new `DatagramFramed` backed by the given socket and codec.
+    ///
+    /// See struct level documentation for more details.
+    pub fn new(socket: S, codec: C) -> Self {
+        Self {
+            socket,
+            codec,
+            out_addr: None,
+            rd: BytesMut::with_capacity(INITIAL_RD_CAPACITY),
+            wr: BytesMut::with_capacity(INITIAL_WR_CAPACITY),
+            flushed: true,
+        }
+    }
+
+    /// Returns a reference to the underlying I/O stream wrapped by `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_ref(&self) -> &S {
+        &self.socket
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.socket
+    }
+
+    /// Consumes the `Framed`, returning its underlying I/O stream.
+    pub fn into_inner(self) -> S {
+        self.socket
+    }
+}

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -22,6 +22,7 @@
 mod macros;
 
 mod bytes_codec;
+mod datagram;
 mod decoder;
 mod encoder;
 mod framed;
@@ -31,6 +32,7 @@ pub mod length_delimited;
 mod lines_codec;
 
 pub use crate::bytes_codec::BytesCodec;
+pub use crate::datagram::{DatagramFramed, DatagramSocket};
 pub use crate::decoder::Decoder;
 pub use crate::encoder::Encoder;
 pub use crate::framed::{Framed, FramedParts};

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -32,7 +32,7 @@ pub mod length_delimited;
 mod lines_codec;
 
 pub use crate::bytes_codec::BytesCodec;
-pub use crate::datagram::{DatagramFramed, DatagramSocket};
+pub use crate::datagram::DatagramFramed;
 pub use crate::decoder::Decoder;
 pub use crate::encoder::Encoder;
 pub use crate::framed::{Framed, FramedParts};

--- a/tokio-io/src/async_datagram.rs
+++ b/tokio-io/src/async_datagram.rs
@@ -1,0 +1,9 @@
+use std::task::{Context, Poll};
+use std::io;
+
+pub trait AsyncDatagram {
+    type Address: Unpin;
+
+    fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, Self::Address), io::Error>>;
+    fn poll_datagram_send(&self, cx: &mut Context<'_>, buf: &mut [u8], target: &Self::Address) -> Poll<io::Result<usize>>;
+}

--- a/tokio-io/src/async_datagram.rs
+++ b/tokio-io/src/async_datagram.rs
@@ -1,9 +1,18 @@
-use std::task::{Context, Poll};
 use std::io;
+use std::task::{Context, Poll};
 
 pub trait AsyncDatagram {
     type Address: Unpin;
 
-    fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, Self::Address), io::Error>>;
-    fn poll_datagram_send(&self, cx: &mut Context<'_>, buf: &mut [u8], target: &Self::Address) -> Poll<io::Result<usize>>;
+    fn poll_datagram_recv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<(usize, Self::Address), io::Error>>;
+    fn poll_datagram_send(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        target: &Self::Address,
+    ) -> Poll<io::Result<usize>>;
 }

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -16,6 +16,7 @@
 //! [low level details]: https://tokio.rs/docs/going-deeper-tokio/core-low-level/
 
 mod async_buf_read;
+mod async_datagram;
 mod async_read;
 mod async_write;
 
@@ -23,6 +24,7 @@ mod async_write;
 mod io;
 
 pub use self::async_buf_read::AsyncBufRead;
+pub use self::async_datagram::AsyncDatagram;
 pub use self::async_read::AsyncRead;
 pub use self::async_write::AsyncWrite;
 

--- a/tokio-net/src/udp/mod.rs
+++ b/tokio-net/src/udp/mod.rs
@@ -7,9 +7,9 @@
 //!
 //! [`UdpSocket`]: struct.UdpSocket
 
-mod frame;
+//mod frame;
 mod socket;
 pub mod split;
 
-pub use self::frame::UdpFramed;
+//pub use self::frame::UdpFramed;
 pub use self::socket::UdpSocket;

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -359,11 +359,20 @@ impl fmt::Debug for UdpSocket {
 impl AsyncDatagram for UdpSocket {
     type Address = SocketAddr;
 
-    fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, SocketAddr), io::Error>> {
+    fn poll_datagram_recv(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<(usize, SocketAddr), io::Error>> {
         self.poll_recv_from_priv(cx, buf)
     }
 
-    fn poll_datagram_send(&self, cx: &mut Context<'_>, buf: &mut [u8], target: &SocketAddr) -> Poll<Result<usize, io::Error>> {
+    fn poll_datagram_send(
+        &self,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+        target: &SocketAddr,
+    ) -> Poll<Result<usize, io::Error>> {
         self.poll_send_to_priv(cx, buf, target)
     }
 }

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::task::{Context, Poll};
-use tokio_codec::DatagramSocket;
+use tokio_io::AsyncDatagram;
 
 /// An I/O object representing a UDP socket.
 pub struct UdpSocket {
@@ -356,7 +356,9 @@ impl fmt::Debug for UdpSocket {
     }
 }
 
-impl DatagramSocket<SocketAddr> for UdpSocket {
+impl AsyncDatagram for UdpSocket {
+    type Address = SocketAddr;
+
     fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, SocketAddr), io::Error>> {
         self.poll_recv_from_priv(cx, buf)
     }

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -10,6 +10,7 @@ use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::task::{Context, Poll};
+use tokio_codec::DatagramSocket;
 
 /// An I/O object representing a UDP socket.
 pub struct UdpSocket {
@@ -352,6 +353,16 @@ impl TryFrom<net::UdpSocket> for UdpSocket {
 impl fmt::Debug for UdpSocket {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.get_ref().fmt(f)
+    }
+}
+
+impl DatagramSocket<SocketAddr> for UdpSocket {
+    fn poll_datagram_recv(&self, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<Result<(usize, SocketAddr), io::Error>> {
+        self.poll_recv_from_priv(cx, buf)
+    }
+
+    fn poll_datagram_send(&self, cx: &mut Context<'_>, buf: &mut [u8], target: &SocketAddr) -> Poll<Result<usize, io::Error>> {
+        self.poll_send_to_priv(cx, buf, target)
     }
 }
 

--- a/tokio-net/tests/support.rs
+++ b/tokio-net/tests/support.rs
@@ -7,13 +7,16 @@ use tokio::timer::Timeout;
 #[cfg(all(unix, feature = "signal"))]
 pub use tokio_net::signal::unix::{signal, SignalKind};
 
+use bytes::{BufMut, BytesMut};
 pub use futures_util::future;
 use futures_util::future::FutureExt;
 pub use futures_util::stream::StreamExt;
 #[cfg(unix)]
 use libc::{c_int, getpid, kill};
 use std::future::Future;
+use std::io;
 use std::time::Duration;
+use tokio_codec::{Decoder, Encoder};
 
 pub fn with_timeout<F: Future>(future: F) -> impl Future<Output = F::Output> {
     Timeout::new(future, Duration::from_secs(3)).map(Result::unwrap)
@@ -30,5 +33,28 @@ where
 pub fn send_signal(signal: c_int) {
     unsafe {
         assert_eq!(kill(getpid(), signal), 0);
+    }
+}
+
+pub struct ByteCodec;
+
+impl Decoder for ByteCodec {
+    type Item = Vec<u8>;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Vec<u8>>, io::Error> {
+        let len = buf.len();
+        Ok(Some(buf.split_to(len).to_vec()))
+    }
+}
+
+impl Encoder for ByteCodec {
+    type Item = Vec<u8>;
+    type Error = io::Error;
+
+    fn encode(&mut self, data: Vec<u8>, buf: &mut BytesMut) -> Result<(), io::Error> {
+        buf.reserve(data.len());
+        buf.put(data);
+        Ok(())
     }
 }

--- a/tokio-net/tests/udp.rs
+++ b/tokio-net/tests/udp.rs
@@ -1,8 +1,8 @@
 #![feature(async_await)]
 #![warn(rust_2018_idioms)]
 
-use tokio_codec::{Decoder, Encoder};
-use tokio_net::udp::{UdpFramed, UdpSocket};
+use tokio_codec::{Decoder, Encoder, DatagramFramed};
+use tokio_net::udp::{UdpSocket};
 
 use bytes::{BufMut, BytesMut};
 use futures_util::{future::FutureExt, sink::SinkExt, stream::StreamExt, try_future::try_join};
@@ -110,8 +110,8 @@ async fn send_framed() -> std::io::Result<()> {
 
     // test sending & receiving bytes
     {
-        let mut a = UdpFramed::new(a_soc, ByteCodec);
-        let mut b = UdpFramed::new(b_soc, ByteCodec);
+        let mut a = DatagramFramed::new(a_soc, ByteCodec);
+        let mut b = DatagramFramed::new(b_soc, ByteCodec);
 
         let msg = b"4567".to_vec();
 
@@ -129,8 +129,8 @@ async fn send_framed() -> std::io::Result<()> {
 
     // test sending & receiving an empty message
     {
-        let mut a = UdpFramed::new(a_soc, ByteCodec);
-        let mut b = UdpFramed::new(b_soc, ByteCodec);
+        let mut a = DatagramFramed::new(a_soc, ByteCodec);
+        let mut b = DatagramFramed::new(b_soc, ByteCodec);
 
         let msg = b"".to_vec();
 

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -55,7 +55,7 @@ pub mod udp {
     pub use tokio_net::udp::{split, UdpSocket};
 }
 #[cfg(feature = "udp")]
-pub use self::udp::{UdpSocket};
+pub use self::udp::UdpSocket;
 
 #[cfg(all(unix, feature = "uds"))]
 pub mod unix {

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -52,10 +52,10 @@ pub mod udp {
     //! The main struct for UDP is the [`UdpSocket`], which represents a UDP socket.
     //!
     //! [`UdpSocket`]: struct.UdpSocket.html
-    pub use tokio_net::udp::{split, UdpFramed, UdpSocket};
+    pub use tokio_net::udp::{split, UdpSocket};
 }
 #[cfg(feature = "udp")]
-pub use self::udp::{UdpFramed, UdpSocket};
+pub use self::udp::{UdpSocket};
 
 #[cfg(all(unix, feature = "uds"))]
 pub mod unix {


### PR DESCRIPTION
This PR attempts to extract a common datagram frame implementation and use it for both UDP and UDS (as suggested by: https://github.com/tokio-rs/tokio/issues/1458).

Right now it's only implemented for UDP.

Questions:
1) Where should the implementation of `DatagramSocket` for UDP and UDS live? Right now it's in the `tokio-net` crate to use the crate private implementations of `UdpSocket`.
2) UDSFramed was not working before this change (it was commented out and using old futures). Should I implement equivalents of `poll_send_to_priv` and `poll_recv_from_priv` found in `UdpSocket` or should this be solved with some public API (this would also allow to implement it directly in `tokio-codec`, as stated in the previous question).

This PR will probably conflict with:
https://github.com/tokio-rs/tokio/pull/1445