### PR TITLE
Add audit check

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,13 +20,3 @@ jobs:
         uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Discord notification
-        if: failure() && (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
-        env:
-          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_USERNAME: GitHub dependency audit
-        uses: Ilshidur/action-discord@f237343
-        with:
-          args: "Dependency security audit failed.\n${{ env.run_url }}"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Audit Check
-        uses: action-rs/audit-check@v1
+        uses: actions-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,4 +1,4 @@
-name: Daily Security Audit
+name: Security Audit
 
 on:
   push:

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -2,6 +2,11 @@ name: Pull Request Security Audit
 
 on:
   push:
+    branches:
+      - master
+    paths:
+      - '**/Cargo.toml'
+  pull_request:
     paths:
       - '**/Cargo.toml'
 
@@ -27,3 +32,13 @@ jobs:
         uses: action-rs/cargo@v1
         with:
           command: audit
+
+      - name: Discord notification
+        if: failure() && (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
+        env:
+          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub dependency audit
+        uses: Ilshidur/action-discord@f237343
+        with:
+          args: "Dependency security audit failed.\n${{ env.run_url }}"

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -16,17 +16,17 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install cargo-audit
-        uses: action-rs/cargo@v1
+        uses: actions-rs/cargo@v1
         with:
           command: install
           args: cargo-audit
 
       - name: Generate lockfile
-        uses: action-rs/cargo@v1
+        uses: actions-rs/cargo@v1
         with:
           command: generate-lockfile
 
       - name: Audit dependencies
-        uses: action-rs/cargo@v1
+        uses: actions-rs/cargo@v1
         with:
           command: audit

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -1,0 +1,29 @@
+name: Pull Request Security Audit
+
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+
+jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    if: !contains('github.event.head_commit.message', 'ci skip')
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install cargo-audit
+        uses: action-rs/cargo@v1
+        with:
+          command: install
+          args: cargo-audit
+
+      - name: Generate lockfile
+        uses: action-rs/cargo@v1
+        with:
+          command: generate-lockfile
+
+      - name: Audit dependencies
+        uses: action-rs/cargo@v1
+        with:
+          command: audit

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -2,8 +2,6 @@ name: Pull Request Security Audit
 
 on:
   push:
-    branches:
-      - master
     paths:
       - '**/Cargo.toml'
   pull_request:
@@ -32,13 +30,3 @@ jobs:
         uses: action-rs/cargo@v1
         with:
           command: audit
-
-      - name: Discord notification
-        if: failure() && (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
-        env:
-          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_USERNAME: GitHub dependency audit
-        uses: Ilshidur/action-discord@f237343
-        with:
-          args: "Dependency security audit failed.\n${{ env.run_url }}"

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   security-audit:
     runs-on: ubuntu-latest
-    if: !contains('github.event.head_commit.message', 'ci skip')
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,6 +1,11 @@
 name: Daily Security Audit
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - '**/Cargo.toml'
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
@@ -15,3 +20,13 @@ jobs:
         uses: action-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Discord notification
+        if: failure() && (github.event_name == 'push' && github.event.ref == 'refs/heads/master')
+        env:
+          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub dependency audit
+        uses: Ilshidur/action-discord@f237343
+        with:
+          args: "Dependency security audit failed.\n${{ env.run_url }}"

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,0 +1,28 @@
+name: Rust security audit
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - 'Cargo.lock'
+
+jobs:
+  security-audit:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1.2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Discord notification
+        if: failure()
+        env:
+          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub dependency audit
+        uses: Ilshidur/action-discord@f237343
+        with:
+          args: "Dependency security audit failed.\n${{ env.run_url }}"

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   security-audit:
     runs-on: ubuntu-latest
-    if: !contains('github.event.head_commit.message', 'ci skip')
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/rust-audit.yml
+++ b/.github/workflows/rust-audit.yml
@@ -1,28 +1,17 @@
-name: Rust security audit
+name: Daily Security Audit
 
 on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
-  push:
-    paths:
-      - '**/Cargo.toml'
-      - 'Cargo.lock'
 
 jobs:
   security-audit:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
+    if: !contains('github.event.head_commit.message', 'ci skip')
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/audit-check@v1.2.0
+
+      - name: Audit Check
+        uses: action-rs/audit-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Discord notification
-        if: failure()
-        env:
-          run_url: "https://github.com/tokio-rs/tokio/actions/runs/${{ github.run_id }}"
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_USERNAME: GitHub dependency audit
-        uses: Ilshidur/action-discord@f237343
-        with:
-          args: "Dependency security audit failed.\n${{ env.run_url }}"


### PR DESCRIPTION
This continues the work started in #2516, adding two workflows to run `cargo audit` on the code and report these failures in a variety of useful ways. The intent is that the closer the code being audited is to being run in production, the louder these checks will complain. In order of increasing severity:

- A "manual" `cargo audit` check is run on each pr and push event containing changes to any `Cargo.toml` in the workspace.  This check only fails the job in order to mark a Pull Request as failing.

- Every day at 02:00 UTC the master branch is audited using the [`actions-rs/audit-check`] action.  When this check fails it will create an issue on github detailing the issue.

[`actions-rs/audit-check`]: /action-rs/audit-check

- On every push to the master branch that contains changes to any `Cargo.toml` in the workspace the same [`actions-rs/audit-check`] is run, and if that check fails an issue will be created and a notification will be sent to the Tokio Discord channel (sending to the correct channel still needs to be set up).

This set of checks is slightly different from what was discussed in the previous PR, but I think that these checks make sense.  We use `actions-rs/audit-check` only in contexts where the `GITHUB_TOKEN` will be accessible, so that on failure the action will be able to create an issue on Github.  We still want to audit any proposed changes to the dependency tree in pull requests, but we don't need to report this in any extra fashion than blocking a merge.