### PR TITLE
io: allocate large buffer directly on heap

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -70,7 +70,7 @@ cfg_io_util! {
             amt: 0,
             pos: 0,
             cap: 0,
-            buf: Box::new([0; 2048]),
+            buf: vec![0; 2048].into_boxed_slice(),
         }
     }
 }


### PR DESCRIPTION
## Motivation
Improve stack usage. The code was creating a temporary large array of bytes on the stack only for it to be moved to the heap via Box::new. 

[This Godbolt example](https://godbolt.org/z/x-YymL) demonstrates the problem and the solution.

## Solution
This PR is a small change that fixes the problem by allocating the buffer directly on the heap via a Vec.
