### PR TITLE
Write guard to read guard downgrading for sync::RwLock

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -348,6 +348,9 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     /// Atomically downgrades a write lock into a read lock without allowing
     /// any writers to take exclusive access of the lock in the meantime.
     ///
+    /// **Note:** this won't *necessarily* allow any additional readers to acquire
+    /// locks, since [`RwLock`] is fair and it's possible a writer is next in line.
+    ///
     /// Returns an RAII guard which will drop the read access of this rwlock
     /// when dropped.
     ///
@@ -378,6 +381,8 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     /// assert_eq!(*lock.read().await, 2, "second writer obtained write lock");
     /// # }
     /// ```
+    ///
+    /// [`RwLock`]: struct@RwLock
     pub fn downgrade(self) -> RwLockReadGuard<'a, T> {
         let RwLockWriteGuard { s, data, .. } = self;
 

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -348,8 +348,9 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     /// Atomically downgrades a write lock into a read lock without allowing
     /// any writers to take exclusive access of the lock in the meantime.
     ///
-    /// **Note:** this won't *necessarily* allow any additional readers to acquire
-    /// locks, since [`RwLock`] is fair and it's possible a writer is next in line.
+    /// **Note:** This won't *necessarily* allow any additional readers to acquire
+    /// locks, since [`RwLock`] is fair and it is possible that a writer is next
+    /// in line.
     ///
     /// Returns an RAII guard which will drop the read access of this rwlock
     /// when dropped.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The asynchronous `sync::RwLock` currently provides no way to atomically downgrade a write guard into a read guard, forcing a pattern of dropping the write guard and reacquiring a read guard to achieve a downgrade. In addition to being non-atomic, this makes it easy to accidentally induce a deadlock by forgetting to drop an existing read guard before attempting to acquire a write guard--this is particularly tricky and non-obvious when shadowing the name of the old read guard.

## Solution

This implements an atomic downgrade operation by taking ownership of a write guard, releasing all but one of the permits it holds, and returning a read guard holding the remaining permit.