### PR TITLE
Fix: tokio_net::tcp::incoming::Incoming type not exported

### DIFF
--- a/tokio-net/src/tcp/mod.rs
+++ b/tokio-net/src/tcp/mod.rs
@@ -23,5 +23,7 @@ mod listener;
 pub mod split;
 mod stream;
 
+#[cfg(feature = "async-traits")]
+pub use self::incoming::Incoming;
 pub use self::listener::TcpListener;
 pub use self::stream::TcpStream;

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -40,7 +40,7 @@ pub mod tcp {
     //! [`TcpListener`]: struct.TcpListener.html
     //! [incoming_method]: struct.TcpListener.html#method.incoming
     //! [`Incoming`]: struct.Incoming.html
-    pub use tokio_net::tcp::{split, TcpListener, TcpStream};
+    pub use tokio_net::tcp::{split, Incoming, TcpListener, TcpStream};
 }
 #[cfg(feature = "tcp")]
 pub use self::tcp::{TcpListener, TcpStream};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

With tokio `0.2.0-alpha.5`, We can't use the `Incoming` stream type in our types, because it's not exported. For the same reason, it can't be viewed [in the documentation](https://docs.rs/tokio/0.2.0-alpha.5/tokio/net/struct.TcpListener.html#method.incoming) (also dead link [here](https://docs.rs/tokio/0.2.0-alpha.5/tokio/net/tcp/index.html)).

## Solution

`pub use` the `Incoming` in the `tcp` module.

Not sure about tests. Does it make sense to make a test for this?
