### PR TITLE
chore: prepare to release 0.2.18

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.18 (April 12, 2020)
+
+### Fixes
+- task: `LocalSet` was incorrectly marked as `Send` (#2398)
+- io: correctly report `WriteZero` failure in `write_int` (#2334)
+
 # 0.2.17 (April 9, 2020)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.17"
+version = "0.2.18"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.17/tokio/"
+documentation = "https://docs.rs/tokio/0.2.18/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.17")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.18")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
### Fixes
- task: `LocalSet` was incorrectly marked as `Send` (#2398)
- io: correctly report `WriteZero` failure in `write_int` (#2334)
