### PR TITLE
Fixed `runtime::Builder` example

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -25,8 +25,9 @@ use std::sync::Arc;
 /// use tokio::runtime::Builder;
 ///
 /// fn main() {
-///     // build Runtime
+///     // build runtime
 ///     let runtime = Builder::new()
+///         .threaded_scheduler()
 ///         .num_threads(4)
 ///         .thread_name("my-custom-name")
 ///         .thread_stack_size(3 * 1024 * 1024)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Current `rutime::Builder` example builds `Runtime` with `num_threads`, `thread_name`, `thread_stack_size` but without `threaded_scheduler()` call, so it's useless. I wrote a [comment](https://github.com/tokio-rs/tokio/pull/1839#issuecomment-559195075) in previous PR : 

> Also there's still a thing that can confuse people - calling num_threads() on Builder without call of threaded_scheduler in fact does nothing.
> Maybe it's a good idea to make debug assertion for this case or warning at least?
> Because when I write code like
> 
> ```rust
> let rt = tokio::runtime::Builder::new().num_threads(4).build().unwrap(); 
> ```
>  I don't expect that num_threads is useless unless threaded_scheduler method is called.

Now it's even missed in docs examples, so I think ordinary users will face this problem anyway.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fixed example and debug assertion (warning) proposal.
