### PR TITLE
WIP: implement cancellation and raw handles

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -91,6 +91,44 @@ impl<T> JoinHandle<T> {
             _p: PhantomData,
         }
     }
+
+    /// Abort the task associated with the handle.
+    ///
+    /// Awaiting a cancelled task might complete as usual if the task was
+    /// already completed at the time it was cancelled, but most likely it
+    /// will complete with a `Err(JoinError::Cancelled)`.
+    ///
+    /// ```rust
+    /// use tokio::time;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///    let mut handles = Vec::new();
+    ///
+    ///    handles.push(tokio::spawn(async {
+    ///       time::delay_for(time::Duration::from_secs(10)).await;
+    ///       true
+    ///    }));
+    ///
+    ///    handles.push(tokio::spawn(async {
+    ///       time::delay_for(time::Duration::from_secs(10)).await;
+    ///       false
+    ///    }));
+    ///
+    ///    for handle in &handles {
+    ///        handle.abort();
+    ///    }
+    ///
+    ///    for handle in handles {
+    ///        assert!(handle.await.unwrap_err().is_cancelled());
+    ///    }
+    /// }
+    /// ```
+    pub fn abort(&self) {
+        if let Some(raw) = self.raw {
+            raw.shutdown();
+        }
+    }
 }
 
 impl<T> Unpin for JoinHandle<T> {}


### PR DESCRIPTION
This is a WIP PR for implementing a simple form of cancellation, as [mentioned here](https://github.com/tokio-rs/tokio/issues/1819#issuecomment-561796700). Since work on [structured concurrency](#1879) is underway this might not be necessary, but I'm setting this up so that others can have a look and provide input.

While related to structured concurrency it does not replace it. It is only a low-level primitive necessary to perform some best-effort graceful shutdown (#1819) over spawned tasks.

Note that this **does not** allow for graceful termination of tasks spawned with `spawn_blocking` that are actively blocking, which includes most [`File` operations](https://docs.rs/tokio/latest/tokio/fs/struct.File.html).

Warning: Naming is provisional, and certain assumptions around task shutdown might not be correct since I'm still not super familiar with the task system.

## Motivation

Support for some form of cancellation is necessary to support graceful termination . This doesn't replace structured concurrency, but should be considered more of an incremental step towards allowing application and library authors to support graceful termination of background tasks without adopting a different API.

## Solution

Hooks into the existing task system, and extends completion polling with a variant which doesn't export the output value to support raw join handles. This allows us to cancel tasks (which are currently not being polled), and `.await` their termination. Hopefully providing their `Output` or a simple completion signal on a best-effort basis.