### PR TITLE
timer: test arm on targets with target_has_atomic less than 64

### DIFF
--- a/ci/azure-cross-compile.yml
+++ b/ci/azure-cross-compile.yml
@@ -17,7 +17,7 @@ jobs:
         target: mips-unknown-linux-gnu
       arm:
         vmImage: ubuntu-16.04
-        target: arm-unknown-linux-gnueabi
+        target: arm-linux-androideabi
   pool:
     vmImage: $(vmImage)
   steps:

--- a/tokio-timer/src/atomic.rs
+++ b/tokio-timer/src/atomic.rs
@@ -7,6 +7,7 @@ pub(crate) use self::imp::AtomicU64;
 // `AtomicU64` can only be used on targets with `target_has_atomic` is 64 or greater.
 // Once `cfg_target_has_atomic` feature is stable, we can replace it with
 // `#[cfg(target_has_atomic = "64")]`.
+// Refs: https://github.com/rust-lang/rust/tree/master/src/librustc_target
 #[cfg(not(any(target_arch = "arm", target_arch = "mips", target_arch = "powerpc")))]
 mod imp {
     pub(crate) use std::sync::atomic::AtomicU64;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

As mentioned in https://github.com/tokio-rs/tokio/pull/1581#discussion_r331846074, it seems [`arm-unknown-linux-gnueabi` has `AtomicU64`](https://github.com/rust-lang/rust/blob/4ac4809ccf5f77083ae7155dcc83e921341c2614/src/librustc_target/spec/arm_unknown_linux_gnueabi.rs#L5).

Among `target_arch = "arm"` targets supported by cross, the following targets have `target_has_atomic` less than 64:
* [arm-linux-androideabi](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/arm_linux_androideabi.rs#L7)
* [armv5te-unknown-linux-musleabi](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/armv5te_unknown_linux_musleabi.rs#L23)
* [thumbv7em-none-eabi](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/thumbv7em_none_eabi.rs#L28)
* [thumbv7em-none-eabihf](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/thumbv7em_none_eabihf.rs#L37)
* [thumbv7m-none-eabi](https://github.com/rust-lang/rust/blob/master/src/librustc_target/spec/thumbv7m_none_eabi.rs#L19)

However, `thumbv*m-none-eabi*` targets don't have `std`, so it cannot compile.

Refs: 
* https://github.com/rust-embedded/cross#supported-targets
* https://github.com/rust-lang/rust/tree/master/src/librustc_target


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
