### PR TITLE
time: fix DelayQueue rewriting delay on insert after Poll::Ready

### DIFF
--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -721,18 +721,16 @@ impl<T> DelayQueue<T> {
                 self.poll = wheel::Poll::new(now);
             }
 
-            self.delay = None;
+            // We poll the wheel to get the next value out before finding the next deadline.
+            let wheel_idx = self.wheel.poll(&mut self.poll, &mut self.slab);
 
-            if let Some(idx) = self.wheel.poll(&mut self.poll, &mut self.slab) {
-                if let Some(deadline) = self.next_deadline() {
-                    self.delay = Some(delay_until(deadline));
-                }
+            self.delay = self.next_deadline().map(|deadline| delay_until(deadline));
+
+            if let Some(idx) = wheel_idx {
                 return Poll::Ready(Some(Ok(idx)));
             }
 
-            if let Some(deadline) = self.next_deadline() {
-                self.delay = Some(delay_until(deadline));
-            } else {
+            if self.delay.is_none() {
                 return Poll::Ready(None);
             }
         }

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -724,6 +724,9 @@ impl<T> DelayQueue<T> {
             self.delay = None;
 
             if let Some(idx) = self.wheel.poll(&mut self.poll, &mut self.slab) {
+                if let Some(deadline) = self.next_deadline() {
+                    self.delay = Some(delay_until(deadline));
+                }
                 return Poll::Ready(Some(Ok(idx)));
             }
 

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -724,7 +724,7 @@ impl<T> DelayQueue<T> {
             // We poll the wheel to get the next value out before finding the next deadline.
             let wheel_idx = self.wheel.poll(&mut self.poll, &mut self.slab);
 
-            self.delay = self.next_deadline().map(|deadline| delay_until(deadline));
+            self.delay = self.next_deadline().map(delay_until);
 
             if let Some(idx) = wheel_idx {
                 return Poll::Ready(Some(Ok(idx)));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes #1700 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Previously, inserting a new item into a `DelayQueue` after a value expired would result in all items in the queue to be postponed until the inserted item was ready. This was due to a delay keeping track of when the next item expires wasn't being updated correctly when a value was extracted from the wheel. 

This PR makes sure that when a item expires, the `DelayQueue` updates the delay until the next item expires accordingly.