### PR TITLE
Implement FusedStream for a few types

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -177,6 +177,12 @@ impl<T> Receiver<T> {
 impl<T> Unpin for Receiver<T> {}
 
 cfg_stream! {
+    impl<T> futures_core::FusedStream for Receiver<T> {
+        fn is_terminated(&self) -> bool {
+            self.chan.is_closed()
+        }
+    }
+
     impl<T> crate::stream::Stream for Receiver<T> {
         type Item = T;
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -322,6 +322,14 @@ where
             }
         })
     }
+
+    /// Test if this receiver side of the channel is closed.
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner
+            .rx_fields
+            .with(|rx_fields_ptr| unsafe { (*rx_fields_ptr).rx_closed })
+            && self.inner.semaphore.is_idle()
+    }
 }
 
 impl<T, S> Drop for Rx<T, S>

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -324,6 +324,7 @@ where
     }
 
     /// Test if this receiver side of the channel is closed.
+    #[cfg(feature = "stream")]
     pub(crate) fn is_closed(&self) -> bool {
         self.inner
             .rx_fields

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -129,11 +129,19 @@ impl Interval {
     }
 }
 
-#[cfg(feature = "stream")]
-impl crate::stream::Stream for Interval {
-    type Item = Instant;
+cfg_stream! {
+    impl futures_core::FusedStream for Interval {
+        fn is_terminated(&self) -> bool {
+            // NB: intervals never terminate.
+            false
+        }
+    }
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Instant>> {
-        Poll::Ready(Some(ready!(self.poll_tick(cx))))
+    impl crate::stream::Stream for Interval {
+        type Item = Instant;
+
+        fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Instant>> {
+            Poll::Ready(Some(ready!(self.poll_tick(cx))))
+        }
     }
 }


### PR DESCRIPTION
This change implements `futures_core::FusedStream` for `tokio::sync::mpsc::Receiver` to make it more convenient to use with [`futures::select!`](https://docs.rs/futures/0.3.1/futures/macro.select.html).

I also noticed that the `FusedStream` impl for `tokio::time::Interval` was removed in #1774, I wouldn't mind resurrecting it since I would make use of it quite heavily.