### PR TITLE
Mention on JoinHandle that the generic parameter is the return type

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -76,16 +76,19 @@ doc_rt_core! {
     /// `Result<Result<i32, &str>, JoinError>`).
     ///
     /// ```
-    /// use tokio::task;
+    /// use std::io;
+    /// use tokio::task::JoinHandle;
     ///
-    /// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
-    /// let join_handle: task::JoinHandle<Result<i32, &str>> = task::spawn(async {
-    ///     Ok(5 + 3)
-    /// } );
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let join_handle: JoinHandle<Result<i32, &str>> = tokio::spawn(async {
+    ///         Ok(5 + 3)
+    ///     });
     ///
-    /// let result = join_handle.await??;
-    /// # Ok(())
-    /// # }
+    ///     let result = join_handle.await??;
+    ///     assert_eq!(result, 8);
+    ///     Ok(())
+    /// }
     /// ```
     ///
     /// Child being detached and outliving its parent:

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -17,8 +17,8 @@ doc_rt_core! {
     /// on it.
     ///
     /// This `struct` is created by the [`task::spawn`] and [`task::spawn_blocking`]
-    /// functions. The struct is parameterized over the return type of the spawned task (which is a
-    /// `Result<T, JoinError>`).
+    /// functions. The struct is parameterized over the return type of the spawned
+    /// task (which is a `Result<T, JoinError>`).
     ///
     /// # Examples
     ///
@@ -48,6 +48,7 @@ doc_rt_core! {
     ///
     /// Explicit JoinHandle<T> specification for a spawned task that does not return a value.
     /// This is parameterized over `()`:
+    ///
     /// ```
     /// use tokio::task;
     ///
@@ -59,6 +60,7 @@ doc_rt_core! {
     /// ```
     ///
     /// Explicit JoinHandle<T> specification for a spawned task that returns a value:
+    ///
     /// ```
     /// use tokio::task;
     ///
@@ -73,6 +75,7 @@ doc_rt_core! {
     /// Returning a `Result` from a spawned task. Note the double chaining of the `?`
     /// operator to match onto the `Ok` value (as, the return value is a
     /// `Result<Result<i32, &str>, JoinError>`).
+    ///
     /// ```
     /// use tokio::task;
     ///

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -46,8 +46,7 @@ doc_rt_core! {
     /// # }
     /// ```
     ///
-    /// Explicit JoinHandle<T> specification for a spawned task that does not return a value.
-    /// This is parameterized over `()`:
+    /// If a task has no return value, the join handle has type `JoinHandle<()>`.
     ///
     /// ```
     /// use tokio::task;

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -17,7 +17,8 @@ doc_rt_core! {
     /// on it.
     ///
     /// This `struct` is created by the [`task::spawn`] and [`task::spawn_blocking`]
-    /// functions.
+    /// functions. The struct is parameterized over the return type of the spawned task (which is a
+    /// `Result<T, JoinError>`).
     ///
     /// # Examples
     ///
@@ -42,6 +43,46 @@ doc_rt_core! {
     /// let join_handle: task::JoinHandle<_> = task::spawn_blocking(|| {
     ///     // some blocking work here
     /// });
+    /// # }
+    /// ```
+    ///
+    /// Explicit JoinHandle<T> specification for a spawned task that does not return a value.
+    /// This is parameterized over `()`:
+    /// ```
+    /// use tokio::task;
+    ///
+    /// # async fn doc() {
+    /// let join_handle: task::JoinHandle<()> = task::spawn(async {
+    ///     println!("I return nothing.")
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// Explicit JoinHandle<T> specification for a spawned task that returns a value:
+    /// ```
+    /// use tokio::task;
+    ///
+    /// # async fn doc() {
+    /// let join_handle: task::JoinHandle<i32> = task::spawn(async {
+    ///     5 + 3
+    /// });
+    /// # }
+    ///
+    /// ```
+    ///
+    /// Returning a `Result` from a spawned task. Note the double chaining of the `?`
+    /// operator to match onto the `Ok` value (as, the return value is a
+    /// `Result<Result<i32, &str>, JoinError>`).
+    /// ```
+    /// use tokio::task;
+    ///
+    /// # async fn doc() -> Result<(), Box<dyn std::error::Error>> {
+    /// let join_handle: task::JoinHandle<Result<i32, &str>> = task::spawn(async {
+    ///     Ok(5 + 3)
+    /// } );
+    ///
+    /// let result = join_handle.await??;
+    /// # Ok(())
     /// # }
     /// ```
     ///

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -91,7 +91,7 @@ doc_rt_core! {
     /// }
     /// ```
     ///
-    /// If the task panics, the error is a `JoinError` that contains the panic:
+    /// If the task panics, the error is a [`JoinError`] that contains the panic:
     ///
     /// ```
     /// use tokio::task;
@@ -140,6 +140,7 @@ doc_rt_core! {
     /// [`task::spawn`]: crate::task::spawn()
     /// [`task::spawn_blocking`]: crate::task::spawn_blocking
     /// [`std::thread::JoinHandle`]: std::thread::JoinHandle
+    /// [`JoinError`]: crate::task::JoinError
     pub struct JoinHandle<T> {
         raw: Option<RawTask>,
         _p: PhantomData<T>,

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -77,10 +77,11 @@ doc_rt_core! {
     ///
     /// ```
     /// use tokio::task;
+    /// use std::io;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let join_handle: task::JoinHandle<Result<i32, &str>> = tokio::spawn(async {
+    /// async fn main() -> io::Result<()> {
+    ///     let join_handle: task::JoinHandle<Result<i32, io::Error>> = tokio::spawn(async {
     ///         Ok(5 + 3)
     ///     });
     ///
@@ -94,11 +95,12 @@ doc_rt_core! {
     ///
     /// ```
     /// use tokio::task;
+    /// use std::io;
     /// use std::panic;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    ///     let join_handle: task::JoinHandle<_> = tokio::spawn(async {
+    /// async fn main() -> io::Result<()> {
+    ///     let join_handle: task::JoinHandle<Result<i32, io::Error>> = tokio::spawn(async {
     ///         panic!("boom");
     ///     });
     ///

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -53,7 +53,7 @@ doc_rt_core! {
     ///
     /// # async fn doc() {
     /// let join_handle: task::JoinHandle<()> = task::spawn(async {
-    ///     println!("I return nothing.")
+    ///     println!("I return nothing.");
     /// });
     /// # }
     /// ```


### PR DESCRIPTION
Added a note to `JoinHandle` docs to provide more context to the generic param `T`. 

Closes #2816.