### PR TITLE
Change norun to no_run

### DIFF
--- a/tokio/src/time/throttle.rs
+++ b/tokio/src/time/throttle.rs
@@ -16,7 +16,7 @@ use pin_project_lite::pin_project;
 /// # Example
 ///
 /// Create a throttled stream.
-/// ```rust,norun
+/// ```rust,no_run
 /// use std::time::Duration;
 /// use tokio::stream::StreamExt;
 /// use tokio::time::throttle;


### PR DESCRIPTION
I was building the docs and got the following documentation warning:
```
warning: unknown attribute `norun`. Did you mean `no_run`?
  --> tokio/src/time/throttle.rs:13:1
   |
13 | / /// Slows down a stream by enforcing a delay between items.
14 | | /// They will be produced not more often than the specified interval.
15 | | ///
16 | | /// # Example
...  |
31 | | /// # }
32 | | /// ```
   | |_______^
   |
   = help: the code block will either not be tested if not marked as a rust one or will be run (which you might not want)
```