### PR TITLE
Prepare for release of 0.2.0-alpha.6

### DIFF
--- a/tokio-codec/CHANGELOG.md
+++ b/tokio-codec/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 - Track tokio release

--- a/tokio-codec/Cargo.toml
+++ b/tokio-codec/Cargo.toml
@@ -7,20 +7,20 @@ name = "tokio-codec"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-codec/0.2.0-alpha.5/tokio_codec"
+documentation = "https://docs.rs/tokio-codec/0.2.0-alpha.6/tokio_codec"
 description = """
 Utilities for encoding and decoding frames.
 """
 categories = ["asynchronous"]
 
 [dependencies]
-tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
+tokio-io = { version = "=0.2.0-alpha.6", path = "../tokio-io" }
 
 bytes = "0.4.7"
 futures-core-preview = "=0.3.0-alpha.19"
@@ -28,8 +28,8 @@ futures-sink-preview = "=0.3.0-alpha.19"
 log = "0.4"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 futures-util-preview = "=0.3.0-alpha.19"
 

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-codec/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-codec/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Fix

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -7,9 +7,9 @@ name = "tokio-executor"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
-documentation = "https://docs.rs/tokio-executor/0.2.0-alpha.5/tokio_executor"
+documentation = "https://docs.rs/tokio-executor/0.2.0-alpha.6/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"
@@ -35,7 +35,7 @@ threadpool = [
 ]
 
 [dependencies]
-tokio-sync = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-sync" }
+tokio-sync = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-sync" }
 
 tracing = { version = "0.1.5", optional = true }
 futures-util-preview = { version = "=0.3.0-alpha.19", features = ["channel"] }
@@ -53,8 +53,8 @@ lazy_static = { version = "1", optional = true }
 slab = { version = "0.4.1", optional = true }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 futures-core-preview = "=0.3.0-alpha.19"
 rand = "0.7"

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-fs/CHANGELOG.md
+++ b/tokio-fs/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Fix

--- a/tokio-fs/Cargo.toml
+++ b/tokio-fs/Cargo.toml
@@ -7,14 +7,14 @@ name = "tokio-fs"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-fs/0.2.0-alpha.5/tokio_fs"
+documentation = "https://docs.rs/tokio-fs/0.2.0-alpha.6/tokio_fs"
 description = """
 Filesystem API for Tokio.
 """
@@ -22,17 +22,17 @@ keywords = ["tokio", "futures", "fs", "file", "async"]
 categories = ["asynchronous", "network-programming", "filesystem"]
 
 [dependencies]
-tokio-io = { version = "=0.2.0-alpha.5", features = ["util"], path = "../tokio-io" }
-tokio-executor = { version = "=0.2.0-alpha.5", features = ["blocking"], path = "../tokio-executor" }
-tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
+tokio-io = { version = "=0.2.0-alpha.6", features = ["util"], path = "../tokio-io" }
+tokio-executor = { version = "=0.2.0-alpha.6", features = ["blocking"], path = "../tokio-executor" }
+tokio-sync = { version = "=0.2.0-alpha.6", path = "../tokio-sync" }
 
 futures-core-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"
 lazy_static = "1.3.0"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 rand = "0.7"
 tempfile = "3"

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-fs/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-fs/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-io/CHANGELOG.md
+++ b/tokio-io/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Added

--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-io"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-io/0.2.0-alpha.5/tokio_io"
+documentation = "https://docs.rs/tokio-io/0.2.0-alpha.6/tokio_io"
 description = """
 Core I/O primitives for asynchronous I/O in Rust.
 """
@@ -30,8 +30,8 @@ memchr = { version = "2.2", optional = true }
 pin-project = { version = "0.4", optional = true }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 futures-util-preview = "=0.3.0-alpha.19"
 

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-io/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-io/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.2.0-alpha.5/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.2.0-alpha.6/tokio_macros"
 description = """
 Tokio's proc macros.
 """
@@ -29,7 +29,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio", default-features = false, features = ["rt-full"] }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", default-features = false, features = ["rt-full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-net/CHANGELOG.md
+++ b/tokio-net/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Added

--- a/tokio-net/Cargo.toml
+++ b/tokio-net/Cargo.toml
@@ -7,14 +7,14 @@ name = "tokio-net"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-net/0.2.0-alpha.5/tokio_net"
+documentation = "https://docs.rs/tokio-net/0.2.0-alpha.6/tokio_net"
 description = """
 Event loop that drives Tokio I/O resources.
 """
@@ -62,10 +62,10 @@ uds = [
 log = ["tracing/log"]
 
 [dependencies]
-tokio-codec = { version = "=0.2.0-alpha.5", path = "../tokio-codec" }
-tokio-executor = { version = "=0.2.0-alpha.5", features = ["blocking"], path = "../tokio-executor" }
-tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
-tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
+tokio-codec = { version = "=0.2.0-alpha.6", path = "../tokio-codec" }
+tokio-executor = { version = "=0.2.0-alpha.6", features = ["blocking"], path = "../tokio-executor" }
+tokio-io = { version = "=0.2.0-alpha.6", path = "../tokio-io" }
+tokio-sync = { version = "=0.2.0-alpha.6", path = "../tokio-sync" }
 
 tracing = { version = "0.1.5", optional = true }
 
@@ -103,8 +103,8 @@ optional = true
 tracing = { version = "0.1.5", features = ["log"] }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 num_cpus = "1.8.0"
 tokio-io-pool = "0.1.4"
 

--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-net/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-net/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-sync/CHANGELOG.md
+++ b/tokio-sync/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Changed

--- a/tokio-sync/Cargo.toml
+++ b/tokio-sync/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-sync"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-sync/0.2.0-alpha.5/tokio_sync"
+documentation = "https://docs.rs/tokio-sync/0.2.0-alpha.6/tokio_sync"
 description = """
 Synchronization utilities.
 """
@@ -29,8 +29,8 @@ futures-sink-preview = { version = "=0.3.0-alpha.19", optional = true }
 futures-util-preview = { version = "=0.3.0-alpha.19" }
 
 [dev-dependencies]
-tokio = { version = "0.2.0-alpha.5", path = "../tokio" }
-tokio-test = { version = "0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "0.2.0-alpha.6", path = "../tokio" }
+tokio-test = { version = "0.2.0-alpha.6", path = "../tokio-test" }
 
 env_logger = { version = "0.6", default-features = false }
 loom = { version = "0.2.1", features = ["futures"] }

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-sync/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-sync/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 - Track tokio release.

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -7,24 +7,24 @@ name = "tokio-test"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-test/0.2.0-alpha.5/tokio_test"
+documentation = "https://docs.rs/tokio-test/0.2.0-alpha.6/tokio_test"
 description = """
 Testing utilities for Tokio- and futures-based code
 """
 categories = ["asynchronous", "testing"]
 
 [dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-executor = { version = "=0.2.0-alpha.5", path = "../tokio-executor" }
-tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
-tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
-tokio-timer = { version = "=0.3.0-alpha.5", path = "../tokio-timer" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-executor = { version = "=0.2.0-alpha.6", path = "../tokio-executor" }
+tokio-io = { version = "=0.2.0-alpha.6", path = "../tokio-io" }
+tokio-sync = { version = "=0.2.0-alpha.6", path = "../tokio-sync" }
+tokio-timer = { version = "=0.3.0-alpha.6", path = "../tokio-timer" }
 
 futures-core-preview = "=0.3.0-alpha.19"
 pin-convert = "0.1.0"

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-test/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-test/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,9 +1,14 @@
-# 0.2.0-alpha.5 (September 19, 2019)
+# 0.3.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
+# 0.3.0-alpha.5 (September 19, 2019)
 
 ### Changed
 - rename `sleep` to `delay_for` (#1518).
 
-# 0.2.0-alpha.4 (August 29, 2019)
+# 0.3.0-alpha.4 (August 29, 2019)
 
 - Track tokio release.
 

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-timer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.3.0-alpha.5/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.3.0-alpha.6/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """
@@ -24,8 +24,8 @@ Timer facilities for Tokio
 async-traits = []
 
 [dependencies]
-tokio-executor = { version = "=0.2.0-alpha.5", path = "../tokio-executor" }
-tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync" }
+tokio-executor = { version = "=0.2.0-alpha.6", path = "../tokio-executor" }
+tokio-sync = { version = "=0.2.0-alpha.6", path = "../tokio-sync" }
 
 futures-core-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"
@@ -36,9 +36,9 @@ slab = "0.4.1"
 # optionals
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-sync = { version = "=0.2.0-alpha.5", path = "../tokio-sync", features = ["async-traits"] }
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-sync = { version = "=0.2.0-alpha.6", path = "../tokio-sync", features = ["async-traits"] }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 rand = "0.7"
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.3.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.3.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-tls/CHANGELOG.md
+++ b/tokio-tls/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.3.0-alpha.5 (September 19, 2019)
 
 ### Added

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -8,13 +8,13 @@ name = "tokio-tls"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.0-alpha.5"
+version = "0.3.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-tls/0.3.0-alpha.5/tokio_tls/"
+documentation = "https://docs.rs/tokio-tls/0.3.0-alpha.6/tokio_tls/"
 description = """
 An implementation of TLS/SSL streams for Tokio giving an implementation of TLS
 for nonblocking I/O streams.
@@ -26,11 +26,11 @@ travis-ci = { repository = "tokio-rs/tokio-tls" }
 
 [dependencies]
 native-tls = "0.2"
-tokio-io = { version = "=0.2.0-alpha.5", path = "../tokio-io" }
+tokio-io = { version = "=0.2.0-alpha.6", path = "../tokio-io" }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.5", path = "../tokio" }
-tokio-net = { version = "=0.2.0-alpha.5", path = "../tokio-net", features = ["tcp", "async-traits"] }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio-net = { version = "=0.2.0-alpha.6", path = "../tokio-net", features = ["tcp", "async-traits"] }
 
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-tls/0.3.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-tls/0.3.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,11 @@
 This changelog only applies to the `tokio` crate proper. Each sub crate
 maintains its own changelog tracking changes made in each respective sub crate.
 
+# 0.2.0-alpha.6 (September 30, 2019)
+
+- Move to `futures-*-preview 0.3.0-alpha.19`
+- Move to `pin-project 0.4`
+
 # 0.2.0-alpha.5 (September 19, 2019)
 
 ### Changed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.0-alpha.5"
+version = "0.2.0-alpha.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.0-alpha.5/tokio/"
+documentation = "https://docs.rs/tokio/0.2.0-alpha.6/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -71,22 +71,22 @@ futures-util-preview = { version = "=0.3.0-alpha.19", features = ["sink"] }
 # Everything else is optional...
 bytes = { version = "0.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
-tokio-codec = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-codec" }
-tokio-fs = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-fs" }
-tokio-io = { version = "=0.2.0-alpha.5", optional = true, features = ["util"], path = "../tokio-io" }
-tokio-executor = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-executor" }
-tokio-macros = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-macros" }
-tokio-net = { version = "=0.2.0-alpha.5", optional = true, features = ["async-traits"], path = "../tokio-net" }
-tokio-sync = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-sync", features = ["async-traits"] }
-tokio-timer = { version = "=0.3.0-alpha.5", optional = true, path = "../tokio-timer", features = ["async-traits"] }
+tokio-codec = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-codec" }
+tokio-fs = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-fs" }
+tokio-io = { version = "=0.2.0-alpha.6", optional = true, features = ["util"], path = "../tokio-io" }
+tokio-executor = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-executor" }
+tokio-macros = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-macros" }
+tokio-net = { version = "=0.2.0-alpha.6", optional = true, features = ["async-traits"], path = "../tokio-net" }
+tokio-sync = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-sync", features = ["async-traits"] }
+tokio-timer = { version = "=0.3.0-alpha.6", optional = true, path = "../tokio-timer", features = ["async-traits"] }
 tracing-core = { version = "0.1", optional = true }
 
 [target.'cfg(feature = "tracing")'.dependencies]
-tokio-net = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-net", features = ["tracing", "async-traits"] }
-tokio-executor = { version = "=0.2.0-alpha.5", optional = true, path = "../tokio-executor", features = ["tracing"] }
+tokio-net = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-net", features = ["tracing", "async-traits"] }
+tokio-executor = { version = "=0.2.0-alpha.6", optional = true, path = "../tokio-executor", features = ["tracing"] }
 
 [dev-dependencies]
-tokio-test = { version = "=0.2.0-alpha.5", path = "../tokio-test" }
+tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 futures-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.0-alpha.6")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Note that `tokio-timer` and `tokio-tls` become 0.3.0-alpha.6 (not 0.2.0).

This changes all the CHANGELOGs in the same way -- we may want to gather more details?