### PR TITLE
Allow block_on inside block_in_place inside block_on

### DIFF
--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -96,3 +96,22 @@ fn no_block_in_basic_block_on() {
         task::block_in_place(|| {});
     });
 }
+
+#[test]
+fn can_enter_basic_rt_from_within_block_in_place() {
+    let mut outer = tokio::runtime::Builder::new()
+        .threaded_scheduler()
+        .build()
+        .unwrap();
+
+    outer.block_on(async {
+        tokio::task::block_in_place(|| {
+            let mut inner = tokio::runtime::Builder::new()
+                .basic_scheduler()
+                .build()
+                .unwrap();
+
+            inner.block_on(async {})
+        })
+    });
+}


### PR DESCRIPTION
A fast path in block_on_place was failing to call exit() in the case where we
were in a block_on call.

Fixes: #2639

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Often synchronous library APIs can be implemented in terms of a private tokio runtime. While it would be preferable to structure calls into these libraries as async calls, this isn't always possible, and so it should be possible to enter a blocking context using `block_in_place` and then `block_on` a different runtime. This works on spawned tasks, but fails in `block_on` calls due to a bug in `block_in_place`.

## Solution

This ensures that `exit` is called from within `block_on` contexts, allowing us to enter a different runtime.