### PR TITLE
32 bit ARM only has 32 bit atomics.

### DIFF
--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -17,7 +17,7 @@ jobs:
         target: mips-unknown-linux-gnu
       arm:
         vmImage: ubuntu-16.04
-        target: arm-unknown-linux-gnu
+        target: arm-unknown-linux-gnueabi
   pool:
     vmImage: $(vmImage)
   steps:

--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -15,6 +15,9 @@ jobs:
       mips:
         vmImage: ubuntu-16.04
         target: mips-unknown-linux-gnu
+      arm:
+        vmImage: ubuntu-16.04
+        target: arm-unknown-linux-gnu
   pool:
     vmImage: $(vmImage)
   steps:

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -7,12 +7,12 @@ pub(crate) use self::imp::AtomicU64;
 // `AtomicU64` can only be used on targets with `target_has_atomic` is 64 or greater.
 // Once `cfg_target_has_atomic` feature is stable, we can replace it with
 // `#[cfg(target_has_atomic = "64")]`.
-#[cfg(not(any(target_arch = "mips", target_arch = "powerpc")))]
+#[cfg(not(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc")))]
 mod imp {
     pub(crate) use std::sync::atomic::AtomicU64;
 }
 
-#[cfg(any(target_arch = "mips", target_arch = "powerpc"))]
+#[cfg(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc"))]
 mod imp {
     use std::sync::atomic::Ordering;
     use std::sync::Mutex;


### PR DESCRIPTION

## Motivation

This enables using tokio on Raspberry Pi and other similar devices

## Solution

Use a locked 64 bit integer instead.