### PR TITLE
runtime: Allow starting the runtime with time in "frozen" mode,

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -397,10 +397,10 @@ cfg_time! {
 
 cfg_test_util! {
     impl Builder {
-        /// Use the runtimes deterministic time source by default.
+        /// Use the runtime's deterministic time source by default.
         ///
-        /// Doing this enables deterministic progression of time for
-        /// the runtime.
+        /// Toggling `freeze_time()` enables deterministic progression of time in
+        /// the Tokio runtime, which is useful for testing time-based code.
         ///
         /// # Examples
         ///
@@ -410,7 +410,7 @@ cfg_test_util! {
         /// let rt = runtime::Builder::new()
         ///     .freeze_time()
         ///     .build()
-        ///     .unwrap();
+        ///     .expect("Unable to build Tokio runtime");
         /// ```
         pub fn freeze_time(&mut self) -> &mut Self {
             self.freeze_time = true;

--- a/tokio/src/runtime/time.rs
+++ b/tokio/src/runtime/time.rs
@@ -15,8 +15,18 @@ mod variant {
     pub(crate) type Driver = Either<driver::Driver<io::Driver>, io::Driver>;
     pub(crate) type Handle = Option<driver::Handle>;
 
-    pub(crate) fn create_clock() -> Clock {
+    #[cfg(not(feature = "test-util"))]
+    pub(crate) fn create_clock(_: bool) -> Clock {
         Clock::new()
+    }
+
+    #[cfg(feature = "test-util")]
+    pub(crate) fn create_clock(frozen: bool) -> Clock {
+        if frozen {
+            Clock::new_frozen()
+        } else {
+            Clock::new()
+        }
     }
 
     /// Create a new timer driver / handle pair
@@ -44,7 +54,7 @@ mod variant {
     pub(crate) type Driver = io::Driver;
     pub(crate) type Handle = ();
 
-    pub(crate) fn create_clock() -> Clock {
+    pub(crate) fn create_clock(_: bool) -> Clock {
         ()
     }
 

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -132,8 +132,7 @@ cfg_test_util! {
             }
         }
 
-        // TODO: delete this. Some tests rely on this
-        #[cfg(all(test, not(loom)))]
+        #[cfg(all(not(loom)))]
         /// Return a new `Clock` instance that uses the current execution context's
         /// source of time.
         pub(crate) fn new_frozen() -> Clock {


### PR DESCRIPTION
runtime: Allow starting the runtime with time in "frozen" mode, supporting deterministic time progression for the runtime.

## Motivation
In support of testing, it's sometimes desirable to start the runtime with frozen time from the outset. This PR adds an option to the runtime builder to do that.
