### PR TITLE
chore: run macOS 10.14 in CI

### DIFF
--- a/ci/azure-check-features.yml
+++ b/ci/azure-check-features.yml
@@ -6,7 +6,7 @@ jobs:
       Linux:
         vmImage: ubuntu-16.04
       MacOS:
-        vmImage: macOS-10.13
+        vmImage: macOS-10.14
       Windows:
         vmImage: vs2017-win2016
   pool:

--- a/ci/azure-test-integration.yml
+++ b/ci/azure-test-integration.yml
@@ -6,7 +6,7 @@ jobs:
       Linux:
         vmImage: ubuntu-16.04
       MacOS:
-        vmImage: macOS-10.13
+        vmImage: macOS-10.14
       Windows:
         vmImage: vs2017-win2016
   pool:

--- a/ci/azure-test-stable.yml
+++ b/ci/azure-test-stable.yml
@@ -8,7 +8,7 @@ jobs:
 
       ${{ if parameters.cross }}:
         MacOS:
-          vmImage: macOS-10.13
+          vmImage: macOS-10.14
         Windows:
           vmImage: vs2017-win2016
   pool:


### PR DESCRIPTION
macOS 10.13 are going to be removed in a few weeks:

https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/