### PR TITLE
runtime: add Handle::try_current

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -61,6 +61,15 @@ impl Handle {
     pub fn current() -> Self {
         context::current().expect("not currently running on the Tokio runtime.")
     }
+
+    /// Returns a Handle view over the currently running Runtime
+    ///
+    /// Returns `None` if no Runtime has been started
+    ///
+    /// Contrary to `current`, this never panics
+    pub fn try_current() -> Option<Self> {
+        context::current()
+    }
 }
 
 cfg_rt_core! {

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -208,7 +208,7 @@ pub(crate) mod enter;
 use self::enter::enter;
 
 mod handle;
-pub use self::handle::Handle;
+pub use self::handle::{Handle, TryCurrentError};
 
 mod io;
 


### PR DESCRIPTION
## Motivation

There is currently no way to conditonnally determine whether `tokio::spawn` will succeed.
Since this is a niche situation, I went for putting a method on the lower-level component.
