### PR TITLE
Refactor blocking into enter_ and exit_blocking_section functions

### DIFF
--- a/tokio-executor/src/threadpool/blocking.rs
+++ b/tokio-executor/src/threadpool/blocking.rs
@@ -1,13 +1,16 @@
 use super::worker::Worker;
 
-use futures_core::ready;
 use std::error::Error;
 use std::fmt;
 use std::task::Poll;
 
 /// Error raised by `blocking`.
-pub struct BlockingError {
-    _p: (),
+pub struct BlockingError(pub(crate) Kind);
+
+#[derive(PartialEq)]
+pub(crate) enum Kind {
+    NotWorker,
+    NoCapacity,
 }
 
 /// Enter a blocking section of code.
@@ -120,22 +123,11 @@ pub fn blocking<F, T>(f: F) -> Poll<Result<T, BlockingError>>
 where
     F: FnOnce() -> T,
 {
-    let res = Worker::with_current(|worker| {
-        let worker = match worker {
-            Some(worker) => worker,
-            None => {
-                return Poll::Ready(Err(BlockingError { _p: () }));
-            }
-        };
-
-        // Transition the worker state to blocking. This will exit the fn early
-        // with `NotReady` if the pool does not have enough capacity to enter
-        // blocking mode.
-        worker.transition_to_blocking()
-    });
-
-    // If the transition cannot happen, exit early
-    ready!(res)?;
+    match enter_blocking_section() {
+        Ok(()) => {}
+        Err(BlockingError(Kind::NoCapacity)) => return Poll::Pending,
+        Err(e @ BlockingError(Kind::NotWorker)) => return Poll::Ready(Err(e)),
+    }
 
     // Currently in blocking mode, so call the inner closure
     //
@@ -143,23 +135,58 @@ where
     // to call a different executor.
     let ret = crate::exit(move || f());
 
-    // Try to transition out of blocking mode. This is a fast path that takes
-    // back ownership of the worker if the worker handoff didn't complete yet.
-    Worker::with_current(|worker| {
-        // Worker must be set since it was above.
-        worker.unwrap().transition_from_blocking();
-    });
+    if let Err(e) = exit_blocking_section() {
+        return Poll::Ready(Err(e));
+    }
 
     // Return the result
     Poll::Ready(Ok(ret))
 }
 
+/// Enter a blocking section of code.  Returns `BlockingError` if called from a
+/// thread not associated with a Tokio thread pool, or if there is no capacity.
+pub fn enter_blocking_section() -> Result<(), BlockingError> {
+    Worker::with_current(|worker| {
+        if let Some(worker) = worker {
+            worker.transition_to_blocking()
+        } else {
+            Err(BlockingError(Kind::NotWorker))
+        }
+    })
+}
+
+/// Try to transition out of blocking mode. This is a fast path that takes back
+/// ownership of the worker if the worker handoff didn't complete yet.  Returns
+/// `BlockingError` if called from a thread not associated with a Tokio thread
+/// pool.
+pub fn exit_blocking_section() -> Result<(), BlockingError> {
+    Worker::with_current(|worker| {
+        if let Some(worker) = worker {
+            worker.transition_from_blocking();
+            Ok(())
+        } else {
+            Err(BlockingError(Kind::NotWorker))
+        }
+    })
+}
+
+impl BlockingError {
+    /// Return true if the error is due to a thread calling `blocking` or
+    /// `enter_blocking_section` that is not a tokio threadpool worker thread.
+    pub fn is_not_worker(&self) -> bool {
+        self.0 == Kind::NotWorker
+    }
+}
+
 impl fmt::Display for BlockingError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            fmt,
-            "`blocking` annotation used from outside the context of a thread pool"
-        )
+        match self.0 {
+            Kind::NotWorker => write!(
+                fmt,
+                "blocking used from outside the context of a thread pool"
+            ),
+            Kind::NoCapacity => write!(fmt, "max blocking threads threshold was reached"),
+        }
     }
 }
 

--- a/tokio-executor/src/threadpool/mod.rs
+++ b/tokio-executor/src/threadpool/mod.rs
@@ -138,7 +138,7 @@ mod thread_pool;
 mod waker;
 mod worker;
 
-pub use self::blocking::{blocking, BlockingError};
+pub use self::blocking::{blocking, enter_blocking_section, exit_blocking_section, BlockingError};
 pub use self::builder::Builder;
 pub use self::sender::Sender;
 pub use self::shutdown::Shutdown;


### PR DESCRIPTION
## Motivation

This addresses part of #588, incrementally.  Given that plan, what is now the `blocking` operation doesn't need to be contained in a closure and return a `Poll` type, since it will eventually become unbounded at this level. 

## Solution

`ThreadPool` `enter_blocking_section` and `exit_blocking_section` functions are factored out of the current `blocking` function. These functions should not return a `Poll` value, because they will eventually be unbounded (as per #588, the plan is to eventually remove the `max_blocking` limit.)  So as an incremental solution, the `BlockingError` is extended to include a `NoCapacity` kind.  Once the `max_blocking` limit is removed, this error will no longer be a possible return, and can be removed along with deprecating or removing the original `blocking` function.

Note that `exit_blocking_section` can also return an error, reserved for any of the following cases:

* (Possibly in future) if `enter_` wasn't previously called on the same thread or if `exit_` is called twice.

* and/or the current thread isn't `ThreadPool` worker thread (for parity with the same `NotWorker`-kind returned by `enter_`).

An alternative would be for exit to just panic, but since the enter and exit calls should be very close together in common usage, it seems ergonomic enough for exit to also return the same error type.
