### PR TITLE
Add more missing must_use attributes to async fn's

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -304,6 +304,7 @@ impl<T> Sender<T> {
     ///     let _ = time::timeout(Duration::from_secs(10), rx).await;
     /// }
     /// ```
+    #[must_use = "Sender::closed does nothing unless polled/`await`-ed"]
     pub async fn closed(&mut self) {
         use crate::future::poll_fn;
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -348,6 +348,7 @@ impl<T> Sender<T> {
     ///
     /// This allows the producer to get notified when interest in the produced
     /// values is canceled and immediately stop doing work.
+    #[must_use = "Sender::closed does nothing unless polled/`await`-ed"]
     pub async fn closed(&mut self) {
         poll_fn(|cx| self.poll_close(cx)).await
     }

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -101,6 +101,7 @@ cfg_test_util! {
     ///
     /// Panics if time is not frozen or if called from outside of the Tokio
     /// runtime.
+    #[must_use = "advance does nothing unless polled/`await`-ed"]
     pub async fn advance(duration: Duration) {
         let clock = context::clock().expect("time cannot be frozen from outside the Tokio runtime");
         clock.advance(duration);


### PR DESCRIPTION
## Motivation

At @hawkw 's suggestion (in #2129) , I found more missing `must_use` attributes for async fn(s) with no return declared, meaning it returns `Future<Output=()>`.

## Solution

Added `#[must_use]` to these (3 fns).