### PR TITLE
process: add a `KillHandle`

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -768,12 +768,15 @@ impl KillHandle {
         // process which happens to reuse the same pid as our child).
         match Weak::upgrade(&self.child) {
             Some(ref mut child) => child_mut(child, Kill::kill),
-            None => Ok(())
+            None => Ok(()),
         }
     }
 }
 
-fn child_mut<R>(child: &mut Arc<Mutex<ChildDropGuard<imp::Child>>>, f: impl FnOnce(&mut ChildDropGuard<imp::Child>) -> R) -> R {
+fn child_mut<R>(
+    child: &mut Arc<Mutex<ChildDropGuard<imp::Child>>>,
+    f: impl FnOnce(&mut ChildDropGuard<imp::Child>) -> R
+) -> R {
     match Arc::get_mut(child) {
         Some(child) => f(child.get_mut().unwrap()),
         None => f(&mut child.lock().unwrap()),

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -775,7 +775,7 @@ impl KillHandle {
 
 fn child_mut<R>(
     child: &mut Arc<Mutex<ChildDropGuard<imp::Child>>>,
-    f: impl FnOnce(&mut ChildDropGuard<imp::Child>) -> R
+    f: impl FnOnce(&mut ChildDropGuard<imp::Child>) -> R,
 ) -> R {
     match Arc::get_mut(child) {
         Some(child) => f(child.get_mut().unwrap()),

--- a/tokio/tests/process_smoke.rs
+++ b/tokio/tests/process_smoke.rs
@@ -4,18 +4,25 @@
 use tokio::process::Command;
 use tokio_test::assert_ok;
 
+macro_rules! cmd {
+    () => {{
+        let mut cmd;
+
+        if cfg!(windows) {
+            cmd = Command::new("cmd");
+            cmd.arg("/c");
+        } else {
+            cmd = Command::new("sh");
+            cmd.arg("-c");
+        }
+
+        cmd
+    }};
+}
+
 #[tokio::test]
 async fn simple() {
-    let mut cmd;
-
-    if cfg!(windows) {
-        cmd = Command::new("cmd");
-        cmd.arg("/c");
-    } else {
-        cmd = Command::new("sh");
-        cmd.arg("-c");
-    }
-
+    let mut cmd = cmd!();
     let mut child = cmd.arg("exit 2").spawn().unwrap();
 
     let id = child.id();
@@ -26,4 +33,25 @@ async fn simple() {
 
     assert_eq!(child.id(), id);
     drop(child.kill());
+}
+
+#[tokio::test]
+async fn kill_handle() {
+    let mut cmd = cmd!();
+    let mut child = cmd.arg("sleep 10").spawn().unwrap();
+
+    let mut kill_handle = child.kill_handle();
+
+    let join = std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        kill_handle.kill().expect("kill failed");
+    });
+
+    let id = child.id();
+    assert!(id > 0);
+
+    let status = assert_ok!((&mut child).await);
+    assert!(!status.success());
+
+    join.join().unwrap();
 }


### PR DESCRIPTION
## Motivation

Today, `kill`ing a child process requires a mutable access to the `Child` struct itself, but this becomes impossible to do if a task is in the middle of calling `child.await`, without resorting to writing custom poll implementations, that is.

## Solution

This change introduces a `KillHandle` that can be used to kill the child "out of band". Thus if the result of a child process suddenly becomes unnecessary, one can utilize the `KillHandle` to end the child process, and unblock any tasks which are `.await`ing it.

Unfortunately this does introduce the use of a `Mutex` as this was the simplest and safest approach I could come up with at the time. This mutex will only be contended if there are concurrent `kill()`, `id()` or `poll()` operations. I would stipulate that `kill` and `id` should be rather rare.