### PR TITLE
Add optional support for futures-task::Spawn

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -32,6 +32,7 @@ full = [
   "blocking",
   "dns",
   "fs",
+  "futures-task",
   "io-driver",
   "io-util",
   "io-std",
@@ -99,6 +100,7 @@ pin-project-lite = "0.1.1"
 # Everything else is optional...
 fnv = { version = "1.0.6", optional = true }
 futures-core = { version = "0.3.0", optional = true }
+futures-task = { version = "0.3.0", optional = true }
 lazy_static = { version = "1.0.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.20", optional = true }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -120,6 +120,15 @@ cfg_rt_core! {
             self.spawner.spawn(future)
         }
     }
+
+    #[cfg(feature = "futures-task")]
+    impl futures_task::Spawn for Handle {
+        fn spawn_obj(&self, f: futures_task::FutureObj<'static, ()>) -> Result<(), futures_task::SpawnError> {
+            self.spawn(f);
+            Ok(())
+        }
+    }
+
 }
 
 /// Error returned by `try_current` when no Runtime has been started

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -490,3 +490,11 @@ impl Runtime {
         blocking_pool.shutdown(Some(duration));
     }
 }
+
+#[cfg(all(feature = "futures-task", feature = "rt-core"))]
+impl futures_task::Spawn for Runtime {
+    fn spawn_obj(&self, f: futures_task::FutureObj<'static, ()>) -> Result<(), futures_task::SpawnError> {
+        self.spawn(f);
+        Ok(())
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

I want to abstract over future executors in my crate, but since tokio doesn't implement `futures-task::Spawn` I'm unable to. This PR provides an optional implementation of this trait, so that downstream users don't have to implement it for a struct in their own crate.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add an optional dependency to tokio that when enabled provides a `futures-task::Spawn` implementation.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
