### PR TITLE
stream: add missing "not" in filter_map docs

### DIFF
--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -303,7 +303,7 @@ pub trait StreamExt: Stream {
     /// As values of this stream are made available, the provided function will
     /// be run on them. If the predicate `f` resolves to
     /// [`Some(item)`](Some) then the stream will yield the value `item`, but if
-    /// it resolves to [`None`] then the next value will be produced.
+    /// it resolves to [`None`] then the next value will not be produced.
     ///
     /// Note that this function consumes the stream passed into it and returns a
     /// wrapped version of it, similar to [`Iterator::filter_map`] method in the

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -303,7 +303,7 @@ pub trait StreamExt: Stream {
     /// As values of this stream are made available, the provided function will
     /// be run on them. If the predicate `f` resolves to
     /// [`Some(item)`](Some) then the stream will yield the value `item`, but if
-    /// it resolves to [`None`] then the next value will not be produced.
+    /// it resolves to [`None`] then the next value will be skipped.
     ///
     /// Note that this function consumes the stream passed into it and returns a
     /// wrapped version of it, similar to [`Iterator::filter_map`] method in the

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -303,7 +303,7 @@ pub trait StreamExt: Stream {
     /// As values of this stream are made available, the provided function will
     /// be run on them. If the predicate `f` resolves to
     /// [`Some(item)`](Some) then the stream will yield the value `item`, but if
-    /// it resolves to [`None`] then the value value will be skipped.
+    /// it resolves to [`None`], then the value value will be skipped.
     ///
     /// Note that this function consumes the stream passed into it and returns a
     /// wrapped version of it, similar to [`Iterator::filter_map`] method in the

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -303,7 +303,7 @@ pub trait StreamExt: Stream {
     /// As values of this stream are made available, the provided function will
     /// be run on them. If the predicate `f` resolves to
     /// [`Some(item)`](Some) then the stream will yield the value `item`, but if
-    /// it resolves to [`None`] then the next value will be skipped.
+    /// it resolves to [`None`] then the value value will be skipped.
     ///
     /// Note that this function consumes the stream passed into it and returns a
     /// wrapped version of it, similar to [`Iterator::filter_map`] method in the


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I noticed a mistake in `StreamExt`, method `filter_map` docs. It says:
```
... if it resolves to None then the next value will be produced.
```
and I think it should say
```
... if it resolves to None then the next value will be skipped.
```
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I reworded the sentence.