### PR TITLE
#1567 deprecate Timer, replace with Clock

### DIFF
--- a/tokio/src/runtime/current_thread/builder.rs
+++ b/tokio/src/runtime/current_thread/builder.rs
@@ -3,7 +3,6 @@ use crate::runtime::current_thread::Runtime;
 use tokio_executor::current_thread::CurrentThread;
 use tokio_net::driver::Reactor;
 use tokio_timer::clock::Clock;
-use tokio_timer::timer::Timer;
 
 use std::io;
 
@@ -66,7 +65,7 @@ impl Builder {
 
         // Place a timer wheel on top of the reactor. If there are no timeouts to fire, it'll let the
         // reactor pick up some new external events.
-        let timer = Timer::new_with_now(reactor, self.clock.clone());
+        let timer = Clock::new_with_now(self.clock.clone());
         let timer_handle = timer.handle();
 
         // And now put a single-threaded executor on top of the timer. When there are no futures ready

--- a/tokio/src/runtime/threadpool/background.rs
+++ b/tokio/src/runtime/threadpool/background.rs
@@ -5,7 +5,6 @@ use tokio_executor::current_thread::CurrentThread;
 use tokio_net::driver::{self, Reactor};
 use tokio_sync::oneshot;
 use tokio_timer::clock::Clock;
-use tokio_timer::timer::{self, Timer};
 
 use std::{io, thread};
 
@@ -23,7 +22,7 @@ pub(crate) fn spawn(clock: &Clock) -> io::Result<Background> {
     let reactor = Reactor::new()?;
     let reactor_handle = reactor.handle();
 
-    let timer = Timer::new_with_now(reactor, clock);
+    let timer = Clock::new_with_now(clock);
     let timer_handle = timer.handle();
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -3,7 +3,6 @@ use super::{background, Inner, Runtime};
 use tokio_executor::threadpool;
 use tokio_net::driver::{self, Reactor};
 use tokio_timer::clock::{self, Clock};
-use tokio_timer::timer::{self, Timer};
 
 use num_cpus;
 use tracing_core as trace;
@@ -321,7 +320,7 @@ impl Builder {
             reactor_handles.push(reactor.handle());
 
             // Create a new timer.
-            let timer = Timer::new_with_now(reactor, self.clock.clone());
+            let timer = Clock::new_with_now(self.clock.clone());
             timer_handles.push(timer.handle());
             timers.push(Mutex::new(Some(timer)));
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
I love Objective-C, I love Rust more than Objective-C. I think that justifies everything.
Issue #1567 and I'm trying to help here! Come on!

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Timer was used solely for one purpose, checked and double checked then replaced.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
