### PR TITLE
v0.1.x: ci: test `tokio-process`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "tokio-fs",
   "tokio-futures",
   "tokio-io",
+  "tokio-process",
   "tokio-reactor",
   "tokio-signal",
   "tokio-sync",

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
     cross: true
     crates:
       - tokio-fs
+      - tokio-process
       - tokio-reactor
       - tokio-signal
       - tokio-tcp

--- a/tokio-process/src/windows.rs
+++ b/tokio-process/src/windows.rs
@@ -35,10 +35,10 @@ use self::winapi::um::threadpoollegacyapiset::*;
 use self::winapi::um::winbase::*;
 use self::winapi::um::winnt::*;
 use super::SpawnedChild;
+use crate::kill::Kill;
 use futures::future::Fuse;
 use futures::sync::oneshot;
 use futures::{Async, Future, Poll};
-use kill::Kill;
 use tokio_reactor::{Handle, PollEvented};
 
 #[must_use = "futures do nothing unless polled"]


### PR DESCRIPTION
## Motivation

The `v0.1.x` branch doesn't have it's CI configured to build and test the `tokio-process` crate.

## Solution

Add `tokio-process` to the list of crates to build
