### PR TITLE
fix: improves panic messages when there is no reactor/timer

### DIFF
--- a/tokio/src/net/driver/reactor/mod.rs
+++ b/tokio/src/net/driver/reactor/mod.rs
@@ -306,7 +306,7 @@ impl Handle {
     pub(super) fn current() -> Self {
         CURRENT_REACTOR.with(|current| match *current.borrow() {
             Some(ref handle) => handle.clone(),
-            None => panic!("no current reactor"),
+            None => panic!("There is no reactor, you must execute from within the tokio runtime"),
         })
     }
 

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -64,7 +64,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Kind::*;
         let descr = match self.0 {
-            Shutdown => "timer is shutdown",
+            Shutdown => "The timer is shutdown, you must execute from within the tokio runtime",
             AtCapacity => "timer is at capacity and cannot create a new entry",
         };
         write!(fmt, "{}", descr)


### PR DESCRIPTION
I want to preface this by saying I'm not entirely sure if these error messages are exactly accurate but I wanted to take a crack at it. 

---

## Motivation

Providing a more actionable error message when tokio expects to be within a runtime. Fixes #1713 

## Solution

New error messages:

When there is no timer:

```
The timer is shutdown, you must execute from within the tokio runtime
```

When there is no reactor:

```
There is no reactor, you must execute from within the tokio runtime
```

---

I'm not in love with the "you must execute from within the tokio runtime", not sure what the best wording there is, would love some pointers :)

