### PR TITLE
uds: illumos can build using existing Solaris support

### DIFF
--- a/tokio-uds/src/ucred.rs
+++ b/tokio-uds/src/ucred.rs
@@ -22,7 +22,7 @@ pub use self::impl_linux::get_peer_cred;
 ))]
 pub use self::impl_macos::get_peer_cred;
 
-#[cfg(any(target_os = "solaris"))]
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
 pub use self::impl_solaris::get_peer_cred;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -102,7 +102,7 @@ pub mod impl_macos {
     }
 }
 
-#[cfg(any(target_os = "solaris"))]
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
 pub mod impl_solaris {
     use std::io;
     use std::os::unix::io::AsRawFd;


### PR DESCRIPTION
First, let me begin by saying I understand that the v0.1 series of tokio is deprecated.  Unfortunately it's still seeing somewhat wide usage in the ecosystem, including in RLS in the official Rust toolchain:

```
$ cargo tree -i -p tokio-uds 
tokio-uds v0.2.6
├── parity-tokio-ipc v0.2.0
│   ├── jsonrpc-client-transports v14.0.5
│   │   └── jsonrpc-core-client v14.0.5
│   │       └── rls-ipc v0.1.0 (/ws/crossrust/work/rust/src/tools/rls/rls-ipc)
│   │           ├── rls v1.41.0 (/ws/crossrust/work/rust/src/tools/rls)
│   │           └── rls-rustc v0.6.0 (/ws/crossrust/work/rust/src/tools/rls/rls-rustc)
│   │               └── rls v1.41.0 (/ws/crossrust/work/rust/src/tools/rls) (*)
│   └── jsonrpc-ipc-server v14.0.3
│       └── rls-ipc v0.1.0 (/ws/crossrust/work/rust/src/tools/rls/rls-ipc) (*)
└── tokio v0.1.22
    ├── jsonrpc-client-transports v14.0.5 (*)
    ├── jsonrpc-server-utils v14.0.5
    │   ├── jsonrpc-client-transports v14.0.5 (*)
    │   └── jsonrpc-ipc-server v14.0.3 (*)
    ├── parity-tokio-ipc v0.2.0 (*)
    ├── rls v1.41.0 (/ws/crossrust/work/rust/src/tools/rls) (*)
    ├── rls-rustc v0.6.0 (/ws/crossrust/work/rust/src/tools/rls/rls-rustc) (*)
    └── tokio-named-pipes v0.1.0
        └── parity-tokio-ipc v0.2.0 (*)
    [dev-dependencies]
    └── rls v1.41.0 (/ws/crossrust/work/rust/src/tools/rls) (*)
```

I'd like to make this small change to allow us to build RLS on illumos, now that support for our host triple is in the compiler (see rust-lang/rust#71145 and rust-lang/rust#55553) and we're on the path to being in the official CI/CD system (see rust-lang/rust#71272 and rust-lang/compiler-team#279).  The existing support in `tokio-uds` here for Solaris systems is sufficient also for illumos, we just need to fix the conditional compilation directives and get a v0.2.7 of `tokio-uds` out the door.

I've run the test suite for `tokio-uds` on a current illumos system and it appears to work.

Thanks!