### PR TITLE
macros: correctly feature gate join/try_join

### DIFF
--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -53,6 +53,7 @@
 /// }
 /// ```
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! join {
     (@ {
         // One `_` for each branch in the `join!` macro. This is not used once

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -8,9 +8,6 @@ mod assert;
 mod cfg;
 
 #[macro_use]
-mod join;
-
-#[macro_use]
 mod loom;
 
 #[macro_use]
@@ -19,16 +16,19 @@ mod pin;
 #[macro_use]
 mod ready;
 
-cfg_macros! {
-    #[macro_use]
-    mod select;
-}
-
 #[macro_use]
 mod thread_local;
 
-#[macro_use]
-mod try_join;
+cfg_macros! {
+    #[macro_use]
+    mod select;
+
+    #[macro_use]
+    mod join;
+
+    #[macro_use]
+    mod try_join;
+}
 
 // Includes re-exports needed to implement macros
 #[doc(hidden)]

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -281,6 +281,7 @@
 /// }
 /// ```
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! select {
     // Uses a declarative macro to do **most** of the work. While it is possible
     // to implement fully with a declarative macro, a procedural macro is used

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -60,6 +60,7 @@
 /// }
 /// ```
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! try_join {
     (@ {
         // One `_` for each branch in the `try_join!` macro. This is not used once


### PR DESCRIPTION
The `macros` feature flag was ommitted despite the fact that these
macros require the feature flag to function. The macros are now scoped
by the `macros` feature flag.

This is *not* a breaking change due to the fact that the macros were
broken without the `macros` feature flag in the first place.