### PR TITLE
sync: fix slow receivers in broadcast

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -736,7 +736,7 @@ impl<T> Receiver<T> {
         guard.drop_no_rem_dec();
         self.next = next;
 
-        return Err(TryRecvError::Lagged(missed));
+        Err(TryRecvError::Lagged(missed))
     }
 }
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -740,6 +740,10 @@ impl<T> Receiver<T> {
         self.next = self.next.wrapping_add(1);
 
         // If the `CLOSED` bit it set on the slot, the channel is closed
+        //
+        // `try_rx_lock` could check for this and bail early. If it's return
+        // value was changed to represent the state of the lock, it could
+        // match on being closed, empty, or available for reading.
         if slot.lock.load(SeqCst) & CLOSED == CLOSED {
             guard.drop_no_rem_dec();
             return Err(TryRecvError::Closed);


### PR DESCRIPTION
## Motivation

Broadcast uses a ring buffer to store values sent to the channel. In order to
deal with slow receivers, the oldest values are overwritten with new values
once the buffer wraps. A receiver should be able to calculate how many values
it has missed.

Additionally, when the broadcast closes, a final value of `None` is sent to
the channel. If the buffer has wrapped, this value overwrites the oldest
value.

This is an issue mainly in a single capacity broadcast when a value is sent
and then the sender is dropped. The original value is immediately overwritten
with `None` meaning that receivers assume they have lagged behind.

Closes #2425

## Solution

A value of `None` is no longer sent to the channel when the final sender has
been dropped. This solves the single capacity broadcast case by completely
removing the behavior of overwriting values when the channel is closed.

Now, when the final sender is dropped a closed bit is set on the next slot
that the channel is supposed to send to.

In the case of a fast receiver, if it finds a slot where the closed bit is
set, it knows the channel is closed without locking the tail.

In the case of a slow receiver, it must first find out if it has missed any
values. This is similar to before, but must be able to account for channel
closure.

If the channel is not closed, the oldest value may be located at index `n`. If
the channel is closed, the oldest value is located at index `n - 1`.

Knowing the index where the oldest value is located, a receiver can calculate
how many values it may have missed and starts to catch up.

Signed-off-by: Kevin Leimkuhler <kevin@kleimkuhler.com>
