### PR TITLE
doc: typo in select.rs

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -30,7 +30,7 @@
 ///
 /// The complete lifecycle of a `select!` expression is as follows:
 ///
-/// 1. Evaluate all provded `<precondition>` expressions. If the precondition
+/// 1. Evaluate all provided `<precondition>` expressions. If the precondition
 ///    returns `false`, disable the branch for the remainder of the current call
 ///    to `select!`. Re-entering `select!` due to a loop clears the "disabled"
 ///    state.


### PR DESCRIPTION
The documentation of the select! macro contained a typo "provded" instead of "provided"

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->
Hello! This is a small PR that only fixes one typo in the `select!` macro documentation. I skipped the later fields of the PR template because this appear self-explanatory to me.
