### PR TITLE
net: add methods for obtaining read/write readiness of tcp stream

### DIFF
--- a/tokio/tests/tcp_readiness.rs
+++ b/tokio/tests/tcp_readiness.rs
@@ -1,0 +1,26 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::net::{TcpListener, TcpStream};
+use tokio_test::assert_ok;
+
+use futures::join;
+
+#[tokio::test]
+async fn readiness() {
+    let mut srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
+    let addr = assert_ok!(srv.local_addr());
+    let addr = format!("localhost:{}", addr.port());
+
+    let server = async {
+        assert_ok!(srv.accept().await);
+    };
+
+    let client = async {
+        let mut client = assert_ok!(TcpStream::connect(addr).await);
+        assert_ok!(client.read_ready().await);
+        assert_ok!(client.write_ready().await);
+    };
+
+    join!(server, client);
+}


### PR DESCRIPTION
This pull requests adds methods to await and obtain read/write readiness
of `TcpStream`.

## Motivation

I recently started writing an [async wrapper](https://github.com/spebern/async-ssh2) for [`ssh2-rs`](https://github.com/alexcrichton/ssh2-rs) which itself wraps
[`libssh2`](https://github.com/libssh2/libssh2).

When using in non-blocking mode the session [can be queried for
the direction(s) it blocks](https://docs.rs/ssh2/0.7.1/ssh2/struct.Session.html#method.block_directions) (inbound, outbound and both). After obtaining
that direction I need to wait for the corresponding readiness, which
currently isn't possible in a nice way.

Something similar was requested in #1629

## Solution

Exposed methods to obtain and await read/write readiness of `TcpStream`.

One problem that I see with this pull request is that `poll_read_ready`
diverges from the one in `mio` as it clears the readiness state.

Happy to hear your thoughts!
