### PR TITLE
Fix new manual_non_exhaustive clippy lint

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -284,6 +284,7 @@ where
 ///
 /// [`Framed`]: crate::codec::Framed
 #[derive(Debug)]
+#[allow(clippy::manual_non_exhaustive)]
 pub struct FramedParts<T, U> {
     /// The inner transport used to read bytes to and write bytes to
     pub io: T,


### PR DESCRIPTION
Our minimum supported Rust version does not allow switching to `#[non_exhaustive]`.