### PR TITLE
Fix up benchmarks so that they compile and run against master.

### DIFF
--- a/tokio/benches/mpsc.rs
+++ b/tokio/benches/mpsc.rs
@@ -1,11 +1,12 @@
 #![feature(test)]
-#![warn(rust_2018_idioms)]
 
 extern crate test;
 
 use tokio::sync::mpsc::*;
 
-use futures::{future, Async, Future, Sink, Stream};
+use futures::{future, task, StreamExt};
+use std::future::Future;
+use std::task::{Context, Poll};
 use std::thread;
 use test::Bencher;
 
@@ -46,9 +47,10 @@ fn send_one_message(b: &mut Bencher) {
 
         // Send
         tx.try_send(1).unwrap();
-
+        let waker = task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
         // Receive
-        assert_eq!(Async::Ready(Some(1)), rx.poll().unwrap());
+        assert_eq!(Poll::Ready(Some(1)), rx.poll_recv(&mut cx));
     })
 }
 
@@ -59,115 +61,155 @@ fn send_one_message_large(b: &mut Bencher) {
 
         // Send
         let _ = tx.try_send([[0; 64]; 64]);
-
+        let waker = task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
         // Receive
-        let _ = test::black_box(&rx.poll());
+        let _ = test::black_box(&rx.poll_recv(&mut cx));
     })
 }
 
 #[bench]
 fn bounded_rx_not_ready(b: &mut Bencher) {
     let (_tx, mut rx) = channel::<i32>(1_000);
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
+        let fut = future::lazy(|mut cx| {
+            assert!(rx.poll_recv(&mut cx).is_pending());
 
             Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        });
+        futures::pin_mut!(fut);
+        loop {
+            if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+                break;
+            }
+        }
     })
 }
 
 #[bench]
 fn bounded_tx_poll_ready(b: &mut Bencher) {
     let (mut tx, _rx) = channel::<i32>(1);
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_ready());
+        let fut = future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_ready());
 
             Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        });
+        futures::pin_mut!(fut);
+        loop {
+            if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+                break;
+            }
+        }
     })
 }
 
 #[bench]
 fn bounded_tx_poll_not_ready(b: &mut Bencher) {
     let (mut tx, _rx) = channel::<i32>(1);
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     tx.try_send(1).unwrap();
     b.iter(|| {
-        future::lazy(|| {
-            assert!(tx.poll_ready().unwrap().is_not_ready());
+        let fut = future::lazy(|cx| {
+            assert!(tx.poll_ready(cx).is_pending());
 
             Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        });
+
+        futures::pin_mut!(fut);
+        loop {
+            if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+                break;
+            }
+        }
     })
 }
 
 #[bench]
 fn unbounded_rx_not_ready(b: &mut Bencher) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
+        let fut = future::lazy(|cx| {
+            assert!(rx.poll_recv(cx).is_pending());
 
             Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        });
+
+        futures::pin_mut!(fut);
+        loop {
+            if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+                break;
+            }
+        }
     })
 }
 
 #[bench]
 fn unbounded_rx_not_ready_x5(b: &mut Bencher) {
     let (_tx, mut rx) = unbounded_channel::<i32>();
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
-        future::lazy(|| {
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
-            assert!(rx.poll().unwrap().is_not_ready());
+        let fut = future::lazy(|mut cx| {
+            assert!(rx.poll_recv(&mut cx).is_pending());
+            assert!(rx.poll_recv(&mut cx).is_pending());
+            assert!(rx.poll_recv(&mut cx).is_pending());
+            assert!(rx.poll_recv(&mut cx).is_pending());
+            assert!(rx.poll_recv(&mut cx).is_pending());
 
             Ok::<_, ()>(())
-        })
-        .wait()
-        .unwrap();
+        });
+
+        futures::pin_mut!(fut);
+        loop {
+            if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+                break;
+            }
+        }
     })
 }
 
 #[bench]
 fn bounded_uncontended_1(b: &mut Bencher) {
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
         let (mut tx, mut rx) = channel(1_000);
 
         for i in 0..1000 {
             tx.try_send(i).unwrap();
             // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
+            assert_eq!(Poll::Ready(Some(i)), rx.poll_recv(&mut cx));
         }
     })
 }
 
 #[bench]
 fn bounded_uncontended_1_large(b: &mut Bencher) {
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
         let (mut tx, mut rx) = channel::<Large>(1_000);
 
         for i in 0..1000 {
             let _ = tx.try_send([[i; 64]; 64]);
             // No need to create a task, because poll is not going to park.
-            let _ = test::black_box(&rx.poll());
+            let _ = test::black_box(&rx.poll_recv(&mut cx));
         }
     })
 }
 
 #[bench]
 fn bounded_uncontended_2(b: &mut Bencher) {
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
     b.iter(|| {
         let (mut tx, mut rx) = channel(1000);
 
@@ -177,7 +219,7 @@ fn bounded_uncontended_2(b: &mut Bencher) {
 
         for i in 0..1000 {
             // No need to create a task, because poll is not going to park.
-            assert_eq!(Async::Ready(Some(i)), rx.poll().unwrap());
+            assert_eq!(Poll::Ready(Some(i)), rx.poll_recv(&mut cx));
         }
     })
 }
@@ -188,21 +230,23 @@ fn contended_unbounded_tx(b: &mut Bencher) {
     let mut txs = vec![];
 
     for _ in 0..4 {
-        let (tx, rx) = ::std::sync::mpsc::channel::<Sender<i32>>();
+        let (tx, rx) = ::std::sync::mpsc::channel::<UnboundedSender<i32>>();
         txs.push(tx);
 
         threads.push(thread::spawn(move || {
-            for mut tx in rx.iter() {
+            for tx in rx.iter() {
                 for i in 0..1_000 {
-                    tx.try_send(i).unwrap();
+                    tx.send(i).unwrap();
                 }
             }
         }));
     }
 
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
+
     b.iter(|| {
-        // TODO make unbounded
-        let (tx, rx) = channel::<i32>(1_000_000);
+        let (tx, rx) = unbounded_channel::<i32>();
 
         for th in &txs {
             th.send(tx.clone()).unwrap();
@@ -210,10 +254,15 @@ fn contended_unbounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(4 * 1_000);
-
-        for v in rx {
-            let _ = test::black_box(v);
+        let rx_fut = rx.take(4 * 1_000).collect::<Vec<_>>();
+        futures::pin_mut!(rx_fut);
+        loop {
+            if let Poll::Ready(result) = rx_fut.as_mut().poll(&mut cx) {
+                for v in result {
+                    let _ = test::black_box(v);
+                }
+                break;
+            }
         }
     });
 
@@ -232,15 +281,27 @@ fn contended_bounded_tx(b: &mut Bencher) {
     let mut threads = vec![];
     let mut txs = vec![];
 
+    let waker = task::noop_waker_ref();
+    let mut cx = Context::from_waker(waker);
+
     for _ in 0..THREADS {
         let (tx, rx) = ::std::sync::mpsc::channel::<Sender<i32>>();
         txs.push(tx);
 
+        let waker = task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
         threads.push(thread::spawn(move || {
-            for tx in rx.iter() {
-                let mut tx = tx.wait();
-                for i in 0..ITERS {
-                    tx.send(i as i32).unwrap();
+            for mut tx in rx.iter() {
+                loop {
+                    if let Poll::Ready(ready) = tx.poll_ready(&mut cx) {
+                        ready.expect("tx dropped");
+                        for i in 0..ITERS {
+                            let fut = tx.send(i as i32);
+                            futures::pin_mut!(fut);
+                            while let Poll::Pending = fut.as_mut().poll(&mut cx) {}
+                        }
+                        break;
+                    }
                 }
             }
         }));
@@ -255,10 +316,15 @@ fn contended_bounded_tx(b: &mut Bencher) {
 
         drop(tx);
 
-        let rx = rx.wait().take(THREADS * ITERS);
-
-        for v in rx {
-            let _ = test::black_box(v);
+        let rx = rx.take(THREADS * ITERS).collect::<Vec<_>>();
+        futures::pin_mut!(rx);
+        loop {
+            if let Poll::Ready(result) = rx.as_mut().poll(&mut cx) {
+                for v in result {
+                    let _ = test::black_box(v);
+                }
+                break;
+            }
         }
     });
 

--- a/tokio/benches/thread_pool.rs
+++ b/tokio/benches/thread_pool.rs
@@ -2,7 +2,7 @@
 
 extern crate test;
 
-use tokio::executor::thread_pool::{Builder, Spawner};
+use tokio::runtime::{Builder, Handle};
 use tokio::sync::oneshot;
 
 use std::future::Future;
@@ -34,26 +34,31 @@ const NUM_THREADS: usize = 6;
 fn spawn_many(b: &mut test::Bencher) {
     const NUM_SPAWN: usize = 10_000;
 
-    let threadpool = Builder::new().num_threads(NUM_THREADS).build();
+    let threadpool = Builder::new()
+        .threaded_scheduler()
+        .num_threads(NUM_THREADS)
+        .build()
+        .unwrap();
+    let handle = threadpool.handle();
+    threadpool.enter(|| {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+        b.iter(|| {
+            rem.store(NUM_SPAWN, Relaxed);
 
-    let (tx, rx) = mpsc::sync_channel(1000);
-    let rem = Arc::new(AtomicUsize::new(0));
+            for _ in 0..NUM_SPAWN {
+                let tx = tx.clone();
+                let rem = rem.clone();
 
-    b.iter(|| {
-        rem.store(NUM_SPAWN, Relaxed);
+                handle.spawn(async move {
+                    if 1 == rem.fetch_sub(1, Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
 
-        for _ in 0..NUM_SPAWN {
-            let tx = tx.clone();
-            let rem = rem.clone();
-
-            threadpool.spawn(async move {
-                if 1 == rem.fetch_sub(1, Relaxed) {
-                    tx.send(()).unwrap();
-                }
-            });
-        }
-
-        let _ = rx.recv().unwrap();
+            let _ = rx.recv().unwrap();
+        });
     });
 }
 
@@ -62,100 +67,116 @@ fn yield_many(b: &mut test::Bencher) {
     const NUM_YIELD: usize = 1_000;
     const TASKS_PER_CPU: usize = 50;
 
-    let threadpool = Builder::new().num_threads(NUM_THREADS).build();
+    let threadpool = Builder::new()
+        .threaded_scheduler()
+        .num_threads(NUM_THREADS)
+        .build()
+        .unwrap();
+    let handle = threadpool.handle().clone();
+    threadpool.enter(|| {
+        let tasks = TASKS_PER_CPU * num_cpus::get_physical();
+        let (tx, rx) = mpsc::sync_channel(tasks);
 
-    let tasks = TASKS_PER_CPU * num_cpus::get_physical();
-    let (tx, rx) = mpsc::sync_channel(tasks);
+        b.iter(move || {
+            for _ in 0..tasks {
+                let tx = tx.clone();
 
-    b.iter(move || {
-        for _ in 0..tasks {
-            let tx = tx.clone();
+                handle.spawn(async move {
+                    let backoff = Backoff(NUM_YIELD);
+                    backoff.await;
+                    tx.send(()).unwrap();
+                });
+            }
 
-            threadpool.spawn(async move {
-                let backoff = Backoff(NUM_YIELD);
-                backoff.await;
-                tx.send(()).unwrap();
-            });
-        }
-
-        for _ in 0..tasks {
-            let _ = rx.recv().unwrap();
-        }
-    });
+            for _ in 0..tasks {
+                let _ = rx.recv().unwrap();
+            }
+        });
+    })
 }
 
 #[bench]
 fn ping_pong(b: &mut test::Bencher) {
     const NUM_PINGS: usize = 1_000;
 
-    let threadpool = Builder::new().num_threads(NUM_THREADS).build();
+    let threadpool = Builder::new()
+        .threaded_scheduler()
+        .num_threads(NUM_THREADS)
+        .build()
+        .unwrap();
+    let handle = threadpool.handle();
+    threadpool.enter(|| {
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
 
-    let (done_tx, done_rx) = mpsc::sync_channel(1000);
-    let rem = Arc::new(AtomicUsize::new(0));
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(NUM_PINGS, Relaxed);
 
-    b.iter(|| {
-        let done_tx = done_tx.clone();
-        let rem = rem.clone();
-        rem.store(NUM_PINGS, Relaxed);
+            let spawner = handle.clone();
 
-        let spawner = threadpool.spawner().clone();
+            handle.spawn(async move {
+                for _ in 0..NUM_PINGS {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
 
-        threadpool.spawn(async move {
-            for _ in 0..NUM_PINGS {
-                let rem = rem.clone();
-                let done_tx = done_tx.clone();
+                    let spawner2 = spawner.clone();
 
-                let spawner2 = spawner.clone();
+                    spawner.spawn(async move {
+                        let (tx1, rx1) = oneshot::channel();
+                        let (tx2, rx2) = oneshot::channel();
 
-                spawner.spawn(async move {
-                    let (tx1, rx1) = oneshot::channel();
-                    let (tx2, rx2) = oneshot::channel();
+                        spawner2.spawn(async move {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        });
 
-                    spawner2.spawn(async move {
-                        rx1.await.unwrap();
-                        tx2.send(()).unwrap();
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Relaxed) {
+                            done_tx.send(()).unwrap();
+                        }
                     });
+                }
+            });
 
-                    tx1.send(()).unwrap();
-                    rx2.await.unwrap();
-
-                    if 1 == rem.fetch_sub(1, Relaxed) {
-                        done_tx.send(()).unwrap();
-                    }
-                });
-            }
+            done_rx.recv().unwrap();
         });
-
-        done_rx.recv().unwrap();
-    });
+    })
 }
 
 #[bench]
 fn chained_spawn(b: &mut test::Bencher) {
     const ITER: usize = 1_000;
 
-    let threadpool = Builder::new().num_threads(NUM_THREADS).build();
-
-    fn iter(spawner: Spawner, done_tx: mpsc::SyncSender<()>, n: usize) {
+    fn iter(handle: Handle, done_tx: mpsc::SyncSender<()>, n: usize) {
         if n == 0 {
             done_tx.send(()).unwrap();
         } else {
-            let s2 = spawner.clone();
-            spawner.spawn(async move {
+            let s2 = handle.clone();
+            handle.spawn(async move {
                 iter(s2, done_tx, n - 1);
             });
         }
     }
+    let threadpool = Builder::new()
+        .threaded_scheduler()
+        .num_threads(NUM_THREADS)
+        .build()
+        .unwrap();
+    let handle = threadpool.handle();
+    threadpool.enter(|| {
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
 
-    let (done_tx, done_rx) = mpsc::sync_channel(1000);
-
-    b.iter(move || {
-        let done_tx = done_tx.clone();
-        let spawner = threadpool.spawner().clone();
-        threadpool.spawn(async move {
-            iter(spawner, done_tx, ITER);
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            let spawner = handle.clone();
+            handle.spawn(async move {
+                iter(spawner, done_tx, ITER);
+            });
+            done_rx.recv().unwrap();
         });
-
-        done_rx.recv().unwrap();
     });
 }


### PR DESCRIPTION
- Fix up benchmarks so that they compile and run against master.
- Fixed a TODO for the `contended_unbounded_tx` benchmark where a channel was not unbounded.

## Motivation
The benchmarks were failing to compile on master.

## Solution
Fix the benchmarks, attempting to port them to Tokio 0.2 and Futures 0.3 equivalent types.