### PR TITLE
timer: fix loom test

### DIFF
--- a/tokio/src/time/driver/tests/mod.rs
+++ b/tokio/src/time/driver/tests/mod.rs
@@ -15,7 +15,7 @@ impl Unpark for MockUnpark {
 
 #[test]
 fn balanced_incr_and_decr() {
-    const OPS: usize = 100;
+    const OPS: usize = 5;
 
     fn incr(inner: Arc<Inner>) {
         for _ in 0..OPS {


### PR DESCRIPTION
Fixes a test from a PR that was written before the recent loom upgrade.
A change in the details how loom executes models resulted in the test to
start failing. The fix is to reduce the number of iterations performed
by the test.