### PR TITLE
Refactor proc macros, add more knobs

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -18,19 +18,168 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use quote::quote;
+use std::num::NonZeroUsize;
 
 enum Runtime {
     Basic,
     Threaded,
-    Auto,
+}
+
+fn parse_knobs(
+    input: syn::ItemFn,
+    args: syn::AttributeArgs,
+    is_test: bool,
+) -> Result<TokenStream, syn::Error> {
+    let ret = &input.sig.output;
+    let name = &input.sig.ident;
+    let inputs = &input.sig.inputs;
+    let body = &input.block;
+    let attrs = &input.attrs;
+    let vis = input.vis;
+
+    if input.sig.asyncness.is_none() {
+        let msg = "the async keyword is missing from the function declaration";
+        return Err(syn::Error::new_spanned(input.sig.fn_token, msg));
+    }
+
+    let mut runtime = None;
+    let mut core_threads = None;
+    let mut max_threads = None;
+
+    for arg in args {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
+                let ident = namevalue.path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(namevalue, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "core_threads" => match &namevalue.lit {
+                        syn::Lit::Int(expr) => {
+                            let num = expr.base10_parse::<NonZeroUsize>().unwrap();
+                            if num.get() > 1 {
+                                runtime = Some(Runtime::Threaded);
+                            } else {
+                                runtime = Some(Runtime::Basic);
+                            }
+
+                            if let Some(v) = max_threads {
+                                if v < num {
+                                    return Err(syn::Error::new_spanned(
+                                        namevalue,
+                                        "max_threads cannot be less than core_threads",
+                                    ));
+                                }
+                            }
+
+                            core_threads = Some(num);
+                        }
+                        _ => {
+                            return Err(syn::Error::new_spanned(
+                                namevalue,
+                                "core_threads argument must be an int",
+                            ))
+                        }
+                    },
+                    "max_threads" => match &namevalue.lit {
+                        syn::Lit::Int(expr) => {
+                            let num = expr.base10_parse::<NonZeroUsize>().unwrap();
+
+                            if let Some(v) = core_threads {
+                                if num < v {
+                                    return Err(syn::Error::new_spanned(
+                                        namevalue,
+                                        "max_threads cannot be less than core_threads",
+                                    ));
+                                }
+                            }
+                            max_threads = Some(num);
+                        }
+                        _ => {
+                            return Err(syn::Error::new_spanned(
+                                namevalue,
+                                "max_threads argument must be an int",
+                            ))
+                        }
+                    },
+                    name => {
+                        let msg = format!("Unknown attribute pair {} is specified; expected one of: `core_threads`, `max_threads`", name);
+                        return Err(syn::Error::new_spanned(namevalue, msg));
+                    }
+                }
+            }
+            syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
+                let ident = path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(path, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "threaded_scheduler" => {
+                        runtime = Some(runtime.unwrap_or_else(|| Runtime::Threaded))
+                    }
+                    "basic_scheduler" => runtime = Some(runtime.unwrap_or_else(|| Runtime::Basic)),
+                    name => {
+                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                        return Err(syn::Error::new_spanned(path, msg));
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "Unknown attribute inside the macro",
+                ));
+            }
+        }
+    }
+
+    let mut rt = quote! { tokio::runtime::Builder::new() };
+    match (runtime, is_test) {
+        (Some(Runtime::Threaded), _) => rt = quote! { #rt.threaded_scheduler() },
+        (Some(Runtime::Basic), _) => rt = quote! { #rt.basic_scheduler() },
+        (None, true) => rt = quote! { #rt.basic_scheduler() },
+        (None, false) => rt = quote! { #rt.threaded_scheduler() },
+    };
+    if let Some(v) = core_threads.map(|v| v.get()) {
+        rt = quote! { #rt.core_threads(#v) };
+    }
+    if let Some(v) = max_threads.map(|v| v.get()) {
+        rt = quote! { #rt.max_threads(#v) };
+    }
+
+    let header = {
+        if is_test {
+            quote! {
+                #[test]
+            }
+        } else {
+            quote! {}
+        }
+    };
+
+    let result = quote! {
+        #header
+        #(#attrs)*
+        #vis fn #name(#inputs) #ret {
+            #rt
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async { #body })
+        }
+    };
+
+    Ok(result.into())
 }
 
 /// Marks async function to be executed by selected runtime.
 ///
 /// ## Options:
 ///
-/// - `basic_scheduler` - All tasks are executed on the current thread.
-/// - `threaded_scheduler` - Uses the multi-threaded scheduler. Used by default.
+/// - `core_threads=n` - Sets core threads to `n`.
+/// - `max_threads=n` - Sets max threads to `n`.
 ///
 /// ## Function arguments:
 ///
@@ -47,10 +196,10 @@ enum Runtime {
 /// }
 /// ```
 ///
-/// ### Select runtime
+/// ### Set number of core threads
 ///
 /// ```rust
-/// #[tokio::main(basic_scheduler)]
+/// #[tokio::main(core_threads = 1)]
 /// async fn main() {
 ///     println!("Hello world");
 /// }
@@ -61,81 +210,29 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
-    let ret = &input.sig.output;
-    let name = &input.sig.ident;
-    let inputs = &input.sig.inputs;
-    let body = &input.block;
-    let attrs = &input.attrs;
-    let vis = input.vis;
-
-    if input.sig.asyncness.is_none() {
-        let msg = "the async keyword is missing from the function declaration";
-        return syn::Error::new_spanned(input.sig.fn_token, msg)
-            .to_compile_error()
-            .into();
-    } else if name == "main" && !inputs.is_empty() {
+    if input.sig.ident == "main" && !input.sig.inputs.is_empty() {
         let msg = "the main function cannot accept arguments";
         return syn::Error::new_spanned(&input.sig.inputs, msg)
             .to_compile_error()
             .into();
     }
 
-    let mut runtime = Runtime::Auto;
-
-    for arg in args {
-        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
-            let ident = path.get_ident();
-            if ident.is_none() {
-                let msg = "Must have specified ident";
-                return syn::Error::new_spanned(path, msg).to_compile_error().into();
-            }
-            match ident.unwrap().to_string().to_lowercase().as_str() {
-                "threaded_scheduler" => runtime = Runtime::Threaded,
-                "basic_scheduler" => runtime = Runtime::Basic,
-                name => {
-                    let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
-                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                }
-            }
-        }
-    }
-
-    let result = match runtime {
-        Runtime::Threaded | Runtime::Auto => quote! {
-            #(#attrs)*
-            #vis fn #name(#inputs) #ret {
-                tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
-            }
-        },
-        Runtime::Basic => quote! {
-            #(#attrs)*
-            #vis fn #name(#inputs) #ret {
-                tokio::runtime::Builder::new()
-                    .basic_scheduler()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .block_on(async { #body })
-            }
-        },
-    };
-
-    result.into()
+    parse_knobs(input, args, false).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 /// Marks async function to be executed by runtime, suitable to test enviornment
 ///
 /// ## Options:
 ///
-/// - `basic_scheduler` - All tasks are executed on the current thread. Used by default.
-/// - `threaded_scheduler` - Use multi-threaded scheduler.
+/// - `core_threads=n` - Sets core threads to `n`.
+/// - `max_threads=n` - Sets max threads to `n`.
 ///
 /// ## Usage
 ///
 /// ### Select runtime
 ///
 /// ```no_run
-/// #[tokio::test(threaded_scheduler)]
+/// #[tokio::test(core_threads = 1)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -154,13 +251,7 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
-    let ret = &input.sig.output;
-    let name = &input.sig.ident;
-    let body = &input.block;
-    let attrs = &input.attrs;
-    let vis = input.vis;
-
-    for attr in attrs {
+    for attr in &input.attrs {
         if attr.path.is_ident("test") {
             let msg = "second test attribute is supplied";
             return syn::Error::new_spanned(&attr, msg)
@@ -169,59 +260,12 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    if input.sig.asyncness.is_none() {
-        let msg = "the async keyword is missing from the function declaration";
-        return syn::Error::new_spanned(&input.sig.fn_token, msg)
-            .to_compile_error()
-            .into();
-    } else if !input.sig.inputs.is_empty() {
+    if !input.sig.inputs.is_empty() {
         let msg = "the test function cannot accept arguments";
         return syn::Error::new_spanned(&input.sig.inputs, msg)
             .to_compile_error()
             .into();
     }
 
-    let mut runtime = Runtime::Auto;
-
-    for arg in args {
-        if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
-            let ident = path.get_ident();
-            if ident.is_none() {
-                let msg = "Must have specified ident";
-                return syn::Error::new_spanned(path, msg).to_compile_error().into();
-            }
-            match ident.unwrap().to_string().to_lowercase().as_str() {
-                "threaded_scheduler" => runtime = Runtime::Threaded,
-                "basic_scheduler" => runtime = Runtime::Basic,
-                name => {
-                    let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
-                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                }
-            }
-        }
-    }
-
-    let result = match runtime {
-        Runtime::Threaded => quote! {
-            #[test]
-            #(#attrs)*
-            #vis fn #name() #ret {
-                tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
-            }
-        },
-        Runtime::Basic | Runtime::Auto => quote! {
-            #[test]
-            #(#attrs)*
-            #vis fn #name() #ret {
-                tokio::runtime::Builder::new()
-                    .basic_scheduler()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .block_on(async { #body })
-            }
-        },
-    };
-
-    result.into()
+    parse_knobs(input, args, true).unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -54,7 +54,7 @@ io-driver = ["mio", "lazy_static"]
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
-macros = ["rt-threaded", "tokio-macros"]
+macros = ["rt-core", "tokio-macros"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
   "io-driver",
@@ -92,7 +92,7 @@ uds = ["io-driver", "mio-uds", "libc"]
 
 
 [dependencies]
-tokio-macros = { version = "0.2.0", optional = true }
+tokio-macros = { version = "0.2.0", path = "../tokio-macros", optional = true }
 
 bytes = "0.5.0"
 pin-project-lite = "0.1.1"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -54,7 +54,7 @@ io-driver = ["mio", "lazy_static"]
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
-macros = ["tokio-macros"]
+macros = ["rt-threaded", "tokio-macros"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
   "io-driver",

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -264,9 +264,17 @@ cfg_time! {
 mod util;
 
 cfg_macros! {
-    #[cfg(not(test))] // Work around for rust-lang/rust#62127
-    pub use tokio_macros::main;
-    pub use tokio_macros::test;
+    cfg_rt_threaded! {
+        #[cfg(not(test))] // Work around for rust-lang/rust#62127
+        pub use tokio_macros::main_threaded as main;
+        pub use tokio_macros::test_threaded as test;
+    }
+
+    cfg_not_rt_threaded! {
+        #[cfg(not(test))] // Work around for rust-lang/rust#62127
+        pub use tokio_macros::main_basic as main;
+        pub use tokio_macros::test_basic as test;
+    }
 }
 
 // Tests


### PR DESCRIPTION
This PR contains general refactoring of `#[tokio::main]` and `#[tokio::test]` macros along with additional `core_threads` and `max_threads` knobs.

Note: `core_threads` knob sets the runtime to `threaded` or `basic` depending on the value. Current `threaded_scheduler` and `basic_scheduler` knobs are only retained for compatibility with existing code and are overridden if `core_threads` is set.