### PR TITLE
docs: fix typo and issue reference

### DIFF
--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -294,9 +294,10 @@ impl Driver {
     /// Drain all data in the global receiver, ensuring we'll get woken up when
     /// there is a write on the other end.
     ///
-    /// We do *NOT* use the existence of any read bytes as evidence a sigal was
+    /// We do *NOT* use the existence of any read bytes as evidence a signal was
     /// received since the `pending` flags would have already been set if that
-    /// was the case. See #38 for more info.
+    /// was the case. See https://github.com/alexcrichton/tokio-signal/issues/38
+    /// for more info.
     fn drain(&mut self, cx: &mut Context<'_>) {
         loop {
             match Pin::new(&mut self.wakeup).poll_read(cx, &mut [0; 128]) {

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -296,8 +296,9 @@ impl Driver {
     ///
     /// We do *NOT* use the existence of any read bytes as evidence a signal was
     /// received since the `pending` flags would have already been set if that
-    /// was the case. See https://github.com/alexcrichton/tokio-signal/issues/38
-    /// for more info.
+    /// was the case. See
+    /// [#38](https://github.com/alexcrichton/tokio-signal/issues/38) for more
+    /// info.
     fn drain(&mut self, cx: &mut Context<'_>) {
         loop {
             match Pin::new(&mut self.wakeup).poll_read(cx, &mut [0; 128]) {


### PR DESCRIPTION
## Motivation

Minor errors in document

## Solution

This PR fixes a typo and a reference to the archived repository.
