### PR TITLE
chore: fix warning in tokio-util tests

### DIFF
--- a/tokio-util/tests/framed_read.rs
+++ b/tokio-util/tests/framed_read.rs
@@ -203,7 +203,7 @@ fn huge_size() {
             if buf.len() < 32 * 1024 {
                 return Ok(None);
             }
-            buf.split_to(32 * 1024);
+            buf.advance(32 * 1024);
             Ok(Some(0))
         }
     }


### PR DESCRIPTION
`bytes` added a warning when using a fn that resulted in a useless clone.