### PR TITLE
chore: prepare v0.2.11 release

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.2.4 (January 27, 2019)
+
+### Fixed
+- generics on `#[tokio::main]` function (#2177).
+
+### Added
+- support for `tokio::select!` (#2152).
+
 # 0.2.3 (January 7, 2019)
 
 ### Fixed

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,7 +7,7 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.1.x" git tag.
-version = "0.2.3"
+version = "0.2.4"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Added
 - optional support for using `parking_lot` internally (#2164).
-- fs: `fs::copy` an async version of `std::fs::copy` (#2079).
+- fs: `fs::copy`, an async version of `std::fs::copy` (#2079).
 - macros: `select!` waits for the first branch to complete (#2152).
 - macros: `join!` waits for all branches to complete (#2158).
 - macros: `try_join!` waits for all branches to complete or the first error (#2169).

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 0.2.11 (January 27, 2019)
+
+### Fixes
+- docs: misc fixes and tweaks (#2155, #2103, #2027, #2167, #2175).
+- macros: handle generics in `#[tokio::main]` method (#2177).
+- sync: `broadcast` potential lost notifications (#2135).
+- rt: improve "no runtime" panic messages (#2145).
+
+### Added
+- optional support for using `parking_lot` internally (#2164).
+- fs: `fs::copy` an async version of `std::fs::copy` (#2079).
+- macros: `select!` waits for the first branch to complete (#2152).
+- macros: `join!` waits for all branches to complete (#2158).
+- macros: `try_join!` waits for all branches to complete or the first error (#2169).
+- macros: `pin!` pins a value to the stack (#2163).
+- net: `ReadHalf::poll()` and `ReadHalf::poll_peak` (#2151)
+- stream: `StreamExt::timeout()` sets a per-item max duration (#2149).
+- stream: `StreamExt::fold()` applies a function, producing a single value. (#2122).
+- sync: impl `Eq`, `PartialEq` for `oneshot::RecvError` (#2168).
+- task: methods for inspecting the `JoinError` cause (#2051).
+
 # 0.2.10 (January 21, 2019)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.10"
+version = "0.2.11"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.10/tokio/"
+documentation = "https://docs.rs/tokio/0.2.11/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -91,7 +91,7 @@ udp = ["io-driver"]
 uds = ["io-driver", "mio-uds", "libc"]
 
 [dependencies]
-tokio-macros = { version = "0.2.3", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "0.2.4", path = "../tokio-macros", optional = true }
 
 bytes = "0.5.0"
 pin-project-lite = "0.1.1"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.10")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.11")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
Also bumps:
- tokio-macros: v0.2.4