### PR TITLE
Add initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,12 @@
 ## Report a security issue
 
-The Tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs).
+The Tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs). Security issues should not be reported via the public Github Issue tracker.
 
 ## Vulnerability coordination
 
-Remediation of security vulnerabilities is prioritized by the project team. The project team coordinates remediation with third-party project stakeholders via [Github Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories).
+Remediation of security vulnerabilities is prioritized by the project team. The project team coordinates remediation with third-party project stakeholders via [Github Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories). Third-party stakeholders may include the reporter of the issue, affected direct or indirect users of Tokio, and maintainers of upstream dependencies if applicable.
+
+Downstream project maintainers and Tokio users can request participation in coordination of applicable security issues by sending your contact email address, Github username(s) and any other salient information to [security@tokio.rs](mailto:security@tokio.rs). Participation in security issue coordination processes is at the discretion of the Tokio team.
 
 ## Security advisories
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 ## Report a security issue
 
-The tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs).
+The Tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs).
 
 ## Vulnerability coordination
 
@@ -8,4 +8,4 @@ Remediation of security vulnerabilities is prioritized by the project team. The 
 
 ## Security advisories
 
-The project team is committed to transparency in the security issue disclosure process. The tokio team announces security issues via [project Github Release notes](https://github.com/tokio-rs/tokio/releases) and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).
+The project team is committed to transparency in the security issue disclosure process. The Tokio team announces security issues via [project Github Release notes](https://github.com/tokio-rs/tokio/releases) and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+## Report a security issue
+
+The tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs).
+
+## Vulnerability coordination
+
+Remediation of security vulnerabilities is prioritized by the project team. The project team coordinates remediation with third-party project stakeholders via [Github Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories).
+
+## Security advisories
+
+The project team is committed to transparency in the security issue disclosure process. The tokio team announces security issues via [project Github Release notes](https://github.com/tokio-rs/tokio/releases) and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).


### PR DESCRIPTION
## Motivation

Build on the great security work already being done in the tokio-rs ecosystem!

## Solution

This PR adds an initial security policy based on email discussions with @carllerche, @hawkw and co. Note that it may be necessary to update the project's Github Issue Template to the [new version](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates) so that the "Report a Security Issue" link appears on the Github Issues workflow ([example](https://github.com/bytecodealliance/wasmtime)). It is not clear from the documentation.