### PR TITLE
sync: Implement From<T> and Default where T: Default for RwLock

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -254,3 +254,18 @@ impl<T> ops::DerefMut for RwLockWriteGuard<'_, T> {
         unsafe { &mut *self.lock.c.get() }
     }
 }
+
+impl<T> From<T> for RwLock<T> {
+    fn from(s: T) -> Self {
+        Self::new(s)
+    }
+}
+
+impl<T> Default for RwLock<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}


### PR DESCRIPTION
# Motivation

Having these two convenience traits implemented for RwLock like they are for Mutex is useful.
