### PR TITLE
io: update rustfmt changes

### DIFF
--- a/tokio/src/io/async_buf_read.rs
+++ b/tokio/src/io/async_buf_read.rs
@@ -60,16 +60,14 @@ pub trait AsyncBufRead: AsyncRead {
 
 macro_rules! deref_async_buf_read {
     () => {
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>)
-            -> Poll<io::Result<&[u8]>>
-        {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
             Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
         }
 
         fn consume(mut self: Pin<&mut Self>, amt: usize) {
             Pin::new(&mut **self).consume(amt)
         }
-    }
+    };
 }
 
 impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {

--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -140,12 +140,14 @@ macro_rules! deref_async_read {
             (**self).prepare_uninitialized_buffer(buf)
         }
 
-        fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
             Pin::new(&mut **self).poll_read(cx, buf)
         }
-    }
+    };
 }
 
 impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for Box<T> {

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -55,13 +55,10 @@ macro_rules! deref_async_seek {
             Pin::new(&mut **self).start_seek(cx, pos)
         }
 
-        fn poll_complete(
-            mut self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<io::Result<u64>> {
+        fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
             Pin::new(&mut **self).poll_complete(cx)
         }
-    }
+    };
 }
 
 impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for Box<T> {

--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -153,9 +153,11 @@ pub trait AsyncWrite {
 
 macro_rules! deref_async_write {
     () => {
-        fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8])
-            -> Poll<io::Result<usize>>
-        {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
             Pin::new(&mut **self).poll_write(cx, buf)
         }
 
@@ -166,7 +168,7 @@ macro_rules! deref_async_write {
         fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
             Pin::new(&mut **self).poll_shutdown(cx)
         }
-    }
+    };
 }
 
 impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for Box<T> {

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -3,7 +3,6 @@ use crate::io::PollEvented;
 use crate::net::unix::{Incoming, UnixStream};
 
 use mio::Ready;
-use mio_uds;
 use std::convert::TryFrom;
 use std::fmt;
 use std::io;


### PR DESCRIPTION
Rustfmt has changed its mind on how some macros should be formatted.

See also rust-lang/rustfmt#4140.