### PR TITLE
Minimal versions compat

### DIFF
--- a/tokio-io/Cargo.toml
+++ b/tokio-io/Cargo.toml
@@ -24,7 +24,6 @@ util = ["memchr", "pin-project"]
 
 [dependencies]
 bytes = "0.4.7"
-log = "0.4"
 futures-core-preview = "=0.3.0-alpha.19"
 memchr = { version = "2.2", optional = true }
 pin-project = { version = "0.4", optional = true }

--- a/tokio-net/Cargo.toml
+++ b/tokio-net/Cargo.toml
@@ -99,7 +99,6 @@ optional = true
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 num_cpus = "1.8.0"
-tokio-io-pool = "0.1.4"
 
 # UDS tests
 tempfile = "3"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -85,7 +85,6 @@ futures-preview = "=0.3.0-alpha.19"
 futures-util-preview = "=0.3.0-alpha.19"
 pin-utils = "=0.1.0-alpha.4"
 env_logger = { version = "0.6", default-features = false }
-flate2 = { version = "1", features = ["tokio"] }
 http = "0.1"
 httparse = "1.0"
 libc = "0.2"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -93,7 +93,7 @@ rand = "0.7.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tempfile = "3.1.0"
-time = "0.1"
+time = "0.1.34"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Bump minimum versions so that `-Z minimum-versions` compilation (mostly) works. Once dtolnay/trybuild#37 has a release, the `build-tests` crate can use that as a minimum. This patchset was made with removing `build-tests` from the workspace so that compilation succeeded in the meantime.

I also removed unused dependencies in the meantime (`flate2` was particularly useful since it was using tokio-0.1 anyways).

## Motivation

`-Z minimum-versions` is becoming more of a thing and `tokio` should work with it since it is so prevalent.

## Solution

Find oldest versions of crates that failed to work with the flag and set that as the minimum version.