### PR TITLE
Test fix assert format args

### DIFF
--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -197,7 +197,7 @@ macro_rules! assert_ready_eq {
     };
 
     ($e:expr, $expect:expr, $($msg:tt)+) => {
-        let val = $crate::assert_ready!($e);
+        let val = $crate::assert_ready!($e, $($msg)*);
         assert_eq!(val, $expect, $($msg)*)
     };
 }

--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -33,13 +33,12 @@ macro_rules! assert_ready {
             Pending => panic!("pending"),
         }
     }};
-    ($e:expr, $($msg:tt),+) => {{
+    ($e:expr, $($msg:tt)+) => {{
         use core::task::Poll::*;
         match $e {
             Ready(v) => v,
             Pending => {
-                let msg = format_args!($($msg),+);
-                panic!("pending; {}", msg)
+                panic!("pending; {}", format_args!($($msg)+))
             }
         }
     }};
@@ -76,10 +75,10 @@ macro_rules! assert_ready_ok {
         let val = assert_ready!($e);
         assert_ok!(val)
     }};
-    ($e:expr, $($msg:tt),+) => {{
+    ($e:expr, $($msg:tt)+) => {{
         use tokio_test::{assert_ready, assert_ok};
-        let val = assert_ready!($e, $($msg),*);
-        assert_ok!(val, $($msg),*)
+        let val = assert_ready!($e, $($msg)*);
+        assert_ok!(val, $($msg)*)
     }};
 }
 
@@ -114,10 +113,10 @@ macro_rules! assert_ready_err {
         let val = assert_ready!($e);
         assert_err!(val)
     }};
-    ($e:expr, $($msg:tt),+) => {{
+    ($e:expr, $($msg:tt)+) => {{
         use tokio_test::{assert_ready, assert_err};
-        let val = assert_ready!($e, $($msg),*);
-        assert_err!(val, $($msg),*)
+        let val = assert_ready!($e, $($msg)*);
+        assert_err!(val, $($msg)*)
     }};
 }
 
@@ -155,13 +154,12 @@ macro_rules! assert_pending {
             Ready(v) => panic!("ready; value = {:?}", v),
         }
     }};
-    ($e:expr, $($msg:tt),+) => {{
+    ($e:expr, $($msg:tt)+) => {{
         use core::task::Poll::*;
         match $e {
             Pending => {}
             Ready(v) => {
-                let msg = format_args!($($msg),+);
-                panic!("ready; value = {:?}; {}", v, msg)
+                panic!("ready; value = {:?}; {}", v, format_args!($($msg)+))
             }
         }
     }};
@@ -198,9 +196,9 @@ macro_rules! assert_ready_eq {
         assert_eq!(val, $expect)
     };
 
-    ($e:expr, $expect:expr, $($msg:tt),+) => {
+    ($e:expr, $expect:expr, $($msg:tt)+) => {
         let val = $crate::assert_ready!($e);
-        assert_eq!(val, $expect, $($msg),*)
+        assert_eq!(val, $expect, $($msg)*)
     };
 }
 

--- a/tokio-test/tests/macros.rs
+++ b/tokio-test/tests/macros.rs
@@ -1,29 +1,45 @@
 #![warn(rust_2018_idioms)]
 
 use std::task::Poll;
-use tokio_test::{assert_pending, assert_ready, assert_ready_eq};
+use tokio_test::{
+    assert_pending, assert_ready, assert_ready_eq, assert_ready_err, assert_ready_ok,
+};
 
 fn ready() -> Poll<()> {
     Poll::Ready(())
+}
+
+fn ready_ok() -> Poll<Result<(), ()>> {
+    Poll::Ready(Ok(()))
+}
+
+fn ready_err() -> Poll<Result<(), ()>> {
+    Poll::Ready(Err(()))
 }
 
 fn pending() -> Poll<()> {
     Poll::Pending
 }
 
+#[derive(Debug)]
+enum Test {
+    Data,
+}
+
 #[test]
 fn assert_ready() {
-    let fut = ready();
-    assert_ready!(fut);
-    let fut = ready();
-    assert_ready!(fut, "some message");
+    let poll = ready();
+    assert_ready!(poll);
+    assert_ready!(poll, "some message");
+    assert_ready!(poll, "{:?}", ());
+    assert_ready!(poll, "{:?}", Test::Data);
 }
 
 #[test]
 #[should_panic]
-fn assert_ready_err() {
-    let fut = pending();
-    assert_ready!(fut);
+fn assert_ready_on_pending() {
+    let poll = pending();
+    assert_ready!(poll);
 }
 
 #[test]
@@ -31,10 +47,61 @@ fn assert_pending() {
     let poll = pending();
     assert_pending!(poll);
     assert_pending!(poll, "some message");
+    assert_pending!(poll, "{:?}", ());
+    assert_pending!(poll, "{:?}", Test::Data);
+}
+
+#[test]
+#[should_panic]
+fn assert_pending_on_ready() {
+    let poll = ready();
+    assert_pending!(poll);
+}
+
+#[test]
+fn assert_ready_ok() {
+    let poll = ready_ok();
+    assert_ready_ok!(poll);
+    assert_ready_ok!(poll, "some message");
+    assert_ready_ok!(poll, "{:?}", ());
+    assert_ready_ok!(poll, "{:?}", Test::Data);
+}
+
+#[test]
+#[should_panic]
+fn assert_ok_on_err() {
+    let poll = ready_err();
+    assert_ready_ok!(poll);
+}
+
+#[test]
+fn assert_ready_err() {
+    let poll = ready_err();
+    assert_ready_err!(poll);
+    assert_ready_err!(poll, "some message");
+    assert_ready_err!(poll, "{:?}", ());
+    assert_ready_err!(poll, "{:?}", Test::Data);
+}
+
+#[test]
+#[should_panic]
+fn assert_err_on_ok() {
+    let poll = ready_ok();
+    assert_ready_err!(poll);
 }
 
 #[test]
 fn assert_ready_eq() {
-    let fut = ready();
-    assert_ready_eq!(fut, ());
+    let poll = ready();
+    assert_ready_eq!(poll, ());
+    assert_ready_eq!(poll, (), "some message");
+    assert_ready_eq!(poll, (), "{:?}", ());
+    assert_ready_eq!(poll, (), "{:?}", Test::Data);
+}
+
+#[test]
+#[should_panic]
+fn assert_eq_on_not_eq() {
+    let poll = ready_err();
+    assert_ready_eq!(poll, Ok(()));
 }

--- a/tokio-test/tests/macros.rs
+++ b/tokio-test/tests/macros.rs
@@ -1,40 +1,40 @@
-#![cfg(feature = "broken")]
 #![warn(rust_2018_idioms)]
 
-use futures::{future, Async, Future, Poll};
-use tokio_macros::{assert_not_ready, assert_ready, assert_ready_eq};
+use std::task::Poll;
+use tokio_test::{assert_pending, assert_ready, assert_ready_eq};
+
+fn ready() -> Poll<()> {
+    Poll::Ready(())
+}
+
+fn pending() -> Poll<()> {
+    Poll::Pending
+}
 
 #[test]
 fn assert_ready() {
-    let mut fut = future::ok::<(), ()>(());
-    assert_ready!(fut.poll());
-    let mut fut = future::ok::<(), ()>(());
-    assert_ready!(fut.poll(), "some message");
+    let fut = ready();
+    assert_ready!(fut);
+    let fut = ready();
+    assert_ready!(fut, "some message");
 }
 
 #[test]
 #[should_panic]
 fn assert_ready_err() {
-    let mut fut = future::err::<(), ()>(());
-    assert_ready!(fut.poll());
+    let fut = pending();
+    assert_ready!(fut);
 }
 
 #[test]
-fn assert_not_ready() {
-    let poll: Poll<(), ()> = Ok(Async::NotReady);
-    assert_not_ready!(poll);
-    assert_not_ready!(poll, "some message");
-}
-
-#[test]
-#[should_panic]
-fn assert_not_ready_err() {
-    let mut fut = future::err::<(), ()>(());
-    assert_not_ready!(fut.poll());
+fn assert_pending() {
+    let poll = pending();
+    assert_pending!(poll);
+    assert_pending!(poll, "some message");
 }
 
 #[test]
 fn assert_ready_eq() {
-    let mut fut = future::ok::<(), ()>(());
-    assert_ready_eq!(fut.poll(), ());
+    let fut = ready();
+    assert_ready_eq!(fut, ());
 }


### PR DESCRIPTION
#Motivation

Fixes #1511 

## Solution

There were two issues at work in issue 1511

First, formatting arguments were not accepted because the macro was attempting to match on comma-separated token trees when it should have been just matching on one-or-more token trees.

Second, some of the uses of `format_args!` were being bound to a local name and then passed to panic for formatting.  This caused an error message that "temporary value dropped while borrowed". The fix for this was just inlining the `format_args!` usage into the place where the args were being formatted.

I also took the opportunity to fix the broken integration tests for these macros and expand it to include coverage of using the formatting arguments.

Finally, I brought the expansion of `assert_ready_eq` into line with the other two composite macros by including the custom error message in both the `assert_ready` and the `assert_eq` portion of the expansion.
