### PR TITLE
util: Prepare `0.3.1` release

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.1 (March 18, 2020)
+
+### Fixed
+
+- Adjust minimum-supported Tokio version to v0.2.5 to account for an internal
+  dependency on features in that version of Tokio. (#2326)
+
 # 0.3.0 (March 4, 2020)
 
 ### Changed

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.3.0/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.3.1/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-util/0.3.1")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
@LucioFranco, as promised in #2326. I modeled this off of #2296—let me know if something looks off!