### PR TITLE
Document common cargo commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,13 @@ rustfmt --check --edition 2018 $(find . -name '*.rs' -print)
 The `--check` argument prints the things that need to be fixed. If you remove
 it, `rustfmt` will update your files locally instead.
 
+You can run loom tests with
+```
+cd tokio # tokio crate in workspace
+LOOM_MAX_PREEMPTIONS=1 RUSTFLAGS="--cfg loom" \
+    cargo test --lib --release --features full -- --test-threads=1 --nocapture
+```
+
 ### Tests
 
 If the change being proposed alters code (as opposed to only documentation for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,32 @@ usually a good idea to first open an issue describing the change to solicit
 feedback and guidance. This will increase the likelihood of the PR getting
 merged.
 
+### Cargo Commands
+
+Due to the extensive use of features in Tokio, you will often need to add extra
+arguments to many common cargo commands. This section lists some commonly needed
+commands.
+
+Some commands just need the `--all-features` argument:
+```
+cargo build --all-features
+cargo check --all-features
+cargo test --all-features
+```
+When building documentation normally, the markers that list the features
+required for various parts of Tokio are missing. To build the documentation
+correctly, use this command:
+```
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+```
+The `cargo fmt` command does not work on the Tokio codebase. You can use the
+command below instead:
+```
+rustfmt --check --edition 2018 $(find . -name '*.rs' -print)
+```
+The `--check` argument prints the things that need to be fixed. If you remove
+it, `rustfmt` will update your files locally instead.
+
 ### Tests
 
 If the change being proposed alters code (as opposed to only documentation for


### PR DESCRIPTION
Currently you have to look inside the ci directory to find the commands, which does not lend itself very well to discoverability for new users. I personally found it difficult to find some of these, and I'm [not the only one][1].

You can view the rendered markdown [here][2].

[1]: https://github.com/tokio-rs/tokio/pull/1921#issuecomment-593762708
[2]: https://github.com/Darksonn/tokio/blob/document-ci-commands/CONTRIBUTING.md#cargo-commands