### PR TITLE
Reset coop budget when blocking in block_on

### DIFF
--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -224,7 +224,7 @@ fn coop_disabled_in_block_in_place_in_block_on() {
         }
         drop(tx);
 
-        let x = outer.block_on(async move {
+        outer.block_on(async move {
             tokio::task::block_in_place(move || {
                 futures::executor::block_on(async move {
                     use tokio::stream::StreamExt;
@@ -233,7 +233,7 @@ fn coop_disabled_in_block_in_place_in_block_on() {
             })
         });
 
-        let _ = done.send(Ok(x));
+        let _ = done.send(Ok(()));
     });
 
     thread::spawn(move || {

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -181,34 +181,7 @@ fn can_shutdown_now_in_runtime() {
 fn coop_disabled_in_block_in_place() {
     let mut outer = tokio::runtime::Builder::new()
         .threaded_scheduler()
-        .build()
-        .unwrap();
-
-    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-    for i in 0..200 {
-        tx.send(i).unwrap();
-    }
-    drop(tx);
-
-    outer
-        .block_on(async move {
-            tokio::spawn(async move {
-                tokio::task::block_in_place(move || {
-                    futures::executor::block_on(async move {
-                        use tokio::stream::StreamExt;
-                        assert_eq!(rx.fold(0, |n, _| n + 1).await, 200);
-                    })
-                })
-            })
-            .await
-        })
-        .unwrap();
-}
-
-#[test]
-fn coop_disabled_in_block_in_place_in_block_on() {
-    let mut outer = tokio::runtime::Builder::new()
-        .threaded_scheduler()
+        .enable_time()
         .build()
         .unwrap();
 
@@ -219,11 +192,54 @@ fn coop_disabled_in_block_in_place_in_block_on() {
     drop(tx);
 
     outer.block_on(async move {
-        tokio::task::block_in_place(move || {
-            futures::executor::block_on(async move {
-                use tokio::stream::StreamExt;
-                assert_eq!(rx.fold(0, |n, _| { dbg!(n + 1) }).await, 200);
+        let jh = tokio::spawn(async move {
+            tokio::task::block_in_place(move || {
+                futures::executor::block_on(async move {
+                    use tokio::stream::StreamExt;
+                    assert_eq!(rx.fold(0, |n, _| n + 1).await, 200);
+                })
             })
-        })
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), jh)
+            .await
+            .expect("timed out (probably hanging)")
+            .unwrap()
     });
+}
+
+#[test]
+fn coop_disabled_in_block_in_place_in_block_on() {
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    let done = done_tx.clone();
+    thread::spawn(move || {
+        let mut outer = tokio::runtime::Builder::new()
+            .threaded_scheduler()
+            .build()
+            .unwrap();
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        for i in 0..200 {
+            tx.send(i).unwrap();
+        }
+        drop(tx);
+
+        let x = outer.block_on(async move {
+            tokio::task::block_in_place(move || {
+                futures::executor::block_on(async move {
+                    use tokio::stream::StreamExt;
+                    assert_eq!(rx.fold(0, |n, _| n + 1).await, 200);
+                })
+            })
+        });
+
+        let _ = done.send(Ok(x));
+    });
+
+    thread::spawn(move || {
+        thread::sleep(Duration::from_secs(1));
+        let _ = done_tx.send(Err("timed out (probably hanging)"));
+    });
+
+    done_rx.recv().unwrap().unwrap();
 }


### PR DESCRIPTION
Previously, we would fail to reset the coop budget in this case, making
it so that `coop::poll_proceed` would perpetually yield `Poll::Pending`
in nested executers even when run in `block_in_place`.

This is also a further improvement on #2645.