### PR TITLE
doc: Add error explanation for UnboundedSender::send()

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -360,8 +360,8 @@ impl<T> Sender<T> {
     /// # Errors
     ///
     /// If the receive half of the channel is closed, either due to [`close`]
-    /// being called or the [`Receiver`] handle dropping, the function returns
-    /// an error. The error includes the value passed to `send`.
+    /// being called or the [`Receiver`] having been dropped,
+    /// the function returns an error. The error includes the value passed to `send`.
     ///
     /// [`close`]: Receiver::close
     /// [`Receiver`]: Receiver

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -162,6 +162,13 @@ impl<T> UnboundedSender<T> {
     }
 
     /// Attempts to send a message on this `UnboundedSender` without blocking.
+    ///
+    /// If the receive half of the channel is closed, either due to [`close`]
+    /// being called or the [`UnboundedReceiver`] having been dropped,
+    /// the function returns an error. The error includes the value passed to `send`.
+    ///
+    /// [`close`]: UnboundedReceiver::close
+    /// [`UnboundedReceiver`]: UnboundedReceiver
     pub fn send(&self, message: T) -> Result<(), SendError<T>> {
         self.chan.send_unbounded(message)?;
         Ok(())


### PR DESCRIPTION
Small doc fix.

I was reading the doc at `UnboundedSender::send()` and even though it's probably more or less obvious why it could fail, I thought it would be better to have it stated explicitly...
