### PR TITLE
perf: Avoid using Arc when there are only two owners

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,5 @@ members = [
   "examples",
   "tests-integration",
 ]
+[profile.bench]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,3 @@ members = [
   "examples",
   "tests-integration",
 ]
-[profile.bench]
-debug = true

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -34,6 +34,10 @@ jobs:
       displayName: ${{ crate }} - cargo test
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
+    # Test benches
+    - script: cargo test --benches --all
+      displayName: Test benchmarks
+
     # Run with all crate features
     - script: cargo test --all-features
       env:
@@ -70,6 +74,10 @@ jobs:
         CI: 'True'
       displayName: ${{ crate }} - cargo test --all-features
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
+
+    # Test benches
+    - script: cargo test --benches --all
+      displayName: Test benchmarks
 
     # Check each specified feature works properly
     # * --each-feature - run for each feature which includes --no-default-features and default features of package

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -119,10 +119,15 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
+criterion_bencher_compat = "0.3"
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
+
+[[bench]]
+name = "oneshot"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -119,15 +119,37 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
-criterion_bencher_compat = "0.3"
+criterion = "0.3"
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
 
 [[bench]]
+name = "latency"
+harness = false
+
+[[bench]]
+name = "mio-ops"
+harness = false
+
+[[bench]]
+name = "mpsc"
+harness = false
+
+[[bench]]
 name = "oneshot"
 harness = false
 
+[[bench]]
+name = "tcp"
+harness = false
+
+# Currently broken
+# [[bench]]
+# name = "thread_pool"
+# harness = false
+
 [package.metadata.docs.rs]
 all-features = true
+

--- a/tokio/benches/mpsc.rs
+++ b/tokio/benches/mpsc.rs
@@ -271,7 +271,7 @@ criterion_group!(mpsc, bench_mpsc);
 fn main() {
     // The large channel tests can run out of stack
     std::thread::Builder::new()
-        .stack_size(3_000_000)
+        .stack_size(10_000_000)
         .spawn(|| {
             mpsc();
 

--- a/tokio/benches/mpsc.rs
+++ b/tokio/benches/mpsc.rs
@@ -1,189 +1,168 @@
-#![feature(test)]
 #![warn(rust_2018_idioms)]
 
-extern crate test;
+use std::{pin::Pin, thread};
 
 use tokio::sync::mpsc::*;
 
-use futures::{future, Async, Future, Sink, Stream};
-use std::thread;
-use test::Bencher;
+use futures::{
+    executor::{block_on, block_on_stream},
+    future,
+    task::Poll,
+};
+
+use criterion::{black_box, criterion_group, Bencher, Criterion};
 
 type Medium = [usize; 64];
 type Large = [Medium; 64];
 
-#[bench]
-fn bounded_new_medium(b: &mut Bencher) {
+fn bounded_new_medium(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&channel::<Medium>(1_000));
+        let _ = black_box(&channel::<Medium>(1_000));
     })
 }
 
-#[bench]
-fn unbounded_new_medium(b: &mut Bencher) {
+fn unbounded_new_medium(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&unbounded_channel::<Medium>());
-    })
-}
-#[bench]
-fn bounded_new_large(b: &mut Bencher) {
-    b.iter(|| {
-        let _ = test::black_box(&channel::<Large>(1_000));
+        let _ = black_box(&unbounded_channel::<Medium>());
     })
 }
 
-#[bench]
-fn unbounded_new_large(b: &mut Bencher) {
+fn bounded_new_large(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&unbounded_channel::<Large>());
+        let _ = black_box(&channel::<Large>(1_000));
     })
 }
 
-#[bench]
-fn send_one_message(b: &mut Bencher) {
+fn unbounded_new_large(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let (mut tx, mut rx) = channel(1_000);
-
-        // Send
-        tx.try_send(1).unwrap();
-
-        // Receive
-        assert_eq!(Async::Ready(Some(1)), rx.poll().unwrap());
+        let _ = black_box(&unbounded_channel::<Large>());
     })
 }
 
-#[bench]
-fn send_one_message_large(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel::<Large>(1_000);
+fn send_one_message(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1_000);
 
-        // Send
-        let _ = tx.try_send([[0; 64]; 64]);
+            // Send
+            tx.try_send(1).unwrap();
 
-        // Receive
-        let _ = test::black_box(&rx.poll());
-    })
+            // Receive
+            assert_eq!(Poll::Ready(Some(1)), rx.poll_recv(cx));
+        })
+    }))
 }
 
-#[bench]
-fn bounded_rx_not_ready(b: &mut Bencher) {
+fn send_one_message_large(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel::<Large>(1_000);
+
+            // Send
+            let _ = tx.try_send([[0; 64]; 64]);
+
+            // Receive
+            let _ = black_box(&rx.poll_recv(cx));
+        })
+    }))
+}
+
+fn bounded_rx_not_ready(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = channel::<i32>(1_000);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(rx.poll_recv(cx).is_pending());
+        }));
     })
 }
 
-#[bench]
-fn bounded_tx_poll_ready(b: &mut Bencher) {
+fn bounded_tx_poll_ready(b: &mut Bencher<'_>) {
     let (mut tx, _rx) = channel::<i32>(1);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_ready());
+        }));
     })
 }
 
-#[bench]
-fn bounded_tx_poll_not_ready(b: &mut Bencher) {
+fn bounded_tx_poll_not_ready(b: &mut Bencher<'_>) {
     let (mut tx, _rx) = channel::<i32>(1);
     tx.try_send(1).unwrap();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_pending());
+        }))
     })
 }
 
-#[bench]
-fn unbounded_rx_not_ready(b: &mut Bencher) {
+fn unbounded_rx_not_ready(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(rx.poll_recv(cx).is_pending());
+        }))
     })
 }
 
-#[bench]
-fn unbounded_rx_not_ready_x5(b: &mut Bencher) {
+fn unbounded_rx_not_ready_x5(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
+        block_on(future::lazy(|cx| {
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+        }));
+    })
+}
 
-            Ok::<_, ()>(())
+fn bounded_uncontended_1(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1_000);
+
+            for i in 0..1000 {
+                tx.try_send(i).unwrap();
+                // No need to create a task, because poll is not going to park.
+                assert_eq!(Poll::Ready(Some(i)), Pin::new(&mut rx).poll_recv(cx));
+            }
         })
-        .wait()
-        .unwrap();
-    })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_1(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel(1_000);
+fn bounded_uncontended_1_large(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel::<Large>(1_000);
 
-        for i in 0..1000 {
-            tx.try_send(i).unwrap();
-            // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
-        }
-    })
+            for i in 0..1000 {
+                let _ = tx.try_send([[i; 64]; 64]);
+                // No need to create a task, because poll is not going to park.
+                let _ = black_box(&Pin::new(&mut rx).poll_recv(cx));
+            }
+        })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_1_large(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel::<Large>(1_000);
+fn bounded_uncontended_2(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1000);
 
-        for i in 0..1000 {
-            let _ = tx.try_send([[i; 64]; 64]);
-            // No need to create a task, because poll is not going to park.
-            let _ = test::black_box(&rx.poll());
-        }
-    })
+            for i in 0..1000 {
+                tx.try_send(i).unwrap();
+            }
+
+            for i in 0..1000 {
+                // No need to create a task, because poll is not going to park.
+                assert_eq!(Poll::Ready(Some(i)), Pin::new(&mut rx).poll_recv(cx));
+            }
+        })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_2(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel(1000);
-
-        for i in 0..1000 {
-            tx.try_send(i).unwrap();
-        }
-
-        for i in 0..1000 {
-            // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
-        }
-    })
-}
-
-#[bench]
-fn contended_unbounded_tx(b: &mut Bencher) {
+fn contended_unbounded_tx(b: &mut Bencher<'_>) {
     let mut threads = vec![];
     let mut txs = vec![];
 
@@ -210,10 +189,10 @@ fn contended_unbounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(4 * 1_000);
+        let rx = block_on_stream(rx).take(4 * 1_000);
 
         for v in rx {
-            let _ = test::black_box(v);
+            let _ = black_box(v);
         }
     });
 
@@ -224,8 +203,7 @@ fn contended_unbounded_tx(b: &mut Bencher) {
     }
 }
 
-#[bench]
-fn contended_bounded_tx(b: &mut Bencher) {
+fn contended_bounded_tx(b: &mut Bencher<'_>) {
     const THREADS: usize = 4;
     const ITERS: usize = 100;
 
@@ -237,12 +215,13 @@ fn contended_bounded_tx(b: &mut Bencher) {
         txs.push(tx);
 
         threads.push(thread::spawn(move || {
-            for tx in rx.iter() {
-                let mut tx = tx.wait();
-                for i in 0..ITERS {
-                    tx.send(i as i32).unwrap();
+            block_on(async move {
+                for mut tx in rx.iter() {
+                    for i in 0..ITERS {
+                        tx.send(i as i32).await.unwrap();
+                    }
                 }
-            }
+            })
         }));
     }
 
@@ -255,10 +234,10 @@ fn contended_bounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(THREADS * ITERS);
+        let rx = block_on_stream(rx).take(THREADS * ITERS);
 
         for v in rx {
-            let _ = test::black_box(v);
+            let _ = black_box(v);
         }
     });
 
@@ -267,4 +246,38 @@ fn contended_bounded_tx(b: &mut Bencher) {
     for th in threads {
         th.join().unwrap();
     }
+}
+
+fn bench_mpsc(c: &mut Criterion) {
+    c.bench_function("bounded_new_medium", bounded_new_medium);
+    c.bench_function("unbounded_new_medium", unbounded_new_medium);
+    c.bench_function("bounded_new_large", bounded_new_large);
+    c.bench_function("unbounded_new_large", unbounded_new_large);
+    c.bench_function("send_one_message", send_one_message);
+    c.bench_function("send_one_message_large", send_one_message_large);
+    c.bench_function("bounded_rx_not_ready", bounded_rx_not_ready);
+    c.bench_function("bounded_tx_poll_ready", bounded_tx_poll_ready);
+    c.bench_function("bounded_tx_poll_not_ready", bounded_tx_poll_not_ready);
+    c.bench_function("unbounded_rx_not_ready", unbounded_rx_not_ready);
+    c.bench_function("unbounded_rx_not_ready_x5", unbounded_rx_not_ready_x5);
+    c.bench_function("bounded_uncontended_1", bounded_uncontended_1);
+    c.bench_function("bounded_uncontended_1_large", bounded_uncontended_1_large);
+    c.bench_function("bounded_uncontended_2", bounded_uncontended_2);
+    c.bench_function("contended_unbounded_tx", contended_unbounded_tx);
+    c.bench_function("contended_bounded_tx", contended_bounded_tx);
+}
+
+criterion_group!(mpsc, bench_mpsc);
+fn main() {
+    // The large channel tests can run out of stack
+    std::thread::Builder::new()
+        .stack_size(3_000_000)
+        .spawn(|| {
+            mpsc();
+
+            Criterion::default().configure_from_args().final_summary();
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }

--- a/tokio/src/dual.rs
+++ b/tokio/src/dual.rs
@@ -1,0 +1,61 @@
+use std::{
+    mem::{self, ManuallyDrop},
+    ops::Deref,
+    ptr,
+    sync::atomic::{AtomicBool, Ordering::AcqRel},
+};
+
+#[derive(Debug)]
+struct Inner<T> {
+    value: T,
+    dropped: AtomicBool,
+}
+
+#[derive(Debug)]
+pub(crate) struct Dual<T>(ManuallyDrop<Box<Inner<T>>>);
+
+impl<T> Drop for Dual<T> {
+    fn drop(&mut self) {
+        // SAFETY Only the second instance to drop will see the `true` set by the first one to drop
+        unsafe {
+            if self.0.dropped.fetch_or(true, AcqRel) {
+                ManuallyDrop::drop(&mut self.0);
+            }
+        }
+    }
+}
+
+impl<T> Deref for Dual<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0.value
+    }
+}
+
+impl<T> Dual<T> {
+    pub(crate) fn new(value: T) -> (Dual<T>, Dual<T>) {
+        let inner = ManuallyDrop::new(Box::new(Inner {
+            value,
+            dropped: AtomicBool::new(false),
+        }));
+
+        // SAFETY Duplicating the `Box` reference is ok since ManuallyDrop::drop must be called to
+        // drop it
+        (Dual(unsafe { ptr::read(&inner) }), Dual(inner))
+    }
+
+    pub(crate) fn join(l: Dual<T>, r: Dual<T>) -> Result<T, (Dual<T>, Dual<T>)> {
+        if ptr::eq::<T>(&*l, &*r) {
+            // SAFETY `l` and `r` point to the same reference, so we can take ownership of the
+            // inner `T` as `Dual::drop` is prevented from running with `mem::forget`
+            unsafe {
+                let value = ptr::read(&l.0.value);
+                mem::forget(l);
+                mem::forget(r);
+                Ok(value)
+            }
+        } else {
+            Err((l, r))
+        }
+    }
+}

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -257,6 +257,7 @@ cfg_macros! {
 }
 
 // Tests
+mod dual;
 #[cfg(test)]
 mod tests;
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -256,8 +256,10 @@ cfg_macros! {
     pub use tokio_macros::test;
 }
 
-// Tests
+#[cfg(any(feature = "sync", feature = "io-util"))]
 mod dual;
+
+// Tests
 #[cfg(test)]
 mod tests;
 

--- a/tokio/src/net/udp/split.rs
+++ b/tokio/src/net/udp/split.rs
@@ -20,24 +20,24 @@ use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 
-use crate::dual::Dual;
+use crate::dual::ExternalDual;
 
 /// The send half after [`split`](super::UdpSocket::split).
 ///
 /// Use [`send_to`](#method.send_to) or [`send`](#method.send) to send
 /// datagrams.
 #[derive(Debug)]
-pub struct SendHalf(Dual<UdpSocket>);
+pub struct SendHalf(ExternalDual<UdpSocket>);
 
 /// The recv half after [`split`](super::UdpSocket::split).
 ///
 /// Use [`recv_from`](#method.recv_from) or [`recv`](#method.recv) to receive
 /// datagrams.
 #[derive(Debug)]
-pub struct RecvHalf(Dual<UdpSocket>);
+pub struct RecvHalf(ExternalDual<UdpSocket>);
 
 pub(crate) fn split(socket: UdpSocket) -> (RecvHalf, SendHalf) {
-    let (recv, send) = Dual::new(socket);
+    let (recv, send) = ExternalDual::new(socket);
     (RecvHalf(recv), SendHalf(send))
 }
 
@@ -58,7 +58,7 @@ impl fmt::Display for ReuniteError {
 impl Error for ReuniteError {}
 
 fn reunite(s: SendHalf, r: RecvHalf) -> Result<UdpSocket, ReuniteError> {
-    Dual::join(s.0, r.0).map_err(|(s, r)| ReuniteError(SendHalf(s), RecvHalf(r)))
+    ExternalDual::join(s.0, r.0).map_err(|(s, r)| ReuniteError(SendHalf(s), RecvHalf(r)))
 }
 
 impl RecvHalf {


### PR DESCRIPTION
## Motivation

`Arc`s are used in a couple of places where it is known that only two owners will ever exist. This introduces some slight memory overhead which can be avoided.

## Solution

Adds the Dual type which allows any value `T` to be shared between two
owners and uses this in the few places that can instead of an `Arc`.
This shrinks the sharing overhead from `2 * usize` to a single `bool`.

In some cases such as `oneshot`, the `bool` could ideally be stored
intrusively in the `T` but that is another PR if this one is accepted.

- [ ] Should/could the atomic usage here be integrated into loom someshow?