### PR TITLE
Fix panics in Merge and Chain size hints

### DIFF
--- a/tokio/src/stream/chain.rs
+++ b/tokio/src/stream/chain.rs
@@ -44,14 +44,6 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (a_lower, a_upper) = self.a.size_hint();
-        let (b_lower, b_upper) = self.b.size_hint();
-
-        let upper = match (a_upper, b_upper) {
-            (Some(a_upper), Some(b_upper)) => Some(a_upper + b_upper),
-            _ => None,
-        };
-
-        (a_lower + b_lower, upper)
+        super::merge_size_hints(self.a.size_hint(), self.b.size_hint())
     }
 }

--- a/tokio/src/stream/merge.rs
+++ b/tokio/src/stream/merge.rs
@@ -52,15 +52,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let (a_lower, a_upper) = self.a.size_hint();
-        let (b_lower, b_upper) = self.b.size_hint();
-
-        let upper = match (a_upper, b_upper) {
-            (Some(a_upper), Some(b_upper)) => Some(a_upper + b_upper),
-            _ => None,
-        };
-
-        (a_lower + b_lower, upper)
+        super::merge_size_hints(self.a.size_hint(), self.b.size_hint())
     }
 }
 

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -817,3 +817,16 @@ pub trait StreamExt: Stream {
 }
 
 impl<St: ?Sized> StreamExt for St where St: Stream {}
+
+/// Merge the size hints from two streams.
+fn merge_size_hints(
+    (left_low, left_high): (usize, Option<usize>),
+    (right_low, right_hign): (usize, Option<usize>),
+) -> (usize, Option<usize>) {
+    let low = left_low.saturating_add(right_low);
+    let high = match (left_high, right_hign) {
+        (Some(h1), Some(h2)) => h1.checked_add(h2),
+        _ => None,
+    };
+    (low, high)
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->
## Motivation
Currently, `Merge` and `Chain` streams incorrectly handle overflows: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2f99c2f8f392d0fd068c050da7092cf3

This PR changes both places to use new `merge_size_hints` function that handles overflow (I believe :) ) properly.
