### PR TITLE
Implement StreamExt::try_next

### DIFF
--- a/tokio/src/stream/try_next.rs
+++ b/tokio/src/stream/try_next.rs
@@ -1,0 +1,31 @@
+use crate::stream::{Stream, Next};
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+
+/// Future for the [`try_next`](super::StreamExt::try_next) method.
+#[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
+pub struct TryNext<'a, St: ?Sized> {
+    inner: Next<'a, St>,
+}
+
+impl<St: ?Sized + Unpin> Unpin for TryNext<'_, St> {}
+
+impl<'a, St: ?Sized + Stream + Unpin> TryNext<'a, St> {
+    pub(super) fn new(stream: &'a mut St) -> Self {
+        Self { inner: Next::new(stream) }
+    }
+}
+
+impl<T, E, St: ?Sized + Stream<Item = Result<T, E>> + Unpin> Future for TryNext<'_, St> {
+    type Output = Result<Option<T>, E>;
+
+    fn poll(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx).map(Option::transpose)
+    }
+}

--- a/tokio/src/stream/try_next.rs
+++ b/tokio/src/stream/try_next.rs
@@ -1,4 +1,4 @@
-use crate::stream::{Stream, Next};
+use crate::stream::{Next, Stream};
 
 use core::future::Future;
 use core::pin::Pin;
@@ -15,17 +15,16 @@ impl<St: ?Sized + Unpin> Unpin for TryNext<'_, St> {}
 
 impl<'a, St: ?Sized + Stream + Unpin> TryNext<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
-        Self { inner: Next::new(stream) }
+        Self {
+            inner: Next::new(stream),
+        }
     }
 }
 
 impl<T, E, St: ?Sized + Stream<Item = Result<T, E>> + Unpin> Future for TryNext<'_, St> {
     type Output = Result<Option<T>, E>;
 
-    fn poll(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         Pin::new(&mut self.inner).poll(cx).map(Option::transpose)
     }
 }


### PR DESCRIPTION
This PR adds `StreamExt::try_next` combinator that allows for easy usage of try operator while iterating upon fallible streams. The key difference between `futures-rs` implementation and this one is that we are going to have this method as a part of the main stream extensions, not separate `TryStreamExt`.