### PR TITLE
chore: prepare to release 0.2.17

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Fixes
 - rt: bug in work-stealing queue (#2387) 
 
+### Changes
+- rt: threadpool uses logical CPU count instead of physical by default (#2391)
+
 # 0.2.16 (April 3, 2020)
 
 ### Fixes

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.17 (April 9, 2020)
+
+### Fixes
+- rt: bug in work-stealing queue (#2387) 
+
 # 0.2.16 (April 3, 2020)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.16"
+version = "0.2.17"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.16/tokio/"
+documentation = "https://docs.rs/tokio/0.2.17/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.16")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.17")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
### Fixes

- rt: bug in work-stealing queue (#2387)

Signed-off-by: Eliza Weisman <eliza@buoyant.io>
