### PR TITLE
Added a note about into_split's drop

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -652,6 +652,8 @@ impl TcpStream {
     /// Unlike [`split`], the owned halves can be moved to separate tasks, however
     /// this comes at the cost of a heap allocation.
     ///
+    /// **Note:** Dropping the write half will close the TCP stream in both directions.
+    ///
     /// [`split`]: TcpStream::split()
     pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
         split_owned(self)


### PR DESCRIPTION
## Motivation

This took me a bit to catch on to this behaviour because I didn't really think there was any reason to investigate the individual documentation of each half. As someone dealing with TCP streams directly for first time (without previous experience from other languages) this caught me by surprise

## Solution

Added a note about the write half's drop behaviour to `into_split` itself