### PR TITLE
fs: Copy file permissions

### DIFF
--- a/tokio/src/fs/copy.rs
+++ b/tokio/src/fs/copy.rs
@@ -20,7 +20,9 @@ use std::path::Path;
 
 pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<u64, std::io::Error> {
     let from = File::open(from).await?;
+    let from_permissions = from.metadata().await?.permissions();
     let to = File::create(to).await?;
+    to.set_permissions(from_permissions).await?;
     let (mut from, mut to) = (io::BufReader::new(from), io::BufWriter::new(to));
     io::copy(&mut from, &mut to).await
 }

--- a/tokio/src/fs/copy.rs
+++ b/tokio/src/fs/copy.rs
@@ -1,5 +1,4 @@
-use crate::fs::File;
-use crate::io;
+use crate::fs::asyncify;
 use std::path::Path;
 
 /// Copies the contents of one file to another. This function will also copy the permission bits of the original file to the destination file.
@@ -19,16 +18,7 @@ use std::path::Path;
 /// ```
 
 pub async fn copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> Result<u64, std::io::Error> {
-    let from = File::open(from).await?;
-    let to = File::create(to).await?;
-
-    // Do not set permissions on already existing non-files like pipes and
-    // fifos.
-    if to.metadata().await?.is_file() {
-        let from_permissions = from.metadata().await?.permissions();
-        to.set_permissions(from_permissions).await?;
-    }
-
-    let (mut from, mut to) = (io::BufReader::new(from), io::BufWriter::new(to));
-    io::copy(&mut from, &mut to).await
+    let from = from.as_ref().to_owned();
+    let to = to.as_ref().to_owned();
+    asyncify(|| std::fs::copy(from, to)).await
 }

--- a/tokio/tests/fs_copy.rs
+++ b/tokio/tests/fs_copy.rs
@@ -23,17 +23,17 @@ async fn copy() {
 #[tokio::test]
 async fn copy_permissions() {
     let dir = tempdir().unwrap();
-    let source_path = dir.path().join("foo.txt");
-    let dest_path = dir.path().join("bar.txt");
+    let from_path = dir.path().join("foo.txt");
+    let to_path = dir.path().join("bar.txt");
 
-    let source = tokio::fs::File::create(&source_path).await.unwrap();
-    let mut source_perms = source.metadata().await.unwrap().permissions();
-    source_perms.set_readonly(true);
-    source.set_permissions(source_perms.clone()).await.unwrap();
+    let from = tokio::fs::File::create(&from_path).await.unwrap();
+    let mut from_perms = from.metadata().await.unwrap().permissions();
+    from_perms.set_readonly(true);
+    from.set_permissions(from_perms.clone()).await.unwrap();
 
-    tokio::fs::copy(source_path, &dest_path).await.unwrap();
+    tokio::fs::copy(from_path, &to_path).await.unwrap();
 
-    let dest_perms = tokio::fs::metadata(dest_path).await.unwrap().permissions();
+    let to_perms = tokio::fs::metadata(to_path).await.unwrap().permissions();
 
-    assert_eq!(source_perms, dest_perms);
+    assert_eq!(from_perms, to_perms);
 }

--- a/tokio/tests/fs_copy.rs
+++ b/tokio/tests/fs_copy.rs
@@ -19,3 +19,21 @@ async fn copy() {
 
     assert_eq!(from, to);
 }
+
+#[tokio::test]
+async fn copy_permissions() {
+    let dir = tempdir().unwrap();
+    let source_path = dir.path().join("foo.txt");
+    let dest_path = dir.path().join("bar.txt");
+
+    let source = tokio::fs::File::create(&source_path).await.unwrap();
+    let mut source_perms = source.metadata().await.unwrap().permissions();
+    source_perms.set_readonly(true);
+    source.set_permissions(source_perms.clone()).await.unwrap();
+
+    tokio::fs::copy(source_path, &dest_path).await.unwrap();
+
+    let dest_perms = tokio::fs::metadata(dest_path).await.unwrap().permissions();
+
+    assert_eq!(source_perms, dest_perms);
+}


### PR DESCRIPTION
File permissions are not properly copied by `fs::copy`.

This change ensures permissions are copied for new and existing files, as well
as adds a test.

Closes #2341 