### PR TITLE
net: Eagerly bind resources to reactors

### DIFF
--- a/tokio-net/src/driver/mod.rs
+++ b/tokio-net/src/driver/mod.rs
@@ -24,6 +24,8 @@
 //! use tokio::net::TcpStream;
 //!
 //! # async fn process<T>(_t: T) {}
+//!
+//! # #[tokio::main]
 //! # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
 //! let stream = TcpStream::connect("93.184.216.34:9243").await?;
 //!
@@ -56,19 +58,15 @@
 //! the task to run on one of its worker threads. This results in the `and_then`
 //! closure to get executed.
 //!
-//! ## Lazy registration
+//! ## Eager registration
 //!
-//! Notice how the snippet above does not explicitly reference a reactor. When
-//! [`TcpStream::connect`] is called, it registers the socket with a reactor,
-//! but no reactor is specified. This works because the registration process
-//! mentioned above is actually lazy. It doesn't *actually* happen in the
-//! [`connect`] function. Instead, the registration is established the first
-//! time that the task is polled (again, see [runtime model]).
-//!
-//! A reactor instance is automatically made available when using the Tokio
-//! [runtime], which is done using [`tokio::run`]. The Tokio runtime's executor
-//! sets a thread-local variable referencing the associated [`Reactor`] instance
-//! and [`Handle::current`] (used by [`Registration`]) returns the reference.
+//! Notice how the snippet does not explicitly reference a reactor. When
+//! [`TcpStream::connect`] is called, it registers the socket with the current
+//! reactor, but no reactor is specified. This works because a reactor
+//! instance is automatically made available when using the Tokio [runtime],
+//! which is done using [`tokio::main`]. The Tokio runtime's executor sets a
+//! thread-local variable referencing the associated [`Reactor`] instance and
+//! [`Handle::current`] (used by [`Registration`]) returns the reference.
 //!
 //! ## Implementation
 //!

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -376,10 +376,15 @@ impl Unpark for Handle {
 }
 
 impl Default for Handle {
-    /// Returns a "default" handle, i.e., a handle that lazily binds to a reactor.
+    /// Returns a "default" handle, i.e., a handle that eagerly binds to a reactor.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if there is no current reactor.
     fn default() -> Handle {
+        let handle = HandlePriv::try_current().expect("no current reactor");
         Handle {
-            inner: Some(HandlePriv::try_current().unwrap()),
+            inner: Some(handle),
         }
     }
 }

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -350,9 +350,8 @@ impl Handle {
     ///
     /// # Returns
     ///
-    /// If there is handle set for the worker thread, returns `Ok<Handle>`.
-    ///
-    /// If there is no handle set for the worker thread, returns `Err`.
+    /// - `Ok<Handle>` if there is reactor set for the current thread
+    /// - `Err` if there is no reactor set for the current thread
     pub fn current() -> io::Result<Handle> {
         let inner = HandlePriv::try_current()?;
         Ok(Handle { inner: Some(inner) })

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -362,6 +362,11 @@ impl Handle {
             })
     }
 
+    pub(crate) fn try_current() -> io::Result<Handle> {
+        let inner = HandlePriv::try_current()?;
+        Ok(Handle { inner: Some(inner) })
+    }
+
     pub(crate) fn as_priv(&self) -> Option<&HandlePriv> {
         self.inner.as_ref()
     }
@@ -371,20 +376,6 @@ impl Unpark for Handle {
     fn unpark(&self) {
         if let Some(ref h) = self.inner {
             h.wakeup();
-        }
-    }
-}
-
-impl Default for Handle {
-    /// Returns a "default" handle, i.e., a handle that eagerly binds to a reactor.
-    ///
-    /// # Panics
-    ///
-    /// This function panics if there is no current reactor.
-    fn default() -> Handle {
-        let handle = HandlePriv::try_current().expect("no current reactor");
-        Handle {
-            inner: Some(handle),
         }
     }
 }

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -378,7 +378,7 @@ impl Unpark for Handle {
 impl Default for Handle {
     /// Returns a "default" handle, i.e., a handle that lazily binds to a reactor.
     fn default() -> Handle {
-        Handle { inner: None }
+        Handle { inner: Some(HandlePriv::try_current().unwrap()) }
     }
 }
 

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -378,7 +378,9 @@ impl Unpark for Handle {
 impl Default for Handle {
     /// Returns a "default" handle, i.e., a handle that lazily binds to a reactor.
     fn default() -> Handle {
-        Handle { inner: Some(HandlePriv::try_current().unwrap()) }
+        Handle {
+            inner: Some(HandlePriv::try_current().unwrap()),
+        }
     }
 }
 

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -39,9 +39,6 @@ pub struct Reactor {
 /// A `Handle` is used for associating I/O objects with an event loop
 /// explicitly. Typically though you won't end up using a `Handle` that often
 /// and will instead use the default reactor for the execution context.
-///
-/// By default, most components bind lazily to reactors.
-/// To get this behavior when manually passing a `Handle`, use `default()`.
 #[derive(Clone)]
 pub struct Handle {
     inner: Option<HandlePriv>,
@@ -349,20 +346,14 @@ impl fmt::Debug for Reactor {
 // ===== impl Handle =====
 
 impl Handle {
-    #[doc(hidden)]
-    #[deprecated(note = "semantics were sometimes surprising, use Handle::default()")]
-    pub fn current() -> Handle {
-        // TODO: Should this panic on error?
-        HandlePriv::try_current()
-            .map(|handle| Handle {
-                inner: Some(handle),
-            })
-            .unwrap_or(Handle {
-                inner: Some(HandlePriv { inner: Weak::new() }),
-            })
-    }
-
-    pub(crate) fn try_current() -> io::Result<Handle> {
+    /// Get a handle to the current reactor.
+    ///
+    /// # Returns
+    ///
+    /// If there is handle set for the worker thread, returns `Ok<Handle>`.
+    ///
+    /// If there is no handle set for the worker thread, returns `Err`.
+    pub fn current() -> io::Result<Handle> {
         let inner = HandlePriv::try_current()?;
         Ok(Handle { inner: Some(inner) })
     }

--- a/tokio-net/src/driver/reactor.rs
+++ b/tokio-net/src/driver/reactor.rs
@@ -330,7 +330,7 @@ impl Handle {
     /// # Panics
     ///
     /// This function panics if there is no current reactor set.
-    pub(crate) fn current() -> Self {
+    pub(super) fn current() -> Self {
         CURRENT_REACTOR.with(|current| match *current.borrow() {
             Some(ref handle) => handle.clone(),
             None => panic!("no current reactor"),

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -59,10 +59,7 @@ impl Registration {
     ///
     /// # Return
     ///
-    /// If the registration happened successfully, `Ok(true)` is returned.
-    ///
-    /// If an I/O resource has previously been successfully registered,
-    /// `Ok(false)` is returned.
+    /// If the registration happened successfully, `Ok` is returned.
     ///
     /// If an error is encountered during registration, `Err` is returned.
     pub fn register<T>(&mut self, io: &T) -> io::Result<()>
@@ -78,10 +75,7 @@ impl Registration {
     /// the first call will establish the registration. Subsequent calls will be
     /// no-ops.
     ///
-    /// If the registration happened successfully, `Ok(true)` is returned.
-    ///
-    /// If an I/O resource has previously been successfully registered,
-    /// `Ok(false)` is returned.
+    /// If the registration happened successfully, `Ok` is returned.
     ///
     /// If an error is encountered during registration, `Err` is returned.
     pub fn register_with<T>(&mut self, io: &T, handle: &Handle) -> io::Result<()>

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -59,9 +59,8 @@ impl Registration {
     ///
     /// # Return
     ///
-    /// If the registration happened successfully, `Ok` is returned.
-    ///
-    /// If an error is encountered during registration, `Err` is returned.
+    /// - `Ok` if the registration happened successfully
+    /// - `Err` if an error was encountered during registration
     pub fn register<T>(&mut self, io: &T) -> io::Result<()>
     where
         T: Evented,

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -2,11 +2,9 @@ use super::platform;
 use super::reactor::{Direction, Handle, HandlePriv};
 
 use mio::{self, Evented};
-use std::cell::UnsafeCell;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::task::{Context, Poll, Waker};
-use std::{io, ptr, usize};
+use std::{io, usize};
 
 /// Associates an I/O resource with the reactor instance that drives it.
 ///
@@ -39,12 +37,9 @@ use std::{io, ptr, usize};
 /// [`register`]: #method.register
 /// [`poll_read_ready`]: #method.poll_read_ready`]
 /// [`poll_write_ready`]: #method.poll_write_ready`]
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Registration {
-    /// Stores the handle. Once set, the value is not changed.
-    ///
-    /// Setting this requires acquiring the lock from state.
-    inner: UnsafeCell<Option<Inner>>,
+    inner: Option<Inner>,
 }
 
 #[derive(Debug)]
@@ -53,42 +48,9 @@ struct Inner {
     token: usize,
 }
 
-/// Tasks waiting on readiness notifications.
-// #[derive(Debug)]
-// struct Node {
-//     direction: Direction,
-//     waker: Waker,
-//     next: *mut Node,
-// }
-
-/// Initial state. The handle is not set and the registration is idle.
-// const INIT: usize = 0;
-
-/// A thread locked the state and will associate a handle.
-// const LOCKED: usize = 1;
-
-/// A handle has been associated with the registration.
-// const READY: usize = 2;
-
-/// Masks the lifecycle state
-// const LIFECYCLE_MASK: usize = 0b11;
-
-/// A fake token used to identify error situations
-const ERROR: usize = usize::MAX;
-
 // ===== impl Registration =====
 
 impl Registration {
-    /// Create a new `Registration`.
-    ///
-    /// This registration is not associated with a Reactor instance. Call
-    /// `register` to establish the association.
-    pub fn new() -> Registration {
-        Registration {
-            inner: UnsafeCell::new(None),
-        }
-    }
-
     /// Register the I/O resource with the default reactor.
     ///
     /// This function is safe to call concurrently and repeatedly. However, only
@@ -103,11 +65,40 @@ impl Registration {
     /// `Ok(false)` is returned.
     ///
     /// If an error is encountered during registration, `Err` is returned.
-    pub fn register<T>(&self, io: &T) -> io::Result<bool>
+    pub fn register<T>(&mut self, io: &T) -> io::Result<()>
     where
         T: Evented,
     {
         self.register2(io, HandlePriv::try_current)
+    }
+
+    /// Register the I/O resource with the specified reactor.
+    ///
+    /// This function is safe to call concurrently and repeatedly. However, only
+    /// the first call will establish the registration. Subsequent calls will be
+    /// no-ops.
+    ///
+    /// If the registration happened successfully, `Ok(true)` is returned.
+    ///
+    /// If an I/O resource has previously been successfully registered,
+    /// `Ok(false)` is returned.
+    ///
+    /// If an error is encountered during registration, `Err` is returned.
+    pub fn register_with<T>(&mut self, io: &T, handle: &Handle) -> io::Result<()>
+    where
+        T: Evented,
+    {
+        self.register2(io, || match handle.as_priv() {
+            Some(handle) => Ok(handle.clone()),
+            None => HandlePriv::try_current(),
+        })
+    }
+
+    pub(crate) fn register_with_priv<T>(&mut self, io: &T, handle: &HandlePriv) -> io::Result<()>
+    where
+        T: Evented,
+    {
+        self.register2(io, || Ok(handle.clone()))
     }
 
     /// Deregister the I/O resource from the reactor it is associated with.
@@ -130,122 +121,21 @@ impl Registration {
     where
         T: Evented,
     {
-        // The state does not need to be checked and coordination is not
-        // necessary as this function takes `&mut self`. This guarantees a
-        // single thread is accessing the instance.
-        if let Some(inner) = unsafe { (*self.inner.get()).as_ref() } {
-            inner.deregister(io)?;
+        if let Some(inner) = self.inner.as_ref() {
+            inner.deregister(io)?
         }
-
         Ok(())
     }
 
-    /// Register the I/O resource with the specified reactor.
-    ///
-    /// This function is safe to call concurrently and repeatedly. However, only
-    /// the first call will establish the registration. Subsequent calls will be
-    /// no-ops.
-    ///
-    /// If the registration happened successfully, `Ok(true)` is returned.
-    ///
-    /// If an I/O resource has previously been successfully registered,
-    /// `Ok(false)` is returned.
-    ///
-    /// If an error is encountered during registration, `Err` is returned.
-    pub fn register_with<T>(&self, io: &T, handle: &Handle) -> io::Result<bool>
-    where
-        T: Evented,
-    {
-        self.register2(io, || match handle.as_priv() {
-            Some(handle) => Ok(handle.clone()),
-            None => HandlePriv::try_current(),
-        })
-    }
-
-    pub(crate) fn register_with_priv<T>(&self, io: &T, handle: &HandlePriv) -> io::Result<bool>
-    where
-        T: Evented,
-    {
-        self.register2(io, || Ok(handle.clone()))
-    }
-
-    fn register2<T, F>(&self, io: &T, f: F) -> io::Result<bool>
+    fn register2<T, F>(&mut self, io: &T, f: F) -> io::Result<()>
     where
         T: Evented,
         F: Fn() -> io::Result<HandlePriv>,
     {
-        // let mut state = self.state.load(SeqCst);
-
-        // loop {
-        //     match state {
-        //         INIT => {
-        //             // Registration is currently not associated with a handle.
-        //             // Get a handle then attempt to lock the state.
-        //             let handle = f()?;
-
-        //             let actual = self.state.compare_and_swap(INIT, LOCKED, SeqCst);
-
-        //             if actual != state {
-        //                 state = actual;
-        //                 continue;
-        //             }
-
-        //             // Create the actual registration
-        //             let (inner, res) = Inner::new(io, handle);
-
-        //             unsafe {
-        //                 *self.inner.get() = Some(inner);
-        //             }
-
-        //             // Transition out of the locked state. This acquires the
-        //             // current value, potentially having a list of tasks that
-        //             // are pending readiness notifications.
-        //             let actual = self.state.swap(READY, SeqCst);
-
-        //             // Consume the stack of nodes
-
-        //             let mut read = false;
-        //             let mut write = false;
-        //             let mut ptr = (actual & !LIFECYCLE_MASK) as *mut Node;
-
-        //             let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
-
-        //             while !ptr.is_null() {
-        //                 let node = unsafe { Box::from_raw(ptr) };
-        //                 let node = *node;
-        //                 let Node {
-        //                     direction,
-        //                     waker,
-        //                     next,
-        //                 } = node;
-
-        //                 let flag = match direction {
-        //                     Direction::Read => &mut read,
-        //                     Direction::Write => &mut write,
-        //                 };
-
-        //                 if !*flag {
-        //                     *flag = true;
-
-        //                     inner.register(direction, waker);
-        //                 }
-
-        //                 ptr = next;
-        //             }
-
-        //             return res.map(|_| true);
-        //         }
-        //         _ => return Ok(false),
-        //     }
-        // }
-
         let handle = f()?;
-
-        let (inner, res) = Inner::new(io, handle);
-
-        unsafe { *self.inner.get() = Some(inner) }
-
-        res.map(|_| true)
+        let inner = Inner::add_source(io, handle)?;
+        self.inner = Some(inner);
+        Ok(())
     }
 
     /// Poll for events on the I/O resource's read readiness stream.
@@ -350,87 +240,23 @@ impl Registration {
         self.poll_ready(Direction::Write, None)
     }
 
+    /// Poll for events on the I/O resource's `direction` readiness stream.
+    ///
+    /// If called with a task context, notify the task when a new event is
+    /// received.
     fn poll_ready(
         &self,
         direction: Direction,
         cx: Option<&mut Context<'_>>,
     ) -> io::Result<Option<mio::Ready>> {
-        // let mut state = self.state.load(SeqCst);
-
-        // // Cache the node pointer
-        // let mut node = None;
-
-        // loop {
-        //     match state {
-        //         INIT => {
-        //             return Err(io::Error::new(
-        //                 io::ErrorKind::Other,
-        //                 "must call register before poll_read_ready",
-        //             ));
-        //         }
-        //         READY => {
-        //             let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
-        //             return inner.poll_ready(direction, cx);
-        //         }
-        //         LOCKED => {
-        //             let cx = if let Some(ref cx) = cx {
-        //                 cx
-        //             } else {
-        //                 // Skip the notification tracking junk.
-        //                 return Ok(None);
-        //             };
-
-        //             let next_ptr = (state & !LIFECYCLE_MASK) as *mut Node;
-
-        //             // Get the node
-        //             let mut n = node.take().unwrap_or_else(|| {
-        //                 Box::new(Node {
-        //                     direction,
-        //                     waker: cx.waker().clone(),
-        //                     next: ptr::null_mut(),
-        //                 })
-        //             });
-
-        //             n.next = next_ptr;
-
-        //             let node_ptr = Box::into_raw(n);
-        //             let next = node_ptr as usize | (state & LIFECYCLE_MASK);
-
-        //             let actual = self.state.compare_and_swap(state, next, SeqCst);
-
-        //             if actual != state {
-        //                 // Back out of the node boxing
-        //                 let n = unsafe { Box::from_raw(node_ptr) };
-
-        //                 // Save this for next loop
-        //                 node = Some(n);
-
-        //                 state = actual;
-        //                 continue;
-        //             }
-
-        //             return Ok(None);
-        //         }
-        //         _ => unreachable!(),
-        //     }
-        // }
-
-        // TODO: make this `if let`?
-        let inner = unsafe { (*self.inner.get()).as_ref().unwrap() };
-        let cxx = if let Some(ref cx) = cx {
-            cx
-        } else {
-            return Ok(None);
-        };
-
-        inner.register(direction, cxx.waker().clone());
+        let inner = self
+            .inner
+            .as_ref()
+            .expect("source has not been registered with an event loop");
+        if let Some(ref cx) = cx {
+            inner.register(direction, cx.waker().clone());
+        }
         inner.poll_ready(direction, cx)
-    }
-}
-
-impl Default for Registration {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -440,39 +266,22 @@ unsafe impl Sync for Registration {}
 // ===== impl Inner =====
 
 impl Inner {
-    fn new<T>(io: &T, handle: HandlePriv) -> (Self, io::Result<()>)
+    fn add_source<E>(io: &E, handle: HandlePriv) -> io::Result<Self>
     where
-        T: Evented,
+        E: Evented,
     {
-        let mut res = Ok(());
-
-        let token = match handle.inner() {
-            Some(inner) => match inner.add_source(io) {
-                Ok(token) => token,
-                Err(e) => {
-                    println!("failed to add source: {}", e);
-                    res = Err(e);
-                    ERROR
-                }
-            },
-            None => {
-                res = Err(io::Error::new(io::ErrorKind::Other, "event loop gone"));
-                ERROR
-            }
+        let token = if let Some(inner) = handle.inner() {
+            inner.add_source(io)?
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to find event loop",
+            ));
         };
-
-        let inner = Inner { handle, token };
-
-        (inner, res)
+        Ok(Self { handle, token })
     }
 
     fn register(&self, direction: Direction, waker: Waker) {
-        if self.token == ERROR {
-            println!("found ERROR in registration::Inner");
-            waker.wake();
-            return;
-        }
-
         let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => {
@@ -480,24 +289,14 @@ impl Inner {
                 return;
             }
         };
-
         inner.register(self.token, direction, waker);
     }
 
     fn deregister<E: Evented>(&self, io: &E) -> io::Result<()> {
-        if self.token == ERROR {
-            println!("failed to deregister; found ERROR");
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "deregister: failed to associate with reactor",
-            ));
-        }
-
         let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
         };
-
         inner.deregister_source(io)
     }
 
@@ -506,14 +305,6 @@ impl Inner {
         direction: Direction,
         cx: Option<&mut Context<'_>>,
     ) -> io::Result<Option<mio::Ready>> {
-        if self.token == ERROR {
-            println!("failed to poll ready");
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                "poll_ready: failed to associate with reactor",
-            ));
-        }
-
         let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return Err(io::Error::new(io::ErrorKind::Other, "reactor gone")),
@@ -561,15 +352,10 @@ impl Inner {
 
 impl Drop for Inner {
     fn drop(&mut self) {
-        if self.token == ERROR {
-            return;
-        }
-
         let inner = match self.handle.inner() {
             Some(inner) => inner,
             None => return,
         };
-
         inner.drop_source(self.token);
     }
 }

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -243,9 +243,7 @@ impl Registration {
 
         let (inner, res) = Inner::new(io, handle);
 
-        unsafe {
-            *self.inner.get() = Some(inner)
-        }
+        unsafe { *self.inner.get() = Some(inner) }
 
         res.map(|_| true)
     }
@@ -422,7 +420,7 @@ impl Registration {
         let cxx = if let Some(ref cx) = cx {
             cx
         } else {
-            return Ok(None)
+            return Ok(None);
         };
 
         inner.register(direction, cxx.waker().clone());

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -249,10 +249,12 @@ impl Registration {
         direction: Direction,
         cx: Option<&mut Context<'_>>,
     ) -> io::Result<Option<mio::Ready>> {
-        let inner = self.inner.as_ref().ok_or(io::Error::new(
-            io::ErrorKind::Other,
-            "I/O resource has not been registered to a reactor",
-        ))?;
+        let inner = self.inner.as_ref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "I/O resource has not been registered to a reactor",
+            )
+        })?;
         if let Some(ref cx) = cx {
             inner.register(direction, cx.waker().clone());
         }

--- a/tokio-net/src/driver/registration.rs
+++ b/tokio-net/src/driver/registration.rs
@@ -69,32 +69,6 @@ impl Registration {
         self.register2(io, HandlePriv::try_current)
     }
 
-    /// Register the I/O resource with the specified reactor.
-    ///
-    /// This function is safe to call concurrently and repeatedly. However, only
-    /// the first call will establish the registration. Subsequent calls will be
-    /// no-ops.
-    ///
-    /// If the registration happened successfully, `Ok` is returned.
-    ///
-    /// If an error is encountered during registration, `Err` is returned.
-    pub fn register_with<T>(&mut self, io: &T, handle: &Handle) -> io::Result<()>
-    where
-        T: Evented,
-    {
-        self.register2(io, || match handle.as_priv() {
-            Some(handle) => Ok(handle.clone()),
-            None => HandlePriv::try_current(),
-        })
-    }
-
-    pub(crate) fn register_with_priv<T>(&mut self, io: &T, handle: &HandlePriv) -> io::Result<()>
-    where
-        T: Evented,
-    {
-        self.register2(io, || Ok(handle.clone()))
-    }
-
     /// Deregister the I/O resource from the reactor it is associated with.
     ///
     /// This function must be called before the I/O resource associated with the
@@ -119,6 +93,32 @@ impl Registration {
             inner.deregister(io)?
         }
         Ok(())
+    }
+
+    /// Register the I/O resource with the specified reactor.
+    ///
+    /// This function is safe to call concurrently and repeatedly. However, only
+    /// the first call will establish the registration. Subsequent calls will be
+    /// no-ops.
+    ///
+    /// If the registration happened successfully, `Ok` is returned.
+    ///
+    /// If an error is encountered during registration, `Err` is returned.
+    pub fn register_with<T>(&mut self, io: &T, handle: &Handle) -> io::Result<()>
+    where
+        T: Evented,
+    {
+        self.register2(io, || match handle.as_priv() {
+            Some(handle) => Ok(handle.clone()),
+            None => HandlePriv::try_current(),
+        })
+    }
+
+    pub(crate) fn register_with_priv<T>(&mut self, io: &T, handle: &HandlePriv) -> io::Result<()>
+    where
+        T: Evented,
+    {
+        self.register2(io, || Ok(handle.clone()))
     }
 
     /// Register an I/O resource with a reactor.

--- a/tokio-net/src/process/unix/mod.rs
+++ b/tokio-net/src/process/unix/mod.rs
@@ -221,5 +221,5 @@ where
             return Err(io::Error::last_os_error());
         }
     }
-    Ok(Some(PollEvented::new(Fd { inner: io })))
+    Ok(Some(PollEvented::new(Fd { inner: io })?))
 }

--- a/tokio-net/src/process/windows.rs
+++ b/tokio-net/src/process/windows.rs
@@ -188,5 +188,5 @@ where
         None => return None,
     };
     let pipe = unsafe { NamedPipe::from_raw_handle(io.into_raw_handle()) };
-    PollEvented::new(pipe)?.ok()
+    PollEvented::new(pipe).ok()
 }

--- a/tokio-net/src/process/windows.rs
+++ b/tokio-net/src/process/windows.rs
@@ -188,5 +188,5 @@ where
         None => return None,
     };
     let pipe = unsafe { NamedPipe::from_raw_handle(io.into_raw_handle()) };
-    Some(PollEvented::new(pipe))
+    PollEvented::new(pipe)?.ok()
 }

--- a/tokio-net/src/signal/unix.rs
+++ b/tokio-net/src/signal/unix.rs
@@ -294,7 +294,7 @@ impl Driver {
         // either, since we can't compare Handles or assume they will always
         // point to the exact same reactor.
         let stream = globals().receiver.try_clone()?;
-        let wakeup = PollEvented::new(stream);
+        let wakeup = PollEvented::new(stream)?;
 
         Ok(Driver { wakeup })
     }

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -173,9 +173,9 @@ impl TcpListener {
     /// bound to and the listener will only be guaranteed to accept connections
     /// of the same address type currently.
     ///
-    /// Finally, the `handle` argument is the event loop that this listener will
-    /// be bound to.
-    /// Use [`Handle::default()`] to lazily bind to an event loop, just like `bind` does.
+    /// The `handle` argument is the event loop that this listener will be
+    /// bound to.
+    /// Use [`Handle::current()`] to eagerly bind to an event loop.
     ///
     /// The platform specific behavior of this function looks like:
     ///
@@ -187,19 +187,21 @@ impl TcpListener {
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
     ///
-    /// [`Handle::default()`]: ../reactor/struct.Handle.html
+    /// [`Handle::current()`]: ../reactor/struct.Handle.html
+    ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```rust,no_run
+    /// use std::error::Error;
     /// use tokio::net::TcpListener;
     /// use tokio_net::driver::Handle;
     ///
-    /// use std::net::TcpListener as StdTcpListener;
-    ///
-    /// let std_listener = StdTcpListener::bind("127.0.0.1:0")?;
-    /// let listener = TcpListener::from_std(std_listener, &Handle::default())?;
-    /// # let _ = listener;
-    /// # Ok::<_, Box<dyn std::error::Error>>(())
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    ///     let std_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    ///     let listener = TcpListener::from_std(std_listener, &Handle::current()?)?;
+    ///     Ok(())
+    /// }
     /// ```
     pub fn from_std(listener: net::TcpListener, handle: &Handle) -> io::Result<TcpListener> {
         let io = mio::net::TcpListener::from_std(listener)?;
@@ -329,10 +331,9 @@ impl TryFrom<net::TcpListener> for TcpListener {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`TcpListener::from_std(stream, &Handle::default())`](TcpListener::from_std).
+    /// [`TcpListener::from_std(stream, &Handle::current())`](TcpListener::from_std).
     fn try_from(stream: net::TcpListener) -> Result<Self, Self::Error> {
-        let handle = Handle::try_current()?;
-        Self::from_std(stream, &handle)
+        Self::from_std(stream, &Handle::current()?)
     }
 }
 

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -175,7 +175,7 @@ impl TcpListener {
     ///
     /// The `handle` argument is the event loop that this listener will be
     /// bound to.
-    /// Use [`Handle::current()`] to eagerly bind to an event loop.
+    /// Use [`Handle::current()`] to bind to the current event loop.
     ///
     /// The platform specific behavior of this function looks like:
     ///
@@ -221,7 +221,7 @@ impl TcpListener {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use tokio::net::TcpListener;
     ///
     /// use std::io;

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -219,7 +219,7 @@ impl TcpListener {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use tokio::net::TcpListener;
     ///
     /// use std::io;

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -172,10 +172,6 @@ impl TcpListener {
     /// bound to and the listener will only be guaranteed to accept connections
     /// of the same address type currently.
     ///
-    /// The `handle` argument is the event loop that this listener will be
-    /// bound to.
-    /// Use [`Handle::current()`] to bind to the current event loop.
-    ///
     /// The platform specific behavior of this function looks like:
     ///
     /// * On Unix, the socket is placed into nonblocking mode and connections
@@ -186,19 +182,16 @@ impl TcpListener {
     ///   `addr` is an IPv4 address then all sockets accepted will be IPv4 as
     ///   well (same for IPv6).
     ///
-    /// [`Handle::current()`]: ../reactor/struct.Handle.html
-    ///
     /// # Examples
     ///
     /// ```rust,no_run
     /// use std::error::Error;
     /// use tokio::net::TcpListener;
-    /// use tokio_net::driver::Handle;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
     ///     let std_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
-    ///     let listener = TcpListener::from_std(std_listener, &Handle::current()?)?;
+    ///     let listener = TcpListener::from_std(std_listener)?;
     ///     Ok(())
     /// }
     /// ```
@@ -330,7 +323,7 @@ impl TryFrom<net::TcpListener> for TcpListener {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`TcpListener::from_std(stream, &Handle::current())`](TcpListener::from_std).
+    /// [`TcpListener::from_std(stream)`](TcpListener::from_std).
     fn try_from(stream: net::TcpListener) -> Result<Self, Self::Error> {
         Self::from_std(stream)
     }

--- a/tokio-net/src/tcp/listener.rs
+++ b/tokio-net/src/tcp/listener.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "async-traits")]
 use super::incoming::Incoming;
 use super::TcpStream;
-use crate::driver::Handle;
 use crate::util::PollEvented;
 use crate::ToSocketAddrs;
 
@@ -203,9 +202,9 @@ impl TcpListener {
     ///     Ok(())
     /// }
     /// ```
-    pub fn from_std(listener: net::TcpListener, handle: &Handle) -> io::Result<TcpListener> {
+    pub fn from_std(listener: net::TcpListener) -> io::Result<TcpListener> {
         let io = mio::net::TcpListener::from_std(listener)?;
-        let io = PollEvented::new_with_handle(io, handle)?;
+        let io = PollEvented::new(io)?;
         Ok(TcpListener { io })
     }
 
@@ -333,7 +332,7 @@ impl TryFrom<net::TcpListener> for TcpListener {
     /// This is equivalent to
     /// [`TcpListener::from_std(stream, &Handle::current())`](TcpListener::from_std).
     fn try_from(stream: net::TcpListener) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -101,7 +101,7 @@ impl TcpStream {
     /// Establish a connection to the specified `addr`.
     async fn connect_addr(addr: SocketAddr) -> io::Result<TcpStream> {
         let sys = mio::net::TcpStream::connect(&addr)?;
-        let stream = TcpStream::new(sys);
+        let stream = TcpStream::new(sys)?;
 
         // Once we've connected, wait for the stream to be writable as
         // that's when the actual connection has been initiated. Once we're
@@ -118,9 +118,9 @@ impl TcpStream {
         Ok(stream)
     }
 
-    pub(crate) fn new(connected: mio::net::TcpStream) -> TcpStream {
-        let io = PollEvented::new(connected);
-        TcpStream { io }
+    pub(crate) fn new(connected: mio::net::TcpStream) -> io::Result<TcpStream> {
+        let io = PollEvented::new(connected)?;
+        Ok(TcpStream { io })
     }
 
     /// Create a new `TcpStream` from a `std::net::TcpStream`.
@@ -745,7 +745,8 @@ impl TryFrom<net::TcpStream> for TcpStream {
     /// This is equivalent to
     /// [`TcpStream::from_std(stream, &Handle::default())`](TcpStream::from_std).
     fn try_from(stream: net::TcpStream) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::default())
+        let handle = Handle::try_current()?;
+        Self::from_std(stream, &handle)
     }
 }
 

--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -130,13 +130,13 @@ impl TcpStream {
     ///
     /// The `handle` argument is the event loop that this listener will be
     /// bound to.
-    /// Use [`Handle::current()`] to eagerly bind to an event loop.
+    /// Use [`Handle::current()`] to bind to the current event loop.
     ///
     /// [`Handle::current()`]: ../reactor/struct.Handle.html
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```rust,no_run
     /// use std::error::Error;
     /// use tokio::net::TcpStream;
     /// use tokio_net::driver::Handle;

--- a/tokio-net/src/tcp/stream.rs
+++ b/tokio-net/src/tcp/stream.rs
@@ -148,9 +148,9 @@ impl TcpStream {
     ///     Ok(())
     /// }
     /// ```
-    pub fn from_std(stream: net::TcpStream, handle: &Handle) -> io::Result<TcpStream> {
+    pub fn from_std(stream: net::TcpStream) -> io::Result<TcpStream> {
         let io = mio::net::TcpStream::from_stream(stream)?;
-        let io = PollEvented::new_with_handle(io, handle)?;
+        let io = PollEvented::new(io)?;
         Ok(TcpStream { io })
     }
 
@@ -161,7 +161,7 @@ impl TcpStream {
     pub async fn connect_std(
         stream: net::TcpStream,
         addr: &SocketAddr,
-        handle: &Handle,
+        handle: Handle,
     ) -> io::Result<TcpStream> {
         let io = mio::net::TcpStream::connect_stream(stream, addr)?;
         let io = PollEvented::new_with_handle(io, handle)?;
@@ -751,7 +751,7 @@ impl TryFrom<net::TcpStream> for TcpStream {
     /// This is equivalent to
     /// [`TcpStream::from_std(stream, &Handle::current())`](TcpStream::from_std).
     fn try_from(stream: net::TcpStream) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -61,7 +61,7 @@ impl UdpSocket {
     ///
     /// The `handle` argument is the event loop that this listener will be
     /// bound to.
-    /// Use [`Handle::current()`] to eagerly bind to an event loop.
+    /// Use [`Handle::current()`] to bind to the current event loop.
     ///
     /// [`Handle::current()`]: ../reactor/struct.Handle.html
     pub fn from_std(socket: net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -40,12 +40,13 @@ impl UdpSocket {
     }
 
     fn bind_addr(addr: SocketAddr) -> io::Result<UdpSocket> {
-        mio::net::UdpSocket::bind(&addr).map(UdpSocket::new)
+        let sys = mio::net::UdpSocket::bind(&addr)?;
+        UdpSocket::new(sys)
     }
 
-    fn new(socket: mio::net::UdpSocket) -> UdpSocket {
-        let io = PollEvented::new(socket);
-        UdpSocket { io }
+    fn new(socket: mio::net::UdpSocket) -> io::Result<UdpSocket> {
+        let io = PollEvented::new(socket)?;
+        Ok(UdpSocket { io })
     }
 
     /// Creates a new `UdpSocket` from the previously bound socket provided.
@@ -388,7 +389,8 @@ impl TryFrom<net::UdpSocket> for UdpSocket {
     /// This is equivalent to
     /// [`UdpSocket::from_std(stream, &Handle::default())`](UdpSocket::from_std).
     fn try_from(stream: net::UdpSocket) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::default())
+        let handle = Handle::try_current()?;
+        Self::from_std(stream, &handle)
     }
 }
 

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -59,7 +59,11 @@ impl UdpSocket {
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
     ///
-    /// Use `Handle::default()` to lazily bind to an event loop, just like `bind` does.
+    /// The `handle` argument is the event loop that this listener will be
+    /// bound to.
+    /// Use [`Handle::current()`] to eagerly bind to an event loop.
+    ///
+    /// [`Handle::current()`]: ../reactor/struct.Handle.html
     pub fn from_std(socket: net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
         let io = PollEvented::new_with_handle(io, handle)?;
@@ -387,10 +391,9 @@ impl TryFrom<net::UdpSocket> for UdpSocket {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UdpSocket::from_std(stream, &Handle::default())`](UdpSocket::from_std).
+    /// [`UdpSocket::from_std(stream, &Handle::current())`](UdpSocket::from_std).
     fn try_from(stream: net::UdpSocket) -> Result<Self, Self::Error> {
-        let handle = Handle::try_current()?;
-        Self::from_std(stream, &handle)
+        Self::from_std(stream, &Handle::current()?)
     }
 }
 

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -57,12 +57,6 @@ impl UdpSocket {
     /// This can be used in conjunction with net2's `UdpBuilder` interface to
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
-    ///
-    /// The `handle` argument is the event loop that this listener will be
-    /// bound to.
-    /// Use [`Handle::current()`] to bind to the current event loop.
-    ///
-    /// [`Handle::current()`]: ../reactor/struct.Handle.html
     pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
         let io = PollEvented::new(io)?;
@@ -390,7 +384,7 @@ impl TryFrom<net::UdpSocket> for UdpSocket {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UdpSocket::from_std(stream, &Handle::current())`](UdpSocket::from_std).
+    /// [`UdpSocket::from_std(stream)`](UdpSocket::from_std).
     fn try_from(stream: net::UdpSocket) -> Result<Self, Self::Error> {
         Self::from_std(stream)
     }

--- a/tokio-net/src/udp/socket.rs
+++ b/tokio-net/src/udp/socket.rs
@@ -1,5 +1,4 @@
 use super::split::{split, UdpSocketRecvHalf, UdpSocketSendHalf};
-use crate::driver::Handle;
 use crate::util::PollEvented;
 use crate::ToSocketAddrs;
 
@@ -64,9 +63,9 @@ impl UdpSocket {
     /// Use [`Handle::current()`] to bind to the current event loop.
     ///
     /// [`Handle::current()`]: ../reactor/struct.Handle.html
-    pub fn from_std(socket: net::UdpSocket, handle: &Handle) -> io::Result<UdpSocket> {
+    pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
-        let io = PollEvented::new_with_handle(io, handle)?;
+        let io = PollEvented::new(io)?;
         Ok(UdpSocket { io })
     }
 
@@ -393,7 +392,7 @@ impl TryFrom<net::UdpSocket> for UdpSocket {
     /// This is equivalent to
     /// [`UdpSocket::from_std(stream, &Handle::current())`](UdpSocket::from_std).
     fn try_from(stream: net::UdpSocket) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/uds/datagram.rs
+++ b/tokio-net/src/uds/datagram.rs
@@ -216,10 +216,9 @@ impl TryFrom<net::UnixDatagram> for UnixDatagram {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixDatagram::from_std(stream, &Handle::default())`](UnixDatagram::from_std).
+    /// [`UnixDatagram::from_std(stream, &Handle::current())`](UnixDatagram::from_std).
     fn try_from(stream: net::UnixDatagram) -> Result<Self, Self::Error> {
-        let handle = Handle::try_current()?;
-        Self::from_std(stream, &handle)
+        Self::from_std(stream, &Handle::current()?)
     }
 }
 

--- a/tokio-net/src/uds/datagram.rs
+++ b/tokio-net/src/uds/datagram.rs
@@ -1,4 +1,3 @@
-use crate::driver::Handle;
 use crate::util::PollEvented;
 
 use futures_core::ready;
@@ -46,9 +45,9 @@ impl UnixDatagram {
     ///
     /// The returned datagram will be associated with the given event loop
     /// specified by `handle` and is ready to perform I/O.
-    pub fn from_std(datagram: net::UnixDatagram, handle: &Handle) -> io::Result<UnixDatagram> {
+    pub fn from_std(datagram: net::UnixDatagram) -> io::Result<UnixDatagram> {
         let socket = mio_uds::UnixDatagram::from_datagram(datagram)?;
-        let io = PollEvented::new_with_handle(socket, handle)?;
+        let io = PollEvented::new(socket)?;
         Ok(UnixDatagram { io })
     }
 
@@ -218,7 +217,7 @@ impl TryFrom<net::UnixDatagram> for UnixDatagram {
     /// This is equivalent to
     /// [`UnixDatagram::from_std(stream, &Handle::current())`](UnixDatagram::from_std).
     fn try_from(stream: net::UnixDatagram) -> Result<Self, Self::Error> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/uds/datagram.rs
+++ b/tokio-net/src/uds/datagram.rs
@@ -215,7 +215,7 @@ impl TryFrom<net::UnixDatagram> for UnixDatagram {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixDatagram::from_std(stream, &Handle::current())`](UnixDatagram::from_std).
+    /// [`UnixDatagram::from_std(stream)`](UnixDatagram::from_std).
     fn try_from(stream: net::UnixDatagram) -> Result<Self, Self::Error> {
         Self::from_std(stream)
     }

--- a/tokio-net/src/uds/listener.rs
+++ b/tokio-net/src/uds/listener.rs
@@ -117,10 +117,9 @@ impl TryFrom<net::UnixListener> for UnixListener {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixListener::from_std(stream, &Handle::default())`](UnixListener::from_std).
+    /// [`UnixListener::from_std(stream, &Handle::current())`](UnixListener::from_std).
     fn try_from(stream: net::UnixListener) -> io::Result<Self> {
-        let handle = Handle::try_current()?;
-        Self::from_std(stream, &handle)
+        Self::from_std(stream, &Handle::current()?)
     }
 }
 

--- a/tokio-net/src/uds/listener.rs
+++ b/tokio-net/src/uds/listener.rs
@@ -1,5 +1,4 @@
 use super::UnixStream;
-use crate::driver::Handle;
 use crate::util::PollEvented;
 
 use futures_core::ready;
@@ -35,9 +34,9 @@ impl UnixListener {
     ///
     /// The returned listener will be associated with the given event loop
     /// specified by `handle` and is ready to perform I/O.
-    pub fn from_std(listener: net::UnixListener, handle: &Handle) -> io::Result<UnixListener> {
+    pub fn from_std(listener: net::UnixListener) -> io::Result<UnixListener> {
         let listener = mio_uds::UnixListener::from_listener(listener)?;
-        let io = PollEvented::new_with_handle(listener, handle)?;
+        let io = PollEvented::new(listener)?;
         Ok(UnixListener { io })
     }
 
@@ -119,7 +118,7 @@ impl TryFrom<net::UnixListener> for UnixListener {
     /// This is equivalent to
     /// [`UnixListener::from_std(stream, &Handle::current())`](UnixListener::from_std).
     fn try_from(stream: net::UnixListener) -> io::Result<Self> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/uds/listener.rs
+++ b/tokio-net/src/uds/listener.rs
@@ -116,7 +116,7 @@ impl TryFrom<net::UnixListener> for UnixListener {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixListener::from_std(stream, &Handle::current())`](UnixListener::from_std).
+    /// [`UnixListener::from_std(stream)`](UnixListener::from_std).
     fn try_from(stream: net::UnixListener) -> io::Result<Self> {
         Self::from_std(stream)
     }

--- a/tokio-net/src/uds/stream.rs
+++ b/tokio-net/src/uds/stream.rs
@@ -134,10 +134,9 @@ impl TryFrom<net::UnixStream> for UnixStream {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixStream::from_std(stream, &Handle::default())`](UnixStream::from_std).
+    /// [`UnixStream::from_std(stream, &Handle::current())`](UnixStream::from_std).
     fn try_from(stream: net::UnixStream) -> io::Result<Self> {
-        let handle = Handle::try_current()?;
-        Self::from_std(stream, &handle)
+        Self::from_std(stream, &Handle::current()?)
     }
 }
 

--- a/tokio-net/src/uds/stream.rs
+++ b/tokio-net/src/uds/stream.rs
@@ -1,6 +1,5 @@
 use super::split::{split, ReadHalf, WriteHalf};
 use super::ucred::{self, UCred};
-use crate::driver::Handle;
 use crate::util::PollEvented;
 
 use tokio_io::{AsyncRead, AsyncWrite};
@@ -50,9 +49,9 @@ impl UnixStream {
     ///
     /// The returned stream will be associated with the given event loop
     /// specified by `handle` and is ready to perform I/O.
-    pub fn from_std(stream: net::UnixStream, handle: &Handle) -> io::Result<UnixStream> {
+    pub fn from_std(stream: net::UnixStream) -> io::Result<UnixStream> {
         let stream = mio_uds::UnixStream::from_stream(stream)?;
-        let io = PollEvented::new_with_handle(stream, handle)?;
+        let io = PollEvented::new(stream)?;
 
         Ok(UnixStream { io })
     }
@@ -136,7 +135,7 @@ impl TryFrom<net::UnixStream> for UnixStream {
     /// This is equivalent to
     /// [`UnixStream::from_std(stream, &Handle::current())`](UnixStream::from_std).
     fn try_from(stream: net::UnixStream) -> io::Result<Self> {
-        Self::from_std(stream, &Handle::current()?)
+        Self::from_std(stream)
     }
 }
 

--- a/tokio-net/src/uds/stream.rs
+++ b/tokio-net/src/uds/stream.rs
@@ -133,7 +133,7 @@ impl TryFrom<net::UnixStream> for UnixStream {
     /// Consumes stream, returning the tokio I/O object.
     ///
     /// This is equivalent to
-    /// [`UnixStream::from_std(stream, &Handle::current())`](UnixStream::from_std).
+    /// [`UnixStream::from_std(stream)`](UnixStream::from_std).
     fn try_from(stream: net::UnixStream) -> io::Result<Self> {
         Self::from_std(stream)
     }

--- a/tokio-net/src/uds/ucred.rs
+++ b/tokio-net/src/uds/ucred.rs
@@ -157,12 +157,12 @@ pub(crate) mod impl_solaris {
 #[cfg(not(target_os = "dragonfly"))]
 #[cfg(test)]
 mod test {
-    use crate::uds::UnixStream;
+    use tokio::net::UnixStream;
 
     use libc::getegid;
     use libc::geteuid;
 
-    #[test]
+    #[tokio::test]
     #[cfg_attr(
         target_os = "freebsd",
         ignore = "Requires FreeBSD 12.0 or later. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=176419"
@@ -171,7 +171,7 @@ mod test {
         target_os = "netbsd",
         ignore = "NetBSD does not support getpeereid() for sockets created by socketpair()"
     )]
-    fn test_socket_pair() {
+    async fn test_socket_pair() {
         let (a, b) = UnixStream::pair().unwrap();
         let cred_a = a.peer_cred().unwrap();
         let cred_b = b.peer_cred().unwrap();

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -166,8 +166,8 @@ where
     E: Evented,
 {
     /// Creates a new `PollEvented` associated with the default reactor.
-    pub fn new(io: E) -> Self {
-        Self::new2(io, None).unwrap()
+    pub fn new(io: E) -> io::Result<Self> {
+        Self::new2(io, None)
     }
 
     /// Creates a new `PollEvented` associated with the specified reactor.

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -339,22 +339,23 @@ where
     }
 
     /// Ensure that the I/O resource is registered with the reactor.
-    fn register(&self, handle: Option<&Handle>) -> io::Result<()> {
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `handle` is some but fails to reference a
+    /// current reactor.
+    fn register(&self, handle: Option<&Handle>) -> io::Result<bool> {
         match handle {
             Some(handle) => {
-                if let Some(handle) = handle.as_priv() {
-                    self.inner
-                        .registration
-                        .register_with_priv(self.io.as_ref().unwrap(), handle)?;
-                }
-            }
-            None => {
+                let handle = handle
+                    .as_priv()
+                    .expect("failed to find reference to reactor");
                 self.inner
                     .registration
-                    .register(self.io.as_ref().unwrap())?;
+                    .register_with_priv(self.io.as_ref().unwrap(), handle)
             }
+            None => self.inner.registration.register(self.io.as_ref().unwrap()),
         }
-        Ok(())
     }
 }
 

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -343,7 +343,7 @@ where
     /// # Panics
     ///
     /// This function panics if `handle` is some but fails to reference a
-    /// current reactor.
+    /// reactor.
     fn register(&mut self, handle: Option<&Handle>) -> io::Result<()> {
         match handle {
             Some(handle) => {

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -326,10 +326,10 @@ where
     }
 
     fn new2(io: E, handle: Option<&Handle>) -> io::Result<Self> {
-        let pe = Self {
+        let mut pe = Self {
             io: Some(io),
             inner: Inner {
-                registration: Registration::new(),
+                registration: Registration::default(),
                 read_readiness: AtomicUsize::new(0),
                 write_readiness: AtomicUsize::new(0),
             },
@@ -344,7 +344,7 @@ where
     ///
     /// This function panics if `handle` is some but fails to reference a
     /// current reactor.
-    fn register(&self, handle: Option<&Handle>) -> io::Result<bool> {
+    fn register(&mut self, handle: Option<&Handle>) -> io::Result<()> {
         match handle {
             Some(handle) => {
                 let handle = handle

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -342,7 +342,7 @@ where
     ///
     /// # Panics
     ///
-    /// This function panics if `handle` is some but fails to reference a
+    /// This function panics if `handle` is `Some` but fails to reference a
     /// reactor.
     fn register(&mut self, handle: Option<&Handle>) -> io::Result<()> {
         match handle {

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -167,16 +167,15 @@ where
 {
     /// Creates a new `PollEvented` associated with the default reactor.
     pub fn new(io: E) -> io::Result<Self> {
-        let mut pe = Self {
+        let registration = Registration::new(&io)?;
+        Ok(Self {
             io: Some(io),
             inner: Inner {
-                registration: Registration::default(),
+                registration,
                 read_readiness: AtomicUsize::new(0),
                 write_readiness: AtomicUsize::new(0),
             },
-        };
-        pe.register()?;
-        Ok(pe)
+        })
     }
 
     /// Returns a shared reference to the underlying I/O object this readiness
@@ -327,11 +326,6 @@ where
         }
 
         Ok(())
-    }
-
-    /// Ensure that the I/O resource is registered with the current reactor.
-    fn register(&mut self) -> io::Result<()> {
-        self.inner.registration.register(self.io.as_ref().unwrap())
     }
 }
 

--- a/tokio-net/src/util/poll_evented.rs
+++ b/tokio-net/src/util/poll_evented.rs
@@ -171,7 +171,7 @@ where
     }
 
     /// Creates a new `PollEvented` associated with the specified reactor.
-    pub fn new_with_handle(io: E, handle: &Handle) -> io::Result<Self> {
+    pub fn new_with_handle(io: E, handle: Handle) -> io::Result<Self> {
         Self::new2(io, Some(handle))
     }
 
@@ -325,7 +325,7 @@ where
         Ok(())
     }
 
-    fn new2(io: E, handle: Option<&Handle>) -> io::Result<Self> {
+    fn new2(io: E, handle: Option<Handle>) -> io::Result<Self> {
         let mut pe = Self {
             io: Some(io),
             inner: Inner {
@@ -344,16 +344,12 @@ where
     ///
     /// This function panics if `handle` is `Some` but fails to reference a
     /// reactor.
-    fn register(&mut self, handle: Option<&Handle>) -> io::Result<()> {
+    fn register(&mut self, handle: Option<Handle>) -> io::Result<()> {
         match handle {
-            Some(handle) => {
-                let handle = handle
-                    .as_priv()
-                    .expect("failed to find reference to reactor");
-                self.inner
-                    .registration
-                    .register_with_priv(self.io.as_ref().unwrap(), handle)
-            }
+            Some(handle) => self
+                .inner
+                .registration
+                .register_with(self.io.as_ref().unwrap(), handle),
             None => self.inner.registration.register(self.io.as_ref().unwrap()),
         }
     }

--- a/tokio-net/tests/bind_resource.rs
+++ b/tokio-net/tests/bind_resource.rs
@@ -1,0 +1,18 @@
+#![cfg(unix)]
+#![cfg(feature = "signal")]
+
+mod support;
+
+use std::convert::TryFrom;
+use std::net;
+use support::*;
+use tokio::net::TcpListener;
+use tokio_test::assert_err;
+
+#[test]
+fn no_runtime_fails_to_bind_resource() {
+    let listener = net::TcpListener::bind("127.0.0.1:0").expect("failed to bind listener");
+    assert_err!(TcpListener::try_from(listener));
+
+    assert_err!(signal(SignalKind::hangup()));
+}

--- a/tokio-net/tests/bind_resource.rs
+++ b/tokio-net/tests/bind_resource.rs
@@ -7,12 +7,16 @@ use std::convert::TryFrom;
 use std::net;
 use support::*;
 use tokio::net::TcpListener;
-use tokio_test::assert_err;
 
 #[test]
-fn no_runtime_fails_to_bind_resource() {
+#[should_panic]
+fn no_runtime_panics_binding_net_tcp_listener() {
     let listener = net::TcpListener::bind("127.0.0.1:0").expect("failed to bind listener");
-    assert_err!(TcpListener::try_from(listener));
+    let _ = TcpListener::try_from(listener);
+}
 
-    assert_err!(signal(SignalKind::hangup()));
+#[test]
+#[should_panic]
+fn no_runtime_panics_creating_signals() {
+    let _ = signal(SignalKind::hangup());
 }

--- a/tokio-net/tests/process_issue_42.rs
+++ b/tokio-net/tests/process_issue_42.rs
@@ -4,7 +4,6 @@
 
 use futures_util::future::FutureExt;
 use futures_util::stream::FuturesOrdered;
-use futures_util::stream::StreamExt;
 use std::process::Stdio;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/tokio-net/tests/process_issue_42.rs
+++ b/tokio-net/tests/process_issue_42.rs
@@ -15,7 +15,7 @@ use tokio_net::process::Command;
 mod support;
 use support::*;
 
-async fn run_test() {
+fn run_test() {
     let finished = Arc::new(AtomicBool::new(false));
     let finished_clone = finished.clone();
 
@@ -47,11 +47,11 @@ async fn run_test() {
     );
 }
 
-#[tokio::test]
-async fn issue_42() {
+#[test]
+fn issue_42() {
     let max = 10;
     for i in 0..max {
         println!("running {}/{}", i, max);
-        run_test().await
+        run_test()
     }
 }

--- a/tokio-net/tests/signal_drop_multi_loop.rs
+++ b/tokio-net/tests/signal_drop_multi_loop.rs
@@ -10,15 +10,17 @@ fn dropping_loops_does_not_cause_starvation() {
     let kind = SignalKind::user_defined1();
 
     let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
-    let mut first_signal = first_rt.block_on(async { signal(kind).expect("failed to register first signal") });
+    let mut first_signal =
+        first_rt.block_on(async { signal(kind).expect("failed to register first signal") });
 
     let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
-    let mut second_signal = second_rt.block_on(async { signal(kind).expect("failed to register second signal") });
+    let mut second_signal =
+        second_rt.block_on(async { signal(kind).expect("failed to register second signal") });
 
     send_signal(libc::SIGUSR1);
 
-    let _ = run_with_timeout(&mut first_rt, first_signal.next())
-        .expect("failed to await first signal");
+    let _ =
+        run_with_timeout(&mut first_rt, first_signal.next()).expect("failed to await first signal");
 
     drop(first_rt);
     drop(first_signal);

--- a/tokio-net/tests/signal_drop_multi_loop.rs
+++ b/tokio-net/tests/signal_drop_multi_loop.rs
@@ -7,30 +7,23 @@ use support::*;
 
 #[test]
 fn dropping_loops_does_not_cause_starvation() {
-    let (mut rt, signal) = {
-        let kind = SignalKind::user_defined1();
+    let kind = SignalKind::user_defined1();
 
-        let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
-        let mut first_signal = signal(kind).expect("failed to register first signal");
+    let mut first_rt = CurrentThreadRuntime::new().expect("failed to init first runtime");
+    let mut first_signal = first_rt.block_on(async { signal(kind).expect("failed to register first signal") });
 
-        let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
-        let mut second_signal = signal(kind).expect("failed to register second signal");
-
-        send_signal(libc::SIGUSR1);
-
-        let _ = run_with_timeout(&mut first_rt, first_signal.next())
-            .expect("failed to await first signal");
-
-        let _ = run_with_timeout(&mut second_rt, second_signal.next())
-            .expect("failed to await second signal");
-
-        drop(first_rt);
-        drop(first_signal);
-
-        (second_rt, second_signal)
-    };
+    let mut second_rt = CurrentThreadRuntime::new().expect("failed to init second runtime");
+    let mut second_signal = second_rt.block_on(async { signal(kind).expect("failed to register second signal") });
 
     send_signal(libc::SIGUSR1);
 
-    let _ = run_with_timeout(&mut rt, signal.into_future());
+    let _ = run_with_timeout(&mut first_rt, first_signal.next())
+        .expect("failed to await first signal");
+
+    drop(first_rt);
+    drop(first_signal);
+
+    send_signal(libc::SIGUSR1);
+
+    let _ = run_with_timeout(&mut second_rt, second_signal.next());
 }

--- a/tokio-net/tests/signal_multi_loop.rs
+++ b/tokio-net/tests/signal_multi_loop.rs
@@ -20,9 +20,11 @@ fn multi_loop() {
                 let sender = sender.clone();
                 thread::spawn(move || {
                     let mut rt = CurrentThreadRuntime::new().unwrap();
-                    let signal = signal(SignalKind::hangup()).unwrap();
-                    sender.send(()).unwrap();
-                    let _ = run_with_timeout(&mut rt, signal.into_future());
+                    let _ = run_with_timeout(&mut rt, async {
+                        let signal = signal(SignalKind::hangup()).unwrap();
+                        sender.send(()).unwrap();
+                        signal.into_future().await
+                    });
                 })
             })
             .collect();

--- a/tokio/tests/drop-core.rs
+++ b/tokio/tests/drop-core.rs
@@ -8,9 +8,8 @@ use tokio_test::{assert_err, assert_pending, assert_ready, task};
 #[test]
 fn tcp_doesnt_block() {
     let reactor = Reactor::new().unwrap();
-    let handle = reactor.handle();
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let mut listener = TcpListener::from_std(listener, &handle).unwrap();
+    let mut listener = TcpListener::from_std(listener).unwrap();
     drop(reactor);
 
     let mut task = task::spawn(async move {
@@ -23,9 +22,8 @@ fn tcp_doesnt_block() {
 #[test]
 fn drop_wakes() {
     let reactor = Reactor::new().unwrap();
-    let handle = reactor.handle();
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let mut listener = TcpListener::from_std(listener, &handle).unwrap();
+    let mut listener = TcpListener::from_std(listener).unwrap();
 
     let mut task = task::spawn(async move {
         assert_err!(listener.accept().await);

--- a/tokio/tests/drop-core.rs
+++ b/tokio/tests/drop-core.rs
@@ -2,12 +2,17 @@
 #![cfg(feature = "default")]
 
 use tokio::net::TcpListener;
-use tokio_net::driver::Reactor;
+use tokio_net::driver::{self, Reactor};
 use tokio_test::{assert_err, assert_pending, assert_ready, task};
 
 #[test]
 fn tcp_doesnt_block() {
     let reactor = Reactor::new().unwrap();
+    let handle = reactor.handle();
+
+    // Set the current reactor for this thread
+    let _reactor_guard = driver::set_default(&handle);
+
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let mut listener = TcpListener::from_std(listener).unwrap();
     drop(reactor);
@@ -22,6 +27,11 @@ fn tcp_doesnt_block() {
 #[test]
 fn drop_wakes() {
     let reactor = Reactor::new().unwrap();
+    let handle = reactor.handle();
+
+    // Set the current reactor for this thread
+    let _reactor_guard = driver::set_default(&handle);
+
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let mut listener = TcpListener::from_std(listener).unwrap();
 


### PR DESCRIPTION
## Motivation

The `tokio_net` resources can be created outside of a runtime due to how tokio
has been used with futures to date. For example, this allows a `TcpStream` to be
created, and later passed into a runtime:

```
let stream = TcpStream::connect(...).and_then(|socket| {
    // do something
});
tokio::run(stream);
```

In order to support this functionality, the reactor was lazily bound to the
resource on the first call to `poll_read_ready`/`poll_write_ready`. This
required a lot of additional complexity in the binding logic to support.

With the tokio 0.2 common case, this is no longer necessary and can be removed.
All resources are expected to be created from within a runtime, and should panic
if not done so.

Closes #1168

## Solution

The `tokio_net` crate now assumes there to be a `CURRENT_REACTOR` set on the
worker thread creating a resource; this can be assumed if called within a tokio
runtime. If there is no current reactor, the application will panic with a "no
current reactor" message.

With this assumption, all the unsafe and atomics have been removed from
`tokio_net::driver::Registration` as it is no longer needed.

There is no longer any reason to pass in handles to the family of `from_std` methods on `net` resources. `Handle::current` has therefore a more restricted private use where it is only used in `driver::Registration::new`.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
