### PR TITLE
implement `spawn_with_handle` in tokio_executor

### DIFF
--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -47,7 +47,7 @@ crossbeam-deque = { version = "0.7.0", optional = true }
 crossbeam-queue = { version = "0.1.0", optional = true }
 crossbeam-utils = { version = "0.6.4", optional = true }
 futures-core-preview = { version = "=0.3.0-alpha.18", optional = true }
-futures-util-preview = { version = "=0.3.0-alpha.18", optional = true }
+futures-util-preview = { version = "=0.3.0-alpha.18", optional = true, features = ["channel"] }
 num_cpus = { version = "1.2", optional = true }
 lazy_static = { version = "1", optional = true }
 slab = { version = "0.4.1", optional = true }

--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -1,4 +1,5 @@
 use super::{Executor, SpawnError};
+use futures_util::future::{FutureExt, RemoteHandle};
 use std::cell::Cell;
 use std::future::Future;
 use std::pin::Pin;
@@ -75,6 +76,19 @@ impl super::Executor for DefaultExecutor {
     ) -> Result<(), SpawnError> {
         DefaultExecutor::with_current(|executor| executor.spawn(future))
             .unwrap_or_else(|| Err(SpawnError::shutdown()))
+    }
+
+    fn spawn_with_handle<Fut>(
+        &mut self,
+        future: Fut,
+    ) -> Result<RemoteHandle<Fut::Output>, SpawnError>
+    where
+        Fut: Future + Send + 'static,
+        Fut::Output: Send,
+    {
+        let (future, handle) = future.remote_handle();
+        self.spawn(future)?;
+        Ok(handle)
     }
 
     fn status(&self) -> Result<(), SpawnError> {

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -78,3 +78,4 @@ pub use crate::error::SpawnError;
 pub use crate::executor::Executor;
 pub use crate::global::{spawn, with_default, DefaultExecutor};
 pub use crate::typed::TypedExecutor;
+pub use futures_util::future::RemoteHandle;


### PR DESCRIPTION
## Motivation

See #1180. This is a step towards achieving the `spawn!` macro, and it was indicated by [this comment](https://github.com/tokio-rs/tokio/issues/1180#issuecomment-523721072) that an additional method would be sufficient as a temporary step. This will allow Rocket to launch on a custom tokio runtime while returning a `Future` that is equivalent to the original server.

## Solution

This code directly relies on `future-preview`'s `RemoteHandle`, and
exposes it via a `spawn_with_handle` method that is identical to
`future-preview`'s implementation.