### PR TITLE
timer: have example use delay_for instead of delay

### DIFF
--- a/tokio/src/timer/mod.rs
+++ b/tokio/src/timer/mod.rs
@@ -30,15 +30,14 @@
 //! Wait 100ms and print "Hello World!"
 //!
 //! ```
-//! use tokio::timer::delay;
+//! use tokio::timer::delay_for;
 //!
 //! use std::time::Duration;
 //!
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let when = tokio::clock::now() + Duration::from_millis(100);
-//!     delay(when).await;
+//!     delay_for(Duration::from_millis(100)).await;
 //!     println!("100 ms have elapsed");
 //! }
 //! ```


### PR DESCRIPTION
## Motivation
It is a more common use case that is to simply cause a delay for an amount of time.

## Solution

I think it is more appropriate to show off `delay_for` in the example rather than `delay` that is useful only for less common use cases.
