### PR TITLE
Fix rust-lang/rust#64477 & rust-lang/rust#64856

### DIFF
--- a/tokio-fs/examples/std-echo.rs
+++ b/tokio-fs/examples/std-echo.rs
@@ -19,8 +19,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             while let Some(line) = input.next().await {
                 let line = line?;
-                output.send(format!("OUT: {}", line)).await?;
-                error.send(format!("ERR: {}", line)).await?;
+                // https://github.com/rust-lang/rust/pull/64856
+                let s = format!("OUT: {}", line);
+                output.send(s).await?;
+                let s = format!("ERR: {}", line);
+                error.send(s).await?;
             }
             Ok(())
         }


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/64477 means that `foo(format!(...)).await` is broken. https://github.com/rust-lang/rust/pull/64856 fixes it, but hasn't landed yet (and may never). See https://github.com/rust-lang/rust/issues/64477#issuecomment-534669068 for a detailed explanation.