### PR TITLE
Add unit tests for tokio::File::AsRaw{Fd,Handle} for Unix and Windows.

### DIFF
--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -39,3 +39,23 @@ async fn basic_write() {
 fn tempfile() -> NamedTempFile {
     NamedTempFile::new().unwrap()
 }
+
+#[tokio::test]
+#[cfg(unix)]
+async fn unix_fd() {
+    use std::os::unix::io::AsRawFd;
+    let tempfile = tempfile();
+
+    let file = File::create(tempfile.path()).await.unwrap();
+    assert!(file.as_raw_fd() as u64 > 0);
+}
+
+#[tokio::test]
+#[cfg(windows)]
+async fn windows_handle() {
+    use std::os::windows::io::AsRawHandle;
+    let tempfile = tempfile();
+
+    let file = File::create(tempfile.path()).await.unwrap();
+    assert!(file.as_raw_handle() as u64 > 0);
+}


### PR DESCRIPTION
Add unit tests for `tokio::File::AsRaw{Fd,Handle}` for Unix and Windows.

Supersedes #1640.