### PR TITLE
More deprecation notices (relates #2036)

### DIFF
--- a/tokio-buf/README.md
+++ b/tokio-buf/README.md
@@ -2,6 +2,8 @@
 
 Asynchronous stream of byte buffers
 
+> **Note:** This crate has been **deprecated in tokio 0.2.x**.
+
 [Documenation](https://docs.rs/tokio-buf)
 
 ## Usage

--- a/tokio-buf/src/lib.rs
+++ b/tokio-buf/src/lib.rs
@@ -3,6 +3,8 @@
 
 //! Asynchronous stream of bytes.
 //!
+//! > **Note:** This crate has been **deprecated in tokio 0.2.x**.
+//!
 //! This crate contains the `BufStream` trait and a number of combinators for
 //! this trait. The trait is similar to `Stream` in the `futures` library, but
 //! instead of yielding arbitrary values, it only yields types that implement

--- a/tokio-codec/README.md
+++ b/tokio-codec/README.md
@@ -2,11 +2,12 @@
 
 Utilities for encoding and decoding frames.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio_util::codec`] of the [`tokio-utils` crate] behind the `codec` feature flag.
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio_util::codec`] of the [`tokio-util` crate] behind the `codec` feature
+> flag.
 
-[`tokio::codec`]: https://docs.rs/tokio-util/latest/tokio_util/codec/index.html
-[`tokio-utils` crate]: https://docs.rs/tokio-util/latest/tokio_util
+[`tokio_util::codec`]: https://docs.rs/tokio-util/latest/tokio_util/codec/index.html
+[`tokio-util` crate]: https://docs.rs/tokio-util/latest/tokio_util
 
 [Documentation](https://docs.rs/tokio-codec)
 

--- a/tokio-codec/src/lib.rs
+++ b/tokio-codec/src/lib.rs
@@ -3,6 +3,13 @@
 
 //! Utilities for encoding and decoding frames.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! into [`tokio_util::codec`] of the [`tokio-util` crate] behind the `codec`
+//! feature flag.
+//!
+//! [`tokio_util::codec`]: https://docs.rs/tokio-util/latest/tokio_util/codec/index.html
+//! [`tokio-util` crate]: https://docs.rs/tokio-util/latest/tokio_util
+//!
 //! Contains adapters to go from streams of bytes, [`AsyncRead`] and
 //! [`AsyncWrite`], to framed streams implementing [`Sink`] and [`Stream`].
 //! Framed streams are also known as [transports].

--- a/tokio-current-thread/README.md
+++ b/tokio-current-thread/README.md
@@ -2,6 +2,15 @@
 
 Single threaded executor for Tokio.
 
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved and
+> refactored into various places in the [`tokio`] crate. The closest replacement
+> is to make use of [`tokio::task::LocalSet::block_on`] which requires the
+> [`rt-util` feature].
+
+[`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+[`tokio::task::LocalSet::block_on`]: https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html#method.block_on
+[`rt-util` feature]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+
 [Documentation](https://docs.rs/tokio-current-thread/0.1.6/tokio_current_thread/)
 
 ## Overview

--- a/tokio-current-thread/src/lib.rs
+++ b/tokio-current-thread/src/lib.rs
@@ -4,6 +4,14 @@
 //! A single-threaded executor which executes tasks on the same thread from which
 //! they are spawned.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > and refactored into various places in the [`tokio`] crate. The closest
+//! replacement is to make use of [`tokio::task::LocalSet::block_on`] which
+//! requires the [`rt-util` feature].
+//!
+//! [`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+//! [`tokio::task::LocalSet::block_on`]: https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html#method.block_on
+//! [`rt-util` feature]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 //!
 //! The crate provides:
 //!

--- a/tokio-io/README.md
+++ b/tokio-io/README.md
@@ -4,6 +4,11 @@ Core I/O abstractions for the Tokio stack.
 
 [![Build Status](https://travis-ci.org/tokio-rs/tokio-io.svg?branch=master)](https://travis-ci.org/tokio-rs/tokio-io)
 
+> **Note:** This crate has been **deprecated in tokio 0.2.x** and has been moved
+> into [`tokio::io`].
+
+[`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
+
 [Documentation](https://docs.rs/tokio-io/0.1.12/tokio_io)
 
 ## Usage

--- a/tokio-io/src/lib.rs
+++ b/tokio-io/src/lib.rs
@@ -3,6 +3,11 @@
 
 //! Core I/O traits and combinators when working with Tokio.
 //!
+//! > **Note:** This crate has been **deprecated in tokio 0.2.x** and has been
+//! > moved into [`tokio::io`].
+//!
+//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
+//!
 //! A description of the high-level I/O combinators can be [found online] in
 //! addition to a description of the [low level details].
 //!

--- a/tokio-reactor/README.md
+++ b/tokio-reactor/README.md
@@ -2,9 +2,10 @@
 
 Event loop that drives Tokio I/O resources.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
-into various places in the [`tokio::runtime`] and [`tokio::io`] modules of the
-[`tokio`] crate. The Reactor has also been renamed the "I/O Driver".
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved and
+> refactored into various places in the [`tokio::runtime`] and [`tokio::io`]
+> modules of the [`tokio`] crate. The Reactor has also been renamed the
+> "I/O Driver".
 
 [`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html

--- a/tokio-reactor/src/lib.rs
+++ b/tokio-reactor/src/lib.rs
@@ -3,6 +3,16 @@
 
 //! Event loop that drives Tokio I/O resources.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > and refactored into various places in the [`tokio::runtime`] and
+//! > [`tokio::io`] modules of the [`tokio`] crate. The Reactor has also been
+//! > renamed the "I/O Driver".
+//!
+//! [`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
+//! [`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+//! [`io-driver` feature]: https://docs.rs/tokio/0.2.9/tokio/index.html#feature-flags
+//!
 //! The reactor is the engine that drives asynchronous I/O resources (like TCP and
 //! UDP sockets). It is backed by [`mio`] and acts as a bridge between [`mio`] and
 //! [`futures`].

--- a/tokio-signal/README.md
+++ b/tokio-signal/README.md
@@ -2,8 +2,8 @@
 
 Unix signal handling for Tokio.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::signal`] behind the `signal` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::signal`] behind the `signal` [feature flag].
 
 [`tokio::signal`]: https://docs.rs/tokio/latest/tokio/signal/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-signal/src/lib.rs
+++ b/tokio-signal/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! Asynchronous signal handling for Tokio
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into [`tokio::signal`] behind the `signal` [feature flag].
+//!
+//! [`tokio::signal`]: https://docs.rs/tokio/latest/tokio/signal/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This crate implements asynchronous signal handling for Tokio, an
 //! asynchronous I/O framework in Rust. The primary type exported from this
 //! crate, `unix::Signal`, allows listening for arbitrary signals on Unix

--- a/tokio-sync/README.md
+++ b/tokio-sync/README.md
@@ -2,8 +2,8 @@
 
 Synchronization utilities
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::sync`] behind the `sync` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::sync`] behind the `sync` [feature flag].
 
 [`tokio::sync`]: https://docs.rs/tokio/latest/tokio/sync/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-sync/src/lib.rs
+++ b/tokio-sync/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! Asynchronous synchronization primitives.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+//! > [`tokio::sync`] behind the `sync` [feature flag].
+//!
+//! [`tokio::sync`]: https://docs.rs/tokio/latest/tokio/sync/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This crate provides primitives for synchronizing asynchronous tasks.
 
 extern crate fnv;

--- a/tokio-tcp/README.md
+++ b/tokio-tcp/README.md
@@ -2,8 +2,8 @@
 
 TCP bindings for `tokio`.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::tcp`] behind the `tcp` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::tcp`] behind the `tcp` [feature flag].
 
 [`tokio::tcp`]: https://docs.rs/tokio/latest/tokio/tcp/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! TCP bindings for `tokio`.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into [`tokio::tcp`] behind the `tcp` [feature flag].
+//!
+//! [`tokio::tcp`]: https://docs.rs/tokio/latest/tokio/tcp/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This module contains the TCP networking types, similar to the standard
 //! library, which can be used to implement networking protocols.
 //!

--- a/tokio-threadpool/README.md
+++ b/tokio-threadpool/README.md
@@ -3,11 +3,11 @@
 A library for scheduling execution of futures concurrently across a pool of
 threads.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved and refactored
-into various places in the [`tokio::runtime`] module of the [`tokio`] crate.
-Note that there is no longer a `ThreadPool` type, you are instead encouraged to
-make use of the thread pool used by a `Runtime` configured to use the
-[threaded scheduler].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved and
+> refactored into various places in the [`tokio::runtime`] module of the
+> [`tokio`] crate. Note that there is no longer a `ThreadPool` type, you are
+> instead encouraged to make use of the thread pool used by a `Runtime`
+> configured to use the [threaded scheduler].
 
 [`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
 [`tokio`]: https://docs.rs/tokio/latest/tokio/index.html

--- a/tokio-threadpool/src/lib.rs
+++ b/tokio-threadpool/src/lib.rs
@@ -3,6 +3,16 @@
 
 //! A work-stealing based thread pool for executing futures.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > and refactored into various places in the [`tokio::runtime`] module of the
+//! > [`tokio`] crate. Note that there is no longer a `ThreadPool` type, you are
+//! > instead encouraged to make use of the thread pool used by a `Runtime`
+//! > configured to use the [threaded scheduler].
+//!
+//! [`tokio::runtime`]: https://docs.rs/tokio/latest/tokio/runtime/index.html
+//! [`tokio`]: https://docs.rs/tokio/latest/tokio/index.html
+//! [threaded scheduler]: https://docs.rs/tokio/latest/tokio/runtime/index.html#threaded-scheduler
+//!
 //! The Tokio thread pool supports scheduling futures and processing them on
 //! multiple CPU cores. It is optimized for the primary Tokio use case of many
 //! independent tasks with limited computation and with most tasks waiting on

--- a/tokio-timer/README.md
+++ b/tokio-timer/README.md
@@ -2,8 +2,8 @@
 
 Timer facilities for Tokio
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::time`] behind the `time` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::time`] behind the `time` [feature flag].
 
 [`tokio::time`]: https://docs.rs/tokio/latest/tokio/time/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-timer/src/lib.rs
+++ b/tokio-timer/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! Utilities for tracking time.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into [`tokio::time`] behind the `time` [feature flag].
+//!
+//! [`tokio::time`]: https://docs.rs/tokio/latest/tokio/time/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This crate provides a number of utilities for working with periods of time:
 //!
 //! * [`Delay`]: A future that completes at a specified instant in time.

--- a/tokio-udp/README.md
+++ b/tokio-udp/README.md
@@ -2,8 +2,8 @@
 
 UDP bindings for `tokio`.
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::udp`] behind the `udp` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::udp`] behind the `udp` [feature flag].
 
 [`tokio::udp`]: https://docs.rs/tokio/latest/tokio/udp/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -3,6 +3,12 @@
 
 //! UDP bindings for `tokio`.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into[`tokio::udp`] behind the `udp` [feature flag].
+//!
+//! [`tokio::udp`]: https://docs.rs/tokio/latest/tokio/udp/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This module contains the UDP networking types, similar to the standard
 //! library, which can be used to implement networking protocols.
 //!

--- a/tokio-uds/README.md
+++ b/tokio-uds/README.md
@@ -2,8 +2,8 @@
 
 An implementation of Unix Domain Sockets for Tokio
 
-This crate is **deprecated in tokio 0.2.x** and has been moved into
-[`tokio::uds`] behind the `uds` [feature flag].
+> **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
+> [`tokio::uds`] behind the `uds` [feature flag].
 
 [`tokio::uds`]: https://docs.rs/tokio-util/latest/tokio/uds/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -4,6 +4,12 @@
 
 //! Unix Domain Sockets for Tokio.
 //!
+//! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
+//! > into [`tokio::uds`] behind the `uds` [feature flag].
+//!
+//! [`tokio::uds`]: https://docs.rs/tokio-util/latest/tokio/uds/index.html
+//! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
+//!
 //! This crate provides APIs for using Unix Domain Sockets with Tokio.
 
 extern crate bytes;


### PR DESCRIPTION
`tokio-buf` and `tokio-current-thread` appear to have straight up been deprecated. It would be nice to add a notice on what to use instead for current thread (`futures::executor::block_on` is an alternative), but I'm not sure what to do.

Using the basic scheduler works, but is somewhat awkard:
```rust
let mut rt = tokio::runtime::Builder::new().basic_scheduler().enable_all().build()?;
let set = tokio::task::LocalSet::new();
let result = set.block_on(&mut rt, /* future */);
```