### PR TITLE
tokio: remove documentation stating `Receiver` is clone-able.

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -2,8 +2,8 @@
 //! all consumers.
 //!
 //! A [`Sender`] is used to broadcast values to **all** connected [`Receiver`]
-//! values. Both [`Sender`] and [`Receiver`] handles are clone-able, allowing
-//! concurrent send and receive actions. Additionally, [`Sender`] is `Sync`.
+//! values. [`Sender`] handles are clone-able, allowing concurrent send and
+//! receive actions. [`Sender`] and [`Receiver`] are both `Send` and `Sync`.
 //!
 //! When a value is sent, **all** [`Receiver`] handles are notified and will
 //! receive the value. The value is stored once inside the channel and cloned on

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -3,7 +3,8 @@
 //!
 //! A [`Sender`] is used to broadcast values to **all** connected [`Receiver`]
 //! values. [`Sender`] handles are clone-able, allowing concurrent send and
-//! receive actions. [`Sender`] and [`Receiver`] are both `Send` and `Sync`.
+//! receive actions. [`Sender`] and [`Receiver`] are both `Send` and `Sync` as
+//! long as `T` is also `Send` or `Sync` respectively.
 //!
 //! When a value is sent, **all** [`Receiver`] handles are notified and will
 //! receive the value. The value is stored once inside the channel and cloned on


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Update documentation to match implementation.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Remove incorrect references to cloning `Receiver` structs. Also mention that `Sender` and `Receiver` are both `Send` and `Sync`. Before, the documentation only mentioned that `Sender` is `Sync`. Both structs have the `Sync` marker trait. It seemed useful to mention that both structs are also `Send` in the same place.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fixes: #2032