### PR TITLE
test: Added read_error() and write_error()

### DIFF
--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 
+use std::io;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_test::io::Builder;
 
@@ -17,9 +18,55 @@ async fn read() {
 }
 
 #[tokio::test]
+async fn read_error() {
+    let error = io::Error::new(io::ErrorKind::Other, "cruel");
+    let mut mock = Builder::new()
+        .read(b"hello ")
+        .read_error(error)
+        .read(b"world!")
+        .build();
+    let mut buf = [0; 256];
+
+    let n = mock.read(&mut buf).await.expect("read 1");
+    assert_eq!(&buf[..n], b"hello ");
+
+    match mock.read(&mut buf).await {
+        Err(error) => {
+            assert_eq!(error.kind(), io::ErrorKind::Other);
+            assert_eq!("cruel", format!("{}", error));
+        }
+        Ok(_) => panic!("error not received"),
+    }
+
+    let n = mock.read(&mut buf).await.expect("read 1");
+    assert_eq!(&buf[..n], b"world!");
+}
+
+#[tokio::test]
 async fn write() {
     let mut mock = Builder::new().write(b"hello ").write(b"world!").build();
 
     mock.write_all(b"hello ").await.expect("write 1");
+    mock.write_all(b"world!").await.expect("write 2");
+}
+
+#[tokio::test]
+async fn write_error() {
+    let error = io::Error::new(io::ErrorKind::Other, "cruel");
+    let mut mock = Builder::new()
+        .write(b"hello ")
+        .write_error(error)
+        .write(b"world!")
+        .build();
+    mock.write_all(b"hello ").await.expect("write 1");
+
+    match mock.write_all(b"whoa").await {
+        Err(error) => {
+            assert_eq!(error.kind(), io::ErrorKind::Other);
+            assert_eq!("cruel", format!("{}", error));
+        }
+        Ok(_) => panic!("error not received"),
+    }
+
     mock.write_all(b"world!").await.expect("write 2");
 }


### PR DESCRIPTION
Enable testing of edge cases caused by io errors.

## Motivation

Needed to test edge cases caused by tcp ConnectionReset events in another project built upon tokio.

Having the ability to simulate it using the `tokio-test` library solved the issue. 

## Solution

Added `read_error()` and `write_error()` to both the `io::Builder` and `Handle` structs.

As the Vector of actions is being processed, the given error is returned. Note that `Arc` is being used so that `Action` remains `Clone` and can keep the current API. 