### PR TITLE
time: add an example using `interval` to the time module

### DIFF
--- a/tokio/src/time/delay.rs
+++ b/tokio/src/time/delay.rs
@@ -33,6 +33,24 @@ pub fn delay_until(deadline: Instant) -> Delay {
 ///
 /// Canceling a delay is done by dropping the returned future. No additional
 /// cleanup work is required.
+///
+/// # Examples
+///
+/// Wait 100ms and print "100 ms have elapsed". Note that no work is
+/// performed while awaiting on the delay to complete. If you wish to do
+/// other work while awaiting please see [`interval`].
+///
+/// ```
+/// use tokio::time::{delay_for, Duration};
+///
+/// #[tokio::main]
+/// async fn main() {
+///     delay_for(Duration::from_millis(100)).await;
+///     println!("100 ms have elapsed");
+/// }
+/// ```
+///
+/// [`interval`]: crate::time::interval()
 #[cfg_attr(docsrs, doc(alias = "sleep"))]
 pub fn delay_for(duration: Duration) -> Delay {
     delay_until(Instant::now() + duration)

--- a/tokio/src/time/delay.rs
+++ b/tokio/src/time/delay.rs
@@ -29,6 +29,8 @@ pub fn delay_until(deadline: Instant) -> Delay {
 /// operates at millisecond granularity and should not be used for tasks that
 /// require high-resolution timers.
 ///
+/// To run something regularly on a schedule, see [`interval`].
+///
 /// # Cancellation
 ///
 /// Canceling a delay is done by dropping the returned future. No additional
@@ -36,9 +38,7 @@ pub fn delay_until(deadline: Instant) -> Delay {
 ///
 /// # Examples
 ///
-/// Wait 100ms and print "100 ms have elapsed". Note that no work is
-/// performed while awaiting on the delay to complete. If you wish to do
-/// other work while awaiting please see [`interval`].
+/// Wait 100ms and print "100 ms have elapsed".
 ///
 /// ```
 /// use tokio::time::{delay_for, Duration};

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -33,6 +33,33 @@ use std::task::{Context, Poll};
 ///     // approximately 20ms have elapsed.
 /// }
 /// ```
+///
+/// A simple example using `tokio::time::interval` to execute a task every
+/// two seconds.
+///
+/// `tokio::time::interval` yields so every iteration of the loop takes
+/// two seconds (except the first as the first `tick` completes immediately).
+/// The difference with `tokio::time::delay_for` is that `delay_for` blocks.
+/// Replacing `interval` with `delay_for` would result in a loop that takes
+/// three seconds per iteration.
+///
+/// ```
+/// use tokio::time;
+///
+/// async fn task_that_takes_a_second() {
+///     println!("hello");
+///     time::delay_for(time::Duration::from_secs(1)).await
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let mut interval = time::interval(time::Duration::from_secs(2));
+///     for _i in 0..5 {
+///         interval.tick().await;
+///         task_that_takes_a_second().await;
+///     }
+/// }
+/// ```
 pub fn interval(period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -34,14 +34,16 @@ use std::task::{Context, Poll};
 /// }
 /// ```
 ///
-/// A simple example using `tokio::time::interval` to execute a task every
-/// two seconds.
+/// A simple example using [`interval`] to execute a task every two seconds.
 ///
-/// `tokio::time::interval` yields so every iteration of the loop takes
-/// two seconds (except the first as the first `tick` completes immediately).
-/// The difference with `tokio::time::delay_for` is that `delay_for` blocks.
-/// Replacing `interval` with `delay_for` would result in a loop that takes
-/// three seconds per iteration.
+/// The difference between [`interval`] and [`delay_for`] is that an
+/// [`interval`] measures the time since the last tick, which means that
+/// `.tick().await` may wait for a shorter time than the duration specified
+/// for the interval if some time has passed between calls to `.tick().await`.
+///
+/// If the tick in the example below was replaced with [`delay_for`], the task
+/// would only be executed once every three seconds, and not every two
+/// seconds.
 ///
 /// ```
 /// use tokio::time;
@@ -60,6 +62,9 @@ use std::task::{Context, Poll};
 ///     }
 /// }
 /// ```
+///
+/// [`delay_for`]: crate::time::delay_for()
+/// [`interval`]: crate::time::interval()
 pub fn interval(period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -34,12 +34,12 @@ use std::task::{Context, Poll};
 /// }
 /// ```
 ///
-/// A simple example using [`interval`] to execute a task every two seconds.
+/// A simple example using `interval` to execute a task every two seconds.
 ///
-/// The difference between [`interval`] and [`delay_for`] is that an
-/// [`interval`] measures the time since the last tick, which means that
-/// `.tick().await` may wait for a shorter time than the duration specified
-/// for the interval if some time has passed between calls to `.tick().await`.
+/// The difference between `interval` and [`delay_for`] is that an `interval`
+/// measures the time since the last tick, which means that `.tick().await`
+/// may wait for a shorter time than the duration specified for the interval
+/// if some time has passed between calls to `.tick().await`.
 ///
 /// If the tick in the example below was replaced with [`delay_for`], the task
 /// would only be executed once every three seconds, and not every two
@@ -64,7 +64,6 @@ use std::task::{Context, Poll};
 /// ```
 ///
 /// [`delay_for`]: crate::time::delay_for()
-/// [`interval`]: crate::time::interval()
 pub fn interval(period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -59,14 +59,16 @@
 //! # }
 //! ```
 //!
-//! A simple example using `tokio::time::interval` to execute a task every
-//! two seconds.
+//! A simple example using [`interval`] to execute a task every two seconds.
 //!
-//! `tokio::time::interval` yields so every iteration of the loop takes
-//! two seconds (except the first as the first `tick` completes immediately).
-//! The difference with `tokio::time::delay_for` is that `delay_for` blocks.
-//! Replacing `interval` with `delay_for` would result in a loop that takes
-//! three seconds per iteration.
+//! The difference between [`interval`] and [`delay_for`] is that an
+//! [`interval`] measures the time since the last tick, which means that
+//! `.tick().await` may wait for a shorter time than the duration specified
+//! for the interval if some time has passed between calls to `.tick().await`.
+//!
+//! If the tick in the example below was replaced with [`delay_for`], the task
+//! would only be executed once every three seconds, and not every two
+//! seconds.
 //!
 //! ```
 //! use tokio::time;
@@ -85,6 +87,9 @@
 //!     }
 //! }
 //! ```
+//!
+//! [`delay_for`]: crate::time::delay_for()
+//! [`interval`]: crate::time::interval()
 
 mod clock;
 pub(crate) use self::clock::Clock;

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -24,7 +24,7 @@
 //!
 //! # Examples
 //!
-//! Wait 100ms and print "Hello World!"
+//! Wait 100ms and print "100 ms have elapsed"
 //!
 //! ```
 //! use tokio::time::delay_for;
@@ -57,6 +57,33 @@
 //!     println!("operation timed out");
 //! }
 //! # }
+//! ```
+//!
+//! A simple example using `tokio::time::interval` to execute a task every
+//! two seconds.
+//!
+//! `tokio::time::interval` yields so every iteration of the loop takes
+//! two seconds (except the first as the first `tick` completes immediately).
+//! The difference with `tokio::time::delay_for` is that `delay_for` blocks.
+//! Replacing `interval` with `delay_for` would result in a loop that takes
+//! three seconds per iteration.
+//!
+//! ```
+//! use tokio::time;
+//!
+//! async fn task_that_takes_a_second() {
+//!     println!("hello");
+//!     time::delay_for(time::Duration::from_secs(1)).await
+//! }
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let mut interval = time::interval(time::Duration::from_secs(2));
+//!     for _i in 0..5 {
+//!         interval.tick().await;
+//!         task_that_takes_a_second().await;
+//!     }
+//! }
 //! ```
 
 mod clock;


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

To add an `interval` example to the time module, add also add examples to the `interval` and `delay_for` functions. (#2494).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Add an example using `interval` to the time module
- Add the same example to the `interval` function
- Copy the `delay_for` example in the module to the `delay_for` function
- Fix the comment for the `delay_for` example in the module

Refs: #2494 