### PR TITLE
Don't export select unless macros is enabled

### DIFF
--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -13,8 +13,10 @@ mod loom;
 #[macro_use]
 mod ready;
 
-#[macro_use]
-mod select;
+cfg_macros! {
+    #[macro_use]
+    mod select;
+}
 
 #[macro_use]
 mod thread_local;


### PR DESCRIPTION
Noticed this when I was building something which only used `rt-core`. The select macro was available but failed to compile since it depends on things from `support`.

This prevents that issue by only exporting select in case `macros` are enabled.