### PR TITLE
ci: use -Z avoid-dev-deps in features check instead of --no-dev-deps

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,7 @@ pr: ["master"]
 
 variables:
   RUSTFLAGS: -Dwarnings
+  nightly: nightly-2019-11-16
 
 jobs:
 # Test top level crate
@@ -43,6 +44,12 @@ jobs:
     name: cross
     rust: stable
 
+# Check each feature works properly
+- template: ci/azure-check-features.yml
+  parameters:
+    rust: $(nightly)
+    name: check_features
+
 # This represents the minimum Rust version supported by
 # Tokio. Updating this should be done in a dedicated PR and
 # cannot be greater than two 0.x releases prior to the
@@ -53,7 +60,7 @@ jobs:
 - template: ci/azure-check-minrust.yml
   parameters:
     name: minrust
-    rust_version: 1.39.0
+    rust: 1.39.0
 
 # Check formatting
 - template: ci/azure-rustfmt.yml
@@ -70,7 +77,7 @@ jobs:
 # Check doc generation
 - template: ci/azure-check-docs.yml
   parameters:
-    rust: nightly-2019-11-16
+    rust: $(nightly)
     name: docs
 
 # - template: ci/azure-tsan.yml
@@ -89,4 +96,5 @@ jobs:
       - loom
       - cross
       - minrust
+      - check_features
 #      - tsan

--- a/ci/azure-check-features.yml
+++ b/ci/azure-check-features.yml
@@ -1,0 +1,32 @@
+jobs:
+- job: ${{ parameters.name }}
+  displayName: Check features
+  strategy:
+    matrix:
+      Linux:
+        vmImage: ubuntu-16.04
+      MacOS:
+        vmImage: macOS-10.13
+      Windows:
+        vmImage: vs2017-win2016
+  pool:
+    vmImage: $(vmImage)
+
+  steps:
+  - template: azure-install-rust.yml
+    parameters:
+      rust_version: ${{ parameters.rust }}
+
+  - template: azure-patch-crates.yml
+
+  - script: cargo install cargo-hack
+    displayName: Install cargo-hack
+
+  # Check each feature works properly
+  # * --each-feature
+  #   run for each feature which includes --no-default-features and default features of package
+  # * -Z avoid-dev-deps
+  #   build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
+  #   tracking-issue: https://github.com/rust-lang/cargo/issues/5133
+  - script: cargo hack check --all --each-feature -Z avoid-dev-deps
+    displayName: cargo hack check --all --each-feature

--- a/ci/azure-check-minrust.yml
+++ b/ci/azure-check-minrust.yml
@@ -6,7 +6,7 @@ jobs:
   steps:
   - template: azure-install-rust.yml
     parameters:
-      rust_version: ${{ parameters.rust_version }}
+      rust_version: ${{ parameters.rust }}
 
   - template: azure-patch-crates.yml
 

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -19,9 +19,6 @@ jobs:
     parameters:
       rust_version: ${{ parameters.rust }}
 
-  - script: cargo install cargo-hack
-    displayName: Install cargo-hack
-
   - template: azure-is-release.yml
 
   - ${{ each crate in parameters.crates }}:
@@ -41,16 +38,6 @@ jobs:
       displayName: ${{ crate }} - cargo test --all-features
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
 
-    # Check each specified feature works properly
-    # * --each-feature - run for each feature which includes --no-default-features and default features of package
-    # * --no-dev-deps - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
-    - script: cargo hack check --each-feature --no-dev-deps
-      env:
-        LOOM_MAX_PREEMPTIONS: 2
-        CI: 'True'
-      displayName: ${{ crate }} - cargo hack check --each-feature
-      workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
-
   - template: azure-patch-crates.yml
 
   - ${{ each crate in parameters.crates }}:
@@ -68,14 +55,4 @@ jobs:
         LOOM_MAX_PREEMPTIONS: 2
         CI: 'True'
       displayName: ${{ crate }} - cargo test --all-features
-      workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
-
-    # Check each specified feature works properly
-    # * --each-feature - run for each feature which includes --no-default-features and default features of package
-    # * --no-dev-deps - build without dev-dependencies to avoid https://github.com/rust-lang/cargo/issues/4866
-    - script: cargo hack check --each-feature --no-dev-deps
-      env:
-        LOOM_MAX_PREEMPTIONS: 2
-        CI: 'True'
-      displayName: ${{ crate }} - cargo hack check --each-feature
       workingDirectory: $(Build.SourcesDirectory)/${{ crate }}


### PR DESCRIPTION
Workaround for https://github.com/taiki-e/cargo-hack/issues/15

`-Z avoid-dev-deps` (tracking-issue: https://github.com/rust-lang/cargo/issues/5133) is an unstable feature of cargo that has almost the same effect as cargo-hack's `--no-dev-deps`. However, unlike `--no-dev-deps`, the manifest file is not edited. 

FWIW: 
`-Z avoid-dev-deps` works well with `cargo check/build/run`, but not with `cargo publish`.
On the other hand, `--no-dev-deps` doesn't work well with `cargo install`.