### PR TITLE
Initial work on expressions in main macro (issue #2662)

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -73,7 +73,8 @@ fn parse_knobs(
                                     runtime = Some(Runtime::Threaded);
                                     match syn::parse_str::<Expr>(&expr.value()) {
                                         Ok(ex) => {
-                                            core_threads = Some(ThreadCount::Expression(Box::new(ex)));
+                                            core_threads =
+                                                Some(ThreadCount::Expression(Box::new(ex)));
                                         }
                                         Err(e) => {
                                             return Err(syn::Error::new_spanned(namevalue, format!("core_threads argument isn't a valid expression: {}", e)));

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -12,7 +12,7 @@ enum Runtime {
 #[derive(Clone)]
 enum ThreadCount {
     Constant(NonZeroUsize),
-    Expression(Expr),
+    Expression(Box<Expr>),
 }
 
 fn parse_knobs(
@@ -73,7 +73,7 @@ fn parse_knobs(
                                     runtime = Some(Runtime::Threaded);
                                     match syn::parse_str::<Expr>(&expr.value()) {
                                         Ok(ex) => {
-                                            core_threads = Some(ThreadCount::Expression(ex));
+                                            core_threads = Some(ThreadCount::Expression(Box::new(ex)));
                                         }
                                         Err(e) => {
                                             return Err(syn::Error::new_spanned(namevalue, format!("core_threads argument isn't a valid expression: {}", e)));
@@ -110,7 +110,7 @@ fn parse_knobs(
                         }
                         syn::Lit::Str(expr) => match syn::parse_str::<Expr>(&expr.value()) {
                             Ok(ex) => {
-                                max_threads = Some(ThreadCount::Expression(ex));
+                                max_threads = Some(ThreadCount::Expression(Box::new(ex)));
                             }
                             Err(e) => {
                                 return Err(syn::Error::new_spanned(


### PR DESCRIPTION
This is currently a WIP implementation of #2662 there's definitely some more work to do including setting it for the `max_threads` as well as core. Currently, I've just implemented it for `core_threads` and tested it with a simple function that returns a usize.

Open questions:

1. Should checks for 1max_threads  >= worker_threads1 be generated?
2. Are the diagnostics good enough for incorrect expressions?