### PR TITLE
Remove incorrect FusedFuture impl on Delay

### DIFF
--- a/tokio-timer/src/delay.rs
+++ b/tokio-timer/src/delay.rs
@@ -91,13 +91,6 @@ impl Delay {
     }
 }
 
-#[cfg(feature = "async-traits")]
-impl futures_core::FusedFuture for Delay {
-    fn is_terminated(&self) -> bool {
-        self.is_elapsed()
-    }
-}
-
 impl Future for Delay {
     type Output = ();
 


### PR DESCRIPTION
Following a discussion on Discord

`is_terminated` must return `false` until the future has been polled at least once to make sure that the associated block in select is called even after the delay has elapsed.

You use `Delay` in a `select!` by [fusing it](https://docs.rs/futures-preview/0.3.0-alpha.19/futures/future/trait.FutureExt.html#method.fuse):

```rust
let delay = tokio::timer::delay(/* ... */);
let delay = delay.fuse();

select! {
    _ = delay => {
        /* work here */
    }
}
```