### PR TITLE
Implement either type

### DIFF
--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -11,7 +11,7 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result}
 ///
 /// This type implements common asynchronous traits such as [`Future`] and those in Tokio.
 ///
-/// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
+/// [`Future`]: std::future::Future
 ///
 /// # Example
 ///

--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -11,6 +11,8 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result}
 ///
 /// This type implements common asynchronous traits such as [`Future`] and those in Tokio.
 ///
+/// [`Future`]: https://doc.rust-lang.org/std/future/trait.Future.html
+///
 /// # Example
 ///
 /// The following code will not work:

--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result}
 
 /// Combines two different futures, streams, or sinks having the same associated types into a single type.
 ///
-/// This type implements common asynchronous traits provided by `tokio`, and also `std::future::Future`.
+/// This type implements common asynchronous traits such as [`Future`] and those in Tokio.
 ///
 /// # Example
 ///
@@ -19,7 +19,6 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result}
 /// # fn some_condition() -> bool { true }
 /// # async fn some_async_function() -> u32 { 10 }
 /// # async fn other_async_function() -> u32 { 20 }
-///
 /// #[tokio::main]
 /// async fn main() {
 ///     let result = if some_condition() {
@@ -32,11 +31,12 @@ use tokio::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result}
 /// }
 /// ```
 ///
-/// This is because while output type for both futures is the same, the exact future types
-/// differ, and compiler is unable to choose appropriate type for the `result` variable.
+// This is because although the output types for both futures is the same, the exact future
+// types are different, but the compiler must be able to choose a single type for the
+// `result` variable.
 ///
-/// However, we can wrap these futures into `Either` (as long as the output type is the same)
-/// and then await for result without worrying about actual types lying behind these futures:
+/// When the output type is the same, we can wrap each future in `Either` to avoid the
+/// issue:
 ///
 /// ```
 /// use tokio_util::either::Either;
@@ -154,11 +154,10 @@ where
     }
 }
 
-#[cfg(feature = "codec")]
-impl<L, R> tokio::stream::Stream for Either<L, R>
+impl<L, R> futures_core::stream::Stream for Either<L, R>
 where
-    L: tokio::stream::Stream,
-    R: tokio::stream::Stream<Item = L::Item>,
+    L: futures_core::stream::Stream,
+    R: futures_core::stream::Stream<Item = L::Item>,
 {
     type Item = L::Item;
 
@@ -175,7 +174,6 @@ mod tests {
         stream::{once, Once, StreamExt},
     };
 
-    #[cfg(feature = "codec")]
     #[tokio::test]
     async fn either_is_stream() {
         let mut either: Either<Once<u32>, Once<u32>> = Either::Left(once(1));

--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -1,0 +1,170 @@
+//! Module defining an Either type.
+use std::{
+    future::Future,
+    io::SeekFrom,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use tokio::{
+    io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf, Result},
+    stream::Stream,
+};
+
+/// Combines two different futures, streams, or sinks having the same associated types into a single type.
+///
+/// This type implements common asynchronous traits provided by `tokio`, and also `std::future::Future`.
+///
+/// # Example
+///
+/// The following code will not work:
+///
+/// ```compile_fail
+/// # fn some_condition() -> bool { true }
+/// # async fn some_async_function() -> u32 { 10 }
+/// # async fn other_async_function() -> u32 { 20 }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let result = if some_condition() {
+///         some_async_function()
+///     } else {
+///         other_async_function() // <- Will print: "`if` and `else` have incompatible types"
+///     };
+///
+///     println!("Result is {}", result.await);
+/// }
+/// ```
+///
+/// This is because while output type for both futures is the same, the exact future types
+/// differ, and compiler is unable to choose appropriate type for the `result` variable.
+///
+/// However, we can wrap these futures into `Either` (as long as the output type is the same)
+/// and then await for result without worrying about actual types lying behind these futures:
+///
+/// ```
+/// use tokio_util::either::Either;
+/// # fn some_condition() -> bool { true }
+/// # async fn some_async_function() -> u32 { 10 }
+/// # async fn other_async_function() -> u32 { 20 }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let result = if some_condition() {
+///         Either::Left(some_async_function())
+///     } else {
+///         Either::Right(other_async_function())
+///     };
+///
+///     let value = result.await;
+///     println!("Result is {}", value);
+///     # assert_eq!(value, 10);
+/// }
+/// ```
+#[allow(missing_docs)] // Doc-comments for variants in this particular case don't make much sense.
+#[derive(Debug, Clone)]
+pub enum Either<L, R> {
+    Left(L),
+    Right(R),
+}
+
+/// A small helper macro which reduces amount of boilerplate in the actual trait method implementation.
+/// It takes an invokation of method as an argument (e.g. `self.poll(cx)`), and redirects it to either
+/// enum variant held in `self`.
+macro_rules! delegate_call {
+    ($self:ident.$method:ident($($args:ident),+)) => {
+        unsafe {
+            match $self.get_unchecked_mut() {
+                Self::Left(l) => Pin::new_unchecked(l).$method($($args),+),
+                Self::Right(r) => Pin::new_unchecked(r).$method($($args),+),
+            }
+        }
+    }
+}
+
+impl<L, R, O> Future for Either<L, R>
+where
+    L: Future<Output = O>,
+    R: Future<Output = O>,
+{
+    type Output = O;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        delegate_call!(self.poll(cx))
+    }
+}
+
+impl<L, R> AsyncRead for Either<L, R>
+where
+    L: AsyncRead,
+    R: AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<()>> {
+        delegate_call!(self.poll_read(cx, buf))
+    }
+}
+
+impl<L, R> AsyncBufRead for Either<L, R>
+where
+    L: AsyncBufRead,
+    R: AsyncBufRead,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+        delegate_call!(self.poll_fill_buf(cx))
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        delegate_call!(self.consume(amt))
+    }
+}
+
+impl<L, R> AsyncSeek for Either<L, R>
+where
+    L: AsyncSeek,
+    R: AsyncSeek,
+{
+    fn start_seek(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        position: SeekFrom,
+    ) -> Poll<Result<()>> {
+        delegate_call!(self.start_seek(cx, position))
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<u64>> {
+        delegate_call!(self.poll_complete(cx))
+    }
+}
+
+impl<L, R> AsyncWrite for Either<L, R>
+where
+    L: AsyncWrite,
+    R: AsyncWrite,
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        delegate_call!(self.poll_write(cx, buf))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<tokio::io::Result<()>> {
+        delegate_call!(self.poll_flush(cx))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<tokio::io::Result<()>> {
+        delegate_call!(self.poll_shutdown(cx))
+    }
+}
+
+impl<L, R> Stream for Either<L, R>
+where
+    L: Stream,
+    R: Stream<Item = L::Item>,
+{
+    type Item = L::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        delegate_call!(self.poll_next(cx))
+    }
+}

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -41,3 +41,5 @@ cfg_compat! {
 pub mod context;
 
 pub mod sync;
+
+pub mod either;


### PR DESCRIPTION
Resolves #1987

## Motivation

`Either` type is rather convenient and may be useful for the broad audience.

## Solution

Implementation is based on the existing third-party crate: [tokio-either](https://crates.io/crates/tokio-either).

A few more traits were implemented for `Either` type (`std::future::Future` among others), and also boiler-plate code was encapsulated into a single macro.
