### PR TITLE
Implement `Stream` for broadcast::Receiver

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -207,7 +207,7 @@ pub struct SendError<T>(pub T);
 ///
 /// [`recv`]: crate::sync::broadcast::Receiver::recv
 /// [`Receiver`]: crate::sync::broadcast::Receiver
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum RecvError {
     /// There are no more active senders implying no further messages will ever
     /// be sent.
@@ -225,7 +225,7 @@ pub enum RecvError {
 ///
 /// [`try_recv`]: crate::sync::broadcast::Receiver::try_recv
 /// [`Receiver`]: crate::sync::broadcast::Receiver
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TryRecvError {
     /// The channel is currently empty. There are still active
     /// [`Sender`][Sender] handles, so data may yet become available.
@@ -862,14 +862,20 @@ where
 }
 
 #[cfg(feature = "stream")]
-impl<T> crate::stream::Stream for Receiver<T> where T: Clone {
+impl<T> crate::stream::Stream for Receiver<T>
+where
+    T: Clone,
+{
     type Item = Result<T, RecvError>;
 
-    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Result<T, RecvError>>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<T, RecvError>>> {
         self.poll_recv(cx).map(|v| match v {
             Ok(v) => Some(Ok(v)),
             lag @ Err(RecvError::Lagged(_)) => Some(lag),
-            Err(RecvError::Closed) => None
+            Err(RecvError::Closed) => None,
         })
     }
 }

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -80,6 +80,23 @@ fn send_two_recv() {
     assert_empty!(rx2);
 }
 
+#[tokio::test]
+async fn send_recv_stream() {
+    use tokio::stream::StreamExt;
+
+    let (tx, mut rx) = broadcast::channel::<i32>(8);
+
+    assert_ok!(tx.send(1));
+    assert_ok!(tx.send(2));
+
+    assert_eq!(Some(Ok(1)), rx.next().await);
+    assert_eq!(Some(Ok(2)), rx.next().await);
+
+    drop(tx);
+
+    assert_eq!(None, rx.next().await);
+}
+
 #[test]
 fn send_recv_bounded() {
     let (tx, mut rx) = broadcast::channel(16);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
The broadcast `Receiver` doesn't have a `Stream` impl.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Implement `Stream` for `broadcast::Receiver`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
