### PR TITLE
Add RwLock::into_inner method

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -241,6 +241,11 @@ impl<T> RwLock<T> {
 
         RwLockWriteGuard { lock: self, permit }
     }
+
+    /// Consumes the lock, returning the underlying data.
+    pub fn into_inner(self) -> T {
+        self.c.into_inner()
+    }
 }
 
 impl<T> ops::Deref for RwLockReadGuard<'_, T> {

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -11,6 +11,12 @@ use tokio::sync::{Barrier, RwLock};
 use tokio_test::task::spawn;
 use tokio_test::{assert_pending, assert_ready};
 
+#[test]
+fn into_inner() {
+    let rwlock = RwLock::new(42);
+    assert_eq!(rwlock.into_inner(), 42);
+}
+
 // multiple reads should be Ready
 #[test]
 fn read_shared() {


### PR DESCRIPTION
Add RwLock::into_inner method that consumes the lock and returns
the wrapped value.

Fixes: #2320