### PR TITLE
net: remove mutability requirement from send/recv on UdpSocket

### DIFF
--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -109,7 +109,7 @@ impl UdpSocket {
     /// will resolve to an error if the socket is not connected.
     ///
     /// [`connect`]: #method.connect
-    pub async fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
         poll_fn(|cx| self.poll_send_priv(cx, buf)).await
     }
 
@@ -151,7 +151,7 @@ impl UdpSocket {
     /// will fail if the socket is not connected.
     ///
     /// [`connect`]: #method.connect
-    pub async fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         poll_fn(|cx| self.poll_recv_priv(cx, buf)).await
     }
 
@@ -176,7 +176,7 @@ impl UdpSocket {
     ///
     /// The future will resolve to an error if the IP version of the socket does
     /// not match that of `target`.
-    pub async fn send_to<A: ToSocketAddrs>(&mut self, buf: &[u8], target: A) -> io::Result<usize> {
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
         let mut addrs = target.to_socket_addrs().await?;
 
         match addrs.next() {
@@ -211,7 +211,7 @@ impl UdpSocket {
     /// The function must be called with valid byte array `buf` of sufficient size
     /// to hold the message bytes. If a message is too long to fit in the supplied
     /// buffer, excess bytes may be discarded.
-    pub async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         poll_fn(|cx| self.poll_recv_from_priv(cx, buf)).await
     }
 

--- a/tokio-net/src/udp/split.rs
+++ b/tokio-net/src/udp/split.rs
@@ -85,7 +85,7 @@ impl UdpSocketRecvHalf {
     /// The function must be called with valid byte array `buf` of sufficient size
     /// to hold the message bytes. If a message is too long to fit in the supplied
     /// buffer, excess bytes may be discarded.
-    pub async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         poll_fn(|cx| self.0.poll_recv_from_priv(cx, buf)).await
     }
 
@@ -101,7 +101,7 @@ impl UdpSocketRecvHalf {
     /// will fail if the socket is not connected.
     ///
     /// [`connect`]: super::UdpSocket::connect
-    pub async fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         poll_fn(|cx| self.0.poll_recv_priv(cx, buf)).await
     }
 }
@@ -119,7 +119,7 @@ impl UdpSocketSendHalf {
     ///
     /// The future will resolve to an error if the IP version of the socket does
     /// not match that of `target`.
-    pub async fn send_to(&mut self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
+    pub async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> io::Result<usize> {
         poll_fn(|cx| self.0.poll_send_to_priv(cx, buf, target)).await
     }
 
@@ -130,7 +130,7 @@ impl UdpSocketSendHalf {
     /// will resolve to an error if the socket is not connected.
     ///
     /// [`connect`]: super::UdpSocket::connect
-    pub async fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
         poll_fn(|cx| self.0.poll_send_priv(cx, buf)).await
     }
 }

--- a/tokio-net/tests/udp.rs
+++ b/tokio-net/tests/udp.rs
@@ -9,8 +9,8 @@ use std::io;
 
 #[tokio::test]
 async fn send_recv() -> std::io::Result<()> {
-    let mut sender = UdpSocket::bind("127.0.0.1:0").await?;
-    let mut receiver = UdpSocket::bind("127.0.0.1:0").await?;
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    let receiver = UdpSocket::bind("127.0.0.1:0").await?;
 
     sender.connect(receiver.local_addr()?).await?;
     receiver.connect(sender.local_addr()?).await?;
@@ -27,8 +27,8 @@ async fn send_recv() -> std::io::Result<()> {
 
 #[tokio::test]
 async fn send_to_recv_from() -> std::io::Result<()> {
-    let mut sender = UdpSocket::bind("127.0.0.1:0").await?;
-    let mut receiver = UdpSocket::bind("127.0.0.1:0").await?;
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    let receiver = UdpSocket::bind("127.0.0.1:0").await?;
 
     let message = b"hello!";
     let receiver_addr = receiver.local_addr()?;
@@ -45,7 +45,7 @@ async fn send_to_recv_from() -> std::io::Result<()> {
 #[tokio::test]
 async fn split() -> std::io::Result<()> {
     let socket = UdpSocket::bind("127.0.0.1:0").await?;
-    let (mut r, mut s) = socket.split();
+    let (r, s) = socket.split();
 
     let msg = b"hello";
     let addr = s.as_ref().local_addr()?;

--- a/tokio/examples/echo-udp.rs
+++ b/tokio/examples/echo-udp.rs
@@ -27,7 +27,7 @@ struct Server {
 impl Server {
     async fn run(self) -> Result<(), io::Error> {
         let Server {
-            mut socket,
+            socket,
             mut buf,
             mut to_send,
         } = self;

--- a/tokio/examples/udp-client.rs
+++ b/tokio/examples/udp-client.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
     .parse()?;
 
-    let mut socket = UdpSocket::bind(local_addr).await?;
+    let socket = UdpSocket::bind(local_addr).await?;
     const MAX_DATAGRAM_SIZE: usize = 65_507;
     socket.connect(&remote_addr).await?;
     let data = get_stdin_data()?;


### PR DESCRIPTION
## Motivation

send/send_to/recv/recv_from all required a mutable reference
to the socket. This mutability is however not required and
introduces some inflexibility when trying to adjust the socket
parameters while we're awaiting on recv() f.e.

Fixes: #1613

