### PR TITLE
fix typo in Notify documentation

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -26,7 +26,7 @@ use std::task::{Context, Poll, Waker};
 /// be made available, consumes the permit, and resumes.  [`notify()`] sets the
 /// permit, waking a pending task if there is one.
 ///
-/// If `notify()` is called **before** `notfied().await`, then the next call to
+/// If `notify()` is called **before** `notified().await`, then the next call to
 /// `notified().await` will complete immediately, consuming the permit. Any
 /// subsequent calls to `notified().await` will wait for a new permit.
 ///


### PR DESCRIPTION
## Motivation

There is a typo in the documentation for `Notify`.

## Solution

The typo has been corrected.
