### PR TITLE
sync::Mutex: Add note about the absence of poisoning

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -26,6 +26,11 @@
 //! }
 //! ```
 //!
+//! Note that in contrast to `std::sync::Mutex`, this implementation does not
+//! poison the mutex when a thread holding the `MutexGuard` panics. In such a
+//! case, the mutex will be unlocked. If the panic is caught, this might leave
+//! the data protected by the mutes in an inconsistent state.
+//!
 //! [`Mutex`]: struct.Mutex.html
 //! [`MutexGuard`]: struct.MutexGuard.html
 


### PR DESCRIPTION
## Motivation

When porting code from `std::sync::Mutex` to `tokio::sync::Mutex` I noticed that the `lock()` method does not return a result anymore.

After a quick discussion in the #tokio-users discord channel, @sfackler confirmed that this mutex implementation does not poison the mutex on panic. That's probably a good default choice, but should be documented.

## Solution

I added a note about the panic behavior to the `Mutex` rustdocs.