### PR TITLE
runtime: add custom keep_alive functionality

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -94,10 +94,7 @@ where
 impl BlockingPool {
     pub(crate) fn new(builder: &Builder, thread_cap: usize) -> BlockingPool {
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
-        #[cfg(feature = "blocking")]
         let keep_alive = builder.keep_alive.unwrap_or(KEEP_ALIVE);
-        #[cfg(not(feature = "blocking"))]
-        let keep_alive = KEEP_ALIVE;
 
         BlockingPool {
             spawner: Spawner {

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -47,6 +47,9 @@ struct Inner {
 
     // Maximum number of threads
     thread_cap: usize,
+
+    // Customizable wait timeout
+    keep_alive: Duration,
 }
 
 struct Shared {
@@ -110,6 +113,7 @@ impl BlockingPool {
                     after_start: builder.after_start.clone(),
                     before_stop: builder.before_stop.clone(),
                     thread_cap,
+                    keep_alive: builder.keep_alive.unwrap_or(KEEP_ALIVE),
                 }),
             },
             shutdown_rx,
@@ -258,7 +262,7 @@ impl Inner {
             shared.num_idle += 1;
 
             while !shared.shutdown {
-                let lock_result = self.condvar.wait_timeout(shared, KEEP_ALIVE).unwrap();
+                let lock_result = self.condvar.wait_timeout(shared, self.keep_alive).unwrap();
 
                 shared = lock_result.0;
                 let timeout_result = lock_result.1;

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -94,7 +94,10 @@ where
 impl BlockingPool {
     pub(crate) fn new(builder: &Builder, thread_cap: usize) -> BlockingPool {
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
+        #[cfg(feature = "blocking")]
         let keep_alive = builder.keep_alive.unwrap_or(KEEP_ALIVE);
+        #[cfg(not(feature = "blocking"))]
+        let keep_alive = KEEP_ALIVE;
 
         BlockingPool {
             spawner: Spawner {

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -94,6 +94,10 @@ where
 impl BlockingPool {
     pub(crate) fn new(builder: &Builder, thread_cap: usize) -> BlockingPool {
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
+        #[cfg(feature = "blocking")]
+        let keep_alive = builder.keep_alive.unwrap_or(KEEP_ALIVE);
+        #[cfg(not(feature = "blocking"))]
+        let keep_alive = KEEP_ALIVE;
 
         BlockingPool {
             spawner: Spawner {
@@ -113,7 +117,7 @@ impl BlockingPool {
                     after_start: builder.after_start.clone(),
                     before_stop: builder.before_stop.clone(),
                     thread_cap,
-                    keep_alive: builder.keep_alive.unwrap_or(KEEP_ALIVE),
+                    keep_alive,
                 }),
             },
             shutdown_rx,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -4,7 +4,6 @@ use crate::runtime::shell::Shell;
 use crate::runtime::{blocking, io, time, Callback, Runtime, Spawner};
 
 use std::fmt;
-#[cfg(feature = "blocking")]
 use std::time::Duration;
 
 /// Builds Tokio Runtime with custom configuration values.

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -389,9 +389,9 @@ impl Builder {
     #[cfg(feature = "blocking")]
     #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
     /// Sets a custom timeout for a thread in the blocking pool.
-    /// By default, the timeout for a thread is constant and defined
-    /// in KEEP_ALIVE. In case the user wants to customize this
-    /// value, then they can use blocking_keep_alive() for it.
+    ///
+    /// By default, the timeout for a thread is set to 10 seconds. This can
+    /// be overriden usinng .blocking_keep_alive().
     ///
     /// # Example
     ///

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -4,6 +4,7 @@ use crate::runtime::shell::Shell;
 use crate::runtime::{blocking, io, time, Callback, Runtime, Spawner};
 
 use std::fmt;
+use std::time::Duration;
 
 /// Builds Tokio Runtime with custom configuration values.
 ///
@@ -65,6 +66,9 @@ pub struct Builder {
 
     /// To run before each worker thread stops
     pub(super) before_stop: Option<Callback>,
+
+    /// Customizable keep alive for BlockingPool
+    pub(super) keep_alive: Option<Duration>,
 }
 
 pub(crate) type ThreadNameFn = std::sync::Arc<dyn Fn() -> String + Send + Sync + 'static>;
@@ -108,6 +112,8 @@ impl Builder {
             // No worker thread callbacks
             after_start: None,
             before_stop: None,
+
+            keep_alive: None,
         }
     }
 
@@ -374,6 +380,26 @@ impl Builder {
             },
             blocking_pool,
         })
+    }
+
+    /// Sets a custom timeout for a thread in the `BlockingPool`.
+    ///
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use tokio::runtime;
+    /// # use std::time::Duration;
+    ///
+    /// # pub fn main() {
+    /// let rt = runtime::Builder::new()
+    ///     .keep_alive(Duration::from_millis(100))
+    ///     .build();
+    /// # }
+    /// ```
+    pub fn keep_alive(&mut self, duration: Duration) -> &mut Self {
+        self.keep_alive = Some(duration);
+        self
     }
 }
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -70,7 +70,7 @@ pub struct Builder {
 
     #[cfg(feature = "blocking")]
     #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
-    /// Customizable keep alive for BlockingPool
+    /// Customizable keep alive timeout for BlockingPool
     pub(super) keep_alive: Option<Duration>,
 }
 
@@ -391,7 +391,7 @@ impl Builder {
     /// Sets a custom timeout for a thread in the blocking pool.
     ///
     /// By default, the timeout for a thread is set to 10 seconds. This can
-    /// be overriden usinng .blocking_keep_alive().
+    /// be overriden using .blocking_keep_alive().
     ///
     /// # Example
     ///

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -68,8 +68,6 @@ pub struct Builder {
     /// To run before each worker thread stops
     pub(super) before_stop: Option<Callback>,
 
-    #[cfg(feature = "blocking")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
     /// Customizable keep alive timeout for BlockingPool
     pub(super) keep_alive: Option<Duration>,
 }
@@ -116,7 +114,6 @@ impl Builder {
             after_start: None,
             before_stop: None,
 
-            #[cfg(feature = "blocking")]
             keep_alive: None,
         }
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -391,7 +391,7 @@ impl Builder {
     /// Sets a custom timeout for a thread in the blocking pool.
     ///
     /// By default, the timeout for a thread is set to 10 seconds. This can
-    /// be overriden using .blocking_keep_alive().
+    /// be overriden using .thread_keep_alive().
     ///
     /// # Example
     ///
@@ -401,11 +401,11 @@ impl Builder {
     ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new()
-    ///     .blocking_keep_alive(Duration::from_millis(100))
+    ///     .thread_keep_alive(Duration::from_millis(100))
     ///     .build();
     /// # }
     /// ```
-    pub fn blocking_keep_alive(&mut self, duration: Duration) -> &mut Self {
+    pub fn thread_keep_alive(&mut self, duration: Duration) -> &mut Self {
         self.keep_alive = Some(duration);
         self
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -4,6 +4,7 @@ use crate::runtime::shell::Shell;
 use crate::runtime::{blocking, io, time, Callback, Runtime, Spawner};
 
 use std::fmt;
+#[cfg(feature = "blocking")]
 use std::time::Duration;
 
 /// Builds Tokio Runtime with custom configuration values.
@@ -67,6 +68,8 @@ pub struct Builder {
     /// To run before each worker thread stops
     pub(super) before_stop: Option<Callback>,
 
+    #[cfg(feature = "blocking")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
     /// Customizable keep alive for BlockingPool
     pub(super) keep_alive: Option<Duration>,
 }
@@ -113,6 +116,7 @@ impl Builder {
             after_start: None,
             before_stop: None,
 
+            #[cfg(feature = "blocking")]
             keep_alive: None,
         }
     }
@@ -382,8 +386,12 @@ impl Builder {
         })
     }
 
-    /// Sets a custom timeout for a thread in the `BlockingPool`.
-    ///
+    #[cfg(feature = "blocking")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
+    /// Sets a custom timeout for a thread in the blocking pool.
+    /// By default, the timeout for a thread is constant and defined
+    /// in KEEP_ALIVE. In case the user wants to customize this
+    /// value, then they can use blocking_keep_alive() for it.
     ///
     /// # Example
     ///
@@ -393,7 +401,7 @@ impl Builder {
     ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new()
-    ///     .keep_alive(Duration::from_millis(100))
+    ///     .blocking_keep_alive(Duration::from_millis(100))
     ///     .build();
     /// # }
     /// ```

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -397,7 +397,7 @@ impl Builder {
     ///     .build();
     /// # }
     /// ```
-    pub fn keep_alive(&mut self, duration: Duration) -> &mut Self {
+    pub fn blocking_keep_alive(&mut self, duration: Duration) -> &mut Self {
         self.keep_alive = Some(duration);
         self
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -68,6 +68,8 @@ pub struct Builder {
     /// To run before each worker thread stops
     pub(super) before_stop: Option<Callback>,
 
+    #[cfg(feature = "blocking")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blocking")))]
     /// Customizable keep alive timeout for BlockingPool
     pub(super) keep_alive: Option<Duration>,
 }
@@ -114,6 +116,7 @@ impl Builder {
             after_start: None,
             before_stop: None,
 
+            #[cfg(feature = "blocking")]
             keep_alive: None,
         }
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -4,6 +4,7 @@ use crate::runtime::shell::Shell;
 use crate::runtime::{blocking, io, time, Callback, Runtime, Spawner};
 
 use std::fmt;
+#[cfg(feature = "blocking")]
 use std::time::Duration;
 
 /// Builds Tokio Runtime with custom configuration values.


### PR DESCRIPTION
Adds a keep_alive attribute in the builder that can be
customized only for the BlockingPool

Fixes: #2585

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
