### PR TITLE
sync: print MutexGuard inner value for debugging

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -61,7 +61,6 @@ pub struct Mutex<T> {
 ///
 /// The lock is automatically released whenever the guard is dropped, at which point `lock`
 /// will succeed yet again.
-#[derive(Debug)]
 pub struct MutexGuard<'a, T> {
     lock: &'a Mutex<T>,
     permit: semaphore::Permit,
@@ -173,6 +172,12 @@ impl<'a, T> DerefMut for MutexGuard<'a, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         assert!(self.permit.is_acquired());
         unsafe { &mut *self.lock.c.get() }
+    }
+}
+
+impl<'a, T: fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
     }
 }
 

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -147,3 +147,11 @@ fn try_lock() {
     let g3 = m.try_lock();
     assert_eq!(g3.is_ok(), true);
 }
+
+#[tokio::main]
+#[test]
+async fn debug_format() {
+    let s = "debug";
+    let m = Mutex::new(s.to_string());
+    assert_eq!(format!("{:?}", s), format!("{:?}", m.lock().await));
+}


### PR DESCRIPTION
We usually want to print values that smart pointers point to when formatting, liking the behavior in the std.