### PR TITLE
blocking: fix `spawn_blocking` after shutdown

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -197,6 +197,9 @@ impl Spawner {
             let mut shared = self.inner.shared.lock().unwrap();
 
             if shared.shutdown {
+                // Shutdown the task
+                task.shutdown();
+
                 // no need to even push this task; it would never get picked up
                 return;
             }


### PR DESCRIPTION
The task handle needs to be shutdown explicitly and not dropped.

Closes #1853