### PR TITLE
chore: update CI config to test on stable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,7 +13,7 @@ task:
   setup_script:
     - pkg install -y curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain beta
+    - sh rustup.sh -y --profile minimal --default-toolchain stable
     - . $HOME/.cargo/env
     - rustup target add i686-unknown-freebsd
     - |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,20 +8,20 @@ jobs:
 # Check formatting
 - template: ci/azure-rustfmt.yml
   parameters:
-    rust: beta
+    rust: stable
     name: rustfmt
 
 # Apply clippy lints to all crates
 - template: ci/azure-clippy.yml
   parameters:
-    rust: beta
+    rust: stable
     name: clippy
 
 # Test top level crate
 - template: ci/azure-test-stable.yml
   parameters:
     name: test_tokio
-    rust: beta
+    rust: stable
     displayName: Test tokio
     cross: true
     crates:
@@ -33,7 +33,7 @@ jobs:
   parameters:
     name: test_linux
     displayName: Test sub crates -
-    rust: beta
+    rust: stable
     crates:
       - tokio-macros
       - tokio-test
@@ -44,7 +44,7 @@ jobs:
 - template: ci/azure-loom.yml
   parameters:
     name: loom
-    rust: beta
+    rust: stable
     crates:
       - tokio
 
@@ -52,7 +52,7 @@ jobs:
 - template: ci/azure-cross-compile.yml
   parameters:
     name: cross
-    rust: beta
+    rust: stable
 
 # # This represents the minimum Rust version supported by
 # # Tokio. Updating this should be done in a dedicated PR and
@@ -69,11 +69,11 @@ jobs:
 # - template: ci/azure-tsan.yml
 #   parameters:
 #     name: tsan
-#     rust: beta
+#     rust: stable
 
 - template: ci/azure-deploy-docs.yml
   parameters:
-    rust: beta
+    rust: stable
     dependsOn:
       - rustfmt
       - clippy

--- a/ci/azure-clippy.yml
+++ b/ci/azure-clippy.yml
@@ -12,5 +12,5 @@ jobs:
         cargo clippy --version
       displayName: Install clippy
     - script: |
-        cargo clippy --all --all-features -- -A clippy::mutex-atomic -A clippy::needless-doctest-main
+        cargo clippy --all --all-features -- -A clippy::mutex-atomic
       displayName: cargo clippy --all

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-beta
+stable


### PR DESCRIPTION
Rust 1.39 has been released: https://blog.rust-lang.org/2019/11/07/Rust-1.39.0.html