### PR TITLE
docs: replace method links with intra-links

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pr: ["master"]
 
 variables:
   RUSTFLAGS: -Dwarnings
-  nightly: nightly-2020-05-24
+  nightly: nightly-2020-05-29
 
 jobs:
 # Test top level crate

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pr: ["master"]
 
 variables:
   RUSTFLAGS: -Dwarnings
-  nightly: nightly-2020-01-25
+  nightly: nightly-2020-05-24
 
 jobs:
 # Test top level crate

--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -73,7 +73,7 @@ pub trait AsyncRead {
     /// that they did not write to.
     ///
     /// [`io::Read`]: std::io::Read
-    /// [`poll_read_buf`]: #method.poll_read_buf
+    /// [`poll_read_buf`]: method@Self::poll_read_buf
     unsafe fn prepare_uninitialized_buffer(&self, buf: &mut [MaybeUninit<u8>]) -> bool {
         for x in buf {
             *x = MaybeUninit::new(0);

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -97,10 +97,10 @@ cfg_io_driver! {
     /// [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
     /// [`Registration`]: struct@Registration
     /// [`TcpListener`]: struct@crate::net::TcpListener
-    /// [`clear_read_ready`]: #method.clear_read_ready
-    /// [`clear_write_ready`]: #method.clear_write_ready
-    /// [`poll_read_ready`]: #method.poll_read_ready
-    /// [`poll_write_ready`]: #method.poll_write_ready
+    /// [`clear_read_ready`]: method@Self::clear_read_ready
+    /// [`clear_write_ready`]: method@Self::clear_write_ready
+    /// [`poll_read_ready`]: method@Self::poll_read_ready
+    /// [`poll_write_ready`]: method@Self::poll_write_ready
     pub struct PollEvented<E: Evented> {
         io: Option<E>,
         inner: Inner,
@@ -253,7 +253,7 @@ where
     /// The I/O resource will remain in a read-ready state until readiness is
     /// cleared by calling [`clear_read_ready`].
     ///
-    /// [`clear_read_ready`]: #method.clear_read_ready
+    /// [`clear_read_ready`]: method@Self::clear_read_ready
     ///
     /// # Panics
     ///
@@ -324,7 +324,7 @@ where
     /// The I/O resource will remain in a write-ready state until readiness is
     /// cleared by calling [`clear_write_ready`].
     ///
-    /// [`clear_write_ready`]: #method.clear_write_ready
+    /// [`clear_write_ready`]: method@Self::clear_write_ready
     ///
     /// # Panics
     ///

--- a/tokio/src/io/registration.rs
+++ b/tokio/src/io/registration.rs
@@ -34,9 +34,9 @@ cfg_io_driver! {
     /// stream. The write readiness event stream is only for `Ready::writable()`
     /// events.
     ///
-    /// [`new`]: #method.new
-    /// [`poll_read_ready`]: #method.poll_read_ready`]
-    /// [`poll_write_ready`]: #method.poll_write_ready`]
+    /// [`new`]: method@Self::new
+    /// [`poll_read_ready`]: method@Self::poll_read_ready`
+    /// [`poll_write_ready`]: method@Self::poll_write_ready`
     #[derive(Debug)]
     pub struct Registration {
         handle: Handle,
@@ -153,8 +153,6 @@ impl Registration {
     /// the function will always return `Ready(HUP)`. This should be treated as
     /// the end of the readiness stream.
     ///
-    /// Ensure that [`register`] has been called first.
-    ///
     /// # Return value
     ///
     /// There are several possible return values:
@@ -166,10 +164,8 @@ impl Registration {
     ///   since the last call to `poll_read_ready`.
     ///
     /// * `Poll::Ready(Err(err))` means that the registration has encountered an
-    ///   error. This error either represents a permanent internal error **or**
-    ///   the fact that [`register`] was not called first.
+    ///   error. This could represent a permanent internal error for example.
     ///
-    /// [`register`]: #method.register
     /// [edge-triggered]: https://docs.rs/mio/0.6/mio/struct.Poll.html#edge-triggered-and-level-triggered
     ///
     /// # Panics
@@ -198,7 +194,7 @@ impl Registration {
     /// will not notify the current task when a new event is received. As such,
     /// it is safe to call this function from outside of a task context.
     ///
-    /// [`poll_read_ready`]: #method.poll_read_ready
+    /// [`poll_read_ready`]: method@Self::poll_read_ready
     pub fn take_read_ready(&self) -> io::Result<Option<mio::Ready>> {
         self.poll_ready(Direction::Read, None)
     }
@@ -213,8 +209,6 @@ impl Registration {
     /// the function will always return `Ready(HUP)`. This should be treated as
     /// the end of the readiness stream.
     ///
-    /// Ensure that [`register`] has been called first.
-    ///
     /// # Return value
     ///
     /// There are several possible return values:
@@ -226,10 +220,8 @@ impl Registration {
     ///   since the last call to `poll_write_ready`.
     ///
     /// * `Poll::Ready(Err(err))` means that the registration has encountered an
-    ///   error. This error either represents a permanent internal error **or**
-    ///   the fact that [`register`] was not called first.
+    ///   error. This could represent a permanent internal error for example.
     ///
-    /// [`register`]: #method.register
     /// [edge-triggered]: https://docs.rs/mio/0.6/mio/struct.Poll.html#edge-triggered-and-level-triggered
     ///
     /// # Panics
@@ -258,7 +250,7 @@ impl Registration {
     /// will not notify the current task when a new event is received. As such,
     /// it is safe to call this function from outside of a task context.
     ///
-    /// [`poll_write_ready`]: #method.poll_write_ready
+    /// [`poll_write_ready`]: method@Self::poll_write_ready
     pub fn take_write_ready(&self) -> io::Result<Option<mio::Ready>> {
         self.poll_ready(Direction::Write, None)
     }

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -322,7 +322,7 @@ impl TcpListener {
     ///
     /// For more information about this option, see [`set_ttl`].
     ///
-    /// [`set_ttl`]: #method.set_ttl
+    /// [`set_ttl`]: method@Self::set_ttl
     ///
     /// # Examples
     ///

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -111,7 +111,7 @@ impl UdpSocket {
     /// The [`connect`] method will connect this socket to a remote address. The future
     /// will resolve to an error if the socket is not connected.
     ///
-    /// [`connect`]: #method.connect
+    /// [`connect`]: method@Self::connect
     pub async fn send(&mut self, buf: &[u8]) -> io::Result<usize> {
         poll_fn(|cx| self.poll_send(cx, buf)).await
     }
@@ -150,7 +150,7 @@ impl UdpSocket {
     /// The [`connect`] method will connect this socket to a remote address. The future
     /// will fail if the socket is not connected.
     ///
-    /// [`connect`]: #method.connect
+    /// [`connect`]: method@Self::connect
     pub async fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         poll_fn(|cx| self.poll_recv(cx, buf)).await
     }
@@ -235,7 +235,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`set_broadcast`].
     ///
-    /// [`set_broadcast`]: #method.set_broadcast
+    /// [`set_broadcast`]: method@Self::set_broadcast
     pub fn broadcast(&self) -> io::Result<bool> {
         self.io.get_ref().broadcast()
     }
@@ -252,7 +252,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`set_multicast_loop_v4`].
     ///
-    /// [`set_multicast_loop_v4`]: #method.set_multicast_loop_v4
+    /// [`set_multicast_loop_v4`]: method@Self::set_multicast_loop_v4
     pub fn multicast_loop_v4(&self) -> io::Result<bool> {
         self.io.get_ref().multicast_loop_v4()
     }
@@ -272,7 +272,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`set_multicast_ttl_v4`].
     ///
-    /// [`set_multicast_ttl_v4`]: #method.set_multicast_ttl_v4
+    /// [`set_multicast_ttl_v4`]: method@Self::set_multicast_ttl_v4
     pub fn multicast_ttl_v4(&self) -> io::Result<u32> {
         self.io.get_ref().multicast_ttl_v4()
     }
@@ -294,7 +294,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`set_multicast_loop_v6`].
     ///
-    /// [`set_multicast_loop_v6`]: #method.set_multicast_loop_v6
+    /// [`set_multicast_loop_v6`]: method@Self::set_multicast_loop_v6
     pub fn multicast_loop_v6(&self) -> io::Result<bool> {
         self.io.get_ref().multicast_loop_v6()
     }
@@ -314,7 +314,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`set_ttl`].
     ///
-    /// [`set_ttl`]: #method.set_ttl
+    /// [`set_ttl`]: method@Self::set_ttl
     pub fn ttl(&self) -> io::Result<u32> {
         self.io.get_ref().ttl()
     }
@@ -351,7 +351,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`join_multicast_v4`].
     ///
-    /// [`join_multicast_v4`]: #method.join_multicast_v4
+    /// [`join_multicast_v4`]: method@Self::join_multicast_v4
     pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v4(&multiaddr, &interface)
     }
@@ -360,7 +360,7 @@ impl UdpSocket {
     ///
     /// For more information about this option, see [`join_multicast_v6`].
     ///
-    /// [`join_multicast_v6`]: #method.join_multicast_v6
+    /// [`join_multicast_v6`]: method@Self::join_multicast_v6
     pub fn leave_multicast_v6(&self, multiaddr: &Ipv6Addr, interface: u32) -> io::Result<()> {
         self.io.get_ref().leave_multicast_v6(multiaddr, interface)
     }

--- a/tokio/src/net/udp/split.rs
+++ b/tokio/src/net/udp/split.rs
@@ -23,14 +23,14 @@ use std::sync::Arc;
 
 /// The send half after [`split`](super::UdpSocket::split).
 ///
-/// Use [`send_to`](#method.send_to) or [`send`](#method.send) to send
+/// Use [`send_to`](method@Self::send_to) or [`send`](method@Self::send) to send
 /// datagrams.
 #[derive(Debug)]
 pub struct SendHalf(Arc<UdpSocket>);
 
 /// The recv half after [`split`](super::UdpSocket::split).
 ///
-/// Use [`recv_from`](#method.recv_from) or [`recv`](#method.recv) to receive
+/// Use [`recv_from`](method@Self::recv_from) or [`recv`](method@Self::recv) to receive
 /// datagrams.
 #[derive(Debug)]
 pub struct RecvHalf(Arc<UdpSocket>);

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -211,7 +211,7 @@ impl Command {
     ///
     /// To pass multiple arguments see [`args`].
     ///
-    /// [`args`]: #method.args
+    /// [`args`]: method@Self::args
     ///
     /// # Examples
     ///
@@ -233,7 +233,7 @@ impl Command {
     ///
     /// To pass a single argument see [`arg`].
     ///
-    /// [`arg`]: #method.arg
+    /// [`arg`]: method@Self::arg
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 /// See function level documentation for details on the various configuration
 /// settings.
 ///
-/// [`build`]: #method.build
-/// [`Builder::new`]: #method.new
+/// [`build`]: method@Self::build
+/// [`Builder::new`]: method@Self::new
 ///
 /// # Examples
 ///

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -268,7 +268,7 @@ use std::time::Duration;
 ///
 /// [timer]: crate::time
 /// [mod]: index.html
-/// [`new`]: #method.new
+/// [`new`]: method@Self::new
 /// [`Builder`]: struct@Builder
 /// [`tokio::run`]: fn@run
 #[derive(Debug)]

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -111,17 +111,17 @@ use std::task::{self, Poll};
 /// }
 /// ```
 ///
-/// [`insert`]: #method.insert
-/// [`insert_at`]: #method.insert_at
+/// [`insert`]: method@Self::insert
+/// [`insert_at`]: method@Self::insert_at
 /// [`Key`]: struct@Key
 /// [`Stream`]: https://docs.rs/futures/0.1/futures/stream/trait.Stream.html
-/// [`poll`]: #method.poll
-/// [`Stream::poll`]: #method.poll
+/// [`poll`]: method@Self::poll
+/// [`Stream::poll`]: method@Self::poll
 /// [`DelayQueue`]: struct@DelayQueue
 /// [`delay_for`]: fn@super::delay_for
 /// [`slab`]: https://docs.rs/slab
-/// [`capacity`]: #method.capacity
-/// [`reserve`]: #method.reserve
+/// [`capacity`]: method@Self::capacity
+/// [`reserve`]: method@Self::reserve
 #[derive(Debug)]
 pub struct DelayQueue<T> {
     /// Stores data associated with entries
@@ -295,9 +295,9 @@ impl<T> DelayQueue<T> {
     /// # }
     /// ```
     ///
-    /// [`poll`]: #method.poll
-    /// [`remove`]: #method.remove
-    /// [`reset`]: #method.reset
+    /// [`poll`]: method@Self::poll
+    /// [`remove`]: method@Self::remove
+    /// [`reset`]: method@Self::reset
     /// [`Key`]: struct@Key
     /// [type]: #
     pub fn insert_at(&mut self, value: T, when: Instant) -> Key {
@@ -403,9 +403,9 @@ impl<T> DelayQueue<T> {
     /// # }
     /// ```
     ///
-    /// [`poll`]: #method.poll
-    /// [`remove`]: #method.remove
-    /// [`reset`]: #method.reset
+    /// [`poll`]: method@Self::poll
+    /// [`remove`]: method@Self::remove
+    /// [`reset`]: method@Self::reset
     /// [`Key`]: struct@Key
     /// [type]: #
     pub fn insert(&mut self, value: T, timeout: Duration) -> Key {
@@ -574,7 +574,7 @@ impl<T> DelayQueue<T> {
     ///
     /// Note that this method has no effect on the allocated capacity.
     ///
-    /// [`poll`]: #method.poll
+    /// [`poll`]: method@Self::poll
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation
Make doc's links more resistant.

## Solution
Delagates doc's links resolution to [`rustdoc`](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md).
 
Refs: #1473