### PR TITLE
Macros doc(cfg) workarounds

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -28,8 +28,9 @@ use proc_macro::TokenStream;
 ///
 /// ## Options:
 ///
-/// - `core_threads=n` - Sets core threads to `n`.
-/// - `max_threads=n` - Sets max threads to `n`.
+///
+/// - `core_threads=n` - Sets core threads to `n` (requires `rt-threaded` feature).
+/// - `max_threads=n` - Sets max threads to `n` (requires `rt-core` or `rt-threaded` feature).
 ///
 /// ## Function arguments:
 ///
@@ -65,7 +66,7 @@ pub fn main_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ## Options:
 ///
 /// - `basic_scheduler` - All tasks are executed on the current thread.
-/// - `threaded_scheduler` - Uses the multi-threaded scheduler. Used by default.
+/// - `threaded_scheduler` - Uses the multi-threaded scheduler. Used by default (requires `rt-threaded` feature).
 ///
 /// ## Function arguments:
 ///
@@ -126,15 +127,15 @@ pub fn main_basic(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Options:
 ///
-/// - `basic_scheduler` - All tasks are executed on the current thread. Used by default.
-/// - `threaded_scheduler` - Use multi-threaded scheduler.
+/// - `core_threads=n` - Sets core threads to `n` (requires `rt-threaded` feature).
+/// - `max_threads=n` - Sets max threads to `n` (requires `rt-core` or `rt-threaded` feature).
 ///
 /// ## Usage
 ///
 /// ### Select runtime
 ///
 /// ```no_run
-/// #[tokio::test(threaded_scheduler)]
+/// #[tokio::test(core_threads = 1)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -157,15 +158,15 @@ pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ## Options:
 ///
-/// - `core_threads=n` - Sets core threads to `n`.
-/// - `max_threads=n` - Sets max threads to `n`.
+/// - `basic_scheduler` - All tasks are executed on the current thread. Used by default.
+/// - `threaded_scheduler` - Use multi-threaded scheduler (requires `rt-threaded` feature).
 ///
 /// ## Usage
 ///
 /// ### Select runtime
 ///
 /// ```no_run
-/// #[tokio::test(core_threads = 1)]
+/// #[tokio::test(threaded_scheduler)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -356,8 +356,14 @@ cfg_macros! {
 
     doc_rt_core! {
         cfg_rt_threaded! {
+            // This is the docs.rs case (with all features) so make sure macros
+            // is included in doc(cfg).
+
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
+            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
             pub use tokio_macros::main_threaded as main;
+
+            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
             pub use tokio_macros::test_threaded as test;
         }
 


### PR DESCRIPTION
## Motivation

Attempted fix for #2075, see also [#2075 (comment)](https://github.com/tokio-rs/tokio/issues/2075#issuecomment-583122347).

## Solution

This tries to work within the 0.2 approach of using `doc(cfg(feature = "…"))` by adding an additional `doc(cfg)` to ensure the `macros` feature requirement is included in rustdoc.

Then it adds some plain-english rustdoc to the descriptions of test and main macro options to explain the feature dependencies on those. There was previously some mixup with what macros these options (and associated usage examples) were applied, so that is also fixed here.

To test this locally, one can use the following:

``` bash
RUSTDOCFLAGS="--cfg docsrs" cargo doc --no-deps --open --all-features
```

Note that this results in the following rustdoc generated output on these macros:

> This is supported on `feature="rt-threaded"` and `feature="macros"` only.

This is not entirely correct, but its better then what it is in [current (0.2.11) docs](https://docs.rs/tokio/0.2.11/tokio/attr.main.html):

> This is supported on `feature="rt-threaded"` only.

I do not see a way to entirely _override_ the `doc(cfg)` without unwinding the whole set of `cfg_*` macros which seems rather invasive. Perhaps this PR can improve 0.2 as a stopgap, and the approach of applying `doc(cfg)` can be more generally revisited for 0.3/1.0?