### PR TITLE
doc: fix a typo in the document

### DIFF
--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -51,7 +51,7 @@ pub trait AsyncWrite {
     /// If the object is not ready for writing, the method returns
     /// `Poll::Pending` and arranges for the current task (via
     /// `cx.waker()`) to receive a notification when the object becomes
-    /// readable or is closed.
+    /// writable or is closed.
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
Fix a typo in the document