### PR TITLE
Automatically activate rt-threaded feature flag for macros

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -54,7 +54,7 @@ io-driver = ["mio", "lazy_static"]
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
-macros = ["tokio-macros"]
+macros = ["tokio-macros", "rt-threaded"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
   "io-driver",


### PR DESCRIPTION
## Motivation

The `tokio::test` and `tokio::main` macros instantiate a runtime.
Hence, the `macros` feature should automatically bring in the necessary code, otherwise only specifying `features = ["macros"]` fails to compile.

## Solution

Add `rt-threaded` to the list of required features for the `macros` feature.

I tried to write a test for this in the tests-build crate using try-build but I couldn't get it to work, so I opted for sending this fix without a test.