### PR TITLE
docs: Remove inapplicable paragraph from 'AsyncReadExt::read_ext()'.

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -238,12 +238,6 @@ cfg_io_util! {
         /// This function reads as many bytes as necessary to completely fill
         /// the specified buffer `buf`.
         ///
-        /// No guarantees are provided about the contents of `buf` when this
-        /// function is called, implementations cannot rely on any property of
-        /// the contents of `buf` being `true`. It is recommended that
-        /// implementations only write data to `buf` instead of reading its
-        /// contents.
-        ///
         /// # Errors
         ///
         /// If the operation encounters an "end of file" before completely


### PR DESCRIPTION
This paragraph from `std::io::Read::read_ext()` applies to
*implementors* of `Read`. Since `AsyncReadExt` can't and shouldn't be
implemented outside of this crate, this documentation is unnecessary.