### PR TITLE
Make DelayQueue wake the task at the right time after insert

### DIFF
--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -326,7 +326,12 @@ impl<T> DelayQueue<T> {
         };
 
         if should_set_delay {
-            self.delay = Some(delay_until(self.start + Duration::from_millis(when)));
+            let delay_time = self.start + Duration::from_millis(when);
+            if let Some(ref mut delay) = &mut self.delay {
+                delay.reset(delay_time);
+            } else {
+                self.delay = Some(delay_until(delay_time));
+            }
         }
 
         Key::new(key)


### PR DESCRIPTION
If an entry is inserted in the queue before the next deadline, the
DelayQueue needs to update the Delay tracking the next time to poll.

If there is an existing Delay, reset that rather than replacing it as if
it's already been polled the task will be waiting for a notification
before it will poll again, and dropping the Delay means that that
notification will never be performed.

## Motivation

In certain cases DelayQueue may not wake the appropriate task if it is modified after it's already been polled.  This PR covers the case where an entry is being inserted before the current deadline.

## Solution

When changing the deadline, if there's an existing Delay then update that rather than creating a new one as creating a new delay throws away the task registration.