### PR TITLE
tls: fix test certificate to work on macOS 10.15

### DIFF
--- a/tokio-tls/tests/smoke.rs
+++ b/tokio-tls/tests/smoke.rs
@@ -53,6 +53,7 @@ fn openssl_keys() -> &'static Keys {
             [ ext ]\n\
             basicConstraints=CA:FALSE,pathlen:0\n\
             subjectAltName = @alt_names
+            extendedKeyUsage=serverAuth,clientAuth
             [alt_names]
             DNS.1 = localhost
         ",


### PR DESCRIPTION
macOS 10.15 introduced new requirements for certificates to be trusted:
https://support.apple.com/en-us/HT210176

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
tls smoke.rs tests are failing on latest macOS.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add extendedKeyUsage to the certificate generated in tests.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
