### PR TITLE
ci: install minimal profile by default

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --default-toolchain beta
+    - sh rustup.sh -y --profile minimal --default-toolchain beta
     - . $HOME/.cargo/env
     - rustup target add i686-unknown-freebsd
     - |

--- a/ci/azure-install-rust.yml
+++ b/ci/azure-install-rust.yml
@@ -2,7 +2,7 @@ steps:
   # Linux and macOS.
   - script: |
       set -e
-      curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+      curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain none
       export PATH=$PATH:$HOME/.cargo/bin
       rustup toolchain install $RUSTUP_TOOLCHAIN
       rustup default $RUSTUP_TOOLCHAIN
@@ -15,7 +15,7 @@ steps:
   # Windows.
   - script: |
       curl -sSf -o rustup-init.exe https://win.rustup.rs
-      rustup-init.exe -y --default-toolchain none
+      rustup-init.exe -y --profile minimal --default-toolchain none
       set PATH=%PATH%;%USERPROFILE%\.cargo\bin
       rustup toolchain install %RUSTUP_TOOLCHAIN%
       rustup default %RUSTUP_TOOLCHAIN%


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

install only the components we need.

https://blog.rust-lang.org/2019/10/15/Rustup-1.20.0.html#profiles

> * The minimal profile includes as few components as possible to get a working compiler (rustc, rust-std, and cargo). It's recommended to use this component on Windows systems if you don't use local documentation, and in CI.
> * The default profile includes all the components previously installed by default (rustc, rust-std, cargo, and rust-docs) plus rustfmt and clippy. This profile will be used by rustup by default, and it's the one recommended for general use.
> * The complete profile includes all the components available through rustup, including miri and IDE integration tools (rls and rust-analysis).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
