### PR TITLE
process: deprecate Child stdio accessors in favor of pub fields

### DIFF
--- a/tests-integration/tests/process_stdio.rs
+++ b/tests-integration/tests/process_stdio.rs
@@ -25,8 +25,8 @@ fn cat() -> Command {
 }
 
 async fn feed_cat(mut cat: Child, n: usize) -> io::Result<ExitStatus> {
-    let mut stdin = cat.stdin().take().unwrap();
-    let stdout = cat.stdout().take().unwrap();
+    let mut stdin = cat.stdin.take().unwrap();
+    let stdout = cat.stdout.take().unwrap();
 
     // Produce n lines on the child's stdout.
     let write = async {
@@ -97,7 +97,7 @@ async fn feed_a_lot() {
 #[tokio::test]
 async fn wait_with_output_captures() {
     let mut child = cat().spawn().unwrap();
-    let mut stdin = child.stdin().take().unwrap();
+    let mut stdin = child.stdin.take().unwrap();
 
     let write_bytes = b"1234";
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -74,7 +74,7 @@
 //!     let mut child = cmd.spawn()
 //!         .expect("failed to spawn command");
 //!
-//!     let stdout = child.stdout().take()
+//!     let stdout = child.stdout.take()
 //!         .expect("child did not have a handle to stdout");
 //!
 //!     let mut reader = BufReader::new(stdout).lines();
@@ -729,9 +729,18 @@ where
 #[derive(Debug)]
 pub struct Child {
     child: ChildDropGuard<imp::Child>,
-    stdin: Option<ChildStdin>,
-    stdout: Option<ChildStdout>,
-    stderr: Option<ChildStderr>,
+
+    /// The handle for writing to the child's standard input (stdin), if it has
+    /// been captured.
+    pub stdin: Option<ChildStdin>,
+
+    /// The handle for reading from the child's standard output (stdout), if it
+    /// has been captured.
+    pub stdout: Option<ChildStdout>,
+
+    /// The handle for reading from the child's standard error (stderr), if it
+    /// has been captured.
+    pub stderr: Option<ChildStderr>,
 }
 
 impl Child {
@@ -747,20 +756,20 @@ impl Child {
         self.child.kill()
     }
 
-    /// Returns a handle for writing to the child's stdin, if it has been
-    /// captured.
+    #[doc(hidden)]
+    #[deprecated(note = "please use `child.stdin` instead")]
     pub fn stdin(&mut self) -> &mut Option<ChildStdin> {
         &mut self.stdin
     }
 
-    /// Returns a handle for reading from the child's stdout, if it has been
-    /// captured.
+    #[doc(hidden)]
+    #[deprecated(note = "please use `child.stdout` instead")]
     pub fn stdout(&mut self) -> &mut Option<ChildStdout> {
         &mut self.stdout
     }
 
-    /// Returns a handle for reading from the child's stderr, if it has been
-    /// captured.
+    #[doc(hidden)]
+    #[deprecated(note = "please use `child.stderr` instead")]
     pub fn stderr(&mut self) -> &mut Option<ChildStderr> {
         &mut self.stderr
     }
@@ -792,7 +801,7 @@ impl Child {
             Ok(vec)
         }
 
-        drop(self.stdin().take());
+        drop(self.stdin.take());
         let stdout_fut = read_to_end(self.stdout.take());
         let stderr_fut = read_to_end(self.stderr.take());
 

--- a/tokio/tests/process_kill_on_drop.rs
+++ b/tokio/tests/process_kill_on_drop.rs
@@ -32,7 +32,7 @@ async fn kill_on_drop() {
 
     delay_for(Duration::from_secs(2)).await;
 
-    let mut out = child.stdout().take().unwrap();
+    let mut out = child.stdout.take().unwrap();
     drop(child);
 
     let mut msg = String::new();


### PR DESCRIPTION
## Motivation

The current strategy of accessing `Child` stdio handles via accessors does not allow for mutably borrowing over multiple stdio handles.

## Solution

Deprecate stdio accessors in favor of public fields. The `Child` struct still has a private member, so we can add additional fields without breaking changes

Fixes #2009
