### PR TITLE
add support for illumos target

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -22,7 +22,7 @@ pub(crate) use self::impl_linux::get_peer_cred;
 ))]
 pub(crate) use self::impl_macos::get_peer_cred;
 
-#[cfg(any(target_os = "solaris"))]
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
 pub(crate) use self::impl_solaris::get_peer_cred;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -110,7 +110,7 @@ pub(crate) mod impl_macos {
     }
 }
 
-#[cfg(any(target_os = "solaris"))]
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
 pub(crate) mod impl_solaris {
     use crate::net::unix::UnixStream;
     use std::io;


### PR DESCRIPTION
Although very similar in many regards, illumos and Solaris have been
diverging since the end of OpenSolaris.  With the addition of illumos as
a Rust target, it must be wired into the same interfaces which it was
consuming when running under the 'solaris' target.

## Motivation

With the addition of the [illumos target](https://github.com/rust-lang/rust/issues/55553) and subsequent to various dependencies (like [mio](https://github.com/tokio-rs/mio/pull/1294)), it would be nice for Tokio to be supported on illumos.


## Solution

Since `ucred` functions the same on illumos as it does on Solaris, they can share that logic.
