### PR TITLE
Fix stdout and stderr buffering on windows

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -214,6 +214,8 @@ cfg_io_driver! {
 }
 
 cfg_io_std! {
+    mod stdio_common;
+
     mod stderr;
     pub use stderr::{stderr, Stderr};
 

--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -1,4 +1,5 @@
 use crate::io::blocking::Blocking;
+use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
 
 use std::io;
@@ -35,7 +36,7 @@ cfg_io_std! {
     /// ```
     #[derive(Debug)]
     pub struct Stderr {
-        std: Blocking<std::io::Stderr>,
+        std: SplitByUtf8BoundaryIfWindows<Blocking<std::io::Stderr>>,
     }
 
     /// Constructs a new handle to the standard error of the current process.
@@ -67,7 +68,7 @@ cfg_io_std! {
     pub fn stderr() -> Stderr {
         let std = io::stderr();
         Stderr {
-            std: Blocking::new(std),
+            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new(std)),
         }
     }
 }

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -27,7 +27,15 @@ where
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, std::io::Error>> {
-        // if windows, remove possible trailing incomplete character
+        // following two ifs are enabled only on windows targets, because
+        // on other targets we do not have problems with incomplete utf8 chars
+
+        // ensure buffer is not longer than MAX_BUF
+        #[cfg(target_os = "windows")]
+        let buf = if buf.len() > crate::io::blocking::MAX_BUF {
+            &buf[..crate::io::blocking::MAX_BUF]
+        };
+        // now remove possible trailing incomplete character
         #[cfg(target_os = "windows")]
         let buf = match std::str::from_utf8(buf) {
             // `buf` is already utf-8, no need to trim it

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -34,6 +34,8 @@ where
         #[cfg(target_os = "windows")]
         let buf = if buf.len() > crate::io::blocking::MAX_BUF {
             &buf[..crate::io::blocking::MAX_BUF]
+        } else {
+            buf
         };
         // now remove possible trailing incomplete character
         #[cfg(target_os = "windows")]

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -1,0 +1,60 @@
+//! Contains utilities for stdout and stderr.
+use crate::io::AsyncWrite;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+/// # Windows
+/// AsyncWrite adapter that finds last char boundary in given buffer and does not write the rest.
+/// That's why, wrapped writer will always receive well-formed utf-8 bytes.
+/// # Other platforms
+/// passes data to `inner` as is
+#[derive(Debug)]
+pub(crate) struct SplitByUtf8BoundaryIfWindows<W> {
+    inner: W,
+}
+
+impl<W> SplitByUtf8BoundaryIfWindows<W> {
+    pub(crate) fn new(inner: W) -> Self {
+        Self { inner }
+    }
+}
+
+impl<W> crate::io::AsyncWrite for SplitByUtf8BoundaryIfWindows<W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, std::io::Error>> {
+        // if windows, remove possible trailing incomplete character
+        #[cfg(target_os = "windows")]
+        let buf = match std::str::from_utf8(buf) {
+            // `buf` is already utf-8, no need to trim it
+            Ok(_) => buf,
+            Err(err) if err.valid_up_to() == 0 => {
+                return Poll::Ready(Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "provided buffer does not contain utf-8 data",
+                )));
+            }
+            Err(err) => &buf[..err.valid_up_to()],
+        };
+        // now pass trimmed input buffer to inner writer
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), std::io::Error>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -102,6 +102,7 @@ mod tests {
         }
     }
     #[test]
+    #[cfg(not(loom))]
     fn test_splitter() {
         let data = str::repeat("█", MAX_BUF);
         let mut wr = super::SplitByUtf8BoundaryIfWindows::new(MockWriter);

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -110,7 +110,6 @@ mod tests {
         };
         crate::runtime::Builder::new()
             .basic_scheduler()
-            .enable_io()
             .build()
             .unwrap()
             .block_on(fut);

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -35,7 +35,7 @@ cfg_io_std! {
     /// ```
     #[derive(Debug)]
     pub struct Stdout {
-        std: SplitByUtf8BoundaryIfWindows<Blocking< std::io::Stdout>>,
+        std: SplitByUtf8BoundaryIfWindows<Blocking<std::io::Stdout>>,
     }
 
     /// Constructs a new handle to the standard output of the current process.

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -35,7 +35,7 @@ cfg_io_std! {
     /// ```
     #[derive(Debug)]
     pub struct Stdout {
-        std: SplitByUtf8BoundaryIfWindows<Blocking< std::io::Stdout>,>
+        std: SplitByUtf8BoundaryIfWindows<Blocking< std::io::Stdout>>,
     }
 
     /// Constructs a new handle to the standard output of the current process.

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -1,6 +1,6 @@
 use crate::io::blocking::Blocking;
+use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
-
 use std::io;
 use std::pin::Pin;
 use std::task::Context;
@@ -35,7 +35,7 @@ cfg_io_std! {
     /// ```
     #[derive(Debug)]
     pub struct Stdout {
-        std: Blocking<std::io::Stdout>,
+        std: SplitByUtf8BoundaryIfWindows<Blocking< std::io::Stdout>,>
     }
 
     /// Constructs a new handle to the standard output of the current process.
@@ -67,7 +67,7 @@ cfg_io_std! {
     pub fn stdout() -> Stdout {
         let std = io::stdout();
         Stdout {
-            std: Blocking::new(std),
+            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new(std)),
         }
     }
 }

--- a/tokio/tests/io_std.rs
+++ b/tokio/tests/io_std.rs
@@ -1,7 +1,0 @@
-#![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
-
-#[tokio::test]
-async fn test_utf8_boundary_adapter_works() {
-    
-}

--- a/tokio/tests/io_std.rs
+++ b/tokio/tests/io_std.rs
@@ -1,0 +1,7 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+#[tokio::test]
+async fn test_utf8_boundary_adapter_works() {
+    
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Should fix #2380 (But not tested on a Windows yet)
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Wrap `Blocking` in Stdout and Stderr in a specall wrapper, which is completely transparent on Linux and intercepts `write`s on Windows:
1) If input buffer is larger that MAX_BUF, we shrink to to MAX_BUF.
2) If input buffer now has incomplete char at the end, we shrink it too.
It should work, because in general it is ok for `AsyncWrite::write` to write less bytes than requested.

I don't think I can add test for it, because on CI stdout is not handle to console, so no panic can occur.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
