### PR TITLE
loom: on macos, fix tokio::loom::std::rand::seed not to open /dev/ura…

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -21,11 +21,12 @@ pub(crate) mod rand {
     use std::sync::atomic::Ordering::Relaxed;
 
     static COUNTER: AtomicU32 = AtomicU32::new(1);
+    lazy_static::lazy_static! {
+        static ref RAND_STATE: RandomState = RandomState::new();
+    }
 
     pub(crate) fn seed() -> u64 {
-        let rand_state = RandomState::new();
-
-        let mut hasher = rand_state.build_hasher();
+        let mut hasher = RAND_STATE.build_hasher();
 
         // Hash some unique-ish data to generate some new state
         COUNTER.fetch_add(1, Relaxed).hash(&mut hasher);


### PR DESCRIPTION
…ndom

On MacOS, RandomState::new() involves opening /dev/urandom which may panic due to "too many open files" on some types of application like HTTP load generator witch opens many files to connect server.
This commit make it call RandomState::new() at startup and reuse it.

I think a property of randomness is still fine because COUNTER is increased each time.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

I'm developing HTTP load generator called [oha](https://github.com/hatoo/oha).
I noticed that tokio's runtime crashes when the app opens too many connections on macOS.
Because tokio calls RandomState::new() which opens `/dev/urandom` to get random seed on runtime in tokio::loom::std::rand::seed. So we need to avoid the call of RandomState::new() in runtime to run apps which opens too many files. 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Cache RandomState::new() at startup using lazy_static and reuse it.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
