### PR TITLE
Implement StableDeref for Guards

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -83,7 +83,7 @@ signal = [
   "winapi/minwindef",
 ]
 stream = ["futures-core"]
-sync = ["fnv"]
+sync = ["fnv", "stable_deref_trait"]
 test-util = []
 tcp = ["io-driver", "iovec"]
 time = ["slab"]
@@ -106,6 +106,7 @@ iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true } # Not in full
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
+stable_deref_trait = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 mio-uds = { version = "0.6.5", optional = true }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -82,6 +82,7 @@
 use crate::future::poll_fn;
 use crate::sync::semaphore_ll as semaphore;
 
+use stable_deref_trait::StableDeref;
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
@@ -117,6 +118,7 @@ pub struct MutexGuard<'a, T> {
 unsafe impl<T> Send for Mutex<T> where T: Send {}
 unsafe impl<T> Sync for Mutex<T> where T: Send {}
 unsafe impl<'a, T> Sync for MutexGuard<'a, T> where T: Send + Sync {}
+unsafe impl<'a, T> StableDeref for MutexGuard<'a, T> {}
 
 /// Error returned from the [`Mutex::try_lock`] function.
 ///

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -1,5 +1,6 @@
 use crate::future::poll_fn;
 use crate::sync::semaphore_ll::{AcquireError, Permit, Semaphore};
+use stable_deref_trait::StableDeref;
 use std::cell::UnsafeCell;
 use std::ops;
 use std::task::{Context, Poll};
@@ -130,6 +131,8 @@ unsafe impl<T> Send for RwLock<T> where T: Send {}
 unsafe impl<T> Sync for RwLock<T> where T: Send + Sync {}
 unsafe impl<'a, T> Sync for RwLockReadGuard<'a, T> where T: Send + Sync {}
 unsafe impl<'a, T> Sync for RwLockWriteGuard<'a, T> where T: Send + Sync {}
+unsafe impl<'a, T> StableDeref for RwLockReadGuard<'a, T> {}
+unsafe impl<'a, T> StableDeref for RwLockWriteGuard<'a, T> {}
 
 impl<T> RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.


### PR DESCRIPTION
## Motivation

Guards at the moment cannot easily be mapped. This means that if I have a struct with a private mutex or RwLock, I can't return a reference to the value inside the mutex:

```rust
pub struct S(Mutex<Vec<i32>>);

impl S {
    // This doesn't compile.
    pub fn first_mut(&self) -> Option<&mut i32> {
        self.0.lock().await.get_mut(0)
    }
}
```

## Solution

This patch implements `StableDeref` from [stable_deref_trait](https://crates.io/crates/stable_deref_trait) for all the guards, allowing them to be mapped with crates like [owning_ref](https://crates.io/crates/owning_ref).

It does introduce an extra dependency, but it is a very small one. Now the above code will look like this:

```rust
pub struct S(Mutex<Vec<i32>>);

impl S {
    // This does compile.
    pub fn first_mut(&self) -> Option<OwningRefMut<MutexGuard<'_, Vec<i32>>, i32>> {
        OwningRefMut::new(self.0.lock().await).try_map_mut(|v| v.get_mut(0).ok_or(())).ok()
    }
}
```