### PR TITLE
task: add Tracing instrumentation to spawned tasks

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead.
 [dev-dependencies]
-tokio = { version = "0.2.0", path = "../tokio", features = ["full"] }
+tokio = { version = "0.2.0", path = "../tokio", features = ["full", "tracing"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
 tokio-util = { version = "0.3.0", path = "../tokio-util", features = ["full"] }
 bytes = "0.5"
 futures = "0.3.0"

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -50,8 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Filter what traces are displayed based on the RUST_LOG environment
         // variable.
         //
-        // Traces emitted by the example code will always be displayed.
-        // If the example is built with `RUSTFLAGS="--cfg tokio_unstable", you
+        // Traces emitted by the example code will always be displayed. You
         // can set `RUST_LOG=tokio=trace` to enable additional traces emitted by
         // Tokio itself.
         .with_env_filter(EnvFilter::from_default_env().add_directive("chat=info".parse()?))

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -43,11 +43,25 @@ use std::task::{Context, Poll};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+    // Configure a `tracing` subscriber that logs traces emitted by the chat
+    // server.
     tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
-        .with_target(false)
-        .with_timer(())
+        // Filter what traces are displayed based on the RUST_LOG environment
+        // variable.
+        //
+        // Traces emitted by the example code will always be displayed.
+        // If the example is built with `RUSTFLAGS="--cfg tokio_unstable", you
+        // can set `RUST_LOG=tokio=trace` to enable additional traces emitted by
+        // Tokio itself.
+        .with_env_filter(EnvFilter::from_default_env().add_directive("chat=info".parse()?))
+        // Log events when `tracing` spans are created, entered, exited, or
+        // closed. When Tokio's internal tracing support is enabled (as
+        // described above), this can be used to track the lifecycle of spawned
+        // tasks on the Tokio runtime.
+        .with_span_events(FmtSpan::FULL)
+        // Set this subscriber as the default, to collect all traces emitted by
+        // the program.
         .init();
 
     // Create the shared state. This is how all the peers communicate.

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -43,6 +43,13 @@ use std::task::{Context, Poll};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_target(false)
+        .with_timer(())
+        .init();
+
     // Create the shared state. This is how all the peers communicate.
     //
     // The server task will hold a handle to this. For every new client, the
@@ -59,7 +66,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Note that this is the Tokio TcpListener, which is fully async.
     let mut listener = TcpListener::bind(&addr).await?;
 
-    println!("server running on {}", addr);
+    tracing::info!("server running on {}", addr);
 
     loop {
         // Asynchronously wait for an inbound TcpStream.
@@ -70,8 +77,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
         // Spawn our handler to be run asynchronously.
         tokio::spawn(async move {
+            tracing::debug!("accepted connection");
             if let Err(e) = process(state, stream, addr).await {
-                println!("an error occurred; error = {:?}", e);
+                tracing::info!("an error occurred; error = {:?}", e);
             }
         });
     }
@@ -200,7 +208,7 @@ async fn process(
         Some(Ok(line)) => line,
         // We didn't get a line so we return early here.
         _ => {
-            println!("Failed to get username from {}. Client disconnected.", addr);
+            tracing::error!("Failed to get username from {}. Client disconnected.", addr);
             return Ok(());
         }
     };
@@ -212,7 +220,7 @@ async fn process(
     {
         let mut state = state.lock().await;
         let msg = format!("{} has joined the chat", username);
-        println!("{}", msg);
+        tracing::info!("{}", msg);
         state.broadcast(addr, &msg).await;
     }
 
@@ -233,9 +241,10 @@ async fn process(
                 peer.lines.send(&msg).await?;
             }
             Err(e) => {
-                println!(
+                tracing::error!(
                     "an error occurred while processing messages for {}; error = {:?}",
-                    username, e
+                    username,
+                    e
                 );
             }
         }
@@ -248,7 +257,7 @@ async fn process(
         state.peers.remove(&addr);
 
         let msg = format!("{} has left the chat", username);
-        println!("{}", msg);
+        tracing::info!("{}", msg);
         state.broadcast(addr, &msg).await;
     }
 

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -45,7 +45,7 @@ use std::task::{Context, Poll};
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
         .with_target(false)
         .with_timer(())
         .init();

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -45,7 +45,7 @@ use std::task::{Context, Poll};
 async fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::ACTIVE)
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::FULL)
         .with_target(false)
         .with_timer(())
         .init();

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -120,6 +120,9 @@ version = "0.3.8"
 default-features = false
 optional = true
 
+[target.'cfg(tokio_unstable)'.dependencies]
+tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true }
+
 [dev-dependencies]
 tokio-test = { version = "0.2.0", path = "../tokio-test" }
 futures = { version = "0.3.0", features = ["async-await"] }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -106,6 +106,7 @@ iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.10.0", optional = true } # Not in full
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
+tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(unix)'.dependencies]
 mio-uds = { version = "0.6.5", optional = true }
@@ -119,9 +120,6 @@ mio-named-pipes = { version = "0.1.6", optional = true }
 version = "0.3.8"
 default-features = false
 optional = true
-
-[target.'cfg(tokio_unstable)'.dependencies]
-tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 tokio-test = { version = "0.2.0", path = "../tokio-test" }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -367,8 +367,8 @@ macro_rules! cfg_unstable {
 macro_rules! cfg_trace {
     ($($item:item)*) => {
         $(
-            #[cfg(all(feature = "tracing", tokio_unstable))]
-            #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+            #[cfg(feature = "tracing")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
             $item
         )*
     }
@@ -377,7 +377,7 @@ macro_rules! cfg_trace {
 macro_rules! cfg_not_trace {
     ($($item:item)*) => {
         $(
-            #[cfg(not(all(feature = "tracing", tokio_unstable)))]
+            #[cfg(not(feature = "tracing"))]
             $item
         )*
     }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -374,6 +374,15 @@ macro_rules! cfg_trace {
     }
 }
 
+macro_rules! cfg_not_trace {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(all(feature = "tracing", tokio_unstable)))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_coop {
     ($($item:item)*) => {
         $(

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -364,6 +364,16 @@ macro_rules! cfg_unstable {
     }
 }
 
+macro_rules! cfg_trace {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "tracing", tokio_unstable))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_coop {
     ($($item:item)*) => {
         $(

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -114,6 +114,20 @@ cfg_blocking! {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
+        #[cfg(all(feature = "tracing", tokio_unstable))]
+        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+        let f = {
+            let span = tracing::trace_span!(
+                target: "tokio::task",
+                "task",
+                kind = %"blocking",
+                function = %std::any::type_name::<F>(),
+            );
+            move || {
+                let _g = span.enter();
+                f
+            }
+        };
         crate::runtime::spawn_blocking(f)
     }
 }

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -114,8 +114,7 @@ cfg_blocking! {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        #[cfg(all(feature = "tracing", tokio_unstable))]
-        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+        #[cfg(feature = "tracing")]
         let f = {
             let span = tracing::trace_span!(
                 target: "tokio::task",

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -125,7 +125,7 @@ cfg_blocking! {
             );
             move || {
                 let _g = span.enter();
-                f
+                f()
             }
         };
         crate::runtime::spawn_blocking(f)

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -201,10 +201,10 @@ cfg_rt_util! {
             let span = tracing::trace_span!(
                 target: "tokio::task",
                 "task",
-                future = %std::any::type_name::<T>(),
+                future = %std::any::type_name::<F>(),
                 kind = %"local",
             );
-            crate::util::Instrumented::new(task, span)
+            crate::util::Instrumented::new(future, span)
         };
 
         CURRENT.with(|maybe_cx| {
@@ -296,9 +296,9 @@ impl LocalSet {
                 target: "tokio::task",
                 "task",
                 kind = %"local",
-                future = %std::any::type_name::<T>(),
+                future = %std::any::type_name::<F>(),
             );
-            crate::util::Instrumented::new(task, span)
+            crate::util::Instrumented::new(future, span)
         };
 
         let (task, handle) = unsafe { task::joinable_local(future) };

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -195,6 +195,18 @@ cfg_rt_util! {
         F: Future + 'static,
         F::Output: 'static,
     {
+        #[cfg(all(feature = "tracing", tokio_unstable))]
+        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+        let future = {
+            let span = tracing::trace_span!(
+                target: "tokio::task",
+                "task",
+                future = %std::any::type_name::<T>(),
+                kind = %"local",
+            );
+            crate::util::Instrumented::new(task, span)
+        };
+
         CURRENT.with(|maybe_cx| {
             let cx = maybe_cx
                 .expect("`spawn_local` called from outside of a `task::LocalSet`");
@@ -277,6 +289,18 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
+        #[cfg(all(feature = "tracing", tokio_unstable))]
+        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+        let future = {
+            let span = tracing::trace_span!(
+                target: "tokio::task",
+                "task",
+                kind = %"local",
+                future = %std::any::type_name::<T>(),
+            );
+            crate::util::Instrumented::new(task, span)
+        };
+
         let (task, handle) = unsafe { task::joinable_local(future) };
         self.context.tasks.borrow_mut().queue.push_back(task);
         handle

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -195,18 +195,7 @@ cfg_rt_util! {
         F: Future + 'static,
         F::Output: 'static,
     {
-        #[cfg(all(feature = "tracing", tokio_unstable))]
-        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
-        let future = {
-            let span = tracing::trace_span!(
-                target: "tokio::task",
-                "task",
-                future = %std::any::type_name::<F>(),
-                kind = %"local",
-            );
-            crate::util::Instrumented::new(future, span)
-        };
-
+        let future = crate::util::trace::task(future, "local");
         CURRENT.with(|maybe_cx| {
             let cx = maybe_cx
                 .expect("`spawn_local` called from outside of a `task::LocalSet`");
@@ -289,18 +278,7 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
-        #[cfg(all(feature = "tracing", tokio_unstable))]
-        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
-        let future = {
-            let span = tracing::trace_span!(
-                target: "tokio::task",
-                "task",
-                kind = %"local",
-                future = %std::any::type_name::<F>(),
-            );
-            crate::util::Instrumented::new(future, span)
-        };
-
+        let future = crate::util::trace::task(future, "local");
         let (task, handle) = unsafe { task::joinable_local(future) };
         self.context.tasks.borrow_mut().queue.push_back(task);
         handle

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -135,6 +135,7 @@ doc_rt_core! {
             let span = tracing::trace_span!(
                 target: "tokio::task",
                 "task",
+                kind = %"task",
                 future = %std::any::type_name::<T>(),
             );
             crate::util::Instrumented::new(task, span)

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -129,17 +129,7 @@ doc_rt_core! {
     {
         let spawn_handle = runtime::context::spawn_handle()
         .expect("must be called from the context of Tokio runtime configured with either `basic_scheduler` or `threaded_scheduler`");
-        #[cfg(all(feature = "tracing", tokio_unstable))]
-        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
-        let task = {
-            let span = tracing::trace_span!(
-                target: "tokio::task",
-                "task",
-                kind = %"task",
-                future = %std::any::type_name::<T>(),
-            );
-            crate::util::Instrumented::new(task, span)
-        };
+        let task = crate::util::trace::task(task, "task");
         spawn_handle.spawn(task)
     }
 }

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -129,6 +129,16 @@ doc_rt_core! {
     {
         let spawn_handle = runtime::context::spawn_handle()
         .expect("must be called from the context of Tokio runtime configured with either `basic_scheduler` or `threaded_scheduler`");
+        #[cfg(all(feature = "tracing", tokio_unstable))]
+        #[cfg_attr(docsrs, doc(cfg(all(feature = tokio_unstable))))]
+        let task = {
+            let span = tracing::trace_span!(
+                target: "tokio::task",
+                "task",
+                future = %std::any::type_name::<T>(),
+            );
+            crate::util::Instrumented::new(task, span)
+        };
         spawn_handle.spawn(task)
     }
 }

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -19,10 +19,7 @@ cfg_rt_threaded! {
     pub(crate) use try_lock::TryLock;
 }
 
-cfg_trace! {
-    mod trace;
-    pub(crate) use trace::Instrumented;
-}
+pub(crate) mod trace;
 
 #[cfg(any(feature = "macros", feature = "stream"))]
 #[cfg_attr(not(feature = "macros"), allow(unreachable_pub))]

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -19,6 +19,11 @@ cfg_rt_threaded! {
     pub(crate) use try_lock::TryLock;
 }
 
+cfg_trace! {
+    mod trace;
+    pub(crate) use trace::Instrumented;
+}
+
 #[cfg(any(feature = "macros", feature = "stream"))]
 #[cfg_attr(not(feature = "macros"), allow(unreachable_pub))]
 pub use rand::thread_rng_n;

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,0 +1,31 @@
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tracing::Span;
+
+// A future, stream, sink, or executor that has been instrumented with a `tracing` span.
+pin_project! {
+    #[derive(Debug, Clone)]
+    pub(crate) struct Instrumented<T> {
+        #[pin]
+        inner: T,
+        span: Span,
+    }
+}
+
+impl<T: Future> Future for Instrumented<T> {
+    type Output = T::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let _enter = this.span.enter();
+        this.inner.poll(cx)
+    }
+}
+
+impl<T> Instrumented<T> {
+    pub(crate) fn new(inner: T, span: Span) -> Self {
+        Self { inner, span }
+    }
+}

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,31 +1,52 @@
-use pin_project_lite::pin_project;
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-use tracing::Span;
+cfg_trace! {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use pin_project_lite::pin_project;
 
-// A future, stream, sink, or executor that has been instrumented with a `tracing` span.
-pin_project! {
-    #[derive(Debug, Clone)]
-    pub(crate) struct Instrumented<T> {
-        #[pin]
-        inner: T,
-        span: Span,
+    use tracing::Span;
+    // A future, stream, sink, or executor that has been instrumented with a `tracing` span.
+    pin_project! {
+        #[derive(Debug, Clone)]
+        pub(crate) struct Instrumented<T> {
+            #[pin]
+            inner: T,
+            span: Span,
+        }
+    }
+
+    impl<T: Future> Future for Instrumented<T> {
+        type Output = T::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = self.project();
+            let _enter = this.span.enter();
+            this.inner.poll(cx)
+        }
+    }
+
+    impl<T> Instrumented<T> {
+        pub(crate) fn new(inner: T, span: Span) -> Self {
+            Self { inner, span }
+        }
+    }
+
+    #[inline]
+    pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
+        let span = tracing::trace_span!(
+            target: "tokio::task",
+            "task",
+            %kind,
+            future = %std::any::type_name::<F>(),
+        );
+        Instrumented::new(task, span)
     }
 }
 
-impl<T: Future> Future for Instrumented<T> {
-    type Output = T::Output;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-        let _enter = this.span.enter();
-        this.inner.poll(cx)
-    }
-}
-
-impl<T> Instrumented<T> {
-    pub(crate) fn new(inner: T, span: Span) -> Self {
-        Self { inner, span }
+cfg_not_trace! {
+    #[inline]
+    pub(crate) fn task<F>(task: F, _: &'static str) -> F {
+        // nop
+        task
     }
 }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -5,11 +5,10 @@ cfg_trace! {
     use pin_project_lite::pin_project;
 
     use tracing::Span;
-    // A future, stream, sink, or executor that has been instrumented with a
-    // `tracing` span.
 
     #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     pin_project! {
+        /// A future that has been instrumented with a `tracing` span.
         #[derive(Debug, Clone)]
         pub(crate) struct Instrumented<T> {
             #[pin]

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -5,7 +5,10 @@ cfg_trace! {
     use pin_project_lite::pin_project;
 
     use tracing::Span;
-    // A future, stream, sink, or executor that has been instrumented with a `tracing` span.
+    // A future, stream, sink, or executor that has been instrumented with a
+    // `tracing` span.
+
+    #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     pin_project! {
         #[derive(Debug, Clone)]
         pub(crate) struct Instrumented<T> {
@@ -15,6 +18,7 @@ cfg_trace! {
         }
     }
 
+    #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     impl<T: Future> Future for Instrumented<T> {
         type Output = T::Output;
 
@@ -25,12 +29,14 @@ cfg_trace! {
         }
     }
 
+    #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     impl<T> Instrumented<T> {
         pub(crate) fn new(inner: T, span: Span) -> Self {
             Self { inner, span }
         }
     }
 
+    #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     #[inline]
     pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
         let span = tracing::trace_span!(
@@ -44,6 +50,7 @@ cfg_trace! {
 }
 
 cfg_not_trace! {
+    #[cfg(any(feature = "rt-core", feature = "rt-util"))]
     #[inline]
     pub(crate) fn task<F>(task: F, _: &'static str) -> F {
         // nop


### PR DESCRIPTION
## Motivation

When debugging asynchronous systems, it can be very valuable to inspect
what tasks are currently active (see #2510). The [`tracing` crate] and
related libraries provide an interface for Rust libraries and
applications to emit and consume structured, contextual, and async-aware
diagnostic information. Because this diagnostic information is
structured and machine-readable, it is a better fit for the
task-tracking use case than textual logging — `tracing` spans can be
consumed to generate metrics ranging from a simple counter of active
tasks to histograms of poll durations, idle durations, and total task
lifetimes. This information is potentially valuable to both Tokio users
*and* to maintainers.

Additionally, `tracing` is maintained by the Tokio project and is
becoming widely adopted by other libraries in the "Tokio stack", such as
[`hyper`], [`h2`], and [`tonic`] and in [other] [parts] of the broader Rust
ecosystem. Therefore, it is suitable for use in Tokio itself.

[`tracing` crate]: https://github.com/tokio-rs/tracing
[`hyper`]: https://github.com/hyperium/hyper/pull/2204
[`h2`]: https://github.com/hyperium/h2/pull/475
[`tonic`]: https://github.com/hyperium/tonic/blob/570c606397e47406ec148fe1763586e87a8f5298/tonic/Cargo.toml#L48
[other]: https://github.com/rust-lang/chalk/pull/525
[parts]: https://github.com/rust-lang/compiler-team/issues/331

## Solution

This PR is an MVP for instrumenting Tokio with `tracing` spans. When the
"tracing" feature flag and the "tokio_unstable" cfg are both enabled,
every spawned future will be instrumented with a `tracing` span. If both
the cfg flag _and_ the "tracing" feature flag are not set, `tokio` will
*not* depend on `tracing`, and no spans will be generated. 

The generated spans are at the `TRACE` verbosity level, and have the
target "tokio::task", which may be used by consumers to filter whether
they should be recorded. They include fields for the type name of the
spawned future and for what kind of task the span corresponds to (a
standard `spawn`ed task, a local task spawned by `spawn_local`, or a
`blocking` task spawned by `spawn_blocking`). Because `tracing` has
separate concepts of "opening/closing" and "entering/exiting" a span, we
enter these spans every time the spawned task is polled. This allows
collecting data such as:

 - the total lifetime of the task from `spawn` to `drop`
 - the number of times the task was polled before it completed
 - the duration of each individual time that the span was polled (and
   therefore, aggregated metrics like histograms or averages of poll
   durations)
 - the total time a span was actively being polled, and the total time
   it was alive but **not** being polled
 - the time between when the task was `spawn`ed and the first poll

As an example, here is the output of a version of the `chat` example
instrumented with `tracing`:
![image](https://user-images.githubusercontent.com/2796466/87231927-e50f6900-c36f-11ea-8a90-6da9b93b9601.png)
And, with multiple connections actually sending messages:
![trace_example_1](https://user-images.githubusercontent.com/2796466/87231876-8d70fd80-c36f-11ea-91f1-0ad1a5b3112f.png)


I haven't added any `tracing` spans in the example, only converted the
existing `println!`s to `tracing::info` and `tracing::error` for
consistency. The span durations in the above output are generated by
`tracing-subscriber`. Of course, Tokio-specific subscriber could
generate even more detailed statistics, but that's follow-up work once
basic tracing support has been added.

Note that the `Instrumented` type from `tracing-futures`, which attaches
a `tracing` span to a future, was reimplemented inside of Tokio to avoid
a dependency on that crate. `tracing-futures` has a feature flag that
enables an optional dependency on Tokio, and I believe that if another
crate in a dependency graph enables that feature while Tokio's `tracing`
support is also enabled, it would create a circular dependency that
Cargo wouldn't be able to handle. Also, it avoids a dependency for a
very small amount of code that is unlikely to ever change.

There is, of course, room for plenty of future work here. This might 
include:

 - instrumenting other parts of `tokio`, such as I/O resources and 
   channels (possibly via waker instrumentation)
 - instrumenting the threadpool so that the state of worker threads
   can be inspected
 - writing `tracing-subscriber` `Layer`s to collect and display
   Tokio-specific data from these traces
 - using `track_caller` (when it's stable) to record _where_ a task 
   was `spawn`ed from
 - moving the feature out of "tokio_unstable" 

However, this is intended as an MVP to get us started on that path.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>