### PR TITLE
sync: add `notify` method to `Receiver` from `watch` module

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -277,7 +277,7 @@ impl<T> Receiver<T> {
     /// }
     /// ```
     pub async fn notify(&mut self) -> Option<()> {
-        poll_fn(|cx| self.poll_recv_ref(cx).map(|x| x.map(|_| ()))).await
+        poll_fn(|cx| self.poll_recv_ref(cx)).await.map(|_| ())
     }
 }
 


### PR DESCRIPTION
## Motivation
Attempt to solve #2404
## Solution
Modified `recv` method to return Option<()> instead of Option< T >
I have added documentation test.
