### PR TITLE
Add sleep alias to delay_for

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -16,6 +16,7 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!

--- a/tokio/src/time/delay.rs
+++ b/tokio/src/time/delay.rs
@@ -33,6 +33,7 @@ pub fn delay_until(deadline: Instant) -> Delay {
 ///
 /// Canceling a delay is done by dropping the returned future. No additional
 /// cleanup work is required.
+#[cfg_attr(docsrs, doc(alias = "sleep"))]
 pub fn delay_for(duration: Duration) -> Delay {
     delay_until(Instant::now() + duration)
 }


### PR DESCRIPTION
This makes `delay_for` easier to find.