### PR TITLE
Fix broadcast link in sync documentation

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -232,7 +232,7 @@
 //!
 //! ## `broadcast` channel
 //!
-//! The [`broadcast` channel[broadcast] supports sending **many** values from
+//! The [`broadcast` channel][broadcast] supports sending **many** values from
 //! **many** producers to **many** consumers. Each consumer will receive
 //! **each** value. This channel can be used to implement "fan out" style
 //! patterns common with pub / sub or "chat" systems.


### PR DESCRIPTION
The "`broadcast` channel" link in the `sync` mod documentation was missing the closing `]`.