### PR TITLE
doc: fix TcpListener example to compile

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -18,7 +18,11 @@ cfg_tcp! {
     /// use tokio::net::TcpListener;
     ///
     /// use std::io;
-    /// # async fn process_socket<T>(_socket: T) {}
+    ///
+    /// async fn process_socket<T>(socket: T) {
+    ///     # drop(socket);
+    ///     // do work with socket here
+    /// }
     ///
     /// #[tokio::main]
     /// async fn main() -> io::Result<()> {


### PR DESCRIPTION
The `process_socket` is hidden from the user which makes the example
fail to compile if copied by the reader.