### PR TITLE
reexport Elapsed from tokio::time

### DIFF
--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -94,7 +94,7 @@ pub use interval::{interval, interval_at, Interval};
 
 mod timeout;
 #[doc(inline)]
-pub use timeout::{timeout, timeout_at, Timeout};
+pub use timeout::{timeout, timeout_at, Timeout, Elapsed};
 
 mod wheel;
 


### PR DESCRIPTION
reexport Elapsed from tokio::time, needed for timeout error result in timeout usage.