### PR TITLE
syscalls: #1845 Introduce unstable Syscall trait.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.cargo

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -392,6 +392,11 @@ cfg_time! {
     pub mod time;
 }
 
+cfg_test_util_unstable! {
+    pub(crate) mod syscall;
+    pub use syscall::Syscalls;
+}
+
 mod util;
 
 cfg_macros! {

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -318,6 +318,22 @@ macro_rules! cfg_not_test_util {
     }
 }
 
+macro_rules! cfg_test_util_unstable {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "test-util", tokio_unstable))]
+            #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_test_util_unstable {
+    ($($item:item)*) => {
+        $( #[cfg(not(all(feature = "test-util", tokio_unstable)))] $item )*
+    }
+}
+
 macro_rules! cfg_time {
     ($($item:item)*) => {
         $(

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -518,7 +518,7 @@ cfg_rt_core! {
                 let (io_driver, io_handle) = crate::runtime::io::create_driver(self.enable_io)?;
                 let clock = time::create_test_clock();
                 let (driver, time_handle) = crate::runtime::time::create_driver(self.enable_time, io_driver, clock.clone());
-                let syscalls = Arc::new(crate::syscall::DefaultSyscalls::new(driver));
+                let syscalls = std::sync::Arc::new(crate::syscall::DefaultSyscalls::new(driver));
                 let scheduler = crate::runtime::test_scheduler::TestScheduler::new(syscalls);
                 let spawner = Spawner::Test(scheduler.spawner().clone());
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -231,7 +231,7 @@ use self::shell::Shell;
 mod spawner;
 use self::spawner::Spawner;
 
-mod time;
+pub(crate) mod time;
 
 cfg_rt_threaded! {
     mod queue;
@@ -301,6 +301,9 @@ enum Kind {
     /// Execute tasks across multiple threads.
     #[cfg(feature = "rt-threaded")]
     ThreadPool(ThreadPool),
+
+    #[cfg(all(feature = "test-util", tokio_unstable))]
+    Test(crate::runtime::test_scheduler::TestScheduler),
 }
 
 /// After thread starts / before thread stops
@@ -402,6 +405,8 @@ impl Runtime {
             #[cfg(feature = "rt-threaded")]
             Kind::ThreadPool(exec) => exec.spawn(future),
             Kind::Basic(exec) => exec.spawn(future),
+            #[cfg(all(feature = "test-util", tokio_unstable))]
+            Kind::Test(exec) => exec.spawn(future),
         }
     }
 
@@ -448,6 +453,8 @@ impl Runtime {
             Kind::Basic(exec) => exec.block_on(future),
             #[cfg(feature = "rt-threaded")]
             Kind::ThreadPool(exec) => exec.block_on(future),
+            #[cfg(all(feature = "test-util", tokio_unstable))]
+            Kind::Test(exec) => exec.block_on(future),
         })
     }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -195,6 +195,10 @@ cfg_rt_core! {
     use basic_scheduler::BasicScheduler;
 
     pub(crate) mod task;
+
+    cfg_test_util_unstable! {
+        mod test_scheduler;
+    }
 }
 
 mod blocking;

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -16,6 +16,8 @@ pub(crate) enum Spawner {
     Basic(basic_scheduler::Spawner),
     #[cfg(feature = "rt-threaded")]
     ThreadPool(thread_pool::Spawner),
+    #[cfg(all(feature = "test-util", tokio_unstable))]
+    Test(crate::runtime::test_scheduler::Spawner),
 }
 
 cfg_rt_core! {
@@ -31,6 +33,8 @@ cfg_rt_core! {
                 Spawner::Basic(spawner) => spawner.spawn(future),
                 #[cfg(feature = "rt-threaded")]
                 Spawner::ThreadPool(spawner) => spawner.spawn(future),
+                #[cfg(all(feature = "test-util", tokio_unstable))]
+                Spawner::Test(spawner) => spawner.spawn(future)
             }
         }
     }

--- a/tokio/src/runtime/syscall.rs
+++ b/tokio/src/runtime/syscall.rs
@@ -1,0 +1,102 @@
+use crate::park::{Park, Unpark};
+use crate::runtime::enter;
+use crate::syscall::Syscalls;
+use crate::task::JoinHandle;
+use crate::util::{waker_ref, Wake};
+use std::future::Future;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll::Ready;
+
+#[derive(Clone)]
+pub(crate) struct SyscallExecutor {
+    inner: Arc<dyn Syscalls>,
+}
+
+impl std::fmt::Debug for SyscallExecutor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SyscallRuntime").finish()
+    }
+}
+
+#[allow(dead_code)]
+impl SyscallExecutor {
+    pub(super) fn new(inner: Arc<dyn Syscalls>) -> SyscallExecutor {
+        SyscallExecutor { inner }
+    }
+
+    pub(super) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let (wrapped, handle) = JoinHandle::<F::Output>::wrap(future);
+        self.inner.spawn(Box::pin(wrapped));
+        return handle;
+    }
+
+    pub(super) fn block_on<F>(&mut self, f: F) -> F::Output
+    where
+        F: Future,
+    {
+        let _e = enter(true);
+        pin!(f);
+
+        let mut park = SyscallPark {
+            inner: Arc::clone(&self.inner),
+        };
+
+        // TODO: Get rid of double Arc
+        let unpark = Arc::new(park.unpark());
+        let waker = waker_ref(&unpark);
+        let mut cx = Context::from_waker(&waker);
+        loop {
+            if let Ready(v) = crate::coop::budget(|| f.as_mut().poll(&mut cx)) {
+                return v;
+            }
+            park.park().unwrap();
+        }
+    }
+}
+
+struct SyscallPark {
+    inner: Arc<dyn Syscalls>,
+}
+
+impl Park for SyscallPark {
+    type Unpark = SyscallUnpark;
+    type Error = std::io::Error;
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.inner.park()
+    }
+
+    fn park_timeout(&mut self, duration: std::time::Duration) -> Result<(), Self::Error> {
+        self.inner.park_timeout(duration)
+    }
+
+    fn unpark(&self) -> Self::Unpark {
+        let inner = Arc::clone(&self.inner);
+        SyscallUnpark { inner }
+    }
+}
+
+struct SyscallUnpark {
+    inner: Arc<dyn Syscalls>,
+}
+
+impl Unpark for SyscallUnpark {
+    fn unpark(&self) {
+        self.inner.unpark()
+    }
+}
+
+impl Wake for SyscallUnpark {
+    fn wake(self: Arc<Self>) {
+        Wake::wake_by_ref(&self);
+    }
+
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.inner.unpark();
+    }
+}

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -76,8 +76,7 @@ doc_rt_core! {
     /// [`task::spawn_blocking`]: crate::task::spawn_blocking
     /// [`std::thread::JoinHandle`]: std::thread::JoinHandle
     pub struct JoinHandle<T> {
-        raw: Option<RawTask>,
-        _p: PhantomData<T>,
+        inner: variant::Inner<T>
     }
 }
 
@@ -86,16 +85,60 @@ unsafe impl<T: Send> Sync for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     pub(super) fn new(raw: RawTask) -> JoinHandle<T> {
-        JoinHandle {
+        let inner = variant::Inner::new(raw);
+        JoinHandle { inner }
+    }
+}
+
+#[cfg(all(feature = "test-util", tokio_unstable))]
+impl<T> JoinHandle<T> {
+    pub(crate) fn wrap<F>(
+        future: F,
+    ) -> (
+        Pin<Box<dyn Future<Output = ()> + Send + 'static>>,
+        JoinHandle<F::Output>,
+    )
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let (wrapped, inner) = variant::Inner::<T>::wrap(future);
+        (wrapped, JoinHandle { inner })
+    }
+}
+
+impl<T> Future for JoinHandle<T> {
+    type Output = super::Result<T>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
+}
+
+impl<T> fmt::Debug for JoinHandle<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("JoinHandle").finish()
+    }
+}
+
+struct RawTaskJoinHandle<T> {
+    raw: Option<RawTask>,
+    _p: PhantomData<T>,
+}
+
+impl<T> RawTaskJoinHandle<T> {
+    pub(super) fn new(raw: RawTask) -> RawTaskJoinHandle<T> {
+        RawTaskJoinHandle {
             raw: Some(raw),
             _p: PhantomData,
         }
     }
 }
 
-impl<T> Unpin for JoinHandle<T> {}
-
-impl<T> Future for JoinHandle<T> {
+impl<T> Future for RawTaskJoinHandle<T> {
     type Output = super::Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -107,6 +150,7 @@ impl<T> Future for JoinHandle<T> {
         // Raw should always be set. If it is not, this is due to polling after
         // completion
         let raw = self
+            .get_mut()
             .raw
             .as_ref()
             .expect("polling after `JoinHandle` already completed");
@@ -130,23 +174,128 @@ impl<T> Future for JoinHandle<T> {
     }
 }
 
-impl<T> Drop for JoinHandle<T> {
+impl<T> Unpin for RawTaskJoinHandle<T> {}
+
+impl<T> Drop for RawTaskJoinHandle<T> {
     fn drop(&mut self) {
         if let Some(raw) = self.raw.take() {
             if raw.header().state.drop_join_handle_fast().is_ok() {
                 return;
             }
-
             raw.drop_join_handle_slow();
         }
     }
 }
 
-impl<T> fmt::Debug for JoinHandle<T>
-where
-    T: fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("JoinHandle").finish()
+#[cfg(not(all(feature = "test-util", tokio_unstable)))]
+mod variant {
+    pub(super) type Inner<T> = super::RawTaskJoinHandle<T>;
+}
+
+#[cfg(all(feature = "test-util", tokio_unstable))]
+mod variant {
+    use super::RawTask;
+    use crate::sync::oneshot;
+    use std::future::Future;
+    use std::panic;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use std::thread;
+
+    /// Inner type for JoinHandle.
+    pub(super) enum Inner<T> {
+        RawTask(super::RawTaskJoinHandle<T>),
+        Oneshot {
+            oneshot: oneshot::Receiver<thread::Result<T>>,
+        },
+    }
+
+    impl<T> Inner<T> {
+        pub(super) fn wrap<F>(
+            future: F,
+        ) -> (
+            Pin<Box<dyn Future<Output = ()> + 'static + Send>>,
+            Inner<F::Output>,
+        )
+        where
+            F: Future + Send + 'static,
+            F::Output: Send + 'static,
+        {
+            let (tx, rx) = oneshot::channel();
+            let handle = Inner::Oneshot { oneshot: rx };
+            let future = Box::pin(future);
+            let wrapped = Wrapped {
+                inner: future,
+                oneshot: Some(tx),
+            };
+            (Box::pin(wrapped), handle)
+        }
+
+        pub(super) fn new(raw: RawTask) -> Inner<T> {
+            Inner::RawTask(super::RawTaskJoinHandle::new(raw))
+        }
+    }
+
+    impl<T> Future for Inner<T> {
+        type Output = super::super::Result<T>;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            unsafe {
+                match self.get_unchecked_mut() {
+                    Inner::Oneshot { ref mut oneshot } => {
+                        match Pin::new_unchecked(oneshot).poll(cx) {
+                            Poll::Pending => Poll::Pending,
+                            Poll::Ready(Ok(Ok(result))) => Poll::Ready(Ok(result)),
+                            Poll::Ready(Ok(Err(p))) => {
+                                Poll::Ready(Err(super::super::JoinError::panic2(p)))
+                            }
+                            // just count all channel errors as cancellation
+                            Poll::Ready(Err(_)) => {
+                                Poll::Ready(Err(super::super::JoinError::cancelled2()))
+                            }
+                        }
+                    }
+                    Inner::RawTask(ref mut inner) => Pin::new(inner).poll(cx),
+                }
+            }
+        }
+    }
+
+    impl<T> Unpin for Inner<T> {}
+
+    /// Wrapped will wrap the Future F in a future which will
+    /// poll the inner future, propagating the results via a oneshot channel
+    /// to the associated Inner.
+    struct Wrapped<F>
+    where
+        F: Future + Unpin,
+    {
+        inner: F,
+        oneshot: Option<oneshot::Sender<thread::Result<F::Output>>>,
+    }
+
+    impl<F> Future for Wrapped<F>
+    where
+        F: Future + Unpin,
+    {
+        type Output = ();
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let inner = Pin::new(&mut self.inner);
+            let result = panic::catch_unwind(panic::AssertUnwindSafe(|| inner.poll(cx)));
+            match result {
+                Ok(Poll::Pending) => Poll::Pending,
+                Ok(Poll::Ready(r)) => {
+                    drop(self.oneshot.take().map(|s| s.send(Ok(r))));
+                    Poll::Ready(())
+                }
+                // If a panic is encountered, the inner future is completed
+                // immediately return.
+                Err(p) => {
+                    drop(self.oneshot.take().map(|s| s.send(Err(p))));
+                    Poll::Ready(())
+                }
+            }
+        }
     }
 }

--- a/tokio/src/runtime/test_scheduler/mod.rs
+++ b/tokio/src/runtime/test_scheduler/mod.rs
@@ -23,16 +23,19 @@ pub(crate) struct Spawner {
     syscalls: Arc<dyn Syscalls>,
 }
 
-
 impl TestScheduler {
     pub(crate) fn new(syscalls: Arc<dyn Syscalls>) -> Self {
         let park = park::SyscallsPark::new(Arc::clone(&syscalls));
         let inner = BasicScheduler::new(park);
         let spawner = Spawner {
             inner: inner.spawner().clone(),
-            syscalls: Arc::clone(&syscalls)
+            syscalls: Arc::clone(&syscalls),
         };
-        TestScheduler { inner, spawner, syscalls }
+        TestScheduler {
+            inner,
+            spawner,
+            syscalls,
+        }
     }
 
     pub(crate) fn spawner(&self) -> &Spawner {

--- a/tokio/src/runtime/test_scheduler/mod.rs
+++ b/tokio/src/runtime/test_scheduler/mod.rs
@@ -1,0 +1,82 @@
+//! Implementer notes:
+//! Right now, the plan is to mirror `basic_scheduler`. We can then intercept
+//! calls to spawn and inject a task ID. Further, we're able to drive the runtime
+//! and the `Syscalls` trait at the same time.
+use crate::park::Park;
+use crate::runtime::BasicScheduler;
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+mod park;
+use crate::syscall::Syscalls;
+use crate::task::JoinHandle;
+
+/// Deterministically executes tasks on the current thread,
+pub(crate) struct TestScheduler<P>
+where
+    P: Park,
+{
+    inner: BasicScheduler<park::SyscallsPark<P>>,
+    spawner: Spawner,
+}
+
+#[derive(Clone)]
+pub(crate) struct Spawner {
+    inner: crate::runtime::basic_scheduler::Spawner,
+}
+
+impl<P> TestScheduler<P>
+where
+    P: Park,
+{
+    fn new(park: P, syscalls: Arc<dyn Syscalls>) -> Self {
+        let park = park::SyscallsPark::new(park, syscalls);
+        let inner = BasicScheduler::new(park);
+        let spawner = Spawner {
+            inner: inner.spawner().clone(),
+        };
+        TestScheduler { inner, spawner }
+    }
+
+    pub(crate) fn spawner(&self) -> &Spawner {
+        &self.spawner
+    }
+
+    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.inner.spawn(future)
+    }
+
+    pub(crate) fn block_on<F>(&mut self, future: F) -> F::Output
+    where
+        F: Future,
+    {
+        self.inner.block_on(future)
+    }
+}
+
+impl<P: Park> fmt::Debug for TestScheduler<P> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("TestScheduler").finish()
+    }
+}
+
+impl Spawner {
+    /// Spawns a future onto the scheduler.
+    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        todo!()
+    }
+}
+
+impl fmt::Debug for Spawner {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Spawner").finish()
+    }
+}

--- a/tokio/src/runtime/test_scheduler/mod.rs
+++ b/tokio/src/runtime/test_scheduler/mod.rs
@@ -2,7 +2,6 @@
 //! Right now, the plan is to mirror `basic_scheduler`. We can then intercept
 //! calls to spawn and inject a task ID. Further, we're able to drive the runtime
 //! and the `Syscalls` trait at the same time.
-use crate::park::Park;
 use crate::runtime::BasicScheduler;
 use std::fmt;
 use std::future::Future;
@@ -12,30 +11,28 @@ use crate::syscall::Syscalls;
 use crate::task::JoinHandle;
 
 /// Deterministically executes tasks on the current thread,
-pub(crate) struct TestScheduler<P>
-where
-    P: Park,
-{
-    inner: BasicScheduler<park::SyscallsPark<P>>,
+pub(crate) struct TestScheduler {
+    inner: BasicScheduler<park::SyscallsPark>,
     spawner: Spawner,
+    syscalls: Arc<dyn Syscalls>,
 }
 
 #[derive(Clone)]
 pub(crate) struct Spawner {
     inner: crate::runtime::basic_scheduler::Spawner,
+    syscalls: Arc<dyn Syscalls>,
 }
 
-impl<P> TestScheduler<P>
-where
-    P: Park,
-{
-    fn new(park: P, syscalls: Arc<dyn Syscalls>) -> Self {
-        let park = park::SyscallsPark::new(park, syscalls);
+
+impl TestScheduler {
+    pub(crate) fn new(syscalls: Arc<dyn Syscalls>) -> Self {
+        let park = park::SyscallsPark::new(Arc::clone(&syscalls));
         let inner = BasicScheduler::new(park);
         let spawner = Spawner {
             inner: inner.spawner().clone(),
+            syscalls: Arc::clone(&syscalls)
         };
-        TestScheduler { inner, spawner }
+        TestScheduler { inner, spawner, syscalls }
     }
 
     pub(crate) fn spawner(&self) -> &Spawner {
@@ -47,7 +44,10 @@ where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        self.inner.spawn(future)
+        let (wrapped, handle) = crate::task::JoinHandle::<F::Output>::wrap(future);
+        let future = self.syscalls.wrap_future(wrapped);
+        self.inner.spawn(future);
+        return handle;
     }
 
     pub(crate) fn block_on<F>(&mut self, future: F) -> F::Output
@@ -58,7 +58,7 @@ where
     }
 }
 
-impl<P: Park> fmt::Debug for TestScheduler<P> {
+impl fmt::Debug for TestScheduler {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("TestScheduler").finish()
     }
@@ -71,7 +71,10 @@ impl Spawner {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        todo!()
+        let (wrapped, handle) = crate::task::JoinHandle::<F::Output>::wrap(future);
+        let future = self.syscalls.wrap_future(wrapped);
+        self.inner.spawn(future);
+        return handle;
     }
 }
 

--- a/tokio/src/runtime/test_scheduler/park.rs
+++ b/tokio/src/runtime/test_scheduler/park.rs
@@ -1,22 +1,19 @@
 use crate::park::{Park, Unpark};
 use crate::syscall::Syscalls;
-use std::sync::Arc;
 use std::io;
+use std::sync::Arc;
 use std::time::Duration;
 pub(crate) struct SyscallsPark {
     syscalls: Arc<dyn Syscalls>,
 }
 
-impl SyscallsPark
-
-{
+impl SyscallsPark {
     pub(crate) fn new(syscalls: Arc<dyn Syscalls>) -> Self {
         Self { syscalls }
     }
 }
 
-impl Park for SyscallsPark
-{
+impl Park for SyscallsPark {
     type Unpark = SyscallsUnpark;
     type Error = io::Error;
 

--- a/tokio/src/runtime/test_scheduler/park.rs
+++ b/tokio/src/runtime/test_scheduler/park.rs
@@ -1,0 +1,62 @@
+use crate::park::{Park, Unpark};
+use crate::syscall::Syscalls;
+use std::sync::Arc;
+use std::time::Duration;
+pub(super) struct SyscallsPark<P>
+where
+    P: Park,
+{
+    park: P,
+    syscalls: Arc<dyn Syscalls>,
+}
+
+impl<P> SyscallsPark<P>
+where
+    P: Park,
+{
+    pub(super) fn new(park: P, syscalls: Arc<dyn Syscalls>) -> Self {
+        Self { park, syscalls }
+    }
+}
+
+impl<P> Park for SyscallsPark<P>
+where
+    P: Park,
+{
+    type Unpark = SyscallsUnpark<P::Unpark>;
+    type Error = P::Error;
+
+    fn unpark(&self) -> Self::Unpark {
+        let syscalls = Arc::clone(&self.syscalls);
+        let unpark = self.park.unpark();
+        SyscallsUnpark { unpark, syscalls }
+    }
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.syscalls.park();
+        self.park.park()
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        self.syscalls.park_timeout(duration);
+        self.park.park_timeout(duration)
+    }
+}
+
+pub(super) struct SyscallsUnpark<P>
+where
+    P: Unpark,
+{
+    unpark: P,
+    syscalls: Arc<dyn Syscalls>,
+}
+
+impl<P> Unpark for SyscallsUnpark<P>
+where
+    P: Unpark,
+{
+    fn unpark(&self) {
+        self.syscalls.unpark();
+        self.unpark.unpark();
+    }
+}

--- a/tokio/src/runtime/test_scheduler/park.rs
+++ b/tokio/src/runtime/test_scheduler/park.rs
@@ -1,62 +1,45 @@
 use crate::park::{Park, Unpark};
 use crate::syscall::Syscalls;
 use std::sync::Arc;
+use std::io;
 use std::time::Duration;
-pub(super) struct SyscallsPark<P>
-where
-    P: Park,
-{
-    park: P,
+pub(crate) struct SyscallsPark {
     syscalls: Arc<dyn Syscalls>,
 }
 
-impl<P> SyscallsPark<P>
-where
-    P: Park,
+impl SyscallsPark
+
 {
-    pub(super) fn new(park: P, syscalls: Arc<dyn Syscalls>) -> Self {
-        Self { park, syscalls }
+    pub(crate) fn new(syscalls: Arc<dyn Syscalls>) -> Self {
+        Self { syscalls }
     }
 }
 
-impl<P> Park for SyscallsPark<P>
-where
-    P: Park,
+impl Park for SyscallsPark
 {
-    type Unpark = SyscallsUnpark<P::Unpark>;
-    type Error = P::Error;
+    type Unpark = SyscallsUnpark;
+    type Error = io::Error;
 
     fn unpark(&self) -> Self::Unpark {
         let syscalls = Arc::clone(&self.syscalls);
-        let unpark = self.park.unpark();
-        SyscallsUnpark { unpark, syscalls }
+        SyscallsUnpark { syscalls }
     }
 
     fn park(&mut self) -> Result<(), Self::Error> {
-        self.syscalls.park();
-        self.park.park()
+        self.syscalls.park()
     }
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
-        self.syscalls.park_timeout(duration);
-        self.park.park_timeout(duration)
+        self.syscalls.park_timeout(duration)
     }
 }
 
-pub(super) struct SyscallsUnpark<P>
-where
-    P: Unpark,
-{
-    unpark: P,
+pub(crate) struct SyscallsUnpark {
     syscalls: Arc<dyn Syscalls>,
 }
 
-impl<P> Unpark for SyscallsUnpark<P>
-where
-    P: Unpark,
-{
+impl Unpark for SyscallsUnpark {
     fn unpark(&self) {
-        self.syscalls.unpark();
-        self.unpark.unpark();
+        self.syscalls.unpark()
     }
 }

--- a/tokio/src/runtime/time.rs
+++ b/tokio/src/runtime/time.rs
@@ -19,12 +19,20 @@ mod variant {
         Clock::new()
     }
 
+    #[cfg(all(feature = "test-util", tokio_unstable))]
+    pub(crate) fn create_test_clock() -> Clock {
+        Clock::new_frozen()
+    }
+
     /// Create a new timer driver / handle pair
-    pub(crate) fn create_driver(
+    pub(crate) fn create_driver<P>(
         enable: bool,
-        io_driver: io::Driver,
+        io_driver: P,
         clock: Clock,
-    ) -> (Driver, Handle) {
+    ) -> (Either<driver::Driver<P>, P>, Handle)
+    where
+        P: crate::park::Park,
+    {
         if enable {
             let driver = driver::Driver::new(io_driver, clock);
             let handle = driver.handle();
@@ -48,12 +56,16 @@ mod variant {
         ()
     }
 
+    #[cfg(all(feature = "test-util", tokio_unstable))]
+    pub(crate) fn create_test_clock() -> Clock {
+        ()
+    }
+
     /// Create a new timer driver / handle pair
-    pub(crate) fn create_driver(
-        _enable: bool,
-        io_driver: io::Driver,
-        _clock: Clock,
-    ) -> (Driver, Handle) {
+    pub(crate) fn create_driver<P>(_enable: bool, io_driver: P, _clock: Clock) -> (P, Handle)
+    where
+        P: crate::park::Park,
+    {
         (io_driver, ())
     }
 }

--- a/tokio/src/syscall/default.rs
+++ b/tokio/src/syscall/default.rs
@@ -1,22 +1,22 @@
 //! Default [Syscalls]
 use super::Syscalls;
-use crate::park::Park;
-use std::sync::Mutex;
-use std::io;
 use crate::park::Either;
+use crate::park::Park;
+use std::io;
+use std::sync::Mutex;
 
 pub(crate) struct DefaultSyscalls {
-    inner: Mutex<Inner>
+    inner: Mutex<Inner>,
 }
 
 struct Inner {
-    io_driver: crate::runtime::time::Driver
+    io_driver: crate::runtime::time::Driver,
 }
 
 impl DefaultSyscalls {
     pub(crate) fn new(io_driver: crate::runtime::time::Driver) -> Self {
         Self {
-            inner: Mutex::new(Inner { io_driver })
+            inner: Mutex::new(Inner { io_driver }),
         }
     }
 }
@@ -26,8 +26,14 @@ impl Syscalls for DefaultSyscalls {
         let mut lock = self.inner.lock().unwrap();
         match lock.io_driver.park() {
             Ok(_) => Ok(()),
-            Err(Either::A(e)) => Err(io::Error::new(io::ErrorKind::Other, format!("park error: {:?}", e))),
-            Err(Either::B(e)) => Err(io::Error::new(io::ErrorKind::Other, format!("park error: {:?}", e)))
+            Err(Either::A(e)) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("park error: {:?}", e),
+            )),
+            Err(Either::B(e)) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("park error: {:?}", e),
+            )),
         }
     }
 
@@ -35,8 +41,14 @@ impl Syscalls for DefaultSyscalls {
         let mut lock = self.inner.lock().unwrap();
         match lock.io_driver.park_timeout(duration) {
             Ok(_) => Ok(()),
-            Err(Either::A(e)) => Err(io::Error::new(io::ErrorKind::Other, format!("park error: {:?}", e))),
-            Err(Either::B(e)) => Err(io::Error::new(io::ErrorKind::Other, format!("park error: {:?}", e)))
+            Err(Either::A(e)) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("park error: {:?}", e),
+            )),
+            Err(Either::B(e)) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("park error: {:?}", e),
+            )),
         }
     }
 

--- a/tokio/src/syscall/default.rs
+++ b/tokio/src/syscall/default.rs
@@ -1,0 +1,28 @@
+//! Default [Syscalls]
+use super::Syscalls;
+use std::future::Future;
+use std::pin::Pin;
+
+pub(crate) struct DefaultSyscalls;
+
+impl Syscalls for DefaultSyscalls {
+    fn spawn(&self, _future: Pin<Box<dyn Future<Output = ()>>>) {
+        todo!("spawn")
+    }
+
+    fn spawn_blocking(&self, _task: Box<dyn FnOnce()>) {
+        todo!("spawn_blocking")
+    }
+
+    fn park(&self) {
+        todo!("park")
+    }
+
+    fn park_timeout(&self, _duration: std::time::Duration) {
+        todo!("park_timeout")
+    }
+
+    fn unpark(&self) {
+        todo!("unpark")
+    }
+}

--- a/tokio/src/syscall/mod.rs
+++ b/tokio/src/syscall/mod.rs
@@ -14,25 +14,24 @@
 //!
 //! [syscall]:crate::syscall
 mod default;
-use std::future::Future;
-
+pub(crate) use default::DefaultSyscalls;
 use std::io;
+use std::future::Future;
 use std::pin::Pin;
 
 /// Syscalls trait allows for hooking into the Tokio runtime.
 pub trait Syscalls: Send + Sync {
-    /// Spawn a Future onto the runtime.
-    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()>>>);
-
-    /// Spawn a blocking task onto the runtime.
-    fn spawn_blocking(&self, task: Box<dyn FnOnce()>);
-
-    /// Drive the runtime forward
-    fn park(&self);
+    /// Drive the runtime forward.
+    fn park(&self) -> io::Result<()>;
 
     /// Drive the runtime forward with a timeout.
-    fn park_timeout(&self, duration: std::time::Duration);
+    fn park_timeout(&self, duration: std::time::Duration) -> io::Result<()>;
 
-    /// Unblock the runtime
+    /// Unpark the runtime.
     fn unpark(&self);
+
+    /// Wrap all spawned futures.
+    fn wrap_future(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+        future
+    }
 }

--- a/tokio/src/syscall/mod.rs
+++ b/tokio/src/syscall/mod.rs
@@ -1,0 +1,38 @@
+//! The [syscall] module is intended to provide a centralized location
+//! for interacting with OS resources such as disks and network.
+//!
+//! This requires both the `"test-util"` feature to be enabled as well
+//! as the `--cfg tokio_unstable` flag to be supplied.
+//!
+//! ## Extension
+//! The Syscall trait allows hooking into implementations of Tokio
+//! disk and networking resources to supply alternate implementations
+//! or mocks.
+//!
+//! Extension requires compiling with `--cfg tokio_unstable` in addition
+//! to the `syscall` feature flag.
+//!
+//! [syscall]:crate::syscall
+mod default;
+use std::future::Future;
+
+use std::io;
+use std::pin::Pin;
+
+/// Syscalls trait allows for hooking into the Tokio runtime.
+pub trait Syscalls: Send + Sync {
+    /// Spawn a Future onto the runtime.
+    fn spawn(&self, future: Pin<Box<dyn Future<Output = ()>>>);
+
+    /// Spawn a blocking task onto the runtime.
+    fn spawn_blocking(&self, task: Box<dyn FnOnce()>);
+
+    /// Drive the runtime forward
+    fn park(&self);
+
+    /// Drive the runtime forward with a timeout.
+    fn park_timeout(&self, duration: std::time::Duration);
+
+    /// Unblock the runtime
+    fn unpark(&self);
+}

--- a/tokio/src/syscall/mod.rs
+++ b/tokio/src/syscall/mod.rs
@@ -15,8 +15,8 @@
 //! [syscall]:crate::syscall
 mod default;
 pub(crate) use default::DefaultSyscalls;
-use std::io;
 use std::future::Future;
+use std::io;
 use std::pin::Pin;
 
 /// Syscalls trait allows for hooking into the Tokio runtime.
@@ -31,7 +31,10 @@ pub trait Syscalls: Send + Sync {
     fn unpark(&self);
 
     /// Wrap all spawned futures.
-    fn wrap_future(&self, future: Pin<Box<dyn Future<Output = ()> + Send>>) -> Pin<Box<dyn Future<Output = ()> + Send>> {
+    fn wrap_future(
+        &self,
+        future: Pin<Box<dyn Future<Output = ()> + Send>>,
+    ) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         future
     }
 }

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -19,6 +19,11 @@ cfg_not_test_util! {
             Clock {}
         }
 
+        #[cfg(all(feature = "test-util", tokio_unstable))]
+        pub(crate) fn new_frozen() -> Clock {
+            Clock {}
+        }
+
         pub(crate) fn now(&self) -> Instant {
             now()
         }
@@ -122,6 +127,18 @@ cfg_test_util! {
                 inner: Arc::new(Mutex::new(Inner {
                     base: now,
                     unfrozen: Some(now),
+                })),
+            }
+        }
+
+        #[cfg(all(feature = "test-util", tokio_unstable))]
+        pub(crate)  fn new_frozen() -> Clock {
+            let now = std::time::Instant::now();
+
+            Clock {
+                inner: Arc::new(Mutex::new(Inner {
+                    base: now,
+                    unfrozen: None,
                 })),
             }
         }


### PR DESCRIPTION
This PR introduces the `Syscalls` trait, gated beind `test-util` and `--cfg tokio_unstable`.

The `Syscalls` trait is currently targeted at allowing users to supply an alternate runtime. Components have been introduced and changed in support of this
