### PR TITLE
use just std instead of ::std in paths

### DIFF
--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -139,7 +139,7 @@ impl<T> Inner<T> {
         } else {
             // Spin... but investigate a better strategy
 
-            ::std::thread::yield_now();
+            std::thread::yield_now();
             cx.waker().wake_by_ref();
 
             Poll::Pending

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -125,10 +125,7 @@ pub(crate) mod impl_solaris {
         fn ucred_geteuid(cred: *const ucred_t) -> super::uid_t;
         fn ucred_getegid(cred: *const ucred_t) -> super::gid_t;
 
-        fn getpeerucred(
-            fd: std::os::raw::c_int,
-            cred: *mut *mut ucred_t,
-        ) -> std::os::raw::c_int;
+        fn getpeerucred(fd: std::os::raw::c_int, cred: *mut *mut ucred_t) -> std::os::raw::c_int;
     }
 
     pub(crate) fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -126,9 +126,9 @@ pub(crate) mod impl_solaris {
         fn ucred_getegid(cred: *const ucred_t) -> super::gid_t;
 
         fn getpeerucred(
-            fd: ::std::os::raw::c_int,
+            fd: std::os::raw::c_int,
             cred: *mut *mut ucred_t,
-        ) -> ::std::os::raw::c_int;
+        ) -> std::os::raw::c_int;
     }
 
     pub(crate) fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {

--- a/tokio/src/runtime/enter.rs
+++ b/tokio/src/runtime/enter.rs
@@ -63,7 +63,7 @@ pub(crate) fn exit<F: FnOnce() -> R, R>(f: F) -> R {
 
     let reset = Reset;
     let ret = f();
-    ::std::mem::forget(reset);
+    std::mem::forget(reset);
 
     ENTERED.with(|c| {
         assert!(!c.get(), "closure claimed permanent executor");

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -294,7 +294,7 @@ enum Kind {
 }
 
 /// After thread starts / before thread stops
-type Callback = ::std::sync::Arc<dyn Fn() + Send + Sync>;
+type Callback = std::sync::Arc<dyn Fn() + Send + Sync>;
 
 impl Runtime {
     /// Create a new runtime instance with default configuration values.

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -13,7 +13,7 @@ impl<T> fmt::Display for SendError<T> {
     }
 }
 
-impl<T: fmt::Debug> ::std::error::Error for SendError<T> {}
+impl<T: fmt::Debug> std::error::Error for SendError<T> {}
 
 // ===== TrySendError =====
 

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -57,7 +57,7 @@ pub mod error {
         }
     }
 
-    impl ::std::error::Error for RecvError {}
+    impl std::error::Error for RecvError {}
 
     // ===== impl TryRecvError =====
 
@@ -70,7 +70,7 @@ pub mod error {
         }
     }
 
-    impl ::std::error::Error for TryRecvError {}
+    impl std::error::Error for TryRecvError {}
 }
 
 use self::error::*;

--- a/tokio/src/sync/semaphore_ll.rs
+++ b/tokio/src/sync/semaphore_ll.rs
@@ -826,7 +826,7 @@ impl fmt::Display for AcquireError {
     }
 }
 
-impl ::std::error::Error for AcquireError {}
+impl std::error::Error for AcquireError {}
 
 // ===== impl TryAcquireError =====
 
@@ -858,7 +858,7 @@ impl fmt::Display for TryAcquireError {
     }
 }
 
-impl ::std::error::Error for TryAcquireError {}
+impl std::error::Error for TryAcquireError {}
 
 // ===== impl Waiter =====
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -117,7 +117,7 @@ pub mod error {
         }
     }
 
-    impl<T: fmt::Debug> ::std::error::Error for SendError<T> {}
+    impl<T: fmt::Debug> std::error::Error for SendError<T> {}
 }
 
 #[derive(Debug)]

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -535,7 +535,7 @@ rt_test! {
 
         impl Drop for Boom {
             fn drop(&mut self) {
-                assert!(::std::thread::panicking());
+                assert!(std::thread::panicking());
                 self.0.take().unwrap().send(()).unwrap();
             }
         }

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-fn is_error<T: ::std::error::Error + Send + Sync>() {}
+fn is_error<T: std::error::Error + Send + Sync>() {}
 
 #[test]
 fn mpsc_error_bound() {


### PR DESCRIPTION

## Motivation

It was a long time ago one had to write `::std` to make rustc recognize the path. Now just `std` works fine. It's both shorter and easier to read.