### PR TITLE
macros: fix select! documentation formatting

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -4,7 +4,7 @@
 /// The `select!` macro must be used inside of async functions, closures, and
 /// blocks.
 ///
-/// The `select` macro accepts one or more branches with the following pattern:
+/// The `select!` macro accepts one or more branches with the following pattern:
 ///
 /// ```text
 /// <pattern> = <async expression> (, if <precondition>)? => <handler>,
@@ -24,7 +24,7 @@
 /// expression.
 ///
 /// Additionally, each branch may include an optional `if` precondition. This
-/// precondition is evaluated **before** the <async expression>. If the
+/// precondition is evaluated **before** the `<async expression>`. If the
 /// precondition returns `false`, the branch is entirely disabled. This
 /// capability is useful when using `select!` within a loop.
 ///
@@ -41,7 +41,7 @@
 /// 4. Once an `<async expression>` returns a value, attempt to apply the value
 ///    to the provided `<pattern>`, if the pattern matches, evaluate `<handler>`
 ///    and return. If the pattern **does not** match, disable the current branch
-///    and for the remainder of the current call to `select!. Continue from step 3.
+///    and for the remainder of the current call to `select!`. Continue from step 3.
 /// 5. If **all** branches are disabled, evaluate the `else` expression. If none
 ///    is provided, panic.
 ///
@@ -210,7 +210,7 @@
 /// }
 /// ```
 ///
-/// Using the same future in multiple select! expressions can be done by passing
+/// Using the same future in multiple `select!` expressions can be done by passing
 /// a reference to the future. Doing so requires the future to be [`Unpin`]. A
 /// future can be made [`Unpin`] by either using [`Box::pin`] or stack pinning.
 ///


### PR DESCRIPTION
## Motivation

Make documentation consistent.

## Solution

Add missing tick marks and consistently use exclamation point.
