### PR TITLE
default all feature flags to off

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,13 @@ an asynchronous application.
 
 A basic TCP echo server with Tokio:
 
-```rust
+```rust,no_run
 use tokio::net::TcpListener;
 use tokio::prelude::*;
-use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let addr = "127.0.0.1:8080".parse::<SocketAddr>()?;
-    let mut listener = TcpListener::bind(&addr).await?;
+    let mut listener = TcpListener::bind("127.0.0.1:8080").await?;
 
     loop {
         let (mut socket, _) = listener.accept().await?;
@@ -77,14 +75,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     Ok(n) if n == 0 => return,
                     Ok(n) => n,
                     Err(e) => {
-                        println!("failed to read from socket; err = {:?}", e);
+                        eprintln!("failed to read from socket; err = {:?}", e);
                         return;
                     }
                 };
 
                 // Write the data back
                 if let Err(e) = socket.write_all(&buf[0..n]).await {
-                    println!("failed to write to socket; err = {:?}", e);
+                    eprintln!("failed to write to socket; err = {:?}", e);
                     return;
                 }
             }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ pr: ["master"]
 
 variables:
   RUSTFLAGS: -Dwarnings
+  nightly: 2019-11-16
 
 jobs:
 # Check formatting
@@ -80,9 +81,7 @@ jobs:
       - clippy
       - test_tokio
       - test_linux
-      # - test_features
       - loom
-#      - test_nightly
       - cross
-#      - minrust
+      - minrust
 #      - tsan

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -25,14 +25,6 @@ jobs:
   - template: azure-is-release.yml
 
   - ${{ each crate in parameters.crates }}:
-    # Run with default crate features
-    - script: cargo test
-      env:
-        LOOM_MAX_PREEMPTIONS: 2
-        CI: 'True'
-      displayName: ${{ crate }} - cargo test
-      workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
-
     # Run with all crate features
     - script: cargo test --all-features
       env:
@@ -54,14 +46,6 @@ jobs:
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
-    # Run with default crate features
-    - script: cargo test
-      env:
-        LOOM_MAX_PREEMPTIONS: 2
-        CI: 'True'
-      displayName: ${{ crate }} - cargo test
-      workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
-
     # Run with all crate features
     - script: cargo test --all-features
       env:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,8 +5,8 @@ publish = false
 edition = "2018"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
-tokio-util = { version = "=0.2.0-alpha.6", path = "../tokio-util" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["full"] }
+tokio-util = { version = "=0.2.0-alpha.6", path = "../tokio-util", features = ["full"] }
 
 bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures = "0.3.0"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
+tokio = { path = "../tokio", features = ["full"] }
+doc-comment = "0.3.1"
 
 [dev-dependencies]
-tokio = { path = "../tokio" }
 tokio-test = { path = "../tokio-test" }
 
 futures = { version = "0.3.0", features = ["async-await"] }

--- a/tests-integration/src/lib.rs
+++ b/tests-integration/src/lib.rs
@@ -1,0 +1,4 @@
+use doc_comment::doc_comment;
+
+// #[doc = include_str!("../../README.md")]
+doc_comment!(include_str!("../../README.md"));

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -29,7 +29,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -20,7 +20,7 @@ Testing utilities for Tokio- and futures-based code
 categories = ["asynchronous", "testing"]
 
 [dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["test-util"] }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["rt-core", "sync", "time", "test-util"] }
 
 bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures-core = "0.3.0"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -26,6 +26,7 @@ bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures-core = "0.3.0"
 
 [dev-dependencies]
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["full"] }
 futures-util = "0.3.0"
 
 [package.metadata.docs.rs]

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -29,6 +29,8 @@ native-tls = "0.2"
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 
 [dev-dependencies]
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["macros", "stream", "rt-core", "io-util", "net"] }
+
 cfg-if = "0.1"
 env_logger = { version = "0.6", default-features = false }
 futures = { version = "0.3.0", features = ["async-await"] }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -19,6 +19,16 @@ Additional utilities for working with Tokio.
 """
 categories = ["asynchronous"]
 
+[features]
+# No features on by default
+default = []
+
+# Shorthand for enabling everything
+full = ["codec", "udp"]
+
+codec = []
+udp = ["tokio/udp"]
+
 [dependencies]
 tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
 
@@ -36,3 +46,4 @@ futures = "0.3.0"
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -39,7 +39,7 @@ log = "0.4"
 pin-project-lite = "0.1.1"
 
 [dev-dependencies]
-tokio = { version = "=0.2.0-alpha.6", path = "../tokio" }
+tokio = { version = "=0.2.0-alpha.6", path = "../tokio", features = ["full"] }
 tokio-test = { version = "=0.2.0-alpha.6", path = "../tokio-test" }
 
 futures = "0.3.0"

--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -1,0 +1,19 @@
+macro_rules! cfg_codec {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "codec")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "codec")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_udp {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "udp", feature = "codec"))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = "udp", feature = "codec"))))]
+            $item
+        )*
+    }
+}

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -10,8 +10,17 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Utilities for working with Tokio.
 
-pub mod codec;
-pub mod udp;
+#[macro_use]
+mod cfg;
+
+cfg_codec! {
+    pub mod codec;
+}
+
+cfg_udp! {
+    pub mod udp;
+}

--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -27,6 +27,7 @@ use std::task::{Context, Poll};
 /// calling `split` on the `UdpFramed` returned by this method, which will break
 /// them into separate objects, allowing them to interact more easily.
 #[must_use = "sinks do nothing unless polled"]
+#[cfg_attr(docsrs, doc(feature = "codec-udp"))]
 #[derive(Debug)]
 pub struct UdpFramed<C> {
     socket: UdpSocket,

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -24,7 +24,8 @@ categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures"]
 
 [features]
-default = ["full"]
+# Include nothing by default
+default = []
 
 # enable everything
 full = [
@@ -48,7 +49,7 @@ full = [
 blocking = ["rt-core"]
 dns = ["rt-core"]
 fs = ["rt-core"]
-io-driver = ["rt-core", "mio", "lazy_static"]
+io-driver = ["mio", "lazy_static"]
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
@@ -83,7 +84,7 @@ stream = ["futures-core"]
 sync = ["fnv"]
 test-util = []
 tcp = ["io-driver"]
-time = ["rt-core", "slab"]
+time = ["slab"]
 udp = ["io-driver"]
 uds = ["io-driver", "mio-uds", "libc"]
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -124,6 +124,7 @@ futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
+doc-comment = "0.3.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -124,7 +124,6 @@ futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
-doc-comment = "0.3.1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -52,6 +52,15 @@ an asynchronous application.
 
 ## Example
 
+To get started, add the following to `Cargo.toml`.
+
+```toml
+tokio = { version = "0.2.0", features = ["full"] }
+```
+
+Tokio requires components to be explicitly enabled using feature flags. As a
+shorthand, the `full` feature enables all components.
+
 A basic TCP echo server with Tokio:
 
 ```rust

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -51,6 +51,13 @@
 //! control what features are present, so that unused code can be eliminated.
 //! This documentation also lists what feature flags are necessary to enable each API.
 //!
+//! The easiest way to get started is to enable all features. Do this by
+//! enabling the `full` feature flag:
+//!
+//! ```toml
+//! tokio = { version = "0.2", features = ["full"] }
+//! ```
+//!
 //! [features]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //!
 //! ## Working With Tasks

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -40,9 +40,11 @@ cfg_not_sync! {
         pub(crate) use task::AtomicWaker;
     }
 
-    cfg_rt_core! {
-        pub(crate) mod oneshot;
-    }
+    #[cfg(any(
+            feature = "rt-core",
+            feature = "process",
+            feature = "signal"))]
+    pub(crate) mod oneshot;
 
     cfg_signal! {
         pub(crate) mod mpsc;

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,0 +1,2 @@
+#![cfg(not(feature = "full"))]
+compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/buffered.rs
+++ b/tokio/tests/buffered.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::TcpListener;
 use tokio::prelude::*;

--- a/tokio/tests/fs_dir.rs
+++ b/tokio/tests/fs_dir.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::fs;
 use tokio_test::assert_ok;

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::fs::File;
 use tokio::prelude::*;

--- a/tokio/tests/fs_file_mocked.rs
+++ b/tokio/tests/fs_file_mocked.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 macro_rules! ready {
     ($e:expr $(,)?) => {

--- a/tokio/tests/fs_link.rs
+++ b/tokio/tests/fs_link.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::fs;
 

--- a/tokio/tests/io_async_read.rs
+++ b/tokio/tests/io_async_read.rs
@@ -1,3 +1,6 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
 use tokio::io::AsyncRead;
 use tokio_test::task;
 use tokio_test::{assert_ready_err, assert_ready_ok};

--- a/tokio/tests/io_chain.rs
+++ b/tokio/tests/io_chain.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_lines.rs
+++ b/tokio/tests/io_lines.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncBufReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read.rs
+++ b/tokio/tests/io_read.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_exact.rs
+++ b/tokio/tests/io_read_exact.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_line.rs
+++ b/tokio/tests/io_read_line.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncBufReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_to_end.rs
+++ b/tokio/tests/io_read_to_end.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_to_string.rs
+++ b/tokio/tests/io_read_to_string.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_read_until.rs
+++ b/tokio/tests/io_read_until.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncBufReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -1,3 +1,6 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
 use tokio::io::{split, AsyncRead, AsyncWrite, ReadHalf, WriteHalf};
 
 use std::io;

--- a/tokio/tests/io_take.rs
+++ b/tokio/tests/io_take.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio_test::assert_ok;

--- a/tokio/tests/io_write.rs
+++ b/tokio/tests/io_write.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_write_all.rs
+++ b/tokio/tests/io_write_all.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,3 +1,6 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
 use tokio::net::TcpListener;
 
 use std::convert::TryFrom;

--- a/tokio/tests/process_issue_42.rs
+++ b/tokio/tests/process_issue_42.rs
@@ -1,6 +1,6 @@
-#![cfg(feature = "process")]
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 use tokio::process::Command;
 use tokio::runtime;

--- a/tokio/tests/process_smoke.rs
+++ b/tokio/tests/process_smoke.rs
@@ -1,5 +1,5 @@
-#![cfg(feature = "process")]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::process::Command;
 use tokio_test::assert_ok;

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,6 +1,7 @@
-// Tests to run on both current-thread & therad-pool runtime variants.
-
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+// Tests to run on both current-thread & therad-pool runtime variants.
 
 macro_rules! rt_test {
     ($($t:tt)*) => {

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/signal_ctrl_c.rs
+++ b/tokio/tests/signal_ctrl_c.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_recv.rs
+++ b/tokio/tests/signal_drop_recv.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_rt.rs
+++ b/tokio/tests/signal_drop_rt.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_signal.rs
+++ b/tokio/tests/signal_drop_signal.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_multi_rt.rs
+++ b/tokio/tests/signal_multi_rt.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_no_rt.rs
+++ b/tokio/tests/signal_no_rt.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 use tokio::signal::unix::{signal, SignalKind};
 

--- a/tokio/tests/signal_notify_both.rs
+++ b/tokio/tests/signal_notify_both.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_twice.rs
+++ b/tokio/tests/signal_twice.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_usr1.rs
+++ b/tokio/tests/signal_usr1.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 mod support {
     pub mod signal;

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::Barrier;
 

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 fn is_error<T: ::std::error::Error + Send + Sync>() {}
 

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TrySendError;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::Mutex;
 use tokio_test::task::spawn;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::oneshot;
 use tokio_test::*;

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::watch;
 use tokio_test::task::spawn;

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::prelude::*;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::time::{self, Duration, Instant};
 use tokio_test::{assert_pending, assert_ready_eq, task};

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::time::*;
 

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::sync::oneshot;
 use tokio::time::{self, timeout, timeout_at, Instant};

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -1,4 +1,5 @@
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 
 use tokio::net::UdpSocket;
 

--- a/tokio/tests/uds_cred.rs
+++ b/tokio/tests/uds_cred.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
-#![cfg(not(target_os = "dragonfly"))]
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(all(unix, not(target_os = "dragonfly")))]
 
 use tokio::net::UnixStream;
 

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -1,36 +1,10 @@
-#![cfg(unix)]
 #![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
 
 use tokio::net::unix::*;
 
 use std::io;
-
-// struct StringDatagramCodec;
-
-// /// A codec to decode datagrams from a unix domain socket as utf-8 text messages.
-// impl Encoder for StringDatagramCodec {
-//     type Item = String;
-//     type Error = io::Error;
-
-//     fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
-//         dst.extend_from_slice(&item.into_bytes());
-//         Ok(())
-//     }
-// }
-
-// /// A codec to decode datagrams from a unix domain socket as utf-8 text messages.
-// impl Decoder for StringDatagramCodec {
-//     type Item = String;
-//     type Error = io::Error;
-
-//     fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-//         let decoded = str::from_utf8(buf)
-//             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
-//             .to_string();
-
-//         Ok(Some(decoded))
-//     }
-// }
 
 async fn echo_server(mut socket: UnixDatagram) -> io::Result<()> {
     let mut recv_buf = vec![0u8; 1024];

--- a/tokio/tests/uds_split.rs
+++ b/tokio/tests/uds_split.rs
@@ -1,5 +1,6 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
 #![cfg(unix)]
-#![deny(warnings, rust_2018_idioms)]
 
 use tokio::net::UnixStream;
 use tokio::prelude::*;

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -1,5 +1,6 @@
-#![cfg(unix)]
+#![cfg(feature = "full")]
 #![warn(rust_2018_idioms)]
+#![cfg(unix)]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::unix::*;


### PR DESCRIPTION
Changes the set of `default` feature flags to `[]`. By default, only
core traits are included without specifying feature flags. This makes it
easier for users to pick the components they need.

For convenience, a `full` feature flag is included that includes all
components.

Tests are configured to require the `full` feature. Testing individual
feature flags will need to be moved to a separate crate.

Closes #1791
