### PR TITLE
doc: remove reference to the Sink trait in the MPSC documentation

### DIFF
--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -6,10 +6,9 @@
 //! Similar to `std`, channel creation provides [`Receiver`] and [`Sender`]
 //! handles. [`Receiver`] implements `Stream` and allows a task to read values
 //! out of the channel. If there is no message to read, the current task will be
-//! notified when a new value is sent.  [`Sender`] implements the `Sink` trait
-//! and allows sending messages into the channel. If the channel is at capacity,
-//! the send is rejected and the task will be notified when additional capacity
-//! is available. In other words, the channel provides backpressure.
+//! notified when a new value is sent. If the channel is at capacity, the send
+//! is rejected and the task will be notified when additional capacity is
+//! available. In other words, the channel provides backpressure.
 //!
 //! Unbounded channels are also available using the `unbounded_channel`
 //! constructor.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

The implementation of the Sink trait was removed in 8a7e5778.

Fixes: #2464
Refs: #2389

## Solution

Remove the reference to the `Sink` trait in [tokio/src/sync/mpsc/mod.rs](https://github.com/tokio-rs/tokio/blob/master/tokio/src/sync/mpsc/mod.rs).
