### PR TITLE
Clarifying that Handle::current must be called on a thread managed by tokio

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -98,12 +98,14 @@ impl Handle {
     ///     println!("now running in the existing Runtime");
     /// });
     ///
+    /// # let handle = 
     /// thread::spawn(move || {
     ///     // Notice that the handle is created outside of this thread and then moved in
     ///     handle.block_on(async { /* ... */ })
     ///     // This next line would cause a panic
     ///     // let handle2 = Handle::current();
-    /// })
+    /// });
+    /// # handle.join().unwrap();
     /// # });
     /// # }
     /// ```

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -71,11 +71,13 @@ impl Handle {
         context::enter(self.clone(), f)
     }
 
-    /// Returns a Handle view over the currently running Runtime
+    /// Returns a `Handle` view over the currently running `Runtime`
     ///
     /// # Panic
     ///
-    /// This will panic if called outside the context of a Tokio runtime.
+    /// This will panic if called outside the context of a Tokio runtime. That means that you must
+    /// call this on one of the threads **being run by the runtime**. Calling this from within a
+    /// thread created by `std::thread::spawn` (for example) will cause a panic.
     ///
     /// # Examples
     ///
@@ -83,6 +85,7 @@ impl Handle {
     /// block or function running on that runtime.
     ///
     /// ```
+    /// # use std::thread;
     /// # use tokio::runtime::Runtime;
     /// # fn dox() {
     /// # let rt = Runtime::new().unwrap();
@@ -93,6 +96,13 @@ impl Handle {
     /// let handle = Handle::current();
     /// handle.spawn(async {
     ///     println!("now running in the existing Runtime");
+    /// });
+    ///
+    /// thread::spawn(move || {
+    ///     // Notice that the handle is created outside of this thread and then moved in
+    ///     handle.block_on(async { /* ... */ })
+    ///     // This next line would cause a panic
+    ///     // let handle2 = Handle::current();
     /// })
     /// # });
     /// # }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -98,7 +98,7 @@ impl Handle {
     ///     println!("now running in the existing Runtime");
     /// });
     ///
-    /// # let handle = 
+    /// # let handle =
     /// thread::spawn(move || {
     ///     // Notice that the handle is created outside of this thread and then moved in
     ///     handle.block_on(async { /* ... */ })


### PR DESCRIPTION
This is a small PR adding some docs to `Handle::current()`. 

I never realized that `Handle::current()` had to be called outside of threads created using `std::thread::spawn`. Through some trial and error I figured out that you need to call it on a thread managed by tokio and then move the handle into the new thread you create. This was despite all of the docs clearly doing this properly. My changes try to make this more explicit so hopefully other people don't run into the same problems I had.

Please feel free to nitpick my wording (preferably using [GitHub suggestions](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#adding-line-comments-to-a-pull-request)). This is my first time contributing docs to tokio. :)

## Screenshot

![image](https://user-images.githubusercontent.com/530939/81135846-b5835100-8f27-11ea-8a62-5d691f6acb43.png)
