### PR TITLE
fs: impl AsRawFd / AsRawHandle for File

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -600,3 +600,17 @@ impl fmt::Debug for File {
             .finish()
     }
 }
+
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for File {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.std.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for File {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.std.as_raw_handle()
+    }
+}

--- a/tokio/tests/support/mock_file.rs
+++ b/tokio/tests/support/mock_file.rs
@@ -263,3 +263,17 @@ impl fmt::Debug for File {
         fmt.debug_struct("mock::File").finish()
     }
 }
+
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for File {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        unimplemented!();
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for File {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        unimplemented!();
+    }
+}


### PR DESCRIPTION
This provides the ability to get the raw OS handle for a `File`. The
`Into*` variant cannot be provided as `File` needs to maintain ownership
of the `File`. The actual handle may have been moved to a background
thread.