### PR TITLE
io: fix the poll_{read,write}_buf functions when dereferencing objects

### DIFF
--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -106,10 +106,7 @@ pub trait AsyncRead {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut B,
-    ) -> Poll<io::Result<usize>>
-    where
-        Self: Sized,
-    {
+    ) -> Poll<io::Result<usize>> {
         if !buf.has_remaining_mut() {
             return Poll::Ready(Ok(0));
         }
@@ -146,6 +143,14 @@ macro_rules! deref_async_read {
             buf: &mut [u8],
         ) -> Poll<io::Result<usize>> {
             Pin::new(&mut **self).poll_read(cx, buf)
+        }
+
+        fn poll_read_buf<B: BufMut>(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut B,
+        ) -> Poll<io::Result<usize>> {
+            Pin::new(&mut **self).poll_read_buf(cx, buf)
         }
     };
 }

--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -137,10 +137,7 @@ pub trait AsyncWrite {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut B,
-    ) -> Poll<Result<usize, io::Error>>
-    where
-        Self: Sized,
-    {
+    ) -> Poll<Result<usize, io::Error>> {
         if !buf.has_remaining() {
             return Poll::Ready(Ok(0));
         }
@@ -159,6 +156,14 @@ macro_rules! deref_async_write {
             buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             Pin::new(&mut **self).poll_write(cx, buf)
+        }
+
+        fn poll_write_buf<B: Buf>(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut B,
+        ) -> Poll<Result<usize, io::Error>> {
+            Pin::new(&mut **self).poll_write_buf(cx, buf)
         }
 
         fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {


### PR DESCRIPTION
## Motivation

See details in #2610

## Solution

Add the implementation of poll_{read,write}_buf in deref_async_{read,write} macros so that the underlying poll_{read,write}_buf functions are correctly called.

Fixes: #2610


I'm not sure about the significant of `Self: Sized` that I removed in the change. 