### PR TITLE
io: add `BufStream::with_capacity`

### DIFF
--- a/tokio/src/io/util/buf_stream.rs
+++ b/tokio/src/io/util/buf_stream.rs
@@ -33,6 +33,23 @@ impl<RW: AsyncRead + AsyncWrite> BufStream<RW> {
         }
     }
 
+    /// Creates a `BufStream` with the specified [`BufReader`] capacity and [`BufWriter`]
+    /// capacity.
+    ///
+    /// See the documentation for those types and [`BufStream`] for details.
+    pub fn with_capacity(
+        reader_capacity: usize,
+        writer_capacity: usize,
+        stream: RW,
+    ) -> BufStream<RW> {
+        BufStream {
+            inner: BufReader::with_capacity(
+                reader_capacity,
+                BufWriter::with_capacity(writer_capacity, stream),
+            ),
+        }
+    }
+
     /// Gets a reference to the underlying I/O object.
     ///
     /// It is inadvisable to directly read from the underlying I/O object.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Currently it's not possible to configure the buffer size when creating a `BufStream`.
I'm using `BufStream` to wrap a `TcpStream` and having to`tokio::io::split` it and pass each half to `BufReader::with_capacity` and `BufWriter::with_capacity` seems sub-optimal.

## Solution

This PR adds a `BufStream::with_capacity` method that takes as input both the capacity of the read buffer and the capacity of the write buffer.
Not sure if this is the best API, but it seemed more flexible than having a single capacity as input.
