### PR TITLE
Add a method to test if split streams come from the same stream.

### DIFF
--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -28,6 +28,14 @@ pub struct WriteHalf<T> {
 }
 
 /// An opaque ID for the parent stream of a split half.
+///
+/// If you keep a `SplitStreamId` around after both halves have been dropped or reunited,
+/// the stream ID is dangling.
+/// The same ID may then be used for other split streams.
+/// To avoid this, do not keep `SplitStreamId` around after both half have been dropped.
+///
+/// Note that it is still impossible to unsplit two halves from a different stream,
+/// since at-least one half has not been dropped in that scenario.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub struct SplitStreamId(usize);
 
@@ -68,8 +76,10 @@ impl<T> ReadHalf<T> {
     ///
     /// This can be used to check if two halves have been split from the
     /// same stream.
-    ///
     /// The stream ID can also be used as key in associative containers.
+    ///
+    /// Note that stream IDs may dangle when both halves are dropped.
+    /// See [`SplitStreamId`] for more information.
     pub fn stream_id(&self) -> SplitStreamId {
         SplitStreamId(&*self.inner as *const Inner<T> as usize)
     }
@@ -80,8 +90,8 @@ impl<T> ReadHalf<T> {
     ///
     /// If this `ReadHalf` and the given `WriteHalf` do not originate from the
     /// same `split` operation this method will panic.
-    /// This can be checked ahead of time by comparing [`Self::stream_id`]
-    /// and [`WriteHalf::stream_id`].
+    /// This can be checked ahead of time by comparing the stream ID
+    /// of the two halves.
     pub fn unsplit(self, wr: WriteHalf<T>) -> T {
         if self.stream_id() == wr.stream_id() {
             drop(wr);
@@ -102,8 +112,10 @@ impl<T> WriteHalf<T> {
     ///
     /// This can be used to check if two halves have been split from the
     /// same stream.
-    ///
     /// The stream ID can also be used as key in associative containers.
+    ///
+    /// Note that stream IDs may dangle when both halves are dropped.
+    /// See [`SplitStreamId`] for more information.
     pub fn stream_id(&self) -> SplitStreamId {
         SplitStreamId(&*self.inner as *const Inner<T> as usize)
     }

--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -27,6 +27,10 @@ pub struct WriteHalf<T> {
     inner: Arc<Inner<T>>,
 }
 
+/// An opaque ID for the parent stream of a split half.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct SplitStreamId(usize);
+
 struct Inner<T> {
     locked: AtomicBool,
     stream: UnsafeCell<T>,
@@ -60,14 +64,26 @@ where
 }
 
 impl<T> ReadHalf<T> {
+    /// Get an opaque ID for the parent stream.
+    ///
+    /// This can be used to check if two halves have been split from the
+    /// same stream.
+    ///
+    /// The stream ID can also be used as key in associative containers.
+    pub fn stream_id(&self) -> SplitStreamId {
+        SplitStreamId(&*self.inner as *const Inner<T> as usize)
+    }
+
     /// Reunite with a previously split `WriteHalf`.
     ///
     /// # Panics
     ///
     /// If this `ReadHalf` and the given `WriteHalf` do not originate from the
     /// same `split` operation this method will panic.
+    /// This can be checked ahead of time by comparing [`Self::stream_id`]
+    /// and [`WriteHalf::stream_id`].
     pub fn unsplit(self, wr: WriteHalf<T>) -> T {
-        if Arc::ptr_eq(&self.inner, &wr.inner) {
+        if self.stream_id() == wr.stream_id() {
             drop(wr);
 
             let inner = Arc::try_unwrap(self.inner)
@@ -78,6 +94,18 @@ impl<T> ReadHalf<T> {
         } else {
             panic!("Unrelated `split::Write` passed to `split::Read::unsplit`.")
         }
+    }
+}
+
+impl<T> WriteHalf<T> {
+    /// Get an opaque ID for the parent stream.
+    ///
+    /// This can be used to check if two halves have been split from the
+    /// same stream.
+    ///
+    /// The stream ID can also be used as key in associative containers.
+    pub fn stream_id(&self) -> SplitStreamId {
+        SplitStreamId(&*self.inner as *const Inner<T> as usize)
     }
 }
 

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -44,6 +44,16 @@ fn is_send_and_sync() {
 }
 
 #[test]
+fn split_stream_id() {
+    let (r1, w1) = split(RW);
+    let (r2, w2) = split(RW);
+    assert_eq!(r1.stream_id(), w1.stream_id());
+    assert_eq!(r1.stream_id(), w1.stream_id());
+    assert_ne!(r1.stream_id(), w2.stream_id());
+    assert_ne!(r2.stream_id(), w1.stream_id());
+}
+
+#[test]
 fn unsplit_ok() {
     let (r, w) = split(RW);
     r.unsplit(w);


### PR DESCRIPTION
This PR adds a `stream_id` function to `io::split::ReadHalf` and `io::split::WriteHalf`. The stream ID can be used to test if halfs belong to the same stream before calling `unsplit`. Additionally, the ID implements `Eq`, `Ord` and `Hash`, so it can be used as a key in associative containers.

My direct motivation for this is that I want to remove the write half from a container when the read half is closed in a server application with independent read and write loops.