### PR TITLE
v0.1.x: prepare to release new reactor, executor, and timer

### DIFF
--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.9 (November 7, 2019)
+# 0.1.9 (November 27, 2019)
 
 ### Added
 - Add `executor::set_default` which behaves like `with_default` but returns a

--- a/tokio-executor/CHANGELOG.md
+++ b/tokio-executor/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.9 (November 7, 2019)
+
+### Added
+- Add `executor::set_default` which behaves like `with_default` but returns a
+  drop guard (#1725).
+
 # 0.1.8 (June 2, 2019)
 
 ### Added

--- a/tokio-executor/Cargo.toml
+++ b/tokio-executor/Cargo.toml
@@ -8,8 +8,8 @@ name = "tokio-executor"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.8"
-documentation = "https://docs.rs/tokio-executor/0.1.7/tokio_executor"
+version = "0.1.9"
+documentation = "https://docs.rs/tokio-executor/0.1.9/tokio_executor"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,7 +2,7 @@
 
 Task execution related traits and utilities.
 
-[Documentation](https://docs.rs/tokio-executor/0.1.8/tokio_executor)
+[Documentation](https://docs.rs/tokio-executor/0.1.9/tokio_executor)
 
 ## Overview
 
@@ -31,10 +31,10 @@ executor, including:
 
 * [`Park`] abstracts over blocking and unblocking the current thread.
 
-[`Executor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/trait.Executor.html
-[`enter`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/fn.enter.html
-[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/struct.DefaultExecutor.html
-[`Park`]: https://docs.rs/tokio-executor/0.1.8/tokio_executor/park/trait.Park.html
+[`Executor`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/trait.Executor.html
+[`enter`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/fn.enter.html
+[`DefaultExecutor`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/struct.DefaultExecutor.html
+[`Park`]: https://docs.rs/tokio-executor/0.1.9/tokio_executor/park/trait.Park.html
 
 ## License
 

--- a/tokio-executor/src/global.rs
+++ b/tokio-executor/src/global.rs
@@ -183,20 +183,6 @@ where
     T: Executor,
     F: FnOnce(&mut Enter) -> R,
 {
-    let _guard = set_default(executor);
-    f(enter)
-}
-
-/// Sets `executor` as the default executor, returning a guard that unsets it when
-/// dropped.
-///
-/// # Panics
-///
-/// This function panics if there already is a default executor set.
-pub fn set_default<T>(executor: &mut T) -> DefaultGuard<'_>
-where
-    T: Executor,
-{
     EXECUTOR.with(|cell| {
         match cell.get() {
             State::Ready(_) | State::Active => {
@@ -204,6 +190,18 @@ where
             }
             _ => {}
         }
+
+        // Ensure that the executor is removed from the thread-local context
+        // when leaving the scope. This handles cases that involve panicking.
+        struct Reset<'a>(&'a Cell<State>);
+
+        impl<'a> Drop for Reset<'a> {
+            fn drop(&mut self) {
+                self.0.set(State::Empty);
+            }
+        }
+
+        let _reset = Reset(cell);
 
         // While scary, this is safe. The function takes a
         // `&mut Executor`, which guarantees that the reference lives for the
@@ -215,6 +213,35 @@ where
         let executor = unsafe { hide_lt(executor as &mut _ as *mut _) };
 
         cell.set(State::Ready(executor));
+
+        f(enter)
+    })
+}
+
+/// Sets `executor` as the default executor, returning a guard that unsets it when
+/// dropped.
+///
+/// # Panics
+///
+/// This function panics if there already is a default executor set.
+pub fn set_default<'a, T>(executor: T) -> DefaultGuard<'a>
+where
+    T: Executor + 'static,
+{
+    EXECUTOR.with(|cell| {
+        match cell.get() {
+            State::Ready(_) | State::Active => {
+                panic!("default executor already set for execution context")
+            }
+            _ => {}
+        }
+
+        // Ensure that the executor will outlive the call to set_default, even
+        // if the drop guard is never dropped due to calls to `mem::forget` or
+        // similar.
+        let executor = Box::new(executor);
+
+        cell.set(State::Ready(Box::into_raw(executor)));
     });
 
     DefaultGuard {
@@ -230,7 +257,13 @@ unsafe fn hide_lt<'a>(p: *mut (dyn Executor + 'a)) -> *mut (dyn Executor + 'stat
 impl<'a> Drop for DefaultGuard<'a> {
     fn drop(&mut self) {
         let _ = EXECUTOR.try_with(|cell| {
-            cell.set(State::Empty);
+            if let State::Ready(prev) = cell.replace(State::Empty) {
+                // drop the previous executor.
+                unsafe {
+                    let prev = Box::from_raw(prev);
+                    drop(prev);
+                };
+            }
         });
     }
 }

--- a/tokio-executor/src/lib.rs
+++ b/tokio-executor/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(missing_docs, missing_debug_implementations)]
-#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/tokio-executor/0.1.9")]
 
 //! Task execution related traits and utilities.
 //!

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.1.11 (November 7, 2019)
+# 0.1.11 (November 27, 2019)
 
 ### Added
 - `set_default`, which functions like `with_default` but returns a drop

--- a/tokio-reactor/CHANGELOG.md
+++ b/tokio-reactor/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.11 (November 7, 2019)
+
+### Added
+- `set_default`, which functions like `with_default` but returns a drop
+  guard (#1725)
+
 # 0.1.10 (September 25, 2019)
 
 ### Changed

--- a/tokio-reactor/Cargo.toml
+++ b/tokio-reactor/Cargo.toml
@@ -8,13 +8,13 @@ name = "tokio-reactor"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-reactor/0.1.10/tokio_reactor"
+documentation = "https://docs.rs/tokio-reactor/0.1.11/tokio_reactor"
 description = """
 Event loop that drives Tokio I/O resources.
 """

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -2,7 +2,7 @@
 
 Event loop that drives Tokio I/O resources.
 
-[Documentation](https://docs.rs/tokio-reactor/0.1.10/tokio_reactor)
+[Documentation](https://docs.rs/tokio-reactor/0.1.11/tokio_reactor)
 
 ## Overview
 
@@ -25,10 +25,10 @@ are building a custom I/O resource.
 
 [`mio`]: http://github.com/carllerche/mio
 [`futures`]: http://github.com/rust-lang-nursery/futures-rs
-[`Reactor`]: https://docs.rs/tokio-reactor/0.1.10/tokio_reactor/struct.Reactor.html
-[`Handle`]: https://docs.rs/tokio-reactor/0.1.10/tokio_reactor/struct.Handle.html
-[`Registration`]: https://docs.rs/tokio-reactor/0.1.10/tokio_reactor/struct.Registration.html
-[`PollEvented`]: https://docs.rs/tokio-reactor/0.1.10/tokio_reactor/struct.PollEvented.html
+[`Reactor`]: https://docs.rs/tokio-reactor/0.1.11/tokio_reactor/struct.Reactor.html
+[`Handle`]: https://docs.rs/tokio-reactor/0.1.11/tokio_reactor/struct.Handle.html
+[`Registration`]: https://docs.rs/tokio-reactor/0.1.11/tokio_reactor/struct.Registration.html
+[`PollEvented`]: https://docs.rs/tokio-reactor/0.1.11/tokio_reactor/struct.PollEvented.html
 [`tokio`]: ../
 
 ## License

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.10")]
+#![doc(html_root_url = "https://docs.rs/tokio-reactor/0.1.11")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! Event loop that drives Tokio I/O resources.

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -68,7 +68,6 @@ use tokio_sync::task::AtomicTask;
 use std::cell::RefCell;
 use std::error::Error;
 use std::io;
-use std::marker::PhantomData;
 use std::mem;
 #[cfg(all(unix, not(target_os = "fuchsia")))]
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -137,8 +136,8 @@ pub type SetDefaultError = SetFallbackError;
 /// Ensure that the default reactor is removed from the thread-local context
 /// when leaving the scope. This handles cases that involve panicking.
 #[derive(Debug)]
-pub struct DefaultGuard<'a> {
-    _lifetime: PhantomData<&'a ()>,
+pub struct DefaultGuard {
+    _p: (),
 }
 
 #[test]
@@ -217,7 +216,7 @@ where
 /// # Panics
 ///
 /// This function panics if there already is a default reactor set.
-pub fn set_default(handle: &Handle) -> DefaultGuard<'_> {
+pub fn set_default(handle: &Handle) -> DefaultGuard {
     CURRENT_REACTOR.with(|current| {
         let mut current = current.borrow_mut();
 
@@ -236,9 +235,7 @@ pub fn set_default(handle: &Handle) -> DefaultGuard<'_> {
 
         *current = Some(handle.clone());
     });
-    DefaultGuard {
-        _lifetime: PhantomData,
-    }
+    DefaultGuard { _p: () }
 }
 
 impl Reactor {
@@ -746,7 +743,7 @@ impl Direction {
     }
 }
 
-impl<'a> Drop for DefaultGuard<'a> {
+impl Drop for DefaultGuard {
     fn drop(&mut self) {
         let _ = CURRENT_REACTOR.try_with(|current| {
             let mut current = current.borrow_mut();

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.12 (November 7, 2019)
+# 0.2.12 (November 27, 2019)
 
 ### Added
 - `timer::set_default`, which functions like `timer::with_default`, but

--- a/tokio-timer/CHANGELOG.md
+++ b/tokio-timer/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.12 (November 7, 2019)
+
+### Added
+- `timer::set_default`, which functions like `timer::with_default`, but
+  returns a drop guard (#1725).
+- `clock::set_default`, which functions like `clock::with_default`, but
+  returns a drop guard (#1725).
+
 # 0.2.11 (May 14, 2019)
 
 ### Added

--- a/tokio-timer/Cargo.toml
+++ b/tokio-timer/Cargo.toml
@@ -8,11 +8,11 @@ name = "tokio-timer"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.11"
+version = "0.2.12"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio-timer/0.2.11/tokio_timer"
+documentation = "https://docs.rs/tokio-timer/0.2.12/tokio_timer"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 description = """

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,7 +2,7 @@
 
 Timer facilities for Tokio
 
-[Documentation](https://docs.rs/tokio-timer/0.2.11/tokio_timer/)
+[Documentation](https://docs.rs/tokio-timer/0.2.12/tokio_timer/)
 
 ## Overview
 

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.11")]
+#![doc(html_root_url = "https://docs.rs/tokio-timer/0.2.12")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! Utilities for tracking time.


### PR DESCRIPTION
# tokio-reactor 0.1.11 (November 7, 2019)

### Added
- `set_default`, which functions like `with_default` but returns a drop
  guard (#1725)

# tokio-executor 0.1.9 (November 7, 2019)

### Added
- Add `executor::set_default` which behaves like `with_default` but returns a
  drop guard (#1725).

# tokio-timer 0.2.12 (November 7, 2019)

### Added
- `timer::set_default`, which functions like `timer::with_default`, but
  returns a drop guard (#1725).
- `clock::set_default`, which functions like `clock::with_default`, but
  returns a drop guard (#1725).

Signed-off-by: Eliza Weisman <eliza@buoyant.io>