### PR TITLE
tokio-test: add macros for asserting completion or timeout of futures

### DIFF
--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -259,3 +259,118 @@ macro_rules! assert_err {
         }
     }};
 }
+
+/// Asserts that the expression completes within a given number of milliseconds.
+///
+/// This will invoke the `panic!` macro if the provided future
+/// expression fails to complete within the given number of
+/// milliseconds. This macro expands to an `await` and must be
+/// invoked inside an async context.
+///
+/// A default timeout of 50ms is used if no duration is passed.
+///
+/// # Examples
+///
+/// ```rust
+/// use tokio_test::assert_completes;
+/// use tokio::time::delay_for;
+///
+/// # let fut =
+/// async {
+///     // Succeeds because default time is longer than delay.
+///     assert_completes!(delay_for(Duration::from_millis(25)));
+/// }
+/// # ;
+/// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
+/// # runtime.block_on(fut);
+///```
+///
+/// ```rust,should_panic
+/// use tokio_test::assert_completes;
+/// use tokio::time::delay_for;
+///
+/// # let fut =
+/// async {
+///     // Fails because timeout is shorter than delay.
+///     assert_completes!(delay_for(Duration::from_millis(25)), 10);
+/// }
+/// # ;
+/// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
+/// # runtime.block_on(fut);
+/// ```
+#[macro_export]
+macro_rules! assert_completes {
+    ($e:expr) => {
+        assert_completes!($e, 50)
+    };
+    ($e:expr, $time:literal) => {{
+        use std::time::Duration;
+        use tokio::time::timeout;
+        match timeout(Duration::from_millis($time), $e).await {
+            Ok(ret) => ret,
+            Err(_) => panic!(
+                "assertion failed: {} timed out after {} ms",
+                stringify!($e),
+                $time,
+            ),
+        }
+    }};
+}
+
+/// Asserts that the expression does not complete within a given number of milliseconds.
+///
+/// This will invoke the `panic!` macro if the provided future
+/// expression completes within the given number of milliseconds.
+/// This macro expands to an `await` and must be invoked inside an
+/// async context.
+///
+///A default timeout of 50ms is used if no duration is passed.
+///
+/// # Examples
+///
+/// ```rust,should_panic
+/// use tokio_test::assert_times_out;
+/// use tokio::time::delay_for;
+///
+/// # let fut =
+/// async {
+///     // Fails because default time is longer than delay.
+///     assert_times_out!(delay_for(Duration::from_millis(25)));
+/// }
+/// # ;
+/// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
+/// # runtime.block_on(fut);
+/// ```
+///
+/// ```rust
+/// use tokio_test::assert_times_out;
+/// use tokio::time::delay_for;
+///
+/// # let fut =
+/// async {
+///     // Succeeds because timeout is shorter than delay.
+///     assert_times_out!(delay_for(Duration::from_millis(25)), 10);
+/// }
+/// # ;
+/// # let mut runtime = tokio::runtime::Runtime::new().unwrap();
+/// # runtime.block_on(fut);
+/// ```
+
+#[macro_export]
+macro_rules! assert_times_out {
+    ($e:expr) => {
+        assert_times_out!($e, 50)
+    };
+    ($e:expr, $time:literal) => {{
+        use std::time::Duration;
+        use tokio::time::timeout;
+        match timeout(Duration::from_millis($time), $e).await {
+            Ok(_) => panic!(
+                "assertion failed: {} completed within {} ms",
+                stringify!($e),
+                $time,
+            ),
+            Err(err) => err,
+        }
+    }};
+}


### PR DESCRIPTION
Adds several macros for use in asserting conditions about whether a future should or should not complete within a given timeout.

## Motivation

While writing my async tests using the current tokio-test utilities I've noticed that as I'm testing I often have half-completed code that ends up causing an `await` in a test to hang forever. This makes the test hang forever, which is terrible feedback about which test is still running.

It's much nicer from a rapid-feedback perspective to put a timeout on these awaits, which is a fair amount of uninteresting boilerplate, but makes for a vastly better error message and test feedback cycle.

## Solution

I created these macros to help with the situation by being making it easy to assert that a particular future should or should not complete.