### PR TITLE
fix: improves panic messages when there is no reactor/timer

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -198,7 +198,8 @@ impl Handle {
     ///
     /// This function panics if there is no current reactor set.
     pub(super) fn current() -> Self {
-        context::io_handle().expect("no current reactor")
+        context::io_handle()
+            .expect("there is no reactor running, must be called from the context of Tokio runtime")
     }
 
     /// Forces a reactor blocked in a call to `turn` to wakeup, or otherwise

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -21,7 +21,8 @@ impl Handle {
     ///
     /// This function panics if there is no current timer set.
     pub(crate) fn current() -> Self {
-        context::time_handle().expect("no current timer")
+        context::time_handle()
+            .expect("there is no timer running, must be called from the context of Tokio runtime")
     }
 
     /// Try to return a strong ref to the inner

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -64,7 +64,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Kind::*;
         let descr = match self.0 {
-            Shutdown => "timer is shutdown",
+            Shutdown => "the timer is shutdown, must be called from the context of Tokio runtime",
             AtCapacity => "timer is at capacity and cannot create a new entry",
         };
         write!(fmt, "{}", descr)

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -1,0 +1,27 @@
+use tokio::net::TcpStream;
+use tokio::sync::oneshot;
+use tokio::time::{timeout, Duration};
+
+use futures::executor::block_on;
+
+use std::net::TcpListener;
+
+#[test]
+#[should_panic(expected = "no timer running")]
+fn panics_when_no_timer() {
+    block_on(timeout_value());
+}
+
+#[test]
+#[should_panic(expected = "no reactor running")]
+fn panics_when_no_reactor() {
+    let srv = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = srv.local_addr().unwrap();
+    block_on(TcpStream::connect(&addr)).unwrap();
+}
+
+async fn timeout_value() {
+    let (_tx, rx) = oneshot::channel::<()>();
+    let dur = Duration::from_millis(20);
+    let _ = timeout(dur, rx).await;
+}


### PR DESCRIPTION
This PR replaces #1789

I want to preface this by saying I'm not entirely sure if these error messages are exactly accurate but I wanted to take a crack at it. 

---

## Motivation

Providing a more actionable error message when tokio expects to be within a runtime. Fixes #1713 

## Solution

New error messages:

When there is no timer:

```
the timer is shutdown, this code must be executed from within a tokio runtime
```

When there is no reactor:

```
there is no reactor running, this code must be executed from within a tokio runtime
```

---

I'm not in love with the "this code must be executed from within a tokio runtime", not sure what the best wording there is, would love some pointers :) I'm also not sure if it's entirely accurate to say "tokio runtime" as perhaps some other runtime could be used instead.

