### PR TITLE
Impl AsRawFd for tokio::fs::File

### DIFF
--- a/tokio-fs/src/file.rs
+++ b/tokio-fs/src/file.rs
@@ -608,3 +608,19 @@ impl fmt::Debug for File {
             .finish()
     }
 }
+
+#[cfg(unix)]
+pub(crate) mod os {
+    use super::File;
+    use std::os::unix::io::{AsRawFd, RawFd};
+
+    impl AsRawFd for File {
+        fn as_raw_fd(&self) -> RawFd {
+            let std = self.std.clone();
+            (&*std).as_raw_fd()
+        }
+    }
+}
+
+#[cfg(not(unix))]
+pub(crate) mod os {}

--- a/tokio-fs/src/lib.rs
+++ b/tokio-fs/src/lib.rs
@@ -82,6 +82,8 @@ pub use crate::write::write;
 
 use std::io;
 
+pub use file::os::*;
+
 async fn asyncify<F, T>(f: F) -> io::Result<T>
 where
     F: FnOnce() -> io::Result<T> + Send + 'static,

--- a/tokio-fs/tests/file.rs
+++ b/tokio-fs/tests/file.rs
@@ -48,6 +48,22 @@ fn tempfile() -> NamedTempFile {
     NamedTempFile::new().unwrap()
 }
 
+#[cfg(unix)]
+mod unix_text {
+    use super::*;
+    use std::os::unix::io::AsRawFd;
+
+    #[test]
+    fn unix_can_access_file_fd() {
+        let tempfile = tempfile();
+        let file = std::fs::File::create(tempfile.path()).unwrap();
+        let file_fd = file.as_raw_fd();
+        let async_file = File::from_std(file);
+        let async_file_fd = async_file.as_raw_fd();
+        assert_eq!(file_fd, async_file_fd)
+    }
+}
+
 /*
 mod pool;
 

--- a/tokio-fs/tests/sys/file.rs
+++ b/tokio-fs/tests/sys/file.rs
@@ -263,3 +263,15 @@ impl fmt::Debug for File {
         fmt.debug_struct("mock::File").finish()
     }
 }
+
+#[cfg(unix)]
+pub(crate) mod os {
+    use super::File;
+    use std::os::unix::io::{AsRawFd, RawFd};
+
+    impl AsRawFd for File {
+        fn as_raw_fd(&self) -> RawFd {
+            -1 as RawFd
+        }
+    }
+}


### PR DESCRIPTION
Hey! This is my first open source rust PR to a major project, so please let me know if anything looks wrong, or if there's a better practice to implement this!

There are cases where a user may want to grab the underlying fd of a
tokio::fs::File, example: if a user wanted to use a non-blocking splice
copy to the file, they would need to be able to pull out the RawFd.
Since std::fs::File implements this, it seems like a safe thing to
expose from tokio::fs::File.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was implementing a non-blocking splice copy, but found that `tokio::fs::File` does not implement `AsRawFd` which was surprising since `std::fs::File` implements this. I thought it would be nice to add here as well.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The solution is pretty easy since the underlying std File type already implements this.