### PR TITLE
test: implement Drop for Mock to panic w/ unconsumed data

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -453,6 +453,16 @@ impl AsyncWrite for Mock {
     }
 }
 
+/// Ensures that Mock isn't dropped with data "inside".
+impl Drop for Mock {
+    fn drop(&mut self) {
+        self.inner.actions.iter().for_each(|a| match a {
+            Action::Read(data) if !data.is_empty() => panic!("There is still data left to read."),
+            Action::Write(data) if !data.is_empty() => panic!("There is still data left to write."),
+            _ => (),
+        })
+    }
+}
 /*
 /// Returns `true` if called from the context of a futures-rs Task
 fn is_task_ctx() -> bool {

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -70,3 +70,17 @@ async fn write_error() {
 
     mock.write_all(b"world!").await.expect("write 2");
 }
+
+#[tokio::test]
+#[should_panic]
+async fn mock_panics_read_data_left() {
+    use tokio_test::io::Builder;
+    Builder::new().read(b"read").build();
+}
+
+#[tokio::test]
+#[should_panic]
+async fn mock_panics_write_data_left() {
+    use tokio_test::io::Builder;
+    Builder::new().write(b"write").build();
+}


### PR DESCRIPTION
Ensures that no data is left to be read or written when Mock is dropped.

Fixes: #2693, #1847

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
