### PR TITLE
Implement `FromRawFd` & `FromRawHandle` for `File`

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -778,9 +778,23 @@ impl std::os::unix::io::AsRawFd for File {
     }
 }
 
+#[cfg(unix)]
+impl std::os::unix::io::FromRawFd for File {
+    unsafe fn from_raw_fd(fd: std::os::unix::io::RawFd) -> Self {
+        sys::File::from_raw_fd(fd).into()
+    }
+}
+
 #[cfg(windows)]
 impl std::os::windows::io::AsRawHandle for File {
     fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
         self.std.as_raw_handle()
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::FromRawHandle for File {
+    unsafe fn from_raw_handle(handle: std::os::windows::io::RawHandle) -> Self {
+        sys::File::from_raw_handle(handle).into()
     }
 }

--- a/tokio/tests/support/mock_file.rs
+++ b/tokio/tests/support/mock_file.rs
@@ -273,9 +273,23 @@ impl std::os::unix::io::AsRawFd for File {
     }
 }
 
+#[cfg(unix)]
+impl std::os::unix::io::FromRawFd for File {
+    unsafe fn from_raw_fd(_: std::os::unix::io::RawFd) -> Self {
+        unimplemented!();
+    }
+}
+
 #[cfg(windows)]
 impl std::os::windows::io::AsRawHandle for File {
     fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        unimplemented!();
+    }
+}
+
+#[cfg(windows)]
+impl std::os::windows::io::FromRawHandle for File {
+    unsafe fn from_raw_handle(_: std::os::windows::io::RawHandle) -> Self {
         unimplemented!();
     }
 }


### PR DESCRIPTION
## Motivation

These traits make it simpler to create instances from the raw OS primitives.

## Solution

Defer to the trait implementations in `std` and convert from the resulting `std::fs::File`.