### PR TITLE
tokio: document missing timer panics

### DIFF
--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -20,6 +20,14 @@ impl Handle {
     /// # Panics
     ///
     /// This function panics if there is no current timer set.
+    /// It can be triggered when `Builder::enable_time()` or `Builder::enable_all()`
+    /// are not included in the builder.
+    ///
+    /// It can also panic whenever a timer is created outside of a Tokio runtime.
+    /// That is why `rt.block_on(delay_for(...))` will panic, since they function is
+    /// executed outside of the runtime. Whereas `rt.block_on(async {delay_for(...)})` doesn't
+    /// panic. And this is because wrapping the function on an async makes it lazy, and so
+    /// gets executed inside the runtime successfuly without panicking.
     pub(crate) fn current() -> Self {
         context::time_handle()
             .expect("there is no timer running, must be called from the context of Tokio runtime")

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -25,7 +25,7 @@ impl Handle {
     ///
     /// It can also panic whenever a timer is created outside of a Tokio runtime.
     /// That is why `rt.block_on(delay_for(...))` will panic, since they function is
-    /// executed outside of the runtime. Whereas `rt.block_on(async {delay_for(...)})` doesn't
+    /// executed outside of the runtime. Whereas `rt.block_on(async {delay_for(...).await})` doesn't
     /// panic. And this is because wrapping the function on an async makes it lazy, and so
     /// gets executed inside the runtime successfuly without panicking.
     pub(crate) fn current() -> Self {

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -20,14 +20,17 @@ impl Handle {
     /// # Panics
     ///
     /// This function panics if there is no current timer set.
-    /// It can be triggered when `Builder::enable_time()` or `Builder::enable_all()`
-    /// are not included in the builder.
     ///
-    /// It can also panic whenever a timer is created outside of a Tokio runtime.
-    /// That is why `rt.block_on(delay_for(...))` will panic, since they function is
-    /// executed outside of the runtime. Whereas `rt.block_on(async {delay_for(...).await})` doesn't
-    /// panic. And this is because wrapping the function on an async makes it lazy, and so
-    /// gets executed inside the runtime successfuly without panicking.
+    /// It can be triggered when `Builder::enable_time()` or
+    /// `Builder::enable_all()` are not included in the builder.
+    ///
+    /// It can also panic whenever a timer is created outside of a Tokio
+    /// runtime. That is why `rt.block_on(delay_for(...))` will panic,
+    /// since the function is executed outside of the runtime.
+    /// Whereas `rt.block_on(async {delay_for(...).await})` doesn't
+    /// panic. And this is because wrapping the function on an async makes it
+    /// lazy, and so gets executed inside the runtime successfuly without
+    /// panicking.
     pub(crate) fn current() -> Self {
         context::time_handle()
             .expect("there is no timer running, must be called from the context of Tokio runtime")


### PR DESCRIPTION
Added in Handle::current() a detailed explanation on when the function
panics.

Fixes: #2696

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
