### PR TITLE
Update runtime doc regarding `runtime::run` function helper

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -14,7 +14,7 @@
 //! boilerplate to run a Tokio application.
 //!
 //! Most applications wont need to use [`Runtime`] directly. Instead, they will
-//! use the [`run`] function, which uses [`Runtime`] under the hood.
+//! use the [`tokio::main`] attribute macro, which uses [`Runtime`] under the hood.
 //!
 //! Creating a [`Runtime`] does the following:
 //!


### PR DESCRIPTION
## Motivation

Documentation references the old helper function `runtime::run`, which has been removed, as mentioned on #1536.

## Solution

I've updated to reference on the runtime module to mention the new `tokio::main` attribute macro.