### PR TITLE
Add `AsyncSeek` implementation for `BufReader` and `BufWriter`

### DIFF
--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -1,5 +1,5 @@
 use crate::io::util::DEFAULT_BUF_SIZE;
-use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncSeek};
+use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
 use pin_project_lite::pin_project;
 use std::io::{self, Read, SeekFrom};
@@ -185,14 +185,22 @@ impl<R: AsyncRead + AsyncSeek> AsyncSeek for BufReader<R> {
             // support seeking by i64::min_value() so we need to handle underflow when subtracting
             // remainder.
             if let Some(offset) = n.checked_sub(remainder) {
-                ready!(self.as_mut().get_pin_mut().start_seek(cx, SeekFrom::Current(offset)))?;
+                ready!(self
+                    .as_mut()
+                    .get_pin_mut()
+                    .start_seek(cx, SeekFrom::Current(offset)))?;
             } else {
                 // seek backwards by our remainder, and then by the offset
-                ready!(self.as_mut().get_pin_mut().start_seek(cx, SeekFrom::Current(-remainder)))?;
+                ready!(self
+                    .as_mut()
+                    .get_pin_mut()
+                    .start_seek(cx, SeekFrom::Current(-remainder)))?;
                 self.as_mut().discard_buffer();
-                ready!(self.as_mut().get_pin_mut().start_seek(cx, SeekFrom::Current(n)))?;
+                ready!(self
+                    .as_mut()
+                    .get_pin_mut()
+                    .start_seek(cx, SeekFrom::Current(n)))?;
             }
-
         } else {
             ready!(self.as_mut().get_pin_mut().start_seek(cx, position))?;
         }

--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -1,9 +1,9 @@
 use crate::io::util::DEFAULT_BUF_SIZE;
-use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, AsyncSeek};
+use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite};
 
 use pin_project_lite::pin_project;
 use std::fmt;
-use std::io::{self, Write, SeekFrom};
+use std::io::{self, SeekFrom, Write};
 use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/io_buf_reader_seek.rs
+++ b/tokio/tests/io_buf_reader_seek.rs
@@ -1,0 +1,36 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::{AsyncReadExt, AsyncSeekExt, BufReader};
+use tokio_test::assert_ok;
+
+use std::io::{Cursor, SeekFrom};
+
+#[tokio::test]
+async fn buf_reader_seek() {
+    let mut cursor = Cursor::new(b"hello\nworld\n\n");
+    let mut reader = BufReader::new(&mut cursor);
+
+    let mut buf: [u8; 5] = [0; 5];
+
+    let n = assert_ok!(reader.read(&mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf.as_ref(), "hello".as_bytes());
+
+    assert_ok!(reader.seek(SeekFrom::Current(-2)).await);
+
+    let n = assert_ok!(reader.read(&mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf.as_ref(), "lo\nwo".as_bytes());
+
+    assert_ok!(reader.seek(SeekFrom::Start(0)).await);
+
+    let n = assert_ok!(reader.read(&mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf.as_ref(), "hello".as_bytes());
+
+    assert_ok!(reader.seek(SeekFrom::End(0)).await);
+
+    let n = assert_ok!(reader.read(&mut buf).await);
+    assert_eq!(n, 0);
+}

--- a/tokio/tests/io_buf_writer_seek.rs
+++ b/tokio/tests/io_buf_writer_seek.rs
@@ -1,0 +1,34 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::{AsyncSeekExt, AsyncWriteExt, BufWriter};
+use tokio_test::assert_ok;
+
+use std::io::{Cursor, SeekFrom};
+
+#[tokio::test]
+async fn buf_writer_seek() {
+    let mut cursor = Cursor::new(Vec::new());
+    let mut writer = BufWriter::new(&mut cursor);
+
+    let n = assert_ok!(writer.write("hello".as_bytes()).await);
+    assert_eq!(n, 5);
+
+    assert_ok!(writer.seek(SeekFrom::Current(-2)).await);
+
+    let n = assert_ok!(writer.write("world".as_bytes()).await);
+    assert_eq!(n, 5);
+
+    assert_ok!(writer.seek(SeekFrom::Start(0)).await);
+
+    let n = assert_ok!(writer.write("hello ".as_bytes()).await);
+    assert_eq!(n, 6);
+
+    assert_ok!(writer.seek(SeekFrom::End(-2)).await);
+
+    let n = assert_ok!(writer.write("world!".as_bytes()).await);
+    assert_eq!(n, 6);
+
+    assert_ok!(writer.flush().await);
+    assert_eq!(cursor.get_ref().as_slice(), "hello world!".as_bytes());
+}


### PR DESCRIPTION
## Motivation

Fixes #2291.

## Solution

Implementation is based on current `AsyncSeek` implementation for `BufReader` and `BufWriter` in `futures` crate.
