### PR TITLE
Remove relative link when possible and fix invalid links

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -367,9 +367,9 @@
 //! [`LengthDelimitedCodec::new()`]: method@LengthDelimitedCodec::new
 //! [`FramedRead`]: struct@FramedRead
 //! [`FramedWrite`]: struct@FramedWrite
-//! [`AsyncRead`]: ../../trait.AsyncRead.html
-//! [`AsyncWrite`]: ../../trait.AsyncWrite.html
-//! [`Encoder`]: ../trait.Encoder.html
+//! [`AsyncRead`]: trait@tokio::io::AsyncRead
+//! [`AsyncWrite`]: trait@tokio::io::AsyncWrite
+//! [`Encoder`]: trait@Encoder
 //! [`BytesMut`]: https://docs.rs/bytes/0.4/bytes/struct.BytesMut.html
 
 use crate::codec::{Decoder, Encoder, Framed, FramedRead, FramedWrite};

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -92,11 +92,11 @@ cfg_io_driver! {
     ///
     /// [`std::io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
     /// [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
-    /// [`AsyncRead`]: ../io/trait.AsyncRead.html
-    /// [`AsyncWrite`]: ../io/trait.AsyncWrite.html
+    /// [`AsyncRead`]: trait@AsyncRead
+    /// [`AsyncWrite`]: trait@AsyncWrite
     /// [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
     /// [`Registration`]: struct@Registration
-    /// [`TcpListener`]: ../net/struct.TcpListener.html
+    /// [`TcpListener`]: struct@crate::net::TcpListener
     /// [`clear_read_ready`]: #method.clear_read_ready
     /// [`clear_write_ready`]: #method.clear_write_ready
     /// [`poll_read_ready`]: #method.poll_read_ready

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -334,7 +334,7 @@ impl Runtime {
     /// ```
     ///
     /// [mod]: index.html
-    /// [main]: ../../tokio_macros/attr.main.html
+    /// [main]: ../attr.main.html
     /// [threaded scheduler]: index.html#threaded-scheduler
     /// [basic scheduler]: index.html#basic-scheduler
     /// [runtime builder]: crate::runtime::Builder

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -29,7 +29,7 @@ use std::{fmt, thread};
 /// See [LocalKey documentation][`tokio::task::LocalKey`] for more
 /// information.
 ///
-/// [`tokio::task::LocalKey`]: ../tokio/task/struct.LocalKey.html
+/// [`tokio::task::LocalKey`]: struct@crate::task::LocalKey
 #[macro_export]
 macro_rules! task_local {
      // empty (base case for the recursion)


### PR DESCRIPTION
Replaces relative links by rusdoc link resolution when possible to have a compile error when links cannot be resolved.

Fix invalid links to AsyncRead and AsyncWrite in tokio-util.

Fix link to tokio::main in Runtime::new().
