### PR TITLE
tls: fix new temporary lifetime rustc error [E0597]

### DIFF
--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -287,7 +287,7 @@ impl TlsConnector {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        handshake(|s| self.0.connect(domain, s), stream).await
+        handshake(move |s| self.0.connect(domain, s), stream).await
     }
 }
 
@@ -318,7 +318,7 @@ impl TlsAcceptor {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        handshake(|s| self.0.accept(s), stream).await
+        handshake(move |s| self.0.accept(s), stream).await
     }
 }
 


### PR DESCRIPTION
Fixes: #1546
Signed-off-by: Kirill Mironov <vetrokm@gmail.com>

## Motivation
Newest rust nightly has this rust-lang/rust#64292 pull request merged, which broke compilation of some crates, including tokio-tls.

## Solution

Make the closure own the values instead of borrowing them