### PR TITLE
Implement Stream for Listener types

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -7,7 +7,6 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
 cfg_tcp! {
@@ -372,7 +371,10 @@ impl TcpListener {
 impl crate::stream::Stream for TcpListener {
     type Item = io::Result<TcpStream>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         let (socket, _) = ready!(self.poll_accept(cx))?;
         Poll::Ready(Some(Ok(socket)))
     }

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -7,13 +7,28 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
+use std::pin::Pin;
 use std::task::{Context, Poll};
 
 cfg_tcp! {
     /// A TCP socket server, listening for connections.
     ///
+    /// Also implements a stream over the connections being received on this listener.
+    ///
+    /// The stream will never return `None` and will also not yield the peer's
+    /// `SocketAddr` structure. Iterating over it is equivalent to calling accept in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Note that accepting a connection can lead to various errors and not all
+    /// of them are necessarily fatal ‒ for example having too many open file
+    /// descriptors or the other side closing the connection while it waits in
+    /// an accept queue. These would terminate the stream if not handled in any
+    /// way.
+    ///
     /// # Examples
     ///
+    /// Using [`TcpListener::accept`]:
     /// ```no_run
     /// use tokio::net::TcpListener;
     ///
@@ -31,6 +46,24 @@ cfg_tcp! {
     ///     loop {
     ///         let (socket, _) = listener.accept().await?;
     ///         process_socket(socket).await;
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// Using `impl Stream`:
+    /// ```no_run
+    /// use tokio::{net::TcpListener, stream::StreamExt};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut listener = TcpListener::bind("127.0.0.1:8080").await.unwrap();
+    ///     while let Some(stream) = listener.next().await {
+    ///         match stream {
+    ///             Ok(stream) => {
+    ///                 println!("new client!");
+    ///             }
+    ///             Err(e) => { /* connection failed */ }
+    ///         }
     ///     }
     /// }
     /// ```
@@ -332,6 +365,16 @@ impl TcpListener {
     /// ```
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.io.get_ref().set_ttl(ttl)
+    }
+}
+
+#[cfg(feature = "stream")]
+impl crate::stream::Stream for TcpListener {
+    type Item = io::Result<TcpStream>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let (socket, _) = ready!(self.poll_accept(cx))?;
+        Poll::Ready(Some(Ok(socket)))
     }
 }
 

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -10,7 +10,6 @@ use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
-use std::pin::Pin;
 use std::task::{Context, Poll};
 
 cfg_uds! {
@@ -180,7 +179,10 @@ impl UnixListener {
 impl crate::stream::Stream for UnixListener {
     type Item = io::Result<UnixStream>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+    fn poll_next(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
         let (socket, _) = ready!(self.poll_accept(cx))?;
         Poll::Ready(Some(Ok(socket)))
     }

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -10,10 +10,44 @@ use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr};
 use std::path::Path;
+use std::pin::Pin;
 use std::task::{Context, Poll};
 
 cfg_uds! {
     /// A Unix socket which can accept connections from other Unix sockets.
+    ///
+    /// Also implements a stream over the connections being received on this listener.
+    ///
+    /// The stream will never return `None` and will also not yield the peer's
+    /// `SocketAddr` structure. Iterating over it is equivalent to calling accept in a loop.
+    ///
+    /// # Errors
+    ///
+    /// Note that accepting a connection can lead to various errors and not all
+    /// of them are necessarily fatal ‒ for example having too many open file
+    /// descriptors or the other side closing the connection while it waits in
+    /// an accept queue. These would terminate the stream if not handled in any
+    /// way.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixListener;
+    /// use tokio::stream::StreamExt;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut listener = UnixListener::bind("/path/to/the/socket").unwrap();
+    ///     while let Some(stream) = listener.next().await {
+    ///         match stream {
+    ///             Ok(stream) => {
+    ///                 println!("new client!");
+    ///             }
+    ///             Err(e) => { /* connection failed */ }
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub struct UnixListener {
         io: PollEvented<mio_uds::UnixListener>,
     }
@@ -139,6 +173,16 @@ impl UnixListener {
     /// ```
     pub fn incoming(&mut self) -> Incoming<'_> {
         Incoming::new(self)
+    }
+}
+
+#[cfg(feature = "stream")]
+impl crate::stream::Stream for UnixListener {
+    type Item = io::Result<UnixStream>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let (socket, _) = ready!(self.poll_accept(cx))?;
+        Poll::Ready(Some(Ok(socket)))
     }
 }
 


### PR DESCRIPTION
## Motivation

The Incoming types currently don't take ownership of the listener, but
in most cases, users who want to use the Listener as a stream will only
want to use the stream from that point on. So, implement Stream directly
on the Listener types.

## Solution

Implement Stream for the Listener types (copy from `Incoming` implementation)

Unresolved question: The two `Incoming` types serve no purpose now and could be removed, but this would break existing code.
