### PR TITLE
DelayQueue::len

### DIFF
--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -611,6 +611,26 @@ impl<T> DelayQueue<T> {
         self.slab.capacity()
     }
 
+    /// Returns the number of elements currently in the queue.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::time::DelayQueue;
+    /// use std::time::Duration;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    ///     let mut delay_queue: DelayQueue<i32> = DelayQueue::with_capacity(10);
+    ///     assert_eq!(delay_queue.len(), 0);
+    ///     delay_queue.insert(3, Duration::from_secs(5));
+    ///     assert_eq!(delay_queue.len(), 1);
+    /// # }
+    /// ```
+    pub fn len(&self) -> usize {
+        self.slab.len()
+    }
+
     /// Reserve capacity for at least `additional` more items to be queued
     /// without allocating.
     ///


### PR DESCRIPTION
## Motivation

Some commits for unimplemented things in the `DelayQueue`.

## Solution

### Add a `DelayQueue::len()`

Sometimes it's useful to keep track of how many items we still have in the queue.

### ~~Implement `FusedStream` for `DelayQueue`~~

~~I'm not sure that this is a correct implementation, cfr #1754, and I'll gladly change the commit to reflect any other needed change.~~ Change removed