### PR TITLE
Add get_ref and get_mut

### DIFF
--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -157,12 +157,18 @@ impl<S> TlsStream<S> {
     }
 
     /// Returns a shared reference to the inner stream.
-    pub fn get_ref(&self) -> &S where S: AsyncRead+ AsyncWrite + Unpin {
+    pub fn get_ref(&self) -> &S
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
         &self.0.get_ref().inner
     }
 
     /// Returns a mutable reference to the inner stream.
-    pub fn get_mut(&mut self) -> &mut S where S: AsyncRead+ AsyncWrite + Unpin {
+    pub fn get_mut(&mut self) -> &mut S
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
         &mut self.0.get_mut().inner
     }
 }

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -155,6 +155,16 @@ impl<S> TlsStream<S> {
         let g = Guard(self);
         f(&mut (g.0).0)
     }
+
+    /// Returns a shared reference to the inner stream.
+    pub fn get_ref(&self) -> &S where S: AsyncRead+ AsyncWrite + Unpin {
+        &self.0.get_ref().inner
+    }
+
+    /// Returns a mutable reference to the inner stream.
+    pub fn get_mut(&mut self) -> &mut S where S: AsyncRead+ AsyncWrite + Unpin {
+        &mut self.0.get_mut().inner
+    }
 }
 
 impl<S> AsyncRead for TlsStream<S>


### PR DESCRIPTION
## Motivation

Previously, it was impossible to access the underlying stream through a `tokio_tls::TlsStream`.

## Solution

This patch adds `get_ref` and `get_mut` on `TlsStream` which return references to the underlying stream.