### PR TITLE
timer: use our own AtomicU64 on targets with target_has_atomic less than 64

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,12 +93,12 @@ jobs:
         - tokio-no-features
         - tokio-with-net
 
-# # Try cross compiling
-# - template: ci/azure-cross-compile.yml
-#   parameters:
-#     name: cross_32bit_linux
-#     target: i686-unknown-linux-gnu
-#
+# Try cross compiling
+- template: ci/azure-cross-compile.yml
+  parameters:
+    name: cross
+    rust: $(nightly)
+
 # # This represents the minimum Rust version supported by
 # # Tokio. Updating this should be done in a dedicated PR and
 # # cannot be greater than two 0.x releases prior to the
@@ -127,6 +127,6 @@ jobs:
       - test_linux
       - test_features
 #      - test_nightly
-#      - cross_32bit_linux
+      - cross
 #      - minrust
 #      - tsan

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -1,27 +1,41 @@
 jobs:
 - job: ${{ parameters.name }}
   displayName: ${{ parameters.displayName }}
+  strategy:
+    matrix:
+      i686:
+        vmImage: ubuntu-16.04
+        target: i686-unknown-linux-gnu
+      powerpc:
+        vmImage: ubuntu-16.04
+        target: powerpc-unknown-linux-gnu
+      powerpc64:
+        vmImage: ubuntu-16.04
+        target: powerpc64-unknown-linux-gnu
+      mips:
+        vmImage: ubuntu-16.04
+        target: mips-unknown-linux-gnu
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: $(vmImage)
   steps:
   - template: azure-install-rust.yml
     parameters:
-      rust_version: stable
+      rust_version: ${{ parameters.rust }}
 
   - script: sudo apt-get update
-    displayName: "apt-get update"
+    displayName: apt-get update
 
   - script: sudo apt-get install gcc-multilib
-    displayName: "Install gcc-multilib"
+    displayName: Install gcc-multilib
 
-  - script: rustup target add ${{ parameters.target }}
-    displayName: "Add target"
+  - script: cargo install cross
+    displayName: Install cross
 
   # Always patch
   - template: azure-patch-crates.yml
 
-  - script: cargo check --all --exclude tokio-tls --target ${{ parameters.target }}
+  - script: cross check --all --exclude tokio-tls --target $(target)
     displayName: Check source
 
-  - script: cargo check --tests --all --exclude tokio-tls --target ${{ parameters.target }}
-    displayName: Check tests
+  # - script: cross check --tests --all --exclude tokio-tls --target $(target)
+  #   displayName: Check tests

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -4,12 +4,15 @@
 
 pub(crate) use self::imp::AtomicU64;
 
-#[cfg(target_pointer_width = "64")]
+// `AtomicU64` can only be used on targets with `target_has_atomic` is 64 or greater.
+// Once `cfg_target_has_atomic` feature is stable, we can replace it with
+// `#[cfg(target_has_atomic = "64")]`.
+#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
 mod imp {
     pub(crate) use std::sync::atomic::AtomicU64;
 }
 
-#[cfg(not(target_pointer_width = "64"))]
+#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
 mod imp {
     use std::sync::atomic::Ordering;
     use std::sync::Mutex;

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -15,33 +15,33 @@ mod imp {
     use std::sync::Mutex;
 
     #[derive(Debug)]
-    pub(crate)  struct AtomicU64 {
+    pub(crate) struct AtomicU64 {
         inner: Mutex<u64>,
     }
 
     impl AtomicU64 {
-        pub(crate)  fn new(val: u64) -> AtomicU64 {
+        pub(crate) fn new(val: u64) -> AtomicU64 {
             AtomicU64 {
                 inner: Mutex::new(val),
             }
         }
 
-        pub(crate)  fn load(&self, _: Ordering) -> u64 {
+        pub(crate) fn load(&self, _: Ordering) -> u64 {
             *self.inner.lock().unwrap()
         }
 
-        pub(crate)  fn store(&self, val: u64, _: Ordering) {
+        pub(crate) fn store(&self, val: u64, _: Ordering) {
             *self.inner.lock().unwrap() = val;
         }
 
-        pub(crate)  fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
+        pub(crate) fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
             let mut lock = self.inner.lock().unwrap();
             let prev = *lock;
             *lock = prev | val;
             prev
         }
 
-        pub(crate)  fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
+        pub(crate) fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
             let mut lock = self.inner.lock().unwrap();
             let prev = *lock;
 

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -1,0 +1,56 @@
+//! Implementation of an atomic u64 cell. On 64 bit platforms, this is a
+//! re-export of `AtomicU64`. On 32 bit platforms, this is implemented using a
+//! `Mutex`.
+
+pub(crate) use self::imp::AtomicU64;
+
+#[cfg(target_pointer_width = "64")]
+mod imp {
+    pub(crate) use std::sync::atomic::AtomicU64;
+}
+
+#[cfg(not(target_pointer_width = "64"))]
+mod imp {
+    use std::sync::atomic::Ordering;
+    use std::sync::Mutex;
+
+    #[derive(Debug)]
+    pub struct AtomicU64 {
+        inner: Mutex<u64>,
+    }
+
+    impl AtomicU64 {
+        pub fn new(val: u64) -> AtomicU64 {
+            AtomicU64 {
+                inner: Mutex::new(val),
+            }
+        }
+
+        pub fn load(&self, _: Ordering) -> u64 {
+            *self.inner.lock().unwrap()
+        }
+
+        pub fn store(&self, val: u64, _: Ordering) {
+            *self.inner.lock().unwrap() = val;
+        }
+
+        pub fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
+            let mut lock = self.inner.lock().unwrap();
+            let prev = *lock;
+            *lock = prev | val;
+            prev
+        }
+
+        pub fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
+            let mut lock = self.inner.lock().unwrap();
+            let prev = *lock;
+
+            if prev != old {
+                return prev;
+            }
+
+            *lock = new;
+            prev
+        }
+    }
+}

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -15,33 +15,33 @@ mod imp {
     use std::sync::Mutex;
 
     #[derive(Debug)]
-    pub struct AtomicU64 {
+    pub(crate)  struct AtomicU64 {
         inner: Mutex<u64>,
     }
 
     impl AtomicU64 {
-        pub fn new(val: u64) -> AtomicU64 {
+        pub(crate)  fn new(val: u64) -> AtomicU64 {
             AtomicU64 {
                 inner: Mutex::new(val),
             }
         }
 
-        pub fn load(&self, _: Ordering) -> u64 {
+        pub(crate)  fn load(&self, _: Ordering) -> u64 {
             *self.inner.lock().unwrap()
         }
 
-        pub fn store(&self, val: u64, _: Ordering) {
+        pub(crate)  fn store(&self, val: u64, _: Ordering) {
             *self.inner.lock().unwrap() = val;
         }
 
-        pub fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
+        pub(crate)  fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
             let mut lock = self.inner.lock().unwrap();
             let prev = *lock;
             *lock = prev | val;
             prev
         }
 
-        pub fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
+        pub(crate)  fn compare_and_swap(&self, old: u64, new: u64, _: Ordering) -> u64 {
             let mut lock = self.inner.lock().unwrap();
             let prev = *lock;
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -42,6 +42,7 @@ pub mod throttle;
 pub mod timeout;
 pub mod timer;
 
+mod atomic;
 mod delay;
 mod error;
 mod interval;

--- a/tokio-timer/src/timer/entry.rs
+++ b/tokio-timer/src/timer/entry.rs
@@ -1,10 +1,11 @@
+use crate::atomic::AtomicU64;
 use crate::timer::{HandlePriv, Inner};
 use crate::Error;
 use crossbeam_utils::CachePadded;
 use std::cell::UnsafeCell;
 use std::ptr;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Weak};
 use std::task::{self, Poll};
 use std::time::{Duration, Instant};

--- a/tokio-timer/src/timer/mod.rs
+++ b/tokio-timer/src/timer/mod.rs
@@ -49,10 +49,11 @@ pub use self::handle::{set_default, Handle};
 pub use self::now::{Now, SystemNow};
 pub(crate) use self::registration::Registration;
 
+use crate::atomic::AtomicU64;
 use crate::wheel;
 use crate::Error;
+use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use std::usize;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Fixes https://github.com/tokio-rs/tokio/pull/1421#issuecomment-527911780

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Reverts part of #1421.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
