### PR TITLE
rt: avoid dropping a task in calls to wake()

### DIFF
--- a/tokio/src/task/queue.rs
+++ b/tokio/src/task/queue.rs
@@ -233,7 +233,7 @@ where
         self.drain_pending_drop();
     }
 
-    /// Drain run queues, shutting down any task.
+    /// Drain both the local and remote run queues, shutting down any tasks.
     ///
     /// # Safety
     ///

--- a/tokio/src/task/queue.rs
+++ b/tokio/src/task/queue.rs
@@ -233,6 +233,16 @@ where
         self.drain_pending_drop();
     }
 
+    /// Drain run queues, shutting down any task.
+    ///
+    /// # Safety
+    ///
+    /// This *must* be called only from the thread that owns the scheduler.
+    pub(crate) unsafe fn drain_queues(&self) {
+        self.close_local();
+        self.close_remote();
+    }
+
     /// Shut down the scheduler's owned task list.
     ///
     /// # Safety
@@ -300,8 +310,10 @@ where
     /// If the queue is open to accept new tasks, the task is pushed to the back
     /// of the queue. Otherwise, if the queue is closed (the scheduler is
     /// shutting down), the new task will be shut down immediately.
-    pub(crate) fn schedule(&mut self, task: Task<S>) {
-        if self.open {
+    ///
+    /// `spawn` should be set if the caller is spawning a new task.
+    pub(crate) fn schedule(&mut self, task: Task<S>, spawn: bool) {
+        if !spawn || self.open {
             self.queue.push_back(task);
         } else {
             task.shutdown();

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -29,8 +29,8 @@ fn spawned_task_does_not_progress_without_block_on() {
 
 #[test]
 fn acquire_mutex_in_drop() {
-    use tokio::task;
     use futures::future::pending;
+    use tokio::task;
 
     let (tx1, rx1) = oneshot::channel();
     let (tx2, rx2) = oneshot::channel();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,66 +1,44 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
-use tokio_test::{assert_err, assert_ok};
-
-use std::thread;
-use std::time::Duration;
-
-#[test]
-fn spawned_task_does_not_progress_without_block_on() {
-    let (tx, mut rx) = oneshot::channel();
-
-    let mut rt = rt();
-
-    rt.spawn(async move {
-        assert_ok!(tx.send("hello"));
-    });
-
-    thread::sleep(Duration::from_millis(50));
-
-    assert_err!(rx.try_recv());
-
-    let out = rt.block_on(async { assert_ok!(rx.await) });
-
-    assert_eq!(out, "hello");
-}
+use tokio::runtime::Runtime;
+use tokio::task::{self, LocalSet};
 
 #[test]
 fn acquire_mutex_in_drop() {
-    use tokio::task;
     use futures::future::pending;
 
     let (tx1, rx1) = oneshot::channel();
     let (tx2, rx2) = oneshot::channel();
 
     let mut rt = rt();
+    let local = task::LocalSet::new();
 
-    rt.spawn(async move {
+    local.spawn_local(async move {
         let _ = rx2.await;
         unreachable!();
     });
 
-    rt.spawn(async move {
+    local.spawn_local(async move {
         let _ = rx1.await;
         let _ = tx2.send(()).unwrap();
         unreachable!();
     });
 
     // Spawn a task that will never notify
-    rt.spawn(async move {
+    local.spawn_local(async move {
         pending::<()>().await;
         tx1.send(()).unwrap();
     });
 
     // Tick the loop
-    rt.block_on(async {
+    local.block_on(&mut rt, async {
         task::yield_now().await;
     });
 
-    // Drop the rt
-    drop(rt);
+    // Drop the LocalSet
+    drop(local);
 }
 
 fn rt() -> Runtime {

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,8 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::sync::oneshot;
 use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
 use tokio::task::{self, LocalSet};
 
 #[test]

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -13,7 +13,7 @@ fn acquire_mutex_in_drop() {
     let (tx2, rx2) = oneshot::channel();
 
     let mut rt = rt();
-    let local = task::LocalSet::new();
+    let local = LocalSet::new();
 
     local.spawn_local(async move {
         let _ = rx2.await;


### PR DESCRIPTION
Calls to tasks should not be nested. Currently, while a task is being
executed and the runtime is shutting down, a call to wake() can result
in the wake target to be dropped. This, in turn, results in the drop
handler being called.

If the user holds a ref cell borrow, a mutex guard, or any such value,
dropping the task inline can result in a deadlock.

The fix is to permit tasks to be scheduled during the shutdown process
and dropping the tasks once they are popped from the queue.

Fixes #1929, #1886

This only fixes single threaded schedulers. I have net yet reproduced the bug in
the threaded scheduler but will continue to explore.