### PR TITLE
Support larger number of permits

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -115,7 +115,7 @@ impl<'a, T: ?Sized> ReleasingPermit<'a, T> {
         lock: &'a RwLock<T>,
         num_permits: u16,
     ) -> Result<ReleasingPermit<'a, T>, AcquireError> {
-        lock.s.acquire(num_permits).await?;
+        lock.s.acquire(num_permits.into()).await?;
         Ok(Self { num_permits, lock })
     }
 }


### PR DESCRIPTION
I'm planning to use permits to limit peak memory usage, and for that `u16` is very limiting.

I don't know if a small type is critical for performance here, so just in case I've opted for `u32` instead of `usize`.

Related to #2605 #2598 