### PR TITLE
macros: Use more consistent runtime names

### DIFF
--- a/build-tests/tests/fail/macros_invalid_input.rs
+++ b/build-tests/tests/fail/macros_invalid_input.rs
@@ -6,7 +6,7 @@ fn main_is_not_async() {}
 #[tokio::main(foo)]
 async fn main_attr_has_unknown_args() {}
 
-#[tokio::main(multi_thread::bar)]
+#[tokio::main(threadpool::bar)]
 async fn main_attr_has_path_args() {}
 
 #[tokio::test]

--- a/build-tests/tests/fail/macros_invalid_input.stderr
+++ b/build-tests/tests/fail/macros_invalid_input.stderr
@@ -4,7 +4,7 @@ error: the async keyword is missing from the function declaration
 4 | fn main_is_not_async() {}
   | ^^
 
-error: Unknown attribute foo is specified; expected `single_thread` or `multi_thread`
+error: Unknown attribute foo is specified; expected `current_thread` or `threadpool`
  --> $DIR/macros_invalid_input.rs:6:15
   |
 6 | #[tokio::main(foo)]
@@ -13,8 +13,8 @@ error: Unknown attribute foo is specified; expected `single_thread` or `multi_th
 error: Must have specified ident
  --> $DIR/macros_invalid_input.rs:9:15
   |
-9 | #[tokio::main(multi_thread::bar)]
-  |               ^^^^^^^^^^^^^^^^^
+9 | #[tokio::main(threadpool::bar)]
+  |               ^^^^^^^^^^^^^^^
 
 error: the async keyword is missing from the function declaration
   --> $DIR/macros_invalid_input.rs:13:1
@@ -28,7 +28,7 @@ error: the test function cannot accept arguments
 16 | async fn test_fn_has_args(_x: u8) {}
    |                           ^^^^^^
 
-error: Unknown attribute foo is specified; expected `single_thread` or `multi_thread`
+error: Unknown attribute foo is specified; expected `current_thread` or `threadpool`
   --> $DIR/macros_invalid_input.rs:18:15
    |
 18 | #[tokio::test(foo)]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -28,8 +28,8 @@ enum RuntimeType {
 ///
 /// ## Options:
 ///
-/// - `single_thread` - Uses `current_thread`.
-/// - `multi_thread` - Uses multi-threaded runtime. Used by default.
+/// - `current_thread` - Uses the `current_thread` runtime.
+/// - `threadpool` - Uses the multi-threaded `threadpool` runtime. Used by default.
 ///
 /// ## Function arguments:
 ///
@@ -40,7 +40,7 @@ enum RuntimeType {
 /// ### Select runtime
 ///
 /// ```rust
-/// #[tokio::main(single_thread)]
+/// #[tokio::main(current_thread)]
 /// async fn main() {
 ///     println!("Hello world");
 /// }
@@ -87,10 +87,10 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
                 return syn::Error::new_spanned(path, msg).to_compile_error().into();
             }
             match ident.unwrap().to_string().to_lowercase().as_str() {
-                "multi_thread" => runtime = RuntimeType::Multi,
-                "single_thread" => runtime = RuntimeType::Single,
+                "threadpool" => runtime = RuntimeType::Multi,
+                "current_thread" => runtime = RuntimeType::Single,
                 name => {
-                    let msg = format!("Unknown attribute {} is specified; expected `single_thread` or `multi_thread`", name);
+                    let msg = format!("Unknown attribute {} is specified; expected `current_thread` or `threadpool`", name);
                     return syn::Error::new_spanned(path, msg).to_compile_error().into();
                 }
             }
@@ -126,15 +126,15 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Options:
 ///
-/// - `single_thread` - Uses `current_thread`. Used by default.
-/// - `multi_thread` - Uses multi-threaded runtime.
+/// - `current_thread` - Uses the `current_thread` runtime. Used by default.
+/// - `threadpool` - Uses multi-threaded runtime.
 ///
 /// ## Usage
 ///
 /// ### Select runtime
 ///
 /// ```no_run
-/// #[tokio::test(multi_thread)]
+/// #[tokio::test(threadpool)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -189,10 +189,10 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
                 return syn::Error::new_spanned(path, msg).to_compile_error().into();
             }
             match ident.unwrap().to_string().to_lowercase().as_str() {
-                "multi_thread" => runtime = RuntimeType::Multi,
-                "single_thread" => runtime = RuntimeType::Single,
+                "threadpool" => runtime = RuntimeType::Multi,
+                "current_thread" => runtime = RuntimeType::Single,
                 name => {
-                    let msg = format!("Unknown attribute {} is specified; expected `single_thread` or `multi_thread`", name);
+                    let msg = format!("Unknown attribute {} is specified; expected `current_thread` or `threadpool`", name);
                     return syn::Error::new_spanned(path, msg).to_compile_error().into();
                 }
             }


### PR DESCRIPTION
As discussed in #1620, the attribute names for `#[tokio::main]` and `#[tokio::test]` aren't great. Specifically, they both use `single_thread` and `multi_thread`, as opposed to names that match the runtime names: `current_thread` and `threadpool`. This PR changes the former to the latter.

Fixes #1627.