### PR TITLE
sync: Add missing Clone boundary to constructor (#2261)

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -365,7 +365,7 @@ const MAX_RECEIVERS: usize = usize::MAX >> 1;
 ///     tx.send(20).unwrap();
 /// }
 /// ```
-pub fn channel<T>(mut capacity: usize) -> (Sender<T>, Receiver<T>) {
+pub fn channel<T: Clone>(mut capacity: usize) -> (Sender<T>, Receiver<T>) {
     assert!(capacity > 0, "capacity is empty");
     assert!(capacity <= usize::MAX >> 1, "requested capacity too large");
 


### PR DESCRIPTION
The `sync::broadcast::Receiver` impl for Stream has a `Clone` boundary on
its type parameter. 

Currently, when creating such a channel parametrized by a type that does not implement `Clone`, a hard to understand compile error occurs.

This fix makes it clear to the user what was wrong.
The issue #2261 includes more details.