### PR TITLE
impl Stream for DelayQueue

### DIFF
--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -730,6 +730,17 @@ impl<T> Default for DelayQueue<T> {
     }
 }
 
+#[cfg(feature = "stream")]
+impl<T> futures_core::Stream for DelayQueue<T> {
+    // DelayQueue seems much more specific, where a user may care that it
+    // has reached capacity, so return those errors instead of panicking.
+    type Item = Result<Expired<T>, Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Option<Self::Item>> {
+        DelayQueue::poll_expired(self.get_mut(), cx)
+    }
+}
+
 impl<T> wheel::Stack for Stack<T> {
     type Owned = usize;
     type Borrowed = usize;


### PR DESCRIPTION
## Motivation

8a7e57786a5dca139f5b4261685e22991ded0859 deleted `impl Stream for DelayQueue`. It also said
>   Since the `Stream` implementation is optional, types that are logically
>   streams provide `async fn next_*` functions to obtain the next value.
>   Avoiding the `next()` name prevents fn conflicts with `StreamExt::next()`.

However, `DelayQueue` only provided `poll_expired`, which makes `DelayQueue` almost unusable in `async` contexts.

## Solution

This PR implements `Stream` on `DelayQueue` behind the feature flag `stream`, which is only a few characters away from the origin implementation that existed before 8a7e57786a5dca139f5b4261685e22991ded0859.

---

If a test is useful for this contribution, or any changes are needed, please let me know. I'm unsure what kind of test to implement for this, so a pointer to an example test for another module would be appreciated in that case.