### PR TITLE
Fix docs links

### DIFF
--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -59,7 +59,7 @@
 //! [`enter`]: fn.enter.html
 //! [`DefaultExecutor`]: struct.DefaultExecutor.html
 //! [`Park`]: park/index.html
-//! [`Future::poll`]: https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll
+//! [`Future::poll`]: std::future::Future::poll
 #[cfg(any(feature = "current-thread", feature = "threadpool"))]
 #[macro_use]
 mod tracing;

--- a/tokio-executor/src/threadpool/mod.rs
+++ b/tokio-executor/src/threadpool/mod.rs
@@ -72,7 +72,7 @@
 //! makes it available to other workers that encounter a [`blocking`] call.
 //!
 //! [`blocking`]: fn.blocking.html
-//! [`runtime`]: https://docs.rs/tokio/0.1/tokio/runtime/
+//! [`runtime`]: https://docs.rs/tokio/*/tokio/runtime/
 
 // ## Crate layout
 //

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -34,9 +34,9 @@
 //! to a *backup* thread immediately. See [tokio-executor] for more details
 //! of the threading model and [`blocking`].
 //!
-//! [`blocking`]: https://docs.rs/tokio-executor/0.2.0-alpha.2/tokio_executor/threadpool/fn.blocking.html
-//! [`AsyncRead`]: https://docs.rs/tokio-io/0.1/tokio_io/trait.AsyncRead.html
-//! [tokio-executor]: https://docs.rs/tokio-executor/0.2.0-alpha.2/tokio_executor/threadpool/index.html
+//! [`blocking`]: https://docs.rs/tokio-executor/*/tokio_executor/threadpool/fn.blocking.html
+//! [`AsyncRead`]: https://docs.rs/tokio-io/*/tokio_io/trait.AsyncRead.html
+//! [tokio-executor]: https://docs.rs/tokio-executor/*/tokio_executor/threadpool/index.html
 
 mod blocking;
 mod create_dir;

--- a/tokio-timer/src/delay_queue.rs
+++ b/tokio-timer/src/delay_queue.rs
@@ -119,7 +119,7 @@ use std::time::{Duration, Instant};
 /// [`insert`]: #method.insert
 /// [`insert_at`]: #method.insert_at
 /// [`Key`]: struct.Key.html
-/// [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
+/// [`Stream`]: https://docs.rs/futures-core-preview/*/futures_core/stream/trait.Stream.html
 /// [`poll`]: #method.poll
 /// [`Stream::poll`]: #method.poll
 /// [`Timer`]: ../struct.Timer.html

--- a/tokio/src/codec/mod.rs
+++ b/tokio/src/codec/mod.rs
@@ -6,8 +6,8 @@
 //!
 //! [`AsyncRead`]: ../io/trait.AsyncRead.html
 //! [`AsyncWrite`]: ../io/trait.AsyncWrite.html
-//! [`Sink`]: https://docs.rs/futures/0.1/futures/sink/trait.Sink.html
-//! [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
+//! [`Sink`]: https://docs.rs/futures-sink-preview/*/futures_sink/trait.Sink.html
+//! [`Stream`]: https://docs.rs/futures-core-preview/*/futures_core/stream/trait.Stream.html
 //! [transports]: https://tokio.rs/docs/going-deeper/frames/
 
 pub use tokio_codec::{

--- a/tokio/src/executor.rs
+++ b/tokio/src/executor.rs
@@ -19,7 +19,7 @@
 //! # `Executor` trait.
 //!
 //! This module provides the [`Executor`] trait (re-exported from
-//! [`tokio-executor`]), which describes the API that all executors must
+//! [`tokio-executor`], which describes the API that all executors must
 //! implement.
 //!
 //! A free [`spawn`] function is provided that allows spawning futures onto the
@@ -32,10 +32,10 @@
 //! thread pool instead of itself, allowing futures to spawn new tasks onto the
 //! thread pool when those tasks are `Send`.
 //!
-//! [`Future::poll`]: https://docs.rs/futures/0.1/futures/future/trait.Future.html#tymethod.poll
-//! [notified]: https://docs.rs/futures/0.1/futures/executor/trait.Notify.html#tymethod.notify
+//! [`Future::poll`]: std::future::Future::poll
+//! [notified]: std::task::Waker
 //! [`runtime`]: ../runtime/index.html
-//! [`tokio-executor`]: https://docs.rs/tokio-executor/0.1
+//! [`tokio-executor`]: https://docs.rs/tokio-executor
 //! [`Executor`]: trait.Executor.html
 //! [`spawn`]: fn.spawn.html
 

--- a/tokio/src/runtime/current_thread/mod.rs
+++ b/tokio/src/runtime/current_thread/mod.rs
@@ -53,7 +53,6 @@
 //!
 //! [rt]: struct.Runtime.html
 //! [concurrent-rt]: ../struct.Runtime.html
-//! [chan]: https://docs.rs/futures/0.1/futures/sync/mpsc/fn.channel.html
 //! [reactor]: ../../reactor/struct.Reactor.html
 //! [executor]: https://tokio.rs/docs/internals/runtime-model/#executors
 //! [timer]: ../../timer/index.html


### PR DESCRIPTION
## Motivation

Changes links to futures & tokio 0.1 to futures-preview and tokio's latest version and some intra-doc links for `Future::poll` etc.

Related to  #1473