### PR TITLE
chore: refine feature flags

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -29,7 +29,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio", default-features = false, features = ["rt-full"] }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -29,7 +29,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio", default-features = false }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -24,14 +24,21 @@ categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures"]
 
 [features]
-default = [
+default = ["full"]
+
+# enable everything
+full = [
   "blocking",
+  "dns",
   "fs",
+  "io-driver",
   "io-util",
-  "io",
+  "io-std",
+  "macros",
   "net",
   "process",
-  "rt-full",
+  "rt-core",
+  "rt-threaded",
   "signal",
   "stream",
   "sync",
@@ -39,15 +46,16 @@ default = [
 ]
 
 blocking = ["rt-core"]
-dns = ["blocking"]
-fs = ["blocking"]
-io-driver = ["mio", "lazy_static", "sync"] # TODO: get rid of sync
+dns = ["rt-core"]
+fs = ["rt-core"]
+io-driver = ["rt-core", "mio", "lazy_static"]
 io-util = ["memchr"]
-io = ["io-util", "blocking"]
+# stdin, stdout, stderr
+io-std = ["rt-core"]
 macros = ["tokio-macros"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
-  "io-util", # TODO: Get rid of
+  "io-driver",
   "libc",
   "mio-named-pipes",
   "signal",
@@ -58,14 +66,9 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt-core = []
-# TODO: rename this -> `rt-threaded`
-rt-full = [
-  "macros",
+rt-threaded = [
   "num_cpus",
-  "net",
   "rt-core",
-  "sync",
-  "time",
 ]
 signal = [
   "io-driver",
@@ -80,7 +83,7 @@ stream = ["futures-core"]
 sync = ["fnv"]
 test-util = []
 tcp = ["io-driver"]
-time = ["rt-core", "sync", "slab"]
+time = ["rt-core", "slab"]
 udp = ["io-driver"]
 uds = ["io-driver", "mio-uds", "libc"]
 

--- a/tokio/src/blocking/mod.rs
+++ b/tokio/src/blocking/mod.rs
@@ -1,7 +1,11 @@
+#![cfg_attr(not(feature = "blocking"), allow(dead_code, unused_imports))]
+
 //! Perform blocking operations from an asynchronous context.
 
-mod pool;
-pub(crate) use self::pool::{spawn_blocking, BlockingPool, Spawner};
+cfg_blocking_impl! {
+    mod pool;
+    pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
 
-mod schedule;
-mod task;
+    mod schedule;
+    mod task;
+}

--- a/tokio/src/blocking/pool.rs
+++ b/tokio/src/blocking/pool.rs
@@ -116,16 +116,20 @@ impl fmt::Debug for BlockingPool {
 
 // ===== impl Spawner =====
 
-impl Spawner {
-    #[cfg(feature = "rt-full")]
-    pub(crate) fn spawn_background<F>(&self, func: F)
-    where
-        F: FnOnce() + Send + 'static,
-    {
-        let task = task::background(BlockingTask::new(func));
-        self.schedule(task);
-    }
 
+cfg_rt_threaded! {
+    impl Spawner {
+        pub(crate) fn spawn_background<F>(&self, func: F)
+        where
+            F: FnOnce() + Send + 'static,
+        {
+            let task = task::background(BlockingTask::new(func));
+            self.schedule(task);
+        }
+    }
+}
+
+impl Spawner {
     /// Set the blocking pool for the duration of the closure
     ///
     /// If a blocking pool is already set, it will be restored when the closure

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -34,13 +34,14 @@ enum State<T> {
     Busy(sys::Blocking<(io::Result<usize>, Buf, T)>),
 }
 
-impl<T> Blocking<T> {
-    #[cfg(feature = "io")]
-    pub(crate) fn new(inner: T) -> Blocking<T> {
-        Blocking {
-            inner: Some(inner),
-            state: State::Idle(Some(Buf::with_capacity(0))),
-            need_flush: false,
+cfg_io_std! {
+    impl<T> Blocking<T> {
+        pub(crate) fn new(inner: T) -> Blocking<T> {
+            Blocking {
+                inner: Some(inner),
+                state: State::Idle(Some(Buf::with_capacity(0))),
+                need_flush: false,
+            }
         }
     }
 }
@@ -264,12 +265,15 @@ impl Buf {
         self.buf.clear();
         res
     }
+}
 
-    #[cfg(feature = "fs")]
-    pub(crate) fn discard_read(&mut self) -> i64 {
-        let ret = -(self.bytes().len() as i64);
-        self.pos = 0;
-        self.buf.truncate(0);
-        ret
+cfg_fs! {
+    impl Buf {
+        pub(crate) fn discard_read(&mut self) -> i64 {
+            let ret = -(self.bytes().len() as i64);
+            self.pos = 0;
+            self.buf.truncate(0);
+            ret
+        }
     }
 }

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -36,8 +36,9 @@
 //! [`ErrorKind`]: enum.ErrorKind.html
 //! [`Result`]: type.Result.html
 
-#[cfg(any(feature = "io", feature = "fs"))]
-pub(crate) mod blocking;
+cfg_io_blocking! {
+    pub(crate) mod blocking;
+}
 
 mod async_buf_read;
 pub use self::async_buf_read::AsyncBufRead;
@@ -48,43 +49,43 @@ pub use self::async_read::AsyncRead;
 mod async_write;
 pub use self::async_write::AsyncWrite;
 
-#[cfg(feature = "io-util")]
-pub mod split;
-#[cfg(feature = "io-util")]
-pub use self::split::split;
+cfg_io_std! {
+    mod stderr;
+    pub use stderr::{stderr, Stderr};
 
-#[cfg(feature = "io-util")]
-mod util;
-#[cfg(feature = "io-util")]
-pub use self::util::{
-    copy, empty, repeat, sink, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufStream,
-    BufWriter, Copy, Empty, Lines, Repeat, Sink, Split, Take,
-};
+    mod stdin;
+    pub use stdin::{stdin, Stdin};
 
-#[cfg(feature = "io")]
-mod stderr;
-#[cfg(feature = "io")]
-pub use self::stderr::{stderr, Stderr};
+    mod stdout;
+    pub use stdout::{stdout, Stdout};
+}
 
-#[cfg(feature = "io")]
-mod stdin;
-#[cfg(feature = "io")]
-pub use self::stdin::{stdin, Stdin};
+cfg_io_util! {
+    pub mod split;
+    pub use split::split;
 
-#[cfg(feature = "io")]
-mod stdout;
-#[cfg(feature = "io")]
-pub use self::stdout::{stdout, Stdout};
+    pub(crate) mod util;
+    pub use util::{
+        copy, empty, repeat, sink, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufStream,
+        BufWriter, Copy, Empty, Lines, Repeat, Sink, Split, Take,
+    };
 
-// Re-export io::Error so that users don't have to deal
-// with conflicts when `use`ing `tokio::io` and `std::io`.
-#[cfg(feature = "io-util")]
-pub use std::io::{Error, ErrorKind, Result};
+    // Re-export io::Error so that users don't have to deal with conflicts when
+    // `use`ing `tokio::io` and `std::io`.
+    pub use std::io::{Error, ErrorKind, Result};
+}
 
-/// Types in this module can be mocked out in tests.
-#[cfg(any(feature = "io", feature = "fs"))]
-mod sys {
-    // TODO: don't rename
-    pub(crate) use crate::blocking::spawn_blocking as run;
-    pub(crate) use crate::task::JoinHandle as Blocking;
+cfg_not_io_util! {
+    cfg_process! {
+        pub(crate) mod util;
+    }
+}
+
+cfg_io_blocking! {
+    /// Types in this module can be mocked out in tests.
+    mod sys {
+        // TODO: don't rename
+        pub(crate) use crate::blocking::spawn_blocking as run;
+        pub(crate) use crate::task::JoinHandle as Blocking;
+    }
 }

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -1,71 +1,75 @@
-mod async_buf_read_ext;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::async_buf_read_ext::AsyncBufReadExt;
+#![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 
-mod async_read_ext;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::async_read_ext::AsyncReadExt;
+cfg_io_util! {
+    mod async_buf_read_ext;
+    pub use async_buf_read_ext::AsyncBufReadExt;
 
-mod async_write_ext;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::async_write_ext::AsyncWriteExt;
+    mod async_read_ext;
+    pub use async_read_ext::AsyncReadExt;
 
-mod buf_reader;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::buf_reader::BufReader;
+    mod async_write_ext;
+    pub use async_write_ext::AsyncWriteExt;
 
-mod buf_stream;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::buf_stream::BufStream;
+    mod buf_reader;
+    pub use buf_reader::BufReader;
 
-mod buf_writer;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::buf_writer::BufWriter;
+    mod buf_stream;
+    pub use buf_stream::BufStream;
 
-mod chain;
+    mod buf_writer;
+    pub use buf_writer::BufWriter;
 
-mod copy;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::copy::{copy, Copy};
+    mod chain;
 
-mod empty;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::empty::{empty, Empty};
+    mod copy;
+    pub use copy::{copy, Copy};
 
-mod flush;
+    mod empty;
+    pub use empty::{empty, Empty};
 
-mod lines;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::lines::Lines;
+    mod flush;
 
-mod read;
-mod read_exact;
-mod read_line;
-mod read_to_end;
-mod read_to_string;
-mod read_until;
+    mod lines;
+    pub use lines::Lines;
 
-mod repeat;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::repeat::{repeat, Repeat};
+    mod read;
+    mod read_exact;
+    mod read_line;
 
-mod shutdown;
+    mod read_to_end;
+    cfg_process! {
+        pub(crate) use read_to_end::read_to_end;
+    }
 
-mod sink;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::sink::{sink, Sink};
+    mod read_to_string;
+    mod read_until;
 
-mod split;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::split::Split;
+    mod repeat;
+    pub use repeat::{repeat, Repeat};
 
-mod take;
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::take::Take;
+    mod shutdown;
 
-mod write;
-mod write_all;
+    mod sink;
+    pub use sink::{sink, Sink};
 
-// used by `BufReader` and `BufWriter`
-// https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/io.rs#L1
-const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+    mod split;
+    pub use split::Split;
+
+    mod take;
+    pub use take::Take;
+
+    mod write;
+    mod write_all;
+
+    // used by `BufReader` and `BufWriter`
+    // https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/io.rs#L1
+    const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+}
+
+cfg_not_io_util! {
+    cfg_process! {
+        mod read_to_end;
+        // Used by process
+        pub(crate) use read_to_end::read_to_end;
+    }
+}

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-full"), allow(unused_imports, dead_code))]
+#![cfg_attr(not(feature = "full"), allow(unused_imports, dead_code))]
 
 mod atomic_u32;
 mod atomic_u64;
@@ -11,7 +11,7 @@ pub(crate) mod cell {
     pub(crate) use super::causal_cell::{CausalCell, CausalCheck};
 }
 
-#[cfg(feature = "sync")]
+#[cfg(any(feature = "sync", feature = "io-driver"))]
 pub(crate) mod future {
     pub(crate) use crate::sync::AtomicWaker;
 }
@@ -51,12 +51,12 @@ pub(crate) mod sync {
 }
 
 pub(crate) mod sys {
-    #[cfg(feature = "rt-full")]
+    #[cfg(feature = "rt-threaded")]
     pub(crate) fn num_cpus() -> usize {
         usize::max(1, num_cpus::get_physical())
     }
 
-    #[cfg(not(feature = "rt-full"))]
+    #[cfg(not(feature = "rt-threaded"))]
     pub(crate) fn num_cpus() -> usize {
         1
     }

--- a/tokio/src/macros/assert.rs
+++ b/tokio/src/macros/assert.rs
@@ -1,0 +1,19 @@
+/// Assert option is some
+macro_rules! assert_some {
+    ($e:expr) => {{
+        match $e {
+            Some(v) => v,
+            _ => panic!("expected some, was none"),
+        }
+    }};
+}
+
+/// Assert option is none
+macro_rules! assert_none {
+    ($e:expr) => {{
+        match $e {
+            Some(v) => panic!("expected none, was {:?}", v),
+            _ => {}
+        }
+    }};
+}

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -1,0 +1,217 @@
+#![allow(unused_macros)]
+
+macro_rules! cfg_atomic_waker {
+    ($($item:item)*) => {
+        $( #[cfg(any(feature = "io-driver", feature = "time"))] $item )*
+    }
+}
+
+macro_rules! cfg_blocking {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "blocking")] $item )*
+    }
+}
+
+/// Enable blocking API internals
+macro_rules! cfg_blocking_impl {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(
+                    feature = "blocking",
+                    feature = "fs",
+                    feature = "dns",
+                    feature = "io-std",
+                    feature = "rt-threaded",
+                    ))]
+            $item
+        )*
+    }
+}
+
+/// Enable blocking API internals
+macro_rules! cfg_not_blocking_impl {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(any(
+                        feature = "blocking",
+                        feature = "fs",
+                        feature = "dns",
+                        feature = "io-std",
+                        feature = "rt-threaded",
+                        )))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_dns {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "dns")] $item )*
+    }
+}
+
+macro_rules! cfg_fs {
+    ($($item:item)*) => { $( #[cfg(feature = "fs")] $item )* }
+}
+
+macro_rules! cfg_io_blocking {
+    ($($item:item)*) => {
+        $( #[cfg(any(feature = "io-std", feature = "fs"))] $item )*
+    }
+}
+
+macro_rules! cfg_io_driver {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "io-driver")] $item )*
+    }
+}
+
+macro_rules! cfg_not_io_driver {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "io-driver"))] $item )*
+    }
+}
+
+macro_rules! cfg_io_std {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "io-std")] $item )*
+    }
+}
+
+macro_rules! cfg_io_util {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "io-util")] $item )*
+    }
+}
+
+macro_rules! cfg_not_io_util {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "io-util"))] $item )*
+    }
+}
+
+macro_rules! cfg_loom {
+    ($($item:item)*) => {
+        $( #[cfg(loom)] $item )*
+    }
+}
+
+macro_rules! cfg_not_loom {
+    ($($item:item)*) => {
+        $( #[cfg(not(loom))] $item )*
+    }
+}
+
+macro_rules! cfg_macros {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "macros")]
+            #[doc(inline)]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_process {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "process")]
+            #[cfg(not(loom))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_signal {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "signal")]
+            #[cfg(not(loom))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_stream {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "stream")] $item )*
+    }
+}
+
+macro_rules! cfg_sync {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "sync")] $item )*
+    }
+}
+
+macro_rules! cfg_not_sync {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "sync"))] $item )*
+    }
+}
+
+macro_rules! cfg_rt_core {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "rt-core")] $item )*
+    }
+}
+
+macro_rules! cfg_not_rt_core {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "rt-core"))] $item )*
+    }
+}
+
+macro_rules! cfg_rt_threaded {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "rt-threaded")] $item )*
+    }
+}
+
+macro_rules! cfg_not_rt_threaded {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "rt-threaded"))] $item )*
+    }
+}
+
+macro_rules! cfg_tcp {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "tcp")] $item )*
+    }
+}
+
+macro_rules! cfg_test_util {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "test-util")] $item )*
+    }
+}
+
+macro_rules! cfg_not_test_util {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "test-util"))] $item )*
+    }
+}
+
+macro_rules! cfg_time {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "time")] $item )*
+    }
+}
+
+macro_rules! cfg_not_time {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "time"))] $item )*
+    }
+}
+
+macro_rules! cfg_udp {
+    ($($item:item)*) => {
+        $( #[cfg(feature = "udp")] $item )*
+    }
+}
+
+macro_rules! cfg_uds {
+    ($($item:item)*) => {
+        $( #[cfg(all(unix, feature = "uds"))] $item )*
+    }
+}

--- a/tokio/src/macros/loom.rs
+++ b/tokio/src/macros/loom.rs
@@ -1,0 +1,12 @@
+macro_rules! if_loom {
+    ($($t:tt)*) => {{
+        #[cfg(loom)]
+        const LOOM: bool = true;
+        #[cfg(not(loom))]
+        const LOOM: bool = false;
+
+        if LOOM {
+            $($t)*
+        }
+    }}
+}

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -1,0 +1,17 @@
+#![cfg_attr(not(feature = "full"), allow(unused_macros))]
+
+#[macro_use]
+#[cfg(test)]
+mod assert;
+
+#[macro_use]
+mod cfg;
+
+#[macro_use]
+mod loom;
+
+#[macro_use]
+mod ready;
+
+#[macro_use]
+mod thread_local;

--- a/tokio/src/macros/ready.rs
+++ b/tokio/src/macros/ready.rs
@@ -1,0 +1,8 @@
+macro_rules! ready {
+    ($e:expr $(,)?) => {
+        match $e {
+            std::task::Poll::Ready(t) => t,
+            std::task::Poll::Pending => return std::task::Poll::Pending,
+        }
+    };
+}

--- a/tokio/src/macros/thread_local.rs
+++ b/tokio/src/macros/thread_local.rs
@@ -1,0 +1,4 @@
+#[cfg(all(loom, test))]
+macro_rules! thread_local {
+    ($($tts:tt)+) => { loom::thread_local!{ $($tts)+ } }
+}

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -24,24 +24,22 @@
 mod addr;
 pub use addr::ToSocketAddrs;
 
-pub mod driver;
+cfg_io_driver! {
+    pub mod driver;
+    pub mod util;
+}
 
-pub mod util;
+cfg_tcp! {
+    pub mod tcp;
+    pub use tcp::{TcpListener, TcpStream};
+}
 
-#[cfg(feature = "tcp")]
-pub mod tcp;
+cfg_udp! {
+    pub mod udp;
+    pub use udp::UdpSocket;
+}
 
-#[cfg(feature = "tcp")]
-pub use self::tcp::{TcpListener, TcpStream};
-
-#[cfg(feature = "udp")]
-pub mod udp;
-
-#[cfg(feature = "udp")]
-pub use self::udp::UdpSocket;
-
-#[cfg(all(unix, feature = "uds"))]
-pub mod unix;
-
-#[cfg(all(unix, feature = "uds"))]
-pub use self::unix::{UnixDatagram, UnixListener, UnixStream};
+cfg_uds! {
+    pub mod unix;
+    pub use unix::{UnixDatagram, UnixListener, UnixStream};
+}

--- a/tokio/src/prelude.rs
+++ b/tokio/src/prelude.rs
@@ -12,6 +12,8 @@
 //! The prelude may grow over time as additional items see ubiquitous use.
 
 pub use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite};
-#[cfg(feature = "io-util")]
-#[doc(no_inline)]
-pub use crate::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
+
+cfg_io_util! {
+    #[doc(no_inline)]
+    pub use crate::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
+}

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -116,7 +116,7 @@ mod imp;
 
 mod kill;
 
-use crate::io::{AsyncRead, AsyncReadExt, AsyncWrite};
+use crate::io::{AsyncRead, AsyncWrite};
 use crate::process::kill::Kill;
 
 use std::ffi::OsStr;
@@ -771,7 +771,7 @@ impl Child {
         async fn read_to_end<A: AsyncRead + Unpin>(io: Option<A>) -> io::Result<Vec<u8>> {
             let mut vec = Vec::new();
             if let Some(mut io) = io {
-                AsyncReadExt::read_to_end(&mut io, &mut vec).await?;
+                crate::io::util::read_to_end(&mut io, &mut vec).await?;
             }
             Ok(vec)
         }

--- a/tokio/src/runtime/blocking.rs
+++ b/tokio/src/runtime/blocking.rs
@@ -3,10 +3,7 @@
 //! shells. This isolates the complexity of dealing with conditional
 //! compilation.
 
-pub(crate) use self::variant::*;
-
-#[cfg(feature = "blocking")]
-mod variant {
+cfg_blocking_impl! {
     pub(crate) use crate::blocking::BlockingPool;
     pub(crate) use crate::blocking::Spawner;
 
@@ -17,8 +14,7 @@ mod variant {
     }
 }
 
-#[cfg(not(feature = "blocking"))]
-mod variant {
+cfg_not_blocking_impl! {
     use crate::runtime::Builder;
 
     #[derive(Debug, Clone)]

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -1,13 +1,15 @@
-#[cfg(feature = "rt-core")]
-use crate::runtime::basic_scheduler;
-#[cfg(feature = "rt-full")]
-use crate::runtime::thread_pool;
 use crate::runtime::{blocking, io, time};
-#[cfg(feature = "rt-core")]
-use crate::task::JoinHandle;
 
-#[cfg(feature = "rt-core")]
-use std::future::Future;
+cfg_rt_core! {
+    use crate::runtime::basic_scheduler;
+    use crate::task::JoinHandle;
+
+    use std::future::Future;
+}
+
+cfg_rt_threaded! {
+    use crate::runtime::thread_pool;
+}
 
 /// Handle to the runtime
 #[derive(Debug, Clone)]
@@ -31,57 +33,11 @@ pub(super) enum Kind {
     Shell,
     #[cfg(feature = "rt-core")]
     Basic(basic_scheduler::Spawner),
-    #[cfg(feature = "rt-full")]
+    #[cfg(feature = "rt-threaded")]
     ThreadPool(thread_pool::Spawner),
 }
 
 impl Handle {
-    /// Spawn a future onto the Tokio runtime.
-    ///
-    /// This spawns the given future onto the runtime's executor, usually a
-    /// thread pool. The thread pool is then responsible for polling the future
-    /// until it completes.
-    ///
-    /// See [module level][mod] documentation for more details.
-    ///
-    /// [mod]: index.html
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tokio::runtime::Runtime;
-    ///
-    /// # fn dox() {
-    /// // Create the runtime
-    /// let rt = Runtime::new().unwrap();
-    /// let handle = rt.handle();
-    ///
-    /// // Spawn a future onto the runtime
-    /// handle.spawn(async {
-    ///     println!("now running on a worker thread");
-    /// });
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// This function panics if the spawn fails. Failure occurs if the executor
-    /// is currently at capacity and is unable to spawn a new future.
-    #[cfg(feature = "rt-core")]
-    pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        match &self.kind {
-            Kind::Shell => panic!("spawning not enabled for runtime"),
-            #[cfg(feature = "rt-core")]
-            Kind::Basic(spawner) => spawner.spawn(future),
-            #[cfg(feature = "rt-full")]
-            Kind::ThreadPool(spawner) => spawner.spawn(future),
-        }
-    }
-
     /// Enter the runtime context
     pub fn enter<F, R>(&self, f: F) -> R
     where
@@ -94,9 +50,58 @@ impl Handle {
                 Kind::Shell => f(),
                 #[cfg(feature = "rt-core")]
                 Kind::Basic(spawner) => spawner.enter(f),
-                #[cfg(feature = "rt-full")]
+                #[cfg(feature = "rt-threaded")]
                 Kind::ThreadPool(spawner) => spawner.enter(f),
             })
         })
+    }
+}
+
+cfg_rt_core! {
+    impl Handle {
+        /// Spawn a future onto the Tokio runtime.
+        ///
+        /// This spawns the given future onto the runtime's executor, usually a
+        /// thread pool. The thread pool is then responsible for polling the future
+        /// until it completes.
+        ///
+        /// See [module level][mod] documentation for more details.
+        ///
+        /// [mod]: index.html
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Runtime;
+        ///
+        /// # fn dox() {
+        /// // Create the runtime
+        /// let rt = Runtime::new().unwrap();
+        /// let handle = rt.handle();
+        ///
+        /// // Spawn a future onto the runtime
+        /// handle.spawn(async {
+        ///     println!("now running on a worker thread");
+        /// });
+        /// # }
+        /// ```
+        ///
+        /// # Panics
+        ///
+        /// This function panics if the spawn fails. Failure occurs if the executor
+        /// is currently at capacity and is unable to spawn a new future.
+        pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            match &self.kind {
+                Kind::Shell => panic!("spawning not enabled for runtime"),
+                #[cfg(feature = "rt-core")]
+                Kind::Basic(spawner) => spawner.spawn(future),
+                #[cfg(feature = "rt-threaded")]
+                Kind::ThreadPool(spawner) => spawner.spawn(future),
+            }
+        }
     }
 }

--- a/tokio/src/runtime/io.rs
+++ b/tokio/src/runtime/io.rs
@@ -3,13 +3,10 @@
 //! shells. This isolates the complexity of dealing with conditional
 //! compilation.
 
-pub(crate) use self::variant::*;
-
 /// Re-exported for convenience.
 pub(crate) use std::io::Result;
 
-#[cfg(feature = "io-driver")]
-mod variant {
+cfg_io_driver! {
     use crate::net::driver;
 
     use std::io;
@@ -38,8 +35,7 @@ mod variant {
     }
 }
 
-#[cfg(not(feature = "io-driver"))]
-mod variant {
+cfg_not_io_driver! {
     use crate::runtime::park::ParkThread;
 
     use std::io;

--- a/tokio/src/runtime/park/mod.rs
+++ b/tokio/src/runtime/park/mod.rs
@@ -45,7 +45,7 @@
 //! [mio]: https://docs.rs/mio/0.6/mio/struct.Poll.html
 
 mod thread;
-#[cfg(feature = "rt-full")]
+#[cfg(feature = "rt-threaded")]
 pub(crate) use self::thread::CachedParkThread;
 #[cfg(not(feature = "io-driver"))]
 pub(crate) use self::thread::ParkThread;

--- a/tokio/src/runtime/park/thread.rs
+++ b/tokio/src/runtime/park/thread.rs
@@ -168,7 +168,7 @@ impl CachedParkThread {
     ///
     /// This type cannot be moved to other threads, so it should be created on
     /// the thread that the caller intends to park.
-    #[cfg(feature = "rt-full")]
+    #[cfg(feature = "rt-threaded")]
     pub(crate) fn new() -> CachedParkThread {
         CachedParkThread {
             _anchor: PhantomData,
@@ -217,7 +217,7 @@ impl Unpark for UnparkThread {
     }
 }
 
-#[cfg(feature = "rt-full")]
+#[cfg(feature = "rt-threaded")]
 mod waker {
     use super::{Inner, UnparkThread};
     use crate::loom::sync::Arc;

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -22,7 +22,9 @@ mod shutdown;
 
 mod worker;
 
-pub(crate) use worker::block_in_place;
+cfg_blocking! {
+    pub(crate) use worker::block_in_place;
+}
 
 /// Unit tests
 #[cfg(test)]

--- a/tokio/src/runtime/time.rs
+++ b/tokio/src/runtime/time.rs
@@ -3,10 +3,7 @@
 //! shells. This isolates the complexity of dealing with conditional
 //! compilation.
 
-pub(crate) use self::variant::*;
-
-#[cfg(feature = "time")]
-mod variant {
+cfg_time! {
     use crate::runtime::io;
     use crate::time::{self, driver};
 
@@ -35,8 +32,7 @@ mod variant {
     }
 }
 
-#[cfg(not(feature = "time"))]
-mod variant {
+cfg_not_time! {
     use crate::runtime::io;
 
     pub(crate) type Clock = ();

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -13,43 +13,40 @@
 //! - [watch](watch/index.html), a single-producer, multi-consumer channel that
 //!   only stores the **most recently** sent value.
 
-macro_rules! debug {
-    ($($t:tt)*) => {
-        if false {
-            println!($($t)*);
-        }
+cfg_sync! {
+    mod barrier;
+    pub use barrier::{Barrier, BarrierWaitResult};
+
+    pub mod mpsc;
+
+    mod mutex;
+    pub use mutex::{Mutex, MutexGuard};
+
+    pub mod oneshot;
+
+    pub(crate) mod semaphore;
+
+    mod task;
+    pub(crate) use task::AtomicWaker;
+
+    pub mod watch;
+}
+
+cfg_not_sync! {
+    cfg_atomic_waker! {
+        mod task;
+        pub(crate) use task::AtomicWaker;
+    }
+
+    cfg_rt_threaded! {
+        pub(crate) mod oneshot;
+    }
+
+    cfg_signal! {
+        pub(crate) mod mpsc;
+        pub(crate) mod semaphore;
     }
 }
-
-macro_rules! if_loom {
-    ($($t:tt)*) => {{
-        #[cfg(loom)]
-        const LOOM: bool = true;
-        #[cfg(not(loom))]
-        const LOOM: bool = false;
-
-        if LOOM {
-            $($t)*
-        }
-    }}
-}
-
-mod barrier;
-pub use barrier::{Barrier, BarrierWaitResult};
-
-pub mod mpsc;
-
-mod mutex;
-pub use mutex::{Mutex, MutexGuard};
-
-pub mod oneshot;
-
-pub mod semaphore;
-
-mod task;
-pub(crate) use task::AtomicWaker;
-
-pub mod watch;
 
 /// Unit tests
 #[cfg(test)]

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -161,12 +161,13 @@ impl<T> Receiver<T> {
 
 impl<T> Unpin for Receiver<T> {}
 
-#[cfg(feature = "stream")]
-impl<T> futures_core::Stream for Receiver<T> {
-    type Item = T;
+cfg_stream! {
+    impl<T> futures_core::Stream for Receiver<T> {
+        type Item = T;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        self.poll_recv(cx)
+        fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+            self.poll_recv(cx)
+        }
     }
 }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -299,12 +299,6 @@ where
             // second time here.
             try_recv!();
 
-            debug!(
-                "recv; rx_closed = {:?}; is_idle = {:?}",
-                rx_fields.rx_closed,
-                self.inner.semaphore.is_idle()
-            );
-
             if rx_fields.rx_closed && self.inner.semaphore.is_idle() {
                 Ready(None)
             } else {

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -169,7 +169,6 @@ impl<T> Tx<T> {
     }
 
     pub(crate) unsafe fn reclaim_block(&self, mut block: NonNull<Block<T>>) {
-        debug!("+ reclaim_block({:p})", block);
         // The block has been removed from the linked list and ownership
         // is reclaimed.
         //
@@ -206,7 +205,6 @@ impl<T> Tx<T> {
         }
 
         if !reused {
-            debug!(" + block freed {:p}", block);
             let _ = Box::from_raw(block.as_ptr());
         }
     }
@@ -226,7 +224,6 @@ impl<T> Rx<T> {
     pub(crate) fn pop(&mut self, tx: &Tx<T>) -> Option<block::Read<T>> {
         // Advance `head`, if needed
         if !self.try_advancing_head() {
-            debug!("+ !self.try_advancing_head() -> false");
             return None;
         }
 
@@ -276,8 +273,6 @@ impl<T> Rx<T> {
     }
 
     fn reclaim_blocks(&mut self, tx: &Tx<T>) {
-        debug!("+ reclaim_blocks()");
-
         while self.free_head != self.head {
             unsafe {
                 // Get a handle to the block that will be freed and update
@@ -316,7 +311,6 @@ impl<T> Rx<T> {
     /// Effectively `Drop` all the blocks. Should only be called once, when
     /// the list is dropping.
     pub(super) unsafe fn free_blocks(&mut self) {
-        debug!("+ free_blocks()");
         debug_assert_ne!(self.free_head, NonNull::dangling());
 
         let mut cur = Some(self.free_head);
@@ -331,7 +325,6 @@ impl<T> Rx<T> {
 
         while let Some(block) = cur {
             cur = block.as_ref().load_next(Relaxed);
-            debug!(" + free: block = {:p}", block);
             drop(Box::from_raw(block.as_ptr()));
         }
     }

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
+
 //! A multi-producer, single-consumer queue for sending values across
 //! asynchronous tasks.
 //!

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
+
 //! A channel for sending a single message between asynchronous tasks.
 
 use crate::loom::cell::CausalCell;

--- a/tokio/src/sync/tests/loom_list.rs
+++ b/tokio/src/sync/tests/loom_list.rs
@@ -21,17 +21,14 @@ fn smoke() {
                 for i in 0..NUM_MSG {
                     tx.push((th, i));
                 }
-                debug!(" + tx thread done");
             });
         }
 
         let mut next = vec![0; NUM_TX];
 
         loop {
-            debug!(" + rx.pop()");
             match rx.pop(&tx) {
                 Some(Value((th, v))) => {
-                    debug!(" + pop() -> Some(Value({}))", v);
                     assert_eq!(v, next[th]);
                     next[th] += 1;
 
@@ -43,7 +40,6 @@ fn smoke() {
                     panic!();
                 }
                 None => {
-                    debug!(" + pop() -> None");
                     thread::yield_now();
                 }
             }

--- a/tokio/src/sync/tests/mod.rs
+++ b/tokio/src/sync/tests/mod.rs
@@ -1,17 +1,12 @@
-#[cfg(not(loom))]
-mod atomic_waker;
+cfg_not_loom! {
+    mod atomic_waker;
+    mod semaphore;
+}
 
-#[cfg(loom)]
-mod loom_atomic_waker;
-
-#[cfg(loom)]
-mod loom_list;
-
-#[cfg(loom)]
-mod loom_mpsc;
-
-#[cfg(loom)]
-mod loom_oneshot;
-
-#[cfg(loom)]
-mod loom_semaphore;
+cfg_loom! {
+    mod loom_atomic_waker;
+    mod loom_list;
+    mod loom_mpsc;
+    mod loom_oneshot;
+    mod loom_semaphore;
+}

--- a/tokio/src/sync/tests/semaphore.rs
+++ b/tokio/src/sync/tests/semaphore.rs
@@ -1,6 +1,4 @@
-#![warn(rust_2018_idioms)]
-
-use tokio::sync::semaphore::{Permit, Semaphore};
+use crate::sync::semaphore::{Permit, Semaphore};
 use tokio_test::task;
 use tokio_test::{assert_pending, assert_ready_err, assert_ready_ok};
 

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -1,62 +1,65 @@
 use crate::blocking;
 use crate::task::JoinHandle;
 
-/// Run the provided blocking function without blocking the executor.
-///
-/// In general, issuing a blocking call or performing a lot of compute in a
-/// future without yielding is not okay, as it may prevent the executor from
-/// driving other futures forward.  If you run a closure through this method,
-/// the current executor thread will relegate all its executor duties to another
-/// (possibly new) thread, and only then poll the task. Note that this requires
-/// additional synchronization.
-///
-/// # Examples
-///
-/// ```
-/// use tokio::task;
-///
-/// # async fn docs() {
-/// task::block_in_place(move || {
-///     // do some compute-heavy work or call synchronous code
-/// });
-/// # }
-/// ```
-#[cfg(feature = "rt-full")]
-pub fn block_in_place<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R,
-{
-    use crate::runtime::{enter, thread_pool};
+cfg_rt_threaded! {
+    /// Run the provided blocking function without blocking the executor.
+    ///
+    /// In general, issuing a blocking call or performing a lot of compute in a
+    /// future without yielding is not okay, as it may prevent the executor from
+    /// driving other futures forward.  If you run a closure through this method,
+    /// the current executor thread will relegate all its executor duties to another
+    /// (possibly new) thread, and only then poll the task. Note that this requires
+    /// additional synchronization.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::task;
+    ///
+    /// # async fn docs() {
+    /// task::block_in_place(move || {
+    ///     // do some compute-heavy work or call synchronous code
+    /// });
+    /// # }
+    /// ```
+    pub fn block_in_place<F, R>(f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        use crate::runtime::{enter, thread_pool};
 
-    enter::exit(|| thread_pool::block_in_place(f))
+        enter::exit(|| thread_pool::block_in_place(f))
+    }
 }
 
-/// Run the provided closure on a thread where blocking is acceptable.
-///
-/// In general, issuing a blocking call or performing a lot of compute in a future without
-/// yielding is not okay, as it may prevent the executor from driving other futures forward.
-/// A closure that is run through this method will instead be run on a dedicated thread pool for
-/// such blocking tasks without holding up the main futures executor.
-///
-/// # Examples
-///
-/// ```
-/// use tokio::task;
-///
-/// # async fn docs() -> Result<(), Box<dyn std::error::Error>>{
-/// let res = task::spawn_blocking(move || {
-///     // do some compute-heavy work or call synchronous code
-///     "done computing"
-/// }).await?;
-///
-/// assert_eq!(res, "done computing");
-/// # Ok(())
-/// # }
-/// ```
-pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
-where
-    F: FnOnce() -> R + Send + 'static,
-    R: Send + 'static,
-{
-    blocking::spawn_blocking(f)
+cfg_blocking! {
+    /// Run the provided closure on a thread where blocking is acceptable.
+    ///
+    /// In general, issuing a blocking call or performing a lot of compute in a future without
+    /// yielding is not okay, as it may prevent the executor from driving other futures forward.
+    /// A closure that is run through this method will instead be run on a dedicated thread pool for
+    /// such blocking tasks without holding up the main futures executor.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::task;
+    ///
+    /// # async fn docs() -> Result<(), Box<dyn std::error::Error>>{
+    /// let res = task::spawn_blocking(move || {
+    ///     // do some compute-heavy work or call synchronous code
+    ///     "done computing"
+    /// }).await?;
+    ///
+    /// assert_eq!(res, "done computing");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        blocking::spawn_blocking(f)
+    }
 }

--- a/tokio/src/task/raw.rs
+++ b/tokio/src/task/raw.rs
@@ -54,16 +54,19 @@ pub(super) fn vtable<T: Future, S: Schedule>() -> &'static Vtable {
     }
 }
 
-impl RawTask {
-    #[cfg(feature = "rt-full")]
-    pub(super) fn new_background<T, S>(task: T) -> RawTask
-    where
-        T: Future + Send + 'static,
-        S: Schedule,
-    {
-        RawTask::new::<_, S>(task, State::new_background())
+cfg_rt_threaded! {
+    impl RawTask {
+        pub(super) fn new_background<T, S>(task: T) -> RawTask
+        where
+            T: Future + Send + 'static,
+            S: Schedule,
+        {
+            RawTask::new::<_, S>(task, State::new_background())
+        }
     }
+}
 
+impl RawTask {
     pub(super) fn new_joinable<T, S>(task: T) -> RawTask
     where
         T: Future + Send + 'static,

--- a/tokio/src/task/state.rs
+++ b/tokio/src/task/state.rs
@@ -58,7 +58,7 @@ const INITIAL_STATE: usize = NOTIFIED;
 /// unambiguous modification order.
 impl State {
     /// Starts with a ref count of 1
-    #[cfg(feature = "rt-full")]
+    #[cfg(feature = "rt-threaded")]
     pub(super) fn new_background() -> State {
         State {
             val: AtomicUsize::new(INITIAL_STATE),

--- a/tokio/src/tests/mod.rs
+++ b/tokio/src/tests/mod.rs
@@ -1,25 +1,3 @@
-#[macro_export]
-/// Assert option is some
-macro_rules! assert_some {
-    ($e:expr) => {{
-        match $e {
-            Some(v) => v,
-            _ => panic!("expected some, was none"),
-        }
-    }};
-}
-
-#[macro_export]
-/// Assert option is none
-macro_rules! assert_none {
-    ($e:expr) => {{
-        match $e {
-            Some(v) => panic!("expected none, was {:?}", v),
-            _ => {}
-        }
-    }};
-}
-
 #[cfg(not(loom))]
 pub(crate) mod backoff;
 

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -4,15 +4,7 @@
 //! `test-util` feature flag is enabled, the values returned for `now()` are
 //! configurable.
 
-#[cfg(feature = "test-util")]
-pub(crate) use self::variant::now;
-pub(crate) use self::variant::Clock;
-#[cfg(feature = "test-util")]
-#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::variant::{advance, pause, resume};
-
-#[cfg(not(feature = "test-util"))]
-mod variant {
+cfg_not_test_util! {
     use crate::time::Instant;
 
     #[derive(Debug, Clone)]
@@ -40,8 +32,7 @@ mod variant {
     }
 }
 
-#[cfg(feature = "test-util")]
-mod variant {
+cfg_test_util! {
     use crate::time::{Duration, Instant};
 
     use std::cell::Cell;

--- a/tokio/tests/fs_file_mocked.rs
+++ b/tokio/tests/fs_file_mocked.rs
@@ -9,6 +9,16 @@ macro_rules! ready {
     };
 }
 
+#[macro_export]
+macro_rules! cfg_fs {
+    ($($item:item)*) => { $($item)* }
+}
+
+#[macro_export]
+macro_rules! cfg_io_std {
+    ($($item:item)*) => { $($item)* }
+}
+
 use futures::future;
 
 // Load source


### PR DESCRIPTION
Removes dependencies between Tokio feature flags. For example, `process`
should not depend on `sync` simply because it uses the `mpsc` channel.
Instead, feature flags represent **public** APIs that become available
with the feature enabled. When the feature is not enabled, the
functionality is removed. If another Tokio component requires the
functionality, it is stays as `pub(crate)`.

The threaded scheduler is now exposed under `rt-threaded`. This feature
flag only enables the threaded scheduler and does not include I/O,
networking, or time. Those features must be explictly enabled.

A `full` feature flag is added that enables all features.

`stdin`, `stdout`, `stderr` are exposed under `io-std`.

Macros are used to scope code by feature flag.