### PR TITLE
Close pending connection on proxy exemple 

### DIFF
--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -64,12 +64,12 @@ async fn transfer(mut inbound: TcpStream, proxy_addr: String) -> Result<(), Box<
     let (mut ro, mut wo) = outbound.split();
 
     let client_to_server = async {
-        io::copy(&mut ri, &mut wo).await;
+        io::copy(&mut ri, &mut wo).await?;
         wo.shutdown().await
     };
 
     let server_to_client = async {
-        io::copy(&mut ro, &mut wi).await;
+        io::copy(&mut ro, &mut wi).await?;
         wi.shutdown().await
     };
 

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -63,8 +63,15 @@ async fn transfer(mut inbound: TcpStream, proxy_addr: String) -> Result<(), Box<
     let (mut ri, mut wi) = inbound.split();
     let (mut ro, mut wo) = outbound.split();
 
-    let client_to_server = io::copy(&mut ri, &mut wo);
-    let server_to_client = io::copy(&mut ro, &mut wi);
+    let client_to_server = async {
+        io::copy(&mut ri, &mut wo).await;
+        wo.shutdown().await
+    };
+
+    let server_to_client = async {
+        io::copy(&mut ro, &mut wi).await;
+        wi.shutdown().await
+    };
 
     try_join(client_to_server, server_to_client).await?;
 

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -23,6 +23,7 @@
 #![warn(rust_2018_idioms)]
 
 use tokio::io;
+use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 
 use futures::future::try_join;


### PR DESCRIPTION
## Motivation
On proxy exemple, if a connection is close from one side, one side stay open, a thread keep infinitly pending. 

Fix : #2406 

## Solution
Close writer after copying totalité of reader
