### PR TITLE
docs: mpsc::bounded minimum buffer size

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -49,7 +49,8 @@ impl<T> fmt::Debug for Receiver<T> {
     }
 }
 
-/// Creates a bounded mpsc channel for communicating between asynchronous tasks.
+/// Creates a bounded mpsc channel for communicating between asynchronous tasks
+/// with backpressure.
 ///
 /// The channel will buffer up to the provided number of messages.  Once the
 /// buffer is full, attempts to `send` new messages will wait until a message is

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -52,6 +52,8 @@ impl<T> fmt::Debug for Receiver<T> {
 /// Creates a bounded mpsc channel for communicating between asynchronous tasks,
 /// returning the sender/receiver halves.
 ///
+/// The provided `buffer` size must be at least 1.
+///
 /// All data sent on `Sender` will become available on `Receiver` in the same
 /// order as it was sent.
 ///

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -49,10 +49,11 @@ impl<T> fmt::Debug for Receiver<T> {
     }
 }
 
-/// Creates a bounded mpsc channel for communicating between asynchronous tasks,
-/// returning the sender/receiver halves.
+/// Creates a bounded mpsc channel for communicating between asynchronous tasks.
 ///
-/// The provided `buffer` size must be at least 1.
+/// The channel will buffer up to the provided number of messages.  Once the
+/// buffer is full, attempts to `send` new messages will wait until a message is
+/// received from the channel. The provided buffer capacity must be at least 1.
 ///
 /// All data sent on `Sender` will become available on `Receiver` in the same
 /// order as it was sent.
@@ -63,6 +64,10 @@ impl<T> fmt::Debug for Receiver<T> {
 /// If the `Receiver` is disconnected while trying to `send`, the `send` method
 /// will return a `SendError`. Similarly, if `Sender` is disconnected while
 /// trying to `recv`, the `recv` method will return a `RecvError`.
+///
+/// # Panics
+///
+/// Panics if the buffer capacity is 0.
 ///
 /// # Examples
 ///

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -11,16 +11,17 @@
 //! This makes the [`UnboundedSender`] usable from both synchronous and
 //! asynchronous code.
 //!
-//! Similar to `std`, the channel constructor functions provide separate send
-//! and receive handles, [`Sender`] and [`Receiver`] for the bounded channel,
-//! [`UnboundedSender`] and [`UnboundedReceiver`] for the unbounded
-//! channel. [`Receiver`] and [`UnboundedReceiver`] both implement [`Stream`]
-//! and allow a task to read values out of the channel. If there is no message
-//! to read, the current task will be notified when a new value is
-//! sent. [`Sender`] and [`UnboundedSender`] allow sending values into the
-//! channel. If the bounded channel is at capacity, the send is rejected and the
-//! task will be notified when additional capacity is available. In other words,
-//! the channel provides backpressure.
+//! Similar to the `mpsc` channels provided in `std`, the channel constructor
+//! functions provide separate send and receive handles, [`Sender`] and
+//! [`Receiver`] for the bounded channel, [`UnboundedSender`] and
+//! [`UnboundedReceiver`] for the unbounded channel. [`Receiver`] and
+//! [`UnboundedReceiver`] both implement [`Stream`] and allow a task to read
+//! values out of the channel. If there is no message to read, the current task
+//! will be notified when a new value is sent. [`Sender`] and
+//! [`UnboundedSender`] allow sending values into the channel. If the bounded
+//! channel is at capacity, the send is rejected and the task will be notified
+//! when additional capacity is available. In other words, the channel provides
+//! backpressure.
 //!
 //!
 //! # Disconnection

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -1,22 +1,27 @@
 #![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
 
-//! A multi-producer, single-consumer queue for sending values across
+//! A multi-producer, single-consumer queue for sending values between
 //! asynchronous tasks.
-//!
-//! Similar to `std`, channel creation provides [`Receiver`] and [`Sender`]
-//! handles. [`Receiver`] implements `Stream` and allows a task to read values
-//! out of the channel. If there is no message to read, the current task will be
-//! notified when a new value is sent. If the channel is at capacity, the send
-//! is rejected and the task will be notified when additional capacity is
-//! available. In other words, the channel provides backpressure.
 //!
 //! This module provides two variants of the channel: bounded and unbounded. The
 //! bounded variant has a limit on the number of messages that the channel can
 //! store, and if this limit is reached, trying to send another message will
 //! wait until a message is received from the channel. An unbounded channel has
-//! an infinite capacity, so the `send` method never does any kind of sleeping.
+//! an infinite capacity, so the `send` method will always complete immediately.
 //! This makes the [`UnboundedSender`] usable from both synchronous and
 //! asynchronous code.
+//!
+//! Similar to `std`, the channel constructor functions provide separate send
+//! and receive handles, [`Sender`] and [`Receiver`] for the bounded channel,
+//! [`UnboundedSender`] and [`UnboundedReceiver`] for the unbounded
+//! channel. [`Receiver`] and [`UnboundedReceiver`] both implement [`Stream`]
+//! and allow a task to read values out of the channel. If there is no message
+//! to read, the current task will be notified when a new value is
+//! sent. [`Sender`] and [`UnboundedSender`] allow sending values into the
+//! channel. If the bounded channel is at capacity, the send is rejected and the
+//! task will be notified when additional capacity is available. In other words,
+//! the channel provides backpressure.
+//!
 //!
 //! # Disconnection
 //!
@@ -56,11 +61,13 @@
 //!
 //! [`Sender`]: crate::sync::mpsc::Sender
 //! [`Receiver`]: crate::sync::mpsc::Receiver
+//! [`Stream`]: crate::stream::Stream
 //! [bounded-send]: crate::sync::mpsc::Sender::send()
 //! [bounded-recv]: crate::sync::mpsc::Receiver::recv()
 //! [blocking-send]: crate::sync::mpsc::Sender::blocking_send()
 //! [blocking-recv]: crate::sync::mpsc::Receiver::blocking_recv()
 //! [`UnboundedSender`]: crate::sync::mpsc::UnboundedSender
+//! [`UnboundedReceiver`]: crate::sync::mpsc::UnboundedReceiver
 //! [`Handle::block_on`]: crate::runtime::Handle::block_on()
 //! [std-unbounded]: std::sync::mpsc::channel
 //! [crossbeam-unbounded]: https://docs.rs/crossbeam/*/crossbeam/channel/fn.unbounded.html

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -11,11 +11,11 @@
 //! This makes the [`UnboundedSender`] usable from both synchronous and
 //! asynchronous code.
 //!
-//! Similar to the `mpsc` channels provided in `std`, the channel constructor
+//! Similar to the `mpsc` channels provided by `std`, the channel constructor
 //! functions provide separate send and receive handles, [`Sender`] and
 //! [`Receiver`] for the bounded channel, [`UnboundedSender`] and
-//! [`UnboundedReceiver`] for the unbounded channel. [`Receiver`] and
-//! [`UnboundedReceiver`] both implement [`Stream`] and allow a task to read
+//! [`UnboundedReceiver`] for the unbounded channel. Both [`Receiver`] and
+//! [`UnboundedReceiver`] implement [`Stream`] and allow a task to read
 //! values out of the channel. If there is no message to read, the current task
 //! will be notified when a new value is sent. [`Sender`] and
 //! [`UnboundedSender`] allow sending values into the channel. If the bounded

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -47,7 +47,7 @@ impl<T> fmt::Debug for UnboundedReceiver<T> {
 }
 
 /// Creates an unbounded mpsc channel for communicating between asynchronous
-/// tasks.
+/// tasks without backpressure.
 ///
 /// A `send` on this channel will always succeed as long as the receive half has
 /// not been closed. If the receiver falls behind, messages will be arbitrarily


### PR DESCRIPTION
## Motivation

I was trying to implement an algorithm that depends on having minimal buffering using a bounded mpsc channel and was moved to find out whether a buffer size of zero was permissible. There is an assertion in the code, but it seems worthy of inclusion in the documentation as well.

## Solution

Added a note to the documentation on the minimum buffer size being 1.