### PR TITLE
chore: reformat some imports for consistency

### DIFF
--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -1,8 +1,6 @@
-use crate::loom::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicPtr, AtomicUsize},
-    thread,
-};
+use crate::loom::cell::UnsafeCell;
+use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
+use crate::loom::thread;
 
 use std::mem::MaybeUninit;
 use std::ops;

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -1,9 +1,7 @@
 //! A concurrent, lock-free, FIFO list.
 
-use crate::loom::{
-    sync::atomic::{AtomicPtr, AtomicUsize},
-    thread,
-};
+use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
+use crate::loom::thread;
 use crate::sync::mpsc::block::{self, Block};
 
 use std::fmt;


### PR DESCRIPTION
We don't usually use multi line imports.