### PR TITLE
fs: add deprecated fs::File::seek fn

### DIFF
--- a/ci/azure-clippy.yml
+++ b/ci/azure-clippy.yml
@@ -12,5 +12,5 @@ jobs:
         cargo clippy --version
       displayName: Install clippy
     - script: |
-        cargo clippy --all --all-features -- -A clippy::mutex-atomic
+        cargo clippy --all --all-features -- -A clippy::mutex-atomic -A clippy::needless-doctest-main
       displayName: cargo clippy --all

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -176,6 +176,12 @@ impl File {
         }
     }
 
+    #[deprecated(note = "use `tokio::io::AsyncSeekExt::seek` instead")]
+    #[doc(hidden)]
+    pub async fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        crate::io::AsyncSeekExt::seek(self, pos).await
+    }
+
     /// Attempts to sync all OS-internal metadata to disk.
     ///
     /// This function will attempt to ensure that all in-core data reaches the


### PR DESCRIPTION
This fixes an API compatibility regression when `AsyncSeek` was added.

Fixes: #1989