### PR TITLE
Watch channel breaking changes

### DIFF
--- a/tokio/src/sync/barrier.rs
+++ b/tokio/src/sync/barrier.rs
@@ -112,7 +112,7 @@ impl Barrier {
         loop {
             // note that the first time through the loop, this _will_ yield a generation
             // immediately, since we cloned a receiver that has never seen any values.
-            if wait.recv().await.expect("sender hasn't been closed") >= generation {
+            if wait.recv().await >= generation {
                 break;
             }
         }

--- a/tokio/src/sync/barrier.rs
+++ b/tokio/src/sync/barrier.rs
@@ -96,7 +96,7 @@ impl Barrier {
                 // wake everyone, increment the generation, and return
                 state
                     .waker
-                    .broadcast(state.generation)
+                    .send(state.generation)
                     .expect("there is at least one receiver");
                 state.arrived = 0;
                 state.generation += 1;

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -358,7 +358,7 @@
 //!             // Receive the **initial** configuration value. As this is the
 //!             // first time the config is received from the watch, it will
 //!             // always complete immediatedly.
-//!             let mut conf = rx.recv().await.unwrap();
+//!             let mut conf = rx.recv().await;
 //!
 //!             let mut op_start = Instant::now();
 //!             let mut delay = time::delay_until(op_start + conf.timeout);
@@ -376,7 +376,7 @@
 //!                         delay = time::delay_until(op_start + conf.timeout);
 //!                     }
 //!                     new_conf = rx.recv() => {
-//!                         conf = new_conf.unwrap();
+//!                         conf = new_conf;
 //!
 //!                         // The configuration has been updated. Update the
 //!                         // `delay` using the new `timeout` value.

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -330,7 +330,7 @@
 //!             // If the configuration changed, send the new config value
 //!             // on the watch channel.
 //!             if new_config != config {
-//!                 tx.broadcast(new_config.clone()).unwrap();
+//!                 tx.send(new_config.clone()).unwrap();
 //!                 config = new_config;
 //!             }
 //!         }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -28,7 +28,7 @@
 //!         }
 //!     });
 //!
-//!     tx.broadcast("world")?;
+//!     tx.send("world")?;
 //! # Ok(())
 //! # }
 //! ```
@@ -167,7 +167,7 @@ const CLOSED: usize = 1;
 ///         }
 ///     });
 ///
-///     tx.broadcast("world")?;
+///     tx.send("world")?;
 /// # Ok(())
 /// # }
 /// ```
@@ -270,7 +270,7 @@ impl<T: Clone> Receiver<T> {
     ///     assert_eq!(v, "hello");
     ///
     ///     tokio::spawn(async move {
-    ///         tx.broadcast("goodbye").unwrap();
+    ///         tx.send("goodbye").unwrap();
     ///     });
     ///
     ///     // Waits for the new task to spawn and send the value.
@@ -320,8 +320,8 @@ impl<T> Drop for Receiver<T> {
 }
 
 impl<T> Sender<T> {
-    /// Broadcasts a new value via the channel, notifying all receivers.
-    pub fn broadcast(&self, value: T) -> Result<(), error::SendError<T>> {
+    /// Sends a new value via the channel, notifying all receivers.
+    pub fn send(&self, value: T) -> Result<(), error::SendError<T>> {
         let shared = match self.shared.upgrade() {
             Some(shared) => shared,
             // All `Watch` handles have been canceled

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -278,7 +278,7 @@ impl<T: Clone> Receiver<T> {
     ///     assert_eq!(v, "goodbye");
     ///
     ///     let v = rx.recv().await;
-    ///     assert_eq!(v, "goodbye"); //TODO(blas) check whether this is true.
+    ///     assert_eq!(v, "goodbye");
     /// }
     /// ```
     pub async fn recv(&mut self) -> T {

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -12,7 +12,7 @@ fn single_rx_recv() {
 
     {
         let mut t = spawn(rx.recv());
-        let v = assert_ready!(t.poll()).unwrap();
+        let v = assert_ready!(t.poll());
         assert_eq!(v, "one");
     }
 
@@ -25,7 +25,7 @@ fn single_rx_recv() {
 
         assert!(t.is_woken());
 
-        let v = assert_ready!(t.poll()).unwrap();
+        let v = assert_ready!(t.poll());
         assert_eq!(v, "two");
     }
 
@@ -37,7 +37,7 @@ fn single_rx_recv() {
         drop(tx);
 
         let res = assert_ready!(t.poll());
-        assert!(res.is_none());
+        assert_eq!(res, "two");
     }
 }
 
@@ -51,10 +51,10 @@ fn multi_rx() {
         let mut t2 = spawn(rx2.recv());
 
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "one");
+        assert_eq!(res, "one");
 
         let res = assert_ready!(t2.poll());
-        assert_eq!(res.unwrap(), "one");
+        assert_eq!(res, "one");
     }
 
     let mut t2 = spawn(rx2.recv());
@@ -71,7 +71,7 @@ fn multi_rx() {
         assert!(t2.is_woken());
 
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "two");
+        assert_eq!(res, "two");
     }
 
     {
@@ -85,10 +85,10 @@ fn multi_rx() {
         assert!(t2.is_woken());
 
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "three");
+        assert_eq!(res, "three");
 
         let res = assert_ready!(t2.poll());
-        assert_eq!(res.unwrap(), "three");
+        assert_eq!(res, "three");
     }
 
     drop(t2);
@@ -103,7 +103,7 @@ fn multi_rx() {
         tx.broadcast("four").unwrap();
 
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "four");
+        assert_eq!(res, "four");
         drop(t1);
 
         let mut t1 = spawn(rx1.recv());
@@ -113,15 +113,15 @@ fn multi_rx() {
 
         assert!(t1.is_woken());
         let res = assert_ready!(t1.poll());
-        assert!(res.is_none());
+        assert_eq!(res, "four");
 
         let res = assert_ready!(t2.poll());
-        assert_eq!(res.unwrap(), "four");
+        assert_eq!(res, "four");
 
         drop(t2);
         let mut t2 = spawn(rx2.recv());
         let res = assert_ready!(t2.poll());
-        assert!(res.is_none());
+        assert_eq!(res, "four");
     }
 }
 
@@ -135,13 +135,13 @@ fn rx_observes_final_value() {
     {
         let mut t1 = spawn(rx.recv());
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "one");
+        assert_eq!(res, "one");
     }
 
     {
         let mut t1 = spawn(rx.recv());
         let res = assert_ready!(t1.poll());
-        assert!(res.is_none());
+        assert_eq!(res, "one");
     }
 
     // Sending a value
@@ -153,7 +153,7 @@ fn rx_observes_final_value() {
     {
         let mut t1 = spawn(rx.recv());
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "two");
+        assert_eq!(res, "two");
     }
 
     {
@@ -166,13 +166,13 @@ fn rx_observes_final_value() {
         assert!(t1.is_woken());
 
         let res = assert_ready!(t1.poll());
-        assert_eq!(res.unwrap(), "three");
+        assert_eq!(res, "three");
     }
 
     {
         let mut t1 = spawn(rx.recv());
         let res = assert_ready!(t1.poll());
-        assert!(res.is_none());
+        assert_eq!(res, "three");
     }
 }
 
@@ -226,6 +226,6 @@ fn stream_impl() {
         drop(tx);
 
         let res = assert_ready!(t.poll());
-        assert!(res.is_none());
+        assert_eq!(res, Some("two"));
     }
 }

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -21,7 +21,7 @@ fn single_rx_recv() {
 
         assert_pending!(t.poll());
 
-        tx.broadcast("two").unwrap();
+        tx.send("two").unwrap();
 
         assert!(t.is_woken());
 
@@ -65,7 +65,7 @@ fn multi_rx() {
         assert_pending!(t1.poll());
         assert_pending!(t2.poll());
 
-        tx.broadcast("two").unwrap();
+        tx.send("two").unwrap();
 
         assert!(t1.is_woken());
         assert!(t2.is_woken());
@@ -79,7 +79,7 @@ fn multi_rx() {
 
         assert_pending!(t1.poll());
 
-        tx.broadcast("three").unwrap();
+        tx.send("three").unwrap();
 
         assert!(t1.is_woken());
         assert!(t2.is_woken());
@@ -100,7 +100,7 @@ fn multi_rx() {
         assert_pending!(t1.poll());
         assert_pending!(t2.poll());
 
-        tx.broadcast("four").unwrap();
+        tx.send("four").unwrap();
 
         let res = assert_ready!(t1.poll());
         assert_eq!(res, "four");
@@ -148,7 +148,7 @@ fn rx_observes_final_value() {
 
     let (tx, mut rx) = watch::channel("one");
 
-    tx.broadcast("two").unwrap();
+    tx.send("two").unwrap();
 
     {
         let mut t1 = spawn(rx.recv());
@@ -160,7 +160,7 @@ fn rx_observes_final_value() {
         let mut t1 = spawn(rx.recv());
         assert_pending!(t1.poll());
 
-        tx.broadcast("three").unwrap();
+        tx.send("three").unwrap();
         drop(tx);
 
         assert!(t1.is_woken());
@@ -190,7 +190,7 @@ fn poll_close() {
         assert_ready!(t.poll());
     }
 
-    assert!(tx.broadcast("two").is_err());
+    assert!(tx.send("two").is_err());
 }
 
 #[test]
@@ -210,7 +210,7 @@ fn stream_impl() {
 
         assert_pending!(t.poll());
 
-        tx.broadcast("two").unwrap();
+        tx.send("two").unwrap();
 
         assert!(t.is_woken());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Fixes: #2172
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
- rename broadcast() to send() for watch channel
- watch channel .recv() returns T
