### PR TITLE
Fix ucred for illumos/solaris

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -112,10 +112,10 @@ pub(crate) mod impl_macos {
 
 #[cfg(any(target_os = "solaris"))]
 pub(crate) mod impl_solaris {
+    use crate::net::unix::UnixStream;
     use std::io;
     use std::os::unix::io::AsRawFd;
     use std::ptr;
-    use UnixStream;
 
     #[allow(non_camel_case_types)]
     enum ucred_t {}


### PR DESCRIPTION
Fixes an incorrect import.

In order to run the test suite successfully on illumos I had to modify
- generator-rs => Xudong-Huang/generator-rs/pull/16
- mio-uds => Not yet fixed (we don't appear to have a way to set `FIOCLEX` on the fds in question)

However, once I patched those via `[patchs.crates-io]` in the workspace the test suite runs to completion with:

`test result: ok. 129 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out`
