### PR TITLE
simplify enter

### DIFF
--- a/tokio/src/runtime/current_thread/mod.rs
+++ b/tokio/src/runtime/current_thread/mod.rs
@@ -139,8 +139,7 @@ where
         let scheduler = &*self.scheduler;
 
         runtime::global::with_current_thread(scheduler, || {
-            let mut _enter =
-                runtime::enter::enter().expect("attempting to block while on a Tokio executor");
+            let mut _enter = runtime::enter();
 
             let raw_waker = RawWaker::new(
                 scheduler as *const Scheduler as *const (),

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -146,6 +146,8 @@ mod current_thread;
 
 #[cfg(feature = "blocking")]
 mod enter;
+#[cfg(feature = "blocking")]
+pub(crate) use self::enter::{enter, try_enter};
 
 mod global;
 pub use self::global::spawn;
@@ -340,10 +342,7 @@ impl Runtime {
         let kind = &mut self.kind;
 
         blocking::with_pool(&self.blocking_pool, || match kind {
-            Kind::Shell => {
-                let mut enter = enter::enter().unwrap();
-                enter.block_on(future)
-            }
+            Kind::Shell => enter().block_on(future),
             #[cfg(feature = "rt-current-thread")]
             Kind::CurrentThread(exec) => exec.block_on(future),
             #[cfg(feature = "rt-full")]

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -147,7 +147,7 @@ mod current_thread;
 #[cfg(feature = "blocking")]
 mod enter;
 #[cfg(feature = "blocking")]
-pub(crate) use self::enter::{enter, try_enter};
+pub(crate) use self::enter::enter;
 
 mod global;
 pub use self::global::spawn;

--- a/tokio/src/runtime/thread_pool/pool.rs
+++ b/tokio/src/runtime/thread_pool/pool.rs
@@ -55,8 +55,7 @@ impl ThreadPool {
         F: Future,
     {
         crate::runtime::global::with_thread_pool(self.spawner(), || {
-            let mut enter = crate::runtime::enter::enter()
-                .expect("attempting to block while on a Tokio executor");
+            let mut enter = crate::runtime::enter();
             crate::runtime::blocking::with_pool(self.spawner.blocking_pool(), || {
                 enter.block_on(future)
             })

--- a/tokio/src/runtime/thread_pool/shutdown.rs
+++ b/tokio/src/runtime/thread_pool/shutdown.rs
@@ -27,18 +27,15 @@ pub(super) fn channel() -> (Sender, Receiver) {
 impl Receiver {
     /// Block the current thread until all `Sender` handles drop.
     pub(crate) fn wait(&mut self) {
-        use crate::runtime::enter::enter;
+        use crate::runtime::{enter, try_enter};
 
-        let mut e = match enter() {
-            Ok(e) => e,
-            Err(_) => {
-                if std::thread::panicking() {
-                    // Already panicking, avoid a double panic
-                    return;
-                } else {
-                    panic!("cannot block on shutdown from the Tokio runtime");
-                }
+        let mut e = if std::thread::panicking() {
+            match try_enter() {
+                Some(enter) => enter,
+                _ => return,
             }
+        } else {
+            enter()
         };
 
         // The oneshot completes with an Err

--- a/tokio/src/runtime/thread_pool/shutdown.rs
+++ b/tokio/src/runtime/thread_pool/shutdown.rs
@@ -27,7 +27,7 @@ pub(super) fn channel() -> (Sender, Receiver) {
 impl Receiver {
     /// Block the current thread until all `Sender` handles drop.
     pub(crate) fn wait(&mut self) {
-        use crate::runtime::{enter, try_enter};
+        use crate::runtime::enter::{enter, try_enter};
 
         let mut e = if std::thread::panicking() {
             match try_enter() {

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -131,8 +131,7 @@ where
 
         // Track the current worker
         current::set(&pool, index, || {
-            let _enter =
-                crate::runtime::enter::enter().expect("executor already running on thread");
+            let _enter = crate::runtime::enter();
 
             crate::runtime::global::with_thread_pool(&spawner, || {
                 crate::runtime::blocking::with_pool(blocking, || {


### PR DESCRIPTION
`enter` is now internal, so we can avoid the `Result` and
`Error `implementation. This also moves the runtime-in-runtime
panic to a single location where a more detailed error message
can be used.