### PR TITLE
Introduce configuration options to control core and max threads

### DIFF
--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -19,13 +19,15 @@ cfg_blocking_impl! {
         io: &io::Handle,
         time: &time::Handle,
         clock: &time::Clock,
+        thread_cap: usize,
     ) -> BlockingPool {
         BlockingPool::new(
             builder,
             spawner,
             io,
             time,
-            clock)
+            clock,
+            thread_cap)
 
     }
 }
@@ -44,6 +46,7 @@ cfg_not_blocking_impl! {
         _io: &io::Handle,
         _time: &time::Handle,
         _clock: &time::Clock,
+        _thread_cap: usize,
     ) -> BlockingPool {
         BlockingPool {}
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -298,8 +298,14 @@ impl Builder {
 
         let spawner = Spawner::Shell;
 
-        let blocking_pool =
-            blocking::create_blocking_pool(self, &spawner, &io_handle, &time_handle, &clock, self.blocking_threads);
+        let blocking_pool = blocking::create_blocking_pool(
+            self,
+            &spawner,
+            &io_handle,
+            &time_handle,
+            &clock,
+            self.blocking_threads,
+        );
         let blocking_spawner = blocking_pool.spawner().clone();
 
         Ok(Runtime {

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -197,6 +197,7 @@ impl Builder {
     /// If `core_threads` is greater than `max_threads`, then core_threads is capped
     /// by `max_threads`
     pub fn max_threads(&mut self, val: usize) -> &mut Self {
+        assert_ne!(val, 0, "Thread limit cannot be zero");
         self.max_threads = val;
         self
     }
@@ -464,9 +465,9 @@ cfg_rt_threaded! {
             use crate::runtime::{Kind, ThreadPool};
             use crate::runtime::park::Parker;
 
-            let clock = time::create_clock();
-
             assert!(self.core_threads <= self.max_threads, "Core threads number cannot be above max limit");
+
+            let clock = time::create_clock();
 
             let (io_driver, io_handle) = io::create_driver(self.enable_io)?;
             let (driver, time_handle) = time::create_driver(self.enable_time, io_driver, clock.clone());

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 ///     // build runtime
 ///     let runtime = Builder::new()
 ///         .threaded_scheduler()
-///         .num_threads(4)
+///         .core_threads(4)
 ///         .thread_name("my-custom-name")
 ///         .thread_stack_size(3 * 1024 * 1024)
 ///         .build()
@@ -47,13 +47,13 @@ pub struct Builder {
     /// Whether or not to enable the time driver
     enable_time: bool,
 
-    /// The number of worker threads.
+    /// The number of worker threads, used by Runtime.
     ///
     /// Only used when not using the current-thread executor.
-    num_threads: usize,
+    core_threads: usize,
 
-    ///Cap on blocking pool.
-    blocking_threads: usize,
+    ///Cap on thread usage.
+    max_threads: usize,
 
     /// Name used for threads spawned by the runtime.
     pub(super) thread_name: String,
@@ -94,9 +94,9 @@ impl Builder {
             enable_time: false,
 
             // Default to use an equal number of threads to number of CPU cores
-            num_threads: crate::loom::sys::num_cpus(),
+            core_threads: crate::loom::sys::num_cpus(),
 
-            blocking_threads: 512,
+            max_threads: 512,
 
             // Default thread name
             thread_name: "tokio-runtime-worker".into(),
@@ -135,6 +135,7 @@ impl Builder {
         self
     }
 
+    #[deprecated(note = "In future will be replaced by core_threads method")]
     /// Set the maximum number of worker threads for the `Runtime`'s thread pool.
     ///
     /// This must be a number between 1 and 32,768 though it is advised to keep
@@ -153,15 +154,50 @@ impl Builder {
     ///     .unwrap();
     /// ```
     pub fn num_threads(&mut self, val: usize) -> &mut Self {
-        self.num_threads = val;
+        self.core_threads = val;
         self
     }
 
-    ///Specifies limit on number of threads, used for blocking annotation.
+    /// Set the core number of worker threads for the `Runtime`'s thread pool.
+    ///
+    /// This must be a number between 1 and 32,768 though it is advised to keep
+    /// this value on the smaller side.
+    ///
+    /// The default value is the number of cores available to the system.
+    ///
+    /// These threads will be always active and running.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime;
+    ///
+    /// let rt = runtime::Builder::new()
+    ///     .core_threads(4)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn core_threads(&mut self, val: usize) -> &mut Self {
+        self.core_threads = val;
+        self
+    }
+
+    ///Specifies limit for threads, spawned by the Runtime.
+    ///
+    ///This is number of threads to be used outside of Runtime core threads.
+    ///In the current implementation it is used to cap number of threads spawned when using
+    ///blocking annotation
     ///
     ///The default value is 512.
-    pub fn blocking_threads(&mut self, val: usize) -> &mut Self {
-        self.blocking_threads = val;
+    ///
+    ///When multi-threaded runtime is not used, will act as limit on additional threads.
+    ///
+    ///Otherwise it limits additional threads as following: `max_threads - core_threads`
+    ///
+    ///If `core_threads` is greater than `max_threads`, then core_threads is capped
+    ///by `max_threads`
+    pub fn max_threads(&mut self, val: usize) -> &mut Self {
+        self.max_threads = val;
         self
     }
 
@@ -304,7 +340,7 @@ impl Builder {
             &io_handle,
             &time_handle,
             &clock,
-            self.blocking_threads,
+            self.max_threads,
         );
         let blocking_spawner = blocking_pool.spawner().clone();
 
@@ -398,7 +434,7 @@ cfg_rt_core! {
             let spawner = Spawner::Basic(scheduler.spawner());
 
             // Blocking pool
-            let blocking_pool = blocking::create_blocking_pool(self, &spawner, &io_handle, &time_handle, &clock, self.blocking_threads);
+            let blocking_pool = blocking::create_blocking_pool(self, &spawner, &io_handle, &time_handle, &clock, self.max_threads);
             let blocking_spawner = blocking_pool.spawner().clone();
 
             Ok(Runtime {
@@ -430,13 +466,19 @@ cfg_rt_threaded! {
 
             let clock = time::create_clock();
 
+            let (core_threads, blocking_threads) = if self.core_threads > self.max_threads {
+                (self.max_threads, 0)
+            } else {
+                (self.core_threads, self.max_threads - self.core_threads)
+            };
+
             let (io_driver, io_handle) = io::create_driver(self.enable_io)?;
             let (driver, time_handle) = time::create_driver(self.enable_time, io_driver, clock.clone());
-            let (scheduler, workers) = ThreadPool::new(self.num_threads, Parker::new(driver));
+            let (scheduler, workers) = ThreadPool::new(core_threads, Parker::new(driver));
             let spawner = Spawner::ThreadPool(scheduler.spawner().clone());
 
             // Create the blocking pool
-            let blocking_pool = blocking::create_blocking_pool(self, &spawner, &io_handle, &time_handle, &clock, self.blocking_threads);
+            let blocking_pool = blocking::create_blocking_pool(self, &spawner, &io_handle, &time_handle, &clock, blocking_threads);
             let blocking_spawner = blocking_pool.spawner().clone();
 
             // Spawn the thread pool workers
@@ -467,7 +509,7 @@ impl fmt::Debug for Builder {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Builder")
             .field("kind", &self.kind)
-            .field("num_threads", &self.num_threads)
+            .field("core_threads", &self.core_threads)
             .field("thread_name", &self.thread_name)
             .field("thread_stack_size", &self.thread_stack_size)
             .field("after_start", &self.after_start.as_ref().map(|_| "..."))

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -142,17 +142,6 @@ impl Builder {
     /// this value on the smaller side.
     ///
     /// The default value is the number of cores available to the system.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tokio::runtime;
-    ///
-    /// let rt = runtime::Builder::new()
-    ///     .num_threads(4)
-    ///     .build()
-    ///     .unwrap();
-    /// ```
     pub fn num_threads(&mut self, val: usize) -> &mut Self {
         self.core_threads = val;
         self

--- a/tokio/src/runtime/tests/loom_blocking.rs
+++ b/tokio/src/runtime/tests/loom_blocking.rs
@@ -25,7 +25,7 @@ fn blocking_shutdown() {
 fn mk_runtime(num_threads: usize) -> Runtime {
     runtime::Builder::new()
         .threaded_scheduler()
-        .num_threads(num_threads)
+        .core_threads(num_threads)
         .build()
         .unwrap()
 }

--- a/tokio/src/runtime/thread_pool/tests/loom_pool.rs
+++ b/tokio/src/runtime/thread_pool/tests/loom_pool.rs
@@ -171,7 +171,7 @@ fn complete_block_on_under_load() {
 fn mk_pool(num_threads: usize) -> Runtime {
     runtime::Builder::new()
         .threaded_scheduler()
-        .num_threads(num_threads)
+        .core_threads(num_threads)
         .build()
         .unwrap()
 }

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -20,7 +20,7 @@ fn single_thread() {
     let _ = runtime::Builder::new()
         .threaded_scheduler()
         .enable_all()
-        .num_threads(1)
+        .core_threads(1)
         .build();
 }
 


### PR DESCRIPTION
## Motivation
User might want to configure cap on blocking pool

## Solution
Add option to runtime and propagate it to blocking pool, upon creating it.

Changes to configuration:

- Max thread num - specifies limit on threads, spawned by runtime
- Core thread num - number of active threads, always in use by runtime.

Blocking threads will be `max - core`
