### PR TITLE
examples: workaround for upstream MSRV breakage

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # [dependencies] instead.
 [dev-dependencies]
 tokio = { version = "0.3.0", path = "../tokio", features = ["full", "tracing"] }
-tracing = "0.1"
+tracing = { version = "0.1.19", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
 tokio-util = { version = "0.4.0", path = "../tokio-util", features = ["full"] }
 bytes = "0.5"


### PR DESCRIPTION
## Motivation

It looks like an upstream change in the `tracing-attributes` crate broke
our MSRV build. Tokio's `tracing` dependency disables the feature flag
for `tracing-attributes`, but the examples do not, although the
`#[instrument]` attribute is not currently used in the examples.

## Solution 

This branch fixes the build failure by disabling default features for
the `examples` crate's `tracing` dependency, which should unbreak our CI
builds. Longer-term, I'm going to try to fix this upstream --- I'm
surprised this happened, since IIRC `tracing` is tied to Tokio's MSRV.
Maybe our MSRV CI build didn't catch it somehow?
