### PR TITLE
macros: `scoped_thread_local` should be private

### DIFF
--- a/tokio/src/macros/scoped_tls.rs
+++ b/tokio/src/macros/scoped_tls.rs
@@ -4,7 +4,6 @@ use std::cell::Cell;
 use std::marker;
 
 /// Set a reference as a thread-local
-#[macro_export]
 macro_rules! scoped_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty) => (
         $(#[$attrs])*


### PR DESCRIPTION
Do not export the `scoped_thread_local` macro outside of the Tokio
crate. This is not considered a breaking change as the macro never
worked if used from outside of the crate due to the generated code
referencing crate-private types.