### PR TITLE
Typo fixes

### DIFF
--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -84,12 +84,12 @@ impl<T, E> FramedWrite<T, E> {
         self.inner.inner.io
     }
 
-    /// Returns a reference to the underlying decoder.
+    /// Returns a reference to the underlying encoder.
     pub fn encoder(&self) -> &E {
         &self.inner.inner.codec
     }
 
-    /// Returns a mutable reference to the underlying decoder.
+    /// Returns a mutable reference to the underlying encoder.
     pub fn encoder_mut(&mut self) -> &mut E {
         &mut self.inner.inner.codec
     }


### PR DESCRIPTION
Changed _decoder_ to _encoder_ in doc comments