### PR TITLE
Stream filtering facilities

### DIFF
--- a/tokio/src/stream/filter.rs
+++ b/tokio/src/stream/filter.rs
@@ -6,7 +6,7 @@ use core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Stream for the [`filter`](super::StreamExt::filter) method.
+    /// Stream returned by the [`filter`](super::StreamExt::filter) method.
     #[must_use = "streams do nothing unless polled"]
     pub struct Filter<St, F> {
         #[pin]

--- a/tokio/src/stream/filter.rs
+++ b/tokio/src/stream/filter.rs
@@ -1,0 +1,62 @@
+use crate::stream::Stream;
+
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Stream for the [`filter`](super::StreamExt::filter) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct Filter<St, F> {
+        #[pin]
+        stream: St,
+        f: F,
+    }
+}
+
+impl<St, F> fmt::Debug for Filter<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Filter")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
+impl<St, F> Filter<St, F>
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> bool,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f }
+    }
+}
+
+impl<St, F> Stream for Filter<St, F>
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> bool,
+{
+    type Item = St::Item;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
+        loop {
+            match ready!(self.as_mut().project().stream.poll_next(cx)) {
+                Some(e) => {
+                    if (self.as_mut().project().f)(&e) {
+                        return Poll::Ready(Some(e));
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.stream.size_hint().1) // can't know a lower bound, due to the predicate
+    }
+}

--- a/tokio/src/stream/filter_map.rs
+++ b/tokio/src/stream/filter_map.rs
@@ -6,7 +6,7 @@ use core::task::{Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
-    /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
+    /// Stream returned by the [`filter_map`](super::StreamExt::filter_map) method.
     #[must_use = "streams do nothing unless polled"]
     pub struct FilterMap<St, F> {
         #[pin]

--- a/tokio/src/stream/filter_map.rs
+++ b/tokio/src/stream/filter_map.rs
@@ -1,0 +1,62 @@
+use crate::stream::Stream;
+
+use core::fmt;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Stream for the [`filter_map`](super::StreamExt::filter_map) method.
+    #[must_use = "streams do nothing unless polled"]
+    pub struct FilterMap<St, F> {
+        #[pin]
+        stream: St,
+        f: F,
+    }
+}
+
+impl<St, F> fmt::Debug for FilterMap<St, F>
+where
+    St: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FilterMap")
+            .field("stream", &self.stream)
+            .finish()
+    }
+}
+
+impl<St, F, T> FilterMap<St, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Option<T>,
+{
+    pub(super) fn new(stream: St, f: F) -> Self {
+        Self { stream, f }
+    }
+}
+
+impl<St, F, T> Stream for FilterMap<St, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Option<T>,
+{
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        loop {
+            match ready!(self.as_mut().project().stream.poll_next(cx)) {
+                Some(e) => {
+                    if let Some(e) = (self.as_mut().project().f)(e) {
+                        return Poll::Ready(Some(e));
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.stream.size_hint().1) // can't know a lower bound, due to the predicate
+    }
+}

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -105,7 +105,7 @@ pub trait StreamExt: Stream {
     /// will be discarded and the next value will be produced.
     ///
     /// Note that this function consumes the stream passed into it and returns a
-    /// wrapped version of it, similar to the existing `filter` methods in the
+    /// wrapped version of it, similar to [`Iterator::filter`] method in the
     /// standard library.
     ///
     /// # Examples
@@ -142,8 +142,8 @@ pub trait StreamExt: Stream {
     /// it resolves to [`None`] then the next value will be produced.
     ///
     /// Note that this function consumes the stream passed into it and returns a
-    /// wrapped version of it, similar to the existing `filter_map` methods in
-    /// the standard library.
+    /// wrapped version of it, similar to [`Iterator::filter_map`] method in the
+    /// standard library.
     ///
     /// # Examples
     /// ```

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -115,10 +115,14 @@ pub trait StreamExt: Stream {
     /// # async fn main() {
     /// use tokio::stream::{self, StreamExt};
     ///
-    /// let stream = stream::iter(1..=10);
-    /// let evens = stream.filter(|x| x % 2 == 0);
+    /// let stream = stream::iter(1..=8);
+    /// let mut evens = stream.filter(|x| x % 2 == 0);
     ///
-    /// assert_eq!(vec![2, 4, 6, 8, 10], evens.collect::<Vec<_>>().await);
+    /// assert_eq!(Some(2), evens.next().await);
+    /// assert_eq!(Some(4), evens.next().await);
+    /// assert_eq!(Some(6), evens.next().await);
+    /// assert_eq!(Some(8), evens.next().await);
+    /// assert_eq!(None, evens.next().await);
     /// # }
     /// ```
     fn filter<F>(self, f: F) -> Filter<Self, F>
@@ -147,12 +151,16 @@ pub trait StreamExt: Stream {
     /// # async fn main() {
     /// use tokio::stream::{self, StreamExt};
     ///
-    /// let stream = stream::iter(1..=10);
-    /// let evens = stream.filter_map(|x| {
+    /// let stream = stream::iter(1..=8);
+    /// let mut evens = stream.filter_map(|x| {
     ///     if x % 2 == 0 { Some(x + 1) } else { None }
     /// });
     ///
-    /// assert_eq!(vec![3, 5, 7, 9, 11], evens.collect::<Vec<_>>().await);
+    /// assert_eq!(Some(3), evens.next().await);
+    /// assert_eq!(Some(5), evens.next().await);
+    /// assert_eq!(Some(7), evens.next().await);
+    /// assert_eq!(Some(9), evens.next().await);
+    /// assert_eq!(None, evens.next().await);
     /// # }
     /// ```
     fn filter_map<T, F>(self, f: F) -> FilterMap<Self, F>

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -4,6 +4,12 @@
 //!
 //! This module provides helpers to work with them.
 
+mod filter;
+use filter::Filter;
+
+mod filter_map;
+use filter_map::FilterMap;
+
 mod iter;
 pub use iter::{iter, Iter};
 
@@ -87,6 +93,74 @@ pub trait StreamExt: Stream {
         Self: Sized,
     {
         Map::new(self, f)
+    }
+
+    /// Filters the values produced by this stream according to the provided
+    /// predicate.
+    ///
+    /// As values of this stream are made available, the provided predicate `f`
+    /// will be run against them. If the predicate
+    /// resolves to `true`, then the stream will yield the value, but if the
+    /// predicate resolves to `false`, then the value
+    /// will be discarded and the next value will be produced.
+    ///
+    /// Note that this function consumes the stream passed into it and returns a
+    /// wrapped version of it, similar to the existing `filter` methods in the
+    /// standard library.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use tokio::stream::{self, StreamExt};
+    ///
+    /// let stream = stream::iter(1..=10);
+    /// let evens = stream.filter(|x| x % 2 == 0);
+    ///
+    /// assert_eq!(vec![2, 4, 6, 8, 10], evens.collect::<Vec<_>>().await);
+    /// # }
+    /// ```
+    fn filter<F>(self, f: F) -> Filter<Self, F>
+    where
+        F: FnMut(&Self::Item) -> bool,
+        Self: Sized,
+    {
+        Filter::new(self, f)
+    }
+
+    /// Filters the values produced by this stream while simultaneously mapping
+    /// them to a different type according to the provided closure.
+    ///
+    /// As values of this stream are made available, the provided function will
+    /// be run on them. If the predicate `f` resolves to
+    /// [`Some(item)`](Some) then the stream will yield the value `item`, but if
+    /// it resolves to [`None`] then the next value will be produced.
+    ///
+    /// Note that this function consumes the stream passed into it and returns a
+    /// wrapped version of it, similar to the existing `filter_map` methods in
+    /// the standard library.
+    ///
+    /// # Examples
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use tokio::stream::{self, StreamExt};
+    ///
+    /// let stream = stream::iter(1..=10);
+    /// let evens = stream.filter_map(|x| {
+    ///     if x % 2 == 0 { Some(x + 1) } else { None }
+    /// });
+    ///
+    /// assert_eq!(vec![3, 5, 7, 9, 11], evens.collect::<Vec<_>>().await);
+    /// # }
+    /// ```
+    fn filter_map<T, F>(self, f: F) -> FilterMap<Self, F>
+    where
+        F: FnMut(Self::Item) -> Option<T>,
+        Self: Sized,
+    {
+        FilterMap::new(self, f)
     }
 }
 


### PR DESCRIPTION
This PR adds `StreamExt::filter` and `StreamExt::filter_map` which allow filtering and mapping items yielded by the wrapped stream.

Unlike the version in #1962 combinators presented here accept *synchronous* predicates which do immediate check upon receiving items from inner stream. The necessity and design of versions for asynchronous predicate is a subject of a further discussion.