### PR TITLE
Add deprecation notices for outdated crates (#2036)

### DIFF
--- a/tokio-codec/README.md
+++ b/tokio-codec/README.md
@@ -2,6 +2,12 @@
 
 Utilities for encoding and decoding frames.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio_util::codec`] of the [`tokio-utils` crate] behind the `codec` feature flag.
+
+[`tokio::codec`]: https://docs.rs/tokio-util/latest/tokio_util/codec/index.html
+[`tokio-utils` crate]: https://docs.rs/tokio-util/latest/tokio_util
+
 [Documentation](https://docs.rs/tokio-codec)
 
 ## Usage

--- a/tokio-executor/README.md
+++ b/tokio-executor/README.md
@@ -2,6 +2,12 @@
 
 Task execution related traits and utilities.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
+into various places in the [`tokio::runtime`] module of the [`tokio`] crate.
+
+[`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+[`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+
 [Documentation](https://docs.rs/tokio-executor/0.1.9/tokio_executor)
 
 ## Overview

--- a/tokio-fs/README.md
+++ b/tokio-fs/README.md
@@ -2,6 +2,12 @@
 
 Asynchronous filesystem manipulation operations (and stdin, stdout, stderr).
 
+This crate has been **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::fs`] behind the `fs` [feature flag].
+
+[`tokio::fs`]: https://docs.rs/tokio/latest/tokio/fs/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-fs/0.1.6/tokio_fs)
 
 ## Overview

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -4,11 +4,12 @@ Event loop that drives Tokio I/O resources.
 
 This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
 into various places in the [`tokio::runtime`] and [`tokio::io`] modules of the
-[`tokio`] crate.
+[`tokio`] crate. The Reactor has also been renamed the "I/O Driver".
 
 [`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
 [`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+[`io-driver` feature]: https://docs.rs/tokio/0.2.9/tokio/index.html#feature-flags
 
 [Documentation](https://docs.rs/tokio-reactor/0.1.11/tokio_reactor)
 

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -2,6 +2,14 @@
 
 Event loop that drives Tokio I/O resources.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
+into various places in the [`tokio::runtime`] and [`tokio::io`] modules of the
+[`tokio`] crate.
+
+[`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+[`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
+[`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+
 [Documentation](https://docs.rs/tokio-reactor/0.1.11/tokio_reactor)
 
 ## Overview

--- a/tokio-signal/README.md
+++ b/tokio-signal/README.md
@@ -2,6 +2,12 @@
 
 Unix signal handling for Tokio.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::signal`] behind the `signal` [feature flag].
+
+[`tokio::signal`]: https://docs.rs/tokio/latest/tokio/signal/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-signal/0.2.8/tokio_signal)
 
 ## Usage

--- a/tokio-sync/README.md
+++ b/tokio-sync/README.md
@@ -2,6 +2,12 @@
 
 Synchronization utilities
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::sync`] behind the `sync` [feature flag].
+
+[`tokio::sync`]: https://docs.rs/tokio/latest/tokio/sync/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-sync/0.1.6/tokio_sync/)
 
 ## Overview

--- a/tokio-tcp/README.md
+++ b/tokio-tcp/README.md
@@ -2,6 +2,12 @@
 
 TCP bindings for `tokio`.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::tcp`] behind the `tcp` [feature flag].
+
+[`tokio::tcp`]: https://docs.rs/tokio/latest/tokio/tcp/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-tcp/0.1.3/tokio_tcp)
 
 ## License

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,6 +3,16 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
+into various places in the [`tokio::runtime`] module of the [`tokio`] crate.
+Note that there is no longer a `ThreadPool` type, you are instead encouraged to
+make use of the thread pool used by a `Runtime` configured to use the
+[threaded scheduler].
+
+[`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+[`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+[threaded scheduler]: https://docs.rs/tokio/latest/tokio/runtime/index.html#threaded-scheduler
+
 [Documentation](https://docs.rs/tokio-threadpool/0.1.17/tokio_threadpool)
 
 ### Why not Rayon?

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,6 +2,12 @@
 
 Timer facilities for Tokio
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::time`] behind the `time` [feature flag].
+
+[`tokio::time`]: https://docs.rs/tokio/latest/tokio/time/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-timer/0.2.12/tokio_timer/)
 
 ## Overview

--- a/tokio-udp/README.md
+++ b/tokio-udp/README.md
@@ -2,6 +2,12 @@
 
 UDP bindings for `tokio`.
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::udp`] behind the `udp` [feature flag].
+
+[`tokio::udp`]: https://docs.rs/tokio/latest/tokio/udp/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-udp/0.1.5/tokio_udp/)
 
 ## License

--- a/tokio-uds/README.md
+++ b/tokio-uds/README.md
@@ -2,6 +2,12 @@
 
 An implementation of Unix Domain Sockets for Tokio
 
+This crate is **deprecated in tokio 0.2.x** and has been moved into
+[`tokio::uds`] behind the `uds` [feature flag].
+
+[`tokio::uds`]: https://docs.rs/tokio-util/latest/tokio/uds/index.html
+[feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-uds/0.2.5/tokio_uds/)
 
 ## License


### PR DESCRIPTION
Add deprecation notices to `0.1.x` crates who's functionality is now owned by the main `tokio` crate.