### PR TITLE
chore: minor fixes

### DIFF
--- a/ci/azure-clippy.yml
+++ b/ci/azure-clippy.yml
@@ -12,5 +12,5 @@ jobs:
         cargo clippy --version
       displayName: Install clippy
     - script: |
-        cargo clippy --all --all-features -- -A clippy::mutex-atomic -A clippy::needless-doctest-main
+        cargo clippy --all --all-features
       displayName: cargo clippy --all

--- a/tokio/src/stream/collect.rs
+++ b/tokio/src/stream/collect.rs
@@ -9,7 +9,7 @@ use pin_project_lite::pin_project;
 
 // Do not export this struct until `FromStream` can be unsealed.
 pin_project! {
-    /// Stream returned by the [`collect`](super::StreamExt::collect) method.
+    /// Future returned by the [`collect`](super::StreamExt::collect) method.
     #[must_use = "streams do nothing unless polled"]
     #[derive(Debug)]
     pub struct Collect<T, U>

--- a/tokio/tests/stream_collect.rs
+++ b/tokio/tests/stream_collect.rs
@@ -4,6 +4,7 @@ use tokio_test::{assert_pending, assert_ready, assert_ready_err, assert_ready_ok
 
 use bytes::{Bytes, BytesMut};
 
+#[allow(clippy::let_unit_value)]
 #[tokio::test]
 async fn empty_unit() {
     // Drains the stream.


### PR DESCRIPTION
A follow up to #2110. I don't know why but this lint only popped up in VS code after the last PR got merged.

I also dropped the special instructions from Azure pipeline definitions since we use targeted whitelisting anyway.