### PR TITLE
codec: Add `Framed::with_capacity`

### DIFF
--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -50,6 +50,20 @@ where
             }),
         }
     }
+
+    /// Creates a new `FramedRead` with the given `decoder` and a buffer of `capacity`
+    /// initial size.
+    pub fn with_capacity(inner: T, decoder: D, capacity: usize) -> FramedRead<T, D> {
+        FramedRead {
+            inner: framed_read2_with_buffer(
+                Fuse {
+                    io: inner,
+                    codec: decoder,
+                },
+                BytesMut::with_capacity(capacity),
+            ),
+        }
+    }
 }
 
 impl<T, D> FramedRead<T, D> {


### PR DESCRIPTION
`FramedRead` users may want to set it's internal buffer size to minimize the chances of it being reallocated. 

In a variety of cases, it is possible to make a good guess on the frame size. Let this be configured instead of sticking with `framed_read::INITIAL_CAPACITY` of `8k`.

Relates to #2156.