### PR TITLE
fs: remove `File::seek`

### DIFF
--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -152,7 +152,6 @@ async_assert_fn!(tokio::fs::DirEntry::file_type(_): Send & Sync);
 
 async_assert_fn!(tokio::fs::File::open(&str): Send & Sync);
 async_assert_fn!(tokio::fs::File::create(&str): Send & Sync);
-async_assert_fn!(tokio::fs::File::seek(_, std::io::SeekFrom): Send & Sync);
 async_assert_fn!(tokio::fs::File::sync_all(_): Send & Sync);
 async_assert_fn!(tokio::fs::File::sync_data(_): Send & Sync);
 async_assert_fn!(tokio::fs::File::set_len(_, u64): Send & Sync);


### PR DESCRIPTION
## Motivation
Since `File` implementes `AsyncSeek`, there is no need to expose a `seek` function
## Solution
Remove `File::seek`

Fixes: #1993

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>