### PR TITLE
macros: fix handling of arguments of #[tokio::main] attribute

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -26,7 +26,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1"
-syn = { version = "1", features = ["full"] }
+syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "=0.2.0-alpha.5", path = "../tokio", default-features = false, features = ["rt-full"] }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -74,16 +74,18 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     let mut runtime = RuntimeType::Multi;
 
     for arg in args {
-        if let syn::NestedMeta::Meta(syn::Meta::Path(ident)) = arg {
-            let seg = ident.segments.first().expect("Must have specified ident");
-            match seg.ident.to_string().to_lowercase().as_str() {
+        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
+            let ident = path.get_ident();
+            if ident.is_none() {
+                let msg = "Must have specified ident";
+                return syn::Error::new_spanned(path, msg).to_compile_error().into();
+            }
+            match ident.unwrap().to_string().to_lowercase().as_str() {
                 "multi_thread" => runtime = RuntimeType::Multi,
                 "single_thread" => runtime = RuntimeType::Single,
                 name => {
                     let msg = format!("Unknown attribute {} is specified", name);
-                    return syn::Error::new_spanned(ident, msg)
-                        .to_compile_error()
-                        .into();
+                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
                 }
             }
         }


### PR DESCRIPTION
cc #1257

Currently `#[tokio::main]` only checks that the first element in the path is multi_thread or single_thread.

Refs: 
* https://docs.rs/syn/1.0.5/syn/struct.Path.html#method.get_ident
* https://github.com/dtolnay/syn/pull/696