### PR TITLE
Support nested block_in_place

### DIFF
--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -191,7 +191,7 @@ cfg_blocking! {
         }
 
         CURRENT.with(|maybe_cx| {
-            let cx = maybe_cx.expect("can call blocking only when running in a spawned task");
+            let cx = maybe_cx.expect("can call blocking only when running in a spawned task on the multi-threaded runtime");
 
             // Get the worker core. If none is set, then blocking is fine!
             let core = match cx.core.borrow_mut().take() {

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -184,7 +184,9 @@ cfg_blocking! {
                 CURRENT.with(|maybe_cx| {
                     if let Some(cx) = maybe_cx {
                         let core = cx.worker.core.take();
-                        *cx.core.borrow_mut() = core;
+                        let mut cx_core = cx.core.borrow_mut();
+                        assert!(cx_core.is_none());
+                        *cx_core = core;
                     }
                 });
             }

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -237,7 +237,11 @@ cfg_blocking! {
 
         let _reset = Reset(had_core);
 
-        f()
+        if had_core {
+            crate::runtime::enter::exit(f)
+        } else {
+            f()
+        }
     }
 }
 

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -32,9 +32,7 @@ cfg_rt_threaded! {
     where
         F: FnOnce() -> R,
     {
-        use crate::runtime::{enter, thread_pool};
-
-        enter::try_exit(|| thread_pool::block_in_place(f)).0
+        crate::runtime::thread_pool::block_in_place(f)
     }
 }
 

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -34,7 +34,7 @@ cfg_rt_threaded! {
     {
         use crate::runtime::{enter, thread_pool};
 
-        enter::exit(|| thread_pool::block_in_place(f))
+        enter::try_exit(|| thread_pool::block_in_place(f)).0
     }
 }
 

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -27,3 +27,23 @@ async fn basic_blocking() {
         assert_eq!(out, "hello");
     }
 }
+
+#[tokio::test(threaded_scheduler)]
+async fn block_in_block() {
+    // Run a few times
+    for _ in 0..100 {
+        let out = assert_ok!(
+            tokio::spawn(async {
+                task::block_in_place(|| {
+                    task::block_in_place(|| {
+                        thread::sleep(Duration::from_millis(5));
+                    });
+                    "hello"
+                })
+            })
+            .await
+        );
+
+        assert_eq!(out, "hello");
+    }
+}


### PR DESCRIPTION
This enables nested calls to `block_in_place` by removing an overly aggressive `debug_assert`.

It is a precursor to what would be needed for #2327.