### PR TITLE
teach the tokio::test macro to fail tests after a configurable timeout

### DIFF
--- a/tests-integration/tests/timeout.rs
+++ b/tests-integration/tests/timeout.rs
@@ -1,0 +1,13 @@
+#![warn(rust_2018_idioms)]
+
+#[tokio::test(timeout = 100)]
+#[should_panic(expected = "test `timeout_as_integer_literal` timed out")]
+async fn timeout_as_integer_literal() {
+    tokio::time::delay_for(std::time::Duration::from_millis(300)).await;
+}
+
+#[tokio::test(timeout = "100ms")]
+#[should_panic(expected = "test `timeout_as_string_literal` timed out")]
+async fn timeout_as_string_literal() {
+    tokio::time::delay_for(std::time::Duration::from_millis(300)).await;
+}

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -27,6 +27,7 @@ proc-macro = true
 [dependencies]
 quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
+humantime = "1.3"
 
 [dev-dependencies]
 tokio = { version = "0.2.0", path = "../tokio", features = ["full"] }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -28,23 +28,21 @@ enum Runtime {
 
 fn parse_duration(lit: &syn::Lit) -> Result<std::time::Duration, syn::Error> {
     match lit {
-        syn::Lit::Int(expr) => {
-            match expr.base10_parse::<u64>() {
-                Ok(v) => Ok(std::time::Duration::from_millis(v)),
-                Err(_) => {
-                    Err(syn::Error::new_spanned(lit, "unable to parse integer literal"))
-                },
-            }
+        syn::Lit::Int(expr) => match expr.base10_parse::<u64>() {
+            Ok(v) => Ok(std::time::Duration::from_millis(v)),
+            Err(_) => Err(syn::Error::new_spanned(
+                lit,
+                "unable to parse integer literal",
+            )),
         },
-        syn::Lit::Str(expr) => {
-            humantime::parse_duration(&expr.value()).map_err(|err| {
-                let msg = format!("unable to parse duration string: {}", err);
-                syn::Error::new_spanned(lit, msg)
-            })
-        },
-        _ => {
-            Err(syn::Error::new_spanned(lit, "expected an integer or string literal specifying duration"))
-        }
+        syn::Lit::Str(expr) => humantime::parse_duration(&expr.value()).map_err(|err| {
+            let msg = format!("unable to parse duration string: {}", err);
+            syn::Error::new_spanned(lit, msg)
+        }),
+        _ => Err(syn::Error::new_spanned(
+            lit,
+            "expected an integer or string literal specifying duration",
+        )),
     }
 }
 
@@ -139,14 +137,17 @@ fn parse_knobs(
                     },
                     "timeout" if is_test => {
                         timeout_opt = Some(parse_duration(&namevalue.lit)?);
-                    },
+                    }
                     name => {
                         let allowed_attributes = if is_test {
                             "`core_threads`, `max_threads`, `timeout`"
                         } else {
                             "`core_threads`, `max_threads`"
                         };
-                        let msg = format!("Unknown attribute pair {} is specified; expected one of: {}", name, allowed_attributes);
+                        let msg = format!(
+                            "Unknown attribute pair {} is specified; expected one of: {}",
+                            name, allowed_attributes
+                        );
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
                 }
@@ -207,7 +208,8 @@ fn parse_knobs(
             let timeout_secs_str = format!("{}", timeout.as_secs());
             let timeout_secs = syn::Lit::Int(syn::LitInt::new(&timeout_secs_str, name.span()));
             let timeout_subsec_nanos_str = format!("{}", timeout.subsec_nanos());
-            let timeout_subsec_nanos = syn::Lit::Int(syn::LitInt::new(&timeout_subsec_nanos_str, name.span()));
+            let timeout_subsec_nanos =
+                syn::Lit::Int(syn::LitInt::new(&timeout_subsec_nanos_str, name.span()));
 
             quote! {
                 let async_body = async {


### PR DESCRIPTION
## Motivation

I was writing tests for a personal project using tokio. One of the tests hung indefinitely while awaiting a receive on a mpsc channel. While I could just add timeouts for specific call sites in the test that can hang, I believe it would be more ergonomic to ensure that tests never hang indefinitely.

## Solution

Add a `timeout = N` argument to time out async tests after N seconds if they do not return to the test harness. This change ensures that async tests cannot hang indefinitely.

Open questions:

1. Should milliseconds or another time unit be used for the `timeout` argument?

2. Does `tests-build` need to be updated? (I see compile error tests there that may need to be updated.)

3. I still need to add documentation to the PR for this change.
