### PR TITLE
tls: Deprecate in favor of `tokio-native-tls`

### DIFF
--- a/tokio-tls/CHANGELOG.md
+++ b/tokio-tls/CHANGELOG.md
@@ -1,11 +1,15 @@
+# 0.3.1 (April 4, 2020)
+
+- Deprecate crate in favor of `tokio-native-tls`.
+
 # 0.3.0 (November 26, 2019)
 
-- Updates for tokio 0.2 release
+- Updates for tokio 0.2 release.
 
 # 0.3.0-alpha.6 (September 30, 2019)
 
-- Move to `futures-*-preview 0.3.0-alpha.19`
-- Move to `pin-project 0.4`
+- Move to `futures-*-preview 0.3.0-alpha.19`.
+- Move to `pin-project 0.4`.
 
 # 0.3.0-alpha.5 (September 19, 2019)
 
@@ -15,7 +19,7 @@
 # 0.3.0-alpha.4 (August 30, 2019)
 
 ### Changed
-- Track `tokio` 0.2.0-alpha.4
+- Track `tokio` 0.2.0-alpha.4.
 
 # 0.3.0-alpha.2 (August 17, 2019)
 

--- a/tokio-tls/Cargo.toml
+++ b/tokio-tls/Cargo.toml
@@ -8,18 +8,21 @@ name = "tokio-tls"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-tls/0.3.0-alpha.6/tokio_tls/"
+documentation = "https://docs.rs/tokio-tls/0.3.1/tokio_tls/"
 description = """
+Deprecated in favor of `tokio-naitve-tls`.
+
 An implementation of TLS/SSL streams for Tokio giving an implementation of TLS
 for nonblocking I/O streams.
 """
 categories = ["asynchronous", "network-programming"]
+maintenance = { status = "deprecated" }
 
 [badges]
 travis-ci = { repository = "tokio-rs/tokio-tls" }

--- a/tokio-tls/README.md
+++ b/tokio-tls/README.md
@@ -1,5 +1,7 @@
 # tokio-tls
 
+**Deprecated** in favor of `tokio-native-tls`.
+
 An implementation of TLS/SSL streams for Tokio built on top of the [`native-tls`
 crate]
 

--- a/tokio-tls/src/lib.rs
+++ b/tokio-tls/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-tls/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-tls/0.3.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,
@@ -12,6 +12,9 @@
 ))]
 
 //! Async TLS streams
+//!
+//! > **Note:** This crate is **deprecated** and has been moved
+//! into the [`tokio-native-tls`] crate.
 //!
 //! This library is an implementation of TLS streams using the most appropriate
 //! system library by default for negotiating the connection. That is, on


### PR DESCRIPTION
Reference #2483

Signed-off-by: Lucio Franco <luciofranco14@gmail.com>


