### PR TITLE
chore: prune dev-dependencies

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -119,24 +119,10 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
-tokio-util = { version = "=0.2.0-alpha.6", path = "../tokio-util" }
-
 futures-preview = { version = "=0.3.0-alpha.19", features = ["async-await"] }
-env_logger = { version = "0.6", default-features = false }
-flate2 = { version = "1", features = ["tokio"] }
-http = "0.1"
-httparse = "1.0"
-libc = "0.2"
 loom = { version = "0.2.12", features = ["futures", "checkpoint"] }
-num_cpus = "1.0"
-rand = "0.7.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tempfile = "3.1.0"
-time = "0.1"
-
-# sharded slab tests
 proptest = "0.9.4"
+tempfile = "3.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/tests/rt_current_thread.rs
+++ b/tokio/tests/rt_current_thread.rs
@@ -282,8 +282,6 @@ fn delay_in_spawn() {
 
 #[test]
 fn client_server_block_on() {
-    let _ = env_logger::try_init();
-
     let mut rt = rt();
     let (tx, rx) = mpsc::channel();
 

--- a/tokio/tests/rt_thread_pool.rs
+++ b/tokio/tests/rt_thread_pool.rs
@@ -44,8 +44,6 @@ fn send_sync_bound() {
 
 #[test]
 fn spawn_shutdown() {
-    let _ = env_logger::try_init();
-
     let mut rt = Runtime::new().unwrap();
     let (tx, rx) = mpsc::channel();
 
@@ -166,8 +164,6 @@ fn nested_enter() {
 #[test]
 fn after_start_and_before_stop_is_called() {
     use std::sync::atomic::{AtomicUsize, Ordering};
-
-    let _ = env_logger::try_init();
 
     let after_start = Arc::new(AtomicUsize::new(0));
     let before_stop = Arc::new(AtomicUsize::new(0));


### PR DESCRIPTION
Most dev dependendencies are unused now that examples are moved into a
separate crate.