### PR TITLE
perf: Use advance over split_to when we don't need the data

### DIFF
--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -7,7 +7,7 @@ use tokio::{
     stream::Stream,
 };
 
-use bytes::BytesMut;
+use bytes::{Buf, BytesMut};
 use futures_core::ready;
 use futures_sink::Sink;
 use log::trace;
@@ -239,8 +239,7 @@ where
                 .into()));
             }
 
-            // TODO: Add a way to `bytes` to do this w/o returning the drained data.
-            let _ = pinned.buffer.split_to(n);
+            pinned.buffer.advance(n);
         }
 
         // Try flushing the underlying IO

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -494,7 +494,7 @@ impl LengthDelimitedCodec {
         let num_skip = self.builder.get_num_skip();
 
         if num_skip > 0 {
-            let _ = src.split_to(num_skip);
+            src.advance(num_skip);
         }
 
         // Ensure that the buffer has enough space to read the incoming


### PR DESCRIPTION
Found two places by grepping for `split_to`