### PR TITLE
time: Remove `HandlePriv`

### DIFF
--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -7,7 +7,7 @@ mod entry;
 use self::entry::Entry;
 
 mod handle;
-pub(crate) use self::handle::{set_default, Handle, HandlePriv};
+pub(crate) use self::handle::{set_default, Handle};
 
 mod registration;
 pub(crate) use self::registration::Registration;


### PR DESCRIPTION
## Motivation

#1800 removed the lazy binding of `Delay`s to timers. With the removal of the
logic required for that, `HandlePriv` is no longer needed. This PR removes the
use of `HandlePriv`.

A `TODO` was also removed that would panic if when registering a new `Delay`
the current timer handle was full. That has been fixed to now immediately
transition that `Delay` to an error state that can be handled in a similar way
to other error states.

Signed-off-by: Kevin Leimkuhler <kleimkuhler@icloud.com>
