### PR TITLE
stream: iter() should yield every so often.

### DIFF
--- a/tokio/src/stream/iter.rs
+++ b/tokio/src/stream/iter.rs
@@ -44,7 +44,8 @@ where
 {
     type Item = I::Item;
 
-    fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<I::Item>> {
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<I::Item>> {
+        ready!(crate::coop::poll_proceed(cx));
         Poll::Ready(self.iter.next())
     }
 

--- a/tokio/tests/stream_iter.rs
+++ b/tokio/tests/stream_iter.rs
@@ -1,0 +1,19 @@
+use tokio::stream;
+use tokio_test::task;
+
+use std::iter;
+
+#[tokio::test]
+async fn coop() {
+    let mut stream = task::spawn(stream::iter(iter::repeat(1)));
+
+    for _ in 0..10_000 {
+        if stream.poll_next().is_pending() {
+            assert!(stream.is_woken());
+            return;
+        }
+    }
+
+    panic!("did not yield");
+}
+

--- a/tokio/tests/stream_iter.rs
+++ b/tokio/tests/stream_iter.rs
@@ -16,4 +16,3 @@ async fn coop() {
 
     panic!("did not yield");
 }
-


### PR DESCRIPTION
`stream::iter()` should yield every so often and participate in the `coop` functionality. However, I'm not sure if it should consume budget on **every** iteration.

Another option would be to consume budget every ~25 steps... but that would require adding state to the stream. Yet another strategy would be to make consuming budget be **weighted**. So `stream::iter` would consume 1 unit every iteration but reading data would consume much more (1 unit per n bytes? not sure)