### PR TITLE
fs: Update the doc comment of File::sync_data

### DIFF
--- a/tokio-fs/src/file.rs
+++ b/tokio-fs/src/file.rs
@@ -266,14 +266,14 @@ impl File {
         asyncify(move || std.sync_all()).await
     }
 
-    /// This function is similar to `poll_sync_all`, except that it may not
+    /// This function is similar to `sync_all`, except that it may not
     /// synchronize file metadata to the filesystem.
     ///
     /// This is intended for use cases that must synchronize content, but don't
     /// need the metadata on disk. The goal of this method is to reduce disk
     /// operations.
     ///
-    /// Note that some platforms may simply implement this in terms of `poll_sync_all`.
+    /// Note that some platforms may simply implement this in terms of `sync_all`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation

The doc comment of `tokio::fs::File::sync_data` refers to `poll_sync_all` which has been modified to `sync_all`.

For reference, the old `poll_sync_all` in 0.1.x: https://github.com/tokio-rs/tokio/blob/59fb5b9a7d89ee84389b8f8a039e874ef8971dbd/tokio-fs/src/file/mod.rs#L269

## Solution

Update the doc comment to reflect the change of the function name.
