### PR TITLE
rt: fix default thread number logic

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -461,10 +461,12 @@ cfg_rt_threaded! {
         }
 
         fn build_threaded_runtime(&mut self) -> io::Result<Runtime> {
+            use crate::loom::sys::num_cpus;
             use crate::runtime::{Kind, ThreadPool};
             use crate::runtime::park::Parker;
+            use std::cmp;
 
-            let core_threads = self.core_threads.unwrap_or_else(crate::loom::sys::num_cpus);
+            let core_threads = self.core_threads.unwrap_or_else(|| cmp::min(self.max_threads, num_cpus()));
             assert!(core_threads <= self.max_threads, "Core threads number cannot be above max limit");
 
             let clock = time::create_clock();

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -322,6 +322,16 @@ fn multi_threadpool() {
     done_rx.recv().unwrap();
 }
 
+// Testing this does not panic
+#[test]
+fn max_threads() {
+    let _rt = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .max_threads(1)
+        .build()
+        .unwrap();
+}
+
 fn rt() -> Runtime {
     Runtime::new().unwrap()
 }


### PR DESCRIPTION
Previously, the function picking the default number of threads for the
threaded runtime did not factor in `max_threads`. Instead, it only used
the value returned by `num_cpus`. However, if `num_cpus` returns a value
greater than `max_threads`, then the function would panic.

This patch fixes the function by limiting the default number of threads
by `max_threads`.

Fixes #2452