### PR TITLE
WIP: Fix docs links

### DIFF
--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Asynchronous stream of bytes.

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Utilities for encoding and decoding frames.

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Task execution related traits and utilities.

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Asynchronous file and standard stream adaptation.

--- a/tokio-fs/src/read_dir.rs
+++ b/tokio-fs/src/read_dir.rs
@@ -16,9 +16,7 @@ use std::task::Poll;
 
 /// Returns a stream over the entries within a directory.
 ///
-/// This is an async version of [`std::fs::read_dir`][std]
-///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.read_dir.html
+/// This is an async version of [`std::fs::read_dir`](std::fs::read_dir)
 pub async fn read_dir<P>(path: P) -> io::Result<ReadDir>
 where
     P: AsRef<Path> + Send + 'static,
@@ -43,8 +41,8 @@ where
 ///
 /// [`read_dir`]: fn.read_dir.html
 /// [`DirEntry`]: struct.DirEntry.html
-/// [`Stream`]: ../futures/stream/trait.Stream.html
-/// [`Err`]: https://doc.rust-lang.org/std/result/enum.Result.html#variant.Err
+/// [`Stream`]: Stream
+/// [`Err`]: std::result::Result::Err
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct ReadDir(State);
@@ -86,14 +84,12 @@ impl Stream for ReadDir {
 ///
 /// [`ReadDir`]: struct.ReadDir.html
 ///
-/// This is a specialized version of [`std::fs::DirEntry`][std] for usage from the
+/// This is a specialized version of [`std::fs::DirEntry`](std::fs::DirEntry) for usage from the
 /// Tokio runtime.
 ///
 /// An instance of `DirEntry` represents an entry inside of a directory on the
 /// filesystem. Each entry can be inspected via methods to learn about the full
 /// path or possibly other metadata through per-platform extension traits.
-///
-/// [std]: https://doc.rust-lang.org/std/fs/struct.DirEntry.html
 #[derive(Debug)]
 pub struct DirEntry(Arc<std::fs::DirEntry>);
 

--- a/tokio-fs/src/read_link.rs
+++ b/tokio-fs/src/read_link.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 ///
 /// This is an async version of [`std::fs::read_link`][std]
 ///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.read_link.html
+/// [std]: std::fs::read_link
 pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::read_link(path)).await

--- a/tokio-fs/src/remove_dir.rs
+++ b/tokio-fs/src/remove_dir.rs
@@ -5,9 +5,7 @@ use std::path::Path;
 
 /// Removes an existing, empty directory.
 ///
-/// This is an async version of [`std::fs::remove_dir`][std]
-///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir.html
+/// This is an async version of [`std::fs::remove_dir`](std::fs::remove_dir)
 pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_dir(path)).await

--- a/tokio-fs/src/rename.rs
+++ b/tokio-fs/src/rename.rs
@@ -8,9 +8,7 @@ use std::path::Path;
 ///
 /// This will not work if the new name is on a different mount point.
 ///
-/// This is an async version of [`std::fs::rename`][std]
-///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.rename.html
+/// This is an async version of [`std::fs::rename`](std::fs::rename)
 pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Core I/O traits and combinators when working with Tokio.

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Macros for use with Tokio

--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-net/src/process/mod.rs
+++ b/tokio-net/src/process/mod.rs
@@ -1,6 +1,6 @@
 //! An implementation of asynchronous process management for Tokio.
 //!
-//! This module provides a [`Command`](Command) struct that imitates the interface of the
+//! This module provides a [`Command`](crate::process::Command) struct that imitates the interface of the
 //! [`std::process::Command`] type in the standard library, but provides asynchronous versions of
 //! functions that create processes. These functions (`spawn`, `status`, `output` and their
 //! variants) return "future aware" types that interoperate with Tokio. The asynchronous process
@@ -101,10 +101,10 @@
 //! While similar to the standard library, this crate's `Child` type differs
 //! importantly in the behavior of `drop`. In the standard library, a child
 //! process will continue running after the instance of [`std::process::Child`]
-//! is dropped. In this crate, however, because [`tokio_net::process::Child`](Child) is a
+//! is dropped. In this crate, however, because [`tokio_net::process::Child`](crate::process::Child) is a
 //! future of the child's `ExitStatus`, a child process is terminated if
 //! `tokio_net::process::Child` is dropped. The behavior of the standard library can
-//! be regained with the [`Child::forget`] method.
+//! be regained with the [`Child::forget`](crate::process::Child::forget) method.
 
 use std::ffi::OsStr;
 use std::fmt;

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Asynchronous synchronization primitives.

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Tokio and Futures based testing utilites

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Utilities for tracking time.

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! Async TLS streams

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -5,6 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
+#![deny(intra_doc_link_resolution_failure)]
 #![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.


### PR DESCRIPTION
#Motivation

Continuing the work started in #1474 to transition all the intra-doc links in the documentation from hard-coded arbitrary urls to using rustdoc item link resolution.

Also related to #1473.