### PR TITLE
UnixStream::poll_shutdown is not a no-op

### DIFF
--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -173,6 +173,7 @@ impl AsyncWrite for UnixStream {
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.shutdown(std::net::Shutdown::Write)?;
         Poll::Ready(Ok(()))
     }
 }

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -33,3 +33,26 @@ async fn accept_read_write() -> std::io::Result<()> {
     assert_eq!(len, 0);
     Ok(())
 }
+
+#[tokio::test]
+async fn shutdown() -> std::io::Result<()> {
+    let dir = tempfile::Builder::new()
+        .prefix("tokio-uds-tests")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("connect.sock");
+
+    let mut listener = UnixListener::bind(&sock_path)?;
+
+    let accept = listener.accept();
+    let connect = UnixStream::connect(&sock_path);
+    let ((mut server, _), mut client) = try_join(accept, connect).await?;
+
+    // Shut down the client
+    AsyncWriteExt::shutdown(&mut client).await?;
+    // Read from the server should return 0 to indicate the channel has been closed.
+    let mut buf = [0u8; 1];
+    let n = server.read(&mut buf).await?;
+    assert_eq!(n, 0);
+    Ok(())
+}


### PR DESCRIPTION
This brings `UnixStream::poll_shutdown` in line with `TcpStream::poll_shutdown`.