### PR TITLE
chore: fix macOS ci on github actions

### DIFF
--- a/.github/workflows/test_tokio.yml
+++ b/.github/workflows/test_tokio.yml
@@ -23,6 +23,13 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable
+        if: matrix.os != 'macos-latest'
+      # https://github.com/rust-lang/rust/issues/73030
+      - name: Install Rust
+        run: rustup update 1.43.1 && rustup default 1.43.1
+        if: matrix.os == 'macos-latest'
 
       # Run `tokio` with only `full`
       - uses: actions-rs/cargo@v1
@@ -64,6 +71,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable
+        if: matrix.os != 'macos-latest'
+      # https://github.com/rust-lang/rust/issues/73030
+      - name: Install Rust
+        run: rustup update 1.43.1 && rustup default 1.43.1
+        if: matrix.os == 'macos-latest'
 
       # Run with all crate features
       - name: ${{ matrix.crate }} - cargo test --all-features
@@ -114,6 +128,13 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@master
+      - name: Install Rust
+        run: rustup update stable
+        if: matrix.os != 'macos-latest'
+      # https://github.com/rust-lang/rust/issues/73030
+      - name: Install Rust
+        run: rustup update 1.43.1 && rustup default 1.43.1
+        if: matrix.os == 'macos-latest'
       - run: cargo install cargo-hack
         name: Install cargo-hack
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

#2593 have only fixed the azure pipelines CI. (Only azure pipelines had a problem when I submitted #2593. This is because our github actions CI use rustc which is installed by default in images.)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.

-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
