### PR TITLE
Fix broken links to tokio::net

### DIFF
--- a/tokio-tcp/README.md
+++ b/tokio-tcp/README.md
@@ -3,9 +3,9 @@
 TCP bindings for `tokio`.
 
 > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
-> [`tokio::tcp`] behind the `tcp` [feature flag].
+> [`tokio::net`] behind the `tcp` [feature flag].
 
-[`tokio::tcp`]: https://docs.rs/tokio/latest/tokio/tcp/index.html
+[`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 
 [Documentation](https://docs.rs/tokio-tcp/0.1.3/tokio_tcp)

--- a/tokio-tcp/src/lib.rs
+++ b/tokio-tcp/src/lib.rs
@@ -4,9 +4,9 @@
 //! TCP bindings for `tokio`.
 //!
 //! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
-//! > into [`tokio::tcp`] behind the `tcp` [feature flag].
+//! > into [`tokio::net`] behind the `tcp` [feature flag].
 //!
-//! [`tokio::tcp`]: https://docs.rs/tokio/latest/tokio/tcp/index.html
+//! [`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 //! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 //!
 //! This module contains the TCP networking types, similar to the standard

--- a/tokio-udp/README.md
+++ b/tokio-udp/README.md
@@ -3,9 +3,9 @@
 UDP bindings for `tokio`.
 
 > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
-> [`tokio::udp`] behind the `udp` [feature flag].
+> [`tokio::net`] behind the `udp` [feature flag].
 
-[`tokio::udp`]: https://docs.rs/tokio/latest/tokio/udp/index.html
+[`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 
 [Documentation](https://docs.rs/tokio-udp/0.1.5/tokio_udp/)

--- a/tokio-udp/src/lib.rs
+++ b/tokio-udp/src/lib.rs
@@ -4,9 +4,9 @@
 //! UDP bindings for `tokio`.
 //!
 //! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
-//! > into[`tokio::udp`] behind the `udp` [feature flag].
+//! > into[`tokio::net`] behind the `udp` [feature flag].
 //!
-//! [`tokio::udp`]: https://docs.rs/tokio/latest/tokio/udp/index.html
+//! [`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 //! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 //!
 //! This module contains the UDP networking types, similar to the standard

--- a/tokio-uds/README.md
+++ b/tokio-uds/README.md
@@ -3,9 +3,9 @@
 An implementation of Unix Domain Sockets for Tokio
 
 > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved into
-> [`tokio::uds`] behind the `uds` [feature flag].
+> [`tokio::net`] behind the `uds` [feature flag].
 
-[`tokio::uds`]: https://docs.rs/tokio-util/latest/tokio/uds/index.html
+[`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 
 [Documentation](https://docs.rs/tokio-uds/0.2.5/tokio_uds/)

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -5,9 +5,9 @@
 //! Unix Domain Sockets for Tokio.
 //!
 //! > **Note:** This crate is **deprecated in tokio 0.2.x** and has been moved
-//! > into [`tokio::uds`] behind the `uds` [feature flag].
+//! > into [`tokio::net`] behind the `uds` [feature flag].
 //!
-//! [`tokio::uds`]: https://docs.rs/tokio-util/latest/tokio/uds/index.html
+//! [`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 //! [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 //!
 //! This crate provides APIs for using Unix Domain Sockets with Tokio.


### PR DESCRIPTION
Messed up some of the links. Besides, they should be linking to `tokio::net` rather than something like `tokio::net::tcp` because that is where the user facing types live, like `TcpListener` and `TcpStream`.

CC: @LucioFranco (sorry!)