### PR TITLE
Add a test for #2119 and failing state assertion

### DIFF
--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -5,7 +5,7 @@
 
 cfg_blocking_impl! {
     mod pool;
-    pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
+    pub(crate) use pool::{spawn_blocking, try_spawn_blocking, BlockingPool, Spawner};
 
     mod schedule;
     mod shutdown;

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -65,8 +65,18 @@ where
     let rt = Handle::current();
 
     let (task, handle) = task::joinable(BlockingTask::new(func));
-    rt.blocking_spawner.spawn(task, &rt);
+    let _ = rt.blocking_spawner.spawn(task, &rt);
     handle
+}
+
+pub(crate) fn try_spawn_blocking<F, R>(func: F) -> Result<(), ()>
+where
+    F: FnOnce() -> R + Send + 'static,
+{
+    let rt = Handle::current();
+
+    let (task, _handle) = task::joinable(BlockingTask::new(func));
+    rt.blocking_spawner.spawn(task, &rt)
 }
 
 // ===== impl BlockingPool =====
@@ -137,7 +147,7 @@ impl fmt::Debug for BlockingPool {
 // ===== impl Spawner =====
 
 impl Spawner {
-    fn spawn(&self, task: Task, rt: &Handle) {
+    fn spawn(&self, task: Task, rt: &Handle) -> Result<(), ()> {
         let shutdown_tx = {
             let mut shared = self.inner.shared.lock().unwrap();
 
@@ -146,7 +156,7 @@ impl Spawner {
                 task.shutdown();
 
                 // no need to even push this task; it would never get picked up
-                return;
+                return Err(());
             }
 
             shared.queue.push_back(task);
@@ -178,6 +188,8 @@ impl Spawner {
         if let Some(shutdown_tx) = shutdown_tx {
             self.spawn_thread(shutdown_tx, rt);
         }
+
+        Ok(())
     }
 
     fn spawn_thread(&self, shutdown_tx: shutdown::Sender, rt: &Handle) {
@@ -217,9 +229,6 @@ impl Inner {
                 run_task(task);
 
                 shared = self.shared.lock().unwrap();
-                if shared.shutdown {
-                    break; // Need to increment idle before we exit
-                }
             }
 
             // IDLE

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -69,6 +69,7 @@ where
     handle
 }
 
+#[allow(dead_code)]
 pub(crate) fn try_spawn_blocking<F, R>(func: F) -> Result<(), ()>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -198,7 +198,7 @@ mod blocking;
 use blocking::BlockingPool;
 
 cfg_blocking_impl! {
-    pub(crate) use blocking::spawn_blocking;
+    pub(crate) use blocking::{spawn_blocking, try_spawn_blocking};
 }
 
 mod builder;

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -198,6 +198,7 @@ mod blocking;
 use blocking::BlockingPool;
 
 cfg_blocking_impl! {
+    #[allow(unused_imports)]
     pub(crate) use blocking::{spawn_blocking, try_spawn_blocking};
 }
 

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -212,12 +212,6 @@ impl Worker {
             return;
         }
 
-        // make sure no subsequent code thinks that it is on a worker
-        current::clear();
-
-        // Track that the worker is gone
-        self.gone.set(true);
-
         // If this method is called, we need to move the entire worker onto a
         // separate (blocking) thread before returning. Once we return, the
         // caller is going to execute some blocking code which would otherwise
@@ -259,7 +253,20 @@ impl Worker {
         };
 
         // Give away the worker
-        runtime::spawn_blocking(move || worker.run());
+        //
+        // Returns `Err` if the spawn failed due to the runtime shutting down
+        let res = runtime::try_spawn_blocking(move || worker.run());
+
+        // If the worker hand-off was successful, clear the local state.
+        // Otherwise, the runtime is in the process of shutting down, so we will
+        // just block on the worker.
+        if res.is_ok() {
+            // make sure no subsequent code thinks that it is on a worker
+            current::clear();
+
+            // Track that the worker is gone
+            self.gone.set(true);
+        }
     }
 }
 


### PR DESCRIPTION
Here's roughly what happens:

 - A worker has tasks in its local queue
 - The worker gets given away due to `block_in_place` (using `spawn_blocking`)
 - The blocking pool is shut down
 - The given-away worker is dropped, rather than run
 - The worker's `shutdown` method is never run