### PR TITLE
v0.1.x: tokio: bump minimum versions

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -69,7 +69,7 @@ tokio-io = { version = "0.1.6", optional = true }
 tokio-executor = { version = "0.1.7", optional = true }
 tokio-reactor = { version = "0.1.1", optional = true }
 tokio-sync = { version = "0.1.5", optional = true }
-tokio-threadpool = { version = "0.1.14", optional = true }
+tokio-threadpool = { version = "0.1.16", optional = true }
 tokio-tcp = { version = "0.1.0", optional = true }
 tokio-udp = { version = "0.1.0", optional = true }
 tokio-timer = { version = "0.2.8", optional = true }
@@ -79,7 +79,7 @@ tracing-core = { version = "0.1", optional = true }
 mio = { version = "0.6.14", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-tokio-uds = { version = "0.2.1", optional = true }
+tokio-uds = { version = "0.2.4", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.6", default-features = false }


### PR DESCRIPTION
tokio-uds 0.2.4 has the `UnixDatagramFramed` which is reexported here
and tokio-threadpool 0.1.16 uses a new enough rand that compiles with
modern toolchains.

---
Link #1656 but for the 0.1 branch. See that PR for the motivation and such.