### PR TITLE
sync: show correct permits on debug mode

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -100,6 +100,9 @@ impl Semaphore {
     /// future.
     pub(crate) const MAX_PERMITS: usize = std::usize::MAX >> 3;
     const CLOSED: usize = 1;
+    // The least-significant bit in the number of permits is reserved to use
+    // as a flag indicating that the semaphore has been closed. Consequently
+    // PERMIT_SHIFT is used to leave that bit for that purpose.
     const PERMIT_SHIFT: usize = 1;
 
     /// Creates a new semaphore with the initial number of permits
@@ -357,7 +360,7 @@ impl Semaphore {
 impl fmt::Debug for Semaphore {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Semaphore")
-            .field("permits", &self.permits.load(Relaxed))
+            .field("permits", &self.available_permits())
             .finish()
     }
 }


### PR DESCRIPTION
Fixes: #2744

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
