### PR TITLE
time: Add comment about cancelation of timed out futures

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -14,7 +14,8 @@ use std::task::{self, Poll};
 /// Require a `Future` to complete before the specified duration has elapsed.
 ///
 /// If the future completes before the duration has elapsed, then the completed
-/// value is returned. Otherwise, an error is returned.
+/// value is returned. Otherwise, an error is returned and the future is
+/// canceled.
 ///
 /// # Cancelation
 ///


### PR DESCRIPTION
While the module documentation explains that a timed out future (as
created through the tokio::time::timeout function) is canceled, the
functions actual documentation doesn't mention that at all. This change
adds this relevant information to the documentation.