### PR TITLE
v0.1.x: Expose CurrentThread runtime's executor handle

### DIFF
--- a/tokio/src/runtime/current_thread/runtime.rs
+++ b/tokio/src/runtime/current_thread/runtime.rs
@@ -55,6 +55,11 @@ impl Handle {
     pub fn status(&self) -> Result<(), tokio_executor::SpawnError> {
         self.0.status()
     }
+
+    /// Retrieve inner `CurrentThread` executor handle
+    pub fn into_inner(self) -> ExecutorHandle {
+        self.0
+    }
 }
 
 impl<T> future::Executor<T> for Handle


### PR DESCRIPTION
## Motivation

The `CurrentThread` runtime's `Handle` is different than the `CurrentThread` executor's `Handle`. This causes interoperability issues with custom runtimes that build on the `CurrentThread` executor.

Actix-rt offers a concrete example of the issue: [`System::run_in_executor`](https://docs.rs/actix-rt/0.2.6/actix_rt/struct.System.html#method.run_in_executor) requires a `CurrentThread` executor handle - the change in this PR allows a `CurrentThread` runtime to be used here.

## Solution

This PR adds `fn into_inner(self)` on the runtime `Handle` that consumes it and returns the underlying `CurrentThread` executor's `Handle`.