### PR TITLE
Allow non-destructive access to the read buffer.

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -120,6 +120,11 @@ impl<T, U> Framed<T, U> {
         &mut self.inner.get_mut().get_mut().1
     }
 
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        self.inner.buffer()
+    }
+
     /// Consumes the `Frame`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -79,6 +79,11 @@ impl<T, D> FramedRead<T, D> {
     pub fn decoder_mut(&mut self) -> &mut D {
         &mut self.inner.inner.1
     }
+
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        &self.inner.buffer
+    }
 }
 
 impl<T, D> Stream for FramedRead<T, D>
@@ -173,6 +178,10 @@ impl<T> FramedRead2<T> {
 
     pub(crate) fn get_mut(&mut self) -> &mut T {
         &mut self.inner
+    }
+
+    pub(crate) fn buffer(&self) -> &BytesMut {
+        &self.buffer
     }
 }
 


### PR DESCRIPTION

## Motivation

I need this to implement SMTP pipelining checks. I mostly need to
flush my send buffer when the read buffer is empty before waiting for
the next command.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Accessors are added on Framed and FramedRead.