### PR TITLE
Fix docs links: Redux

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -81,7 +81,7 @@ impl Stream for ReadDir {
 ///
 /// [`ReadDir`]: struct.ReadDir.html
 ///
-/// This is a specialized version of [`std::fs::DirEntry`](std::fs::DirEntry) for usage from the
+/// This is a specialized version of [`std::fs::DirEntry`] for usage from the
 /// Tokio runtime.
 ///
 /// An instance of `DirEntry` represents an entry inside of a directory on the

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -36,8 +36,8 @@ pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
 /// This [`Stream`] will return an [`Err`] if there's some sort of intermittent
 /// IO error during iteration.
 ///
-/// [`read_dir`]: fn.read_dir.html
-/// [`DirEntry`]: struct.DirEntry.html
+/// [`read_dir`]: read_dir
+/// [`DirEntry`]: DirEntry
 /// [`Stream`]: Stream
 /// [`Err`]: std::result::Result::Err
 #[derive(Debug)]

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1,6 +1,6 @@
 //! An implementation of asynchronous process management for Tokio.
 //!
-//! This module provides a [`Command`](crate::process::Command) struct that imitates the interface of the
+//! This module provides a [`Command`] struct that imitates the interface of the
 //! [`std::process::Command`] type in the standard library, but provides asynchronous versions of
 //! functions that create processes. These functions (`spawn`, `status`, `output` and their
 //! variants) return "future aware" types that interoperate with Tokio. The asynchronous process
@@ -102,7 +102,7 @@
 //! While similar to the standard library, this crate's `Child` type differs
 //! importantly in the behavior of `drop`. In the standard library, a child
 //! process will continue running after the instance of [`std::process::Child`]
-//! is dropped. In this crate, however, because [`tokio::process::Child`](crate::process::Child) is a
+//! is dropped. In this crate, however, because [`tokio::process::Child`] is a
 //! future of the child's `ExitStatus`, a child process is terminated if
 //! `tokio::process::Child` is dropped. The behavior of the standard library can
 //! be regained with the [`Child::forget`](crate::process::Child::forget) method.


### PR DESCRIPTION
# Motivation

Continuing the work started in #1474 to transition all the intra-doc links in the documentation from hard-coded arbitrary urls to using rustdoc item link resolution.

Also related to #1473 and #1523.