### PR TITLE
Fix doc comment spelling in lib.rs

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -122,7 +122,7 @@ pub fn main_basic(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::main(args, item, false)
 }
 
-/// Marks async function to be executed by runtime, suitable to test enviornment
+/// Marks async function to be executed by runtime, suitable to test environment
 ///
 /// ## Options:
 ///
@@ -153,7 +153,7 @@ pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::test(args, item, true)
 }
 
-/// Marks async function to be executed by runtime, suitable to test enviornment
+/// Marks async function to be executed by runtime, suitable to test environment
 ///
 /// ## Options:
 ///
@@ -184,7 +184,7 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::old::test(args, item)
 }
 
-/// Marks async function to be executed by runtime, suitable to test enviornment
+/// Marks async function to be executed by runtime, suitable to test environment
 ///
 /// ## Options:
 ///


### PR DESCRIPTION
thx for all your hard work on this crate!! been really fantastic using it

## Motivation

the spelling of `enviornment ` is wrong

## Solution

i fixed the spelling