### PR TITLE
util: Add Framed::read_buffer_mut()

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -195,6 +195,11 @@ impl<T, U> Framed<T, U> {
         &self.inner.state.read.buffer
     }
 
+    /// Returns a mutable reference to the read buffer.
+    pub fn read_buffer_mut(&mut self) -> &mut BytesMut {
+        &mut self.inner.state.read.buffer
+    }
+
     /// Consumes the `Framed`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream


### PR DESCRIPTION
Adds a method to retrieve a mutable reference to the Framed stream's read buffer.
This makes it possible to e.g. externally clear the buffer to prevent the codec from
parsing stale data.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
-->

## Motivation

Allow write access to the Framed's read buffer so it can be altered externally.

This is demonstrated in [tokio-modbus](https://github.com/slowtec/tokio-modbus/issues/60) where the codec tries to detect a data frame and gets confused by malformed data. Clearing the read buffer before sending a modbus request effectively bypasses the problem.

There are other ways to solve this, but getting a mutable reference to the buffer is by far the most performant and obvious.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add the `read_buffer_mut` method.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
