### PR TITLE
tokio-io: impl asRawFd/AsRawHandle for stdio

### DIFF
--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -72,6 +72,20 @@ cfg_io_std! {
     }
 }
 
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for Stderr {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        std::io::stderr().as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for Stderr {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        std::io::stderr().as_raw_handle()
+    }
+}
+
 impl AsyncWrite for Stderr {
     fn poll_write(
         mut self: Pin<&mut Self>,

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -45,6 +45,20 @@ cfg_io_std! {
     }
 }
 
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for Stdin {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        std::io::stdin().as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for Stdin {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        std::io::stdin().as_raw_handle()
+    }
+}
+
 impl AsyncRead for Stdin {
     fn poll_read(
         mut self: Pin<&mut Self>,

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -72,6 +72,20 @@ cfg_io_std! {
     }
 }
 
+#[cfg(unix)]
+impl std::os::unix::io::AsRawFd for Stdout {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        std::io::stdout().as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::AsRawHandle for Stdout {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        std::io::stdout().as_raw_handle()
+    }
+}
+
 impl AsyncWrite for Stdout {
     fn poll_write(
         mut self: Pin<&mut Self>,


### PR DESCRIPTION
fixes: #2311

provides an implementation of AsRawFd and AsRawHandle for Stdin, Stdout and Stderr to match the std counterpart behavior.

## Motivation

It is sometimes necessary to manipulate stdio as raw file descriptors, to set attributes for example. 

## Solution

The Std* is wrapped in an Option in a  Blocking, which makes it impossible to take it out in a non blocking way. I implemented it the same way Async-std did it, and retrieve another instance of std::io::Std*, and use it to retrieve an new RawFd.