### PR TITLE
doc: fix typo from "Rust langague" to "Rust language"

### DIFF
--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -18,7 +18,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV
 /// conversion directly, use [`lookup_host()`](super::lookup_host()).
 ///
 /// This trait is sealed and is intended to be opaque. The details of the trait
-/// will change. Stabilization is pending enhancements to the Rust langague.
+/// will change. Stabilization is pending enhancements to the Rust language.
 pub trait ToSocketAddrs: sealed::ToSocketAddrsPriv {}
 
 type ReadyFuture<T> = future::Ready<io::Result<T>>;

--- a/tokio/src/stream/collect.rs
+++ b/tokio/src/stream/collect.rs
@@ -32,7 +32,7 @@ pin_project! {
 ///
 /// Currently, this trait may not be implemented by third parties. The trait is
 /// sealed in order to make changes in the future. Stabilization is pending
-/// enhancements to the Rust langague.
+/// enhancements to the Rust language.
 pub trait FromStream<T>: sealed::FromStreamPriv<T> {}
 
 impl<T, U> Collect<T, U>

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -702,7 +702,7 @@ pub trait StreamExt: Stream {
     /// # Notes
     ///
     /// `FromStream` is currently a sealed trait. Stabilization is pending
-    /// enhancements to the Rust langague.
+    /// enhancements to the Rust language.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Simple typo fix of "Rust language" instead of "Rust langague" in several files.