### PR TITLE
Fix unresolved import in pin!

### DIFF
--- a/tokio/src/macros/pin.rs
+++ b/tokio/src/macros/pin.rs
@@ -138,7 +138,7 @@ macro_rules! pin {
     )*) => {
         $(
             let $x = $init;
-            crate::pin!($x);
+            $crate::pin!($x);
         )*
     };
 }

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,11 +1,9 @@
-use tokio::pin;
-
 async fn one() {}
 async fn two() {}
 
 #[tokio::test]
 async fn multi_pin() {
-    pin! {
+    tokio::pin! {
         let f1 = one();
         let f2 = two();
     }


### PR DESCRIPTION
## Motivation
A new assignment form of `pin!` macro introduced in v0.2.12 causes 'unresolved import' in this code.

```rust
fn main() {
    tokio::pin! {
        let x = 0;
    }
}
```

## Solution
The macro uses `crate` instead of `$crate`. This PR fixes this incorrect usage.