### PR TITLE
Add Noria as a tokio benchmark

### DIFF
--- a/benches/noria/.gitignore
+++ b/benches/noria/.gitignore
@@ -1,0 +1,3 @@
+checkout/
+*.log
+*.err

--- a/benches/noria/README.md
+++ b/benches/noria/README.md
@@ -7,7 +7,7 @@ benchmark that covers many aspects of tokio's performance profile.
 
 ```console
 $ ./run.sh
-# go get tea/coffee
+# this takes a while, so go get tea/coffee
 $ ls noria-*.log
 ```
 

--- a/benches/noria/README.md
+++ b/benches/noria/README.md
@@ -1,0 +1,60 @@
+This directory is for running one of the main benchmarks for
+[noria](https://github.com/mit-pdos/noria), a highly concurrent
+research-prototype database that uses tokio. This is intended as a macro
+benchmark that covers many aspects of tokio's performance profile.
+
+## To run
+
+```console
+$ ./run.sh
+# go get tea/coffee
+$ ls noria-*.log
+```
+
+## To understand
+
+The underlying application is quite complex, and it can be difficult to
+figure out exactly how changes to tokio affect the benchmark
+performance. Similarly, it can be difficult to diagnose the root cause
+of performance problems. Nevertheless, here are some pointers into the
+code that may be useful.
+
+First of all, the benchmark is "[open
+loop](https://www.usenix.org/legacy/event/nsdi06/tech/full_papers/schroeder/schroeder.pdf)",
+meaning it issues requests independently of whether outstanding requests
+have completed. This allows you to accurately measure latency spikes
+(see the link for details). The general idea of such a benchmark is that
+you run it with a given target throughput, and you see what the latency
+is. You then keep increasing the target throughput until the latency
+starts to spike. When the latency spikes, the system is no longer
+keeping up, and you've found the peak supported load.
+
+The benchmark consists of two "halves", the benchmark client and the
+server. The client runs some number of "load generator" threads (you'll
+see these hit ~100% CPU usage during the benchmark as they spin), and
+issues batches of requests and measures their latency. The client
+requests are multiplexed over a dynamically-sized [connection
+pool](https://docs.rs/tower-balance/0.3.0/tower_balance/pool/index.html).
+Each batch is either a batch of reads or a batch of writes.
+
+On the server side, reads and writes arrive at different ports, and are
+handled by different code paths. Writes go to a "replica", which is the
+giant hand-written future in `noria-server/src/worker/replica.rs`. When
+the benchmark is run with `--shards 0`, there is only one, whereas if it
+is run with `--shards N`, there are `N` of them. Load will be mostly
+uniformly spread across the `N` replicas.
+
+Reads go through the `handle_message` method in
+`noria-server/src/worker/readers.rs`, and often complete immediately.
+Some reads may miss in Noria's internal cache, and have to wait for that
+cache entry to be populated. It does this by "triggering a replay",
+which involves sending a message over a channel to one of the replicas
+from above (see the `Replica` field `locals`). It then spawns a
+`BlockingRead` future which retries the reads that did not previously
+complete on a timer. When sharding is enabled, a single client read will
+be spread across `N` independent calls to `handle_message`, and the
+client request completes when all of them have completed.
+
+The code makes somewhat heavy use of tokio's `block_in_place`.
+Specifically, it is used to handle every write and every "triggered
+replay". This may or may not be relevant.

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -2,7 +2,7 @@
 set -o nounset
 set -o errexit
 
-commit="88c4086c0e82d6f1ef427460144d2ecde7ab1725"
+commit="e5be3fea69e1785a54b7e0ca7d3f4f6a877e162b"
 
 # get the right version of noria
 if [[ ! -d checkout ]]; then

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -14,11 +14,11 @@ if grep -E '^tokio =' checkout/Cargo.toml > /dev/null; then
 	# in case there's already an override in Cargo.toml
 	sed -i '/^tokio /d' checkout/Cargo.toml
 fi
-if ! grep '[patch.crates-io]' checkout/Cargo.toml > /dev/null; then
+if ! grep 'patch.crates-io' checkout/Cargo.toml > /dev/null; then
 	# in case there are _no_ overrides in Cargo.toml
 	echo '[patch.crates-io]' >> checkout/Cargo.toml
 fi
-sed -i '/patch.crates-io/a tokio = { path = "../../tokio/" }' checkout/Cargo.toml
+sed -i '/patch.crates-io/a tokio = { path = "../../../tokio/" }' checkout/Cargo.toml
 
 # time to build! sit back and relax
 cd checkout

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/bash
+set -o nounset
+set -o errexit
 
 commit="88c4086c0e82d6f1ef427460144d2ecde7ab1725"
 
@@ -33,11 +35,15 @@ for shards in 0 4; do
 			name="noria-s${shards}-$load"
 		fi
 		echo "run --target $load --shards $shards"
-		cargo run --release --bin vote -- --warmup 10 --runtime 20 --target $load -d skewed localsoup --shards $shards > ../$name.log 2> ../$name.err
-		if [[ $? -ne 0 ]]; then
+		if ! cargo run --release --bin vote -- \
+			--warmup 10 --runtime 20 --target $load -d skewed \
+			localsoup --shards $shards \
+			> ../$name.log 2> ../$name.err; then
+			echo " -> run command failed"
 			break
 		fi
 		if grep 'clients are falling behind' ../$name.err > /dev/null; then
+			echo " -> cancelling early as server is not keeping up"
 			break;
 		fi
 	done

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -26,7 +26,7 @@ cargo build --release --bin vote
 
 # let's run some benchmarks
 for shards in 0 4; do
-	for load in 1000000 2000000 3000000 4000000 5000000; do
+	for load in {1,2,3,4,5,6,7,8,9,10}000000; do
 		if [[ $shards -eq 0 ]]; then
 			name="noria-unsharded-$load"
 		else

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/bash
+
+commit="0e1d9e2641ec11ae4fdc3f6bed8da94879d8c917"
+
+# get the right version of noria
+if [[ ! -d checkout ]]; then
+	git clone https://github.com/mit-pdos/noria.git checkout
+fi
+git -C checkout fetch origin
+git -C checkout checkout "$commit"
+
+# patch to use local version of tokio
+if grep -E '^tokio =' checkout/Cargo.toml > /dev/null; then
+	# in case there's already an override in Cargo.toml
+	sed -i '/^tokio /d' checkout/Cargo.toml
+fi
+if ! grep '[patch.crates-io]' checkout/Cargo.toml > /dev/null; then
+	# in case there are _no_ overrides in Cargo.toml
+	echo '[patch.crates-io]' >> checkout/Cargo.toml
+fi
+sed -i '/patch.crates-io/a tokio = { path = "../../tokio/" }' checkout/Cargo.toml
+
+# time to build! sit back and relax
+cd checkout
+cargo build --release --bin vote
+
+# let's run some benchmarks
+for shards in 0 4; do
+	for load in 1000000 2000000 3000000 4000000 5000000; do
+		if [[ $shards -eq 0 ]]; then
+			name="noria-unsharded-$load"
+		else
+			name="noria-s${shards}-$load"
+		fi
+		echo "run --target $load --shards $shards"
+		cargo run --release --bin vote -- --warmup 10 --runtime 20 --target $load -d skewed localsoup --shards $shards > ../$name.log 2> ../$name.err
+		if [[ $? -ne 0 ]]; then
+			break
+		fi
+		if grep 'clients are falling behind' ../$name.err > /dev/null; then
+			break;
+		fi
+	done
+done

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-commit="0e1d9e2641ec11ae4fdc3f6bed8da94879d8c917"
+commit="88c4086c0e82d6f1ef427460144d2ecde7ab1725"
 
 # get the right version of noria
 if [[ ! -d checkout ]]; then

--- a/benches/noria/run.sh
+++ b/benches/noria/run.sh
@@ -2,7 +2,7 @@
 set -o nounset
 set -o errexit
 
-commit="e5be3fea69e1785a54b7e0ca7d3f4f6a877e162b"
+commit="77098a819fafd20a8d65c675d0fd0b5012daea22"
 
 # get the right version of noria
 if [[ ! -d checkout ]]; then


### PR DESCRIPTION
This adds `benches/noria/`, which includes a simple script for checking out and building [noria](https://github.com/mit-pdos/noria), and then running the [vote](https://github.com/mit-pdos/noria/tree/master/noria-benchmarks/vote) benchmark at various levels of load. The `README` file in the directory gives an overview of the most relevant aspects of noria when it comes to tokio's performance.