### PR TITLE
Use logical CPUs instead of physical by default

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -75,7 +75,7 @@ pub(crate) mod sync {
 pub(crate) mod sys {
     #[cfg(feature = "rt-threaded")]
     pub(crate) fn num_cpus() -> usize {
-        usize::max(1, num_cpus::get_physical())
+        usize::max(1, num_cpus::get())
     }
 
     #[cfg(not(feature = "rt-threaded"))]


### PR DESCRIPTION
Some reasons to prefer logical count as the default:

- Chips reporting many logical CPUs vs physical, such as via
hyperthreading, probably know better than us about the workload the CPUs
can handle.
- The logical count (`num_cpus::get()`) takes into consideration
schedular affinity, and cgroups CPU quota, in case the user wants to
limit the amount of CPUs a process can use.

Closes #2269 