### PR TITLE
Re-enable writev support in TcpStreams

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -85,7 +85,7 @@ signal = [
 stream = ["futures-core"]
 sync = ["fnv"]
 test-util = []
-tcp = ["io-driver"]
+tcp = ["io-driver", "iovec"]
 time = ["slab"]
 udp = ["io-driver"]
 uds = ["io-driver", "mio-uds", "libc"]
@@ -103,6 +103,7 @@ futures-core = { version = "0.3.0", optional = true }
 lazy_static = { version = "1.0.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.20", optional = true }
+iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 # Backs `DelayQueue`
 slab = { version = "0.4.1", optional = true }

--- a/tokio/src/net/tcp/split.rs
+++ b/tokio/src/net/tcp/split.rs
@@ -11,6 +11,7 @@
 use crate::io::{AsyncRead, AsyncWrite};
 use crate::net::TcpStream;
 
+use bytes::Buf;
 use std::io;
 use std::mem::MaybeUninit;
 use std::net::Shutdown;
@@ -53,6 +54,14 @@ impl AsyncWrite for WriteHalf<'_> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         self.0.poll_write_priv(cx, buf)
+    }
+
+    fn poll_write_buf<B: Buf>(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_buf_priv(cx, buf)
     }
 
     #[inline]


### PR DESCRIPTION
While we still use a version of `mio` that uses `iovec` instead of `IoSlice`, we can support `writev` by converting the `IoSlice` into `IoVec`s.