### PR TITLE
doc: fix a few broken links by using rustdoc

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -135,7 +135,7 @@ impl TcpListener {
     /// established, the corresponding [`TcpStream`] and the remote peer's
     /// address will be returned.
     ///
-    /// [`TcpStream`]: ../struct.TcpStream.html
+    /// [`TcpStream`]: struct@crate::net::TcpStream
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -245,7 +245,7 @@ use std::time::Duration;
 
 /// The Tokio runtime.
 ///
-/// The runtime provides an I/O [driver], task scheduler, [timer], and blocking
+/// The runtime provides an I/O driver, task scheduler, [timer], and blocking
 /// pool, necessary for running asynchronous tasks.
 ///
 /// Instances of `Runtime` can be created using [`new`] or [`Builder`]. However,
@@ -266,7 +266,6 @@ use std::time::Duration;
 /// that reactor will no longer function. Calling any method on them will
 /// result in an error.
 ///
-/// [driver]: crate::io::driver
 /// [timer]: crate::time
 /// [mod]: index.html
 /// [`new`]: #method.new

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -337,7 +337,7 @@ impl LocalSet {
     ///
     /// [`spawn_local`]: fn@spawn_local
     /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
-    /// [in-place blocking]: ../blocking/fn.in_place.html
+    /// [in-place blocking]: fn@crate::task::block_in_place
     /// [`spawn_blocking`]: fn@crate::task::spawn_blocking
     pub fn block_on<F>(&self, rt: &mut crate::runtime::Runtime, future: F) -> F::Output
     where

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -106,7 +106,7 @@ cfg_rt_util! {
     ///
     /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
     /// [local task set]: struct@LocalSet
-    /// [`Runtime::block_on`]: ../struct.Runtime.html#method.block_on
+    /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
     /// [`task::spawn_local`]: fn@spawn_local
     pub struct LocalSet {
         /// Current scheduler tick
@@ -336,7 +336,7 @@ impl LocalSet {
     /// ```
     ///
     /// [`spawn_local`]: fn@spawn_local
-    /// [`Runtime::block_on`]: ../struct.Runtime.html#method.block_on
+    /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
     /// [in-place blocking]: ../blocking/fn.in_place.html
     /// [`spawn_blocking`]: ../blocking/fn.spawn_blocking.html
     pub fn block_on<F>(&self, rt: &mut crate::runtime::Runtime, future: F) -> F::Output

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -338,7 +338,7 @@ impl LocalSet {
     /// [`spawn_local`]: fn@spawn_local
     /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
     /// [in-place blocking]: ../blocking/fn.in_place.html
-    /// [`spawn_blocking`]: ../blocking/fn.spawn_blocking.html
+    /// [`spawn_blocking`]: fn@crate::task::spawn_blocking
     pub fn block_on<F>(&self, rt: &mut crate::runtime::Runtime, future: F) -> F::Output
     where
         F: Future,

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -50,13 +50,12 @@ use std::task::{self, Poll};
 ///
 /// # Implementation
 ///
-/// The `DelayQueue` is backed by the same hashed timing wheel implementation as
-/// [`Timer`] as such, it offers the same performance benefits. See [`Timer`]
-/// for further implementation notes.
+/// The [`DelayQueue`] is backed by a separate instance of the same timer wheel used internally by
+/// Tokio's standalone timer utilities such as [`delay_for`]. Because of this, it offers the same
+/// performance and scalability benefits.
 ///
-/// State associated with each entry is stored in a [`slab`]. This allows
-/// amortizing the cost of allocation. Space created for expired entries is
-/// reused when inserting new entries.
+/// State associated with each entry is stored in a [`slab`]. This amortizes the cost of allocation,
+/// and allows reuse of the memory allocated for expired entires.
 ///
 /// Capacity can be checked using [`capacity`] and allocated preemptively by using
 /// the [`reserve`] method.
@@ -118,7 +117,8 @@ use std::task::{self, Poll};
 /// [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
 /// [`poll`]: #method.poll
 /// [`Stream::poll`]: #method.poll
-/// [`Timer`]: ../struct.Timer.html
+/// [`DelayQueue`]: struct@DelayQueue
+/// [`delay_for`]: fn@super::delay_for
 /// [`slab`]: https://docs.rs/slab
 /// [`capacity`]: #method.capacity
 /// [`reserve`]: #method.reserve


### PR DESCRIPTION
Also, the link for `driver` is removed because `driver` is now `pub(crate)`, so can't be used in docs.
 

## Motivation
Make doc's links more resistant.

## Solution
Delagates doc's links resolution to [`rustdoc`](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md).
 
Refs: #1473