### PR TITLE
timer, executor: Expose next wheel expiration on CurrentThread executor

### DIFF
--- a/tokio-current-thread/Cargo.toml
+++ b/tokio-current-thread/Cargo.toml
@@ -23,3 +23,4 @@ categories = ["concurrency", "asynchronous"]
 [dependencies]
 tokio-executor = "0.1.7"
 futures = "0.1.19"
+tokio-timer = { version = "0.2", path = "../tokio-timer" }

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -275,11 +275,11 @@ impl CurrentThread<ParkThread> {
 }
 
 impl<P> CurrentThread<P>
-where P: Park + HasWheel
+where
+    P: Park + HasWheel,
 {
     /// Get the next expiration of the underlying `Park`'s timer wheel
-    pub fn next_expiration_in(&mut self) -> Option<Duration>
-    {
+    pub fn next_expiration_in(&mut self) -> Option<Duration> {
         self.park.next_expiration_in()
     }
 }

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -27,6 +27,7 @@
 
 extern crate futures;
 extern crate tokio_executor;
+extern crate tokio_timer;
 
 mod scheduler;
 
@@ -34,6 +35,7 @@ use self::scheduler::Scheduler;
 
 use tokio_executor::park::{Park, ParkThread, Unpark};
 use tokio_executor::{Enter, SpawnError};
+use tokio_timer::timer::HasWheel;
 
 use futures::future::{ExecuteError, ExecuteErrorKind, Executor};
 use futures::{executor, Async, Future};
@@ -269,6 +271,16 @@ impl CurrentThread<ParkThread> {
     /// Create a new instance of `CurrentThread`.
     pub fn new() -> Self {
         CurrentThread::new_with_park(ParkThread::new())
+    }
+}
+
+impl<P> CurrentThread<P>
+where P: Park + HasWheel
+{
+    /// Get the next expiration of the underlying `Park`'s timer wheel
+    pub fn next_expiration_in(&mut self) -> Option<Duration>
+    {
+        self.park.next_expiration_in()
     }
 }
 


### PR DESCRIPTION
## Motivation

Integrations that run Tokio alongside another reactor cannot currently handle timer-based futures in an optimal fashion. Integrations like this currently need to use a fixed interval timer to drive executor turns. Exposing the next expiration allows integrations to intelligently schedule turns of the Tokio executor. This offers significantly improved execution behavior.

## Solution

This PR exposes the next timer expiration for `CurrentThread` executors that are backed by a timer wheel.

## Note

This is implemented here for v0.1.x, but it rebases cleanly onto `master`. I'm happy to do that here or in a separate PR.