### PR TITLE
ci: bring back build tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ members = [
 
   # Internal
   "examples",
+  "tests-build",
   "tests-integration",
 ]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,13 @@ jobs:
       - tokio-util
       - examples
 
+# Run tests from `tests-build`. This requires a different process
+- template: ci/azure-test-build.yml
+  parameters:
+    name: test_build
+    displayName: Test build permutations
+    rust: stable
+
 # Run loom tests
 - template: ci/azure-loom.yml
   parameters:
@@ -86,6 +93,7 @@ jobs:
       - clippy
       - test_tokio
       - test_linux
+      - test_build
       - loom
       - cross
       - minrust

--- a/ci/azure-test-build.yml
+++ b/ci/azure-test-build.yml
@@ -14,4 +14,4 @@ jobs:
 
   - script: cargo hack test --each-feature
     displayName: cargo hack test --each-feature
-    workingDirectory: $(Build.SourcesDirectory)/${{ crate }}
+    workingDirectory: $(Build.SourcesDirectory)/tests-build

--- a/ci/azure-test-build.yml
+++ b/ci/azure-test-build.yml
@@ -1,0 +1,17 @@
+jobs:
+- job: ${{ parameters.name }}
+  displayName: ${{ parameters.displayName }}
+  pool:
+    vmImage: 'Ubuntu 16.04'
+
+  steps:
+  - template: azure-install-rust.yml
+    parameters:
+      rust_version: ${{ parameters.rust }}
+
+  - script: cargo install cargo-hack
+    displayName: Install cargo-hack
+
+  - script: cargo hack test --each-feature
+    displayName: cargo hack test --each-feature
+    workingDirectory: $(Build.SourcesDirectory)/${{ crate }}

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "tests-build"
+version = "0.1.0"
+authors = ["Tokio Contributors <team@tokio.rs>"]
+edition = "2018"
+publish = false
+
+[features]
+full = ["tokio/full"]
+
+[dependencies]
+tokio = { path = "../tokio", optional = true }
+
+[dev-dependencies]
+trybuild = "1.0"

--- a/tests-build/README.md
+++ b/tests-build/README.md
@@ -1,0 +1,2 @@
+Tests the various combination of feature flags. This is broken out to a separate
+crate to work around limitations with cargo features.

--- a/tests-build/src/lib.rs
+++ b/tests-build/src/lib.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "tokio")]
+pub use tokio;

--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -1,0 +1,25 @@
+use tests_build::tokio;
+
+#[tokio::main]
+fn main_is_not_async() {}
+
+#[tokio::main(foo)]
+async fn main_attr_has_unknown_args() {}
+
+#[tokio::main(threadpool::bar)]
+async fn main_attr_has_path_args() {}
+
+#[tokio::test]
+fn test_is_not_async() {}
+
+#[tokio::test]
+async fn test_fn_has_args(_x: u8) {}
+
+#[tokio::test(foo)]
+async fn test_attr_has_args() {}
+
+#[tokio::test]
+#[test]
+async fn test_has_second_test_attr() {}
+
+fn main() {}

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -1,0 +1,41 @@
+error: the async keyword is missing from the function declaration
+ --> $DIR/macros_invalid_input.rs:4:1
+  |
+4 | fn main_is_not_async() {}
+  | ^^
+
+error: Unknown attribute foo is specified; expected `basic_scheduler` or `threaded_scheduler`
+ --> $DIR/macros_invalid_input.rs:6:15
+  |
+6 | #[tokio::main(foo)]
+  |               ^^^
+
+error: Must have specified ident
+ --> $DIR/macros_invalid_input.rs:9:15
+  |
+9 | #[tokio::main(threadpool::bar)]
+  |               ^^^^^^^^^^^^^^^
+
+error: the async keyword is missing from the function declaration
+  --> $DIR/macros_invalid_input.rs:13:1
+   |
+13 | fn test_is_not_async() {}
+   | ^^
+
+error: the test function cannot accept arguments
+  --> $DIR/macros_invalid_input.rs:16:27
+   |
+16 | async fn test_fn_has_args(_x: u8) {}
+   |                           ^^^^^^
+
+error: Unknown attribute foo is specified; expected `basic_scheduler` or `threaded_scheduler`
+  --> $DIR/macros_invalid_input.rs:18:15
+   |
+18 | #[tokio::test(foo)]
+   |               ^^^
+
+error: second test attribute is supplied
+  --> $DIR/macros_invalid_input.rs:22:1
+   |
+22 | #[test]
+   | ^^^^^^^

--- a/tests-build/tests/macros.rs
+++ b/tests-build/tests/macros.rs
@@ -1,0 +1,9 @@
+#[test]
+fn compile_fail() {
+    let t = trybuild::TestCases::new();
+
+    #[cfg(feature = "full")]
+    t.compile_fail("tests/fail/macros_invalid_input.rs");
+
+    drop(t);
+}


### PR DESCRIPTION
This directory was deleted when `cargo hack` was introduced, however
there were some tests that were still useful (macro failure output).

Also, additional build tests will be added over time