### PR TITLE
chore: bump MSRV to 1.45

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   nightly: nightly-2020-07-12
-  minrust: 1.39.0
+  minrust: 1.45.2
 
 jobs:
   # Depends on all action sthat are required for a "successful" CI run.


### PR DESCRIPTION
As 0.3 is a breaking change, the minimum supported Rust version can be
changed.