### PR TITLE
Yield now docs

### DIFF
--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -122,6 +122,8 @@
 //! Instead, Tokio provides two APIs for running blocking operations in an
 //! asynchronous context: [`task::spawn_blocking`] and [`task::block_in_place`].
 //!
+//! #### spawn_blocking
+//!
 //! The `task::spawn_blocking` function is similar to the `task::spawn` function
 //! discussed in the previous section, but rather than spawning an
 //! _non-blocking_ future on the Tokio runtime, it instead spawns a
@@ -155,6 +157,8 @@
 //! # }
 //! ```
 //!
+//! #### block_in_place
+//!
 //! When using the [threaded runtime][rt-threaded], the [`task::block_in_place`]
 //! function is also available. Like `task::spawn_blocking`, this function
 //! allows running a blocking operation from an asynchronous context. Unlike
@@ -178,11 +182,14 @@
 //! # }
 //! ```
 //!
-//! In addition, this module also provides a [`task::yield_now`] async function
-//! that is analogous to the standard library's [`thread::yield_now`]. Calling and
-//! `await`ing this function will cause the current task to yield to the Tokio
-//! runtime's scheduler, allowing another task to be scheduled. Eventually, the
-//! yielding task will be polled again, allowing it to execute. For example:
+//! #### yield_now
+//!
+//! In addition, this module provides a [`task::yield_now`] async function
+//! that is analogous to the standard library's [`thread::yield_now`]. Calling
+//! and `await`ing this function will cause the current task to yield to the
+//! Tokio runtime's scheduler, allowing other tasks to be
+//! scheduled. Eventually, the yielding task will be polled again, allowing it
+//! to execute. For example:
 //!
 //! ```rust
 //! use tokio::task;

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -13,6 +13,7 @@ doc_rt_core! {
     /// the task to continue.
     ///
     /// See also the usage example in the [task module](index.html#yield_now).
+    #[must_use = "yield_now does nothing unless polled/`await`-ed"]
     pub async fn yield_now() {
         /// Yield implementation
         struct YieldNow {

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -3,7 +3,16 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 doc_rt_core! {
-    /// Yield execution back to the Tokio runtime.
+    /// Return a `Future` that can be `await`-ed to yield execution back to the
+    /// Tokio runtime.
+    ///
+    /// A task yields by awaiting the returned `Future`, and may resume when
+    /// that future completes (with no output.) The current task will be
+    /// re-added as a pending task at the _back_ of the pending queue. Any
+    /// other pending tasks will be scheduled. No other waking is required for
+    /// the task to continue.
+    ///
+    /// See also the usage example in the [task module](index.html#yield_now).
     pub async fn yield_now() {
         /// Yield implementation
         struct YieldNow {


### PR DESCRIPTION
# Motivation

Based on a [URLO thread](https://users.rust-lang.org/t/blocking-permit/36865/7) and discord conversation with @hawkw and @Matthias247, I learned a great deal about what `tokio::task::yield_now` does, noticing that the rustdoc for that method can be improved.

## Solution

rustdoc-o
