### PR TITLE
tokio-macros: Add a runtime builder argument to the tokio::main macro

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -118,7 +118,7 @@ fn parse_knobs(
                         }
                     },
                     name => {
-                        let msg = format!("Unknown attribute pair {} is specified; expected one of: `core_threads`, `max_threads`", name);
+                        let msg = format!("Unknown attribute pair {} is specified; expected one of: `core_threads`, `max_threads`, `runtime_builder`", name);
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
                 }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -35,7 +35,9 @@ use proc_macro::TokenStream;
 ///
 /// - `core_threads=n` - Sets core threads to `n` (requires `rt-threaded` feature).
 /// - `max_threads=n` - Sets max threads to `n` (requires `rt-core` or `rt-threaded` feature).
-/// - `basic_scheduler` - Use the basic schduler (requires `rt-core`).
+/// - `basic_scheduler` - Use the basic scheduler (requires `rt-core`).
+/// - `runtime_builder` - Use the provided function to build a runtime (see the corresponding
+///    section in "usage" for details).
 ///
 /// ## Function arguments:
 ///
@@ -117,6 +119,30 @@ use proc_macro::TokenStream;
 ///         })
 /// }
 /// ```
+///
+/// ### Provide a runtime builder function
+///
+/// ```rust
+/// fn build_runtime() -> tokio::runtime::Runtime {
+///    tokio::runtime::Builder::new()
+///         .threaded_scheduler()
+///         .core_threads(2)
+///         .enable_all()
+///         .build()
+///         .unwrap()
+/// }
+///
+/// #[tokio::main(runtime_builder = "build_runtime")]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+///
+/// The `runtime_builder` does not have to return a `tokio::runtime::Runtime` object, it may
+/// return any object compatible with its interface, e.g. one providing `block_on` function
+/// which takes a `std::future::Future` as an argument.
+///
+/// If `runtime_builder` argument is provided, all the other configuration arguments are ignored.
 ///
 /// ### NOTE:
 ///

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -147,9 +147,9 @@ use proc_macro::TokenStream;
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
@@ -220,9 +220,9 @@ pub fn main_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
@@ -271,9 +271,9 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
@@ -311,9 +311,9 @@ pub fn main_basic(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -350,9 +350,9 @@ pub fn test_threaded(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -377,9 +377,9 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### NOTE:
 ///
 /// If you rename the tokio crate in your dependencies this macro
-/// will not work. If you must rename the 0.2 version of tokio because
+/// will not work. If you must rename the 0.3 version of tokio because
 /// you're also using the 0.1 version of tokio, you _must_ make the
-/// tokio 0.2 crate available as `tokio` in the module where this
+/// tokio 0.3 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
 pub fn test_basic(args: TokenStream, item: TokenStream) -> TokenStream {


### PR DESCRIPTION
This PR introduces a new optional argument for the `tokio::main` macro: `runtime_builder`.

This argument must contain a name of a function to be used to build a `Runtime` for the application.

## Motivation

Currently the `tokio::main` macro provides several options to customize a `Runtime`, but nonetheless some of the parameters are omitted (e.g. "thread_name"). This means that if available arguments are not sufficient, user has to build the `Runtime` manually.

Ability to provide a builder function may be convenient because of the following reasons:

- If user project contains several binaries which have the similar runtime configuration, they may implement a builder function once, and just re-use it with convenience of the `tokio::main` macro.
- If user uses some non-standard `Runtime`which is still based on `tokio`, a builder function argument will allow them to use it.

## Solution

A new optional argument `runtime_builder` is now recognized by the `tokio::main` macro. If it's provided, it's considered to be a name of the function to use to build a `Runtime`.

## Additional note

I noticed that the crate version was updated to `0.3`, but in doc-comments I've edited a `0.2` version was still mentioned. I felt weird about editing a comment while leaving this finding as-is, thus fixed it in this file. If it's not desired to mix different things in one PR, I may revert these changes.
