### PR TITLE
Added `get_mut`, `get_ref` and `into_inner` for Lines.

### DIFF
--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -60,17 +60,20 @@ where
         poll_fn(|cx| Pin::new(&mut *self).poll_next_line(cx)).await
     }
 
-    /// Obtain a mutable reference to a byte of the underlying reader
+    /// Obtain a mutable reference to the underlying reader
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.reader
     }
 
-    /// Obtain a reference to a byte of the underlying reader
+    /// Obtain a reference to the underlying reader
     pub fn get_ref(&mut self) -> &R {
         &self.reader
     }
 
-    /// Consume the line, returning the underlying bytes
+    /// Unwraps this `Lines<R>`, returning the underlying reader.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    /// Therefore, a following read from the underlying reader may lead to data loss.
     pub fn into_inner(self) -> R {
         self.reader
     }

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -59,6 +59,21 @@ where
 
         poll_fn(|cx| Pin::new(&mut *self).poll_next_line(cx)).await
     }
+
+    /// Obtain a mutable reference to a byte of the underlying reader
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Obtain a reference to a byte of the underlying reader
+    pub fn get_ref(&mut self) -> &R {
+        &self.reader
+    }
+
+    /// Consume the line, returning the underlying bytes
+    pub fn into_inner(self) -> R {
+        self.reader
+    }
 }
 
 impl<R> Lines<R>


### PR DESCRIPTION
Related issue #2433

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Provides a convenient method to obtain the underlying reader of `Lines`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Implemented `get_mut`, `get_ref` and `into_inner`. I simply took the implementation from other similar stuffs I see in the code base. Let me know if these are wrong.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
