### PR TITLE
io: Drop AsyncBufRead bound on BufStream impl (fixes #2064, #2106)

### DIFF
--- a/tokio/src/io/util/buf_stream.rs
+++ b/tokio/src/io/util/buf_stream.rs
@@ -131,7 +131,7 @@ impl<RW: AsyncRead + AsyncWrite> AsyncRead for BufStream<RW> {
     }
 }
 
-impl<RW: AsyncBufRead + AsyncRead + AsyncWrite> AsyncBufRead for BufStream<RW> {
+impl<RW: AsyncRead + AsyncWrite> AsyncBufRead for BufStream<RW> {
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         self.project().inner.poll_fill_buf(cx)
     }


### PR DESCRIPTION
This is a bad bound, as per #2064 and #2106.

Relaxing this bound might in theory have unintended side effects that would warrant a major release (like in certain blanket impls), but since this makes `BufStream` practically unusable that might not matter.