### PR TITLE
v0.1.x: allow overriding blocking behavior

### DIFF
--- a/tokio-threadpool/src/blocking/global.rs
+++ b/tokio-threadpool/src/blocking/global.rs
@@ -11,6 +11,11 @@ thread_local! {
 
 /// Ensures that the executor is removed from the thread-local context
 /// when leaving the scope. This handles cases that involve panicking.
+///
+/// **NOTE:** This is intended specifically for use by `tokio` 0.2's
+/// backwards-compatibility layer. In general, user code should not override the
+/// blocking implementation. If you use this, make sure you know what you're
+/// doing.
 pub struct DefaultGuard<'a> {
     prior: BlockingImpl,
     _lifetime: PhantomData<&'a ()>,
@@ -18,6 +23,11 @@ pub struct DefaultGuard<'a> {
 
 /// Set the default blocking implementation, returning a guard that resets the
 /// blocking implementation when dropped.
+///
+/// **NOTE:** This is intended specifically for use by `tokio` 0.2's
+/// backwards-compatibility layer. In general, user code should not override the
+/// blocking implementation. If you use this, make sure you know what you're
+/// doing.
 pub fn set_default<'a>(blocking: BlockingImpl) -> DefaultGuard<'a> {
     CURRENT.with(|cell| {
         let prior = cell.replace(blocking);
@@ -28,7 +38,12 @@ pub fn set_default<'a>(blocking: BlockingImpl) -> DefaultGuard<'a> {
     })
 }
 
-/// Set the default blocking implementation for the duration of the closure
+/// Set the default blocking implementation for the duration of the closure.
+///
+/// **NOTE:** This is intended specifically for use by `tokio` 0.2's
+/// backwards-compatibility layer. In general, user code should not override the
+/// blocking implementation. If you use this, make sure you know what you're
+/// doing.
 pub fn with_default<F, R>(blocking: BlockingImpl, enter: &mut Enter, f: F) -> R
 where
     F: FnOnce(&mut Enter) -> R,

--- a/tokio-threadpool/src/blocking/global.rs
+++ b/tokio-threadpool/src/blocking/global.rs
@@ -199,3 +199,13 @@ where
         Ok(ret.into())
     })
 }
+
+impl<'a> Drop for DefaultGuard<'a> {
+    fn drop(&mut self) {
+        // if the TLS value has already been torn down, there's nothing else we
+        // can do. we're almost certainly panicking anyway.
+        let _ = CURRENT.try_with(|cell| {
+            cell.set(self.prior);
+        });
+    }
+}

--- a/tokio-threadpool/src/blocking/global.rs
+++ b/tokio-threadpool/src/blocking/global.rs
@@ -165,15 +165,17 @@ where
         // the blocking call finishes.
         let mut f = Some(f);
         let mut ret = None;
-        let ret2 = &mut ret;
-        let mut run = move || {
-            let f = f
-                .take()
-                .expect("blocking closure invoked twice; this is a bug!");
-            *ret2 = Some((f)());
-        };
+        {
+            let ret2 = &mut ret;
+            let mut run = move || {
+                let f = f
+                    .take()
+                    .expect("blocking closure invoked twice; this is a bug!");
+                *ret2 = Some((f)());
+            };
 
-        try_ready!((blocking)(&mut run));
+            try_ready!((blocking)(&mut run));
+        }
 
         // Return the result
         let ret =

--- a/tokio-threadpool/src/blocking/mod.rs
+++ b/tokio-threadpool/src/blocking/mod.rs
@@ -1,0 +1,73 @@
+use worker::Worker;
+
+use futures::Poll;
+use tokio_executor;
+
+use std::error::Error;
+use std::fmt;
+
+mod global;
+
+pub use self::global::blocking;
+#[doc(hidden)]
+pub use self::global::with_default;
+
+/// Error raised by `blocking`.
+pub struct BlockingError {
+    _p: (),
+}
+
+pub trait Blocking {
+    fn enter_blocking(&self) -> Poll<(), BlockingError>;
+    fn exit_blocking(&self);
+}
+
+struct DefaultBlocking;
+static DEFAULT_BLOCKING: DefaultBlocking = DefaultBlocking;
+
+impl Blocking for DefaultBlocking {
+    fn enter_blocking(&self) -> Poll<(), BlockingError> {
+        Worker::with_current(|worker| {
+            let worker = match worker {
+                Some(worker) => worker,
+                None => {
+                    return Err(BlockingError { _p: () });
+                }
+            };
+
+            // Transition the worker state to blocking. This will exit the fn early
+            // with `NotReady` if the pool does not have enough capacity to enter
+            // blocking mode.
+            worker.transition_to_blocking()
+        })
+    }
+
+    fn exit_blocking(&self) {
+        // Try to transition out of blocking mode. This is a fast path that takes
+        // back ownership of the worker if the worker handoff didn't complete yet.
+        Worker::with_current(|worker| {
+            // Worker must be set since it was above.
+            worker.unwrap().transition_from_blocking();
+        });
+    }
+}
+
+impl fmt::Display for BlockingError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{}", self.description())
+    }
+}
+
+impl fmt::Debug for BlockingError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("BlockingError")
+            .field("reason", &self.description())
+            .finish()
+    }
+}
+
+impl Error for BlockingError {
+    fn description(&self) -> &str {
+        "`blocking` annotation used from outside the context of a thread pool"
+    }
+}

--- a/tokio-threadpool/src/blocking/mod.rs
+++ b/tokio-threadpool/src/blocking/mod.rs
@@ -7,7 +7,9 @@ use std::error::Error;
 use std::fmt;
 
 mod global;
-pub use self::global::{blocking, set_default, with_default, DefaultGuard};
+pub use self::global::blocking;
+#[doc(hidden)]
+pub use self::global::{set_default, with_default, DefaultGuard};
 
 /// Error raised by `blocking`.
 pub struct BlockingError {
@@ -15,6 +17,12 @@ pub struct BlockingError {
 }
 
 /// A function implementing the behavior run on calls to `blocking`.
+///
+/// **NOTE:** This is intended specifically for use by `tokio` 0.2's
+/// backwards-compatibility layer. In general, user code should not override the
+/// blocking implementation. If you use this, make sure you know what you're
+/// doing.
+#[doc(hidden)]
 pub type BlockingImpl = fn(&mut dyn FnMut()) -> Poll<(), BlockingError>;
 
 fn default_blocking(f: &mut dyn FnMut()) -> Poll<(), BlockingError> {
@@ -53,6 +61,7 @@ fn default_blocking(f: &mut dyn FnMut()) -> Poll<(), BlockingError> {
 
 impl BlockingError {
     /// Returns a new `BlockingError`.
+    #[doc(hidden)]
     pub fn new() -> Self {
         Self { _p: () }
     }

--- a/tokio-threadpool/src/blocking/mod.rs
+++ b/tokio-threadpool/src/blocking/mod.rs
@@ -52,7 +52,7 @@ fn default_blocking(f: &mut dyn FnMut()) -> Poll<(), BlockingError> {
 }
 
 impl BlockingError {
-    #[doc(hidden)]
+    /// Returns a new `BlockingError`.
     pub fn new() -> Self {
         Self { _p: () }
     }

--- a/tokio-threadpool/src/blocking/mod.rs
+++ b/tokio-threadpool/src/blocking/mod.rs
@@ -7,10 +7,7 @@ use std::error::Error;
 use std::fmt;
 
 mod global;
-
-pub use self::global::blocking;
-#[doc(hidden)]
-pub use self::global::with_default;
+pub use self::global::{blocking, set_default, with_default, DefaultGuard};
 
 /// Error raised by `blocking`.
 pub struct BlockingError {

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -142,13 +142,13 @@ extern crate log;
 //
 // [Treiber stack]: https://en.wikipedia.org/wiki/Treiber_Stack
 
-pub mod park;
-
-mod blocking;
+#[doc(hidden)]
+pub mod blocking;
 mod builder;
 mod callback;
 mod config;
 mod notifier;
+pub mod park;
 mod pool;
 mod sender;
 mod shutdown;


### PR DESCRIPTION
## Motivation

The initial version of `tokio-compat`'s compatibility runtime added in
#1663 doesn't support the calls to `tokio_threadpool` 0.1's `blocking`.
This is because (unlike the timer, executor, and reactor), there's no
way to override the global `blocking` functionality in
`tokio-threadpool`.

## Solution

As discussed [here][1], this branch adds APIs to the v0.1.x version of
`tokio-threadpool` that allow overriding the behavior used by calls to
`blocking`. The threadpool crate now exposes `blocking::set_default` and
`blocking::with_default` functions, like `executor`, `timer`, and
`reactor`. This will allow `tokio-compat` to override calls to 0.1's
`blocking` to use the new `tokio` 0.2 blocking APIs.

Unlike the similar APIs in `executor`, `timer`, and `reactor`, the hooks
for overriding blocking behaviour are `#[doc(hidden)]` and have comments
warning against their use outside of `tokio-compat`. In general, there 
probably won't be a compelling reason to override these outside of the 
compatibility layer.

Refs: #1722

[1]: https://github.com/tokio-rs/tokio/pull/1663#issuecomment-548661766