### PR TITLE
sync: Add `is_closed` method to mpsc senders

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -523,6 +523,20 @@ impl<T> Sender<T> {
         enter_handle.block_on(self.send(value)).unwrap()
     }
 
+    /// Checks if `Receiver` is still alive.
+    /// ```
+    /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(42);
+    /// assert!(!tx.is_closed());
+    /// let tx2 = tx.clone();
+    /// assert!(!tx2.is_closed());
+    /// std::mem::drop(rx);
+    /// assert!(tx.is_closed());
+    /// assert!(tx2.is_closed());
+    /// ```
+    pub fn is_closed(&self) -> bool {
+        self.chan.is_closed()
+    }
+    
     /// Wait for channel capacity. Once capacity to send one message is
     /// available, it is reserved for the caller.
     ///
@@ -531,6 +545,7 @@ impl<T> Sender<T> {
     /// message is reserved for the caller. A [`Permit`] is returned to track
     /// the reserved capacity. The [`send`] function on [`Permit`] consumes the
     /// reserved capacity.
+    /// Undo a successful call to `poll_ready`.
     ///
     /// Dropping [`Permit`] without sending a message releases the capacity back
     /// to the channel.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -527,14 +527,16 @@ impl<T> Sender<T> {
     /// [`Receiver`] is dropped, or when the [`Receiver::close`] method is
     /// called.
     ///
-    /// [`Receiver`]: struct@crate::sync::mpsc::Receiver
-    /// [`Receiver::close`]: fn@crate::sync::mpsc::Receiver::close
+    /// [`Receiver`]: crate::sync::mpsc::Receiver
+    /// [`Receiver::close`]: crate::sync::mpsc::Receiver::close
     ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(42);
     /// assert!(!tx.is_closed());
+    ///
     /// let tx2 = tx.clone();
     /// assert!(!tx2.is_closed());
+    ///
     /// std::mem::drop(rx);
     /// assert!(tx.is_closed());
     /// assert!(tx2.is_closed());

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -537,7 +537,7 @@ impl<T> Sender<T> {
     pub fn is_closed(&self) -> bool {
         self.chan.is_closed()
     }
-    
+
     /// Wait for channel capacity. Once capacity to send one message is
     /// available, it is reserved for the caller.
     ///

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -546,7 +546,6 @@ impl<T> Sender<T> {
     /// message is reserved for the caller. A [`Permit`] is returned to track
     /// the reserved capacity. The [`send`] function on [`Permit`] consumes the
     /// reserved capacity.
-    /// Undo a successful call to `poll_ready`.
     ///
     /// Dropping [`Permit`] without sending a message releases the capacity back
     /// to the channel.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -523,7 +523,12 @@ impl<T> Sender<T> {
         enter_handle.block_on(self.send(value)).unwrap()
     }
 
-    /// Checks if `Receiver` is still alive.
+    /// Checks if the channel has been closed. This happens when the
+    /// [`Receiver`] is dropped, or when the [`Receiver::close`] method is
+    /// called.
+    ///
+    /// [`Receiver`]: struct@crate::sync::mpsc::Receiver
+    /// [`Receiver::close`]: fn@crate::sync::mpsc::Receiver::close
     ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(42);

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -524,6 +524,7 @@ impl<T> Sender<T> {
     }
 
     /// Checks if `Receiver` is still alive.
+    ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(42);
     /// assert!(!tx.is_closed());

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -537,7 +537,7 @@ impl<T> Sender<T> {
     /// let tx2 = tx.clone();
     /// assert!(!tx2.is_closed());
     ///
-    /// std::mem::drop(rx);
+    /// drop(rx);
     /// assert!(tx.is_closed());
     /// assert!(tx2.is_closed());
     /// ```

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -370,7 +370,7 @@ impl Semaphore for (crate::sync::batch_semaphore::Semaphore, usize) {
         let waker = crate::util::waker_ref(&waker);
         let mut noop_cx = std::task::Context::from_waker(&*waker);
         let mut permit = Permit::new();
-        match self.poll_acquire(&mut noop_cx, &mut permit) {
+        match permit.poll_acquire(&mut noop_cx, 1, &self.0) {
             Poll::Ready(Err(_)) => true,
             Poll::Ready(Ok(())) => {
                 permit.release(1, &self.0);

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -363,8 +363,8 @@ impl Semaphore for (crate::sync::batch_semaphore::Semaphore, usize) {
         // TODO find more efficient way
         struct NoopWaker;
         impl crate::util::Wake for NoopWaker {
-            fn wake(self: Arc<Self>) {}
-            fn wake_by_ref(_arc_self: &Arc<Self>) {}
+            fn wake(self: std::sync::Arc<Self>) {}
+            fn wake_by_ref(_arc_self: &std::sync::Arc<Self>) {}
         }
         let waker = Arc::new(NoopWaker);
         let waker = crate::util::waker_ref(&waker);

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -134,18 +134,11 @@ pub(crate) fn channel<T, S: Semaphore>(semaphore: S) -> (Tx<T, S>, Rx<T, S>) {
 
 impl<T, S> Tx<T, S> {
     fn new(chan: Arc<Chan<T, S>>) -> Tx<T, S> {
-        Tx {
-            inner: chan,
-            permit: S::new_permit(),
-        }
+        Tx { inner: chan }
     }
 
     pub(crate) fn is_closed(&self) -> bool {
         self.inner.semaphore.is_closed()
-    }
-
-    pub(crate) fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ClosedError>> {
-        self.inner.semaphore.poll_acquire(cx, &mut self.permit)
     }
 
     pub(super) fn semaphore(&self) -> &S {

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -366,7 +366,7 @@ impl Semaphore for (crate::sync::batch_semaphore::Semaphore, usize) {
             fn wake(self: std::sync::Arc<Self>) {}
             fn wake_by_ref(_arc_self: &std::sync::Arc<Self>) {}
         }
-        let waker = Arc::new(NoopWaker);
+        let waker = std::sync::Arc::new(NoopWaker);
         let waker = crate::util::waker_ref(&waker);
         let mut noop_cx = std::task::Context::from_waker(&*waker);
         let mut permit = Permit::new();

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -342,16 +342,16 @@ impl Semaphore for (crate::sync::batch_semaphore::Semaphore, usize) {
         self.0.release(1)
     }
 
-    fn is_closed(&self) -> bool {
-        self.0.is_closed()
-    }
-
     fn is_idle(&self) -> bool {
         self.0.available_permits() == self.1
     }
 
     fn close(&self) {
         self.0.close();
+    }
+
+    fn is_closed(&self) -> bool {
+        self.0.is_closed()
     }
 }
 
@@ -370,15 +370,15 @@ impl Semaphore for AtomicUsize {
         }
     }
 
-    fn is_closed(&self) -> bool {
-        self.load(Acquire) & 1 == 1
-    }
-
     fn is_idle(&self) -> bool {
         self.load(Acquire) >> 1 == 0
     }
 
     fn close(&self) {
         self.fetch_or(1, Release);
+    }
+
+    fn is_closed(&self) -> bool {
+        self.load(Acquire) & 1 == 1
     }
 }

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -360,24 +360,7 @@ impl Semaphore for (crate::sync::batch_semaphore::Semaphore, usize) {
     }
 
     fn is_closed(&self) -> bool {
-        // TODO find more efficient way
-        struct NoopWaker;
-        impl crate::util::Wake for NoopWaker {
-            fn wake(self: std::sync::Arc<Self>) {}
-            fn wake_by_ref(_arc_self: &std::sync::Arc<Self>) {}
-        }
-        let waker = std::sync::Arc::new(NoopWaker);
-        let waker = crate::util::waker_ref(&waker);
-        let mut noop_cx = std::task::Context::from_waker(&*waker);
-        let mut permit = Permit::new();
-        match permit.poll_acquire(&mut noop_cx, 1, &self.0) {
-            Poll::Ready(Err(_)) => true,
-            Poll::Ready(Ok(())) => {
-                permit.release(1, &self.0);
-                false
-            }
-            Poll::Pending => false,
-        }
+        self.0.is_closed()
     }
 
     fn is_idle(&self) -> bool {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -246,8 +246,8 @@ impl<T> UnboundedSender<T> {
         self.chan.closed().await
     }
     /// Checks if the channel has been closed. This happens when the
-    /// [`UnboundedReceiver`] is dropped, or when
-    /// the [`UnboundedReceiver::close`] method is called.
+    /// [`UnboundedReceiver`] is dropped, or when the
+    /// [`UnboundedReceiver::close`] method is called.
     ///
     /// [`UnboundedReceiver`]: crate::sync::mpsc::UnboundedReceiver
     /// [`UnboundedReceiver::close`]: crate::sync::mpsc::UnboundedReceiver::close

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -259,7 +259,7 @@ impl<T> UnboundedSender<T> {
     /// let tx2 = tx.clone();
     /// assert!(!tx2.is_closed());
     ///
-    /// std::mem::drop(rx);
+    /// drop(rx);
     /// assert!(tx.is_closed());
     /// assert!(tx2.is_closed());
     /// ```

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -245,13 +245,20 @@ impl<T> UnboundedSender<T> {
     pub async fn closed(&mut self) {
         self.chan.closed().await
     }
-    /// Checks if `UnboundedReceiver` is still alive.
+    /// Checks if the channel has been closed. This happens when the
+    /// [`UnboundedReceiver`] is dropped, or when
+    /// the [`UnboundedReceiver::close`] method is called.
+    ///
+    /// [`UnboundedReceiver`]: crate::sync::mpsc::UnboundedReceiver
+    /// [`UnboundedReceiver::close`]: crate::sync::mpsc::UnboundedReceiver::close
     ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
     /// assert!(!tx.is_closed());
+    ///
     /// let tx2 = tx.clone();
     /// assert!(!tx2.is_closed());
+    ///
     /// std::mem::drop(rx);
     /// assert!(tx.is_closed());
     /// assert!(tx2.is_closed());

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -246,6 +246,7 @@ impl<T> UnboundedSender<T> {
         self.chan.closed().await
     }
     /// Checks if `UnboundedReceiver` is still alive.
+    ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
     /// assert!(!tx.is_closed());

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -245,4 +245,17 @@ impl<T> UnboundedSender<T> {
     pub async fn closed(&mut self) {
         self.chan.closed().await
     }
+    /// Checks if `UnboundedReceiver` is still alive.
+    /// ```
+    /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    /// assert!(!tx.is_closed());
+    /// let tx2 = tx.clone();
+    /// assert!(!tx2.is_closed());
+    /// std::mem::drop(rx);
+    /// assert!(tx.is_closed());
+    /// assert!(tx2.is_closed());
+    /// ```
+    pub fn is_closed(&self) -> bool {
+        self.chan.is_closed()
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #2469 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I should note that I looked at mpsc internals first time, so I can be wrong / selected wrong implementation path.
I discovered that both Sender kinds (bounded and Unbounded) implement on top of `tokio::sync::mpsc::Chan`, which in turn uses `Semaphore` trait. I added new method `is_closed` to this trait. I was able to implement it properly for unbounded implementation.
However, I didn't find beautiful way to check if `semaphore_ll` is closed, so I implemented hack (we try to acquire new permit and immediately release it back). While it is inefficient and probably ugly, from the user side it should work OK (for example, it does not mess Sender internal state and it does not take mutable reference to sender).

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
