### PR TITLE
parking_lot Mutex/Condvar via feature gate (take 2)

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -104,7 +104,7 @@ memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.20", optional = true }
 iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
-parking_lot = { version = "0.10.0", optional = true }
+parking_lot = { version = "0.10.0", optional = true } # Not in full
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [target.'cfg(unix)'.dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -90,7 +90,6 @@ time = ["slab"]
 udp = ["io-driver"]
 uds = ["io-driver", "mio-uds", "libc"]
 
-
 [dependencies]
 tokio-macros = { version = "0.2.3", path = "../tokio-macros", optional = true }
 
@@ -105,8 +104,8 @@ memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.20", optional = true }
 iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
-# Backs `DelayQueue`
-slab = { version = "0.4.1", optional = true }
+parking_lot = { version = "0.10.0", optional = true }
+slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [target.'cfg(unix)'.dependencies]
 mio-uds = { version = "0.6.5", optional = true }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -66,13 +66,13 @@
 //! is possible to just enable certain features over others. By default, Tokio
 //! does not enable any features but allows one to enable a subset for their use
 //! case. Below is a list of the available feature flags. You may also notice
-//! above each function, struct and trait there is a set of feature flags
-//! that are required for that item to be enabled. If you are new to Tokio it is
-//! recommended that you use the `full` feature flag which will enable everything.
+//! above each function, struct and trait there is listed one or more feature flags
+//! that are required for that item to be used. If you are new to Tokio it is
+//! recommended that you use the `full` feature flag which will enable all public APIs.
 //! Beware though that this will pull in many extra dependencies that you may not
 //! need.
 //!
-//! - `full`: Enables all Tokio features and every API will be available.
+//! - `full`: Enables all Tokio public API features listed below.
 //! - `rt-core`: Enables `tokio::spawn` and the basic (single-threaded) scheduler.
 //! - `rt-threaded`: Enables the heavier, multi-threaded, work-stealing scheduler.
 //! - `rt-util`: Enables non-scheduler utilities.
@@ -95,15 +95,25 @@
 //! - `test-util`: Enables testing based infrastructure for the Tokio runtime.
 //! - `blocking`: Enables `block_in_place` and `spawn_blocking`.
 //!
-//! _Note: `AsyncRead` and `AsyncWrite` do not require any features and are
-//! enabled by default._
+//! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are
+//! always available._
+//!
+//! ### Internal features
+//!
+//! These features do not expose any new API, but influence internal
+//! implementation aspects of Tokio, and can pull in additional
+//! dependencies. They are not included in `full`:
+//!
+//! - `parking_lot`: As a potential optimization, use the _parking_lot_ crate's
+//! synchronization primitives internally. MSRV may increase according to the
+//! _parking_lot_ release in use.
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //!
 //! ### Authoring applications
 //!
 //! Tokio is great for writing applications and most users in this case shouldn't
-//! worry to much about what features they should pick. If you're unsure, we suggest
+//! worry too much about what features they should pick. If you're unsure, we suggest
 //! going with `full` to ensure that you don't run into any road blocks while you're
 //! building your application.
 //!

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -38,7 +38,26 @@ pub(crate) mod rand {
 }
 
 pub(crate) mod sync {
-    pub(crate) use std::sync::*;
+    pub(crate) use std::sync::Arc;
+
+    #[cfg(feature = "parking_lot")]
+    mod pl_wrappers;
+
+    // Below, make sure all the feature-influenced types are exported for
+    // internal use. Note however that some are not _currently_ named by
+    // consuming code.
+
+    #[cfg(feature = "parking_lot")]
+    #[allow(unused_imports)]
+    pub(crate) use pl_wrappers::{Condvar, Mutex};
+
+    #[cfg(feature = "parking_lot")]
+    #[allow(unused_imports)]
+    pub(crate) use parking_lot::{MutexGuard, WaitTimeoutResult};
+
+    #[cfg(not(feature = "parking_lot"))]
+    #[allow(unused_imports)]
+    pub(crate) use std::sync::{Condvar, Mutex, MutexGuard, WaitTimeoutResult};
 
     pub(crate) mod atomic {
         pub(crate) use crate::loom::std::atomic_u32::AtomicU32;

--- a/tokio/src/loom/std/sync/pl_wrappers.rs
+++ b/tokio/src/loom/std/sync/pl_wrappers.rs
@@ -1,0 +1,83 @@
+use std::sync::{LockResult, TryLockResult, TryLockError};
+use std::time::Duration;
+
+use parking_lot as pl;
+
+/// Adapter for `parking_lot::Mutex` to the `std::sync::Mutex` interface.
+#[derive(Debug)]
+pub(crate) struct Mutex<T: ?Sized>(pl::Mutex<T>);
+
+impl<T> Mutex<T> {
+    #[inline]
+    pub(crate) fn new(t: T) -> Mutex<T> {
+        Mutex(pl::Mutex::new(t))
+    }
+
+    #[inline]
+    pub(crate) fn lock(&self) -> LockResult<pl::MutexGuard<'_, T>> {
+        Ok(self.0.lock())
+    }
+
+    #[inline]
+    pub(crate) fn try_lock(&self) -> TryLockResult<pl::MutexGuard<'_, T>> {
+        match self.0.try_lock() {
+            Some(guard) => Ok(guard),
+            None => Err(TryLockError::WouldBlock),
+        }
+    }
+
+    #[allow(unused)]
+    #[inline]
+    pub(crate) fn is_poisoned(&self) -> bool {
+        false
+    }
+
+    #[allow(unused)]
+    #[inline]
+    pub(crate) fn into_inner(self) -> LockResult<T> {
+        Ok(self.0.into_inner())
+    }
+}
+
+/// Adapter for `parking_lot::Condvar` to the `std::sync::Condvar` interface.
+#[derive(Debug)]
+pub(crate) struct Condvar(pl::Condvar);
+
+impl Condvar {
+    #[inline]
+    pub(crate) fn new() -> Condvar {
+        Condvar(pl::Condvar::new())
+    }
+
+    #[inline]
+    pub(crate) fn notify_one(&self) {
+        self.0.notify_one();
+    }
+
+    #[inline]
+    pub(crate) fn notify_all(&self) {
+        self.0.notify_all();
+    }
+
+    #[inline]
+    pub(crate) fn wait<'a, T>(&self, mut guard: pl::MutexGuard<'a, T>)
+        -> LockResult<pl::MutexGuard<'a, T>>
+    {
+        self.0.wait(&mut guard);
+        Ok(guard)
+    }
+
+    #[inline]
+    pub(crate) fn wait_timeout<'a, T>(
+        &self,
+        mut guard: pl::MutexGuard<'a, T>,
+        timeout: Duration)
+        -> LockResult<(pl::MutexGuard<'a, T>, pl::WaitTimeoutResult)>
+    {
+        let wtr = self.0.wait_for(&mut guard, timeout);
+        Ok((guard, wtr))
+    }
+
+    // Note: Additional methods `wait_timeout_ms`, `wait_timeout_until`,
+    // `wait_until` can be provided here as needed.
+}

--- a/tokio/src/loom/std/sync/pl_wrappers.rs
+++ b/tokio/src/loom/std/sync/pl_wrappers.rs
@@ -3,7 +3,7 @@
 //!
 //! This can be extended to additional types/methods as required.
 
-use std::sync::{LockResult, TryLockResult, TryLockError};
+use std::sync::{LockResult, TryLockError, TryLockResult};
 use std::time::Duration;
 
 use parking_lot as pl;
@@ -56,9 +56,10 @@ impl Condvar {
     }
 
     #[inline]
-    pub(crate) fn wait<'a, T>(&self, mut guard: pl::MutexGuard<'a, T>)
-        -> LockResult<pl::MutexGuard<'a, T>>
-    {
+    pub(crate) fn wait<'a, T>(
+        &self,
+        mut guard: pl::MutexGuard<'a, T>,
+    ) -> LockResult<pl::MutexGuard<'a, T>> {
         self.0.wait(&mut guard);
         Ok(guard)
     }
@@ -67,9 +68,8 @@ impl Condvar {
     pub(crate) fn wait_timeout<'a, T>(
         &self,
         mut guard: pl::MutexGuard<'a, T>,
-        timeout: Duration)
-        -> LockResult<(pl::MutexGuard<'a, T>, pl::WaitTimeoutResult)>
-    {
+        timeout: Duration,
+    ) -> LockResult<(pl::MutexGuard<'a, T>, pl::WaitTimeoutResult)> {
         let wtr = self.0.wait_for(&mut guard, timeout);
         Ok((guard, wtr))
     }

--- a/tokio/src/loom/std/sync/pl_wrappers.rs
+++ b/tokio/src/loom/std/sync/pl_wrappers.rs
@@ -1,3 +1,8 @@
+//! A minimal adaption of the `parking_lot` synchronization primitives to the
+//! equivalent `std::sync` types.
+//!
+//! This can be extended to additional types/methods as required.
+
 use std::sync::{LockResult, TryLockResult, TryLockError};
 use std::time::Duration;
 
@@ -26,17 +31,8 @@ impl<T> Mutex<T> {
         }
     }
 
-    #[allow(unused)]
-    #[inline]
-    pub(crate) fn is_poisoned(&self) -> bool {
-        false
-    }
-
-    #[allow(unused)]
-    #[inline]
-    pub(crate) fn into_inner(self) -> LockResult<T> {
-        Ok(self.0.into_inner())
-    }
+    // Note: Additional methods `is_poisoned` and `into_inner`, can be
+    // provided here as needed.
 }
 
 /// Adapter for `parking_lot::Condvar` to the `std::sync::Condvar` interface.


### PR DESCRIPTION
This is a second attempt at #2130, as discussed on discord.

## Motivation

* The _parking_lot_ crate's `Mutex` and `Condvar` still best _libstd_ in benchmarks.  
* From Amanieu/parking_lot#119 (and linked rust-lang PR), it does not appear (AFAICT) that replacing libstd's current implementations with _parking_lot_ inspired types is particularly close to being accepted. (When that does happen and in MSRV, this PR should be easy enough to revert.)

## Solution

With a non-default, not included in "full" *parking_lot* feature enabled, new `Mutex` and `Condvar` adapter types are included which bridge the parking_lot types to the std::sync interface.  Note that for compatibility, the adapters return types in the form `Result<_, *LockError>` but never actually error, because _parking_lot_ does not have poisoning. To quote https://docs.rs/parking_lot/0.10.0/parking_lot/type.Mutex.html:

> * No poisoning, the lock is released normally on panic.

I have not found a case in the current codebase where tokio attempts to recover from a poisoned `Mutex`, or is dependent `panic!` from posion error `unwrap`-ing.

## Possible Followup Steps

IMO this should be deferred until after reviewing and hopefully merging this PR:

1. Not all references to `Mutex` and `Condvar` in the tree go through the `loom` module. It may or may not make sense to replace all of these cases, including in tests? 

``` txt
git grep -n -E  "use.*Mutex" | grep -v "loom::" | grep -v "tokio::sync" | grep -v "src/loom"
tokio-test/src/task.rs:9:use std::sync::{Arc, Condvar, Mutex};
tokio/src/process/unix/orphan.rs:3:use std::sync::Mutex;
tokio/src/runtime/tests/loom_oneshot.rs:3:use std::sync::{Arc, Mutex};
tokio/src/signal/registry.rs:11:use std::sync::Mutex;
tokio/src/sync/barrier.rs:3:use std::sync::Mutex;
tokio/src/sync/mod.rs:27:    pub use mutex::{Mutex, MutexGuard};
tokio/src/sync/watch.rs:61:use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
tokio/src/task/error.rs:4:use std::sync::Mutex;
tokio/src/tests/loom_schedule.rs:5:use std::sync::Mutex;
tokio/src/tests/mock_schedule.rs:5:use std::sync::Mutex;
tokio/src/time/clock.rs:38:    use std::sync::{Arc, Mutex};
tokio/tests/fs_dir.rs:7:use std::sync::{Arc, Mutex};
tokio/tests/io_driver.rs:12:use std::sync::{mpsc, Arc, Mutex};
tokio/tests/support/mock_file.rs:10:use std::sync::{Arc, Mutex};
```
## Benchmarks

See results comparing parking_lot enabled vs disabled in #2130. I did not find any significant difference in results with the new implementation in this PR. 

