### PR TITLE
net: invert split return type for consistency

### DIFF
--- a/tokio-net/src/tcp/split.rs
+++ b/tokio-net/src/tcp/split.rs
@@ -36,11 +36,11 @@ pub struct TcpStreamReadHalf(Arc<TcpStream>);
 #[derive(Debug)]
 pub struct TcpStreamWriteHalf(Arc<TcpStream>);
 
-pub(crate) fn split(stream: TcpStream) -> (TcpStreamReadHalf, TcpStreamWriteHalf) {
+pub(crate) fn split(stream: TcpStream) -> (TcpStreamWriteHalf, TcpStreamReadHalf) {
     let shared = Arc::new(stream);
     (
-        TcpStreamReadHalf(shared.clone()),
-        TcpStreamWriteHalf(shared),
+        TcpStreamWriteHalf(shared.clone()),
+        TcpStreamReadHalf(shared),
     )
 }
 
@@ -57,10 +57,10 @@ pub struct TcpStreamWriteHalfMut<'a>(&'a TcpStream);
 
 pub(crate) fn split_mut(
     stream: &mut TcpStream,
-) -> (TcpStreamReadHalfMut<'_>, TcpStreamWriteHalfMut<'_>) {
+) -> (TcpStreamWriteHalfMut<'_>, TcpStreamReadHalfMut<'_>) {
     (
-        TcpStreamReadHalfMut(&*stream),
         TcpStreamWriteHalfMut(&*stream),
+        TcpStreamReadHalfMut(&*stream),
     )
 }
 

--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -584,7 +584,7 @@ impl TcpStream {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split(self) -> (TcpStreamReadHalf, TcpStreamWriteHalf) {
+    pub fn split(self) -> (TcpStreamWriteHalf, TcpStreamReadHalf) {
         split(self)
     }
 
@@ -593,7 +593,7 @@ impl TcpStream {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split_mut(&mut self) -> (TcpStreamReadHalfMut<'_>, TcpStreamWriteHalfMut<'_>) {
+    pub fn split_mut(&mut self) -> (TcpStreamWriteHalfMut<'_>, TcpStreamReadHalfMut<'_>) {
         split_mut(self)
     }
 

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -71,7 +71,7 @@ impl UdpSocket {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split(self) -> (UdpSocketRecvHalf, UdpSocketSendHalf) {
+    pub fn split(self) -> (UdpSocketSendHalf, UdpSocketRecvHalf) {
         split(self)
     }
 

--- a/tokio-net/src/udp/split.rs
+++ b/tokio-net/src/udp/split.rs
@@ -35,11 +35,11 @@ pub struct UdpSocketSendHalf(Arc<UdpSocket>);
 #[derive(Debug)]
 pub struct UdpSocketRecvHalf(Arc<UdpSocket>);
 
-pub(crate) fn split(socket: UdpSocket) -> (UdpSocketRecvHalf, UdpSocketSendHalf) {
+pub(crate) fn split(socket: UdpSocket) -> (UdpSocketSendHalf, UdpSocketRecvHalf) {
     let shared = Arc::new(socket);
     let send = shared.clone();
     let recv = shared;
-    (UdpSocketRecvHalf(recv), UdpSocketSendHalf(send))
+    (UdpSocketSendHalf(send), UdpSocketRecvHalf(recv))
 }
 
 /// Error indicating two halves were not from the same socket, and thus could

--- a/tokio-net/src/uds/split.rs
+++ b/tokio-net/src/uds/split.rs
@@ -44,20 +44,20 @@ pub struct UnixStreamReadHalfMut<'a>(&'a UnixStream);
 #[derive(Debug)]
 pub struct UnixStreamWriteHalfMut<'a>(&'a UnixStream);
 
-pub(crate) fn split(stream: UnixStream) -> (UnixStreamReadHalf, UnixStreamWriteHalf) {
+pub(crate) fn split(stream: UnixStream) -> (UnixStreamWriteHalf, UnixStreamReadHalf) {
     let shared = Arc::new(stream);
     (
-        UnixStreamReadHalf(shared.clone()),
-        UnixStreamWriteHalf(shared),
+        UnixStreamWriteHalf(shared.clone()),
+        UnixStreamReadHalf(shared),
     )
 }
 
 pub(crate) fn split_mut(
     stream: &mut UnixStream,
-) -> (UnixStreamReadHalfMut<'_>, UnixStreamWriteHalfMut<'_>) {
+) -> (UnixStreamWriteHalfMut<'_>, UnixStreamReadHalfMut<'_>) {
     (
-        UnixStreamReadHalfMut(stream),
         UnixStreamWriteHalfMut(stream),
+        UnixStreamReadHalfMut(stream),
     )
 }
 

--- a/tokio-net/src/uds/stream.rs
+++ b/tokio-net/src/uds/stream.rs
@@ -112,7 +112,7 @@ impl UnixStream {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split(self) -> (UnixStreamReadHalf, UnixStreamWriteHalf) {
+    pub fn split(self) -> (UnixStreamWriteHalf, UnixStreamReadHalf) {
         split(self)
     }
 
@@ -121,7 +121,7 @@ impl UnixStream {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split_mut(&mut self) -> (UnixStreamReadHalfMut<'_>, UnixStreamWriteHalfMut<'_>) {
+    pub fn split_mut(&mut self) -> (UnixStreamWriteHalfMut<'_>, UnixStreamReadHalfMut<'_>) {
         split_mut(self)
     }
 }

--- a/tokio-net/tests/tcp_echo.rs
+++ b/tokio-net/tests/tcp_echo.rs
@@ -32,7 +32,7 @@ async fn echo_server() {
     });
 
     let (stream, _) = assert_ok!(srv.accept().await);
-    let (mut rd, mut wr) = stream.split();
+    let (mut wr, mut rd) = stream.split();
 
     let n = assert_ok!(rd.copy(&mut wr).await);
     assert_eq!(n, (ITER * msg.len()) as u64);

--- a/tokio-net/tests/tcp_shutdown.rs
+++ b/tokio-net/tests/tcp_shutdown.rs
@@ -21,7 +21,7 @@ async fn shutdown() {
     });
 
     let (stream, _) = assert_ok!(srv.accept().await);
-    let (mut rd, mut wr) = stream.split();
+    let (mut wr, mut rd) = stream.split();
 
     let n = assert_ok!(rd.copy(&mut wr).await);
     assert_eq!(n, 0);

--- a/tokio-net/tests/tcp_split.rs
+++ b/tokio-net/tests/tcp_split.rs
@@ -6,7 +6,7 @@ async fn split_reunite() -> std::io::Result<()> {
     let addr = listener.local_addr()?;
     let stream = TcpStream::connect(&addr).await?;
 
-    let (r, w) = stream.split();
+    let (w, r) = stream.split();
     assert!(r.reunite(w).is_ok());
     Ok(())
 }
@@ -18,8 +18,8 @@ async fn split_reunite_error() -> std::io::Result<()> {
     let stream = TcpStream::connect(&addr).await?;
     let stream1 = TcpStream::connect(&addr).await?;
 
-    let (r, _) = stream.split();
-    let (_, w) = stream1.split();
+    let (_, r) = stream.split();
+    let (w, _) = stream1.split();
     assert!(r.reunite(w).is_err());
     Ok(())
 }

--- a/tokio-net/tests/udp.rs
+++ b/tokio-net/tests/udp.rs
@@ -45,7 +45,7 @@ async fn send_to_recv_from() -> std::io::Result<()> {
 #[tokio::test]
 async fn split() -> std::io::Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0").await?;
-    let (mut r, mut s) = socket.split();
+    let (mut s, mut r) = socket.split();
 
     let msg = b"hello";
     let addr = s.as_ref().local_addr()?;
@@ -61,7 +61,7 @@ async fn split() -> std::io::Result<()> {
 #[tokio::test]
 async fn reunite() -> std::io::Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0").await?;
-    let (s, r) = socket.split();
+    let (r, s) = socket.split();
     assert!(s.reunite(r).is_ok());
     Ok(())
 }
@@ -70,8 +70,8 @@ async fn reunite() -> std::io::Result<()> {
 async fn reunite_error() -> std::io::Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0").await?;
     let socket1 = UdpSocket::bind("127.0.0.1:0").await?;
-    let (s, _) = socket.split();
-    let (_, r1) = socket1.split();
+    let (_, s) = socket.split();
+    let (r1, _) = socket1.split();
     assert!(s.reunite(r1).is_err());
     Ok(())
 }

--- a/tokio-net/tests/uds_split.rs
+++ b/tokio-net/tests/uds_split.rs
@@ -13,8 +13,8 @@ use tokio::prelude::*;
 async fn split() -> std::io::Result<()> {
     let (a, mut b) = UnixStream::pair()?;
 
-    let (mut a_read, mut a_write) = a.split();
-    let (mut b_read, mut b_write) = b.split_mut();
+    let (mut a_write, mut a_read) = a.split();
+    let (mut b_write, mut b_read) = b.split_mut();
 
     let (a_response, b_response) = futures::future::try_join(
         send_recv_all(&mut a_read, &mut a_write, b"A"),

--- a/tokio-tls/examples_old/echo.rs
+++ b/tokio-tls/examples_old/echo.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .accept(tcp)
                 .and_then(move |tls| {
                     // Split up the read and write halves
-                    let (reader, writer) = tls.split();
+                    let (writer, reader) = tls.split();
 
                     // Copy the data back to the client
                     let conn = io::copy(reader, writer)

--- a/tokio/examples/connect.rs
+++ b/tokio/examples/connect.rs
@@ -93,7 +93,7 @@ mod tcp {
         stdin: impl Stream<Item = Result<Vec<u8>, io::Error>> + Unpin,
         mut stdout: impl Sink<Vec<u8>, Error = io::Error> + Unpin,
     ) -> Result<(), Box<dyn Error>> {
-        let (r, w) = TcpStream::connect(addr).await?.split();
+        let (w, r) = TcpStream::connect(addr).await?.split();
         let sink = FramedWrite::new(w, codec::Bytes);
         let mut stream = FramedRead::new(r, codec::Bytes).filter_map(|i| match i {
             Ok(i) => future::ready(Some(i)),
@@ -133,7 +133,7 @@ mod udp {
 
         let socket = UdpSocket::bind(&bind_addr).await?;
         socket.connect(addr).await?;
-        let (mut r, mut w) = socket.split();
+        let (mut w, mut r) = socket.split();
 
         future::try_join(send(stdin, &mut w), recv(stdout, &mut r)).await?;
 

--- a/tokio/examples/proxy.rs
+++ b/tokio/examples/proxy.rs
@@ -55,8 +55,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
 async fn transfer(inbound: TcpStream, proxy_addr: String) -> Result<(), Box<dyn Error>> {
     let outbound = TcpStream::connect(proxy_addr).await?;
 
-    let (mut ri, mut wi) = inbound.split();
-    let (mut ro, mut wo) = outbound.split();
+    let (mut wi, mut ri) = inbound.split();
+    let (mut wo, mut ro) = outbound.split();
 
     let client_to_server = ri.copy(&mut wo);
     let server_to_client = ro.copy(&mut wi);


### PR DESCRIPTION
futures::stream::StreamExt::split is defined as:
```
  fn split<Item>(self) -> (SplitSink<Self, Item>, SplitStream<Self>)
  where Self: Sink<Item>
```
see https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.18/futures/stream/trait.StreamExt.html#method.split

This commit inverts the return type for consistency with futures.