### PR TITLE
Fix compile error in README with latest nightly and tokio version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ A basic TCP echo server with Tokio:
 ```rust
 use tokio::net::TcpListener;
 use tokio::prelude::*;
+use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "127.0.0.1:8080".parse()?;
-    let mut listener = TcpListener::bind(&addr).unwrap();
+    let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
+    let mut listener = TcpListener::bind(&addr).await?;
 
     loop {
         let (mut socket, _) = listener.accept().await?;
@@ -90,6 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         });
     }
 }
+
 ```
 
 More examples can be found [here](tokio/examples). Note that the `master` branch


### PR DESCRIPTION
Hi,

I wanted to compile the example from the README but it had compile errors.
My pull request contains the version that does indeed compile with the current
nightly compiler and tokio version 0.2.0-alpha.4.

Cheers