### PR TITLE
sync: derive PartialEq for error enums

### DIFF
--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -69,7 +69,7 @@ impl Error for RecvError {}
 
 /// This enumeration is the list of the possible reasons that try_recv
 /// could not return data when called.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum TryRecvError {
     /// This channel is currently empty, but the Sender(s) have not yet
     /// disconnected, so data may yet become available.

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -40,7 +40,7 @@ pub mod error {
     pub struct RecvError(pub(super) ());
 
     /// Error returned by the `try_recv` function on `Receiver`.
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub enum TryRecvError {
         /// The send half of the channel has not yet sent a value.
         Empty,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Similar to [`tokio::sync::broadcast::TryRecvError`](https://github.com/tokio-rs/tokio/blob/1475448bdfa5f0bed35abb6e3d5620a22cc27f53/tokio/src/sync/broadcast.rs#L229-L230), it will be useful if we derive `PartialEq` for other non-parametrized error types.

This PR will allow us to check inequality of `try_recv` results like below:

```rust
let (_tx, mut rx) = mpsc::channel::<()>(1);
if rx.try_recv() != Err(mpsc::error::TryRecvError::Closed) {
...
}
```

## Solution

just derive `PartialEq` for `mpsc::error::TryRecvError` and `oneshot::TryRecvError`.
