### PR TITLE
io: flatten `split` module

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -71,8 +71,8 @@ cfg_io_std! {
 }
 
 cfg_io_util! {
-    pub mod split;
-    pub use split::split;
+    mod split;
+    pub use split::{split, ReadHalf, WriteHalf};
 
     pub(crate) mod util;
     pub use util::{

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -1,5 +1,4 @@
-use tokio::io::split::{ReadHalf, WriteHalf};
-use tokio::io::{split, AsyncRead, AsyncWrite};
+use tokio::io::{split, AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 
 use std::io;
 use std::pin::Pin;


### PR DESCRIPTION
matches #1797.