### PR TITLE
rt: add optional throttling to BasicScheduler

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -111,7 +111,18 @@ cfg_rt_core! {
             F: Future + Send + 'static,
             F::Output: Send + 'static,
         {
-            self.spawner.spawn(future)
+            self.spawner.spawn(future, false)
+        }
+
+        /// Spawns the `future` on the scheduler.
+        ///
+        /// The scheduler is woken up if it was asleep.
+        pub fn awake_and_spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            self.spawner.spawn(future, true)
         }
     }
 }

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -20,7 +20,11 @@ pub(crate) enum Spawner {
 
 cfg_rt_core! {
     impl Spawner {
-        pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+        /// Spawns the `future` on the scheduler.
+        ///
+        /// If `must_awake` is `true`, and throttling is activated,
+        /// the scheduler is woken up if it was asleep.
+        pub(crate) fn spawn<F>(&self, future: F, must_awake: bool) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,
             F::Output: Send + 'static,
@@ -28,7 +32,7 @@ cfg_rt_core! {
             match self {
                 Spawner::Shell => panic!("spawning not enabled for runtime"),
                 #[cfg(feature = "rt-core")]
-                Spawner::Basic(spawner) => spawner.spawn(future),
+                Spawner::Basic(spawner) => spawner.spawn(future, must_awake),
                 #[cfg(feature = "rt-threaded")]
                 Spawner::ThreadPool(spawner) => spawner.spawn(future),
             }

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -247,7 +247,7 @@ cfg_rt_core! {
     use self::raw::RawTask;
 
     mod spawn;
-    pub use spawn::spawn;
+    pub use spawn::{spawn, awake_and_spawn};
 
     mod stack;
     pub(crate) use self::stack::TransferStack;

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -125,6 +125,19 @@ doc_rt_core! {
     {
         let spawn_handle = runtime::context::spawn_handle()
         .expect("must be called from the context of Tokio runtime configured with either `basic_scheduler` or `threaded_scheduler`");
-        spawn_handle.spawn(task)
+        spawn_handle.spawn(task, false)
+    }
+
+    /// Spawns the `future` on the scheduler.
+    ///
+    /// The scheduler is woken up if it was asleep.
+    pub fn awake_and_spawn<T>(task: T, must_awake: bool) -> JoinHandle<T::Output>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        let spawn_handle = runtime::context::spawn_handle()
+        .expect("must be called from the context of Tokio runtime configured with either `basic_scheduler` or `threaded_scheduler`");
+        spawn_handle.spawn(task, must_awake)
     }
 }

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -88,6 +88,9 @@ pub(crate) struct Driver<T> {
 
     /// Source of "now" instances
     clock: Clock,
+
+    /// Throttling mode affects the behavior of `park_timeout`
+    is_throttling: bool,
 }
 
 /// Timer state shared between `Driver`, `Handle`, and `Registration`.
@@ -129,6 +132,7 @@ where
             wheel: wheel::Wheel::new(),
             park,
             clock,
+            is_throttling: false,
         }
     }
 
@@ -142,15 +146,23 @@ where
         Handle::new(Arc::downgrade(&self.inner))
     }
 
+    /// Sets the driver in `throttling` mode.
+    pub(crate) fn enable_throttling(&mut self) {
+        self.is_throttling = true;
+    }
+
     /// Converts an `Expiration` to an `Instant`.
     fn expiration_instant(&self, when: u64) -> Instant {
         self.inner.start + Duration::from_millis(when)
     }
 
     /// Runs timer related logic
-    fn process(&mut self) {
+    ///
+    /// The `offset` allows triggering timers by anticipation.
+    /// This is required for the throttling mode.
+    fn process(&mut self, offset: Duration) {
         let now = crate::time::ms(
-            self.clock.now() - self.inner.start,
+            self.clock.now() + offset - self.inner.start,
             crate::time::Round::Down,
         );
         let mut poll = wheel::Poll::new(now);
@@ -262,7 +274,7 @@ where
             }
         }
 
-        self.process();
+        self.process(Duration::from_secs(0));
 
         Ok(())
     }
@@ -270,30 +282,48 @@ where
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         self.process_queue();
 
-        match self.wheel.poll_at() {
-            Some(when) => {
-                let now = self.clock.now();
-                let deadline = self.expiration_instant(when);
+        if !self.is_throttling {
+            match self.wheel.poll_at() {
+                Some(when) => {
+                    let now = self.clock.now();
+                    let deadline = self.expiration_instant(when);
 
-                if deadline > now {
-                    let duration = cmp::min(deadline - now, duration);
+                    if deadline > now {
+                        let duration = cmp::min(deadline - now, duration);
 
-                    if self.clock.is_frozen() {
-                        self.park.park_timeout(Duration::from_secs(0))?;
-                        self.clock.advance(duration);
+                        if self.clock.is_frozen() {
+                            self.park.park_timeout(Duration::from_secs(0))?;
+                            self.clock.advance(duration);
+                        } else {
+                            self.park.park_timeout(duration)?;
+                        }
                     } else {
-                        self.park.park_timeout(duration)?;
+                        self.park.park_timeout(Duration::from_secs(0))?;
                     }
-                } else {
-                    self.park.park_timeout(Duration::from_secs(0))?;
+                }
+                None => {
+                    self.park.park_timeout(duration)?;
                 }
             }
-            None => {
-                self.park.park_timeout(duration)?;
-            }
-        }
 
-        self.process();
+            self.process(Duration::from_secs(0));
+        } else {
+            // In throttling mode, we try to group timers by time frames.
+            // If we intend to throttle the thread for `duration` now,
+            // we need to fire future timers that are closer
+            // to `now` than to the beginning of next time frame.
+
+            // Actual throttling pause is to be handled by caller
+            // depending on tasks availability.
+            self.park.park_timeout(Duration::from_secs(0))?;
+
+            // Won't be called before the beginning of next time frame.
+            if self.clock.is_frozen() {
+                self.clock.advance(duration);
+            }
+
+            self.process(duration / 2);
+        }
 
         Ok(())
     }

--- a/tokio/tests/rt_basic_throttling.rs
+++ b/tokio/tests/rt_basic_throttling.rs
@@ -1,0 +1,222 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::runtime::Runtime;
+use tokio::sync::oneshot;
+use tokio::time;
+use tokio_test::assert_ok;
+
+use std::time::{Duration, Instant};
+
+const MAX_THROTTLING: Duration = Duration::from_millis(200);
+
+// One time frame duration
+//
+// Depending on when the `delay` is created, it might be fired either:
+//
+// - at the beginning of time frame tf2
+//
+//      tf1   tf2   tf3
+//    |--:--|--:--|--:--|...
+//      ^---x
+//      <-dur->
+//
+//
+// - or, at the beginning of tme frame tf3
+//
+//      tf1   tf2   tf3
+//    |--:--|--:--|--:--|...
+//        ^-------x
+//        <-dur->
+
+#[test]
+fn delay_at_root_one_time_frame() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING;
+
+    let elapsed = rt.block_on(async move {
+        let now = Instant::now();
+        time::delay_for(dur).await;
+        now.elapsed()
+    });
+
+    // delay can be fired earlier if it was created
+    // before half of the time frame
+    assert!(elapsed + (MAX_THROTTLING / 2) >= dur);
+    // delay is created during the first time frame
+    // and must be fired at the beginning of the next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(elapsed < dur + MAX_THROTTLING);
+}
+
+#[test]
+fn delay_in_spawn_one_time_frame() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING;
+
+    let elapsed = rt.block_on(async move {
+        let (tx, rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let now = Instant::now();
+            time::delay_for(dur).await;
+            assert_ok!(tx.send(now.elapsed()));
+        });
+
+        assert_ok!(rx.await)
+    });
+
+    // delay can be fired earlier if it was created
+    // before half of the time frame
+    assert!(elapsed + (MAX_THROTTLING / 2) >= dur);
+    // delay is created during the first time frame
+    // and must be fired at the beginning of the next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(elapsed < dur + MAX_THROTTLING);
+}
+
+// One time frame + 2/3 (i.e. more than a half) duration
+//
+// Whenever the `delay` is created in tf1, it will always be fired
+// at the beginning of time frame tf2:
+//
+//      tf1   tf2   tf3
+//    |--:--|--:--|--:--|...
+//      ^---------x
+//      <--dur.-->
+//
+//      tf1   tf2   tf3
+//    |--:--|--:--|--:--|...
+//        ^-------x
+//        <--dur.-->
+
+#[test]
+fn delay_at_root_one_time_frame_2_3() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING + MAX_THROTTLING * 2 / 3;
+
+    let _elapsed = rt.block_on(async move {
+        let now = Instant::now();
+        time::delay_for(dur).await;
+        now.elapsed()
+    });
+
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(_elapsed >= dur);
+    // delay is created during the first time frame
+    // and must be fired at the beginning of the next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(_elapsed < dur + MAX_THROTTLING);
+}
+
+#[test]
+fn delay_in_spawn_one_time_frame_2_3() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING + MAX_THROTTLING * 2 / 3;
+
+    let _elapsed = rt.block_on(async move {
+        let (tx, rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let now = Instant::now();
+            time::delay_for(dur).await;
+            assert_ok!(tx.send(now.elapsed()));
+        });
+
+        assert_ok!(rx.await)
+    });
+
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(_elapsed >= dur);
+    // delay is created during the first time frame
+    // and must be fired at the beginning of the next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(_elapsed < dur + MAX_THROTTLING);
+}
+
+// Two time frames duration
+//
+// Depending on when the `delay` is created, it might be fired either:
+//
+// - at the beginning of time frame tf3
+//
+//      tf1   tf2   tf3   tf4
+//    |--:--|--:--|--:--|--:--|...
+//      ^---------x
+//      <----dur---->
+//
+// - or, at the beginning of tme frame tf4
+//
+//      tf1   tf2   tf3   tf4
+//    |--:--|--:--|--:--|--:--|...
+//        ^-------------x
+//        <----dur---->
+
+#[test]
+fn delay_at_root_two_time_frames() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING * 2;
+
+    let elapsed = rt.block_on(async move {
+        let now = Instant::now();
+        time::delay_for(dur).await;
+        now.elapsed()
+    });
+
+    // delay can be fired earlier if it was created
+    // before half of the time frame
+    assert!(elapsed + (MAX_THROTTLING / 2) >= dur);
+    // delay is created during the first time frame
+    // and must be fired after the end of next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(elapsed < dur + MAX_THROTTLING);
+}
+
+#[test]
+fn delay_in_spawn_two_time_frames() {
+    let mut rt = rt();
+
+    let dur = MAX_THROTTLING * 2;
+
+    let elapsed = rt.block_on(async move {
+        let (tx, rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            let now = Instant::now();
+            time::delay_for(dur).await;
+            assert_ok!(tx.send(now.elapsed()));
+        });
+
+        assert_ok!(rx.await)
+    });
+
+    // delay can be fired earlier if it was created
+    // before half of the time frame
+    assert!(elapsed + (MAX_THROTTLING / 2) >= dur);
+    // delay is created during the first time frame
+    // and must be fired after the end of next time frame
+    // Discard this check for macos as CI behavior regarding time is not consistent
+    #[cfg(not(target_os = "macos"))]
+    assert!(elapsed < dur + MAX_THROTTLING);
+}
+
+fn rt() -> Runtime {
+    tokio::runtime::Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .max_throttling(MAX_THROTTLING)
+        .build()
+        .unwrap()
+}

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -18,6 +18,19 @@ macro_rules! rt_test {
             }
         }
 
+        mod basic_scheduler_throttling {
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new()
+                    .basic_scheduler()
+                    .enable_all()
+                    .max_throttling(std::time::Duration::from_millis(1))
+                    .build()
+                    .unwrap()
+            }
+        }
+
         mod threaded_scheduler {
             $($t)*
 


### PR DESCRIPTION
## Motivation

This PR is a continuation of https://github.com/tokio-rs/tokio/issues/1887.

[`gst-plugin-threadshare`] is a framework and a collection of `GStreamer`
elements which are developped with the Rust programming language and use the
[`gstreamer-rs`] bindings to the [`GStreamer`] C-based libraries.

In the regular `GStreamer` model, pipeline elements spawn there own threads to
deal with asynchronous processing. Most of the time, these threads wait for
something to happen which causes multiple overheads. The [`gst-plugin-threadshare`]
model allows elements to share threads which reduces context switches and system
calls, thus lowering CPU load.

The framework executor uses `tokio`. Until release `0.2.0`, `tokio` featured
functions that gave control on the iterations of the executor:

  - `turn` would execute one iteration and indicate if tasks were handled by
    the executor.
  - The user could request the executor to `park` & `unpark`.

Thanks to these features the framework could benefit from the `tokio` executor
while implementing a throttling strategy. The throttling strategy consists in
grouping tasks, timers and I/O handling by forcing the thread to sleep during a
short duration. For use cases where a large number of events are to be handled
randomly (e.g. 2,000+ live multimedia streams), this induces an even more
efficient use of the CPU and wider bandwidth.

Since the throttling strategy introduces pauses in the execution thread, timers
need a special treatment so that they are fired close enough to their target
instant. In order to avoid timers from being triggered too late,
`gst-plugin-threadshare` implemented its own timers management.

See [this blog post] for a more in-depth explanation of the throttling strategy.

Two solutions are considered for `gst-plugin-threadshare` to keep up with
`tokio` new versions (see [this thread](https://github.com/tokio-rs/tokio/issues/1887)):

  1. Introduce the throttling strategy as an option in `tokio`'s executor.
  2. Re-introduce an API in `tokio`'s executor so that `gst-plugin-threadshare`
     can keep its throttling strategy.

Solution (1) presents the following benefits:

  - Other projects could activate the throttling strategy depending on their
    use cases.
  - The timers special handling with regard to throttling would be implemented
    in `tokio`, meaning `gst-plugin-threadshare` would not implement its own
    timers management.

This PR is an implementation of solution (1). Follow [this link](https://github.com/fengalin/fengalin-github.io/tree/master/evaluating_throttling_implementations#testing-tokio-throttling)
for an evaluation of the resulting behavior for the `BasicScheduler`.

## Solution

This PR introduces a new optional duration parameter `max_throttling`. If the
user provides a non-null duration and selects the basic scheduler, the
throttling strategy is activated. `max_throttling` is the maximum duration
of the thread pauses and the minimal duration between two consecutive timers &
I/O polls.

When throttling is activated, the `BasicScheduler` loops on the new
`tick_throttling` function instead of `tick`. The `tick_throttling` function
uses a state machine to control the descent to the state where the thread would
be actually paused if the `max_throttling` hasn't elapsed yet since the instant the
timers & I/O where last polled.

The purpose of the thread pause is to not be awaken before the intended duration
has elapsed, so the actual pause doesn't rely on a driver's park implementation,
but on a call to `std::thread::sleep`.

Since timers I/O are never polled more often than `max_throttling` ms, timers
need a special care. The idea is to consider time frames which start at a polling
instant. Consider a time frame starting now. Since current time frame will last
at least `max_throttling` ms, we need to fire timers that will elapse before
the first half of current timer frame, otherwise they would be fire further to
their intended instant and always too late.

In order to implement this strategy with minimal impact on existing code, it was
decided to add a new mode to the `time::Driver`. When this mode is activated,
the `park_timeout` method fires the timers as described above, polls the I/O
via the inner driver and returns immediately. This way the scheduler can still
trigger tasks that would depend on the timers before going to sleep.

## Tests

In order to ensure on par behavior with the regular `tick` algorithm,
`basic_scheduler_throttling` was added to `rt_common`. A new test
`rt_basic_throttling.rs` takes care of checking the time frame strategy.

Tests were also conducted as part of [this evaluation](https://github.com/fengalin/fengalin-github.io/tree/master/evaluating_throttling_implementations#testing-tokio-throttling)
which covers a [`tokio` only benchmark] as well as a comparison of the
implementations used for the [`gst-plugin-threadshare`] framework.


[`gst-plugin-threadshare`]: https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/tree/master/gst-plugin-threadshare
[`gstreamer-rs`]: https://gitlab.freedesktop.org/gstreamer/gstreamer-rs
[`GStreamer`]: https://gstreamer.freedesktop.org/
[this blog post]: https://coaxion.net/blog/2018/04/improving-gstreamer-performance-on-a-high-number-of-network-streams-by-sharing-threads-between-elements-with-rusts-tokio-crate
[`tokio` only benchmark]: https://github.com/fengalin/tokio-udp-receiver-benchmark/tree/ccee51f336baf77367a9a4b4e99458289820b45a