### PR TITLE
Fix all clippy lints in tests

### DIFF
--- a/ci/azure-clippy.yml
+++ b/ci/azure-clippy.yml
@@ -12,5 +12,5 @@ jobs:
         cargo clippy --version
       displayName: Install clippy
     - script: |
-        cargo clippy --all --all-features
-      displayName: cargo clippy --all
+        cargo clippy --all --all-features --tests
+      displayName: cargo clippy --all --tests

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -236,7 +236,7 @@ fn close_semaphore_notifies_permit2() {
 #[test]
 fn cancel_acquire_releases_permits() {
     let s = Semaphore::new(10);
-    let _permit1 = s.try_acquire(4).expect("uncontended try_acquire succeeds");
+    s.try_acquire(4).expect("uncontended try_acquire succeeds");
     assert_eq!(6, s.available_permits());
 
     let mut acquire = task::spawn(s.acquire(8));

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::blacklisted_name)]
 use tokio::sync::oneshot;
 use tokio_test::{assert_pending, assert_ready, task};
 

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::blacklisted_name)]
 use tokio::sync::{mpsc, oneshot};
 use tokio::task;
 use tokio_test::{assert_ok, assert_pending, assert_ready};

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::blacklisted_name)]
 use tokio::sync::oneshot;
 use tokio_test::{assert_pending, assert_ready, task};
 

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -36,7 +36,7 @@ fn straight_execution() {
 fn readiness() {
     let l = Arc::new(Mutex::new(100));
     let mut t1 = spawn(l.clone().lock_owned());
-    let mut t2 = spawn(l.clone().lock_owned());
+    let mut t2 = spawn(l.lock_owned());
 
     let g = assert_ready!(t1.poll());
 

--- a/tokio/tests/time_delay_queue.rs
+++ b/tokio/tests/time_delay_queue.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::blacklisted_name)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

First commit allows `blacklisted_name`.
Second commit fixes all other warnings .
Third commit updates CI config so that clippy will check tests too.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
