### PR TITLE
docs: replace some html links with rustdoc paths

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -364,9 +364,9 @@
 //! +------------+--------------+
 //! ```
 //!
-//! [`LengthDelimitedCodec::new()`]: struct.LengthDelimitedCodec.html#method.new
-//! [`FramedRead`]: struct.FramedRead.html
-//! [`FramedWrite`]: struct.FramedWrite.html
+//! [`LengthDelimitedCodec::new()`]: method@LengthDelimitedCodec::new
+//! [`FramedRead`]: struct@FramedRead
+//! [`FramedWrite`]: struct@FramedWrite
 //! [`AsyncRead`]: ../../trait.AsyncRead.html
 //! [`AsyncWrite`]: ../../trait.AsyncWrite.html
 //! [`Encoder`]: ../trait.Encoder.html

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -280,7 +280,7 @@ pin_project_lite::pin_project! {
     /// # }
     /// ```
     ///
-    /// [`poll_proceed`]: fn.poll_proceed.html
+    /// [`poll_proceed`]: fn@poll_proceed
     #[derive(Debug)]
     #[allow(unreachable_pub, dead_code)]
     pub struct CoopFuture<F> {

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -99,7 +99,7 @@ impl crate::stream::Stream for ReadDir {
 
 /// Entries returned by the [`ReadDir`] stream.
 ///
-/// [`ReadDir`]: struct.ReadDir.html
+/// [`ReadDir`]: struct@ReadDir
 ///
 /// This is a specialized version of [`std::fs::DirEntry`] for usage from the
 /// Tokio runtime.

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -138,20 +138,20 @@
 //! context of the Tokio runtime, as they require Tokio-specific features to
 //! function. Calling these functions outside of a Tokio runtime will panic.
 //!
-//! [input]: fn.stdin.html
-//! [output]: fn.stdout.html
-//! [error]: fn.stderr.html
+//! [input]: fn@stdin
+//! [output]: fn@stdout
+//! [error]: fn@stderr
 //!
 //! # `std` re-exports
 //!
 //! Additionally, [`Error`], [`ErrorKind`], and [`Result`] are re-exported
 //! from `std::io` for ease of use.
 //!
-//! [`AsyncRead`]: trait.AsyncRead.html
-//! [`AsyncWrite`]: trait.AsyncWrite.html
-//! [`Error`]: struct.Error.html
-//! [`ErrorKind`]: enum.ErrorKind.html
-//! [`Result`]: type.Result.html
+//! [`AsyncRead`]: trait@AsyncRead
+//! [`AsyncWrite`]: trait@AsyncWrite
+//! [`Error`]: struct@Error
+//! [`ErrorKind`]: enum@ErrorKind
+//! [`Result`]: type@Result
 //! [`Read`]: std::io::Read
 //! [`Write`]: std::io::Write
 cfg_io_blocking! {

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -95,7 +95,7 @@ cfg_io_driver! {
     /// [`AsyncRead`]: ../io/trait.AsyncRead.html
     /// [`AsyncWrite`]: ../io/trait.AsyncWrite.html
     /// [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
-    /// [`Registration`]: struct.Registration.html
+    /// [`Registration`]: struct@Registration
     /// [`TcpListener`]: ../net/struct.TcpListener.html
     /// [`clear_read_ready`]: #method.clear_read_ready
     /// [`clear_write_ready`]: #method.clear_write_ready

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -20,8 +20,8 @@ cfg_io_std! {
     ///
     /// Created by the [`stdin`] function.
     ///
-    /// [`stdin`]: fn.stdin.html
-    /// [`AsyncRead`]: trait.AsyncRead.html
+    /// [`stdin`]: fn@stdin
+    /// [`AsyncRead`]: trait@AsyncRead
     #[derive(Debug)]
     pub struct Stdin {
         std: Blocking<std::io::Stdin>,

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -13,7 +13,7 @@ cfg_io_util! {
     ///
     /// This is an asynchronous version of [`std::io::empty`][std].
     ///
-    /// [`empty`]: fn.empty.html
+    /// [`empty`]: fn@empty
     /// [std]: std::io::empty
     pub struct Empty {
         _p: (),

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -13,7 +13,7 @@ cfg_io_util! {
     ///
     /// This is an asynchronous version of [`std::io::Repeat`][std].
     ///
-    /// [repeat]: fn.repeat.html
+    /// [repeat]: fn@repeat
     /// [std]: std::io::Repeat
     #[derive(Debug)]
     pub struct Repeat {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -20,9 +20,9 @@ cfg_tcp! {
     /// A TCP stream can either be created by connecting to an endpoint, via the
     /// [`connect`] method, or by [accepting] a connection from a [listener].
     ///
-    /// [`connect`]: struct.TcpStream.html#method.connect
-    /// [accepting]: struct.TcpListener.html#method.accept
-    /// [listener]: struct.TcpListener.html
+    /// [`connect`]: method@TcpStream::connect
+    /// [accepting]: method@TcpListener::accept
+    /// [listener]: struct@TcpListener
     ///
     /// # Examples
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -21,8 +21,8 @@ cfg_tcp! {
     /// [`connect`] method, or by [accepting] a connection from a [listener].
     ///
     /// [`connect`]: method@TcpStream::connect
-    /// [accepting]: method@TcpListener::accept
-    /// [listener]: struct@TcpListener
+    /// [accepting]: method@super::TcpListener::accept
+    /// [listener]: struct@super::TcpListener
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -49,7 +49,7 @@ cfg_rt_core! {
 
 /// Set this [`ThreadContext`] as the current active [`ThreadContext`].
 ///
-/// [`ThreadContext`]: struct.ThreadContext.html
+/// [`ThreadContext`]: struct@ThreadContext
 pub(crate) fn enter<F, R>(new: Handle, f: F) -> R
 where
     F: FnOnce() -> R,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -270,8 +270,8 @@ use std::time::Duration;
 /// [timer]: crate::time
 /// [mod]: index.html
 /// [`new`]: #method.new
-/// [`Builder`]: struct.Builder.html
-/// [`tokio::run`]: fn.run.html
+/// [`Builder`]: struct@Builder
+/// [`tokio::run`]: fn@run
 #[derive(Debug)]
 pub struct Runtime {
     /// Task executor

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -36,7 +36,7 @@ pub(crate) struct ThreadPool {
 ///
 /// `Spawner` instances are obtained by calling [`ThreadPool::spawner`].
 ///
-/// [`ThreadPool::spawner`]: struct.ThreadPool.html#method.spawner
+/// [`ThreadPool::spawner`]: method@ThreadPool::spawner
 #[derive(Clone)]
 pub(crate) struct Spawner {
     shared: Arc<worker::Shared>,

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -76,8 +76,8 @@
 //! case, the mutex will be unlocked. If the panic is caught, this might leave
 //! the data protected by the mutex in an inconsistent state.
 //!
-//! [`Mutex`]: struct.Mutex.html
-//! [`MutexGuard`]: struct.MutexGuard.html
+//! [`Mutex`]: struct@Mutex
+//! [`MutexGuard`]: struct@MutexGuard
 use crate::coop::CoopFutureExt;
 use crate::sync::batch_semaphore as semaphore;
 

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -16,7 +16,7 @@ use std::task::{Context, Poll, Waker};
 
 /// Sends a value to the associated `Receiver`.
 ///
-/// Instances are created by the [`channel`](fn.channel.html) function.
+/// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Sender<T> {
     inner: Option<Arc<Inner<T>>>,
@@ -24,7 +24,7 @@ pub struct Sender<T> {
 
 /// Receive a value from the associated `Sender`.
 ///
-/// Instances are created by the [`channel`](fn.channel.html) function.
+/// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Receiver<T> {
     inner: Option<Arc<Inner<T>>>,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -62,10 +62,10 @@ const MAX_READS: usize = 10;
 /// }
 /// ```
 ///
-/// [`Mutex`]: struct.Mutex.html
-/// [`RwLock`]: struct.RwLock.html
-/// [`RwLockReadGuard`]: struct.RwLockReadGuard.html
-/// [`RwLockWriteGuard`]: struct.RwLockWriteGuard.html
+/// [`Mutex`]: struct@Mutex
+/// [`RwLock`]: struct@RwLock
+/// [`RwLockReadGuard`]: struct@RwLockReadGuard
+/// [`RwLockWriteGuard`]: struct@RwLockWriteGuard
 /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
 #[derive(Debug)]
@@ -83,7 +83,7 @@ pub struct RwLock<T> {
 /// This structure is created by the [`read`] method on
 /// [`RwLock`].
 ///
-/// [`read`]: struct.RwLock.html#method.read
+/// [`read`]: method@RwLock::read
 #[derive(Debug)]
 pub struct RwLockReadGuard<'a, T> {
     permit: ReleasingPermit<'a, T>,
@@ -96,8 +96,8 @@ pub struct RwLockReadGuard<'a, T> {
 /// This structure is created by the [`write`] and method
 /// on [`RwLock`].
 ///
-/// [`write`]: struct.RwLock.html#method.write
-/// [`RwLock`]: struct.RwLock.html
+/// [`write`]: method@RwLock::write
+/// [`RwLock`]: struct@RwLock
 #[derive(Debug)]
 pub struct RwLockWriteGuard<'a, T> {
     permit: ReleasingPermit<'a, T>,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -62,7 +62,7 @@ const MAX_READS: usize = 10;
 /// }
 /// ```
 ///
-/// [`Mutex`]: struct@Mutex
+/// [`Mutex`]: struct@super::Mutex
 /// [`RwLock`]: struct@RwLock
 /// [`RwLockReadGuard`]: struct@RwLockReadGuard
 /// [`RwLockWriteGuard`]: struct@RwLockWriteGuard

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -62,9 +62,9 @@ use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
 use std::task::Poll::{Pending, Ready};
 use std::task::{Context, Poll};
 
-/// Receives values from the associated [`Sender`](struct.Sender.html).
+/// Receives values from the associated [`Sender`](struct@Sender).
 ///
-/// Instances are created by the [`channel`](fn.channel.html) function.
+/// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Receiver<T> {
     /// Pointer to the shared state
@@ -74,9 +74,9 @@ pub struct Receiver<T> {
     inner: Watcher,
 }
 
-/// Sends values to the associated [`Receiver`](struct.Receiver.html).
+/// Sends values to the associated [`Receiver`](struct@Receiver).
 ///
-/// Instances are created by the [`channel`](fn.channel.html) function.
+/// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Sender<T> {
     shared: Weak<Shared<T>>,
@@ -172,8 +172,8 @@ const CLOSED: usize = 1;
 /// # }
 /// ```
 ///
-/// [`Sender`]: struct.Sender.html
-/// [`Receiver`]: struct.Receiver.html
+/// [`Sender`]: struct@Sender
+/// [`Receiver`]: struct@Receiver
 pub fn channel<T: Clone>(init: T) -> (Sender<T>, Receiver<T>) {
     const VERSION_0: usize = 0;
     const VERSION_1: usize = 2;

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -107,7 +107,7 @@ cfg_rt_util! {
     /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
     /// [local task set]: struct@LocalSet
     /// [`Runtime::block_on`]: ../struct.Runtime.html#method.block_on
-    /// [`task::spawn_local`]: fn@spawn
+    /// [`task::spawn_local`]: fn@spawn_local
     pub struct LocalSet {
         /// Current scheduler tick
         tick: Cell<u8>,

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -105,9 +105,9 @@ cfg_rt_util! {
     /// ```
     ///
     /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
-    /// [local task set]: struct.LocalSet.html
+    /// [local task set]: struct@LocalSet
     /// [`Runtime::block_on`]: ../struct.Runtime.html#method.block_on
-    /// [`task::spawn_local`]: fn.spawn.html
+    /// [`task::spawn_local`]: fn@spawn
     pub struct LocalSet {
         /// Current scheduler tick
         tick: Cell<u8>,
@@ -266,7 +266,7 @@ impl LocalSet {
     ///     }).await;
     /// }
     /// ```
-    /// [`spawn_local`]: fn.spawn_local.html
+    /// [`spawn_local`]: fn@spawn_local
     pub fn spawn_local<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
@@ -335,7 +335,7 @@ impl LocalSet {
     /// })
     /// ```
     ///
-    /// [`spawn_local`]: fn.spawn_local.html
+    /// [`spawn_local`]: fn@spawn_local
     /// [`Runtime::block_on`]: ../struct.Runtime.html#method.block_on
     /// [in-place blocking]: ../blocking/fn.in_place.html
     /// [`spawn_blocking`]: ../blocking/fn.spawn_blocking.html
@@ -372,7 +372,7 @@ impl LocalSet {
     /// }
     /// ```
     ///
-    /// [`spawn_local`]: fn.spawn_local.html
+    /// [`spawn_local`]: fn@spawn_local
     /// [awaiting the local set]: #awaiting-a-localset
     pub async fn run_until<F>(&self, future: F) -> F::Output
     where

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -219,7 +219,7 @@ impl<T: 'static, F: Future> Future for TaskLocalFuture<T, F> {
 trait StaticLifetime: 'static {}
 impl<T: 'static> StaticLifetime for T {}
 
-/// An error returned by [`LocalKey::try_with`](struct.LocalKey.html#method.try_with).
+/// An error returned by [`LocalKey::try_with`](method@LocalKey::try_with).
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct AccessError {
     _private: (),

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`DelayQueue`] for more details.
 //!
-//! [`DelayQueue`]: struct.DelayQueue.html
+//! [`DelayQueue`]: struct@DelayQueue
 
 use crate::time::wheel::{self, Wheel};
 use crate::time::{delay_until, Delay, Duration, Error, Instant};
@@ -114,7 +114,7 @@ use std::task::{self, Poll};
 ///
 /// [`insert`]: #method.insert
 /// [`insert_at`]: #method.insert_at
-/// [`Key`]: struct.Key.html
+/// [`Key`]: struct@Key
 /// [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
 /// [`poll`]: #method.poll
 /// [`Stream::poll`]: #method.poll
@@ -148,7 +148,7 @@ pub struct DelayQueue<T> {
 ///
 /// Values are returned by [`DelayQueue::poll`].
 ///
-/// [`DelayQueue::poll`]: struct.DelayQueue.html#method.poll
+/// [`DelayQueue::poll`]: method@DelayQueue::poll
 #[derive(Debug)]
 pub struct Expired<T> {
     /// The data stored in the queue
@@ -166,8 +166,8 @@ pub struct Expired<T> {
 /// Instances of `Key` are returned by [`DelayQueue::insert`]. See [`DelayQueue`]
 /// documentation for more details.
 ///
-/// [`DelayQueue`]: struct.DelayQueue.html
-/// [`DelayQueue::insert`]: struct.DelayQueue.html#method.insert
+/// [`DelayQueue`]: struct@DelayQueue
+/// [`DelayQueue::insert`]: method@DelayQueue::insert
 #[derive(Debug, Clone)]
 pub struct Key {
     index: usize,
@@ -298,7 +298,7 @@ impl<T> DelayQueue<T> {
     /// [`poll`]: #method.poll
     /// [`remove`]: #method.remove
     /// [`reset`]: #method.reset
-    /// [`Key`]: struct.Key.html
+    /// [`Key`]: struct@Key
     /// [type]: #
     pub fn insert_at(&mut self, value: T, when: Instant) -> Key {
         assert!(self.slab.len() < MAX_ENTRIES, "max entries exceeded");
@@ -406,7 +406,7 @@ impl<T> DelayQueue<T> {
     /// [`poll`]: #method.poll
     /// [`remove`]: #method.remove
     /// [`reset`]: #method.reset
-    /// [`Key`]: struct.Key.html
+    /// [`Key`]: struct@Key
     /// [type]: #
     pub fn insert(&mut self, value: T, timeout: Duration) -> Key {
         self.insert_at(value, Instant::now() + timeout)

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -2,7 +2,7 @@
 //!
 //! See [`Timeout`] documentation for more details.
 //!
-//! [`Timeout`]: struct.Timeout.html
+//! [`Timeout`]: struct@Timeout
 
 use crate::time::{delay_until, Delay, Duration, Instant};
 


### PR DESCRIPTION
Included changes
- all simple references like `<type>.<name>.html` for these types
    - enum
    - fn
    - struct
    - trait
    - type
- simple references for methods, like struct.DelayQueue.html#method.poll

Refs: #1473

## Motivation
Make doc's links more resistant.

## Solution
Delagates doc's links resolution to [`rustdoc`](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md).
