### PR TITLE
net: Expose `resolve_host`, a function that asynchronously resolves DNS.

### DIFF
--- a/tokio-net/src/addr.rs
+++ b/tokio-net/src/addr.rs
@@ -31,6 +31,18 @@ impl sealed::ToSocketAddrsPriv for SocketAddr {
     }
 }
 
+/// `resolve_host` takes `ToSocketAddrs` and returns the first entry it resolves.
+pub async fn resolve_host<T: ToSocketAddrs>(source: T) -> Result<SocketAddr, io::Error> {
+    let mut socket_addrs = source.to_socket_addrs().await?;
+    match socket_addrs.next() {
+        Some(addr) => Ok(addr),
+        None => Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "domain could be resolved",
+        )),
+    }
+}
+
 // ===== impl str =====
 
 impl ToSocketAddrs for str {}

--- a/tokio-net/src/lib.rs
+++ b/tokio-net/src/lib.rs
@@ -41,7 +41,7 @@
 //! [reactor module]: https://docs.rs/tokio/0.1/tokio/reactor/index.html
 
 mod addr;
-pub use addr::ToSocketAddrs;
+pub use addr::{resolve_host, ToSocketAddrs};
 
 pub mod driver;
 pub mod util;

--- a/tokio-net/tests/to_socket_addrs.rs
+++ b/tokio-net/tests/to_socket_addrs.rs
@@ -1,0 +1,22 @@
+use std::{
+    io::{Error, ErrorKind},
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+};
+use tokio_net::resolve_host;
+
+#[tokio::test]
+async fn resolve_host_ok() -> Result<(), Error> {
+    let addr = resolve_host("127.0.0.1:8000").await?;
+    let expected = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8000);
+    assert_eq!(addr, expected);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn resolve_host_err() -> Result<(), Error> {
+    let err = resolve_host("local-not-host:8000").await.unwrap_err();
+    assert_eq!(err.kind(), ErrorKind::Other);
+
+    Ok(())
+}


### PR DESCRIPTION
Currently,`tokio` does not provide a mechanism to resolve DNS asynchronously. This means that libraries like Hyper must re-implement functionality that exists in `tokio` themselves.