### PR TITLE
Update all benchmarks except thread_pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,5 @@ members = [
   "tests-build",
   "tests-integration",
 ]
+[profile.bench]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ members = [
   "tests-build",
   "tests-integration",
 ]
-[profile.bench]
-debug = true
+

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -22,6 +22,10 @@ jobs:
   - template: azure-is-release.yml
 
   - ${{ each crate in parameters.crates }}:
+    # Test benches
+    - script: cargo test --benches --all
+      displayName: Test benchmarks
+
     # Run with all crate features
     - script: cargo test --all-features
       env:
@@ -40,3 +44,7 @@ jobs:
         CI: 'True'
       displayName: ${{ crate }} - cargo test --all-features
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
+
+    # Test benches
+    - script: cargo test --benches --all
+      displayName: Test benchmarks

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -122,15 +122,36 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "0.2.0" }
-criterion_bencher_compat = "0.3"
+criterion = "0.3"
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
 
 [[bench]]
+name = "latency"
+harness = false
+
+[[bench]]
+name = "mio-ops"
+harness = false
+
+[[bench]]
+name = "mpsc"
+harness = false
+
+[[bench]]
 name = "oneshot"
 harness = false
+
+[[bench]]
+name = "tcp"
+harness = false
+
+# Currently broken
+# [[bench]]
+# name = "thread_pool"
+# harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -122,10 +122,15 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "0.2.0" }
+criterion_bencher_compat = "0.3"
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
+
+[[bench]]
+name = "oneshot"
+harness = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/benches/mpsc.rs
+++ b/tokio/benches/mpsc.rs
@@ -271,7 +271,7 @@ criterion_group!(mpsc, bench_mpsc);
 fn main() {
     // The large channel tests can run out of stack
     std::thread::Builder::new()
-        .stack_size(3_000_000)
+        .stack_size(10_000_000)
         .spawn(|| {
             mpsc();
 

--- a/tokio/benches/mpsc.rs
+++ b/tokio/benches/mpsc.rs
@@ -1,189 +1,168 @@
-#![feature(test)]
 #![warn(rust_2018_idioms)]
 
-extern crate test;
+use std::{pin::Pin, thread};
 
 use tokio::sync::mpsc::*;
 
-use futures::{future, Async, Future, Sink, Stream};
-use std::thread;
-use test::Bencher;
+use futures::{
+    executor::{block_on, block_on_stream},
+    future,
+    task::Poll,
+};
+
+use criterion::{black_box, criterion_group, Bencher, Criterion};
 
 type Medium = [usize; 64];
 type Large = [Medium; 64];
 
-#[bench]
-fn bounded_new_medium(b: &mut Bencher) {
+fn bounded_new_medium(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&channel::<Medium>(1_000));
+        let _ = black_box(&channel::<Medium>(1_000));
     })
 }
 
-#[bench]
-fn unbounded_new_medium(b: &mut Bencher) {
+fn unbounded_new_medium(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&unbounded_channel::<Medium>());
-    })
-}
-#[bench]
-fn bounded_new_large(b: &mut Bencher) {
-    b.iter(|| {
-        let _ = test::black_box(&channel::<Large>(1_000));
+        let _ = black_box(&unbounded_channel::<Medium>());
     })
 }
 
-#[bench]
-fn unbounded_new_large(b: &mut Bencher) {
+fn bounded_new_large(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let _ = test::black_box(&unbounded_channel::<Large>());
+        let _ = black_box(&channel::<Large>(1_000));
     })
 }
 
-#[bench]
-fn send_one_message(b: &mut Bencher) {
+fn unbounded_new_large(b: &mut Bencher<'_>) {
     b.iter(|| {
-        let (mut tx, mut rx) = channel(1_000);
-
-        // Send
-        tx.try_send(1).unwrap();
-
-        // Receive
-        assert_eq!(Async::Ready(Some(1)), rx.poll().unwrap());
+        let _ = black_box(&unbounded_channel::<Large>());
     })
 }
 
-#[bench]
-fn send_one_message_large(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel::<Large>(1_000);
+fn send_one_message(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1_000);
 
-        // Send
-        let _ = tx.try_send([[0; 64]; 64]);
+            // Send
+            tx.try_send(1).unwrap();
 
-        // Receive
-        let _ = test::black_box(&rx.poll());
-    })
+            // Receive
+            assert_eq!(Poll::Ready(Some(1)), rx.poll_recv(cx));
+        })
+    }))
 }
 
-#[bench]
-fn bounded_rx_not_ready(b: &mut Bencher) {
+fn send_one_message_large(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel::<Large>(1_000);
+
+            // Send
+            let _ = tx.try_send([[0; 64]; 64]);
+
+            // Receive
+            let _ = black_box(&rx.poll_recv(cx));
+        })
+    }))
+}
+
+fn bounded_rx_not_ready(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = channel::<i32>(1_000);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(rx.poll_recv(cx).is_pending());
+        }));
     })
 }
 
-#[bench]
-fn bounded_tx_poll_ready(b: &mut Bencher) {
+fn bounded_tx_poll_ready(b: &mut Bencher<'_>) {
     let (mut tx, _rx) = channel::<i32>(1);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_ready());
+        }));
     })
 }
 
-#[bench]
-fn bounded_tx_poll_not_ready(b: &mut Bencher) {
+fn bounded_tx_poll_not_ready(b: &mut Bencher<'_>) {
     let (mut tx, _rx) = channel::<i32>(1);
     tx.try_send(1).unwrap();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_pending());
+        }))
     })
 }
 
-#[bench]
-fn unbounded_rx_not_ready(b: &mut Bencher) {
+fn unbounded_rx_not_ready(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-
-            Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        block_on(future::lazy(|cx| {
+            assert!(rx.poll_recv(cx).is_pending());
+        }))
     })
 }
 
-#[bench]
-fn unbounded_rx_not_ready_x5(b: &mut Bencher) {
+fn unbounded_rx_not_ready_x5(b: &mut Bencher<'_>) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
+        block_on(future::lazy(|cx| {
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+            assert!(Pin::new(&mut rx).poll_recv(cx).is_pending());
+        }));
+    })
+}
 
-            Ok::<_, ()>(())
+fn bounded_uncontended_1(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1_000);
+
+            for i in 0..1000 {
+                tx.try_send(i).unwrap();
+                // No need to create a task, because poll is not going to park.
+                assert_eq!(Poll::Ready(Some(i)), Pin::new(&mut rx).poll_recv(cx));
+            }
         })
-        .wait()
-        .unwrap();
-    })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_1(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel(1_000);
+fn bounded_uncontended_1_large(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel::<Large>(1_000);
 
-        for i in 0..1000 {
-            tx.try_send(i).unwrap();
-            // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
-        }
-    })
+            for i in 0..1000 {
+                let _ = tx.try_send([[i; 64]; 64]);
+                // No need to create a task, because poll is not going to park.
+                let _ = black_box(&Pin::new(&mut rx).poll_recv(cx));
+            }
+        })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_1_large(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel::<Large>(1_000);
+fn bounded_uncontended_2(b: &mut Bencher<'_>) {
+    block_on(future::lazy(|cx| {
+        b.iter(|| {
+            let (mut tx, mut rx) = channel(1000);
 
-        for i in 0..1000 {
-            let _ = tx.try_send([[i; 64]; 64]);
-            // No need to create a task, because poll is not going to park.
-            let _ = test::black_box(&rx.poll());
-        }
-    })
+            for i in 0..1000 {
+                tx.try_send(i).unwrap();
+            }
+
+            for i in 0..1000 {
+                // No need to create a task, because poll is not going to park.
+                assert_eq!(Poll::Ready(Some(i)), Pin::new(&mut rx).poll_recv(cx));
+            }
+        })
+    }))
 }
 
-#[bench]
-fn bounded_uncontended_2(b: &mut Bencher) {
-    b.iter(|| {
-        let (mut tx, mut rx) = channel(1000);
-
-        for i in 0..1000 {
-            tx.try_send(i).unwrap();
-        }
-
-        for i in 0..1000 {
-            // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
-        }
-    })
-}
-
-#[bench]
-fn contended_unbounded_tx(b: &mut Bencher) {
+fn contended_unbounded_tx(b: &mut Bencher<'_>) {
     let mut threads = vec![];
     let mut txs = vec![];
 
@@ -210,10 +189,10 @@ fn contended_unbounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(4 * 1_000);
+        let rx = block_on_stream(rx).take(4 * 1_000);
 
         for v in rx {
-            let _ = test::black_box(v);
+            let _ = black_box(v);
         }
     });
 
@@ -224,8 +203,7 @@ fn contended_unbounded_tx(b: &mut Bencher) {
     }
 }
 
-#[bench]
-fn contended_bounded_tx(b: &mut Bencher) {
+fn contended_bounded_tx(b: &mut Bencher<'_>) {
     const THREADS: usize = 4;
     const ITERS: usize = 100;
 
@@ -237,12 +215,13 @@ fn contended_bounded_tx(b: &mut Bencher) {
         txs.push(tx);
 
         threads.push(thread::spawn(move || {
-            for tx in rx.iter() {
-                let mut tx = tx.wait();
-                for i in 0..ITERS {
-                    tx.send(i as i32).unwrap();
+            block_on(async move {
+                for mut tx in rx.iter() {
+                    for i in 0..ITERS {
+                        tx.send(i as i32).await.unwrap();
+                    }
                 }
-            }
+            })
         }));
     }
 
@@ -255,10 +234,10 @@ fn contended_bounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(THREADS * ITERS);
+        let rx = block_on_stream(rx).take(THREADS * ITERS);
 
         for v in rx {
-            let _ = test::black_box(v);
+            let _ = black_box(v);
         }
     });
 
@@ -267,4 +246,38 @@ fn contended_bounded_tx(b: &mut Bencher) {
     for th in threads {
         th.join().unwrap();
     }
+}
+
+fn bench_mpsc(c: &mut Criterion) {
+    c.bench_function("bounded_new_medium", bounded_new_medium);
+    c.bench_function("unbounded_new_medium", unbounded_new_medium);
+    c.bench_function("bounded_new_large", bounded_new_large);
+    c.bench_function("unbounded_new_large", unbounded_new_large);
+    c.bench_function("send_one_message", send_one_message);
+    c.bench_function("send_one_message_large", send_one_message_large);
+    c.bench_function("bounded_rx_not_ready", bounded_rx_not_ready);
+    c.bench_function("bounded_tx_poll_ready", bounded_tx_poll_ready);
+    c.bench_function("bounded_tx_poll_not_ready", bounded_tx_poll_not_ready);
+    c.bench_function("unbounded_rx_not_ready", unbounded_rx_not_ready);
+    c.bench_function("unbounded_rx_not_ready_x5", unbounded_rx_not_ready_x5);
+    c.bench_function("bounded_uncontended_1", bounded_uncontended_1);
+    c.bench_function("bounded_uncontended_1_large", bounded_uncontended_1_large);
+    c.bench_function("bounded_uncontended_2", bounded_uncontended_2);
+    c.bench_function("contended_unbounded_tx", contended_unbounded_tx);
+    c.bench_function("contended_bounded_tx", contended_bounded_tx);
+}
+
+criterion_group!(mpsc, bench_mpsc);
+fn main() {
+    // The large channel tests can run out of stack
+    std::thread::Builder::new()
+        .stack_size(3_000_000)
+        .spawn(|| {
+            mpsc();
+
+            Criterion::default().configure_from_args().final_summary();
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }

--- a/tokio/benches/tcp.rs
+++ b/tokio/benches/tcp.rs
@@ -34,7 +34,7 @@ mod connect_churn {
 
         b.iter(move || {
             let result: io::Result<_> = block_on(async {
-                let listener = TcpListener::bind(&addr).await.unwrap();
+                let mut listener = TcpListener::bind(&addr).await.unwrap();
                 let addr = listener.local_addr().unwrap();
 
                 // Spawn a single future that accepts & drops connections
@@ -76,7 +76,7 @@ mod connect_churn {
         let server_thread = thread::spawn(move || {
             block_on(async {
                 // Bind the TCP listener
-                let listener = TcpListener::bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap())
+                let mut listener = TcpListener::bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap())
                     .await
                     .unwrap();
 
@@ -218,7 +218,7 @@ mod transfer {
 
         b.iter(move || {
             let result: io::Result<_> = block_on(async move {
-                let listener = TcpListener::bind(&addr).await?;
+                let mut listener = TcpListener::bind(&addr).await?;
                 let addr = listener.local_addr().unwrap();
 
                 // Spawn a single future that accepts 1 connection, Drain it and drops

--- a/tokio/benches/tcp.rs
+++ b/tokio/benches/tcp.rs
@@ -1,19 +1,26 @@
-#![cfg(feature = "broken")]
-#![feature(test)]
 #![warn(rust_2018_idioms)]
 
-pub extern crate test;
-
 mod prelude {
-    pub use futures::*;
-    pub use tokio::net::{TcpListener, TcpStream};
-    pub use tokio::reactor::Reactor;
-    pub use tokio_io::io::read_to_end;
+    pub use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 
-    pub use std::io::{self, Read, Write};
+    pub use futures::{task::Poll, *};
+    pub use tokio::{
+        io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    pub use std::io;
+    pub use std::net::SocketAddr;
+    pub use std::pin::Pin;
     pub use std::thread;
     pub use std::time::Duration;
-    pub use test::{self, Bencher};
+
+    pub fn block_on<F>(f: F) -> F::Output
+    where
+        F: Future,
+    {
+        tokio::runtime::Runtime::new().unwrap().block_on(f)
+    }
 }
 
 mod connect_churn {
@@ -22,73 +29,80 @@ mod connect_churn {
     const NUM: usize = 300;
     const CONCURRENT: usize = 8;
 
-    #[bench]
-    fn one_thread(b: &mut Bencher) {
-        let addr = "127.0.0.1:0".parse().unwrap();
+    pub fn one_thread(b: &mut Bencher<'_>) {
+        let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
 
         b.iter(move || {
-            let listener = TcpListener::bind(&addr).unwrap();
-            let addr = listener.local_addr().unwrap();
+            let result: io::Result<_> = block_on(async {
+                let listener = TcpListener::bind(&addr).await.unwrap();
+                let addr = listener.local_addr().unwrap();
 
-            // Spawn a single future that accepts & drops connections
-            let serve_incomings = listener
-                .incoming()
-                .map_err(|e| panic!("server err: {:?}", e))
-                .for_each(|_| Ok(()));
+                // Spawn a single future that accepts & drops connections
+                let serve_incomings = listener
+                    .incoming()
+                    .map_err(|e| panic!("server err: {:?}", e))
+                    .try_for_each(|_| async { Ok(()) });
 
-            let connects = stream::iter_result((0..NUM).map(|_| {
-                Ok(TcpStream::connect(&addr).and_then(|sock| {
-                    sock.set_linger(Some(Duration::from_secs(0))).unwrap();
-                    read_to_end(sock, vec![])
-                }))
-            }));
+                let connects = stream::iter((0..NUM).map(|_| {
+                    Ok(TcpStream::connect(&addr).and_then(|mut sock| {
+                        async move {
+                            sock.set_linger(Some(Duration::from_secs(0))).unwrap();
+                            sock.read_to_end(&mut vec![]).await
+                        }
+                    }))
+                }));
 
-            let connects_concurrent = connects
-                .buffer_unordered(CONCURRENT)
-                .map_err(|e| panic!("client err: {:?}", e))
-                .for_each(|_| Ok(()));
+                let connects_concurrent = connects
+                    .try_buffer_unordered(CONCURRENT)
+                    .map_err(|e| panic!("client err: {:?}", e))
+                    .try_for_each(|_| async { Ok(()) });
 
-            serve_incomings
-                .select(connects_concurrent)
-                .map(|_| ())
-                .map_err(|_| ())
-                .wait()
-                .unwrap();
+                future::try_select(Box::pin(serve_incomings), Box::pin(connects_concurrent))
+                    .map_ok(|_| ())
+                    .map_err(|_| ())
+                    .await
+                    .unwrap();
+                Ok(())
+            });
+            result.unwrap();
         });
     }
 
-    fn n_workers(n: usize, b: &mut Bencher) {
-        let (shutdown_tx, shutdown_rx) = sync::oneshot::channel();
-        let (addr_tx, addr_rx) = sync::oneshot::channel();
+    fn n_workers(n: usize, b: &mut Bencher<'_>) {
+        let (shutdown_tx, shutdown_rx) = channel::oneshot::channel();
+        let (addr_tx, addr_rx) = channel::oneshot::channel();
 
         // Spawn reactor thread
         let server_thread = thread::spawn(move || {
-            // Bind the TCP listener
-            let listener = TcpListener::bind(&"127.0.0.1:0".parse().unwrap()).unwrap();
+            block_on(async {
+                // Bind the TCP listener
+                let listener = TcpListener::bind(&"127.0.0.1:0".parse::<SocketAddr>().unwrap())
+                    .await
+                    .unwrap();
 
-            // Get the address being listened on.
-            let addr = listener.local_addr().unwrap();
+                // Get the address being listened on.
+                let addr = listener.local_addr().unwrap();
 
-            // Send the remote & address back to the main thread
-            addr_tx.send(addr).unwrap();
+                // Send the remote & address back to the main thread
+                addr_tx.send(addr).unwrap();
 
-            // Spawn a single future that accepts & drops connections
-            let serve_incomings = listener
-                .incoming()
-                .map_err(|e| panic!("server err: {:?}", e))
-                .for_each(|_| Ok(()));
+                // Spawn a single future that accepts & drops connections
+                let serve_incomings = listener
+                    .incoming()
+                    .map_err(|e| panic!("server err: {:?}", e))
+                    .try_for_each(|_| async { Ok(()) });
 
-            // Run server
-            serve_incomings
-                .select(shutdown_rx)
-                .map(|_| ())
-                .map_err(|_| ())
-                .wait()
-                .unwrap();
+                // Run server
+                future::try_select(Box::pin(serve_incomings), Box::pin(shutdown_rx))
+                    .map_ok(|_| ())
+                    .map_err(|_| ())
+                    .await
+            })
+            .unwrap();
         });
 
         // Get the bind addr of the server
-        let addr = addr_rx.wait().unwrap();
+        let addr = block_on(addr_rx).unwrap();
 
         b.iter(move || {
             use std::sync::{Arc, Barrier};
@@ -103,23 +117,26 @@ mod connect_churn {
                     let addr = addr.clone();
 
                     thread::spawn(move || {
-                        let connects = stream::iter_result((0..(NUM / n)).map(|_| {
+                        let connects = stream::iter((0..(NUM / n)).map(|_| {
                             Ok(TcpStream::connect(&addr)
                                 .map_err(|e| panic!("connect err: {:?}", e))
-                                .and_then(|sock| {
-                                    sock.set_linger(Some(Duration::from_secs(0))).unwrap();
-                                    read_to_end(sock, vec![])
+                                .and_then(|mut sock| {
+                                    async move {
+                                        sock.set_linger(Some(Duration::from_secs(0))).unwrap();
+                                        sock.read_to_end(&mut vec![]).await
+                                    }
                                 }))
                         }));
 
                         barrier.wait();
 
-                        connects
-                            .buffer_unordered(CONCURRENT)
-                            .map_err(|e| panic!("client err: {:?}", e))
-                            .for_each(|_| Ok(()))
-                            .wait()
-                            .unwrap();
+                        block_on(
+                            connects
+                                .try_buffer_unordered(CONCURRENT)
+                                .map_err(|e| panic!("client err: {:?}", e))
+                                .try_for_each(|_| async { Ok(()) }),
+                        )
+                        .unwrap();
                     })
                 })
                 .collect();
@@ -136,13 +153,11 @@ mod connect_churn {
         server_thread.join().unwrap();
     }
 
-    #[bench]
-    fn two_threads(b: &mut Bencher) {
+    pub fn two_threads(b: &mut Bencher<'_>) {
         n_workers(1, b);
     }
 
-    #[bench]
-    fn multi_threads(b: &mut Bencher) {
+    pub fn multi_threads(b: &mut Bencher<'_>) {
         n_workers(4, b);
     }
 }
@@ -150,7 +165,6 @@ mod connect_churn {
 mod transfer {
     use crate::prelude::*;
     use std::{cmp, mem};
-    use tokio_io::try_nb;
 
     const MB: usize = 3 * 1024 * 1024;
 
@@ -160,15 +174,15 @@ mod transfer {
     }
 
     impl Future for Drain {
-        type Item = ();
-        type Error = io::Error;
+        type Output = io::Result<()>;
 
-        fn poll(&mut self) -> Poll<(), io::Error> {
-            let mut buf: [u8; 1024] = unsafe { mem::uninitialized() };
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
+            let mut buf: [u8; 1024] = unsafe { mem::MaybeUninit::uninit().assume_init() };
 
+            let self_ = &mut *self;
             loop {
-                match try_nb!(self.sock.read(&mut buf[..self.chunk])) {
-                    0 => return Ok(Async::Ready(())),
+                match ready!(Pin::new(&mut self_.sock).poll_read(cx, &mut buf[..self_.chunk]))? {
+                    0 => return Poll::Ready(Ok(())),
                     _ => {}
                 }
             }
@@ -182,76 +196,82 @@ mod transfer {
     }
 
     impl Future for Transfer {
-        type Item = ();
-        type Error = io::Error;
+        type Output = io::Result<()>;
 
-        fn poll(&mut self) -> Poll<(), io::Error> {
+        fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<io::Result<()>> {
             while self.rem > 0 {
                 let len = cmp::min(self.rem, self.chunk);
                 let buf = &DATA[..len];
 
-                let n = try_nb!(self.sock.write(&buf));
+                let n = ready!(Pin::new(&mut self.sock).poll_write(cx, &buf))?;
                 self.rem -= n;
             }
 
-            Ok(Async::Ready(()))
+            Poll::Ready(Ok(()))
         }
     }
 
     static DATA: [u8; 1024] = [0; 1024];
 
-    fn one_thread(b: &mut Bencher, read_size: usize, write_size: usize) {
-        let addr = "127.0.0.1:0".parse().unwrap();
+    fn one_thread(b: &mut Bencher<'_>, read_size: usize, write_size: usize) {
+        let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
 
         b.iter(move || {
-            let listener = TcpListener::bind(&addr).unwrap();
-            let addr = listener.local_addr().unwrap();
+            let result: io::Result<_> = block_on(async move {
+                let listener = TcpListener::bind(&addr).await?;
+                let addr = listener.local_addr().unwrap();
 
-            // Spawn a single future that accepts 1 connection, Drain it and drops
-            let server = listener
-                .incoming()
-                .into_future() // take the first connection
-                .map_err(|(e, _other_incomings)| e)
-                .map(|(connection, _other_incomings)| connection.unwrap())
-                .and_then(|sock| {
+                // Spawn a single future that accepts 1 connection, Drain it and drops
+                let server = async move {
+                    // take the first connection
+                    let sock = listener.incoming().into_future().await.0.unwrap()?;
                     sock.set_linger(Some(Duration::from_secs(0))).unwrap();
                     let drain = Drain {
                         sock,
                         chunk: read_size,
                     };
-                    drain
-                        .map(|_| ())
-                        .map_err(|e| panic!("server error: {:?}", e))
-                })
-                .map_err(|e| panic!("server err: {:?}", e));
+                    drain.map_ok(|_| ()).await
+                };
 
-            let client = TcpStream::connect(&addr)
-                .and_then(move |sock| Transfer {
+                let client = TcpStream::connect(&addr).and_then(move |sock| Transfer {
                     sock,
                     rem: MB,
                     chunk: write_size,
-                })
-                .map_err(|e| panic!("client err: {:?}", e));
+                });
 
-            server.join(client).wait().unwrap();
+                future::try_join(server, client).await
+            });
+            result.unwrap()
         });
     }
 
-    mod small_chunks {
+    pub mod small_chunks {
         use crate::prelude::*;
 
-        #[bench]
-        fn one_thread(b: &mut Bencher) {
+        pub fn one_thread(b: &mut Bencher<'_>) {
             super::one_thread(b, 32, 32);
         }
     }
 
-    mod big_chunks {
+    pub mod big_chunks {
         use crate::prelude::*;
 
-        #[bench]
-        fn one_thread(b: &mut Bencher) {
+        pub fn one_thread(b: &mut Bencher<'_>) {
             super::one_thread(b, 1_024, 1_024);
         }
     }
 }
+
+use prelude::*;
+
+fn bench_tcp(c: &mut Criterion) {
+    c.bench_function("connect_churn/one_thread", connect_churn::one_thread);
+    c.bench_function("connect_churn/two_threads", connect_churn::two_threads);
+    c.bench_function("connect_churn/multi_threads", connect_churn::multi_threads);
+
+    c.bench_function("transfer/small_chunks", transfer::small_chunks::one_thread);
+    c.bench_function("transfer/big_chunks", transfer::big_chunks::one_thread);
+}
+
+criterion_group!(tcp, bench_tcp);
+criterion_main!(tcp);


### PR DESCRIPTION
Found out that the benchmarks had bitrotted in #1710 so this updates them to use criterion instead of the unstable test crate, letting them run without needing nightly rust.

Also enables benchmark testing on CI.