### PR TITLE
udp: Fix UdpFramed decode

### DIFF
--- a/tokio-udp/src/frame.rs
+++ b/tokio-udp/src/frame.rs
@@ -34,6 +34,7 @@ pub struct UdpFramed<C> {
     out_addr: SocketAddr,
     flushed: bool,
     is_readable: bool,
+    repeat_decode: bool,
     current_addr: Option<SocketAddr>,
 }
 
@@ -44,36 +45,58 @@ impl<C: Decoder> Stream for UdpFramed<C> {
     fn poll(&mut self) -> Poll<Option<(Self::Item)>, Self::Error> {
         self.rd.reserve(INITIAL_RD_CAPACITY);
 
-        loop {
-            // Are there are still bytes left in the read buffer to decode?
-            if self.is_readable {
-                if let Some(frame) = self.codec.decode(&mut self.rd)? {
-                    trace!("frame decoded from buffer");
+        if self.repeat_decode {
+            loop {
+                // Are there are still bytes left in the read buffer to decode?
+                if self.is_readable {
+                    // Use deocde_eof since every datagram contains its own
+                    // eof which is just the end of the datagram. This supports
+                    // the lines use case where there may not be a terminating
+                    // delimiter and thus you may never get the end of the frame.
+                    // This is generally fine for most implementations of codec
+                    // since by default this will defer to calling decode.
+                    if let Some(frame) = self.codec.decode_eof(&mut self.rd)? {
+                        trace!("frame decoded from buffer");
 
-                    let current_addr = self
-                        .current_addr
-                        .expect("will always be set before this line is called");
+                        let current_addr = self
+                            .current_addr
+                            .expect("will always be set before this line is called");
 
-                    return Ok(Async::Ready(Some((frame, current_addr))));
+                        return Ok(Async::Ready(Some((frame, current_addr))));
+                    }
+
+                    // if this line has been reached then decode has returned `None`.
+                    self.is_readable = false;
+                    self.rd.clear();
                 }
 
-                // if this line has been reached then decode has returned `None`.
-                self.is_readable = false;
-                self.rd.clear();
-            }
+                // We're out of data. Try and fetch more data to decode
+                let (n, addr) = unsafe {
+                    // Read into the buffer without having to initialize the memory.
+                    let (n, addr) = try_ready!(self.socket.poll_recv_from(self.rd.bytes_mut()));
+                    self.rd.advance_mut(n);
+                    (n, addr)
+                };
 
-            // We're out of data. Try and fetch more data to decode
+                self.current_addr = Some(addr);
+                self.is_readable = true;
+
+                trace!("received {} bytes, decoding", n);
+            }
+        } else {
             let (n, addr) = unsafe {
                 // Read into the buffer without having to initialize the memory.
                 let (n, addr) = try_ready!(self.socket.poll_recv_from(self.rd.bytes_mut()));
                 self.rd.advance_mut(n);
                 (n, addr)
             };
-
-            self.current_addr = Some(addr);
-            self.is_readable = true;
-
             trace!("received {} bytes, decoding", n);
+            let frame_res = self.codec.decode(&mut self.rd);
+            self.rd.clear();
+            let frame = frame_res?;
+            let result = frame.map(|frame| (frame, addr)); // frame -> (frame, addr)
+            trace!("frame decoded from buffer");
+            Ok(Async::Ready(result))
         }
     }
 }
@@ -147,6 +170,25 @@ impl<C> UdpFramed<C> {
             wr: BytesMut::with_capacity(INITIAL_WR_CAPACITY),
             flushed: true,
             is_readable: false,
+            repeat_decode: false,
+            current_addr: None,
+        }
+    }
+
+    /// Create a new `UdpFramed` backed by the given socket and codec. That will
+    /// continue to call `decode_eof` until the decoder has cleared the entire buffer.
+    ///
+    /// See struct level documentation for more details.
+    pub fn with_decode(socket: UdpSocket, codec: C, repeat_decode: bool) -> UdpFramed<C> {
+        UdpFramed {
+            socket: socket,
+            codec: codec,
+            out_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
+            rd: BytesMut::with_capacity(INITIAL_RD_CAPACITY),
+            wr: BytesMut::with_capacity(INITIAL_WR_CAPACITY),
+            flushed: true,
+            is_readable: false,
+            repeat_decode,
             current_addr: None,
         }
     }


### PR DESCRIPTION
This fixes two things:

- Repeated decodes now just use decode_eof reference the workaround we needed https://github.com/timberio/vector/blob/master/src/sources/udp.rs#L104 this now avoids this usage and makes LinesCodec work as expected.
- It reverts the change implemented that caused https://github.com/tokio-rs/tokio/issues/1510 by providing the old implementation and a new constructor that will allow you to enable the fix for repeated decodes.