### PR TITLE
chore: prepare v0.2.5 release

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 0.2.1 (December 18, 2019)
 
 ### Fixes
-- maintain fn visibility when transforming (#1954).
+- inherit visibility when wrapping async fn (#1954).
 
 # 0.2.0 (November 26, 2019)
 

--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.1 (December 18, 2019)
+
+### Fixes
+- maintain fn visibility when transforming (#1954).
+
 # 0.2.0 (November 26, 2019)
 
 - Initial release

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.2.0/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.2.1/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Changes
 - runtime threads are configured with `runtime::Builder::core_threads` and
-  `runtime::Builder::num_threads`. `runtime::Builder::num_threads` is
+  `runtime::Builder::max_threads`. `runtime::Builder::num_threads` is
   deprecated (#1977).
 
 # 0.2.4 (December 6, 2019)

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,27 @@
+# 0.2.5 (December 18, 2019)
+
+### Added
+- `io::AsyncSeek` trait (#1924).
+- `Mutex::try_lock` (#1939)
+- `mpsc::Receiver::try_recv` and `mpsc::UnboundedReceiver::try_recv` (#1939).
+- `writev` support for `TcpStream` (#1956).
+- `time::throttle` for throttling streams (#1949).
+- implement `Stream` for `time::DelayQueue` (#1975).
+- `sync::broadcast` provides a fan-out channel (#1943).
+- `sync::Semaphore` provides an async semaphore (#1973).
+- `stream::StreamExt` provides stream utilities (#1962).
+
+### Fixes
+- deadlock risk while shutting down the runtime (#1972).
+- panic while shutting down the runtime (#1978).
+- `sync::MutexGuard` debug output (#1961).
+- misc doc improvements (#1933, #1934, #1940, #1942).
+
+### Changes
+- runtime threads are configured with `runtime::Builder::core_threads` and
+  `runtime::Builder::num_threads`. `runtime::Builder::num_threads` is
+  deprecated (#1977).
+
 # 0.2.4 (December 6, 2019)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.4"
+version = "0.2.5"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.4/tokio/"
+documentation = "https://docs.rs/tokio/0.2.5/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.4")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.5")]
 #![allow(clippy::cognitive_complexity)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
Also includes:
- `tokio-macros` v0.2.1