### PR TITLE
macros: fix breaking changes

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,4 +1,11 @@
+# 0.2.3 (January 7, 2019)
+
+### Fixed
+- Revert breaking change.
+
 # 0.2.2 (January 7, 2019)
+
+### Added
 - General refactoring and inclusion of additional runtime options (#2022 and #2038)
 
 # 0.2.1 (December 18, 2019)

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.2.2"
+version = "0.2.3"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.2.2/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.2.3/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -294,7 +294,6 @@ fn main_impl(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenSt
     parse_knobs(input, args, false, rt_threaded).unwrap_or_else(|e| e.to_compile_error().into())
 }
 
-
 /// Marks async function to be executed by runtime, suitable to test enviornment
 ///
 /// ## Options:

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -251,7 +251,7 @@ pub fn main_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
-    main_impl(args, item, true)
+    old::main(args, item)
 }
 
 /// Marks async function to be executed by selected runtime.
@@ -354,7 +354,7 @@ pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
-    test_impl(args, item, true)
+    old::test(args, item)
 }
 
 /// Marks async function to be executed by runtime, suitable to test enviornment

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -280,6 +280,7 @@ pub fn main_basic(args: TokenStream, item: TokenStream) -> TokenStream {
     main_impl(args, item, false)
 }
 
+#[cfg(not(test))] // Work around for rust-lang/rust#62127
 fn main_impl(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
@@ -408,6 +409,7 @@ mod old {
         Auto,
     }
 
+    #[cfg(not(test))] // Work around for rust-lang/rust#62127
     pub(crate) fn main(args: TokenStream, item: TokenStream) -> TokenStream {
         let input = syn::parse_macro_input!(item as syn::ItemFn);
         let args = syn::parse_macro_input!(args as syn::AttributeArgs);

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.3")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,
@@ -215,7 +215,43 @@ fn parse_knobs(
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
-    main(args, item, true)
+    main_impl(args, item, true)
+}
+
+/// Marks async function to be executed by selected runtime.
+///
+/// ## Options:
+///
+/// - `basic_scheduler` - All tasks are executed on the current thread.
+/// - `threaded_scheduler` - Uses the multi-threaded scheduler. Used by default.
+///
+/// ## Function arguments:
+///
+/// Arguments are allowed for any functions aside from `main` which is special
+///
+/// ## Usage
+///
+/// ### Using default
+///
+/// ```rust
+/// #[tokio::main]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+///
+/// ### Select runtime
+///
+/// ```rust
+/// #[tokio::main(basic_scheduler)]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+#[proc_macro_attribute]
+#[cfg(not(test))] // Work around for rust-lang/rust#62127
+pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
+    main_impl(args, item, true)
 }
 
 /// Marks async function to be executed by selected runtime.
@@ -241,10 +277,10 @@ pub fn main_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main_basic(args: TokenStream, item: TokenStream) -> TokenStream {
-    main(args, item, false)
+    main_impl(args, item, false)
 }
 
-fn main(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
+fn main_impl(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
@@ -256,6 +292,38 @@ fn main(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream 
     }
 
     parse_knobs(input, args, false, rt_threaded).unwrap_or_else(|e| e.to_compile_error().into())
+}
+
+
+/// Marks async function to be executed by runtime, suitable to test enviornment
+///
+/// ## Options:
+///
+/// - `basic_scheduler` - All tasks are executed on the current thread. Used by default.
+/// - `threaded_scheduler` - Use multi-threaded scheduler.
+///
+/// ## Usage
+///
+/// ### Select runtime
+///
+/// ```no_run
+/// #[tokio::test(threaded_scheduler)]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+///
+/// ### Using default
+///
+/// ```no_run
+/// #[tokio::test]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+#[proc_macro_attribute]
+pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
+    test_impl(args, item, true)
 }
 
 /// Marks async function to be executed by runtime, suitable to test enviornment
@@ -285,8 +353,8 @@ fn main(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream 
 /// }
 /// ```
 #[proc_macro_attribute]
-pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
-    test(args, item, true)
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+    test_impl(args, item, true)
 }
 
 /// Marks async function to be executed by runtime, suitable to test enviornment
@@ -305,10 +373,10 @@ pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 #[proc_macro_attribute]
 pub fn test_basic(args: TokenStream, item: TokenStream) -> TokenStream {
-    test(args, item, false)
+    test_impl(args, item, false)
 }
 
-fn test(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
+fn test_impl(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
     let input = syn::parse_macro_input!(item as syn::ItemFn);
     let args = syn::parse_macro_input!(args as syn::AttributeArgs);
 
@@ -329,4 +397,157 @@ fn test(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream 
     }
 
     parse_knobs(input, args, true, rt_threaded).unwrap_or_else(|e| e.to_compile_error().into())
+}
+
+mod old {
+    use proc_macro::TokenStream;
+    use quote::quote;
+
+    enum Runtime {
+        Basic,
+        Threaded,
+        Auto,
+    }
+
+    pub(crate) fn main(args: TokenStream, item: TokenStream) -> TokenStream {
+        let input = syn::parse_macro_input!(item as syn::ItemFn);
+        let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+
+        let ret = &input.sig.output;
+        let name = &input.sig.ident;
+        let inputs = &input.sig.inputs;
+        let body = &input.block;
+        let attrs = &input.attrs;
+        let vis = input.vis;
+
+        if input.sig.asyncness.is_none() {
+            let msg = "the async keyword is missing from the function declaration";
+            return syn::Error::new_spanned(input.sig.fn_token, msg)
+                .to_compile_error()
+                .into();
+        } else if name == "main" && !inputs.is_empty() {
+            let msg = "the main function cannot accept arguments";
+            return syn::Error::new_spanned(&input.sig.inputs, msg)
+                .to_compile_error()
+                .into();
+        }
+
+        let mut runtime = Runtime::Auto;
+
+        for arg in args {
+            if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
+                let ident = path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "threaded_scheduler" => runtime = Runtime::Threaded,
+                    "basic_scheduler" => runtime = Runtime::Basic,
+                    name => {
+                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                        return syn::Error::new_spanned(path, msg).to_compile_error().into();
+                    }
+                }
+            }
+        }
+
+        let result = match runtime {
+            Runtime::Threaded | Runtime::Auto => quote! {
+                #(#attrs)*
+                #vis fn #name(#inputs) #ret {
+                    tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
+                }
+            },
+            Runtime::Basic => quote! {
+                #(#attrs)*
+                #vis fn #name(#inputs) #ret {
+                    tokio::runtime::Builder::new()
+                        .basic_scheduler()
+                        .enable_all()
+                        .build()
+                        .unwrap()
+                        .block_on(async { #body })
+                }
+            },
+        };
+
+        result.into()
+    }
+
+    pub(crate) fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+        let input = syn::parse_macro_input!(item as syn::ItemFn);
+        let args = syn::parse_macro_input!(args as syn::AttributeArgs);
+
+        let ret = &input.sig.output;
+        let name = &input.sig.ident;
+        let body = &input.block;
+        let attrs = &input.attrs;
+        let vis = input.vis;
+
+        for attr in attrs {
+            if attr.path.is_ident("test") {
+                let msg = "second test attribute is supplied";
+                return syn::Error::new_spanned(&attr, msg)
+                    .to_compile_error()
+                    .into();
+            }
+        }
+
+        if input.sig.asyncness.is_none() {
+            let msg = "the async keyword is missing from the function declaration";
+            return syn::Error::new_spanned(&input.sig.fn_token, msg)
+                .to_compile_error()
+                .into();
+        } else if !input.sig.inputs.is_empty() {
+            let msg = "the test function cannot accept arguments";
+            return syn::Error::new_spanned(&input.sig.inputs, msg)
+                .to_compile_error()
+                .into();
+        }
+
+        let mut runtime = Runtime::Auto;
+
+        for arg in args {
+            if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
+                let ident = path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "threaded_scheduler" => runtime = Runtime::Threaded,
+                    "basic_scheduler" => runtime = Runtime::Basic,
+                    name => {
+                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
+                        return syn::Error::new_spanned(path, msg).to_compile_error().into();
+                    }
+                }
+            }
+        }
+
+        let result = match runtime {
+            Runtime::Threaded => quote! {
+                #[test]
+                #(#attrs)*
+                #vis fn #name() #ret {
+                    tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
+                }
+            },
+            Runtime::Basic | Runtime::Auto => quote! {
+                #[test]
+                #(#attrs)*
+                #vis fn #name() #ret {
+                    tokio::runtime::Builder::new()
+                        .basic_scheduler()
+                        .enable_all()
+                        .build()
+                        .unwrap()
+                        .block_on(async { #body })
+                }
+            },
+        };
+
+        result.into()
+    }
 }

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.8 (January 8, 2019)
+
+### Fixes
+- depend on new version of `tokio-macros`.
+
 # 0.2.7 (January 7, 2019)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.7"
+version = "0.2.8"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.7/tokio/"
+documentation = "https://docs.rs/tokio/0.2.8/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -92,7 +92,7 @@ uds = ["io-driver", "mio-uds", "libc"]
 
 
 [dependencies]
-tokio-macros = { version = "0.2.2", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "0.2.3", path = "../tokio-macros", optional = true }
 
 bytes = "0.5.0"
 pin-project-lite = "0.1.1"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.7")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.8")]
 #![allow(clippy::cognitive_complexity, clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
Brings back old macro implementations and updates the version of
tokio-macros that tokio depends on.