### PR TITLE
Add a message on how to fix rustfmt errors.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,11 @@ jobs:
       # Check fmt
       - name: "rustfmt --check"
         # Workaround for rust-lang/cargo#7732
-        run: rustfmt --check --edition 2018 $(find . -name '*.rs' -print)
+        run: |
+          if ! rustfmt --check --edition 2018 $(find . -name '*.rs' -print); then
+            printf "Please run \`rustfmt --edition 2018 \$(find . -name '*.rs' -print)\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
+            exit 1
+          fi
 
   clippy:
     name: clippy


### PR DESCRIPTION
## Motivation

(Suggested by @seanmonstar) `cargo fmt` doesn't work (see rust-lang/rustfmt#4078), so CI invokes `rustfmt --check --edition 2018 $(find . -name '*.rs' -print)` instead. Users won't necessarily know this, and may run `cargo fmt` and wonder why it doesn't work.

## Solution

This PR adds a message indicating the correct command to run.

## Unresolved

* [ ] The message is placed in both the job display name and in the job output, to evaluate the accessibility of each location.
* [ ] It shows the unix-style command, and does not include the windows equivalent that can be found in CONTRIBUTING.md