### PR TITLE
sync: allow unsized types in Mutex and RwLock

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -97,11 +97,10 @@ use std::sync::Arc;
 /// [`std::sync::Mutex`]: struct@std::sync::Mutex
 /// [`Send`]: trait@std::marker::Send
 /// [`lock`]: method@Mutex::lock
-
 #[derive(Debug)]
-pub struct Mutex<T> {
-    c: UnsafeCell<T>,
+pub struct Mutex<T: ?Sized> {
     s: semaphore::Semaphore,
+    c: UnsafeCell<T>,
 }
 
 /// A handle to a held `Mutex`.
@@ -112,7 +111,7 @@ pub struct Mutex<T> {
 ///
 /// The lock is automatically released whenever the guard is dropped, at which
 /// point `lock` will succeed yet again.
-pub struct MutexGuard<'a, T> {
+pub struct MutexGuard<'a, T: ?Sized> {
     lock: &'a Mutex<T>,
 }
 
@@ -131,17 +130,17 @@ pub struct MutexGuard<'a, T> {
 /// point `lock` will succeed yet again.
 ///
 /// [`Arc`]: std::sync::Arc
-pub struct OwnedMutexGuard<T> {
+pub struct OwnedMutexGuard<T: ?Sized> {
     lock: Arc<Mutex<T>>,
 }
 
 // As long as T: Send, it's fine to send and share Mutex<T> between threads.
 // If T was not Send, sending and sharing a Mutex<T> would be bad, since you can
 // access T through Mutex<T>.
-unsafe impl<T> Send for Mutex<T> where T: Send {}
-unsafe impl<T> Sync for Mutex<T> where T: Send {}
-unsafe impl<'a, T> Sync for MutexGuard<'a, T> where T: Send + Sync {}
-unsafe impl<T> Sync for OwnedMutexGuard<T> where T: Send + Sync {}
+unsafe impl<T> Send for Mutex<T> where T: ?Sized + Send {}
+unsafe impl<T> Sync for Mutex<T> where T: ?Sized + Send {}
+unsafe impl<T> Sync for MutexGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
 
 /// Error returned from the [`Mutex::try_lock`] function.
 ///
@@ -183,7 +182,7 @@ fn bounds() {
     check_static_val(arc_mutex.lock_owned());
 }
 
-impl<T> Mutex<T> {
+impl<T: ?Sized> Mutex<T> {
     /// Creates a new lock in an unlocked state ready for use.
     ///
     /// # Examples
@@ -193,7 +192,10 @@ impl<T> Mutex<T> {
     ///
     /// let lock = Mutex::new(5);
     /// ```
-    pub fn new(t: T) -> Self {
+    pub fn new(t: T) -> Self
+    where
+        T: Sized,
+    {
         Self {
             c: UnsafeCell::new(t),
             s: semaphore::Semaphore::new(1),
@@ -330,7 +332,10 @@ impl<T> Mutex<T> {
     ///     assert_eq!(n, 1);
     /// }
     /// ```
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(self) -> T
+    where
+        T: Sized,
+    {
         self.c.into_inner()
     }
 }
@@ -352,32 +357,32 @@ where
 
 // === impl MutexGuard ===
 
-impl<'a, T> Drop for MutexGuard<'a, T> {
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
         self.lock.s.release(1)
     }
 }
 
-impl<'a, T> Deref for MutexGuard<'a, T> {
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.lock.c.get() }
     }
 }
 
-impl<'a, T> DerefMut for MutexGuard<'a, T> {
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.lock.c.get() }
     }
 }
 
-impl<'a, T: fmt::Debug> fmt::Debug for MutexGuard<'a, T> {
+impl<T: ?Sized + fmt::Debug> fmt::Debug for MutexGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<'a, T: fmt::Display> fmt::Display for MutexGuard<'a, T> {
+impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
@@ -385,32 +390,32 @@ impl<'a, T: fmt::Display> fmt::Display for MutexGuard<'a, T> {
 
 // === impl OwnedMutexGuard ===
 
-impl<T> Drop for OwnedMutexGuard<T> {
+impl<T: ?Sized> Drop for OwnedMutexGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(1)
     }
 }
 
-impl<T> Deref for OwnedMutexGuard<T> {
+impl<T: ?Sized> Deref for OwnedMutexGuard<T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
         unsafe { &*self.lock.c.get() }
     }
 }
 
-impl<T> DerefMut for OwnedMutexGuard<T> {
+impl<T: ?Sized> DerefMut for OwnedMutexGuard<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { &mut *self.lock.c.get() }
     }
 }
 
-impl<T: fmt::Debug> fmt::Debug for OwnedMutexGuard<T> {
+impl<T: ?Sized + fmt::Debug> fmt::Debug for OwnedMutexGuard<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<T: fmt::Display> fmt::Display for OwnedMutexGuard<T> {
+impl<T: ?Sized + fmt::Display> fmt::Display for OwnedMutexGuard<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -68,7 +68,7 @@ const MAX_READS: usize = 10;
 /// [`Send`]: trait@std::marker::Send
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
 #[derive(Debug)]
-pub struct RwLock<T> {
+pub struct RwLock<T: ?Sized> {
     //semaphore to coordinate read and write access to T
     s: Semaphore,
 
@@ -84,7 +84,7 @@ pub struct RwLock<T> {
 ///
 /// [`read`]: method@RwLock::read
 #[derive(Debug)]
-pub struct RwLockReadGuard<'a, T> {
+pub struct RwLockReadGuard<'a, T: ?Sized> {
     permit: ReleasingPermit<'a, T>,
     lock: &'a RwLock<T>,
 }
@@ -98,19 +98,19 @@ pub struct RwLockReadGuard<'a, T> {
 /// [`write`]: method@RwLock::write
 /// [`RwLock`]: struct@RwLock
 #[derive(Debug)]
-pub struct RwLockWriteGuard<'a, T> {
+pub struct RwLockWriteGuard<'a, T: ?Sized> {
     permit: ReleasingPermit<'a, T>,
     lock: &'a RwLock<T>,
 }
 
 // Wrapper arround Permit that releases on Drop
 #[derive(Debug)]
-struct ReleasingPermit<'a, T> {
+struct ReleasingPermit<'a, T: ?Sized> {
     num_permits: u16,
     lock: &'a RwLock<T>,
 }
 
-impl<'a, T> ReleasingPermit<'a, T> {
+impl<'a, T: ?Sized> ReleasingPermit<'a, T> {
     async fn acquire(
         lock: &'a RwLock<T>,
         num_permits: u16,
@@ -120,7 +120,7 @@ impl<'a, T> ReleasingPermit<'a, T> {
     }
 }
 
-impl<'a, T> Drop for ReleasingPermit<'a, T> {
+impl<T: ?Sized> Drop for ReleasingPermit<'_, T> {
     fn drop(&mut self) {
         self.lock.s.release(self.num_permits as usize);
     }
@@ -153,12 +153,12 @@ fn bounds() {
 // As long as T: Send + Sync, it's fine to send and share RwLock<T> between threads.
 // If T were not Send, sending and sharing a RwLock<T> would be bad, since you can access T through
 // RwLock<T>.
-unsafe impl<T> Send for RwLock<T> where T: Send {}
-unsafe impl<T> Sync for RwLock<T> where T: Send + Sync {}
-unsafe impl<'a, T> Sync for RwLockReadGuard<'a, T> where T: Send + Sync {}
-unsafe impl<'a, T> Sync for RwLockWriteGuard<'a, T> where T: Send + Sync {}
+unsafe impl<T> Send for RwLock<T> where T: ?Sized + Send {}
+unsafe impl<T> Sync for RwLock<T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for RwLockReadGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for RwLockWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
 
-impl<T> RwLock<T> {
+impl<T: ?Sized> RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
     ///
     /// # Examples
@@ -168,7 +168,10 @@ impl<T> RwLock<T> {
     ///
     /// let lock = RwLock::new(5);
     /// ```
-    pub fn new(value: T) -> RwLock<T> {
+    pub fn new(value: T) -> RwLock<T>
+    where
+        T: Sized,
+    {
         RwLock {
             c: UnsafeCell::new(value),
             s: Semaphore::new(MAX_READS),
@@ -250,12 +253,15 @@ impl<T> RwLock<T> {
     }
 
     /// Consumes the lock, returning the underlying data.
-    pub fn into_inner(self) -> T {
+    pub fn into_inner(self) -> T
+    where
+        T: Sized,
+    {
         self.c.into_inner()
     }
 }
 
-impl<T> ops::Deref for RwLockReadGuard<'_, T> {
+impl<T: ?Sized> ops::Deref for RwLockReadGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -263,7 +269,7 @@ impl<T> ops::Deref for RwLockReadGuard<'_, T> {
     }
 }
 
-impl<T> ops::Deref for RwLockWriteGuard<'_, T> {
+impl<T: ?Sized> ops::Deref for RwLockWriteGuard<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -271,7 +277,7 @@ impl<T> ops::Deref for RwLockWriteGuard<'_, T> {
     }
 }
 
-impl<T> ops::DerefMut for RwLockWriteGuard<'_, T> {
+impl<T: ?Sized> ops::DerefMut for RwLockWriteGuard<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         unsafe { &mut *self.lock.c.get() }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #2209

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
