### PR TITLE
v0.1.x: prepare to release tokio-timer 0.2.12

### DIFF
--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.12 (November 7, 2019)
+
+### Added
+- `timer::set_default`, which functions like `timer::with_default`, but
+  returns a drop guard (#1725).
+- `clock::set_default`, which functions like `clock::with_default`, but
+  returns a drop guard (#1725).
+
 # 0.2.11 (May 14, 2019)
 
 ### Added

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -8,11 +8,11 @@ name = "tokio-timer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.11/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.12/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,7 +2,7 @@
 
 Timer facilities for Tokio
 
-[Documentation](https://docs.rs/tokio-timer/0.2.11/tokio_timer/)
+[Documentation](https://docs.rs/tokio-timer/0.2.12/tokio_timer/)
 
 ## Overview
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.11")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.12")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! Utilities for tracking time.


### PR DESCRIPTION
# 0.2.12 (November 7, 2019)

### Added
- `timer::set_default`, which functions like `timer::with_default`, but
  returns a drop guard (#1725).
- `clock::set_default`, which functions like `clock::with_default`, but
  returns a drop guard (#1725).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>