### PR TITLE
Proposing new `AsyncRead` / `AsyncWrite` traits

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -93,7 +93,7 @@ futures-sink-preview = "=0.3.0-alpha.19"
 futures-util-preview = { version = "=0.3.0-alpha.19", features = ["sink", "channel"] }
 
 # Everything else is optional...
-bytes = { version = "0.4", optional = true }
+bytes = { git = "https://github.com/tokio-rs/bytes", optional = true }
 fnv = { version = "1.0.6", optional = true }
 iovec = { version = "0.1", optional = true }
 lazy_static = { version = "1.0.2", optional = true }

--- a/tokio/src/io/io/async_read_ext.rs
+++ b/tokio/src/io/io/async_read_ext.rs
@@ -1,3 +1,5 @@
+use bytes::BufMut;
+
 use crate::io::io::chain::{chain, Chain};
 use crate::io::io::copy::{copy, Copy};
 use crate::io::io::read::{read, Read};
@@ -44,17 +46,19 @@ pub trait AsyncReadExt: AsyncRead {
     ///
     /// The returned future will resolve to the number of bytes read once the
     /// read operation is completed.
-    fn read<'a>(&'a mut self, dst: &'a mut [u8]) -> Read<'a, Self>
+    fn read<'a, B>(&'a mut self, dst: &'a mut B) -> Read<'a, Self, B>
     where
         Self: Unpin,
+        B: BufMut + Unpin,
     {
         read(self, dst)
     }
 
     /// Read exactly the amount of data needed to fill the provided buffer.
-    fn read_exact<'a>(&'a mut self, dst: &'a mut [u8]) -> ReadExact<'a, Self>
+    fn read_exact<'a, B>(&'a mut self, dst: &'a mut B) -> ReadExact<'a, Self, B>
     where
         Self: Unpin,
+        B: BufMut + Unpin,
     {
         read_exact(self, dst)
     }

--- a/tokio/src/io/io/async_write_ext.rs
+++ b/tokio/src/io/io/async_write_ext.rs
@@ -1,3 +1,5 @@
+use bytes::Buf;
+
 use crate::io::io::flush::{flush, Flush};
 use crate::io::io::shutdown::{shutdown, Shutdown};
 use crate::io::io::write::{write, Write};
@@ -7,19 +9,21 @@ use crate::io::AsyncWrite;
 /// An extension trait which adds utility methods to `AsyncWrite` types.
 pub trait AsyncWriteExt: AsyncWrite {
     /// Write a buffer into this writter, returning how many bytes were written.
-    fn write<'a>(&'a mut self, src: &'a [u8]) -> Write<'a, Self>
+    fn write<'a, B>(&'a mut self, buf: B) -> Write<'a, Self, B>
     where
         Self: Unpin,
+        B: Buf + Unpin,
     {
-        write(self, src)
+        write(self, buf)
     }
 
     /// Attempt to write an entire buffer into this writter.
-    fn write_all<'a>(&'a mut self, src: &'a [u8]) -> WriteAll<'a, Self>
+    fn write_all<'a, B>(&'a mut self, buf: B) -> WriteAll<'a, Self, B>
     where
         Self: Unpin,
+        B: Buf + Unpin,
     {
-        write_all(self, src)
+        write_all(self, buf)
     }
 
     /// Flush the contents of this writer.

--- a/tokio/src/io/io/buf_stream.rs
+++ b/tokio/src/io/io/buf_stream.rs
@@ -1,6 +1,7 @@
 use crate::io::io::{BufReader, BufWriter};
 use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite};
 
+use bytes::{Buf, BufMut};
 use pin_project::pin_project;
 use std::io::{self};
 use std::{
@@ -94,7 +95,7 @@ impl<RW: AsyncRead + AsyncWrite> AsyncWrite for BufStream<RW> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         self.project().0.poll_write(cx, buf)
     }
@@ -112,14 +113,9 @@ impl<RW: AsyncRead + AsyncWrite> AsyncRead for BufStream<RW> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         self.project().0.poll_read(cx, buf)
-    }
-
-    // we can't skip unconditionally because of the large buffer case in read.
-    unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [u8]) -> bool {
-        self.0.prepare_uninitialized_buffer(buf)
     }
 }
 

--- a/tokio/src/io/io/copy.rs
+++ b/tokio/src/io/io/copy.rs
@@ -87,7 +87,7 @@ where
             // continue.
             if self.pos == self.cap && !self.read_done {
                 let me = &mut *self;
-                let n = ready!(Pin::new(&mut *me.reader).poll_read(cx, &mut me.buf))?;
+                let n = ready!(Pin::new(&mut *me.reader).poll_read(cx, &mut &mut me.buf[..]))?;
                 if n == 0 {
                     self.read_done = true;
                 } else {
@@ -99,7 +99,8 @@ where
             // If our buffer has some data, let's write it out!
             while self.pos < self.cap {
                 let me = &mut *self;
-                let i = ready!(Pin::new(&mut *me.writer).poll_write(cx, &me.buf[me.pos..me.cap]))?;
+                let i =
+                    ready!(Pin::new(&mut *me.writer).poll_write(cx, &mut &me.buf[me.pos..me.cap]))?;
                 if i == 0 {
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::WriteZero,

--- a/tokio/src/io/io/empty.rs
+++ b/tokio/src/io/io/empty.rs
@@ -1,5 +1,6 @@
 use crate::io::{AsyncBufRead, AsyncRead};
 
+use bytes::BufMut;
 use std::fmt;
 use std::io;
 use std::pin::Pin;
@@ -47,7 +48,7 @@ impl AsyncRead for Empty {
     fn poll_read(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
-        _: &mut [u8],
+        _: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         Poll::Ready(Ok(0))
     }

--- a/tokio/src/io/io/read_exact.rs
+++ b/tokio/src/io/io/read_exact.rs
@@ -1,5 +1,6 @@
 use crate::io::AsyncRead;
 
+use bytes::BufMut;
 use futures_core::ready;
 use std::future::Future;
 use std::io;
@@ -11,15 +12,12 @@ use std::task::{Context, Poll};
 /// a buffer.
 ///
 /// Created by the [`AsyncRead::read_exact`].
-pub(crate) fn read_exact<'a, A>(reader: &'a mut A, buf: &'a mut [u8]) -> ReadExact<'a, A>
+pub(crate) fn read_exact<'a, A, B>(reader: &'a mut A, buf: &'a mut B) -> ReadExact<'a, A, B>
 where
     A: AsyncRead + Unpin + ?Sized,
+    B: BufMut + Unpin,
 {
-    ReadExact {
-        reader,
-        buf,
-        pos: 0,
-    }
+    ReadExact { reader, buf }
 }
 
 /// Creates a future which will read exactly enough bytes to fill `buf`,
@@ -28,38 +26,32 @@ where
 /// On success the number of bytes is returned
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ReadExact<'a, A: ?Sized> {
+pub struct ReadExact<'a, A: ?Sized, B> {
     reader: &'a mut A,
-    buf: &'a mut [u8],
-    pos: usize,
+    buf: &'a mut B,
 }
 
 fn eof() -> io::Error {
     io::Error::new(io::ErrorKind::UnexpectedEof, "early eof")
 }
 
-impl<A> Future for ReadExact<'_, A>
+impl<A, B> Future for ReadExact<'_, A, B>
 where
     A: AsyncRead + Unpin + ?Sized,
+    B: BufMut + Unpin,
 {
-    type Output = io::Result<usize>;
+    type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        loop {
-            // if our buffer is empty, then we need to read some data to continue.
-            if self.pos < self.buf.len() {
-                let me = &mut *self;
-                let n = ready!(Pin::new(&mut *me.reader).poll_read(cx, &mut me.buf[me.pos..]))?;
-                me.pos += n;
-                if n == 0 {
-                    return Err(eof()).into();
-                }
-            }
-
-            if self.pos >= self.buf.len() {
-                return Poll::Ready(Ok(self.pos));
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let me = &mut *self;
+        while me.buf.has_remaining_mut() {
+            let n = ready!(Pin::new(&mut *me.reader).poll_read(cx, me.buf))?;
+            if n == 0 {
+                return Err(eof()).into();
             }
         }
+
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -70,6 +62,6 @@ mod tests {
     #[test]
     fn assert_unpin() {
         use std::marker::PhantomPinned;
-        crate::is_unpin::<ReadExact<'_, PhantomPinned>>();
+        crate::is_unpin::<ReadExact<'_, PhantomPinned, PhantomPinned>>();
     }
 }

--- a/tokio/src/io/io/read_to_end.rs
+++ b/tokio/src/io/io/read_to_end.rs
@@ -65,11 +65,10 @@ pub(super) fn read_to_end_internal<R: AsyncRead + ?Sized>(
                 g.buf.reserve(32);
                 let capacity = g.buf.capacity();
                 g.buf.set_len(capacity);
-                rd.prepare_uninitialized_buffer(&mut g.buf[g.len..]);
             }
         }
 
-        match ready!(rd.as_mut().poll_read(cx, &mut g.buf[g.len..])) {
+        match ready!(rd.as_mut().poll_read(cx, &mut g.buf)) {
             Ok(0) => {
                 ret = Poll::Ready(Ok(g.len - start_len));
                 break;

--- a/tokio/src/io/io/sink.rs
+++ b/tokio/src/io/io/sink.rs
@@ -1,5 +1,6 @@
 use crate::io::AsyncWrite;
 
+use bytes::Buf;
 use std::fmt;
 use std::io;
 use std::pin::Pin;
@@ -45,9 +46,11 @@ impl AsyncWrite for Sink {
     fn poll_write(
         self: Pin<&mut Self>,
         _: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<Result<usize, io::Error>> {
-        Poll::Ready(Ok(buf.len()))
+        let n = buf.remaining();
+        buf.advance(n);
+        Poll::Ready(Ok(n))
     }
 
     #[inline]

--- a/tokio/src/io/io/write.rs
+++ b/tokio/src/io/io/write.rs
@@ -1,5 +1,6 @@
 use crate::io::AsyncWrite;
 
+use bytes::Buf;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -8,29 +9,31 @@ use std::task::{Context, Poll};
 /// A future to write some of the buffer to an `AsyncWrite`.
 #[derive(Debug)]
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Write<'a, W: ?Sized> {
+pub struct Write<'a, W: ?Sized, B> {
     writer: &'a mut W,
-    buf: &'a [u8],
+    buf: B,
 }
 
 /// Tries to write some bytes from the given `buf` to the writer in an
 /// asynchronous manner, returning a future.
-pub(crate) fn write<'a, W>(writer: &'a mut W, buf: &'a [u8]) -> Write<'a, W>
+pub(crate) fn write<'a, W, B>(writer: &'a mut W, buf: B) -> Write<'a, W, B>
 where
     W: AsyncWrite + Unpin + ?Sized,
+    B: Buf + Unpin,
 {
     Write { writer, buf }
 }
 
-impl<W> Future for Write<'_, W>
+impl<W, B> Future for Write<'_, W, B>
 where
     W: AsyncWrite + Unpin + ?Sized,
+    B: Buf + Unpin,
 {
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let me = &mut *self;
-        Pin::new(&mut *me.writer).poll_write(cx, me.buf)
+        Pin::new(&mut *me.writer).poll_write(cx, &mut me.buf)
     }
 }
 

--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -85,19 +85,10 @@ impl<T: AsyncRead> AsyncRead for ReadHalf<T> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         let mut inner = ready!(self.inner.poll_lock(cx));
         inner.stream_pin().poll_read(cx, buf)
-    }
-
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        let mut inner = ready!(self.inner.poll_lock(cx));
-        inner.stream_pin().poll_read_buf(cx, buf)
     }
 }
 
@@ -105,7 +96,7 @@ impl<T: AsyncWrite> AsyncWrite for WriteHalf<T> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<Result<usize, io::Error>> {
         let mut inner = ready!(self.inner.poll_lock(cx));
         inner.stream_pin().poll_write(cx, buf)
@@ -119,15 +110,6 @@ impl<T: AsyncWrite> AsyncWrite for WriteHalf<T> {
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         let mut inner = ready!(self.inner.poll_lock(cx));
         inner.stream_pin().poll_shutdown(cx)
-    }
-
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>> {
-        let mut inner = ready!(self.inner.poll_lock(cx));
-        inner.stream_pin().poll_write_buf(cx, buf)
     }
 }
 

--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -1,6 +1,7 @@
 use crate::fs::blocking::Blocking;
 use crate::io::AsyncWrite;
 
+use bytes::Buf;
 use std::io;
 use std::pin::Pin;
 use std::task::Context;
@@ -35,7 +36,7 @@ impl AsyncWrite for Stderr {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.std).poll_write(cx, buf)
     }

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -1,6 +1,7 @@
 use crate::fs::blocking::Blocking;
 use crate::io::AsyncRead;
 
+use bytes::BufMut;
 use std::io;
 use std::pin::Pin;
 use std::task::Context;
@@ -41,7 +42,7 @@ impl AsyncRead for Stdin {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.std).poll_read(cx, buf)
     }

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -1,6 +1,7 @@
 use crate::fs::blocking::Blocking;
 use crate::io::AsyncWrite;
 
+use bytes::Buf;
 use std::io;
 use std::pin::Pin;
 use std::task::Context;
@@ -35,7 +36,7 @@ impl AsyncWrite for Stdout {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.std).poll_write(cx, buf)
     }

--- a/tokio/src/net/unix/split.rs
+++ b/tokio/src/net/unix/split.rs
@@ -30,24 +30,12 @@ pub(crate) fn split(stream: &mut UnixStream) -> (ReadHalf<'_>, WriteHalf<'_>) {
 }
 
 impl AsyncRead for ReadHalf<'_> {
-    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
-        false
-    }
-
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         self.0.poll_read_priv(cx, buf)
-    }
-
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.0.poll_read_buf_priv(cx, buf)
     }
 }
 
@@ -55,7 +43,7 @@ impl AsyncWrite for WriteHalf<'_> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         self.0.poll_write_priv(cx, buf)
     }
@@ -66,14 +54,6 @@ impl AsyncWrite for WriteHalf<'_> {
 
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.0.shutdown(Shutdown::Write).into()
-    }
-
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.0.poll_write_buf_priv(cx, buf)
     }
 }
 

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -6,10 +6,10 @@ use crate::net::util::PollEvented;
 use bytes::{Buf, BufMut};
 use futures_core::ready;
 use futures_util::future::poll_fn;
-use iovec::IoVec;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read, Write};
+use std::mem::{self, MaybeUninit};
 use std::net::Shutdown;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
@@ -139,24 +139,12 @@ impl TryFrom<net::UnixStream> for UnixStream {
 }
 
 impl AsyncRead for UnixStream {
-    unsafe fn prepare_uninitialized_buffer(&self, _: &mut [u8]) -> bool {
-        false
-    }
-
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         self.poll_read_priv(cx, buf)
-    }
-
-    fn poll_read_buf<B: BufMut>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.poll_read_buf_priv(cx, buf)
     }
 }
 
@@ -164,7 +152,7 @@ impl AsyncWrite for UnixStream {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         self.poll_write_priv(cx, buf)
     }
@@ -175,14 +163,6 @@ impl AsyncWrite for UnixStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
-    }
-
-    fn poll_write_buf<B: Buf>(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        self.poll_write_buf_priv(cx, buf)
     }
 }
 
@@ -201,30 +181,12 @@ impl UnixStream {
     pub(crate) fn poll_read_priv(
         &self,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         ready!(self.io.poll_read_ready(cx, mio::Ready::readable()))?;
 
-        match self.io.get_ref().read(buf) {
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.clear_read_ready(cx, mio::Ready::readable())?;
-                Poll::Pending
-            }
-            x => Poll::Ready(x),
-        }
-    }
-
-    pub(crate) fn poll_read_buf_priv<B: BufMut>(
-        &self,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        ready!(self.io.poll_read_ready(cx, mio::Ready::readable()))?;
-
+        /* TODO: re-implement when mio supports IoSliceMut
         let r = unsafe {
-            // The `IoVec` type can't have a 0-length size, so we create a bunch
-            // of dummy versions on the stack with 1 length which we'll quickly
-            // overwrite.
             let b1: &mut [u8] = &mut [0];
             let b2: &mut [u8] = &mut [0];
             let b3: &mut [u8] = &mut [0];
@@ -262,45 +224,32 @@ impl UnixStream {
             let n = buf.bytes_vec_mut(&mut bufs);
             self.io.get_ref().read_bufs(&mut bufs[..n])
         };
+        */
 
-        match r {
-            Ok(n) => {
-                unsafe {
-                    buf.advance_mut(n);
-                }
-                Poll::Ready(Ok(n))
-            }
+        match self.io.get_ref().read(unsafe {
+            // UDS read() won't look at the bytes
+            mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(buf.bytes_mut())
+        }) {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 self.io.clear_read_ready(cx, mio::Ready::readable())?;
                 Poll::Pending
             }
             Err(e) => Poll::Ready(Err(e)),
+            Ok(n) => {
+                unsafe { buf.advance_mut(n) };
+                Poll::Ready(Ok(n))
+            }
         }
     }
 
     pub(crate) fn poll_write_priv(
         &self,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         ready!(self.io.poll_write_ready(cx))?;
 
-        match self.io.get_ref().write(buf) {
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                self.io.clear_write_ready(cx)?;
-                Poll::Pending
-            }
-            x => Poll::Ready(x),
-        }
-    }
-
-    pub(crate) fn poll_write_buf_priv<B: Buf>(
-        &self,
-        cx: &mut Context<'_>,
-        buf: &mut B,
-    ) -> Poll<io::Result<usize>> {
-        ready!(self.io.poll_write_ready(cx))?;
-
+        /* TODO: bring back when mio supports IoSlice
         let r = {
             // The `IoVec` type can't have a zero-length size, so create a dummy
             // version from a 1-length slice which we'll overwrite with the
@@ -311,16 +260,18 @@ impl UnixStream {
             let n = buf.bytes_vec(&mut bufs);
             self.io.get_ref().write_bufs(&bufs[..n])
         };
-        match r {
-            Ok(n) => {
-                buf.advance(n);
-                Poll::Ready(Ok(n))
-            }
+        */
+
+        match self.io.get_ref().write(buf.bytes()) {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 self.io.clear_write_ready(cx)?;
                 Poll::Pending
             }
             Err(e) => Poll::Ready(Err(e)),
+            Ok(n) => {
+                buf.advance(n);
+                Poll::Ready(Ok(n))
+            }
         }
     }
 }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -120,6 +120,7 @@ mod kill;
 use crate::io::{AsyncRead, AsyncReadExt, AsyncWrite};
 use crate::process::kill::Kill;
 
+use bytes::{Buf, BufMut};
 use futures_core::TryFuture;
 use futures_util::try_future::try_join3;
 use std::ffi::OsStr;
@@ -854,7 +855,7 @@ impl AsyncWrite for ChildStdin {
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &[u8],
+        buf: &mut dyn Buf,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_write(cx, buf)
     }
@@ -872,7 +873,7 @@ impl AsyncRead for ChildStdout {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_read(cx, buf)
     }
@@ -882,7 +883,7 @@ impl AsyncRead for ChildStderr {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut [u8],
+        buf: &mut dyn BufMut,
     ) -> Poll<io::Result<usize>> {
         Pin::new(&mut self.inner).poll_read(cx, buf)
     }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -304,7 +304,7 @@ impl Driver {
     /// was the case. See #38 for more info.
     fn drain(mut self: Pin<&mut Self>, cx: &mut Context<'_>) {
         loop {
-            match Pin::new(&mut self.wakeup).poll_read(cx, &mut [0; 128]) {
+            match Pin::new(&mut self.wakeup).poll_read(cx, &mut &mut [0u8; 128][..]) {
                 Poll::Ready(Ok(0)) => panic!("EOF on self-pipe"),
                 Poll::Ready(Ok(_)) => {}
                 Poll::Ready(Err(e)) => panic!("Bad read on self-pipe: {}", e),


### PR DESCRIPTION
Introduce new `AsyncRead` / `AsyncWrite`
​
This PR introduces new versions of `AsyncRead` / `AsyncWrite` traits.
The proposed changes aim to improve:
​
- ergonomics.
- integration of vectored operations
- working with uninitialized byte slices.
​
## Overview
​
The PR changes the `AsyncRead` and `AsyncWrite` traits to accept `T:
Buf` and `T: BufMut` values instead of `&[u8]` and `&mut [u8]`. Because
`&[u8]` implements `Buf` and `&mut [u8]` implements `BufMut`, the same
calling patterns used today are still possible. Additionally, any type
that implements `Buf` and `BufMut` may be used. This includes
`Cursor<&[u8]>`, `Bytes`, ...
​
### Improvement in ergonomics
​
Calls to `read` and `write` accept buffers, but do not necessary use up
the entirety of the buffer. Both functions return a `usize` representing
the number of bytes read / written. Because of this, it is common to
write loops such as:
​
```rust
let mut rem = &my_data[..];
​
while !rem.is_empty() {
    let n = my_socket.write(rem).await?;
    rem = &rem[n..];
}
```
​
The key point to notice is having to use the return value to update the
position in the cursor. This is both common and error prone. The `Buf` /
`BufMut` traits aim to ease this by building the cursor concept directly
into the buffer. By using these traits with `AsyncRead` / `AsyncWrite`,
the above loop can be simplified as:
​
```rust
let mut buf = Cursor::new(&my_data[..]);
​
while buf.has_remaining() {
    my_socket.write(&mut buf).await?;
}
```
​
A small reduction in code, but it removes an error prone bit of logic
that must be often repeated.
​
### Integration of vectored operations
​
In the `AsyncRead` / `AsyncWrite` traits provided by `futures-io`,
vectored operations are covered using separate fns: `poll_read_vectored`
and `poll_write_vectored`. These two functions have default
implementations that call the non-vectored operations.
​
This has a draw back, when implementing `AsyncRead` / `AsyncWrite`,
usually as a layer on top of a type such as `TcpStream`, the implementor
must not forget to impleement these two additional functions. Otherwise,
the implementation will not be able to use vectored operations even if
the underlying TcpStream supports it. Secondly, it requires duplication
of logic: one `poll_read` implementation and one `poll_read_vectored`
implementation. It is possible to implement one in terms of the other,
but this can result in sub-optimial implementations.
​
Imagine a situation where a [rope](https://en.wikipedia.org/wiki/Rope)
data structure is being written to a socket. This structure is comprised
of many smaller byte slices (perhaps thousands). To write it efficiently
to the socket, avoiding copying data is preferable. To do this, the byte
slices need to be loaded in an `IoSlice`. Since modern linux systems
support a max of 1024 slices, we initialize an array of 1024 slices,
iterate the rope to populate this array and call `poll_write_vectored`.
The problem is that, as the caller, we don't know if the `AsyncWrite`
type supports vectored operations or not, `poll_write_vectored` is
called optimistically. However, the implementation "forgot" to proxy its
function to `TcpStream`, so `poll_read` is called w/ the first entry in
the `IoSlice`. The problem is, for each call to `poll_read_vectored`, we
must iterate 1024 nodes in our rope to only have one chunk written at a
time.
​
By using `T: Buf` as the argument, the decision of whether or not to use
vectored operations is left up to the leaf `AsyncWrite` type.
Intermediate layers only implement `poll_write` w/ `T: Buf` and pass it
along to the inner stream. The `TcpStream` implementation will know that
it supports vectored operations and know how many slices it can write at
a time and do "the right thing".
​
### Working with uninitialized byte slices
​
When passing buffers to `AsyncRead`, it is desirable to pass in
**uninitialized memory** which the `poll_read` call will write to. This
avoids the expensive step of zeroing out the memory (doing so has
measurable impact at the macro level). The problem is that uninitialized
memory is "unsafe", as such, care must be taken.
​
Tokio initially attempted to handle this by adding a
[`prepare_uninitialized_buffer`](https://docs.rs/tokio-io/0.2.0-alpha.6/tokio_io/trait.AsyncRead.html#method.prepare_uninitialized_buffer)
function. `std` is investigating adding a
[similar](https://doc.rust-lang.org/std/io/trait.Read.html#method.initializer)
though improved variant of this API. However, over the years, we have
learned that the `prepare_uninitialized_buffer` API is sub optimal for
multiple reasons.
​
First, the same problem applies as vectored operations. If an
implementation "forgets" to implement `prepare_uninitialized_buffer`
then all slices must be zeroed out before passing it to `poll_read`,
even if the implementation does "the right thing" (not read from
initialized memory). In practice, most implementors end up forgetting to
implement this function, resulting in memory being zeroed out.
​
Secondly, implementations of `AsyncRead` that **should not** require
`unsafe` to implement now must add `unsafe` simply to avoid having
memory zeroed out.
​
Switching the argument to `T: BufMut` solves this problem via the
`BufMut` trait. First, `BufMut` provides low-level functions that return
`&mut [MaybeUninitialized<u8>]`. Second, it provides utility functions
that provide safe APIs for writing to the buffer (`put_slice`, `put_u8`,
...). Again, only the leaf `AsyncRead` implementations (`TcpStream`)
must use the unsafe APIs. All layers may take advantage of uninitialized
memory without the associated unsafety.
​
## Drawbacks
​
The primary drawback is genericizing the `AsyncRead` and `AsyncWrite`
traits. This adds complexity. We feel that the added benefits discussed
above outweighs the drawbacks, but only trying it out will validate it.
​
## Relation to `futures-io`, `std`, and roadmap
​
The relationship between `tokio`'s I/O traits and `futures-io` has come
up a few times in the past. Tokio has historically maintained its own
traits. `futures-io` has just been released with a simplified version of
the traits. There is also talk of standardizing `AsyncRead` and
`AsyncWrite` in `std`. Because of this, we believe that **now** is the
perfect time to experiment with these traits. This will allow us to gain
more experience before committing to traits in `std`.
​
The next version of Tokio will **not** be 1.0. This allows us to
experiment with these traits and remove them for 1.0 if they do not pan
out.
​
Once `AsyncRead` / `AsyncWrite` are added to `std`, Tokio will provide
implementations for its types. Until then, `tokio-util` will provide a
compatibility layer between Tokio types and `futures-io`.