### PR TITLE
Add `is_closed` for MPSC channel

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -489,4 +489,12 @@ impl<T> Sender<T> {
             false
         }
     }
+
+    /// Returns `true` when the channel is closed.
+    ///
+    /// From the Sender point of view, the channel is considered closed if the
+    /// receiver half of the channel is closed.
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -177,6 +177,19 @@ impl<T> Receiver<T> {
     pub fn close(&mut self) {
         self.chan.close();
     }
+
+    /// Returns `true` when the channel is closed.
+    ///
+    /// The channel is considered closed if one of this conditions is true:
+    ///
+    /// - the number of outstanding sender handles is zero, thus the send half
+    ///   of the channel is closed;
+    /// - if  [`close`] is called.
+    ///
+    /// [`close`]: Receiver::close
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }
 
 impl<T> Unpin for Receiver<T> {}

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -173,4 +173,12 @@ impl<T> UnboundedSender<T> {
         self.chan.send_unbounded(message)?;
         Ok(())
     }
+
+    /// Returns `true` when the channel is closed.
+    ///
+    /// From the Sender point of view, the channel is considered closed if
+    /// the receiver half of the channel is closed.
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -145,6 +145,19 @@ impl<T> UnboundedReceiver<T> {
     pub fn close(&mut self) {
         self.chan.close();
     }
+
+    /// Returns `true` when the channel is closed.
+    ///
+    /// The channel is considered closed if one of this conditions is true:
+    ///
+    /// - the number of outstanding sender handles is zero, thus the send half
+    ///   of the channel is closed;
+    /// - if  [`close`] is called.
+    ///
+    /// [`close`]: UnboundedReceiver::close
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }
 
 #[cfg(feature = "stream")]


### PR DESCRIPTION
## Motivation

This PR is addressing the issue _"mpsc channel should have an is_closed function"_ (#2469).

## Solution

I've made an exploratory attempt to implement an `is_closed` function and I would like to ask for feedback to validate the approach.

I'm not yet completely comfortable with the internals of `sync::mpsc`; according to my understanding a `Sender` wraps a `chan::Tx` and a `Receiver` wraps a `chan::Rx`. Both `Tx` and `Rx` have an `inner inner: Arc<Chan>`. A `Chan` has a `tx_count` that is incremented for every `clone` of `Tx` and decremented on `drop`, and it has a `rx_fields` with a boolean field `rx_closed`.

With this approach, the `tx_count` and `rx_closed` fields are used to implement a function `is_closed` in both `Tx` and `Rx` (then have it exposed in `Sender` and `Receiver`, bounded and unbounded).

A very simple tests seems to support the idea but I may have overlooked something and I would like your feedback about this. Lastly, I'm not entirely convinced by the partial repetition in the 2 `is_close` implementations.

Thank you in advance.