### PR TITLE
argument position impl trait instead of generic where appropriate

### DIFF
--- a/tokio/src/fs/create_dir.rs
+++ b/tokio/src/fs/create_dir.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::create_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.create_dir.html
-pub async fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn create_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::create_dir(path)).await
 }

--- a/tokio/src/fs/create_dir_all.rs
+++ b/tokio/src/fs/create_dir_all.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::create_dir_all`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.create_dir_all.html
-pub async fn create_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn create_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::create_dir_all(path)).await
 }

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -116,10 +116,7 @@ impl File {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn open<P>(path: P) -> io::Result<File>
-    where
-        P: AsRef<Path>,
-    {
+    pub async fn open(path: impl AsRef<Path>) -> io::Result<File> {
         let path = path.as_ref().to_owned();
         let std = asyncify(|| sys::File::open(path)).await?;
 
@@ -154,10 +151,7 @@ impl File {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn create<P>(path: P) -> io::Result<File>
-    where
-        P: AsRef<Path>,
-    {
+    pub async fn create(path: impl AsRef<Path>) -> io::Result<File> {
         let path = path.as_ref().to_owned();
         let std_file = asyncify(move || sys::File::create(path)).await?;
         Ok(File::from_std(std_file))

--- a/tokio/src/fs/hard_link.rs
+++ b/tokio/src/fs/hard_link.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::hard_link`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.hard_link.html
-pub async fn hard_link<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+pub async fn hard_link(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/src/fs/metadata.rs
+++ b/tokio/src/fs/metadata.rs
@@ -5,10 +5,7 @@ use std::io;
 use std::path::Path;
 
 /// Queries the file system metadata for a path.
-pub async fn metadata<P>(path: P) -> io::Result<Metadata>
-where
-    P: AsRef<Path>,
-{
+pub async fn metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_owned();
     asyncify(|| std::fs::metadata(path)).await
 }

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -88,10 +88,7 @@ impl OpenOptions {
     /// Tokio runtime or if the underlying [`open`] call results in an error.
     ///
     /// [`open`]: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open
-    pub async fn open<P>(&self, path: P) -> io::Result<File>
-    where
-        P: AsRef<Path>,
-    {
+    pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
         let path = path.as_ref().to_owned();
         let opts = self.0.clone();
 

--- a/tokio/src/fs/os/unix/symlink.rs
+++ b/tokio/src/fs/os/unix/symlink.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 /// This is an async version of [`std::os::unix::fs::symlink`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/unix/fs/fn.symlink.html
-pub async fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+pub async fn symlink(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/src/fs/os/windows/symlink_dir.rs
+++ b/tokio/src/fs/os/windows/symlink_dir.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 /// This is an async version of [`std::os::windows::fs::symlink_dir`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_dir.html
-pub async fn symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+pub async fn symlink_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/src/fs/os/windows/symlink_file.rs
+++ b/tokio/src/fs/os/windows/symlink_file.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 /// This is an async version of [`std::os::windows::fs::symlink_file`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/os/windows/fs/fn.symlink_file.html
-pub async fn symlink_file<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) -> io::Result<()> {
+pub async fn symlink_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -18,10 +18,7 @@ use std::{io, path::Path};
 /// # Ok(())
 /// # }
 /// ```
-pub async fn read<P>(path: P) -> io::Result<Vec<u8>>
-where
-    P: AsRef<Path>,
-{
+pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::read(path)).await
 }

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -17,10 +17,7 @@ use std::task::Poll;
 /// Returns a stream over the entries within a directory.
 ///
 /// This is an async version of [`std::fs::read_dir`](std::fs::read_dir)
-pub async fn read_dir<P>(path: P) -> io::Result<ReadDir>
-where
-    P: AsRef<Path>,
-{
+pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
     let path = path.as_ref().to_owned();
     let std = asyncify(|| std::fs::read_dir(path)).await?;
 

--- a/tokio/src/fs/read_link.rs
+++ b/tokio/src/fs/read_link.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 /// This is an async version of [`std::fs::read_link`][std]
 ///
 /// [std]: std::fs::read_link
-pub async fn read_link<P: AsRef<Path>>(path: P) -> io::Result<PathBuf> {
+pub async fn read_link(path: impl AsRef<Path>) -> io::Result<PathBuf> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::read_link(path)).await
 }

--- a/tokio/src/fs/read_to_string.rs
+++ b/tokio/src/fs/read_to_string.rs
@@ -18,10 +18,7 @@ use std::{io, path::Path};
 /// # Ok(())
 /// # }
 /// ```
-pub async fn read_to_string<P>(path: P) -> io::Result<String>
-where
-    P: AsRef<Path>,
-{
+pub async fn read_to_string(path: impl AsRef<Path>) -> io::Result<String> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::read_to_string(path)).await
 }

--- a/tokio/src/fs/remove_dir.rs
+++ b/tokio/src/fs/remove_dir.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 /// Removes an existing, empty directory.
 ///
 /// This is an async version of [`std::fs::remove_dir`](std::fs::remove_dir)
-pub async fn remove_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn remove_dir(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_dir(path)).await
 }

--- a/tokio/src/fs/remove_dir_all.rs
+++ b/tokio/src/fs/remove_dir_all.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::remove_dir_all`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
-pub async fn remove_dir_all<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_dir_all(path)).await
 }

--- a/tokio/src/fs/remove_file.rs
+++ b/tokio/src/fs/remove_file.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::remove_file`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.remove_file.html
-pub async fn remove_file<P: AsRef<Path>>(path: P) -> io::Result<()> {
+pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_file(path)).await
 }

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// This will not work if the new name is on a different mount point.
 ///
 /// This is an async version of [`std::fs::rename`](std::fs::rename)
-pub async fn rename<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<()> {
+pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
 

--- a/tokio/src/fs/set_permissions.rs
+++ b/tokio/src/fs/set_permissions.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::set_permissions`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
-pub async fn set_permissions<P: AsRef<Path>>(path: P, perm: Permissions) -> io::Result<()> {
+pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(|| std::fs::set_permissions(path, perm)).await
 }

--- a/tokio/src/fs/symlink_metadata.rs
+++ b/tokio/src/fs/symlink_metadata.rs
@@ -9,10 +9,7 @@ use std::path::Path;
 /// This is an async version of [`std::fs::symlink_metadata`][std]
 ///
 /// [std]: https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html
-pub async fn symlink_metadata<P>(path: P) -> io::Result<Metadata>
-where
-    P: AsRef<Path>,
-{
+pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_owned();
     asyncify(|| std::fs::symlink_metadata(path)).await
 }

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -17,10 +17,7 @@ use std::{io, path::Path};
 /// # Ok(())
 /// # }
 /// ```
-pub async fn write<P, C: AsRef<[u8]> + Unpin>(path: P, contents: C) -> io::Result<()>
-where
-    P: AsRef<Path>,
-{
+pub async fn write<C: AsRef<[u8]> + Unpin>(path: impl AsRef<Path>, contents: C) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     let contents = contents.as_ref().to_owned();
 

--- a/tokio/src/runtime/current_thread/runtime.rs
+++ b/tokio/src/runtime/current_thread/runtime.rs
@@ -164,10 +164,7 @@ impl Runtime {
     ///
     /// The caller is responsible for ensuring that other spawned futures
     /// complete execution by calling `block_on` or `run`.
-    pub fn block_on<F>(&mut self, f: F) -> F::Output
-    where
-        F: Future,
-    {
+    pub fn block_on<F: Future>(&mut self, f: F) -> F::Output {
         self.enter(|executor| {
             // Run the provided future
             executor.block_on(f)

--- a/tokio/src/runtime/threadpool/builder.rs
+++ b/tokio/src/runtime/threadpool/builder.rs
@@ -125,7 +125,7 @@ impl Builder {
     ///     .build();
     /// # }
     /// ```
-    pub fn name<S: Into<String>>(&mut self, val: S) -> &mut Self {
+    pub fn name(&mut self, val: impl Into<String>) -> &mut Self {
         self.thread_pool_builder.name(val);
         self
     }

--- a/tokio/src/runtime/threadpool/mod.rs
+++ b/tokio/src/runtime/threadpool/mod.rs
@@ -111,7 +111,8 @@ impl Runtime {
     /// This function panics if the spawn fails. Failure occurs if the executor
     /// is currently at capacity and is unable to spawn a new future.
     pub fn spawn<F>(&self, future: F) -> &Self
-    where F: Future<Output = ()> + Send + 'static,
+    where
+        F: Future<Output = ()> + Send + 'static,
     {
         self.inner().pool.spawn(future);
         self
@@ -129,10 +130,7 @@ impl Runtime {
     ///
     /// This function panics if the executor is at capacity, if the provided
     /// future panics, or if called within an asynchronous execution context.
-    pub fn block_on<F>(&self, future: F) -> F::Output
-    where
-        F: Future,
-    {
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let _reactor = driver::set_default(&self.inner().reactor_handles[0]);
         let _timer = timer::set_default(&self.inner().timer_handles[0]);
 

--- a/tokio/src/timer/clock/mod.rs
+++ b/tokio/src/timer/clock/mod.rs
@@ -77,7 +77,7 @@ impl Clock {
     }
 
     /// Return a new `Clock` instance that uses `now` as the source of time.
-    pub fn new_with_now<T: Now>(now: T) -> Clock {
+    pub fn new_with_now(now: impl Now) -> Clock {
         Clock {
             now: Some(Arc::new(now)),
         }


### PR DESCRIPTION
## Motivation

There is a lot of code like the following:
```rust
pub async fn open<P>(&self, path: P) -> io::Result<File>
where
    P: AsRef<Path>,
{
```
Downsides:
* `P` is likely never specified by the caller
* `path: P` does not convey much. The reader has to move their eyes to two other places to see it's a local generic and which bounds it has
* It takes four lines of code.

Since quite a while back we have argument position `impl Trait` that can be used for situations like this. However, changing from a generic to `impl Trait` is technically breaking. So any such changes has to be made before `tokio 0.2` is released.

## Solution

For cases like the above I changed it to
```rust
pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
```
Single line of code, and it's very easy to see what type `path` has to be.

I opted to keep `<F: Future>(future: F)`. The `future: F` part is very common in tokio so any reader is going to be very familiar with it. Most cases where there is an `F: Future` bound there are also a bunch of other bounds, making it not optimal to specify as an `impl Trait` anyway. So I stayed with what was most consistent with those places.

So far I only applied this to tokio proper. Since the other crates are in so much flux right now.