### PR TITLE
tokio-process: Implement From<StdCommand> for Command

### DIFF
--- a/tokio-net/src/process/mod.rs
+++ b/tokio-net/src/process/mod.rs
@@ -571,6 +571,12 @@ impl Command {
     }
 }
 
+impl From<StdCommand> for Command {
+    fn from(std: StdCommand) -> Command {
+        Command { std }
+    }
+}
+
 /// A drop guard which ensures the child process is killed on drop to maintain
 /// the contract of dropping a Future leads to "cancellation".
 #[derive(Debug)]


### PR DESCRIPTION
This allows the usage of `std::os::{unix,windows}::process::CommandExt`, which can't be implemented on `tokio_process::Command` since their methods have `&mut StdCommand` return types.