### PR TITLE
Runtime::block_on_stream

### DIFF
--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -5,6 +5,8 @@ use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
 use tokio_test::{assert_err, assert_ok};
 
+use futures::stream;
+
 use std::thread;
 use std::time::Duration;
 
@@ -61,6 +63,14 @@ fn acquire_mutex_in_drop() {
 
     // Drop the rt
     drop(rt);
+}
+
+#[test]
+fn block_on_stream() {
+    let stream = stream::iter(vec![10, 20, 30]);
+
+    let items: Vec<u32> = rt().block_on_stream(stream).collect();
+    assert_eq!(vec![10, 20, 30], items);
 }
 
 fn rt() -> Runtime {


### PR DESCRIPTION
When converting a project from tokio 0.1 to 0.2, `Stream::wait`
function is missing. That function is useful in tests, and
`Runtime::block_on_stream` is a substitute for this function.

I'm not sure I understand tokio 0.2 model properly, so feel free to drop this PR if this PR is wrong.