### PR TITLE
Avoid modulo by 1

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -359,7 +359,7 @@ macro_rules! select {
                 let start = $crate::macros::support::thread_rng_n(BRANCHES);
 
                 for i in 0..BRANCHES {
-                    let branch = (start + i) % BRANCHES;
+                    let branch = if BRANCHES == 1 { 0 } else { (start + i) % BRANCHES };
 
                     match branch {
                         $(


### PR DESCRIPTION
## Motivation

By default, clippy objects to modding out by 1: https://rust-lang.github.io/rust-clippy/master/index.html#modulo_one
(c.f. https://github.com/tokio-rs/tokio/issues/2251)
## Solution
Add a special case when BRANCHES == 1