### PR TITLE
Expose `try_wait` method to `Child`

### DIFF
--- a/tokio-net/src/process/mod.rs
+++ b/tokio-net/src/process/mod.rs
@@ -725,6 +725,10 @@ impl Child {
         self.child.inner.id()
     }
 
+    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
+        self.child.inner.try_wait()
+    }
+
     /// Forces the child to exit.
     ///
     /// This is equivalent to sending a SIGKILL on unix platforms.


### PR DESCRIPTION
Expose `try_wait` method to `Child`, using the existing implementations for Unix and Windows.

## Motivation

The standard library exposes the `try_wait` method for `process::Child` instances spawned with `Command`. This allows the user to check if the process is still alive.

In tokio async processes, the `Wait::try_wait` method is `pub(crate)`, which makes it unavailable for library consumers.

## Solution

Since `try_wait` is implemented for both platforms, we just expose it as a method of `Child` in the overall module.

## TODO before merging
- [ ] Public API documentation
- [ ] Testing
