### PR TITLE
Enhance documentation of tokio::task::block_in_place

### DIFF
--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -26,7 +26,9 @@ cfg_blocking! {
         ON_BLOCK.with(|ob| {
             let allow_blocking = ob
                 .get()
-                .expect("can only call blocking when on Tokio runtime");
+                // `block_in_place` can only be called from a spawned task when
+                // working with the threaded scheduler.
+                .expect("can call blocking only when running in a spawned task");
 
             // This is safe, because ON_BLOCK was set from an &mut dyn FnMut in the worker that wraps
             // the worker's operation, and is unset just prior to when the FnMut is dropped.

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -10,6 +10,12 @@ cfg_rt_threaded! {
     /// (possibly new) thread, and only then poll the task. Note that this requires
     /// additional synchronization.
     ///
+    /// # Note
+    ///
+    /// This function can only be called from a spawned task when working with
+    /// the [threaded scheduler](https://docs.rs/tokio/0.2.10/tokio/runtime/index.html#threaded-scheduler).
+    /// Consider using [tokio::task::spawn_blocking](https://docs.rs/tokio/0.2.10/tokio/task/fn.spawn_blocking.html).
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
This is a very small change to enhance the documentation of `tokio::task::block_in_place` with a Note, and also a change to the error message when the runtime panics because unable to run `tokio::task::block_in_place` from a not spawned task.

## Motivation

The previous error message was slightly misleading when stating that the error was due to being unable to call `tokio::task::block_in_place` because not running on the Tokio runtime.
