### PR TITLE
task: Ensure the visibility modifier is propagated when constructing a task local

### DIFF
--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -49,7 +49,7 @@ macro_rules! task_local {
 #[macro_export]
 macro_rules! __task_local_inner {
     ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty) => {
-        static $name: $crate::task::LocalKey<$t> = {
+        $vis static $name: $crate::task::LocalKey<$t> = {
             std::thread_local! {
                 static __KEY: std::cell::RefCell<Option<$t>> = std::cell::RefCell::new(None);
             }


### PR DESCRIPTION
Ensure the visibility modifier is propagated static when constructing a `task_local!`.