### PR TITLE
docs: use intra-links in the docs

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -370,7 +370,7 @@
 //! [`AsyncRead`]: trait@tokio::io::AsyncRead
 //! [`AsyncWrite`]: trait@tokio::io::AsyncWrite
 //! [`Encoder`]: trait@Encoder
-//! [`BytesMut`]: https://docs.rs/bytes/0.4/bytes/struct.BytesMut.html
+//! [`BytesMut`]: bytes::BytesMut
 
 use crate::codec::{Decoder, Encoder, Framed, FramedRead, FramedWrite};
 

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -45,7 +45,7 @@
 //! other futures. By doing this, you avoid double-counting each iteration of
 //! the outer future against the cooperating budget.
 //!
-//! [`poll`]: https://doc.rust-lang.org/std/future/trait.Future.html#tymethod.poll
+//! [`poll`]: method@std::future::Future::poll
 
 // NOTE: The doctests in this module are ignored since the whole module is (currently) private.
 

--- a/tokio/src/fs/remove_dir_all.rs
+++ b/tokio/src/fs/remove_dir_all.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 ///
 /// This is an async version of [`std::fs::remove_dir_all`][std]
 ///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.remove_dir_all.html
+/// [std]: fn@std::fs::remove_dir_all
 pub async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_dir_all(path)).await

--- a/tokio/src/fs/set_permissions.rs
+++ b/tokio/src/fs/set_permissions.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 ///
 /// This is an async version of [`std::fs::set_permissions`][std]
 ///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.set_permissions.html
+/// [std]: fn@std::fs::set_permissions
 pub async fn set_permissions(path: impl AsRef<Path>, perm: Permissions) -> io::Result<()> {
     let path = path.as_ref().to_owned();
     asyncify(|| std::fs::set_permissions(path, perm)).await

--- a/tokio/src/fs/symlink_metadata.rs
+++ b/tokio/src/fs/symlink_metadata.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 ///
 /// This is an async version of [`std::fs::symlink_metadata`][std]
 ///
-/// [std]: https://doc.rust-lang.org/std/fs/fn.symlink_metadata.html
+/// [std]: fn@std::fs::symlink_metadata
 pub async fn symlink_metadata(path: impl AsRef<Path>) -> io::Result<Metadata> {
     let path = path.as_ref().to_owned();
     asyncify(|| std::fs::symlink_metadata(path)).await

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -57,7 +57,7 @@
 //! [`File`]: crate::fs::File
 //! [`TcpStream`]: crate::net::TcpStream
 //! [`std::fs::File`]: std::fs::File
-//! [std_example]: https://doc.rust-lang.org/std/io/index.html#read-and-write
+//! [std_example]: std::io#read-and-write
 //!
 //! ## Buffered Readers and Writers
 //!
@@ -114,7 +114,7 @@
 //! }
 //! ```
 //!
-//! [stdbuf]: https://doc.rust-lang.org/std/io/index.html#bufreader-and-bufwriter
+//! [stdbuf]: std::io#bufreader-and-bufwriter
 //! [`std::io::BufRead`]: std::io::BufRead
 //! [`AsyncBufRead`]: crate::io::AsyncBufRead
 //! [`BufReader`]: crate::io::BufReader

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -90,11 +90,11 @@ cfg_io_driver! {
     /// These events are included as part of the read readiness event stream. The
     /// write readiness event stream is only for `Ready::writable()` events.
     ///
-    /// [`std::io::Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-    /// [`std::io::Write`]: https://doc.rust-lang.org/std/io/trait.Write.html
+    /// [`std::io::Read`]: trait@std::io::Read
+    /// [`std::io::Write`]: trait@std::io::Write
     /// [`AsyncRead`]: trait@AsyncRead
     /// [`AsyncWrite`]: trait@AsyncWrite
-    /// [`mio::Evented`]: https://docs.rs/mio/0.6/mio/trait.Evented.html
+    /// [`mio::Evented`]: trait@mio::Evented
     /// [`Registration`]: struct@Registration
     /// [`TcpListener`]: struct@crate::net::TcpListener
     /// [`clear_read_ready`]: method@Self::clear_read_ready

--- a/tokio/src/io/registration.rs
+++ b/tokio/src/io/registration.rs
@@ -166,7 +166,7 @@ impl Registration {
     /// * `Poll::Ready(Err(err))` means that the registration has encountered an
     ///   error. This could represent a permanent internal error for example.
     ///
-    /// [edge-triggered]: https://docs.rs/mio/0.6/mio/struct.Poll.html#edge-triggered-and-level-triggered
+    /// [edge-triggered]: struct@mio::Poll#edge-triggered-and-level-triggered
     ///
     /// # Panics
     ///
@@ -222,7 +222,7 @@ impl Registration {
     /// * `Poll::Ready(Err(err))` means that the registration has encountered an
     ///   error. This could represent a permanent internal error for example.
     ///
-    /// [edge-triggered]: https://docs.rs/mio/0.6/mio/struct.Poll.html#edge-triggered-and-level-triggered
+    /// [edge-triggered]: struct@mio::Poll#edge-triggered-and-level-triggered
     ///
     /// # Panics
     ///

--- a/tokio/src/macros/pin.rs
+++ b/tokio/src/macros/pin.rs
@@ -43,7 +43,7 @@
 /// Pinning is useful when using `select!` and stream operators that require `T:
 /// Stream + Unpin`.
 ///
-/// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
+/// [`Future`]: trait@std::future::Future
 /// [`Box::pin`]: #
 ///
 /// # Usage

--- a/tokio/src/net/udp/split.rs
+++ b/tokio/src/net/udp/split.rs
@@ -1,6 +1,6 @@
-//! [`UdpSocket`](../struct.UdpSocket.html) split support.
+//! [`UdpSocket`](crate::net::UdpSocket) split support.
 //!
-//! The [`split`](../struct.UdpSocket.html#method.split) method splits a
+//! The [`split`](method@crate::net::UdpSocket::split) method splits a
 //! `UdpSocket` into a receive half and a send half, which can be used to
 //! receive and send datagrams concurrently, even from two different tasks.
 //!

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -401,7 +401,7 @@ pub struct Signal {
 /// * If the lower-level C functions fail for some reason.
 /// * If the previous initialization of this specific signal failed.
 /// * If the signal is one of
-///   [`signal_hook::FORBIDDEN`](https://docs.rs/signal-hook/*/signal_hook/fn.register.html#panics)
+///   [`signal_hook::FORBIDDEN`](fn@signal_hook_registry::register#panics)
 pub fn signal(kind: SignalKind) -> io::Result<Signal> {
     let signal = kind.0;
 

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -93,9 +93,9 @@ use std::sync::Arc;
 ///
 /// [`Mutex`]: struct@Mutex
 /// [`MutexGuard`]: struct@MutexGuard
-/// [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
-/// [`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
-/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+/// [`Arc`]: struct@std::sync::Arc
+/// [`std::sync::Mutex`]: struct@std::sync::Mutex
+/// [`Send`]: trait@std::marker::Send
 /// [`lock`]: method@Mutex::lock
 
 #[derive(Debug)]

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -31,8 +31,8 @@ const MAX_READS: usize = 10;
 ///
 /// The type parameter `T` represents the data that this lock protects. It is
 /// required that `T` satisfies [`Send`] to be shared across threads. The RAII guards
-/// returned from the locking methods implement [`Deref`](https://doc.rust-lang.org/std/ops/trait.Deref.html)
-/// (and [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html)
+/// returned from the locking methods implement [`Deref`](trait@std::ops::Deref)
+/// (and [`DerefMut`](trait@std::ops::DerefMut)
 /// for the `write` methods) to allow access to the content of the lock.
 ///
 /// # Examples
@@ -65,7 +65,7 @@ const MAX_READS: usize = 10;
 /// [`RwLock`]: struct@RwLock
 /// [`RwLockReadGuard`]: struct@RwLockReadGuard
 /// [`RwLockWriteGuard`]: struct@RwLockWriteGuard
-/// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+/// [`Send`]: trait@std::marker::Send
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
 #[derive(Debug)]
 pub struct RwLock<T> {

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -29,7 +29,7 @@ cfg_rt_threaded! {
     /// [blocking]: ../index.html#cpu-bound-tasks-and-blocking-code
     /// [threaded scheduler]: fn@crate::runtime::Builder::threaded_scheduler
     /// [`spawn_blocking`]: fn@crate::task::spawn_blocking
-    /// [`join!`]: ../macro.join.html
+    /// [`join!`]: macro@join
     /// [`thread::spawn`]: fn@std::thread::spawn
     /// [`shutdown_timeout`]: fn@crate::runtime::Runtime::shutdown_timeout
     ///

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -105,7 +105,7 @@ cfg_rt_util! {
     /// }
     /// ```
     ///
-    /// [`Send`]: https://doc.rust-lang.org/std/marker/trait.Send.html
+    /// [`Send`]: trait@std::marker::Send
     /// [local task set]: struct@LocalSet
     /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
     /// [`task::spawn_local`]: fn@spawn_local

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -89,7 +89,7 @@ macro_rules! __task_local_inner {
 /// }).await;
 /// # }
 /// ```
-/// [`std::thread::LocalKey`]: https://doc.rust-lang.org/std/thread/struct.LocalKey.html
+/// [`std::thread::LocalKey`]: struct@std::thread::LocalKey
 pub struct LocalKey<T: 'static> {
     #[doc(hidden)]
     pub inner: thread::LocalKey<RefCell<Option<T>>>,

--- a/tokio/src/time/delay_queue.rs
+++ b/tokio/src/time/delay_queue.rs
@@ -119,7 +119,7 @@ use std::task::{self, Poll};
 /// [`Stream::poll`]: method@Self::poll
 /// [`DelayQueue`]: struct@DelayQueue
 /// [`delay_for`]: fn@super::delay_for
-/// [`slab`]: https://docs.rs/slab
+/// [`slab`]: slab
 /// [`capacity`]: method@Self::capacity
 /// [`reserve`]: method@Self::reserve
 #[derive(Debug)]


### PR DESCRIPTION
## Motivation
Make doc's links more resistant.

## Solution
Delegates doc's links resolution to [`rustdoc`](https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md).
 
Refs: #1473