### PR TITLE
Fix add_permits document

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -228,7 +228,7 @@
 //! on the number of blocking threads is very large. These limits can be
 //! configured on the [`Builder`].
 //!
-//! Two spawn a blocking task, you should use the [`spawn_blocking`] function.
+//! To spawn a blocking task, you should use the [`spawn_blocking`] function.
 //!
 //! [`Builder`]: crate::runtime::Builder
 //! [`spawn_blocking`]: crate::task::spawn_blocking()

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -123,11 +123,7 @@ impl Semaphore {
         self.permits.load(Acquire) >> Self::PERMIT_SHIFT
     }
 
-    /// Adds `n` new permits to the semaphore.
-    ///
-    /// `n` must less than [`MAX_PERMITS`]
-    ///
-    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
+    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
     pub(crate) fn release(&self, added: usize) {
         if added == 0 {
             return;

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -123,7 +123,9 @@ impl Semaphore {
         self.permits.load(Acquire) >> Self::PERMIT_SHIFT
     }
 
-    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
+    /// Adds `added` new permits to the semaphore.
+    ///
+    /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.
     pub(crate) fn release(&self, added: usize) {
         if added == 0 {
             return;

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -124,6 +124,10 @@ impl Semaphore {
     }
 
     /// Adds `n` new permits to the semaphore.
+    ///
+    /// `n` must less than [`MAX_PERMITS`]
+    ///
+    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
     pub(crate) fn release(&self, added: usize) {
         if added == 0 {
             return;

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -80,6 +80,10 @@ impl Semaphore {
     }
 
     /// Adds `n` new permits to the semaphore.
+    ///
+    /// `n` must less than [`MAX_PERMITS`]
+    ///
+    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
     pub fn add_permits(&self, n: usize) {
         self.ll_sem.release(n);
     }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -78,7 +78,7 @@ impl Semaphore {
     pub fn available_permits(&self) -> usize {
         self.ll_sem.available_permits()
     }
-    
+
     /// Adds `n` new permits to the semaphore.
     ///
     /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -78,12 +78,8 @@ impl Semaphore {
     pub fn available_permits(&self) -> usize {
         self.ll_sem.available_permits()
     }
-
-    /// Adds `n` new permits to the semaphore.
-    ///
-    /// `n` must less than [`MAX_PERMITS`]
-    ///
-    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
+    
+    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
     pub fn add_permits(&self, n: usize) {
         self.ll_sem.release(n);
     }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -79,7 +79,9 @@ impl Semaphore {
         self.ll_sem.available_permits()
     }
     
-    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
+    /// Adds `n` new permits to the semaphore.
+    ///
+    /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.
     pub fn add_permits(&self, n: usize) {
         self.ll_sem.release(n);
     }

--- a/tokio/src/sync/semaphore_ll.rs
+++ b/tokio/src/sync/semaphore_ll.rs
@@ -335,6 +335,10 @@ impl Semaphore {
     }
 
     /// Adds `n` new permits to the semaphore.
+    ///
+    /// `n` must less than [`MAX_PERMITS`]
+    ///
+    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
     pub(crate) fn add_permits(&self, n: usize) {
         if n == 0 {
             return;

--- a/tokio/src/sync/semaphore_ll.rs
+++ b/tokio/src/sync/semaphore_ll.rs
@@ -334,11 +334,7 @@ impl Semaphore {
         self.add_permits_locked(0, true);
     }
 
-    /// Adds `n` new permits to the semaphore.
-    ///
-    /// `n` must less than [`MAX_PERMITS`]
-    ///
-    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
+    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
     pub(crate) fn add_permits(&self, n: usize) {
         if n == 0 {
             return;

--- a/tokio/src/sync/semaphore_ll.rs
+++ b/tokio/src/sync/semaphore_ll.rs
@@ -333,8 +333,9 @@ impl Semaphore {
 
         self.add_permits_locked(0, true);
     }
-
-    /// The maximum number of permits is usize::MAX >> 3, and this function will panic if the limit is exceeded.
+    /// Adds `n` new permits to the semaphore.
+    ///
+    /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.
     pub(crate) fn add_permits(&self, n: usize) {
         if n == 0 {
             return;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation
Fix the document.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add the ```MAX_PERMITS``` link
Example:
```rust
    /// Adds `n` new permits to the semaphore.
    ///
    /// `n` must less than [`MAX_PERMITS`]
    ///
    /// [`MAX_PERMITS`]: Semaphore::MAX_PERMITS
    pub fn add_permits(&self, n: usize) {
        self.ll_sem.release(n);
    }
````
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
