### PR TITLE
tokio: add `rt-current-thread` optional feature

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -37,15 +37,21 @@ default = [
 codec = ["io", "tokio-codec", "bytes"]
 fs = ["tokio-fs"]
 io = ["tokio-io"]
+macros = ["tokio-macros"]
 net = ["tcp", "udp", "uds"]
+rt-current-thread = [
+  "timer",
+  "tokio-net",
+  "tokio-executor/current-thread",
+]
 rt-full = [
+  "macros",
   "num_cpus",
   "net",
   "sync",
   "timer",
   "tokio-executor/current-thread",
   "tokio-executor/threadpool",
-  "tokio-macros",
   "tracing-core",
 ]
 signal = ["tokio-net/signal"]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -72,7 +72,10 @@
 
 macro_rules! if_runtime {
     ($($i:item)*) => ($(
-        #[cfg(any(feature = "rt-full"))]
+        #[cfg(any(
+            feature = "rt-full",
+            feature = "rt-current-thread",
+        ))]
         $i
     )*)
 }
@@ -103,8 +106,10 @@ if_runtime! {
     pub use crate::executor::spawn;
 
     #[cfg(not(test))] // Work around for rust-lang/rust#62127
+    #[cfg(feature = "macros")]
     #[doc(inline)]
     pub use tokio_macros::main;
+    #[cfg(feature = "macros")]
     #[doc(inline)]
     pub use tokio_macros::test;
 }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -135,10 +135,24 @@
 //! [`tokio::main`]: ../../tokio_macros/attr.main.html
 
 pub mod current_thread;
+#[cfg(feature = "rt-full")]
 mod threadpool;
 
+#[cfg(feature = "rt-full")]
 pub use self::threadpool::{
     Builder,
     Runtime,
     TaskExecutor,
 };
+
+// Internal export, don't use.
+// This exists to support "auto" runtime selection when using the
+// #[tokio::main] attribute.
+#[doc(hidden)]
+pub mod __main {
+    #[cfg(feature = "rt-full")]
+    pub use super::Runtime;
+
+    #[cfg(not(feature = "rt-full"))]
+    pub use super::current_thread::Runtime;
+}


### PR DESCRIPTION
## Motivation

To allow smaller builds using tokio, it would be useful to allow exposing the current-thread runtime without enabling so many features as `rt-full` does.

## Solution

- Adds a minimum `rt-current-thread` optional feature that exports
  `tokio::runtime::current_thread`.
- Adds a `macros` optional feature to enable the `#[tokio::main]` and
  `#[tokio::test]` attributes.
- Adjusts `#[tokio::main]` macro to select a runtime "automatically" if
  a specific strategy isn't specified. Allows using the macro with only
  the rt-current-thread feature.
