### PR TITLE
v0.1.x: prepare to release tokio-threadpool 0.1.17

### DIFF
--- a/tokio-threadpool/CHANGELOG.md
+++ b/tokio-threadpool/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.1.17 (December 3, 2019)
+
+### Added
+- Internal APIs for overriding blocking behavior (#1752)
+
 # 0.1.16 (September 25, 2019)
 
 ### Changed

--- a/tokio-threadpool/Cargo.toml
+++ b/tokio-threadpool/Cargo.toml
@@ -8,8 +8,8 @@ name = "tokio-threadpool"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.1.16"
-documentation = "https://docs.rs/tokio-threadpool/0.1.16/tokio_threadpool"
+version = "0.1.17"
+documentation = "https://docs.rs/tokio-threadpool/0.1.17/tokio_threadpool"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
 license = "MIT"

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,7 +3,7 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-[Documentation](https://docs.rs/tokio-threadpool/0.1.16/tokio_threadpool)
+[Documentation](https://docs.rs/tokio-threadpool/0.1.17/tokio_threadpool)
 
 ### Why not Rayon?
 

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.16")]
+#![doc(html_root_url = "https://docs.rs/tokio-threadpool/0.1.17")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! A work-stealing based thread pool for executing futures.


### PR DESCRIPTION
# 0.1.17 (December 3, 2019)

### Added
- Internal APIs for overriding blocking behavior (#1752)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
