### PR TITLE
Correct link to the guide on tokio.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ the Rust programming language. It is:
 [discord-url]: https://discord.gg/tokio
 
 [Website](https://tokio.rs) |
-[Guides](https://tokio.rs/docs/) |
+[Guides](https://tokio.rs/docs/overview/) |
 [API Docs](https://docs.rs/tokio/latest/tokio) |
 [Roadmap](https://github.com/tokio-rs/tokio/blob/master/ROADMAP.md) |
 [Chat](https://discord.gg/tokio)


### PR DESCRIPTION
The current link to tokio.rs/docs 404's.  This change redirects the "guides" link to the docs overview (which may be what was intended).

## Motivation

I'm not a fan of links that 404 in documentation.  I have forked the repo, issued a pull request and live in hope that it is pulled.

## Solution

If the link that I have suggested is not the correct link, feel free to close this pull request and provide the correct url.   Back and forth for something this simple is not required.

Thank you.

