### PR TITLE
io: fix unsound pin projection in read_buf and write_buf

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -221,7 +221,7 @@ cfg_io_util! {
         /// ```
         fn read_buf<'a, B>(&'a mut self, buf: &'a mut B) -> ReadBuf<'a, Self, B>
         where
-            Self: Sized,
+            Self: Sized + Unpin,
             B: BufMut,
         {
             read_buf(self, buf)

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -180,7 +180,7 @@ cfg_io_util! {
         /// ```
         fn write_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteBuf<'a, Self, B>
         where
-            Self: Sized,
+            Self: Sized + Unpin,
             B: Buf,
         {
             write_buf(self, src)

--- a/tokio/src/io/util/write_buf.rs
+++ b/tokio/src/io/util/write_buf.rs
@@ -20,7 +20,7 @@ cfg_io_util! {
 /// asynchronous manner, returning a future.
 pub(crate) fn write_buf<'a, W, B>(writer: &'a mut W, buf: &'a mut B) -> WriteBuf<'a, W, B>
 where
-    W: AsyncWrite,
+    W: AsyncWrite + Unpin,
     B: Buf,
 {
     WriteBuf { writer, buf }
@@ -28,16 +28,13 @@ where
 
 impl<W, B> Future for WriteBuf<'_, W, B>
 where
-    W: AsyncWrite,
+    W: AsyncWrite + Unpin,
     B: Buf,
 {
     type Output = io::Result<usize>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        // safety: no data is moved from self
-        unsafe {
-            let me = self.get_unchecked_mut();
-            Pin::new_unchecked(&mut *me.writer).poll_write_buf(cx, &mut me.buf)
-        }
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        let me = &mut *self;
+        Pin::new(&mut *me.writer).poll_write_buf(cx, me.buf)
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

https://github.com/tokio-rs/tokio/blob/1636910f0a6bdb2084362be6b4daea70bcdceebc/tokio/src/io/util/write_buf.rs#L37-L41

This is a `Pin<&mut Type>` to `Pin<Field>` projection and is unsound if `W` is not `Unpin` (*you can move `W` after `WriteBuf` dropped*):
https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=c4740885e4bdb8169e6e5e335fca72d6

The correct projection is `Pin<&mut Type>` to `Pin<&mut Field>`. In `WriteBuf`, it is `Pin<&mut WriteBuf<'_, W, B>>` to `Pin<&mut &mut W>`, and it needs to add `W: Unpin` bounds to convert `Pin<&mut &mut W>` to `Pin<&mut W>`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `Self: Unpin` bounds to `AsyncReadExt::read_buf` and  `AsyncWriteExt::write_buf`.
This changes the public API, but I don't think there is any other way to fix this.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
