### PR TITLE
io: Add doc warning about concurrently calling poll_read/write_ready

### DIFF
--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -233,6 +233,10 @@ where
     ///
     /// * `ready` includes writable.
     /// * called from outside of a task context.
+    ///
+    /// # Warning
+    ///
+    /// Calling this function concurrently will mess up mio's internal state.
     pub fn poll_read_ready(
         &self,
         cx: &mut Context<'_>,
@@ -299,6 +303,10 @@ where
     ///
     /// * `ready` contains bits besides `writable` and `hup`.
     /// * called from outside of a task context.
+    ///
+    /// # Warning
+    ///
+    /// Calling this function concurrently will mess up mio's internal state.
     pub fn poll_write_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<mio::Ready>> {
         poll_ready!(
             self,

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -236,8 +236,8 @@ where
     ///
     /// # Warning
     ///
-    /// &self is to allow concurrently calling poll_read_ready and poll_write_ready.
-    /// But calling this function concurrently will mess up mio's internal state.
+    /// This method may not be called concurrently. It takes `&self` to allow
+    /// calling it concurrently with `poll_write_ready`.
     pub fn poll_read_ready(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -307,8 +307,8 @@ where
     ///
     /// # Warning
     ///
-    /// &self is to allow concurrently calling poll_read_ready and poll_write_ready.
-    /// But calling this function concurrently will mess up mio's internal state.
+    /// This method may not be called concurrently. It takes `&self` to allow
+    /// calling it concurrently with `poll_read_ready`.
     pub fn poll_write_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<mio::Ready>> {
         poll_ready!(
             self,

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -236,7 +236,8 @@ where
     ///
     /// # Warning
     ///
-    /// Calling this function concurrently will mess up mio's internal state.
+    /// &self is to allow concurrently calling poll_read_ready and poll_write_ready.
+    /// But calling this function concurrently will mess up mio's internal state.
     pub fn poll_read_ready(
         &self,
         cx: &mut Context<'_>,
@@ -306,7 +307,8 @@ where
     ///
     /// # Warning
     ///
-    /// Calling this function concurrently will mess up mio's internal state.
+    /// &self is to allow concurrently calling poll_read_ready and poll_write_ready.
+    /// But calling this function concurrently will mess up mio's internal state.
     pub fn poll_write_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<mio::Ready>> {
         poll_ready!(
             self,


### PR DESCRIPTION
## Motivation

To address #2429 

In io/poll_evented.rs, `poll_read_ready` and `poll_write_ready` shall not be called concurrently because it will mess up mio's internal state.

## Solution

Add doc comments warning about this.
