### PR TITLE
coop: Undo budget decrement on Pending

### DIFF
--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -217,7 +217,7 @@ cfg_coop! {
             }
         }
 
-        fn is_unconstrained(&self) -> bool {
+        fn is_unconstrained(self) -> bool {
             self.0.is_none()
         }
     }

--- a/tokio/src/stream/iter.rs
+++ b/tokio/src/stream/iter.rs
@@ -45,7 +45,8 @@ where
     type Item = I::Item;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<I::Item>> {
-        ready!(crate::coop::poll_proceed(cx));
+        let coop = ready!(crate::coop::poll_proceed(cx));
+        coop.made_progress();
         Poll::Ready(self.iter.next())
     }
 

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -389,7 +389,7 @@ impl Future for Acquire<'_> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         // First, ensure the current task has enough budget to proceed.
-        ready!(crate::coop::poll_proceed(cx));
+        let coop = ready!(crate::coop::poll_proceed(cx));
 
         let (node, semaphore, needed, queued) = self.project();
 
@@ -399,6 +399,7 @@ impl Future for Acquire<'_> {
                 Pending
             }
             Ready(r) => {
+                coop.made_progress();
                 r?;
                 *queued = false;
                 Ready(Ok(()))

--- a/tokio/src/time/driver/registration.rs
+++ b/tokio/src/time/driver/registration.rs
@@ -40,9 +40,12 @@ impl Registration {
 
     pub(crate) fn poll_elapsed(&self, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         // Keep track of task budget
-        ready!(crate::coop::poll_proceed(cx));
+        let coop = ready!(crate::coop::poll_proceed(cx));
 
-        self.entry.poll_elapsed(cx)
+        self.entry.poll_elapsed(cx).map(move |r| {
+            coop.made_progress();
+            r
+        })
     }
 }
 


### PR DESCRIPTION
This patch updates the coop logic so that the budget is only decremented if a future makes progress (that is, if it returns `Ready`). This is realized by restoring the budget to its former value after `poll_proceed` _unless_ the caller indicates that it made progress.

The thinking here is that we always want tasks to make progress when we poll them. With the way things were, if a task polled 128 resources that could make no progress, and just returned `Pending`, then a 129th resource that _could_ make progress would not be polled. Worse yet, this could manifest as a deadlock, if the first 128 resources were all _waiting_ for the 129th resource, since it would _never_ be polled.

The downside of this change is that `Pending` resources now do not take up any part of the budget, even though they _do_ take up time on the executor. If a task is particularly aggressive (or unoptimized), and polls a large number of resources that cannot make progress whenever it is polled, then coop will allow it to run potentially much longer before yielding than it could before. The impact of this should be relatively contained though, because tasks that behaved in this way in the past probably ignored `Pending` _anyway_, so whether a resource returned `Pending` due to coop or due to lack of progress may not make a difference to it.
