### PR TITLE
Added Ord and Hash as derived traits for tokio::time::Instant

### DIFF
--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 /// A measurement of the system clock, useful for talking to
 /// external entities like the file system or other processes.
-#[derive(Clone, Copy, Eq, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Instant {
     std: std::time::Instant,
 }


### PR DESCRIPTION
The added derived traits mirror the traits of std::time::Instant. As
tokio::time::Instant is just a wrapper around std::time::Instant, it
should also derive all the traits std::time::Instant derives.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

tokio::time::Instant is just a wrapper around std::time::Instant, as such it should
behave just like std::time::Instant. That should include what kind of
traits it derives.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Just added the same derived traits as std::time::Instant
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
