### PR TITLE
stream: correct trait bounds for all

### DIFF
--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -318,6 +318,7 @@ pub trait StreamExt: Stream {
     fn all<F>(&mut self, f: F) -> AllFuture<'_, Self, F>
     where
         Self: Unpin,
+        F: FnMut(Self::Item) -> bool,
     {
         AllFuture::new(self, f)
     }


### PR DESCRIPTION
This is a follow up to #2035 as suggested in post-merge review comments.