### PR TITLE
fix: delay_for should use tokio_timer::clock::now

### DIFF
--- a/tokio-timer/src/interval.rs
+++ b/tokio-timer/src/interval.rs
@@ -40,7 +40,7 @@ impl Interval {
 
     /// Creates new `Interval` that yields with interval of `duration`.
     ///
-    /// The function is shortcut for `Interval::new(Instant::now() + duration, duration)`.
+    /// The function is shortcut for `Interval::new(tokio_timer::clock::now() + duration, duration)`.
     ///
     /// The `duration` argument must be a non-zero duration.
     ///

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -70,9 +70,9 @@ pub fn delay(deadline: Instant) -> Delay {
 
 /// Create a Future that completes in `duration` from now.
 ///
-/// Equivalent to `delay(Instant::now() + duration)`. Analogous to `std::thread::sleep`.
+/// Equivalent to `delay(tokio_timer::clock::now() + duration)`. Analogous to `std::thread::sleep`.
 pub fn delay_for(duration: Duration) -> Delay {
-    delay(Instant::now() + duration)
+    delay(clock::now() + duration)
 }
 
 // ===== Internal utils =====

--- a/tokio/tests/clock.rs
+++ b/tokio/tests/clock.rs
@@ -47,3 +47,13 @@ fn clock_and_timer_single_threaded() {
         assert!(Instant::now() < when);
     });
 }
+
+#[test]
+fn mocked_clock_delay_for() {
+    tokio_test::clock::mock(|handle| {
+        let mut f = tokio_test::task::spawn(delay_for(Duration::from_millis(1)));
+        tokio_test::assert_pending!(f.poll());
+        handle.advance(Duration::from_millis(1));
+        tokio_test::assert_ready!(f.poll());
+    });
+}


### PR DESCRIPTION
##  Motivation

`delay_for` should be usable with a mocked clock.

## Solution

Call the (potentially) mocked clock.