### PR TITLE
Update futures to 0.3.1

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -9,7 +9,7 @@ tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 tokio-util = { version = "=0.2.0-alpha.6", path = "../tokio-util" }
 
 bytes = { git = "https://github.com/tokio-rs/bytes" }
-futures = "0.3.0"
+futures = "0.3.1"
 
 [[example]]
 name = "chat"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -11,4 +11,4 @@ publish = false
 tokio = { path = "../tokio" }
 tokio-test = { path = "../tokio-test" }
 
-futures = { version = "0.3.0", features = ["async-await"] }
+futures = { version = "0.3.1", features = ["async-await"] }

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -23,10 +23,10 @@ categories = ["asynchronous", "testing"]
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["test-util"] }
 
 bytes = { git = "https://github.com/tokio-rs/bytes" }
-futures-core = "0.3.0"
+futures-core = "0.3.1"
 
 [dev-dependencies]
-futures-util = "0.3.0"
+futures-util = "0.3.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 [dev-dependencies]
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
-futures = { version = "0.3.0", features = ["async-await"] }
+futures = { version = "0.3.1", features = ["async-await"] }
 
 [target.'cfg(all(not(target_os = "macos"), not(windows), not(target_os = "ios")))'.dev-dependencies]
 openssl = "0.10"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -23,8 +23,8 @@ categories = ["asynchronous"]
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 
 bytes = { git = "https://github.com/tokio-rs/bytes" }
-futures-core = "0.3.0"
-futures-sink = "0.3.0"
+futures-core = "0.3.1"
+futures-sink = "0.3.1"
 log = "0.4"
 pin-project-lite = "0.1.1"
 
@@ -32,7 +32,7 @@ pin-project-lite = "0.1.1"
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
-futures = "0.3.0"
+futures = "0.3.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -96,7 +96,7 @@ pin-project-lite = "0.1.1"
 
 # Everything else is optional...
 fnv = { version = "1.0.6", optional = true }
-futures-core = { version = "0.3.0", optional = true }
+futures-core = { version = "0.3.1", optional = true }
 lazy_static = { version = "1.0.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.14", optional = true }
@@ -119,7 +119,7 @@ optional = true
 
 [dev-dependencies]
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
-futures = { version = "0.3.0", features = ["async-await"] }
+futures = { version = "0.3.1", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"


### PR DESCRIPTION
SpawnExt should take &self as their base traits
https://github.com/rust-lang-nursery/futures-rs/pull/1959

## Motivation

It seems that we might be cutting a new alpha soon ™️ https://github.com/tokio-rs/tokio/issues/1708
We should probably use futures 0.3.1 because various libs that have been moving to the futures 0.3 like hyper, actix-net etc are on 0.3.1.
Building 2 versions of futures to include tokio when the alpha is cut would not be ideal

## Solution

Update from futures 0.3.0 -> 0.3.1

