### PR TITLE
Test and avoid replicate unnecessary polling over I/O futures

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -277,20 +277,12 @@ impl Inner {
             .get(token)
             .unwrap_or_else(|| panic!("IO resource for token {:?} does not exist!", token));
 
-        let readiness = sched
-            .get_readiness(token)
-            .unwrap_or_else(|| panic!("token {:?} no longer valid!", token));
-
-        let (waker, ready) = match dir {
-            Direction::Read => (&sched.reader, !mio::Ready::writable()),
-            Direction::Write => (&sched.writer, mio::Ready::writable()),
+        let waker = match dir {
+            Direction::Read => &sched.reader,
+            Direction::Write => &sched.writer,
         };
 
         waker.register(w);
-
-        if readiness & ready.as_usize() != 0 {
-            waker.wake();
-        }
     }
 }
 

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -56,6 +56,7 @@ impl Default for ScheduledIo {
 }
 
 impl ScheduledIo {
+    #[allow(dead_code)]
     /// Returns the current readiness value of this `ScheduledIo`, if the
     /// provided `token` is still a valid access.
     ///

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -56,7 +56,7 @@ impl Default for ScheduledIo {
 }
 
 impl ScheduledIo {
-    #[allow(dead_code)]
+    #[cfg(all(test, loom))]
     /// Returns the current readiness value of this `ScheduledIo`, if the
     /// provided `token` is still a valid access.
     ///

--- a/tokio/src/util/bit.rs
+++ b/tokio/src/util/bit.rs
@@ -33,6 +33,7 @@ impl Pack {
     }
 
     /// Mask used to unpack value
+    #[cfg(all(test, loom))]
     pub(crate) const fn mask(&self) -> usize {
         self.mask
     }

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "full")]
 
 use tokio::runtime::Runtime;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio_test::{assert_err, assert_ok};
 
 use std::thread;
@@ -25,6 +25,69 @@ fn spawned_task_does_not_progress_without_block_on() {
     let out = rt.block_on(async { assert_ok!(rx.await) });
 
     assert_eq!(out, "hello");
+}
+
+#[test]
+fn no_extra_poll() {
+    use std::pin::Pin;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering::SeqCst},
+        Arc,
+    };
+    use std::task::{Context, Poll};
+    use tokio::stream::{Stream, StreamExt};
+
+    struct TrackPolls<S> {
+        npolls: Arc<AtomicUsize>,
+        s: S,
+    }
+
+    impl<S> Stream for TrackPolls<S>
+    where
+        S: Stream,
+    {
+        type Item = S::Item;
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            // safety: we do not move s
+            let this = unsafe { self.get_unchecked_mut() };
+            this.npolls.fetch_add(1, SeqCst);
+            // safety: we are pinned, and so is s
+            unsafe { Pin::new_unchecked(&mut this.s) }.poll_next(cx)
+        }
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut rx = TrackPolls {
+        npolls: Arc::new(AtomicUsize::new(0)),
+        s: rx,
+    };
+    let npolls = Arc::clone(&rx.npolls);
+
+    let mut rt = rt();
+
+    rt.spawn(async move { while let Some(_) = rx.next().await {} });
+    rt.block_on(async {
+        tokio::task::yield_now().await;
+    });
+
+    // should have been polled exactly once: the initial poll
+    assert_eq!(npolls.load(SeqCst), 1);
+
+    tx.send(()).unwrap();
+    rt.block_on(async {
+        tokio::task::yield_now().await;
+    });
+
+    // should have been polled twice more: once to yield Some(), then once to yield Pending
+    assert_eq!(npolls.load(SeqCst), 1 + 2);
+
+    drop(tx);
+    rt.block_on(async {
+        tokio::task::yield_now().await;
+    });
+
+    // should have been polled once more: to yield None
+    assert_eq!(npolls.load(SeqCst), 1 + 2 + 1);
 }
 
 #[test]

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -38,3 +38,59 @@ test_accept! {
     (str_port_tuple, ("127.0.0.1", 0)),
     (ip_port_tuple, ("127.0.0.1".parse::<IpAddr>().unwrap(), 0)),
 }
+
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering::SeqCst},
+    Arc,
+};
+use std::task::{Context, Poll};
+use tokio::stream::{Stream, StreamExt};
+
+struct TrackPolls<S> {
+    npolls: Arc<AtomicUsize>,
+    s: S,
+}
+
+impl<S> Stream for TrackPolls<S>
+where
+    S: Stream,
+{
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // safety: we do not move s
+        let this = unsafe { self.get_unchecked_mut() };
+        this.npolls.fetch_add(1, SeqCst);
+        // safety: we are pinned, and so is s
+        unsafe { Pin::new_unchecked(&mut this.s) }.poll_next(cx)
+    }
+}
+
+#[tokio::test]
+async fn no_extra_poll() {
+    let mut listener = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
+    let addr = listener.local_addr().unwrap();
+
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        let mut incoming = TrackPolls {
+            npolls: Arc::new(AtomicUsize::new(0)),
+            s: listener.incoming(),
+        };
+        assert_ok!(tx.send(Arc::clone(&incoming.npolls)));
+        while let Some(_) = incoming.next().await {}
+    });
+
+    let npolls = assert_ok!(rx.await);
+    tokio::task::yield_now().await;
+
+    // should have been polled exactly once: the initial poll
+    assert_eq!(npolls.load(SeqCst), 1);
+
+    let _ = assert_ok!(TcpStream::connect(&addr).await);
+    tokio::task::yield_now().await;
+
+    // should have been polled twice more: once to yield Some(), then once to yield Pending
+    assert_eq!(npolls.load(SeqCst), 1 + 2);
+}


### PR DESCRIPTION
See #2222.

This adds a test that replicates the issue (the I/O one; the channel one does not exhibit the issue). It then also introduces a fix by removing the (in theory) extraneous call to `wake()` in `io::Driver::register`.