### PR TITLE
chore: prepare v0.2.2 release

### DIFF
--- a/ci/azure-loom.yml
+++ b/ci/azure-loom.yml
@@ -10,7 +10,7 @@ jobs:
       rust_version: ${{ parameters.rust }}
 
   - ${{ each crate in parameters.crates }}:
-    - script: RUSTFLAGS="--cfg loom" cargo test --lib --release -- --test-threads=1 --nocapture
+    - script: RUSTFLAGS="--cfg loom" cargo test --lib --release --features "full" -- --test-threads=1 --nocapture
       env:
         LOOM_MAX_PREEMPTIONS: 1
         CI: 'True'

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.2.2 (November 28, 2019)
+
+### Fixes
+- Update `spawn` panic message to specify that a task scheduler is required (#1839).
+- API docs example for `runtime::Builder` to include a task scheduler (#1841).
+- general documentation (#1834).
+- building on illumos/solaris (#1772).
+- panic when dropping `LocalSet` (#1843).
+- API docs mention the required Cargo features for `Builder::{basic, threaded}_scheduler` (#1858).
+
+### Added
+- impl `Stream` for `signal::unix::Signal` (#1849).
+- API docs for platform specific behavior of `signal::ctrl_c` and `signal::unix::Signal` (#1854).
+- API docs for `signal::unix::Signal::{recv, poll_recv}` and `signal::windows::CtrlBreak::{recv, poll_recv}` (#1854).
+- `File::into_std` and `File::try_into_std` methods (#1856).
+
 # 0.2.1 (November 26, 2019)
 
 ### Fixes

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 0.2.2 (November 29, 2019)
 
 ### Fixes
-- Update `spawn` panic message to specify that a task scheduler is required (#1839).
+- scheduling with `basic_scheduler` (#1861).
+- update `spawn` panic message to specify that a task scheduler is required (#1839).
 - API docs example for `runtime::Builder` to include a task scheduler (#1841).
 - general documentation (#1834).
 - building on illumos/solaris (#1772).

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 0.2.2 (November 28, 2019)
+# 0.2.2 (November 29, 2019)
 
 ### Fixes
 - Update `spawn` panic message to specify that a task scheduler is required (#1839).

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.1/tokio/"
+documentation = "https://docs.rs/tokio/0.2.2/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -92,7 +92,7 @@ uds = ["io-driver", "mio-uds", "libc"]
 
 
 [dependencies]
-tokio-macros = { version = "0.2.0", optional = true, path = "../tokio-macros" }
+tokio-macros = { version = "0.2.0", optional = true }
 
 bytes = "0.5.0"
 pin-project-lite = "0.1.1"
@@ -121,7 +121,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.2.0", path = "../tokio-test" }
+tokio-test = { version = "0.2.0" }
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -121,7 +121,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.2.0", path = "../tokio-test" }
+tokio-test = { version = "0.2.0" }
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -121,7 +121,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.2.0" }
+tokio-test = { version = "0.2.0", path = "../tokio-test" }
 futures = { version = "0.3.0", features = ["async-await"] }
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.1")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.2")]
 #![warn(
     missing_debug_implementations,
     missing_docs,


### PR DESCRIPTION
Steps taken:
- [x] Ensure that the release crate has no path dependencies
  - Path dependencies have been removed, no changes have been made to those crates since the last release
  - Ran `bin/publish --dry-run tokio 0.2.2`
- [x] Update Cargo metadata. 
  - Nothing else to do here, the other `tokio-*` crates have not had any other releases
- [x] Update other documentation links. 
- [x] Update the changelog for the crate.
- [x] Perform a final audit for breaking changes.
  - No breaking changes present
- [x] Open a pull request with your changes.
- [ ] Release the crate.