### PR TITLE
docs: fix link to website

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -40,7 +40,7 @@
 //! [signal]: crate::signal
 //! [fs]: crate::fs
 //! [runtime]: crate::runtime
-//! [website]: https://tokio.rs/docs/
+//! [website]: https://tokio.rs/docs/overview/
 //!
 //! # A Tour of Tokio
 //!


### PR DESCRIPTION
Replace website link in tokio documentation 

## Motivation

Previous website link in documentation was broken

## Solution

Replacement of link 