### PR TITLE
fs: add support for DirBuilder and DirBuilderExt

### DIFF
--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -20,7 +20,7 @@ pub struct DirBuilder {
 
     /// Set the Unix mode for newly created directories.
     #[cfg(unix)]
-    mode: Option<u32>,
+    pub(super) mode: Option<u32>,
 }
 
 impl DirBuilder {

--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -1,0 +1,137 @@
+use crate::fs::asyncify;
+
+use std::io;
+use std::path::Path;
+
+/// A builder for creating directories in various manners.
+///
+/// Additional Unix-specific options are available via importing the
+/// [os::unix::fs::DirBuilderExt] trait.
+///
+/// This is a specialized version of [`std::fs::DirBuilder`] for usage from
+/// the Tokio runtime.
+///
+/// [os::unix::fs::DirBuilderExt]: ../os/unix/fs/trait.DirBuilderExt.html
+/// [std::fs::DirBuilder]: https://doc.rust-lang.org/std/fs/struct.DirBuilder.html
+#[derive(Debug, Default)]
+pub struct DirBuilder {
+    /// Indicates whether to create parent directories if they are missing.
+    recursive: bool,
+
+    /// Set the Unix mode for newly created directories.
+    #[cfg(unix)]
+    mode: Option<u32>,
+}
+
+impl DirBuilder {
+    /// Creates a new set of options with default mode/security settings for all
+    /// platforms and also non-recursive.
+    ///
+    /// This is an async version of [`std::fs::DirBuilder::new`][std]
+    ///
+    /// [std]: std::fs::DirBuilder::new
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::DirBuilder;
+    ///
+    /// let builder = DirBuilder::new();
+    /// ```
+    pub fn new() -> DirBuilder {
+        #[cfg(not(unix))]
+        let builder = DirBuilder { recursive: false };
+
+        #[cfg(unix)]
+        let builder = DirBuilder {
+            recursive: false,
+            mode: None,
+        };
+
+        builder
+    }
+
+    /// Indicates whether to create directories recursively (including all parent directories).
+    /// Parents that do not exist are created with the same security and permissions settings.
+    ///
+    /// This option defaults to `false`.
+    ///
+    /// This is an async version of [`std::fs::DirBuilder::recursive`][std]
+    ///
+    /// [std]: std::fs::DirBuilder::recursive
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::DirBuilder;
+    ///
+    /// let mut builder = DirBuilder::new();
+    /// builder.recursive(true);
+    /// ```
+    pub fn recursive(&mut self, recursive: bool) -> &mut Self {
+        self.recursive = recursive;
+        self
+    }
+
+    /// Creates the specified directory with the configured options.
+    ///
+    /// It is considered an error if the directory already exists unless
+    /// recursive mode is enabled.
+    ///
+    /// This is an async version of [`std::fs::DirBuilder::create`][std]
+    ///
+    /// [std]: std::fs::DirBuilder::create
+    ///
+    /// # Errors
+    ///
+    /// An error will be returned under the following circumstances:
+    ///
+    /// * Path already points to an existing file.
+    /// * Path already points to an existing directory and the mode is
+    ///   non-recursive.
+    /// * The calling process doesn't have permissions to create the directory
+    ///   or its missing parents.
+    /// * Other I/O error occurred.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::DirBuilder;
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     DirBuilder::new()
+    ///         .recursive(true)
+    ///         .create("/tmp/foo/bar/baz")
+    ///         .await?;
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub async fn create<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        let path = path.as_ref().to_owned();
+        let mut builder = std::fs::DirBuilder::new();
+        builder.recursive(self.recursive);
+
+        #[cfg(unix)]
+        {
+            if let Some(mode) = self.mode {
+                std::os::unix::fs::DirBuilderExt::mode(&mut builder, mode);
+            }
+        }
+
+        asyncify(move || builder.create(path)).await
+    }
+}
+
+cfg_unix! {
+    use std::os::unix::fs::DirBuilderExt;
+
+    impl DirBuilderExt for DirBuilder {
+        fn mode(&mut self, mode: u32) -> &mut Self {
+            self.mode = Some(mode);
+            self
+        }
+    }
+}

--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -38,17 +38,8 @@ impl DirBuilder {
     ///
     /// let builder = DirBuilder::new();
     /// ```
-    pub fn new() -> DirBuilder {
-        #[cfg(not(unix))]
-        let builder = DirBuilder { recursive: false };
-
-        #[cfg(unix)]
-        let builder = DirBuilder {
-            recursive: false,
-            mode: None,
-        };
-
-        builder
+    pub fn new() -> Self {
+        Default::default()
     }
 
     /// Indicates whether to create directories recursively (including all parent directories).
@@ -122,16 +113,5 @@ impl DirBuilder {
         }
 
         asyncify(move || builder.create(path)).await
-    }
-}
-
-cfg_unix! {
-    use std::os::unix::fs::DirBuilderExt;
-
-    impl DirBuilderExt for DirBuilder {
-        fn mode(&mut self, mode: u32) -> &mut Self {
-            self.mode = Some(mode);
-            self
-        }
     }
 }

--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -6,13 +6,13 @@ use std::path::Path;
 /// A builder for creating directories in various manners.
 ///
 /// Additional Unix-specific options are available via importing the
-/// [os::unix::fs::DirBuilderExt] trait.
+/// [`DirBuilderExt`] trait.
 ///
-/// This is a specialized version of [`std::fs::DirBuilder`] for usage from
+/// This is a specialized version of [`std::fs::DirBuilder`] for usage on
 /// the Tokio runtime.
 ///
-/// [os::unix::fs::DirBuilderExt]: ../os/unix/fs/trait.DirBuilderExt.html
-/// [std::fs::DirBuilder]: https://doc.rust-lang.org/std/fs/struct.DirBuilder.html
+/// [std::fs::DirBuilder]: std::fs::DirBuilder
+/// [`DirBuilderExt`]: crate::fs::os::unix::DirBuilderExt
 #[derive(Debug, Default)]
 pub struct DirBuilder {
     /// Indicates whether to create parent directories if they are missing.

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -33,6 +33,9 @@ pub use self::create_dir::create_dir;
 mod create_dir_all;
 pub use self::create_dir_all::create_dir_all;
 
+mod dir_builder;
+pub use self::dir_builder::DirBuilder;
+
 mod file;
 pub use self::file::File;
 

--- a/tokio/src/fs/os/unix/dir_builder_ext.rs
+++ b/tokio/src/fs/os/unix/dir_builder_ext.rs
@@ -1,8 +1,8 @@
 use crate::fs::dir_builder::DirBuilder;
 
-/// Unix-specific extensions to [`DirBuilderExt`].
+/// Unix-specific extensions to [`DirBuilder`].
 ///
-/// [crate::fs::os::unix::DirBuilderExt]: DirBuilderExt
+/// [`DirBuilder`]: crate::fs::DirBuilder
 pub trait DirBuilderExt {
     /// Sets the mode to create new directories with.
     ///

--- a/tokio/src/fs/os/unix/dir_builder_ext.rs
+++ b/tokio/src/fs/os/unix/dir_builder_ext.rs
@@ -1,0 +1,29 @@
+use crate::fs::dir_builder::DirBuilder;
+
+/// Unix-specific extensions to [`DirBuilderExt`].
+///
+/// [crate::fs::os::unix::DirBuilderExt]: DirBuilderExt
+pub trait DirBuilderExt {
+    /// Sets the mode to create new directories with.
+    ///
+    /// This option defaults to 0o777.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```no_run
+    /// use tokio::fs::DirBuilder;
+    /// use tokio::fs::os::unix::DirBuilderExt;
+    ///
+    /// let mut builder = DirBuilder::new();
+    /// builder.mode(0o775);
+    /// ```
+    fn mode(&mut self, mode: u32) -> &mut Self;
+}
+
+impl DirBuilderExt for DirBuilder {
+    fn mode(&mut self, mode: u32) -> &mut Self {
+        self.mode = Some(mode);
+        self
+    }
+}

--- a/tokio/src/fs/os/unix/mod.rs
+++ b/tokio/src/fs/os/unix/mod.rs
@@ -2,3 +2,6 @@
 
 mod symlink;
 pub use self::symlink::symlink;
+
+mod dir_builder_ext;
+pub use self::dir_builder_ext::DirBuilderExt;

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -354,15 +354,6 @@ macro_rules! cfg_uds {
     }
 }
 
-macro_rules! cfg_unix {
-    ($($item:item)*) => {
-        $(
-            #[cfg(unix)]
-            $item
-        )*
-    }
-}
-
 macro_rules! cfg_unstable {
     ($($item:item)*) => {
         $(

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -354,6 +354,15 @@ macro_rules! cfg_uds {
     }
 }
 
+macro_rules! cfg_unix {
+    ($($item:item)*) => {
+        $(
+            #[cfg(unix)]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_unstable {
     ($($item:item)*) => {
         $(

--- a/tokio/tests/fs_dir.rs
+++ b/tokio/tests/fs_dir.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "full")]
 
 use tokio::fs;
-use tokio_test::assert_ok;
+use tokio_test::{assert_err, assert_ok};
 
 use std::sync::{Arc, Mutex};
 use tempfile::tempdir;
@@ -26,6 +26,23 @@ async fn create_all() {
 
     assert_ok!(fs::create_dir_all(new_dir).await);
     assert!(new_dir_2.is_dir());
+}
+
+#[tokio::test]
+async fn build_dir() {
+    let base_dir = tempdir().unwrap();
+    let new_dir = base_dir.path().join("foo").join("bar");
+    let new_dir_2 = new_dir.clone();
+
+    assert_ok!(fs::DirBuilder::new().recursive(true).create(new_dir).await);
+
+    assert!(new_dir_2.is_dir());
+    assert_err!(
+        fs::DirBuilder::new()
+            .recursive(false)
+            .create(new_dir_2)
+            .await
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

`tokio` doesn't have an asynchronous version of `std::fs::DirBuilder` yet.
This PR adds support for `std::fs::DirBuilder` and implementation for the `std::os::unix::fs::DirBuilderExt` trait.

## Solution

The initial idea was to implement  a thin wrapper  around an internally
held `std::fs::DirBuilder` instance.  This, however, didn't work due to
`std::fs::DirBuilder` not having Copy/Clone traits implemented, which
was necessary for constructing an instance to move-capture it into a
closure.

Instead,  we have mirrored the `std::fs::DirBuilder` configuration by  storing
the `recursive` and (unix-only) `mode`  parameters locally,  which were then
used to construct the `std::fs::DirBuilder` instance on-the-fly.

The (unix-only) `DirBuilderExt` trait  has  been  implemented  in-place
within the `dir_builder` crate. Despite it might have looked better to
have it separated somewhere in `../fs/os/unix`, I haven't found a clean
and idiomatic way to do so (due to Rust's "orphan rules").  I'd be glad
to hear  the propositions  in case someone  sees  a  way for this to be
further simplified.

Edit: force-pushed immediately after the initial commit was made.
Hope it was quick enough to not break any local repo's.

Fixes: #2369 