### PR TITLE
made stream timeout return type public

### DIFF
--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -70,7 +70,7 @@ use take_while::TakeWhile;
 
 cfg_time! {
     mod timeout;
-    use timeout::Timeout;
+    pub use timeout::Timeout;
     use std::time::Duration;
 }
 


### PR DESCRIPTION
Fixes: #2188

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`tokio::stream::timeout::Timeout` was private, thus making it impossible to store in a struct when returned from `timeout()`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Made the type public.