### PR TITLE
sync: fixed a small typo in sync docs

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -395,7 +395,7 @@
 //!
 //! # State synchronization
 //!
-//! The remainding synchronization primitives focus on synchronizing state.
+//! The remaining synchronization primitives focus on synchronizing state.
 //! These are asynchronous equivalents to versions provided by `std`. They
 //! operate in a similar way as their `std` counterparts parts but will wait
 //! asynchronously instead of blocking the thread.


### PR DESCRIPTION
## Motivation
Reading the `sync` documentation, I found a small spelling error.

## Solution
I fixed the error.

Signed-off-by: Matt Butcher <matt.butcher@microsoft.com>