### PR TITLE
thread-pool: test additional shutdown cases

### DIFF
--- a/tokio-executor/src/thread_pool/tests/loom_pool.rs
+++ b/tokio-executor/src/thread_pool/tests/loom_pool.rs
@@ -86,6 +86,10 @@ fn pool_shutdown() {
             gated2(true).await;
         });
 
+        pool.spawn(async move {
+            gated2(false).await;
+        });
+
         drop(pool);
     });
 }


### PR DESCRIPTION
This adds an extra spawned task during the thread-pool shutdown loom
test. This results in additional cases being tested, primarily tasks
being stolen.