### PR TITLE
show mutex module doc, add method examples

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -428,7 +428,7 @@ cfg_sync! {
     pub mod mpsc;
 
     mod mutex;
-    pub use mutex::{Mutex, MutexGuard};
+    pub use mutex::{Mutex, MutexGuard, TryLockError};
 
     mod notify;
     pub use notify::Notify;

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -9,8 +9,8 @@ use std::ops::{Deref, DerefMut};
 /// An asynchronous `Mutex`-like type.
 ///
 /// This type acts similarly to an asynchronous [`std::sync::Mutex`], with one
-/// major difference: [`lock`] does not block.\
-/// Another difference is that [`MutexGuard`] is [`Send`]
+/// major difference: [`lock`] does not block.  
+/// Another difference is [`lock`] can be held across await points.
 /// This allows you to do something along the lines of:
 ///
 /// ```rust,no_run
@@ -69,8 +69,8 @@ use std::ops::{Deref, DerefMut};
 /// 3. Mutation of the data the Mutex is protecting is done by de-referencing the the obtained lock
 ///    as seen on lines 23 and 30.
 ///
-/// Tokio's Mutex works in a simple FIFO (first in, first out) style where as requests for a lock are
-/// made Tokio will queue them up and provide a lock when it is that requester's turn. In that way
+/// Tokio's Mutex works in a simple FIFO (first in, first out) style where all calls
+/// to lock complete in the order they were performed. In that way
 /// the Mutex is "fair" and predictable in how it distributes the locks to inner data. This is why
 /// the output of this program is an in-order count to 50. Locks are released and reacquired
 /// after every iteration, so basically, each thread goes to the back of the line after it increments

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -10,7 +10,7 @@ use std::ops::{Deref, DerefMut};
 ///
 /// This type acts similarly to an asynchronous [`std::sync::Mutex`], with one
 /// major difference: [`lock`] does not block.  
-/// Another difference is [`lock`] can be held across await points.
+/// Another difference is that the lock guard can be held across await points.
 /// This allows you to do something along the lines of:
 ///
 /// ```rust,no_run
@@ -66,15 +66,15 @@ use std::ops::{Deref, DerefMut};
 /// There are a few things of note here to pay attention to in this example.
 /// 1. The mutex is wrapped in an [`Arc`] to allow it to be shared across threads.
 /// 2. Each spawned task obtains a lock and releases it on every iteration.
-/// 3. Mutation of the data the Mutex is protecting is done by de-referencing the the obtained lock
+/// 3. Mutation of the data protected by the Mutex is done by de-referencing the the obtained lock
 ///    as seen on lines 23 and 30.
 ///
 /// Tokio's Mutex works in a simple FIFO (first in, first out) style where all calls
-/// to lock complete in the order they were performed. In that way
+/// to [`lock`] complete in the order they were performed. In that way
 /// the Mutex is "fair" and predictable in how it distributes the locks to inner data. This is why
-/// the output of this program is an in-order count to 50. Locks are released and reacquired
+/// the output of the program above is an in-order count to 50. Locks are released and reacquired
 /// after every iteration, so basically, each thread goes to the back of the line after it increments
-/// the value once. Also, since there is only a single valid lock at any given time there is no
+/// the value once. Finally, since there is only a single valid lock at any given time, there is no
 /// possibility of a race condition when mutating the inner value.
 ///
 /// Note that in contrast to [`std::sync::Mutex`], this implementation does not
@@ -165,7 +165,7 @@ impl<T> Mutex<T> {
 
     /// Locks this mutex, causing the current task
     /// to yield until the lock has been acquired.
-    /// When acquired function returns a [`MutexGuard`]
+    /// When the lock has been acquired, function returns a [`MutexGuard`].
     ///
     /// # Examples
     ///
@@ -189,8 +189,8 @@ impl<T> Mutex<T> {
         MutexGuard { lock: self }
     }
 
-    /// Attempts to acquire the lock returning [`TryLockError`] if
-    /// lock is already acquired
+    /// Attempts to acquire the lock, and returns [`TryLockError`] if the
+    /// lock is currently held somewhere else.
     ///
     /// [`TryLockError`]: TryLockError
     /// # Examples

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -34,11 +34,10 @@ use std::ops::{Deref, DerefMut};
 ///
 /// Another example
 /// ```rust,no_run
-/// #![warn(rust_2018_idioms)]
-///
+/// # #![warn(rust_2018_idioms)]
+/// #
 /// use tokio::sync::Mutex;
 /// use std::sync::Arc;
-///
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -60,7 +59,7 @@ use std::ops::{Deref, DerefMut};
 ///             break;
 ///         }
 ///     }
-///    println!("Count hit 50.");
+///     println!("Count hit 50.");
 /// }
 /// ```
 /// There are a few things of note here to pay attention to in this example.

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -34,8 +34,6 @@ use std::ops::{Deref, DerefMut};
 ///
 /// Another example
 /// ```rust,no_run
-/// # #![warn(rust_2018_idioms)]
-/// #
 /// use tokio::sync::Mutex;
 /// use std::sync::Arc;
 ///

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -1,83 +1,3 @@
-//! An asynchronous `Mutex`-like type.
-//!
-//! This module provides [`Mutex`], a type that acts similarly to an asynchronous `Mutex`, with one
-//! major difference: the [`MutexGuard`] returned by `lock` is not tied to the lifetime of the
-//! `Mutex`. This enables you to acquire a lock, and then pass that guard into a future, and then
-//! release it at some later point in time.
-//!
-//! This allows you to do something along the lines of:
-//!
-//! ```rust,no_run
-//! use tokio::sync::Mutex;
-//! use std::sync::Arc;
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let data1 = Arc::new(Mutex::new(0));
-//!     let data2 = Arc::clone(&data1);
-//!
-//!     tokio::spawn(async move {
-//!         let mut lock = data2.lock().await;
-//!         *lock += 1;
-//!     });
-//!
-//!     let mut lock = data1.lock().await;
-//!     *lock += 1;
-//! }
-//! ```
-//!
-//! Another example
-//! ```rust,no_run
-//! #![warn(rust_2018_idioms)]
-//!
-//! use tokio::sync::Mutex;
-//! use std::sync::Arc;
-//!
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!    let count = Arc::new(Mutex::new(0));
-//!
-//!    for _ in 0..5 {
-//!        let my_count = Arc::clone(&count);
-//!        tokio::spawn(async move {
-//!            for _ in 0..10 {
-//!                let mut lock = my_count.lock().await;
-//!                *lock += 1;
-//!                println!("{}", lock);
-//!            }
-//!        });
-//!    }
-//!
-//!    loop {
-//!        if *count.lock().await >= 50 {
-//!            break;
-//!        }
-//!    }
-//!   println!("Count hit 50.");
-//! }
-//! ```
-//! There are a few things of note here to pay attention to in this example.
-//! 1. The mutex is wrapped in an [`std::sync::Arc`] to allow it to be shared across threads.
-//! 2. Each spawned task obtains a lock and releases it on every iteration.
-//! 3. Mutation of the data the Mutex is protecting is done by de-referencing the the obtained lock
-//!    as seen on lines 23 and 30.
-//!
-//! Tokio's Mutex works in a simple FIFO (first in, first out) style where as requests for a lock are
-//! made Tokio will queue them up and provide a lock when it is that requester's turn. In that way
-//! the Mutex is "fair" and predictable in how it distributes the locks to inner data. This is why
-//! the output of this program is an in-order count to 50. Locks are released and reacquired
-//! after every iteration, so basically, each thread goes to the back of the line after it increments
-//! the value once. Also, since there is only a single valid lock at any given time there is no
-//! possibility of a race condition when mutating the inner value.
-//!
-//! Note that in contrast to `std::sync::Mutex`, this implementation does not
-//! poison the mutex when a thread holding the `MutexGuard` panics. In such a
-//! case, the mutex will be unlocked. If the panic is caught, this might leave
-//! the data protected by the mutex in an inconsistent state.
-//!
-//! [`Mutex`]: struct@Mutex
-//! [`MutexGuard`]: struct@MutexGuard
 use crate::coop::CoopFutureExt;
 use crate::sync::batch_semaphore as semaphore;
 
@@ -86,11 +6,89 @@ use std::error::Error;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
-/// An asynchronous mutual exclusion primitive useful for protecting shared data
+/// An asynchronous `Mutex`-like type.
 ///
-/// Each mutex has a type parameter (`T`) which represents the data that it is protecting. The data
-/// can only be accessed through the RAII guards returned from `lock`, which
-/// guarantees that the data is only ever accessed when the mutex is locked.
+/// This module provides [`Mutex`], a type that acts similarly to an asynchronous [`std::sync::Mutex`], with one
+/// major difference: the [`MutexGuard`] returned by `lock` is not tied to the lifetime of the
+/// `Mutex`. This enables you to acquire a lock, and then pass that guard into a future, and then
+/// release it at some later point in time.
+///
+/// This allows you to do something along the lines of:
+///
+/// ```rust,no_run
+/// use tokio::sync::Mutex;
+/// use std::sync::Arc;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let data1 = Arc::new(Mutex::new(0));
+///     let data2 = Arc::clone(&data1);
+///
+///     tokio::spawn(async move {
+///         let mut lock = data2.lock().await;
+///         *lock += 1;
+///     });
+///
+///     let mut lock = data1.lock().await;
+///     *lock += 1;
+/// }
+/// ```
+///
+/// Another example
+/// ```rust,no_run
+/// #![warn(rust_2018_idioms)]
+///
+/// use tokio::sync::Mutex;
+/// use std::sync::Arc;
+///
+///
+/// #[tokio::main]
+/// async fn main() {
+///    let count = Arc::new(Mutex::new(0));
+///
+///    for _ in 0..5 {
+///        let my_count = Arc::clone(&count);
+///        tokio::spawn(async move {
+///            for _ in 0..10 {
+///                let mut lock = my_count.lock().await;
+///                *lock += 1;
+///                println!("{}", lock);
+///            }
+///        });
+///    }
+///
+///    loop {
+///        if *count.lock().await >= 50 {
+///            break;
+///        }
+///    }
+///   println!("Count hit 50.");
+/// }
+/// ```
+/// There are a few things of note here to pay attention to in this example.
+/// 1. The mutex is wrapped in an [`Arc`] to allow it to be shared across threads.
+/// 2. Each spawned task obtains a lock and releases it on every iteration.
+/// 3. Mutation of the data the Mutex is protecting is done by de-referencing the the obtained lock
+///    as seen on lines 23 and 30.
+///
+/// Tokio's Mutex works in a simple FIFO (first in, first out) style where as requests for a lock are
+/// made Tokio will queue them up and provide a lock when it is that requester's turn. In that way
+/// the Mutex is "fair" and predictable in how it distributes the locks to inner data. This is why
+/// the output of this program is an in-order count to 50. Locks are released and reacquired
+/// after every iteration, so basically, each thread goes to the back of the line after it increments
+/// the value once. Also, since there is only a single valid lock at any given time there is no
+/// possibility of a race condition when mutating the inner value.
+///
+/// Note that in contrast to [`std::sync::Mutex`], this implementation does not
+/// poison the mutex when a thread holding the [`MutexGuard`] panics. In such a
+/// case, the mutex will be unlocked. If the panic is caught, this might leave
+/// the data protected by the mutex in an inconsistent state.
+///
+/// [`Mutex`]: struct@Mutex
+/// [`MutexGuard`]: struct@MutexGuard
+/// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+/// [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
+
 #[derive(Debug)]
 pub struct Mutex<T> {
     c: UnsafeCell<T>,
@@ -150,6 +148,14 @@ fn bounds() {
 
 impl<T> Mutex<T> {
     /// Creates a new lock in an unlocked state ready for use.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Mutex;
+    ///
+    /// let lock = Mutex::new(5);
+    /// ```
     pub fn new(t: T) -> Self {
         Self {
             c: UnsafeCell::new(t),
@@ -157,7 +163,23 @@ impl<T> Mutex<T> {
         }
     }
 
-    /// A future that resolves on acquiring the lock and returns the `MutexGuard`.
+    /// Locks this mutex, causing the current task
+    /// to yield until the lock has been acquired.
+    /// When acquired function returns a [`MutexGuard`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Mutex;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mutex = Mutex::new(1);
+    ///
+    ///     let n = mutex.lock().await;
+    ///     *n = 2;
+    ///}
+    /// ```
     pub async fn lock(&self) -> MutexGuard<'_, T> {
         self.s.acquire(1).cooperate().await.unwrap_or_else(|_| {
             // The semaphore was closed. but, we never explicitly close it, and we have a
@@ -167,7 +189,19 @@ impl<T> Mutex<T> {
         MutexGuard { lock: self }
     }
 
-    /// Tries to acquire the lock
+    /// Attempts to acquire the lock returning [`TryLockError`] if
+    /// lock is already acquired
+    ///
+    /// [`TryLockError`]: TryLockError
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Mutex;
+    ///
+    ///   let mutex = Mutex::new(1);
+    ///
+    ///   let n = mutex.try_lock()?;
+    ///   assert_eq!(n, 1);
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
             Ok(_) => Ok(MutexGuard { lock: self }),
@@ -176,6 +210,19 @@ impl<T> Mutex<T> {
     }
 
     /// Consumes the mutex, returning the underlying data.
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Mutex;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mutex = Mutex::new(1);
+    ///
+    ///     let n = mutex.into_inner()
+    ///     assert_eq!(n, 1);
+    ///}
+    /// ```
     pub fn into_inner(self) -> T {
         self.c.into_inner()
     }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -73,7 +73,7 @@ use std::ops::{Deref, DerefMut};
 /// There are a few things of note here to pay attention to in this example.
 /// 1. The mutex is wrapped in an [`Arc`] to allow it to be shared across threads.
 /// 2. Each spawned task obtains a lock and releases it on every iteration.
-/// 3. Mutation of the data protected by the Mutex is done by de-referencing the the obtained lock
+/// 3. Mutation of the data protected by the Mutex is done by de-referencing the obtained lock
 ///    as seen on lines 23 and 30.
 ///
 /// Tokio's Mutex works in a simple FIFO (first in, first out) style where all calls

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -8,7 +8,7 @@ use std::ops::{Deref, DerefMut};
 
 /// An asynchronous `Mutex`-like type.
 ///
-/// This module provides [`Mutex`], a type that acts similarly to an asynchronous [`std::sync::Mutex`], with one
+/// This type acts similarly to an asynchronous [`std::sync::Mutex`], with one
 /// major difference: the [`MutexGuard`] returned by `lock` is not tied to the lifetime of the
 /// `Mutex`. This enables you to acquire a lock, and then pass that guard into a future, and then
 /// release it at some later point in time.

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -176,7 +176,7 @@ impl<T> Mutex<T> {
     /// async fn main() {
     ///     let mutex = Mutex::new(1);
     ///
-    ///     let n = mutex.lock().await;
+    ///     let mut n = mutex.lock().await;
     ///     *n = 2;
     /// }
     /// ```
@@ -197,11 +197,14 @@ impl<T> Mutex<T> {
     ///
     /// ```
     /// use tokio::sync::Mutex;
+    /// # async fn dox() -> Result<(), tokio::sync::TryLockError> {
     ///
     /// let mutex = Mutex::new(1);
     ///
     /// let n = mutex.try_lock()?;
-    /// assert_eq!(n, 1);
+    /// assert_eq!(*n, 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
@@ -220,7 +223,7 @@ impl<T> Mutex<T> {
     /// async fn main() {
     ///     let mutex = Mutex::new(1);
     ///
-    ///     let n = mutex.into_inner()
+    ///     let n = mutex.into_inner();
     ///     assert_eq!(n, 1);
     /// }
     /// ```

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -74,7 +74,7 @@ use std::ops::{Deref, DerefMut};
 /// 1. The mutex is wrapped in an [`Arc`] to allow it to be shared across threads.
 /// 2. Each spawned task obtains a lock and releases it on every iteration.
 /// 3. Mutation of the data protected by the Mutex is done by de-referencing the obtained lock
-///    as seen on lines 23 and 30.
+///    as seen on lines 12 and 19.
 ///
 /// Tokio's Mutex works in a simple FIFO (first in, first out) style where all calls
 /// to [`lock`] complete in the order they were performed. In that way

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -9,8 +9,18 @@ use std::ops::{Deref, DerefMut};
 /// An asynchronous `Mutex`-like type.
 ///
 /// This type acts similarly to an asynchronous [`std::sync::Mutex`], with one
-/// major difference: [`lock`] does not block.  
-/// Another difference is that the lock guard can be held across await points.
+/// major difference: [`lock`] does not block. Another difference is that the
+/// lock guard can be held across await points.
+///
+/// There are some situations where you should prefer the mutex from the
+/// standard library. Generally this is the case if:
+///
+///  1. The lock does not need to be held across await points.
+///  2. The duration of any single lock is near-instant.
+///
+/// On the other hand, the Tokio mutex is for the situation where the lock needs
+/// to be held for longer periods of time, or across await points.
+///
 /// This allows you to do something along the lines of:
 ///
 /// ```rust,no_run

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -21,7 +21,7 @@ use std::ops::{Deref, DerefMut};
 /// On the other hand, the Tokio mutex is for the situation where the lock needs
 /// to be held for longer periods of time, or across await points.
 ///
-/// This allows you to do something along the lines of:
+/// # Examples:
 ///
 /// ```rust,no_run
 /// use tokio::sync::Mutex;
@@ -42,7 +42,7 @@ use std::ops::{Deref, DerefMut};
 /// }
 /// ```
 ///
-/// Another example
+///
 /// ```rust,no_run
 /// use tokio::sync::Mutex;
 /// use std::sync::Arc;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
Mutex module doc is not showing, doc is using inner doc comments, but the `Mutex` mod is private
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
this PR makes it visible again by switching the inner doc comments with outer doc comments. 
This Pr also adds examples to Mutex's methods
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
