### PR TITLE
chore: update futures-preview to 0.3.0-alpha.19

### DIFF
--- a/ci/patch.toml
+++ b/ci/patch.toml
@@ -11,5 +11,3 @@ tokio-net = { path = "tokio-net" }
 tokio-sync = { path = "tokio-sync" }
 tokio-timer = { path = "tokio-timer" }
 tokio-tls = { path = "tokio-tls" }
-
-loom = { git = "https://github.com/taiki-e/loom", branch = "futures" }

--- a/ci/patch.toml
+++ b/ci/patch.toml
@@ -11,3 +11,5 @@ tokio-net = { path = "tokio-net" }
 tokio-sync = { path = "tokio-sync" }
 tokio-timer = { path = "tokio-timer" }
 tokio-tls = { path = "tokio-tls" }
+
+loom = { git = "https://github.com/taiki-e/loom", branch = "futures" }

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -23,15 +23,15 @@ categories = ["asynchronous"]
 tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
 
 bytes = "0.4.7"
-futures-core-preview = "=0.3.0-alpha.18"
-futures-sink-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-sink-preview = "=0.3.0-alpha.19"
 log = "0.4"
 
 [dev-dependencies]
 tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
 tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
 
-futures-util-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -38,7 +38,7 @@ threadpool = [
 tokio-sync = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-sync" }
 
 tracing = { version = "0.1.5", optional = true }
-futures-util-preview = { version = "=0.3.0-alpha.18", features = ["channel"] }
+futures-util-preview = { version = "=0.3.0-alpha.19", features = ["channel"] }
 
 # current-thread dependencies
 crossbeam-channel = { version = "0.3.8", optional = true }
@@ -47,7 +47,7 @@ crossbeam-channel = { version = "0.3.8", optional = true }
 crossbeam-deque = { version = "0.7.0", optional = true }
 crossbeam-queue = { version = "0.1.0", optional = true }
 crossbeam-utils = { version = "0.6.4", optional = true }
-futures-core-preview = { version = "=0.3.0-alpha.18", optional = true }
+futures-core-preview = { version = "=0.3.0-alpha.19", optional = true }
 num_cpus = { version = "1.2", optional = true }
 lazy_static = { version = "1", optional = true }
 slab = { version = "0.4.1", optional = true }
@@ -56,7 +56,7 @@ slab = { version = "0.4.1", optional = true }
 tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
 tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
 
-futures-core-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
 rand = "0.7"
 
 [package.metadata.docs.rs]

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -26,8 +26,8 @@ tokio-io = { version = "=0.2.0-alpha.5", features = ["util"], path = "../tokio-i
 tokio-executor = { version = "=0.2.0-alpha.5", features = ["blocking"], path = "../tokio-executor" }
 tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
 
-futures-core-preview = "=0.3.0-alpha.18"
-futures-util-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-util-preview = "=0.3.0-alpha.19"
 lazy_static = "1.3.0"
 
 [dev-dependencies]

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -25,7 +25,7 @@ util = ["memchr", "pin-project"]
 [dependencies]
 bytes = "0.4.7"
 log = "0.4"
-futures-core-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
 memchr = { version = "2.2", optional = true }
 pin-project = { version = "=0.4.0-beta.1", optional = true }
 
@@ -33,7 +33,7 @@ pin-project = { version = "=0.4.0-beta.1", optional = true }
 tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
 tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
 
-futures-util-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-net/Cargo.toml
+++ b/tokio-net/Cargo.toml
@@ -71,8 +71,8 @@ tracing = { version = "0.1.5", optional = true }
 
 # driver implementation
 crossbeam-utils = "0.6.0"
-futures-core-preview = "=0.3.0-alpha.18"
-futures-util-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-util-preview = "=0.3.0-alpha.19"
 lazy_static = "1.0.2"
 mio = "0.6.14"
 num_cpus = "1.8.0"
@@ -81,7 +81,7 @@ slab = "0.4.0"
 
 # TCP / UDP
 bytes = { version = "0.4", optional = true }
-futures-sink-preview = { version = "=0.3.0-alpha.18", optional = true }
+futures-sink-preview = { version = "=0.3.0-alpha.19", optional = true }
 iovec = { version = "0.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -110,7 +110,7 @@ tokio-io-pool = "0.1.4"
 
 # UDS tests
 tempfile = "3"
-futures-preview = { version = "=0.3.0-alpha.18", features = ["nightly", "async-await"] }
+futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -24,9 +24,9 @@ async-traits = ["futures-sink-preview"]
 
 [dependencies]
 fnv = "1.0.6"
-futures-core-preview = { version = "=0.3.0-alpha.18" }
-futures-sink-preview = { version = "=0.3.0-alpha.18", optional = true }
-futures-util-preview = { version = "=0.3.0-alpha.18" }
+futures-core-preview = { version = "=0.3.0-alpha.19" }
+futures-sink-preview = { version = "=0.3.0-alpha.19", optional = true }
+futures-util-preview = { version = "=0.3.0-alpha.19" }
 
 [dev-dependencies]
 tokio = { version = "0.2.0-alpha.5", path = "../tokio" }

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -26,11 +26,11 @@ tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
 tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
 tokio-timer = { version = "=0.3.0-alpha.5", path = "../tokio-timer" }
 
-futures-core-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
 pin-convert = "0.1.0"
 
 [dev-dependencies]
-futures-util-preview = "=0.3.0-alpha.18"
+futures-util-preview = "=0.3.0-alpha.19"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -27,8 +27,8 @@ async-traits = []
 tokio-executor = { version = "=0.2.0-alpha.5", path = "../tokio-executor" }
 tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
 
-futures-core-preview = "=0.3.0-alpha.18"
-futures-util-preview = "=0.3.0-alpha.18"
+futures-core-preview = "=0.3.0-alpha.19"
+futures-util-preview = "=0.3.0-alpha.19"
 
 crossbeam-utils = "0.6.0"
 # Backs `DelayQueue`

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -34,7 +34,7 @@ tokio-net = { version = "=0.2.0-alpha.5", path = "../tokio-net", features = ["tc
 
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
-futures-preview = { version = "=0.3.0-alpha.18", features = ["async-await", "nightly"] }
+futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -64,9 +64,9 @@ uds = ["io", "tokio-net/uds"]
 process = ["io", "tokio-net/process"]
 
 [dependencies]
-futures-core-preview = "=0.3.0-alpha.18"
-futures-sink-preview = "=0.3.0-alpha.18"
-futures-util-preview = { version = "=0.3.0-alpha.18", features = ["sink"] }
+futures-core-preview = "=0.3.0-alpha.19"
+futures-sink-preview = "=0.3.0-alpha.19"
+futures-util-preview = { version = "=0.3.0-alpha.19", features = ["sink"] }
 
 # Everything else is optional...
 bytes = { version = "0.4", optional = true }
@@ -88,8 +88,8 @@ tokio-executor = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
 
-futures-preview = "=0.3.0-alpha.18"
-futures-util-preview = "=0.3.0-alpha.18"
+futures-preview = "=0.3.0-alpha.19"
+futures-util-preview = "=0.3.0-alpha.19"
 pin-utils = "=0.1.0-alpha.4"
 env_logger = { version = "0.6", default-features = false }
 flate2 = { version = "1", features = ["tokio"] }


### PR DESCRIPTION
~~Depends on https://github.com/carllerche/loom/pull/70.~~
Blocked on https://github.com/carllerche/loom/pull/71 and the next release of loom.