### PR TITLE
Make JoinError Sync

### DIFF
--- a/tokio/src/task/error.rs
+++ b/tokio/src/task/error.rs
@@ -16,15 +16,25 @@ enum Repr {
 }
 
 impl JoinError {
-    /// Create a new `cancelled` error
-    pub(crate) fn cancelled() -> JoinError {
+    #[doc(hidden)]
+    #[deprecated]
+    pub fn cancelled() -> JoinError {
+        Self::cancelled2()
+    }
+
+    pub(crate) fn cancelled2() -> JoinError {
         JoinError {
             repr: Repr::Cancelled,
         }
     }
 
-    /// Create a new `panic` error
-    pub(crate) fn panic(err: Box<dyn Any + Send + 'static>) -> JoinError {
+    #[doc(hidden)]
+    #[deprecated]
+    pub fn panic(err: Box<dyn Any + Send + 'static>) -> JoinError {
+        Self::panic2(err)
+    }
+
+    pub(crate) fn panic2(err: Box<dyn Any + Send + 'static>) -> JoinError {
         JoinError {
             repr: Repr::Panic(Mutex::new(err)),
         }

--- a/tokio/src/task/error.rs
+++ b/tokio/src/task/error.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 use std::fmt;
 use std::io;
+use std::sync::Mutex;
 
 doc_rt_core! {
     /// Task failed to execute to completion.
@@ -11,21 +12,21 @@ doc_rt_core! {
 
 enum Repr {
     Cancelled,
-    Panic(Box<dyn Any + Send + Sync + 'static>),
+    Panic(Mutex<Box<dyn Any + Send + 'static>>),
 }
 
 impl JoinError {
     /// Create a new `cancelled` error
-    pub fn cancelled() -> JoinError {
+    pub(crate) fn cancelled() -> JoinError {
         JoinError {
             repr: Repr::Cancelled,
         }
     }
 
     /// Create a new `panic` error
-    pub fn panic(err: Box<dyn Any + Send + Sync + 'static>) -> JoinError {
+    pub(crate) fn panic(err: Box<dyn Any + Send + 'static>) -> JoinError {
         JoinError {
-            repr: Repr::Panic(err),
+            repr: Repr::Panic(Mutex::new(err)),
         }
     }
 }

--- a/tokio/src/task/error.rs
+++ b/tokio/src/task/error.rs
@@ -11,7 +11,7 @@ doc_rt_core! {
 
 enum Repr {
     Cancelled,
-    Panic(Box<dyn Any + Send + 'static>),
+    Panic(Box<dyn Any + Send + Sync + 'static>),
 }
 
 impl JoinError {
@@ -23,7 +23,7 @@ impl JoinError {
     }
 
     /// Create a new `panic` error
-    pub fn panic(err: Box<dyn Any + Send + 'static>) -> JoinError {
+    pub fn panic(err: Box<dyn Any + Send + Sync + 'static>) -> JoinError {
         JoinError {
             repr: Repr::Panic(err),
         }

--- a/tokio/src/task/harness.rs
+++ b/tokio/src/task/harness.rs
@@ -142,7 +142,7 @@ where
                 }
             }
             Err(err) => {
-                self.complete(executor, join_interest, Err(JoinError::panic(err)));
+                self.complete(executor, join_interest, Err(JoinError::panic2(err)));
                 false
             }
         }
@@ -192,7 +192,7 @@ where
         state: Snapshot,
     ) {
         if state.is_canceled() {
-            dst.write(Track::new(Err(JoinError::cancelled())));
+            dst.write(Track::new(Err(JoinError::cancelled2())));
         } else {
             self.core().read_output(dst);
         }

--- a/tokio/src/task/harness.rs
+++ b/tokio/src/task/harness.rs
@@ -8,6 +8,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ptr::NonNull;
+use std::sync::Mutex;
 use std::task::{Poll, Waker};
 
 /// Typed raw task handle
@@ -142,7 +143,7 @@ where
                 }
             }
             Err(err) => {
-                self.complete(executor, join_interest, Err(JoinError::panic(err)));
+                self.complete(executor, join_interest, Err(JoinError::panic(Box::new(Mutex::new(err)))));
                 false
             }
         }

--- a/tokio/src/task/harness.rs
+++ b/tokio/src/task/harness.rs
@@ -8,7 +8,6 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::mem::{ManuallyDrop, MaybeUninit};
 use std::ptr::NonNull;
-use std::sync::Mutex;
 use std::task::{Poll, Waker};
 
 /// Typed raw task handle
@@ -143,7 +142,7 @@ where
                 }
             }
             Err(err) => {
-                self.complete(executor, join_interest, Err(JoinError::panic(Box::new(Mutex::new(err)))));
+                self.complete(executor, join_interest, Err(JoinError::panic(err)));
                 false
             }
         }


### PR DESCRIPTION
This is a fix for #1883.

Box and Mutex add overhead but they work and since it's not happy path, I figured they should suffice.