### PR TITLE
Docs: Module level docs for tokio::stream

### DIFF
--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -13,7 +13,7 @@
 //! `Stream` use `while let` as follows:
 //!
 //! ```rust
-//! use tokio::stream::self;
+//! use tokio::stream::{self, StreamExt};
 //!
 //! #[tokio::main]
 //! async fn main() {

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -48,7 +48,7 @@
 //! [`tokio::io`]: crate::io
 //! [`AsyncRead`]: crate::io::AsyncRead
 //! [`AsyncWrite`]: crate::io::AsyncWrite
-//! ["ReaderStream"]: https://docs.rs/tokio-util/0.3/tokio_util/io/struct.ReaderStream.html
+//! [`ReaderStream`]: https://docs.rs/tokio-util/0.3/tokio_util/io/struct.ReaderStream.html
 //! [`StreamReader`]: https://docs.rs/tokio-util/0.3/tokio_util/io/struct.StreamReader.html
 
 mod all;

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -3,7 +3,9 @@
 //! A `Stream` is an asynchronous sequence of values. It can be thought of as
 //! an asynchronous version of the standard library's `Iterator` trait.
 //!
-//! This module provides helpers to work with them.
+//! This module provides helpers to work with them. For examples of usage and a more in-depth
+//! description of streams you can also refer to the [streams
+//! tutorial](https://tokio.rs/tokio/tutorial/streams) on the tokio website.
 //!
 //! # Iterating over a Stream
 //!

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -3,6 +3,13 @@
 //! A `Stream` is an asynchronous sequence of values. It can be thought of as an asynchronous version of the standard library's `Iterator` trait.
 //!
 //! This module provides helpers to work with them.
+//!
+//! # Converting from `Stream` to `AsyncRead`
+//!
+//! Often a user may want to convert from a `Stream` to an `AsyncRead` for this usecase refer to
+//! [`stream_reader`]
+//!
+//! [`stream_reader`]: crate::io::stream_reader
 
 mod all;
 use all::AllFuture;

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -39,26 +39,17 @@
 //!
 //! It is often desirable to convert a `Stream` into an [`AsyncRead`],
 //! especially when dealing with plaintext formats streamed over the network.
-//! To enable this functionality, [`tokio::io`] provides the [`stream_reader`]
-//! function for this purpose.
-//!
-//! The inverse conversion to go from an [`AsyncRead`] into a [`Stream`]
-//! is also a commonly desired feature. For this usecase, Tokio
-//! provides some utility traits in the [tokio-util] crate that
-//! abstract the asynchronous buffering that is required and allows
-//! you to write [`Encoder`] and [`Decoder`] functions working with a
-//! buffer of bytes, and then use that ["codec"] to transform anything
-//! that implements [`AsyncRead`] into a `Stream` of your structured data.
+//! The opposite conversion from an [`AsyncRead`] into a `Stream` is also
+//! another commonly required feature. To enable these conversions,
+//! [`tokio-util`] provides the [`StreamReader`] and [`ReaderStream`]
+//! types when the io feature is enabled.
 //!
 //! [tokio-util]: https://docs.rs/tokio-util/0.3/tokio_util/codec/index.html
 //! [`tokio::io`]: crate::io
 //! [`AsyncRead`]: crate::io::AsyncRead
 //! [`AsyncWrite`]: crate::io::AsyncWrite
-//! [`stream_reader`]: crate::io::stream_reader
-//! [`Sink`]: https://docs.rs/futures/0.3/futures/sink/trait.Sink.html
-//! ["codec"]: https://docs.rs/tokio-util/0.3/tokio_util/codec/index.html
-//! [`Encoder`]: https://docs.rs/tokio-util/0.3/tokio_util/codec/trait.Encoder.html
-//! [`Decoder`]: https://docs.rs/tokio-util/0.3/tokio_util/codec/trait.Decoder.html
+//! ["ReaderStream"]: https://docs.rs/tokio-util/0.3/tokio_util/io/struct.ReaderStream.html
+//! [`StreamReader`]: https://docs.rs/tokio-util/0.3/tokio_util/io/struct.StreamReader.html
 
 mod all;
 use all::AllFuture;

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -8,9 +8,9 @@
 //! # Iterating over a Stream
 //!
 //! Due to similarities with the standard library's `Iterator` trait, some new
-//! users may assume they can use `for in` syntax to iterate over a `Stream`.  
-//! However, this isn't the case so instead to iterate over the values in a
-//! `Stream` use `while let` as follows:
+//! users may assume that they can use `for in` syntax to iterate over a
+//! `Stream`, but this is unfortunately not possible. Instead, you can use a
+//! `while let` loop as follows:
 //!
 //! ```rust
 //! use tokio::stream::{self, StreamExt};
@@ -30,27 +30,25 @@
 //! A common way to stream values from a function is to pass in the sender
 //! half of a channel and use the receiver as the stream. This requires awaiting
 //! both futures to ensure progress is made. Another alternative is the
-//! [async-stream] crate which contains macros which provide a `yield` keyword
+//! [async-stream] crate, which contains macros that provide a `yield` keyword
 //! and allow you to return an `impl Stream`.
 //!
-//! [async-stream]: https://docs.rs/async-stream/0.3/async_stream/index.html
+//! [async-stream]: https://docs.rs/async-stream
 //!
-//! # Conversion to and from the AsyncRead/AsyncWrite
+//! # Conversion to and from AsyncRead/AsyncWrite
 //!
-//! It is often desirable to convert from a `Stream` to an [`AsyncRead`],
+//! It is often desirable to convert a `Stream` into an [`AsyncRead`],
 //! especially when dealing with plaintext formats streamed over the network.
-//! To enable this functionality more ergonomically, [`tokio::io`] provides a
-//! function [`stream_reader`] for this purpose.
+//! To enable this functionality, [`tokio::io`] provides the [`stream_reader`]
+//! function for this purpose.
 //!
-//! It is often convenient to encapsulate the reading and writing of
-//! bytes and instead work with a [`Sink`] or `Stream` of some data
-//! type that is encoded as bytes and/or decoded from bytes. Tokio
+//! The inverse conversion to go from an [`AsyncRead`] into a [`Stream`]
+//! is also a commonly desired feature. For this usecase, Tokio
 //! provides some utility traits in the [tokio-util] crate that
 //! abstract the asynchronous buffering that is required and allows
 //! you to write [`Encoder`] and [`Decoder`] functions working with a
 //! buffer of bytes, and then use that ["codec"] to transform anything
-//! that implements [`AsyncRead`] and [`AsyncWrite`] into a `Sink`/`Stream` of
-//! your structured data.
+//! that implements [`AsyncRead`] into a `Stream` of your structured data.
 //!
 //! [tokio-util]: https://docs.rs/tokio-util/0.3/tokio_util/codec/index.html
 //! [`tokio::io`]: crate::io


### PR DESCRIPTION
The module docs for stream were a bit more minimal compared to other modules. This aims to fill in information on some common usage and use-cases where the solution may rely on other crates in the ecosystem or not be intuitive for newcomers. 