### PR TITLE
io: fix 'Seek::poll' when the underlying 'AsyncRead::start_seek' call immediately returns Ready.

### DIFF
--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -3,6 +3,28 @@ use crate::io::AsyncSeek;
 use std::io::SeekFrom;
 
 /// An extension trait which adds utility methods to `AsyncSeek` types.
+///
+/// # Examples
+///
+/// ```
+/// use std::io::{Cursor, SeekFrom};
+/// use tokio::prelude::*;
+///
+/// #[tokio::main]
+/// async fn main() -> io::Result<()> {
+///     let mut cursor = Cursor::new(b"abcdefg");
+///
+///     // the `seek` method is defined by this trait
+///     cursor.seek(SeekFrom::Start(3)).await?;
+///
+///     let mut buf = [0; 1];
+///     let n = cursor.read(&mut buf).await?;
+///     assert_eq!(n, 1);
+///     assert_eq!(buf, [b'd']);
+///
+///     Ok(())
+/// }
+/// ```
 pub trait AsyncSeekExt: AsyncSeek {
     /// Creates a future which will seek an IO object, and then yield the
     /// new position in the object and the object itself.


### PR DESCRIPTION
This is the case with `Cursor`, for example.

EDIT: This is also the case with `File` if it is not already busy.