### PR TITLE
new example illustrating calling tokio from non-async code

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -37,6 +37,10 @@ name = "hello_world"
 path = "hello_world.rs"
 
 [[example]]
+name = "no-async-main"
+path = "no-async-main.rs"
+
+[[example]]
 name = "print_each_packet"
 path = "print_each_packet.rs"
 

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -5,19 +5,19 @@
 //!
 //!     cargo run --example no-async-main
 
-use tokio::sync::{oneshot, mpsc};
 use tokio::runtime::{Handle, Runtime};
+use tokio::sync::{mpsc, oneshot};
 use Command::Increment;
 
 #[derive(Debug)]
 enum Command {
-    Increment,
-    // Other commands can be added here
+  Increment,
+  // Other commands can be added here
 }
 
 #[derive(Debug)]
 enum Response {
-  IncrementCompleted(u64)
+  IncrementCompleted(u64),
 }
 
 struct Commander {
@@ -27,7 +27,7 @@ struct Commander {
 #[derive(Clone)]
 struct Sender {
   handle: Handle,
-  cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>
+  cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>,
 }
 
 impl Commander {
@@ -43,33 +43,28 @@ impl Commander {
       let mut counter: u64 = 0;
       while let Some((cmd, response)) = cmd_rx.recv().await {
         match cmd {
-            Increment => {
-                counter += 1;
-                response.send(Response::IncrementCompleted(counter)).unwrap();
-            }
+          Increment => {
+            counter += 1;
+            response
+              .send(Response::IncrementCompleted(counter))
+              .unwrap();
+          }
         }
       }
     });
     ready_callback(Sender::new(cmd_tx, self.runtime.handle().clone()));
   }
-
 }
 
 impl Sender {
-  pub fn new(cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>,
-             handle: Handle) -> Self {
-    Sender {
-      handle,
-      cmd_tx
-    }
+  pub fn new(cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>, handle: Handle) -> Self {
+    Sender { handle, cmd_tx }
   }
 
-  pub fn send_command(&mut self, cmd: Command, f: impl Fn(Response) -> () + Send + 'static)
-  {
+  pub fn send_command(&mut self, cmd: Command, f: impl Fn(Response) -> () + Send + 'static) {
     let (resp_tx, resp_rx) = oneshot::channel::<Response>();
     let mut cmd_tx = self.cmd_tx.clone();
     self.handle.spawn(async move {
-
       cmd_tx.send((cmd, resp_tx)).await.ok().unwrap();
       let res: Response = resp_rx.await.unwrap();
 
@@ -79,18 +74,18 @@ impl Sender {
   }
 } // impl Sender
 
-
 fn main() {
   let c = Commander::new();
   c.connect(move |mut sender| {
-      println!("Yay!");
-      sender.send_command(Increment, |response| {
-        println!("  ==> received response {:?}", response);
-      })
+    println!("Yay!");
+    sender.send_command(Increment, |response| {
+      println!("  ==> received response {:?}", response);
+    })
   });
 
   let mut input = String::new();
   println!("press return to quit");
-  std::io::stdin().read_line(&mut input).expect("stdio read_line");
-
+  std::io::stdin()
+    .read_line(&mut input)
+    .expect("stdio read_line");
 }

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -5,8 +5,7 @@
 //! -- it does not compile 
 //! -- may not be using the best idioms for what I'm attempting to illustrate
 //!
-//!
-//! And then in another terminal run:
+//! To run the example:
 //!
 //!     cargo run --example no-async-main
 

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -1,0 +1,102 @@
+//! A simple client that does some work and triggers a callback asynchronously
+//! with an API can be called from no-async code and uses async tokio inside
+//!
+//!  THIS DOES NOT WORK YET 
+//! -- it does not compile 
+//! -- may not be using the best idioms for what I'm attempting to illustrate
+//!
+//!
+//! And then in another terminal run:
+//!
+//!     cargo run --example no-async-main
+
+use std::net::SocketAddr;
+use tokio::sync::{oneshot, mpsc};
+use tokio::runtime::Runtime;
+use Command::Increment;
+
+#[derive(Debug)]
+enum Command {
+    Increment,
+    // Other commands can be added here
+}
+
+#[derive(Debug)]
+enum Response {
+  IncrementCompleted(u64)
+}
+
+struct Commander {
+  runtime: Runtime,
+  cmd_tx: Option<mpsc::Sender<(Command, oneshot::Sender<Response>)>>
+  // join_handles: Vec<>  = vec![]
+}
+
+impl Commander {
+  pub fn new() -> Commander {
+    Commander {
+      runtime: Runtime::new().unwrap(),
+      cmd_tx: None
+    }
+  }
+
+  pub fn send_command(&mut self, cmd: Command, f: impl Fn(Response) -> () + Send + 'static)
+  {
+    if let Some(self_cmd_tx) = &self.cmd_tx {
+      let (resp_tx, resp_rx) = oneshot::channel::<Response>();
+
+      let mut cmd_tx = self_cmd_tx.clone();
+      self.runtime.spawn(async move {
+
+            cmd_tx.send((cmd, resp_tx)).await.ok().unwrap();
+            let res: Response = resp_rx.await.unwrap();
+
+            println!("=> {:?}", res);
+            f(res);
+        });
+    } else {
+      panic!("need to connect before calling send_command")
+    }
+  }
+
+  pub fn connect(&mut self, _addr: SocketAddr,
+                            f: impl FnMut(bool) -> () + Send + 'static) {
+    let (cmd_tx, mut cmd_rx) = mpsc::channel::<(Command, oneshot::Sender<Response>)>(100);
+    self.cmd_tx = Some(cmd_tx);
+
+    // Spawn a task to manage the counter
+    self.runtime.spawn(async move {
+      // imagine we connect TCPsocket or something other slow thing here
+      f(true);
+      let mut counter: u64 = 0;
+      while let Some((cmd, response)) = cmd_rx.recv().await {
+        match cmd {
+            Increment => {
+                counter += 1;
+                response.send(Response::IncrementCompleted(counter)).unwrap();
+            }
+        }
+      }
+    });
+  }
+} // impl Commander
+
+fn main() {
+  let addr: SocketAddr = "127.0.0.1:1234".parse().unwrap();
+  let mut c = Commander::new();
+  c.connect(addr, move |connected| {
+    if connected {
+      println!("Yay!");
+      c.send_command(Increment, |response| {
+        println!("received response {:?}", response);
+      })
+    } else {
+      println!("sorry.. try again later");
+    }
+  });
+
+  let mut input = String::new();
+  println!("press return to quit");
+  std::io::stdin().read_line(&mut input).expect("stdio read_line");
+
+}

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -36,7 +36,7 @@ impl Commander {
       runtime: Runtime::new().unwrap(),
     }
   }
-  pub fn connect(&mut self, mut ready_callback: impl FnMut(Sender) -> () + Send + 'static) {
+  pub fn connect(&self, ready_callback: impl Fn(Sender) -> () + Send + 'static) {
     let (cmd_tx, mut cmd_rx) = mpsc::channel::<(Command, oneshot::Sender<Response>)>(100);
     // Spawn a task to manage the counter
     self.runtime.spawn(async move {
@@ -81,7 +81,7 @@ impl Sender {
 
 
 fn main() {
-  let mut c = Commander::new();
+  let c = Commander::new();
   c.connect(move |mut sender| {
       println!("Yay!");
       sender.send_command(Increment, |response| {

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -4,88 +4,87 @@
 //! To run the example:
 //!
 //!     cargo run --example no-async-main
-
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::{mpsc, oneshot};
 use Command::Increment;
 
 #[derive(Debug)]
 enum Command {
-  Increment,
-  // Other commands can be added here
+    Increment,
+    // Other commands can be added here
 }
 
 #[derive(Debug)]
 enum Response {
-  IncrementCompleted(u64),
+    IncrementCompleted(u64),
 }
 
 struct Commander {
-  runtime: Runtime,
+    runtime: Runtime,
 }
 
 #[derive(Clone)]
 struct Sender {
-  handle: Handle,
-  cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>,
+    handle: Handle,
+    cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>,
 }
 
 impl Commander {
-  pub fn new() -> Commander {
-    Commander {
-      runtime: Runtime::new().unwrap(),
-    }
-  }
-  pub fn connect(&self, ready_callback: impl Fn(Sender) -> () + Send + 'static) {
-    let (cmd_tx, mut cmd_rx) = mpsc::channel::<(Command, oneshot::Sender<Response>)>(100);
-    // Spawn a task to manage the counter
-    self.runtime.spawn(async move {
-      let mut counter: u64 = 0;
-      while let Some((cmd, response)) = cmd_rx.recv().await {
-        match cmd {
-          Increment => {
-            counter += 1;
-            response
-              .send(Response::IncrementCompleted(counter))
-              .unwrap();
-          }
+    pub fn new() -> Commander {
+        Commander {
+            runtime: Runtime::new().unwrap(),
         }
-      }
-    });
-    ready_callback(Sender::new(cmd_tx, self.runtime.handle().clone()));
-  }
+    }
+    pub fn connect(&self, ready_callback: impl Fn(Sender) -> () + Send + 'static) {
+        let (cmd_tx, mut cmd_rx) = mpsc::channel::<(Command, oneshot::Sender<Response>)>(100);
+        // Spawn a task to manage the counter
+        self.runtime.spawn(async move {
+            let mut counter: u64 = 0;
+            while let Some((cmd, response)) = cmd_rx.recv().await {
+                match cmd {
+                    Increment => {
+                        counter += 1;
+                        response
+                            .send(Response::IncrementCompleted(counter))
+                            .unwrap();
+                    }
+                }
+            }
+        });
+        ready_callback(Sender::new(cmd_tx, self.runtime.handle().clone()));
+    }
 }
 
 impl Sender {
-  pub fn new(cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>, handle: Handle) -> Self {
-    Sender { handle, cmd_tx }
-  }
+    pub fn new(cmd_tx: mpsc::Sender<(Command, oneshot::Sender<Response>)>, handle: Handle) -> Self {
+        Sender { handle, cmd_tx }
+    }
 
-  pub fn send_command(&mut self, cmd: Command, f: impl Fn(Response) -> () + Send + 'static) {
-    let (resp_tx, resp_rx) = oneshot::channel::<Response>();
-    let mut cmd_tx = self.cmd_tx.clone();
-    self.handle.spawn(async move {
-      cmd_tx.send((cmd, resp_tx)).await.ok().unwrap();
-      let res: Response = resp_rx.await.unwrap();
+    pub fn send_command(&mut self, cmd: Command, f: impl Fn(Response) -> () + Send + 'static) {
+        let (resp_tx, resp_rx) = oneshot::channel::<Response>();
+        let mut cmd_tx = self.cmd_tx.clone();
+        self.handle.spawn(async move {
+            cmd_tx.send((cmd, resp_tx)).await.ok().unwrap();
+            let res: Response = resp_rx.await.unwrap();
 
-      println!("  => {:?}", res);
-      f(res);
-    });
-  }
+            println!("  => {:?}", res);
+            f(res);
+        });
+    }
 } // impl Sender
 
 fn main() {
-  let c = Commander::new();
-  c.connect(move |mut sender| {
-    println!("Yay!");
-    sender.send_command(Increment, |response| {
-      println!("  ==> received response {:?}", response);
-    })
-  });
+    let c = Commander::new();
+    c.connect(move |mut sender| {
+        println!("Yay!");
+        sender.send_command(Increment, |response| {
+            println!("  ==> received response {:?}", response);
+        })
+    });
 
-  let mut input = String::new();
-  println!("press return to quit");
-  std::io::stdin()
-    .read_line(&mut input)
-    .expect("stdio read_line");
+    let mut input = String::new();
+    println!("press return to quit");
+    std::io::stdin()
+        .read_line(&mut input)
+        .expect("stdio read_line");
 }

--- a/examples/no-async-main.rs
+++ b/examples/no-async-main.rs
@@ -1,10 +1,6 @@
 //! A simple client that does some work and triggers a callback asynchronously
 //! with an API can be called from no-async code and uses async tokio inside
 //!
-//!  THIS DOES NOT WORK YET 
-//! -- it does not compile 
-//! -- may not be using the best idioms for what I'm attempting to illustrate
-//!
 //! To run the example:
 //!
 //!     cargo run --example no-async-main


### PR DESCRIPTION
to address: https://github.com/tokio-rs/tokio/issues/1988

I thought a good scenario to address the question would be to make an API that could be called from non-async-code that did something a bit oversimplified, yet still real-world-ish.

The core of the example was taken from https://docs.rs/tokio/0.2.11/tokio/sync/index.html and then modified to remove async from main and create an old-school callback kind of API.

Update: the example now compiles and (I think) functions as intended

---- original description
This PR doesn't compile (error below).  I wasn't sure if I should change `Commander` to have interior mutability with `Arc<Mutex<...>>` or something or if there is some other pattern folks would recommend?  Also, got a bit stuck on rust syntax for mutability of closure... not quite sure how to fix that one.  

```
error[E0596]: cannot borrow `f` as mutable, as it is not declared as mutable
  --> examples/callback.rs:58:7
   |
51 |                             f: impl FnMut(bool) -> () + Send + 'static) {
   |                             - help: consider changing this to be mutable: `mut f`
...
58 |       f(true);
   |       ^ cannot borrow as mutable

error[E0505]: cannot move out of `c` because it is borrowed
  --> examples/callback.rs:75:19
   |
75 |   c.connect(addr, move |connected| {
   |   - -------       ^^^^^^^^^^^^^^^^ move out of `c` occurs here
   |   | |
   |   | borrow later used by call
   |   borrow of `c` occurs here
...
78 |       c.send_command(Increment, |response| {
   |       - move occurs due to use in closure

error: aborting due to 2 previous errors

Some errors have detailed explanations: E0505, E0596.
For more information about an error, try `rustc --explain E0505`.
error: could not compile `irc-tokio`.
```