### PR TITLE
chore: prepare tokio-uds v0.2.7 release

### DIFF
--- a/tokio-uds/CHANGELOG.md
+++ b/tokio-uds/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.7 (July 1, 2020)
+
+* Add Illumos support. (#2563)
+
 # 0.2.6 (February 4, 2020)
 
 * Add `tokio 0.2.x` deprecation notice.

--- a/tokio-uds/Cargo.toml
+++ b/tokio-uds/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio-uds"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Carl Lerche <me@carllerche.com>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://github.com/tokio-rs/tokio"
-documentation = "https://docs.rs/tokio-uds/0.2.5/tokio_uds/"
+documentation = "https://docs.rs/tokio-uds/0.2.7/tokio_uds/"
 description = """
 Unix Domain sockets for Tokio
 """

--- a/tokio-uds/README.md
+++ b/tokio-uds/README.md
@@ -8,7 +8,7 @@ An implementation of Unix Domain Sockets for Tokio
 [`tokio::net`]: https://docs.rs/tokio/latest/tokio/net/index.html
 [feature flag]: https://docs.rs/tokio/latest/tokio/index.html#feature-flags
 
-[Documentation](https://docs.rs/tokio-uds/0.2.5/tokio_uds/)
+[Documentation](https://docs.rs/tokio-uds/0.2.7/tokio_uds/)
 
 ## License
 

--- a/tokio-uds/src/lib.rs
+++ b/tokio-uds/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(unix)]
-#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.6")]
+#![doc(html_root_url = "https://docs.rs/tokio-uds/0.2.7")]
 #![deny(missing_docs, missing_debug_implementations)]
 
 //! Unix Domain Sockets for Tokio.


### PR DESCRIPTION
This release includes just #2563.