### PR TITLE
tokio-util: fix minimum supported version of tokio

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -31,7 +31,7 @@ codec = ["tokio/stream"]
 udp = ["tokio/udp"]
 
 [dependencies]
-tokio = { version = "0.2.0", path = "../tokio" }
+tokio = { version = "0.2.5", path = "../tokio" }
 
 bytes = "0.5.0"
 futures-core = "0.3.0"


### PR DESCRIPTION
tokio-util uses tokio::stream::StreamExt, which was not introduced until
tokio v0.2.5. The current dependency specification is incorrect, and
breaks with cargo update -Z minimal-versions.

This is preventing h2 from upgrading to tokio-util 0.3