### PR TITLE
Shut down TCP write when asked to shut down

### DIFF
--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -827,6 +827,7 @@ impl AsyncWrite for TcpStream {
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Poll::Ready(Ok(()))
     }
 

--- a/tokio-net/tests/tcp_shutdown.rs
+++ b/tokio-net/tests/tcp_shutdown.rs
@@ -1,0 +1,29 @@
+#![warn(rust_2018_idioms)]
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::*;
+use tokio::io::AsyncWriteExt;
+use tokio_test::assert_ok;
+
+#[tokio::test]
+async fn shutdown() {
+    let addr = assert_ok!("127.0.0.1:0".parse());
+    let mut srv = assert_ok!(TcpListener::bind(&addr));
+    let addr = assert_ok!(srv.local_addr());
+
+    tokio::spawn(async move {
+        let mut stream = assert_ok!(TcpStream::connect(&addr).await);
+
+        assert_ok!(AsyncWriteExt::shutdown(&mut stream).await);
+
+        let mut buf = [0; 1];
+        let n = assert_ok!(stream.read(&mut buf).await);
+        assert_eq!(n, 0);
+    });
+
+    let (stream, _) = assert_ok!(srv.accept().await);
+    let (mut rd, mut wr) = stream.split();
+
+    let n = assert_ok!(rd.copy(&mut wr).await);
+    assert_eq!(n, 0);
+}

--- a/tokio-net/tests/tcp_shutdown.rs
+++ b/tokio-net/tests/tcp_shutdown.rs
@@ -1,8 +1,8 @@
 #![warn(rust_2018_idioms)]
 
+use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;
-use tokio::io::AsyncWriteExt;
 use tokio_test::assert_ok;
 
 #[tokio::test]


### PR DESCRIPTION
Previously, `poll_shutdown` (and thus `AsyncWriteExt::shutdown`) on `TcpStream` did nothing. This PR makes it actually shut down the send side of the TCP connection so that the other side receives EOF.