### PR TITLE
Create BufStream from a BufReader + BufWriter

### DIFF
--- a/tokio-io/src/io/buf_reader.rs
+++ b/tokio-io/src/io/buf_reader.rs
@@ -26,10 +26,10 @@ use std::{cmp, fmt};
 #[pin_project]
 pub struct BufReader<R> {
     #[pin]
-    inner: R,
-    buf: Box<[u8]>,
-    pos: usize,
-    cap: usize,
+    pub(super) inner: R,
+    pub(super) buf: Box<[u8]>,
+    pub(super) pos: usize,
+    pub(super) cap: usize,
 }
 
 impl<R: AsyncRead> BufReader<R> {

--- a/tokio-io/src/io/buf_writer.rs
+++ b/tokio-io/src/io/buf_writer.rs
@@ -31,9 +31,9 @@ use std::task::{Context, Poll};
 #[pin_project]
 pub struct BufWriter<W> {
     #[pin]
-    inner: W,
-    buf: Vec<u8>,
-    written: usize,
+    pub(super) inner: W,
+    pub(super) buf: Vec<u8>,
+    pub(super) written: usize,
 }
 
 impl<W: AsyncWrite> BufWriter<W> {


### PR DESCRIPTION
This can be useful in cases where you want to share a common type between an arm that uses `BufStream::new` and one that manually creates the `BufReader` and `BufWriter` using `with_capacity`.