### PR TITLE
udp::split: make API consistent

### DIFF
--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -1,4 +1,4 @@
-use super::split::{split, UdpSocketRecvHalf, UdpSocketSendHalf};
+use super::split::{split, split_owned, RecvHalf, SendHalf, RecvHalfOwned, SendHalfOwned};
 use crate::driver::Handle;
 use crate::util::PollEvented;
 use crate::ToSocketAddrs;
@@ -71,8 +71,18 @@ impl UdpSocket {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split(&mut self) -> (UdpSocketRecvHalf<'_>, UdpSocketSendHalf<'_>) {
+    pub fn split(&mut self) -> (RecvHalf<'_>, SendHalf<'_>) {
         split(self)
+    }
+
+    /// Split the `UdpSocket` into a receive half and a send half. The two parts
+    /// can be used to receive and send datagrams concurrently, even from two
+    /// different tasks.
+    ///
+    /// See the module level documenation of [`split`](super::split) for more
+    /// details.
+    pub fn split_owned(self) -> (RecvHalfOwned, SendHalfOwned) {
+        split_owned(self)
     }
 
     /// Returns the local address that this socket is bound to.

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -1,4 +1,4 @@
-use super::split::{split, split_owned, RecvHalf, SendHalf, RecvHalfOwned, SendHalfOwned};
+use super::split::{split, split_owned, RecvHalf, RecvHalfOwned, SendHalf, SendHalfOwned};
 use crate::driver::Handle;
 use crate::util::PollEvented;
 use crate::ToSocketAddrs;

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -71,7 +71,7 @@ impl UdpSocket {
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.
-    pub fn split(self) -> (UdpSocketRecvHalf, UdpSocketSendHalf) {
+    pub fn split(&mut self) -> (UdpSocketRecvHalf<'_>, UdpSocketSendHalf<'_>) {
         split(self)
     }
 

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -66,8 +66,7 @@ impl UdpSocket {
     }
 
     /// Split the `UdpSocket` into a receive half and a send half. The two parts
-    /// can be used to receive and send datagrams concurrently, even from two
-    /// different tasks.
+    /// can be used to receive and send datagrams concurrently.
     ///
     /// See the module level documenation of [`split`](super::split) for more
     /// details.

--- a/tokio-net/src/udp/split.rs
+++ b/tokio-net/src/udp/split.rs
@@ -110,14 +110,14 @@ impl AsRef<UdpSocket> for RecvHalf<'_> {
     }
 }
 
-/// The send half after [`split`](super::UdpSocket::split).
+/// The send half after [`split_owned`](super::UdpSocket::split_owned).
 ///
 /// Use [`send_to`](#method.send_to) or [`send`](#method.send) to send
 /// datagrams.
 #[derive(Debug)]
 pub struct SendHalfOwned(Arc<UdpSocket>);
 
-/// The recv half after [`split`](super::UdpSocket::split).
+/// The recv half after [`split_owned`](super::UdpSocket::split_owned).
 ///
 /// Use [`recv_from`](#method.recv_from) or [`recv`](#method.recv) to receive
 /// datagrams.
@@ -163,7 +163,7 @@ fn reunite(s: SendHalfOwned, r: RecvHalfOwned) -> Result<UdpSocket, ReuniteError
 impl RecvHalfOwned {
     /// Attempts to put the two "halves" of a `UdpSocket` back together and
     /// recover the original socket. Succeeds only if the two "halves"
-    /// originated from the same call to `UdpSocket::split`.
+    /// originated from the same call to `UdpSocket::split_owned`.
     pub fn reunite(self, other: SendHalfOwned) -> Result<UdpSocket, ReuniteError> {
         reunite(other, self)
     }
@@ -198,7 +198,7 @@ impl RecvHalfOwned {
 impl SendHalfOwned {
     /// Attempts to put the two "halves" of a `UdpSocket` back together and
     /// recover the original socket. Succeeds only if the two "halves"
-    /// originated from the same call to `UdpSocket::split`.
+    /// originated from the same call to `UdpSocket::split_owned`.
     pub fn reunite(self, other: RecvHalfOwned) -> Result<UdpSocket, ReuniteError> {
         reunite(self, other)
     }

--- a/tokio-net/src/udp/split.rs
+++ b/tokio-net/src/udp/split.rs
@@ -14,13 +14,13 @@
 
 use super::UdpSocket;
 
+use crate::ToSocketAddrs;
 use futures_util::future::poll_fn;
 use std::error::Error;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use crate::ToSocketAddrs;
 
 /// The send half after [`split`](super::UdpSocket::split).
 ///
@@ -109,7 +109,6 @@ impl AsRef<UdpSocket> for RecvHalf<'_> {
         self.0
     }
 }
-
 
 /// The send half after [`split`](super::UdpSocket::split).
 ///

--- a/tokio-net/src/udp/split.rs
+++ b/tokio-net/src/udp/split.rs
@@ -15,8 +15,11 @@
 use super::UdpSocket;
 
 use futures_util::future::poll_fn;
+use std::error::Error;
+use std::fmt;
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 use crate::ToSocketAddrs;
 
 /// The send half after [`split`](super::UdpSocket::split).
@@ -24,20 +27,20 @@ use crate::ToSocketAddrs;
 /// Use [`send_to`](#method.send_to) or [`send`](#method.send) to send
 /// datagrams.
 #[derive(Debug)]
-pub struct UdpSocketSendHalf<'a>(&'a UdpSocket);
+pub struct SendHalf<'a>(&'a UdpSocket);
 
 /// The recv half after [`split`](super::UdpSocket::split).
 ///
 /// Use [`recv_from`](#method.recv_from) or [`recv`](#method.recv) to receive
 /// datagrams.
 #[derive(Debug)]
-pub struct UdpSocketRecvHalf<'a>(&'a UdpSocket);
+pub struct RecvHalf<'a>(&'a UdpSocket);
 
-pub(crate) fn split(socket: &mut UdpSocket) -> (UdpSocketRecvHalf<'_>, UdpSocketSendHalf<'_>) {
-    (UdpSocketRecvHalf(&*socket), UdpSocketSendHalf(&*socket))
+pub(crate) fn split(socket: &mut UdpSocket) -> (RecvHalf<'_>, SendHalf<'_>) {
+    (RecvHalf(&*socket), SendHalf(&*socket))
 }
 
-impl<'a> UdpSocketRecvHalf<'a> {
+impl<'a> RecvHalf<'a> {
     /// Returns a future that receives a single datagram on the socket. On success,
     /// the future resolves to the number of bytes read and the origin.
     ///
@@ -65,7 +68,7 @@ impl<'a> UdpSocketRecvHalf<'a> {
     }
 }
 
-impl<'a> UdpSocketSendHalf<'a> {
+impl<'a> SendHalf<'a> {
     /// Returns a future that sends data on the socket to the given address.
     /// On success, the future will resolve to the number of bytes written.
     ///
@@ -95,14 +98,149 @@ impl<'a> UdpSocketSendHalf<'a> {
     }
 }
 
-impl AsRef<UdpSocket> for UdpSocketSendHalf<'_> {
+impl AsRef<UdpSocket> for SendHalf<'_> {
     fn as_ref(&self) -> &UdpSocket {
         self.0
     }
 }
 
-impl AsRef<UdpSocket> for UdpSocketRecvHalf<'_> {
+impl AsRef<UdpSocket> for RecvHalf<'_> {
     fn as_ref(&self) -> &UdpSocket {
         self.0
+    }
+}
+
+
+/// The send half after [`split`](super::UdpSocket::split).
+///
+/// Use [`send_to`](#method.send_to) or [`send`](#method.send) to send
+/// datagrams.
+#[derive(Debug)]
+pub struct SendHalfOwned(Arc<UdpSocket>);
+
+/// The recv half after [`split`](super::UdpSocket::split).
+///
+/// Use [`recv_from`](#method.recv_from) or [`recv`](#method.recv) to receive
+/// datagrams.
+#[derive(Debug)]
+pub struct RecvHalfOwned(Arc<UdpSocket>);
+
+pub(crate) fn split_owned(socket: UdpSocket) -> (RecvHalfOwned, SendHalfOwned) {
+    let shared = Arc::new(socket);
+    let send = shared.clone();
+    let recv = shared;
+    (RecvHalfOwned(recv), SendHalfOwned(send))
+}
+
+/// Error indicating two halves were not from the same socket, and thus could
+/// not be `reunite`d.
+#[derive(Debug)]
+pub struct ReuniteError(pub SendHalfOwned, pub RecvHalfOwned);
+
+impl fmt::Display for ReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same socket"
+        )
+    }
+}
+
+impl Error for ReuniteError {}
+
+fn reunite(s: SendHalfOwned, r: RecvHalfOwned) -> Result<UdpSocket, ReuniteError> {
+    if Arc::ptr_eq(&s.0, &r.0) {
+        drop(r);
+        // Only two instances of the `Arc` are ever created, one for the
+        // receiver and one for the sender, and those `Arc`s are never exposed
+        // externally. And so when we drop one here, the other one must be the
+        // only remaining one.
+        Ok(Arc::try_unwrap(s.0).expect("udp: try_unwrap failed in reunite"))
+    } else {
+        Err(ReuniteError(s, r))
+    }
+}
+
+impl RecvHalfOwned {
+    /// Attempts to put the two "halves" of a `UdpSocket` back together and
+    /// recover the original socket. Succeeds only if the two "halves"
+    /// originated from the same call to `UdpSocket::split`.
+    pub fn reunite(self, other: SendHalfOwned) -> Result<UdpSocket, ReuniteError> {
+        reunite(other, self)
+    }
+
+    /// Returns a future that receives a single datagram on the socket. On success,
+    /// the future resolves to the number of bytes read and the origin.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size
+    /// to hold the message bytes. If a message is too long to fit in the supplied
+    /// buffer, excess bytes may be discarded.
+    pub async fn recv_from(&mut self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        poll_fn(|cx| self.0.poll_recv_from_priv(cx, buf)).await
+    }
+
+    /// Returns a future that receives a single datagram message on the socket from
+    /// the remote address to which it is connected. On success, the future will resolve
+    /// to the number of bytes read.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size to
+    /// hold the message bytes. If a message is too long to fit in the supplied buffer,
+    /// excess bytes may be discarded.
+    ///
+    /// The [`connect`] method will connect this socket to a remote address. The future
+    /// will fail if the socket is not connected.
+    ///
+    /// [`connect`]: super::UdpSocket::connect
+    pub async fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        poll_fn(|cx| self.0.poll_recv_priv(cx, buf)).await
+    }
+}
+
+impl SendHalfOwned {
+    /// Attempts to put the two "halves" of a `UdpSocket` back together and
+    /// recover the original socket. Succeeds only if the two "halves"
+    /// originated from the same call to `UdpSocket::split`.
+    pub fn reunite(self, other: RecvHalfOwned) -> Result<UdpSocket, ReuniteError> {
+        reunite(self, other)
+    }
+
+    /// Returns a future that sends data on the socket to the given address.
+    /// On success, the future will resolve to the number of bytes written.
+    ///
+    /// The future will resolve to an error if the IP version of the socket does
+    /// not match that of `target`.
+    pub async fn send_to<A: ToSocketAddrs>(&mut self, buf: &[u8], target: A) -> io::Result<usize> {
+        let mut addrs = target.to_socket_addrs().await?;
+
+        match addrs.next() {
+            Some(target) => poll_fn(|cx| self.0.poll_send_to_priv(cx, buf, &target)).await,
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "no addresses to send data to",
+            )),
+        }
+    }
+
+    /// Returns a future that sends data on the socket to the remote address to which it is connected.
+    /// On success, the future will resolve to the number of bytes written.
+    ///
+    /// The [`connect`] method will connect this socket to a remote address. The future
+    /// will resolve to an error if the socket is not connected.
+    ///
+    /// [`connect`]: super::UdpSocket::connect
+    pub async fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
+        poll_fn(|cx| self.0.poll_send_priv(cx, buf)).await
+    }
+}
+
+impl AsRef<UdpSocket> for SendHalfOwned {
+    fn as_ref(&self) -> &UdpSocket {
+        &self.0
+    }
+}
+
+impl AsRef<UdpSocket> for RecvHalfOwned {
+    fn as_ref(&self) -> &UdpSocket {
+        &self.0
     }
 }

--- a/tokio-net/tests/udp.rs
+++ b/tokio-net/tests/udp.rs
@@ -4,7 +4,12 @@ use tokio_codec::{Decoder, Encoder};
 use tokio_net::udp::{UdpFramed, UdpSocket};
 
 use bytes::{BufMut, BytesMut};
-use futures_util::{future::{FutureExt, join}, sink::SinkExt, stream::StreamExt, try_future::try_join};
+use futures_util::{
+    future::{join, FutureExt},
+    sink::SinkExt,
+    stream::StreamExt,
+    try_future::try_join,
+};
 use std::io;
 
 #[tokio::test]
@@ -49,13 +54,17 @@ async fn split() -> std::io::Result<()> {
 
     let msg = b"hello";
     let addr = s.as_ref().local_addr()?;
-    join(async move {
-        s.send_to(msg, &addr).await.unwrap();
-    }, async move {
-        let mut recv_buf = [0u8; 32];
-        let (len, _) = r.recv_from(&mut recv_buf[..]).await.unwrap();
-        assert_eq!(&recv_buf[..len], msg);
-    }).await;
+    join(
+        async move {
+            s.send_to(msg, &addr).await.unwrap();
+        },
+        async move {
+            let mut recv_buf = [0u8; 32];
+            let (len, _) = r.recv_from(&mut recv_buf[..]).await.unwrap();
+            assert_eq!(&recv_buf[..len], msg);
+        },
+    )
+    .await;
     Ok(())
 }
 

--- a/tokio/examples/connect.rs
+++ b/tokio/examples/connect.rs
@@ -115,7 +115,7 @@ mod udp {
     use futures::{future, Sink, SinkExt, Stream, StreamExt};
     use std::{error::Error, io, net::SocketAddr};
     use tokio::net::udp::{
-        split::{UdpSocketRecvHalf, UdpSocketSendHalf},
+        split::{RecvHalf, SendHalf},
         UdpSocket,
     };
 
@@ -143,7 +143,7 @@ mod udp {
 
     async fn send(
         mut stdin: impl Stream<Item = Result<Vec<u8>, io::Error>> + Unpin,
-        writer: &mut UdpSocketSendHalf,
+        writer: &mut SendHalf<'_>,
     ) -> Result<(), io::Error> {
         while let Some(item) = stdin.next().await {
             let buf = item?;
@@ -155,7 +155,7 @@ mod udp {
 
     async fn recv(
         mut stdout: impl Sink<Vec<u8>, Error = io::Error> + Unpin,
-        reader: &mut UdpSocketRecvHalf,
+        reader: &mut RecvHalf<'_>,
     ) -> Result<(), io::Error> {
         loop {
             let mut buf = vec![0; 1024];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
The original discussion can be found in #1226.

The API design of `udp::split` is inconsistent with `tcp::split`. This PR changes the API to make it consistent with `tcp::split` and `io::split`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


Changes:

- `UdpSocket::split`

  Before:
  ```rust
  fn split(self) -> (UdpSocketRecvHalf, UdpSocketSendHalf)
  ```

  After:
  ```rust
  fn split(&mut self) -> (RecvHalf<'_>, SendHalf<'_>)
  ```

  Reference: `TcpStream::split`

  ```rust
  fn split(&mut self) -> (ReadHalf<'_>, WriteHalf<'_>)
  ```

- Add `UdpSocket::split_owned`:

  ```rust
  fn split_owned(self) -> (RecvHalfOwned, SendHalfOwned)
  ```

  Reference: `io::split`

  ```rust
  fn split<T>(stream: T) -> (ReadHalf<T>, WriteHalf<T>)
  ```

- Add `RecvHalf` & `SendHalf`
- Rename `UdpSocketRecvHalf` & `UdpSocketSendHalf` to `RecvHalfOwned` & `SendHalfOwned`
- `SendHalfOwned::send_to` now accepts `impl ToSocketAddrs`

  Before:
  ```rust
  fn send_to(
      &'_ mut self,
      buf: &'_ [u8],
      target: &'_ SocketAddr
  ) -> impl Future<Output = Result<usize, Error>>
  ```

  After:
  ```rust
  async fn send_to<A: ToSocketAddrs>(&mut self, buf: &[u8], target: A) -> Result<usize>
  ```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
