### PR TITLE
sync: Make Lock more similar to std::sync::Mutex

### DIFF
--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -29,13 +29,12 @@ macro_rules! if_fuzz {
     }}
 }
 
-mod lock;
 mod loom;
 pub mod mpsc;
+pub mod mutex;
 pub mod oneshot;
 pub mod semaphore;
 mod task;
 pub mod watch;
 
-pub use lock::{Lock, LockGuard};
 pub use task::AtomicWaker;

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -31,10 +31,11 @@ macro_rules! if_fuzz {
 
 mod loom;
 pub mod mpsc;
-pub mod mutex;
+mod mutex;
 pub mod oneshot;
 pub mod semaphore;
 mod task;
 pub mod watch;
 
+pub use mutex::{Mutex, MutexGuard};
 pub use task::AtomicWaker;

--- a/tokio-sync/src/mutex.rs
+++ b/tokio-sync/src/mutex.rs
@@ -9,11 +9,12 @@
 //!
 //! ```rust,no_run
 //! use tokio::sync::Mutex;
+//! use std::sync::Arc;
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let mut data1 = Mutex::new(0);
-//!     let mut data2 = data1.clone();
+//!     let data1 = Arc::new(Mutex::new(0));
+//!     let data2 = Arc::clone(&data1);
 //!
 //!     tokio::spawn(async move {
 //!         let mut lock = data2.lock().await;

--- a/tokio-sync/tests/mutex.rs
+++ b/tokio-sync/tests/mutex.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 
 use std::sync::Arc;
-use tokio_sync::mutex::Mutex;
+use tokio_sync::Mutex;
 use tokio_test::task::spawn;
 use tokio_test::{assert_pending, assert_ready};
 

--- a/tokio-sync/tests/mutex.rs
+++ b/tokio-sync/tests/mutex.rs
@@ -1,12 +1,13 @@
 #![warn(rust_2018_idioms)]
 
+use std::sync::Arc;
 use tokio_sync::mutex::Mutex;
 use tokio_test::task::spawn;
 use tokio_test::{assert_pending, assert_ready};
 
 #[test]
 fn straight_execution() {
-    let mut l = Mutex::new(100);
+    let l = Mutex::new(100);
 
     {
         let mut t = spawn(l.lock());
@@ -22,21 +23,15 @@ fn straight_execution() {
     }
     {
         let mut t = spawn(l.lock());
-        let mut g = assert_ready!(t.poll());
+        let g = assert_ready!(t.poll());
         assert_eq!(&*g, &98);
-
-        // We can continue to access the guard even if the lock is dropped
-        drop(t);
-        drop(l);
-        *g = 97;
-        assert_eq!(&*g, &97);
     }
 }
 
 #[test]
 fn readiness() {
-    let mut l1 = Mutex::new(100);
-    let mut l2 = l1.clone();
+    let l1 = Arc::new(Mutex::new(100));
+    let l2 = Arc::clone(&l1);
     let mut t1 = spawn(l1.lock());
     let mut t2 = spawn(l2.lock());
 

--- a/tokio-sync/tests/mutex.rs
+++ b/tokio-sync/tests/mutex.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 
-use tokio_sync::Lock;
+use tokio_sync::mutex::Mutex;
 use tokio_test::task::spawn;
 use tokio_test::{assert_pending, assert_ready};
 
 #[test]
 fn straight_execution() {
-    let mut l = Lock::new(100);
+    let mut l = Mutex::new(100);
 
     {
         let mut t = spawn(l.lock());
@@ -35,7 +35,7 @@ fn straight_execution() {
 
 #[test]
 fn readiness() {
-    let mut l1 = Lock::new(100);
+    let mut l1 = Mutex::new(100);
     let mut l2 = l1.clone();
     let mut t1 = spawn(l1.lock());
     let mut t2 = spawn(l2.lock());
@@ -55,7 +55,7 @@ fn readiness() {
 #[test]
 #[ignore]
 fn lock() {
-    let mut lock = Lock::new(false);
+    let mut lock = Mutex::new(false);
 
     let mut lock2 = lock.clone();
     std::thread::spawn(move || {

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -35,7 +35,7 @@ use tokio::{
     self,
     codec::{Framed, LinesCodec, LinesCodecError},
     net::{TcpListener, TcpStream},
-    sync::{mpsc, mutex::Mutex},
+    sync::{mpsc, Mutex},
 };
 
 #[tokio::main]
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let (stream, addr) = listener.accept().await?;
 
         // Clone a handle to the `Shared` state for the new connection.
-        let state = state.clone();
+        let state = Arc::clone(&state);
 
         // Spawn our handler to be run asynchronously.
         tokio::spawn(async move {

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -27,7 +27,10 @@
 #![warn(rust_2018_idioms)]
 
 use futures::{Poll, SinkExt, Stream, StreamExt};
-use std::{collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin, task::Context};
+use std::{
+    collections::HashMap, env, error::Error, io, net::SocketAddr, pin::Pin, sync::Arc,
+    task::Context,
+};
 use tokio::{
     self,
     codec::{Framed, LinesCodec, LinesCodecError},
@@ -42,7 +45,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // The server task will hold a handle to this. For every new client, the
     // `state` handle is cloned and passed into the task that processes the
     // client connection.
-    let state = Mutex::new(Shared::new());
+    let state = Arc::new(Mutex::new(Shared::new()));
 
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:6142".to_string());
 
@@ -129,7 +132,7 @@ impl Shared {
 impl Peer {
     /// Create a new instance of `Peer`.
     async fn new(
-        mut state: Mutex<Shared>,
+        state: Arc<Mutex<Shared>>,
         lines: Framed<TcpStream, LinesCodec>,
     ) -> io::Result<Peer> {
         // Get the client socket address
@@ -184,7 +187,7 @@ impl Stream for Peer {
 
 /// Process an individual chat client
 async fn process(
-    mut state: Mutex<Shared>,
+    state: Arc<Mutex<Shared>>,
     stream: TcpStream,
     addr: SocketAddr,
 ) -> Result<(), Box<dyn Error>> {

--- a/tokio/examples/chat.rs
+++ b/tokio/examples/chat.rs
@@ -32,7 +32,7 @@ use tokio::{
     self,
     codec::{Framed, LinesCodec, LinesCodecError},
     net::{TcpListener, TcpStream},
-    sync::{mpsc, Lock},
+    sync::{mpsc, mutex::Mutex},
 };
 
 #[tokio::main]
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // The server task will hold a handle to this. For every new client, the
     // `state` handle is cloned and passed into the task that processes the
     // client connection.
-    let state = Lock::new(Shared::new());
+    let state = Mutex::new(Shared::new());
 
     let addr = env::args().nth(1).unwrap_or("127.0.0.1:6142".to_string());
 
@@ -129,7 +129,7 @@ impl Shared {
 impl Peer {
     /// Create a new instance of `Peer`.
     async fn new(
-        mut state: Lock<Shared>,
+        mut state: Mutex<Shared>,
         lines: Framed<TcpStream, LinesCodec>,
     ) -> io::Result<Peer> {
         // Get the client socket address
@@ -184,7 +184,7 @@ impl Stream for Peer {
 
 /// Process an individual chat client
 async fn process(
-    mut state: Lock<Shared>,
+    mut state: Mutex<Shared>,
     stream: TcpStream,
     addr: SocketAddr,
 ) -> Result<(), Box<dyn Error>> {

--- a/tokio/src/sync.rs
+++ b/tokio/src/sync.rs
@@ -13,5 +13,4 @@
 //! - [watch](watch/index.html), a single-producer, multi-consumer channel that
 //!   only stores the **most recently** sent value.
 
-pub use tokio_sync::{mpsc, oneshot, watch};
-pub use tokio_sync::{Lock, LockGuard};
+pub use tokio_sync::{mpsc, mutex, oneshot, watch};

--- a/tokio/src/sync.rs
+++ b/tokio/src/sync.rs
@@ -9,8 +9,9 @@
 //!   from one task to another.
 //! - [mpsc](mpsc/index.html), a multi-producer, single-consumer channel for
 //!   sending values between tasks.
-//! - [lock](lock/index.html), an asynchronous `Mutex`-like type.
+//! - [`Mutex`](struct.Mutex.html), an asynchronous `Mutex`-like type.
 //! - [watch](watch/index.html), a single-producer, multi-consumer channel that
 //!   only stores the **most recently** sent value.
 
-pub use tokio_sync::{mpsc, mutex, oneshot, watch};
+pub use tokio_sync::{mpsc, oneshot, watch};
+pub use tokio_sync::{Mutex, MutexGuard};


### PR DESCRIPTION
This renames `Lock` to `Mutex`, and brings the API more in line with `std::sync::Mutex`. In partcular, locking now only takes `&self`, with the expectation that you place the `Mutex` in an `Arc` (or something similar) to share it between threads.

Fixes #1544.
Part of #1210.