### PR TITLE
Remove misleading comment in `sync::watch::Sender::broadcast`

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -338,7 +338,6 @@ impl<T> Sender<T> {
         // Notify all watchers
         notify_all(&*shared);
 
-        // Return the old value
         Ok(())
     }
 


### PR DESCRIPTION
We are not returning the old value. I suppose this was once indented and this is a leftover.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Some Cleanup
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Remove the comment
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
