### PR TITLE
tokio: move `signal` and `process` reexports to crate root

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,10 @@ jobs:
         - codec
         - fs
         - io
-        - rt-full
         - net
+        - process
+        - rt-full
+        - signal
         - sync
         - tcp
         - timer

--- a/tokio-net/tests/process_issue_42.rs
+++ b/tokio-net/tests/process_issue_42.rs
@@ -42,7 +42,7 @@ fn run_test() {
         finished_clone.store(true, Ordering::SeqCst);
     });
 
-    thread::sleep(Duration::from_millis(100));
+    thread::sleep(Duration::from_millis(1000));
     assert!(
         finished.load(Ordering::SeqCst),
         "FINISHED flag not set, maybe we deadlocked?"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -29,7 +29,9 @@ default = [
   "fs",
   "io",
   "net",
+  "process",
   "rt-full",
+  "signal",
   "sync",
   "timer",
 ]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -92,6 +92,10 @@ pub mod io;
 #[cfg(any(feature = "tcp", feature = "udp", feature = "uds"))]
 pub mod net;
 pub mod prelude;
+#[cfg(feature = "process")]
+pub mod process;
+#[cfg(feature = "signal")]
+pub mod signal;
 pub mod stream;
 #[cfg(feature = "sync")]
 pub mod sync;

--- a/tokio/src/net.rs
+++ b/tokio/src/net.rs
@@ -57,20 +57,6 @@ pub mod udp {
 #[cfg(feature = "udp")]
 pub use self::udp::{UdpFramed, UdpSocket};
 
-#[cfg(feature = "signal")]
-pub mod signal {
-    //! Asynchronous signal handling for `tokio`. ctrl-C notifications are
-    //! supported on both unix and windows systems. For finer grained signal
-    //! handling support on unix systems, see `tokio_net::signal::unix::Signal`.
-    pub use tokio_net::signal::ctrl_c;
-}
-
-#[cfg(feature = "process")]
-pub mod process {
-    //! An implementation of asynchronous process management for Tokio.
-    pub use tokio_net::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};
-}
-
 #[cfg(all(unix, feature = "uds"))]
 pub mod unix {
     //! Unix domain socket bindings for `tokio` (only available on unix systems).

--- a/tokio/src/process.rs
+++ b/tokio/src/process.rs
@@ -1,0 +1,2 @@
+//! An implementation of asynchronous process management for Tokio.
+pub use tokio_net::process::{Child, ChildStderr, ChildStdin, ChildStdout, Command};

--- a/tokio/src/signal.rs
+++ b/tokio/src/signal.rs
@@ -1,0 +1,4 @@
+//! Asynchronous signal handling for `tokio`. ctrl-C notifications are
+//! supported on both unix and windows systems. For finer grained signal
+//! handling support on unix systems, see `tokio_net::signal::unix::Signal`.
+pub use tokio_net::signal::ctrl_c;


### PR DESCRIPTION
### Motivation
Currently, the `signal` and `process` functionality is rexported in the main `tokio` crate under `tokio::net` since the actual implementations live in the `tokio_net` crate. However, this is causing some confusion for where to find the imports as reported in #1563

## Solution
We instead reexport the public types directly under `tokio::{signal, process}` to make discovery easier.
