### PR TITLE
use release ordering in `drop_join_handle_fast`

### DIFF
--- a/tokio/src/task/state.rs
+++ b/tokio/src/task/state.rs
@@ -266,7 +266,7 @@ impl State {
             .compare_exchange_weak(
                 INITIAL_STATE | JOIN_INTEREST,
                 INITIAL_STATE,
-                Relaxed,
+                Release,
                 Relaxed,
             )
             .is_ok()


### PR DESCRIPTION
Previously acquire operations reading a value written by a successful
CAS in `drop_join_handle_fast` did not synchronize with it. The CAS
wasn't guaranteed to happen before the task deallocation, and so
created a data race between the two.

Use release success ordering to ensure synchronization.