### PR TITLE
chore: only depend on loom when not windows

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -124,9 +124,12 @@ optional = true
 [dev-dependencies]
 tokio-test = { version = "0.2.0" }
 futures = { version = "0.3.0", features = ["async-await"] }
-loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 proptest = "0.9.4"
 tempfile = "3.1.0"
+
+# loom is currently not compiling on windows.
+[target.'cfg(not(windows))'.dev-dependencies]
+loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -128,6 +128,7 @@ proptest = "0.9.4"
 tempfile = "3.1.0"
 
 # loom is currently not compiling on windows.
+# See: https://github.com/Xudong-Huang/generator-rs/issues/19
 [target.'cfg(not(windows))'.dev-dependencies]
 loom = { version = "0.2.13", features = ["futures", "checkpoint"] }
 


### PR DESCRIPTION
It looks like the `generator` crate is not compiling on windows. This crate
is only used as part of `loom`. For now, restrict `loom` to non-windows
platforms.