### PR TITLE
rt: fix storing Runtime in thread-local

### DIFF
--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -50,10 +50,10 @@ cfg_resource_drivers! {
 }
 
 mod thread;
-pub(crate) use self::thread::{ParkError, ParkThread};
+pub(crate) use self::thread::ParkThread;
 
 cfg_blocking_impl! {
-    pub(crate) use self::thread::CachedParkThread;
+    pub(crate) use self::thread::{CachedParkThread, ParkError};
 }
 
 use std::sync::Arc;

--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -50,7 +50,7 @@ cfg_resource_drivers! {
 }
 
 mod thread;
-pub(crate) use self::thread::{ParkThread, ParkError};
+pub(crate) use self::thread::{ParkError, ParkThread};
 
 cfg_blocking_impl! {
     pub(crate) use self::thread::CachedParkThread;

--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -50,7 +50,7 @@ cfg_resource_drivers! {
 }
 
 mod thread;
-pub(crate) use self::thread::ParkThread;
+pub(crate) use self::thread::{ParkThread, ParkError};
 
 cfg_blocking_impl! {
     pub(crate) use self::thread::CachedParkThread;

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -232,12 +232,17 @@ cfg_blocking_impl! {
             }
         }
 
+        pub(crate) fn get_unpark(&self) -> Result<UnparkThread, ParkError> {
+            self.with_current(|park_thread| park_thread.unpark())
+        }
+
         /// Get a reference to the `ParkThread` handle for this thread.
-        fn with_current<F, R>(&self, f: F) -> R
+        fn with_current<F, R>(&self, f: F) -> Result<R, ParkError>
         where
             F: FnOnce(&ParkThread) -> R,
         {
-            CURRENT_PARKER.with(|inner| f(inner))
+            CURRENT_PARKER.try_with(|inner| f(inner))
+                .map_err(|_| ParkError { _p: () })
         }
     }
 
@@ -246,16 +251,16 @@ cfg_blocking_impl! {
         type Error = ParkError;
 
         fn unpark(&self) -> Self::Unpark {
-            self.with_current(|park_thread| park_thread.unpark())
+            self.get_unpark().unwrap()
         }
 
         fn park(&mut self) -> Result<(), Self::Error> {
-            self.with_current(|park_thread| park_thread.inner.park());
+            self.with_current(|park_thread| park_thread.inner.park())?;
             Ok(())
         }
 
         fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
-            self.with_current(|park_thread| park_thread.inner.park_timeout(duration));
+            self.with_current(|park_thread| park_thread.inner.park_timeout(duration))?;
             Ok(())
         }
     }

--- a/tokio/src/runtime/blocking/shutdown.rs
+++ b/tokio/src/runtime/blocking/shutdown.rs
@@ -39,6 +39,10 @@ impl Receiver {
         };
 
         // The oneshot completes with an Err
+        //
+        // If blocking fails to wait, this indicates a problem parking the
+        // current thread (usually, shutting down a runtime stored in a
+        // thread-local).
         let _ = e.block_on(&mut self.rx);
     }
 }

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -91,8 +91,7 @@ impl ThreadPool {
     {
         self.spawner.enter(|| {
             let mut enter = crate::runtime::enter();
-            enter.block_on(future)
-                .expect("failed to park thread")
+            enter.block_on(future).expect("failed to park thread")
         })
     }
 }

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -92,6 +92,7 @@ impl ThreadPool {
         self.spawner.enter(|| {
             let mut enter = crate::runtime::enter();
             enter.block_on(future)
+                .expect("failed to park thread")
         })
     }
 }

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -602,6 +602,24 @@ rt_test! {
         assert_ok!(drop_rx.recv());
     }
 
+    #[test]
+    fn runtime_in_thread_local() {
+        use std::cell::RefCell;
+        use std::thread;
+
+        thread_local!(
+            static R: RefCell<Option<Runtime>> = RefCell::new(None);
+        );
+
+        thread::spawn(|| {
+            R.with(|cell| {
+                *cell.borrow_mut() = Some(rt());
+            });
+
+            let _rt = rt();
+        }).join().unwrap();
+    }
+
     async fn client_server(tx: mpsc::Sender<()>) {
         let mut server = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
 


### PR DESCRIPTION
Storing a `Runtime` value in a thread-local resulted in a panic due to
the inability to access the parker.

This fixes the bug by skipping parking if it fails. In general, there
isn't much that we can do besides not parking.
