### PR TITLE
timer: Rename `sleep` to `delay_for`, reexport from tokio

### DIFF
--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -64,7 +64,9 @@ pub fn delay(deadline: Instant) -> Delay {
 }
 
 /// Create a Future that completes in `duration` from now.
-pub fn sleep(duration: Duration) -> Delay {
+///
+/// Equivalent to `delay(Instant::now() + duration)`. Analogous to `std::thread::sleep`.
+pub fn delay_for(duration: Duration) -> Delay {
     delay(Instant::now() + duration)
 }
 

--- a/tokio/src/timer.rs
+++ b/tokio/src/timer.rs
@@ -75,4 +75,6 @@
 //! [Interval]: struct.Interval.html
 //! [`DelayQueue`]: struct.DelayQueue.html
 
-pub use tokio_timer::{delay, delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout};
+pub use tokio_timer::{
+    delay, delay_for, delay_queue, timeout, Delay, DelayQueue, Error, Interval, Timeout,
+};


### PR DESCRIPTION
## Motivation

Expose convenience function for `Duration`-based waiting

## Solution

Renames `sleep` to `delay_for` for consistency and reexports from `tokio::timer`. Additionally, the docs are tweaked to mention "sleep" for better discoverability. We considered standardizing on the `sleep` name instead, but `Sleep` as a type makes for an awkward noun.
