### PR TITLE
Added map associated function to MutexGuard that uses new MappedMutexGuard type

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -436,7 +436,7 @@ cfg_sync! {
     pub mod mpsc;
 
     mod mutex;
-    pub use mutex::{Mutex, MutexGuard, TryLockError, OwnedMutexGuard};
+    pub use mutex::{Mutex, MutexGuard, TryLockError, OwnedMutexGuard, MappedMutexGuard};
 
     pub(crate) mod notify;
     pub use notify::Notify;

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -436,7 +436,7 @@ cfg_sync! {
     pub mod mpsc;
 
     mod mutex;
-    pub use mutex::{Mutex, MutexGuard, TryLockError, OwnedMutexGuard, MappedMutexGuard};
+    pub use mutex::{Mutex, MutexGuard, TryLockError, OwnedMutexGuard};
 
     pub(crate) mod notify;
     pub use notify::Notify;

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -180,7 +180,8 @@ unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
 unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
 unsafe impl<T> Sync for MutexGuard<'_, T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
-unsafe impl<T> Sync for MappedMutexGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<'a, T> Sync for MappedMutexGuard<'a, T> where T: ?Sized + Sync + 'a {}
+unsafe impl<'a, T> Send for MappedMutexGuard<'a, T> where T: ?Sized + Send + 'a {}
 
 /// Error returned from the [`Mutex::try_lock`], [`RwLock::try_read`] and
 /// [`RwLock::try_write`] functions.

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -4,11 +4,9 @@ use crate::sync::batch_semaphore as semaphore;
 
 use std::cell::UnsafeCell;
 use std::error::Error;
-use std::fmt;
-use std::marker;
-use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
+use std::{fmt, marker, mem};
 
 /// An asynchronous `Mutex`-like type.
 ///
@@ -140,10 +138,7 @@ pub struct Mutex<T: ?Sized> {
 /// The lock is automatically released whenever the guard is dropped, at which
 /// point `lock` will succeed yet again.
 pub struct MutexGuard<'a, T: ?Sized> {
-    s: &'a semaphore::Semaphore,
-    data: *mut T,
-    // Needed to tell the borrow checker that we are holding a `&mut T`
-    marker: marker::PhantomData<&'a mut T>,
+    lock: &'a Mutex<T>,
 }
 
 /// An owned handle to a held `Mutex`.
@@ -165,14 +160,27 @@ pub struct OwnedMutexGuard<T: ?Sized> {
     lock: Arc<Mutex<T>>,
 }
 
+/// A handle to a held `Mutex` that has had a function applied to it via [`MutexGuard::map`].
+///
+/// This can be used to hold a subfield of the protected data.
+///
+/// [`MutexGuard::map`]: method@MutexGuard::map
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MappedMutexGuard<'a, T: ?Sized> {
+    s: &'a semaphore::Semaphore,
+    data: *mut T,
+    // Needed to tell the borrow checker that we are holding a `&mut T`
+    marker: marker::PhantomData<&'a mut T>,
+}
+
 // As long as T: Send, it's fine to send and share Mutex<T> between threads.
 // If T was not Send, sending and sharing a Mutex<T> would be bad, since you can
 // access T through Mutex<T>.
 unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
 unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
-unsafe impl<'a, T> Send for MutexGuard<'a, T> where T: ?Sized + Send + Sync {}
-unsafe impl<'a, T> Sync for MutexGuard<'a, T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for MutexGuard<'_, T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for MappedMutexGuard<'_, T> where T: ?Sized + Send + Sync {}
 
 /// Error returned from the [`Mutex::try_lock`], [`RwLock::try_read`] and
 /// [`RwLock::try_write`] functions.
@@ -283,11 +291,7 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     pub async fn lock(&self) -> MutexGuard<'_, T> {
         self.acquire().await;
-        MutexGuard {
-            s: &self.s,
-            data: self.c.get(),
-            marker: marker::PhantomData,
-        }
+        MutexGuard { lock: self }
     }
 
     /// Locks this mutex, causing the current task to yield until the lock has
@@ -348,11 +352,7 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
-            Ok(_) => Ok(MutexGuard {
-                s: &self.s,
-                data: self.c.get(),
-                marker: marker::PhantomData,
-            }),
+            Ok(_) => Ok(MutexGuard { lock: self }),
             Err(_) => Err(TryLockError(())),
         }
     }
@@ -466,9 +466,7 @@ where
 // === impl MutexGuard ===
 
 impl<'a, T: ?Sized> MutexGuard<'a, T> {
-    /// Makes a new [`MutexGuard`] for a component of the locked data.
-    ///
-    /// This can be used to hold a subfield of the protected data.
+    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
     ///
     /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
     ///
@@ -497,26 +495,23 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
     /// ```
     ///
     /// [`MutexGuard`]: struct@MutexGuard
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
     #[inline]
-    pub fn map<U, F>(mut this: Self, f: F) -> MutexGuard<'a, U>
+    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
     where
         F: FnOnce(&mut T) -> &mut U,
     {
         let data = f(&mut *this) as *mut U;
-        let s = this.s;
-
-        // Need to forget `this` so that the mutex does not unlock when that is dropped
-        // Essentially transferring ownership to the new `MutexGuard`
+        let s = &this.lock.s;
         mem::forget(this);
-
-        MutexGuard {
+        MappedMutexGuard {
             s,
             data,
             marker: marker::PhantomData,
         }
     }
 
-    /// Attempts to make a new [`MutexGuard`] for a component of the locked data. The
+    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
     /// original guard is returned if the closure returns `None`.
     ///
     /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
@@ -547,8 +542,9 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
     /// ```
     ///
     /// [`MutexGuard`]: struct@MutexGuard
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
     #[inline]
-    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MutexGuard<'a, U>, Self>
+    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
     where
         F: FnOnce(&mut T) -> Option<&mut U>,
     {
@@ -556,13 +552,9 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             Some(data) => data as *mut U,
             None => return Err(this),
         };
-        let s = this.s;
-
-        // Need to forget `this` so that the mutex does not unlock when that is dropped
-        // Essentially transferring ownership to the new `MutexGuard`
+        let s = &this.lock.s;
         mem::forget(this);
-
-        Ok(MutexGuard {
+        Ok(MappedMutexGuard {
             s,
             data,
             marker: marker::PhantomData,
@@ -572,20 +564,20 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
-        self.s.release(1)
+        self.lock.s.release(1)
     }
 }
 
 impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        unsafe { &*self.data }
+        unsafe { &*self.lock.c.get() }
     }
 }
 
 impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.data }
+        unsafe { &mut *self.lock.c.get() }
     }
 }
 
@@ -629,6 +621,91 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for OwnedMutexGuard<T> {
 }
 
 impl<T: ?Sized + fmt::Display> fmt::Display for OwnedMutexGuard<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+// === impl MappedMutexGuard ===
+
+impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
+    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
+    ///
+    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MappedMutexGuard::map(...)`. A
+    /// method would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+    {
+        let data = f(&mut *this) as *mut U;
+        let s = this.s;
+        mem::forget(this);
+        MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        }
+    }
+
+    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
+    /// original guard is returned if the closure returns `None`.
+    ///
+    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MappedMutexGuard::try_map(...)`. A
+    /// method would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    where
+        F: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        let data = match f(&mut *this) {
+            Some(data) => data as *mut U,
+            None => return Err(this),
+        };
+        let s = this.s;
+        mem::forget(this);
+        Ok(MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        })
+    }
+}
+
+impl<'a, T: ?Sized> Drop for MappedMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        self.s.release(1)
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MappedMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.data }
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MappedMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MappedMutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for MappedMutexGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -140,7 +140,10 @@ pub struct Mutex<T: ?Sized> {
 /// The lock is automatically released whenever the guard is dropped, at which
 /// point `lock` will succeed yet again.
 pub struct MutexGuard<'a, T: ?Sized> {
-    lock: &'a Mutex<T>,
+    s: &'a semaphore::Semaphore,
+    data: *mut T,
+    // Needed to tell the borrow checker that we are holding a `&mut T`
+    marker: marker::PhantomData<&'a mut T>,
 }
 
 /// An owned handle to a held `Mutex`.
@@ -162,27 +165,14 @@ pub struct OwnedMutexGuard<T: ?Sized> {
     lock: Arc<Mutex<T>>,
 }
 
-/// A handle to a held `Mutex` that has had a function applied to it via [`MutexGuard::map`].
-///
-/// This can be used to hold a subfield of the protected data.
-///
-/// [`MutexGuard::map`]: method@MutexGuard::map
-#[must_use = "if unused the Mutex will immediately unlock"]
-pub struct MappedMutexGuard<'a, T: ?Sized> {
-    s: &'a semaphore::Semaphore,
-    data: *mut T,
-    // Needed to tell the borrow checker that we are holding a `&mut T`
-    marker: marker::PhantomData<&'a mut T>,
-}
-
 // As long as T: Send, it's fine to send and share Mutex<T> between threads.
 // If T was not Send, sending and sharing a Mutex<T> would be bad, since you can
 // access T through Mutex<T>.
 unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
 unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
+unsafe impl<'a, T> Send for MutexGuard<'a, T> where T: ?Sized + Send + Sync {}
 unsafe impl<'a, T> Sync for MutexGuard<'a, T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
-unsafe impl<'a, T> Sync for MappedMutexGuard<'a, T> where T: ?Sized + Send + Sync {}
 
 /// Error returned from the [`Mutex::try_lock`], [`RwLock::try_read`] and
 /// [`RwLock::try_write`] functions.
@@ -293,7 +283,11 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     pub async fn lock(&self) -> MutexGuard<'_, T> {
         self.acquire().await;
-        MutexGuard { lock: self }
+        MutexGuard {
+            s: &self.s,
+            data: self.c.get(),
+            marker: marker::PhantomData,
+        }
     }
 
     /// Locks this mutex, causing the current task to yield until the lock has
@@ -354,7 +348,11 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
-            Ok(_) => Ok(MutexGuard { lock: self }),
+            Ok(_) => Ok(MutexGuard {
+                s: &self.s,
+                data: self.c.get(),
+                marker: marker::PhantomData,
+            }),
             Err(_) => Err(TryLockError(())),
         }
     }
@@ -468,7 +466,9 @@ where
 // === impl MutexGuard ===
 
 impl<'a, T: ?Sized> MutexGuard<'a, T> {
-    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
+    /// Makes a new [`MutexGuard`] for a component of the locked data.
+    ///
+    /// This can be used to hold a subfield of the protected data.
     ///
     /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
     ///
@@ -497,23 +497,26 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
     /// ```
     ///
     /// [`MutexGuard`]: struct@MutexGuard
-    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
     #[inline]
-    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
+    pub fn map<U, F>(mut this: Self, f: F) -> MutexGuard<'a, U>
     where
         F: FnOnce(&mut T) -> &mut U,
     {
         let data = f(&mut *this) as *mut U;
-        let s = &this.lock.s;
+        let s = this.s;
+
+        // Need to forget `this` so that the mutex does not unlock when that is dropped
+        // Essentially transferring ownership to the new `MutexGuard`
         mem::forget(this);
-        MappedMutexGuard {
+
+        MutexGuard {
             s,
             data,
             marker: marker::PhantomData,
         }
     }
 
-    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
+    /// Attempts to make a new [`MutexGuard`] for a component of the locked data. The
     /// original guard is returned if the closure returns `None`.
     ///
     /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
@@ -544,9 +547,8 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
     /// ```
     ///
     /// [`MutexGuard`]: struct@MutexGuard
-    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
     #[inline]
-    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MutexGuard<'a, U>, Self>
     where
         F: FnOnce(&mut T) -> Option<&mut U>,
     {
@@ -554,9 +556,13 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             Some(data) => data as *mut U,
             None => return Err(this),
         };
-        let s = &this.lock.s;
+        let s = this.s;
+
+        // Need to forget `this` so that the mutex does not unlock when that is dropped
+        // Essentially transferring ownership to the new `MutexGuard`
         mem::forget(this);
-        Ok(MappedMutexGuard {
+
+        Ok(MutexGuard {
             s,
             data,
             marker: marker::PhantomData,
@@ -566,20 +572,20 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
-        self.lock.s.release(1)
+        self.s.release(1)
     }
 }
 
 impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        unsafe { &*self.lock.c.get() }
+        unsafe { &*self.data }
     }
 }
 
 impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.lock.c.get() }
+        unsafe { &mut *self.data }
     }
 }
 
@@ -623,91 +629,6 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for OwnedMutexGuard<T> {
 }
 
 impl<T: ?Sized + fmt::Display> fmt::Display for OwnedMutexGuard<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&**self, f)
-    }
-}
-
-// === impl MappedMutexGuard ===
-
-impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
-    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
-    ///
-    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
-    ///
-    /// This is an associated function that needs to be used as `MappedMutexGuard::map(...)`. A
-    /// method would interfere with methods of the same name on the contents of the locked data.
-    ///
-    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
-    #[inline]
-    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
-    where
-        F: FnOnce(&mut T) -> &mut U,
-    {
-        let data = f(&mut *this) as *mut U;
-        let s = this.s;
-        mem::forget(this);
-        MappedMutexGuard {
-            s,
-            data,
-            marker: marker::PhantomData,
-        }
-    }
-
-    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
-    /// original guard is returned if the closure returns `None`.
-    ///
-    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
-    ///
-    /// This is an associated function that needs to be used as `MappedMutexGuard::try_map(...)`. A
-    /// method would interfere with methods of the same name on the contents of the locked data.
-    ///
-    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
-    #[inline]
-    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
-    where
-        F: FnOnce(&mut T) -> Option<&mut U>,
-    {
-        let data = match f(&mut *this) {
-            Some(data) => data as *mut U,
-            None => return Err(this),
-        };
-        let s = this.s;
-        mem::forget(this);
-        Ok(MappedMutexGuard {
-            s,
-            data,
-            marker: marker::PhantomData,
-        })
-    }
-}
-
-impl<'a, T: ?Sized> Drop for MappedMutexGuard<'a, T> {
-    fn drop(&mut self) {
-        self.s.release(1)
-    }
-}
-
-impl<'a, T: ?Sized> Deref for MappedMutexGuard<'a, T> {
-    type Target = T;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.data }
-    }
-}
-
-impl<'a, T: ?Sized> DerefMut for MappedMutexGuard<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *self.data }
-    }
-}
-
-impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MappedMutexGuard<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(&**self, f)
-    }
-}
-
-impl<'a, T: ?Sized + fmt::Display> fmt::Display for MappedMutexGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -5,6 +5,8 @@ use crate::sync::batch_semaphore as semaphore;
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::fmt;
+use std::marker;
+use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
@@ -160,13 +162,27 @@ pub struct OwnedMutexGuard<T: ?Sized> {
     lock: Arc<Mutex<T>>,
 }
 
+/// A handle to a held `Mutex` that has had a function applied to it via [`MutexGuard::map`].
+///
+/// This can be used to hold a subfield of the protected data.
+///
+/// [`MutexGuard::map`]: method@MutexGuard::map
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MappedMutexGuard<'a, T: ?Sized> {
+    s: &'a semaphore::Semaphore,
+    data: *mut T,
+    // Needed to tell the borrow checker that we are holding a `&mut T`
+    marker: marker::PhantomData<&'a mut T>,
+}
+
 // As long as T: Send, it's fine to send and share Mutex<T> between threads.
 // If T was not Send, sending and sharing a Mutex<T> would be bad, since you can
 // access T through Mutex<T>.
 unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
 unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
-unsafe impl<T> Sync for MutexGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<'a, T> Sync for MutexGuard<'a, T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
+unsafe impl<'a, T> Sync for MappedMutexGuard<'a, T> where T: ?Sized + Send + Sync {}
 
 /// Error returned from the [`Mutex::try_lock`], [`RwLock::try_read`] and
 /// [`RwLock::try_write`] functions.
@@ -451,6 +467,103 @@ where
 
 // === impl MutexGuard ===
 
+impl<'a, T: ?Sized> MutexGuard<'a, T> {
+    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
+    ///
+    /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MutexGuard::map(...)`. A method
+    /// would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::{Mutex, MutexGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let foo = Mutex::new(Foo(1));
+    ///
+    /// {
+    ///     let mut mapped = MutexGuard::map(foo.lock().await, |f| &mut f.0);
+    ///     *mapped = 2;
+    /// }
+    ///
+    /// assert_eq!(Foo(2), *foo.lock().await);
+    /// # }
+    /// ```
+    ///
+    /// [`MutexGuard`]: struct@MutexGuard
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+    {
+        let data = f(&mut *this) as *mut U;
+        let s = &this.lock.s;
+        mem::forget(this);
+        MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        }
+    }
+
+    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
+    /// original guard is returned if the closure returns `None`.
+    ///
+    /// This operation cannot fail as the [`MutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MutexGuard::try_map(...)`. A
+    /// method would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::{Mutex, MutexGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let foo = Mutex::new(Foo(1));
+    ///
+    /// {
+    ///     let mut mapped = MutexGuard::try_map(foo.lock().await, |f| Some(&mut f.0))
+    ///         .expect("should not fail");
+    ///     *mapped = 2;
+    /// }
+    ///
+    /// assert_eq!(Foo(2), *foo.lock().await);
+    /// # }
+    /// ```
+    ///
+    /// [`MutexGuard`]: struct@MutexGuard
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    where
+        F: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        let data = match f(&mut *this) {
+            Some(data) => data as *mut U,
+            None => return Err(this),
+        };
+        let s = &this.lock.s;
+        mem::forget(this);
+        Ok(MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        })
+    }
+}
+
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
         self.lock.s.release(1)
@@ -510,6 +623,91 @@ impl<T: ?Sized + fmt::Debug> fmt::Debug for OwnedMutexGuard<T> {
 }
 
 impl<T: ?Sized + fmt::Display> fmt::Display for OwnedMutexGuard<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+// === impl MappedMutexGuard ===
+
+impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
+    /// Makes a new [`MappedMutexGuard`] for a component of the locked data.
+    ///
+    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MappedMutexGuard::map(...)`. A
+    /// method would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn map<U, F>(mut this: Self, f: F) -> MappedMutexGuard<'a, U>
+    where
+        F: FnOnce(&mut T) -> &mut U,
+    {
+        let data = f(&mut *this) as *mut U;
+        let s = this.s;
+        mem::forget(this);
+        MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        }
+    }
+
+    /// Attempts to make a new [`MappedMutexGuard`] for a component of the locked data. The
+    /// original guard is returned if the closure returns `None`.
+    ///
+    /// This operation cannot fail as the [`MappedMutexGuard`] passed in already locked the mutex.
+    ///
+    /// This is an associated function that needs to be used as `MappedMutexGuard::try_map(...)`. A
+    /// method would interfere with methods of the same name on the contents of the locked data.
+    ///
+    /// [`MappedMutexGuard`]: struct@MappedMutexGuard
+    #[inline]
+    pub fn try_map<U, F>(mut this: Self, f: F) -> Result<MappedMutexGuard<'a, U>, Self>
+    where
+        F: FnOnce(&mut T) -> Option<&mut U>,
+    {
+        let data = match f(&mut *this) {
+            Some(data) => data as *mut U,
+            None => return Err(this),
+        };
+        let s = this.s;
+        mem::forget(this);
+        Ok(MappedMutexGuard {
+            s,
+            data,
+            marker: marker::PhantomData,
+        })
+    }
+}
+
+impl<'a, T: ?Sized> Drop for MappedMutexGuard<'a, T> {
+    fn drop(&mut self) {
+        self.s.release(1)
+    }
+}
+
+impl<'a, T: ?Sized> Deref for MappedMutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.data }
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MappedMutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Debug> fmt::Debug for MappedMutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for MappedMutexGuard<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -47,7 +47,7 @@ fn readiness() {
     // But once g unlocks, we can acquire it
     drop(g);
     assert!(t2.is_woken());
-    assert_ready!(t2.poll());
+    let _g = assert_ready!(t2.poll());
 }
 
 /*
@@ -93,7 +93,7 @@ async fn aborted_future_1() {
         timeout(Duration::from_millis(1u64), async move {
             let iv = interval(Duration::from_millis(1000));
             tokio::pin!(iv);
-            m2.lock().await;
+            let _g = m2.lock().await;
             iv.as_mut().tick().await;
             iv.as_mut().tick().await;
         })
@@ -102,7 +102,7 @@ async fn aborted_future_1() {
     }
     // This should succeed as there is no lock left for the mutex.
     timeout(Duration::from_millis(1u64), async move {
-        m1.lock().await;
+        let _g = m1.lock().await;
     })
     .await
     .expect("Mutex is locked");
@@ -120,7 +120,7 @@ async fn aborted_future_2() {
             let m2 = m1.clone();
             // Try to lock mutex in a future that is aborted prematurely
             timeout(Duration::from_millis(1u64), async move {
-                m2.lock().await;
+                let _g = m2.lock().await;
             })
             .await
             .unwrap_err();
@@ -128,7 +128,7 @@ async fn aborted_future_2() {
     }
     // This should succeed as there is no lock left for the mutex.
     timeout(Duration::from_millis(1u64), async move {
-        m1.lock().await;
+        let _g = m1.lock().await;
     })
     .await
     .expect("Mutex is locked");

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -47,7 +47,7 @@ fn readiness() {
     // But once g unlocks, we can acquire it
     drop(g);
     assert!(t2.is_woken());
-    let _g = assert_ready!(t2.poll());
+    assert_ready!(t2.poll());
 }
 
 /*
@@ -93,7 +93,7 @@ async fn aborted_future_1() {
         timeout(Duration::from_millis(1u64), async move {
             let iv = interval(Duration::from_millis(1000));
             tokio::pin!(iv);
-            let _g = m2.lock().await;
+            m2.lock().await;
             iv.as_mut().tick().await;
             iv.as_mut().tick().await;
         })
@@ -102,7 +102,7 @@ async fn aborted_future_1() {
     }
     // This should succeed as there is no lock left for the mutex.
     timeout(Duration::from_millis(1u64), async move {
-        let _g = m1.lock().await;
+        m1.lock().await;
     })
     .await
     .expect("Mutex is locked");
@@ -120,7 +120,7 @@ async fn aborted_future_2() {
             let m2 = m1.clone();
             // Try to lock mutex in a future that is aborted prematurely
             timeout(Duration::from_millis(1u64), async move {
-                let _g = m2.lock().await;
+                m2.lock().await;
             })
             .await
             .unwrap_err();
@@ -128,7 +128,7 @@ async fn aborted_future_2() {
     }
     // This should succeed as there is no lock left for the mutex.
     timeout(Duration::from_millis(1u64), async move {
-        let _g = m1.lock().await;
+        m1.lock().await;
     })
     .await
     .expect("Mutex is locked");


### PR DESCRIPTION
Part of #2471, extends the work of #2445. Both this PR and #2445 together close #2471.

This PR introduces the `MappedMutexGuard` type and adds a `map` associated function to `MutexGuard`. The work here is largely based on #2445, so thanks @udoprog for the great PR. This was very easy to implement using your work as a reference.

`MappedMutexGuard` works almost exactly the same as [`parking_lot::MappedMutexGuard`](https://docs.rs/lock_api/0.3.4/lock_api/struct.MappedMutexGuard.html), but adapted to the internals of `tokio::sync::Mutex`. The `MappedMutexGuard` type stores a reference to the semaphore from the original `Mutex` as well as a raw pointer `*mut T` that is the result of calling the function passed to `map`. The `Mutex` does not hold a mutable reference to its data (it uses an `UnsafeCell`), so I do not believe that it is possible to accidentally run into any aliasing issues.

I added documentation based on the work in #2445 and the documentation in `parking_lot`/`lock_api`. There are doctests in both `map` and `try_map` that are almost exactly the same as the ones in #2445 for `RwLockWriteGuard`. I generated the docs with `cargo doc` and everything looks great. :tada: 