### PR TITLE
io: expose `Chain` stream

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -232,6 +232,7 @@ cfg_io_util! {
     pub use util::{
         copy, duplex, empty, repeat, sink, AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt,
         BufReader, BufStream, BufWriter, DuplexStream, Copy, Empty, Lines, Repeat, Sink, Split, Take,
+        Chain
     };
 
     cfg_stream! {

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -23,6 +23,7 @@ cfg_io_util! {
     pub use buf_writer::BufWriter;
 
     mod chain;
+    pub use chain::Chain;
 
     mod copy;
     pub use copy::{copy, Copy};


### PR DESCRIPTION
This commit simply makes the `Chain` adapter stream public. This allow the type to be referenced in dependent crates.