### PR TITLE
fix timer out of bounds error

### DIFF
--- a/tokio/src/time/wheel/mod.rs
+++ b/tokio/src/time/wheel/mod.rs
@@ -43,7 +43,7 @@ pub(crate) struct Wheel<T> {
 const NUM_LEVELS: usize = 6;
 
 /// The maximum duration of a delay
-const MAX_DURATION: u64 = 1 << (6 * NUM_LEVELS);
+const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
 
 #[derive(Debug)]
 pub(crate) enum InsertError {

--- a/tokio/tests/time_delay.rs
+++ b/tokio/tests/time_delay.rs
@@ -155,6 +155,22 @@ async fn greater_than_max() {
     time::delay_until(Instant::now() + ms(YR_5)).await;
 }
 
+const NUM_LEVELS: usize = 6;
+const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
+
+#[should_panic]
+#[tokio::test]
+async fn exactly_max() {
+    // TODO: this should not panic but `time::ms()` is acting up
+    time::delay_for(ms(MAX_DURATION)).await;
+}
+
+#[tokio::test]
+async fn no_out_of_bounds_close_to_max() {
+    time::pause();
+    time::delay_for(ms(MAX_DURATION - 1)).await;
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }


### PR DESCRIPTION
## Motivation

There is an out of bounds error when attempting to set a delay of `MAX_DURATION` - 1 ms

```
delay_for(Duration::from_millis(MAX_DURATION - 1)).await;
=> panicked at 'index out of bounds: the len is 6 but the index is 6
```

## Solution
The easiest way out seems to be to change `MAX_DURATION` to `MAX_DURATION - 1`.  
