### PR TITLE
share vtable between waker and waker ref

### DIFF
--- a/tokio/src/task/harness.rs
+++ b/tokio/src/task/harness.rs
@@ -300,10 +300,6 @@ where
         self.drop_waker();
     }
 
-    pub(super) fn wake_by_local_ref(&self) {
-        self.wake_by_ref();
-    }
-
     pub(super) fn wake_by_ref(&self) {
         if self.header().state.transition_to_notified() {
             unsafe {

--- a/tokio/src/task/waker.rs
+++ b/tokio/src/task/waker.rs
@@ -3,11 +3,12 @@ use crate::task::{Header, Schedule};
 
 use std::future::Future;
 use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 use std::ops;
 use std::task::{RawWaker, RawWakerVTable, Waker};
 
 pub(super) struct WakerRef<'a, S: 'static> {
-    waker: Waker,
+    waker: ManuallyDrop<Waker>,
     _p: PhantomData<(&'a Header, S)>,
 }
 
@@ -18,16 +19,7 @@ where
     T: Future,
     S: Schedule,
 {
-    let ptr = meta as *const _ as *const ();
-
-    let vtable = &RawWakerVTable::new(
-        clone_waker::<T, S>,
-        wake_unreachable,
-        wake_by_local_ref::<T, S>,
-        noop,
-    );
-
-    let waker = unsafe { Waker::from_raw(RawWaker::new(ptr, vtable)) };
+    let waker = unsafe { ManuallyDrop::new(Waker::from_raw(raw_waker::<T, S>(meta))) };
 
     WakerRef {
         waker,
@@ -50,15 +42,7 @@ where
 {
     let meta = ptr as *const Header;
     (*meta).state.ref_inc();
-
-    let vtable = &RawWakerVTable::new(
-        clone_waker::<T, S>,
-        wake_by_val::<T, S>,
-        wake_by_ref::<T, S>,
-        drop_waker::<T, S>,
-    );
-
-    RawWaker::new(ptr, vtable)
+    raw_waker::<T, S>(meta)
 }
 
 unsafe fn drop_waker<T, S>(ptr: *const ())
@@ -70,11 +54,6 @@ where
     harness.drop_waker();
 }
 
-// `wake()` cannot be called on the ref variaant.
-unsafe fn wake_unreachable(_data: *const ()) {
-    unreachable!();
-}
-
 unsafe fn wake_by_val<T, S>(ptr: *const ())
 where
     T: Future,
@@ -82,16 +61,6 @@ where
 {
     let harness = Harness::<T, S>::from_raw(ptr as *mut _);
     harness.wake_by_val();
-}
-
-// This function can only be called when on the runtime.
-unsafe fn wake_by_local_ref<T, S>(ptr: *const ())
-where
-    T: Future,
-    S: Schedule,
-{
-    let harness = Harness::<T, S>::from_raw(ptr as *mut _);
-    harness.wake_by_local_ref();
 }
 
 // Wake without consuming the waker
@@ -104,4 +73,17 @@ where
     harness.wake_by_ref();
 }
 
-unsafe fn noop(_ptr: *const ()) {}
+fn raw_waker<T, S>(meta: *const Header) -> RawWaker
+where
+    T: Future,
+    S: Schedule,
+{
+    let ptr = meta as *const ();
+    let vtable = &RawWakerVTable::new(
+        clone_waker::<T, S>,
+        wake_by_val::<T, S>,
+        wake_by_ref::<T, S>,
+        drop_waker::<T, S>,
+    );
+    RawWaker::new(ptr, vtable)
+}


### PR DESCRIPTION
The `Waker::will_wake` compares both a data pointer and a vtable to
decide if wakers are equivalent. To avoid false negatives during
comparison, use the same vtable for a waker stored in `WakerRef`.