### PR TITLE
chore: deny warnings for doc tests

### DIFF
--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Asynchronous stream of bytes.
 //!

--- a/tokio-codec/src/length_delimited.rs
+++ b/tokio-codec/src/length_delimited.rs
@@ -315,7 +315,6 @@
 //! ```
 //! # use tokio_io::AsyncWrite;
 //! # use tokio_codec::LengthDelimitedCodec;
-//! # use bytes::BytesMut;
 //! # fn write_frame<T: AsyncWrite>(io: T) {
 //! # let _ =
 //! LengthDelimitedCodec::builder()
@@ -842,7 +841,6 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # use tokio_io::AsyncRead;
     /// use tokio_codec::LengthDelimitedCodec;
     /// # pub fn main() {
     /// LengthDelimitedCodec::builder()
@@ -892,7 +890,6 @@ impl Builder {
     /// ```
     /// # use tokio_io::AsyncWrite;
     /// # use tokio_codec::LengthDelimitedCodec;
-    /// # use bytes::BytesMut;
     /// # fn write_frame<T: AsyncWrite>(io: T) {
     /// LengthDelimitedCodec::builder()
     ///     .length_field_length(2)
@@ -914,7 +911,6 @@ impl Builder {
     /// ```
     /// # use tokio_io::{AsyncRead, AsyncWrite};
     /// # use tokio_codec::LengthDelimitedCodec;
-    /// # use bytes::BytesMut;
     /// # fn write_frame<T: AsyncRead + AsyncWrite>(io: T) {
     /// # let _ =
     /// LengthDelimitedCodec::builder()

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Utilities for encoding and decoding frames.
 //!

--- a/tokio-executor/src/executor.rs
+++ b/tokio-executor/src/executor.rs
@@ -149,7 +149,7 @@ impl dyn Executor {
     ///     println!("running on the executor");
     /// })).unwrap();
     ///
-    /// handle.map(|_| println!("the future has completed"));
+    /// let handle = handle.map(|_| println!("the future has completed"));
     /// # }
     /// ```
     pub fn spawn_with_handle<Fut>(

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-executor/src/threadpool/blocking.rs
+++ b/tokio-executor/src/threadpool/blocking.rs
@@ -104,7 +104,7 @@ pub struct BlockingError {
 ///         // from the context of a `Future` implementation. Since we don't
 ///         // have a complicated requirement, we can use `poll_fn` in this
 ///         // case.
-///         poll_fn(move |_| {
+///         let _ = poll_fn(move |_| {
 ///             blocking(|| {
 ///                 let msg = rx.recv().unwrap();
 ///                 println!("message = {}", msg);

--- a/tokio-executor/src/typed.rs
+++ b/tokio-executor/src/typed.rs
@@ -63,7 +63,7 @@ use crate::SpawnError;
 ///             if item.is_none() { break; }
 ///         }
 ///
-///         self.tx.take().unwrap().send(()).map_err(|_| ());
+///         let _ = self.tx.take().unwrap().send(()).map_err(|_| ());
 ///         Poll::Ready(())
 ///     }
 /// }

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Asynchronous file and standard stream adaptation.
 //!

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Core I/O traits and combinators when working with Tokio.
 //!

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Macros for use with Tokio
 

--- a/tokio-net/src/driver/mod.rs
+++ b/tokio-net/src/driver/mod.rs
@@ -23,7 +23,7 @@
 //! ```
 //! use tokio::net::TcpStream;
 //!
-//! # async fn process<T>(t: T) {}
+//! # async fn process<T>(_t: T) {}
 //! # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
 //! let stream = TcpStream::connect("93.184.216.34:9243").await?;
 //!

--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Event loop that drives Tokio I/O resources.
 //!

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -25,7 +25,7 @@ use std::task::{Context, Poll};
 /// use tokio::net::TcpListener;
 ///
 /// use std::io;
-/// # async fn process_socket<T>(socket: T) {}
+/// # async fn process_socket<T>(_socket: T) {}
 ///
 /// #[tokio::main]
 /// async fn main() -> io::Result<()> {
@@ -33,7 +33,7 @@ use std::task::{Context, Poll};
 ///
 ///     loop {
 ///         let (socket, _) = listener.accept().await?;
-///         process_socket(socket);
+///         process_socket(socket).await;
 ///     }
 /// }
 /// ```
@@ -70,6 +70,7 @@ impl TcpListener {
     ///
     ///     // use the listener
     ///
+    ///     # let _ = listener;
     ///     Ok(())
     /// }
     /// ```
@@ -197,6 +198,7 @@ impl TcpListener {
     ///
     /// let std_listener = StdTcpListener::bind("127.0.0.1:0")?;
     /// let listener = TcpListener::from_std(std_listener, &Handle::default())?;
+    /// # let _ = listener;
     /// # Ok::<_, Box<dyn std::error::Error>>(())
     /// ```
     pub fn from_std(listener: net::TcpListener, handle: &Handle) -> io::Result<TcpListener> {

--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -270,14 +270,13 @@ impl TcpStream {
     ///
     /// ```no_run
     /// use tokio::net::TcpStream;
-    /// use tokio::prelude::*;
     /// use std::error::Error;
     /// use std::net::Shutdown;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
     ///     // Connect to a peer
-    ///     let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
+    ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
     ///
     ///     // Shutdown the stream
     ///     stream.shutdown(Shutdown::Write)?;

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -76,7 +76,7 @@ use std::task::{Context, Poll};
 ///         match self.poll_evented.get_ref().accept() {
 ///             Ok((socket, _)) => Poll::Ready(Ok(socket)),
 ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-///                 self.poll_evented.clear_read_ready(cx, ready);
+///                 self.poll_evented.clear_read_ready(cx, ready)?;
 ///                 Poll::Pending
 ///             }
 ///             Err(e) => Poll::Ready(Err(e)),

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Asynchronous synchronization primitives.
 //!

--- a/tokio-sync/src/watch.rs
+++ b/tokio-sync/src/watch.rs
@@ -21,7 +21,7 @@
 //! use tokio::sync::watch;
 //!
 //! # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
-//!     let (mut tx, mut rx) = watch::channel("hello");
+//!     let (tx, mut rx) = watch::channel("hello");
 //!
 //!     tokio::spawn(async move {
 //!         while let Some(value) = rx.recv().await {
@@ -172,7 +172,7 @@ const CLOSED: usize = 1;
 /// use tokio::sync::watch;
 ///
 /// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
-///     let (mut tx, mut rx) = watch::channel("hello");
+///     let (tx, mut rx) = watch::channel("hello");
 ///
 ///     tokio::spawn(async move {
 ///         while let Some(value) = rx.recv().await {

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Tokio and Futures based testing utilites
 

--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -134,7 +134,6 @@ macro_rules! assert_ready_err {
 ///
 /// ```
 /// use std::future::Future;
-/// use std::task::Poll;
 /// use futures_util::{future, pin_mut};
 /// use tokio_test::{assert_pending, task};
 ///

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Utilities for tracking time.
 //!

--- a/tokio-timer/src/timeout.rs
+++ b/tokio-timer/src/timeout.rs
@@ -38,7 +38,7 @@ use std::time::{Duration, Instant};
 /// use std::thread;
 /// use std::time::Duration;
 ///
-/// # async fn dox() {
+/// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
 /// let (mut tx, rx) = mpsc::unbounded_channel();
 ///
 /// thread::spawn(move || {
@@ -54,7 +54,8 @@ use std::time::{Duration, Instant};
 /// });
 ///
 /// // Wrap the future with a `Timeout` set to expire in 10 milliseconds.
-/// process.timeout(Duration::from_millis(10)).await;
+/// process.timeout(Duration::from_millis(10)).await?;
+/// # Ok(())
 /// # }
 /// ```
 ///
@@ -99,13 +100,14 @@ impl<T> Timeout<T> {
     ///
     /// use std::time::Duration;
     ///
-    /// # async fn dox() {
+    /// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
     /// let (tx, rx) = oneshot::channel();
     /// # tx.send(()).unwrap();
     ///
     /// // Wrap the future with a `Timeout` set to expire in 10 milliseconds.
-    /// Timeout::new(rx, Duration::from_millis(10)).await;
-    /// }
+    /// Timeout::new(rx, Duration::from_millis(10)).await??;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(value: T, timeout: Duration) -> Timeout<T> {
         let delay = Delay::new_timeout(now() + timeout, timeout);

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! Async TLS streams
 //!

--- a/tokio/src/executor.rs
+++ b/tokio/src/executor.rs
@@ -71,7 +71,7 @@ pub struct Spawn(());
 /// ```
 /// use tokio::net::TcpListener;
 ///
-/// # async fn process<T>(t: T) {}
+/// # async fn process<T>(_t: T) {}
 /// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
 /// let mut listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -5,7 +5,10 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![doc(test(no_crate_inject, attr(deny(rust_2018_idioms))))]
+#![doc(test(
+    no_crate_inject,
+    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
+))]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!

--- a/tokio/src/runtime/current_thread/mod.rs
+++ b/tokio/src/runtime/current_thread/mod.rs
@@ -25,14 +25,13 @@
 //!
 //! ```
 //! use tokio::runtime::current_thread::Runtime;
-//! use tokio::prelude::*;
 //! use std::thread;
 //!
-//! let mut runtime = Runtime::new().unwrap();
+//! let runtime = Runtime::new().unwrap();
 //! let handle = runtime.handle();
 //!
 //! thread::spawn(move || {
-//!     handle.spawn(async {
+//!     let _ = handle.spawn(async {
 //!         println!("hello world");
 //!     });
 //! }).join().unwrap();
@@ -45,9 +44,8 @@
 //!
 //! ```
 //! use tokio::runtime::current_thread::Runtime;
-//! use tokio::prelude::*;
 //!
-//! let mut runtime = Runtime::new().unwrap();
+//! let runtime = Runtime::new().unwrap();
 //!
 //! // Use the runtime...
 //! // runtime.block_on(f); // where f is a future

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -86,7 +86,7 @@
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     // Create the runtime
-//!     let mut rt = Runtime::new()?;
+//!     let rt = Runtime::new()?;
 //!
 //!     // Spawn the root task
 //!     rt.block_on(async {

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -35,7 +35,7 @@ use std::any::Any;
 ///
 /// fn main() {
 ///     // build Runtime
-///     let mut runtime = Builder::new()
+///     let runtime = Builder::new()
 ///         .blocking_threads(4)
 ///         .clock(Clock::system())
 ///         .core_threads(4)
@@ -99,7 +99,7 @@ impl Builder {
     /// # use tokio::runtime;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .panic_handler(|err| std::panic::resume_unwind(err))
     ///     .build()
     ///     .unwrap();
@@ -127,7 +127,7 @@ impl Builder {
     /// # use tokio::runtime;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .core_threads(4)
     ///     .build()
     ///     .unwrap();
@@ -157,7 +157,7 @@ impl Builder {
     /// # use tokio::runtime;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .blocking_threads(200)
     ///     .build();
     /// # }
@@ -186,7 +186,7 @@ impl Builder {
     /// use std::time::Duration;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .keep_alive(Some(Duration::from_secs(30)))
     ///     .build();
     /// # }
@@ -210,7 +210,7 @@ impl Builder {
     /// # use tokio::runtime;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .name_prefix("my-pool-")
     ///     .build();
     /// # }
@@ -234,7 +234,7 @@ impl Builder {
     /// # use tokio::runtime;
     ///
     /// # pub fn main() {
-    /// let mut rt = runtime::Builder::new()
+    /// let rt = runtime::Builder::new()
     ///     .stack_size(32 * 1024)
     ///     .build();
     /// # }

--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -75,7 +75,6 @@ impl Runtime {
     ///
     /// ```
     /// use tokio::runtime::Runtime;
-    /// use tokio::prelude::*;
     ///
     /// let rt = Runtime::new()
     ///     .unwrap();
@@ -198,7 +197,6 @@ impl Runtime {
     ///
     /// ```
     /// use tokio::runtime::Runtime;
-    /// use tokio::prelude::*;
     ///
     /// let rt = Runtime::new()
     ///     .unwrap();
@@ -239,7 +237,6 @@ impl Runtime {
     ///
     /// ```
     /// use tokio::runtime::Runtime;
-    /// use tokio::prelude::*;
     ///
     /// let rt = Runtime::new()
     ///     .unwrap();

--- a/tokio/src/runtime/threadpool/task_executor.rs
+++ b/tokio/src/runtime/threadpool/task_executor.rs
@@ -33,7 +33,7 @@ impl TaskExecutor {
     ///
     /// # fn dox() {
     /// // Create the runtime
-    /// let mut rt = Runtime::new().unwrap();
+    /// let rt = Runtime::new().unwrap();
     /// let executor = rt.executor();
     ///
     /// // Spawn a future onto the runtime

--- a/tokio/src/timer.rs
+++ b/tokio/src/timer.rs
@@ -30,10 +30,9 @@
 //! Wait 100ms and print "Hello World!"
 //!
 //! ```
-//! use tokio::prelude::*;
 //! use tokio::timer::delay;
 //!
-//! use std::time::{Duration, Instant};
+//! use std::time::Duration;
 //!
 //!
 //! #[tokio::main]


### PR DESCRIPTION
Denies all warnings except `dead_code` and `unused_variables`.

cc #1086
Refs: https://github.com/rust-lang-nursery/futures-rs/pull/1672