### PR TITLE
v0.1.x: prepare to release `tokio-executor` 0.1.9

### DIFF
--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.9 (November 7, 2019)
+
+### Added
+- Add `executor::set_default` which behaves like `with_default` but returns a
+  drop guard (#1725).
+
 # 0.1.8 (June 2, 2019)
 
 ### Added

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -8,8 +8,8 @@ name = "tokio-executor"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
-documentation = "https://docs.rs/tokio-executor/0.1.7/tokio_executor"
+version = "0.1.9"
+documentation = "https://docs.rs/tokio-executor/0.1.9/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,7 +2,7 @@
 
 Task execution related traits and utilities.
 
-[Documentation](https://docs.rs/tokio-executor/0.1.8/tokio_executor)
+[Documentation](https://docs.rs/tokio-executor/0.1.9/tokio_executor)
 
 ## Overview
 
@@ -31,10 +31,10 @@ executor, including:
 
 * [`Park`] abstracts over blocking and unblocking the current thread.
 
-[`Executor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/trait.Executor.html
-[`enter`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/fn.enter.html
-[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/struct.DefaultExecutor.html
-[`Park`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/park/trait.Park.html
+[`Executor`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/trait.Executor.html
+[`enter`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/fn.enter.html
+[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/struct.DefaultExecutor.html
+[`Park`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/park/trait.Park.html
 
 ## License
 

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.9")]
 
 //! Task execution related traits and utilities.
 //!


### PR DESCRIPTION
# 0.1.9 (November 7, 2019)

### Added
- Add `executor::set_default` which behaves like `with_default` but returns a
  drop guard (#1725).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>