### PR TITLE
test: remove unnecessary unsafe code

### DIFF
--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -119,20 +119,16 @@ impl<T: Stream> Spawn<T> {
 impl<T: Future> Future for Spawn<T> {
     type Output = T::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // Safety: we only expose &mut T if T: Unpin therefore this is safe.
-        let future = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
-        future.poll(cx)
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.future.as_mut().poll(cx)
     }
 }
 
 impl<T: Stream> Stream for Spawn<T> {
     type Item = T::Item;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Safety: we only expose &mut T if T: Unpin therefore this is safe.
-        let stream = unsafe { self.map_unchecked_mut(|s| &mut s.future) };
-        stream.poll_next(cx)
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.future.as_mut().poll_next(cx)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

`tokio_test::task::Spawn` is `Unpin`, so unsafe `map_unchecked_mut` is not needed.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
