### PR TITLE
Add `Mutex::into_inner` method

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -174,6 +174,11 @@ impl<T> Mutex<T> {
             Err(_) => Err(TryLockError(())),
         }
     }
+
+    /// Consumes the mutex, returning the underlying data.
+    pub fn into_inner(self) -> T {
+        self.c.into_inner()
+    }
 }
 
 impl<'a, T> Drop for MutexGuard<'a, T> {


### PR DESCRIPTION
Add `Mutex::into_inner` method that consumes mutex
and return underlying value.

I'm not sure what to test here, so I didn't add any tests.

Fixes #2211

## Motivation

There are cases when you need to get ownership over the underlying value.

Also, both [`std::sync::Mutex`][stdm] and [`futures::sync::Mutex`][fm] have the methods `into_inner` that allow you to consume the mutex and get the owned value from it.

[stdm]: https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.into_inner
[fm]: https://docs.rs/futures/0.3.1/futures/lock/struct.Mutex.html#method.into_inner

## Solution

Add `into_inner` method for `sync::Mutex`  that simply calls `into_inner` on inner `UnsafeCell`