### PR TITLE
future: provide try_join! macro

### DIFF
--- a/tokio/src/future/maybe_done.rs
+++ b/tokio/src/future/maybe_done.rs
@@ -30,7 +30,7 @@ impl<Fut: Future> MaybeDone<Fut> {
     /// The output of this method will be [`Some`] if and only if the inner
     /// future has been completed and [`take_output`](MaybeDone::take_output)
     /// has not yet been called.
-    pub(crate) fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
+    pub fn output_mut(self: Pin<&mut Self>) -> Option<&mut Fut::Output> {
         unsafe {
             let this = self.get_unchecked_mut();
             match this {

--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -12,7 +12,7 @@
 /// for **all** branches complete regardless if any complete with `Err`. Use
 /// [`try_join!`] to return early when `Err` is encountered.
 ///
-/// [`try_join!`]: crate::try_join
+/// [`try_join!`]: macro@try_join
 ///
 /// # Notes
 ///

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -27,6 +27,9 @@ cfg_macros! {
 #[macro_use]
 mod thread_local;
 
+#[macro_use]
+mod try_join;
+
 // Includes re-exports needed to implement macros
 #[doc(hidden)]
 pub mod support;

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -30,7 +30,7 @@
 ///
 /// # Examples
 ///
-/// Basic try_join with two branches
+/// Basic try_join with two branches.
 ///
 /// ```
 /// async fn do_stuff_async() -> Result<(), &'static str> {

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -1,18 +1,16 @@
 /// Wait on multiple concurrent branches, returning when **all** branches
-/// complete.
+/// complete with `Ok(_)` or on the first `Err(_)`.
 ///
-/// The `join!` macro must be used inside of async functions, closures, and
+/// The `try_join!` macro must be used inside of async functions, closures, and
 /// blocks.
 ///
-/// The `join!` macro takes a list of async expressions and evaluates them
-/// concurrently on the same task. Each async expression evaluates to a future
-/// and the futures from each expression are multiplexed on the current task.
+/// Similar to [`join!`], the `try_join!` macro takes a list of async
+/// expressions and evaluates them concurrently on the same task. Each async
+/// expression evaluates to a future and the futures from each expression are
+/// multiplexed on the current task. The `try_join!` macro returns when **all**
+/// branches return with `Ok` or when the **first** branch returns with `Err`.
 ///
-/// When working with async expressions returning `Result`, `join!` will wait
-/// for **all** branches complete regardless if any complete with `Err`. Use
-/// [`try_join!`] to return early when `Err` is encountered.
-///
-/// [`try_join!`]: crate::try_join
+/// [`join!`]: crate::join
 ///
 /// # Notes
 ///
@@ -26,40 +24,49 @@
 /// expressions are run on the same thread and if one branch blocks the thread,
 /// all other expressions will be unable to continue. If parallelism is
 /// required, spawn each async expression using [`tokio::spawn`] and pass the
-/// join handle to `join!`.
+/// join handle to `try_join!`.
 ///
 /// [`tokio::spawn`]: crate::spawn
 ///
 /// # Examples
 ///
-/// Basic join with two branches
+/// Basic try_join with two branches
 ///
 /// ```
-/// async fn do_stuff_async() {
+/// async fn do_stuff_async() -> Result<(), &'static str> {
 ///     // async work
+/// # Ok(())
 /// }
 ///
-/// async fn more_async_work() {
+/// async fn more_async_work() -> Result<(), &'static str> {
 ///     // more here
+/// # Ok(())
 /// }
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let (first, second) = tokio::join!(
+///     let res = tokio::try_join!(
 ///         do_stuff_async(),
 ///         more_async_work());
 ///
-///     // do something with the values
+///     match res {
+///          Ok((first, second)) => {
+///              // do something with the values
+///          }
+///          Err(err) => {
+///             println!("processing failed; error = {}", err);
+///          }
+///     }
 /// }
 /// ```
 #[macro_export]
-macro_rules! join {
+macro_rules! try_join {
     (@ {
-        // One `_` for each branch in the `join!` macro. This is not used once
+        // One `_` for each branch in the `try_join!` macro. This is not used once
         // normalization is complete.
         ( $($count:tt)* )
 
-        // Normalized join! branches
+        // Normalized try_join! branches
         $( ( $($skip:tt)* ) $e:expr, )*
 
     }) => {{
@@ -82,15 +89,17 @@ macro_rules! join {
                 let mut fut = unsafe { Pin::new_unchecked(fut) };
 
                 // Try polling
-                if fut.poll(cx).is_pending() {
+                if fut.as_mut().poll(cx).is_pending() {
                     is_pending = true;
+                } else if fut.as_mut().output_mut().expect("expected completed future").is_err() {
+                    return Ready(Err(fut.take_output().expect("expected completed future").err().unwrap()))
                 }
             )*
 
             if is_pending {
                 Pending
             } else {
-                Ready(($({
+                Ready(Ok(($({
                     // Extract the future for this branch from the tuple.
                     let ( $($skip,)* fut, .. ) = &mut futures;
 
@@ -98,8 +107,12 @@ macro_rules! join {
                     // and never moved.
                     let mut fut = unsafe { Pin::new_unchecked(fut) };
 
-                    fut.take_output().expect("expected completed future")
-                },)*))
+                    fut
+                        .take_output()
+                        .expect("expected completed future")
+                        .ok()
+                        .expect("expected Ok(_)")
+                },)*)))
             }
         }).await
     }};
@@ -107,12 +120,13 @@ macro_rules! join {
     // ===== Normalize =====
 
     (@ { ( $($s:tt)* ) $($t:tt)* } $e:expr, $($r:tt)* ) => {
-        $crate::join!(@{ ($($s)* _) $($t)* ($($s)*) $e, } $($r)*)
+        $crate::try_join!(@{ ($($s)* _) $($t)* ($($s)*) $e, } $($r)*)
     };
 
     // ===== Entry point =====
 
     ( $($e:expr),* $(,)?) => {
-        $crate::join!(@{ () } $($e,)*)
+        $crate::try_join!(@{ () } $($e,)*)
     };
 }
+

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -10,7 +10,7 @@
 /// multiplexed on the current task. The `try_join!` macro returns when **all**
 /// branches return with `Ok` or when the **first** branch returns with `Err`.
 ///
-/// [`join!`]: crate::join
+/// [`join!`]: macro@join
 ///
 /// # Notes
 ///
@@ -129,4 +129,3 @@ macro_rules! try_join {
         $crate::try_join!(@{ () } $($e,)*)
     };
 }
-

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -30,9 +30,9 @@ async fn sync_two_lit_expr_no_comma() {
 }
 
 #[tokio::test]
-async fn sync_two_await() {
-    let (tx1, rx1) = oneshot::channel();
-    let (tx2, rx2) = oneshot::channel();
+async fn two_await() {
+    let (tx1, rx1) = oneshot::channel::<&str>();
+    let (tx2, rx2) = oneshot::channel::<u32>();
 
     let mut join = task::spawn(async {
         tokio::join!(async { rx1.await.unwrap() }, async { rx2.await.unwrap() })

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -17,20 +17,14 @@ async fn sync_one_lit_expr_no_comma() {
 
 #[tokio::test]
 async fn sync_two_lit_expr_comma() {
-    let foo = tokio::try_join!(
-        async { ok(1) },
-        async { ok(2) },
-    );
+    let foo = tokio::try_join!(async { ok(1) }, async { ok(2) },);
 
     assert_eq!(foo, Ok((1, 2)));
 }
 
 #[tokio::test]
 async fn sync_two_lit_expr_no_comma() {
-    let foo = tokio::try_join!(
-        async { ok(1) },
-        async { ok(2) }
-    );
+    let foo = tokio::try_join!(async { ok(1) }, async { ok(2) });
 
     assert_eq!(foo, Ok((1, 2)));
 }
@@ -40,11 +34,8 @@ async fn two_await() {
     let (tx1, rx1) = oneshot::channel::<&str>();
     let (tx2, rx2) = oneshot::channel::<u32>();
 
-    let mut join = task::spawn(async {
-        tokio::try_join!(
-            async { rx1.await },
-            async { rx2.await })
-    });
+    let mut join =
+        task::spawn(async { tokio::try_join!(async { rx1.await }, async { rx2.await }) });
 
     assert_pending!(join.poll());
 
@@ -66,10 +57,9 @@ async fn err_abort_early() {
     let (_tx3, rx3) = oneshot::channel::<u32>();
 
     let mut join = task::spawn(async {
-        tokio::try_join!(
-            async { rx1.await },
-            async { rx2.await },
-            async { rx3.await })
+        tokio::try_join!(async { rx1.await }, async { rx2.await }, async {
+            rx3.await
+        })
     });
 
     assert_pending!(join.poll());

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -1,0 +1,110 @@
+use tokio::sync::oneshot;
+use tokio_test::{assert_pending, assert_ready, task};
+
+#[tokio::test]
+async fn sync_one_lit_expr_comma() {
+    let foo = tokio::try_join!(async { ok(1) },);
+
+    assert_eq!(foo, Ok((1,)));
+}
+
+#[tokio::test]
+async fn sync_one_lit_expr_no_comma() {
+    let foo = tokio::try_join!(async { ok(1) });
+
+    assert_eq!(foo, Ok((1,)));
+}
+
+#[tokio::test]
+async fn sync_two_lit_expr_comma() {
+    let foo = tokio::try_join!(
+        async { ok(1) },
+        async { ok(2) },
+    );
+
+    assert_eq!(foo, Ok((1, 2)));
+}
+
+#[tokio::test]
+async fn sync_two_lit_expr_no_comma() {
+    let foo = tokio::try_join!(
+        async { ok(1) },
+        async { ok(2) }
+    );
+
+    assert_eq!(foo, Ok((1, 2)));
+}
+
+#[tokio::test]
+async fn two_await() {
+    let (tx1, rx1) = oneshot::channel::<&str>();
+    let (tx2, rx2) = oneshot::channel::<u32>();
+
+    let mut join = task::spawn(async {
+        tokio::try_join!(
+            async { rx1.await },
+            async { rx2.await })
+    });
+
+    assert_pending!(join.poll());
+
+    tx2.send(123).unwrap();
+    assert!(join.is_woken());
+    assert_pending!(join.poll());
+
+    tx1.send("hello").unwrap();
+    assert!(join.is_woken());
+    let res: Result<(&str, u32), _> = assert_ready!(join.poll());
+
+    assert_eq!(Ok(("hello", 123)), res);
+}
+
+#[tokio::test]
+async fn err_abort_early() {
+    let (tx1, rx1) = oneshot::channel::<&str>();
+    let (tx2, rx2) = oneshot::channel::<u32>();
+    let (_tx3, rx3) = oneshot::channel::<u32>();
+
+    let mut join = task::spawn(async {
+        tokio::try_join!(
+            async { rx1.await },
+            async { rx2.await },
+            async { rx3.await })
+    });
+
+    assert_pending!(join.poll());
+
+    tx2.send(123).unwrap();
+    assert!(join.is_woken());
+    assert_pending!(join.poll());
+
+    drop(tx1);
+    assert!(join.is_woken());
+
+    let res = assert_ready!(join.poll());
+
+    assert!(res.is_err());
+}
+
+#[test]
+fn join_size() {
+    use futures::future;
+    use std::mem;
+
+    let fut = async {
+        let ready = future::ready(ok(0i32));
+        tokio::try_join!(ready)
+    };
+    assert_eq!(mem::size_of_val(&fut), 16);
+
+    let fut = async {
+        let ready1 = future::ready(ok(0i32));
+        let ready2 = future::ready(ok(0i32));
+        tokio::try_join!(ready1, ready2)
+    };
+    assert_eq!(mem::size_of_val(&fut), 28);
+}
+
+fn ok<T>(val: T) -> Result<T, ()> {
+    Ok(val)
+}


### PR DESCRIPTION
Provides a `try_join!` macro that supports concurrently driving multiple
`Result` futures on the same task and await the completion of all the
futures as `Ok` or the **first** `Err` future.

Refs #2158, #2152