### PR TITLE
sync: rename `Notify::notify()` -> `notify_one()`

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -19,20 +19,20 @@ type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
 /// another task to perform an operation.
 ///
 /// `Notify` can be thought of as a [`Semaphore`] starting with 0 permits.
-/// [`notified().await`] waits for a permit to become available, and [`notify()`]
+/// [`notified().await`] waits for a permit to become available, and [`notify_one()`]
 /// sets a permit **if there currently are no available permits**.
 ///
 /// The synchronization details of `Notify` are similar to
 /// [`thread::park`][park] and [`Thread::unpark`][unpark] from std. A [`Notify`]
 /// value contains a single permit. [`notified().await`] waits for the permit to
-/// be made available, consumes the permit, and resumes.  [`notify()`] sets the
+/// be made available, consumes the permit, and resumes.  [`notify_one()`] sets the
 /// permit, waking a pending task if there is one.
 ///
-/// If `notify()` is called **before** `notified().await`, then the next call to
+/// If `notify_one()` is called **before** `notified().await`, then the next call to
 /// `notified().await` will complete immediately, consuming the permit. Any
 /// subsequent calls to `notified().await` will wait for a new permit.
 ///
-/// If `notify()` is called **multiple** times before `notified().await`, only a
+/// If `notify_one()` is called **multiple** times before `notified().await`, only a
 /// **single** permit is stored. The next call to `notified().await` will
 /// complete immediately, but the one after will wait for a new permit.
 ///
@@ -55,7 +55,7 @@ type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
 ///     });
 ///
 ///     println!("sending notification");
-///     notify.notify();
+///     notify.notify_one();
 /// }
 /// ```
 ///
@@ -78,7 +78,7 @@ type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
 ///             .push_back(value);
 ///
 ///         // Notify the consumer a value is available
-///         self.notify.notify();
+///         self.notify.notify_one();
 ///     }
 ///
 ///     pub async fn recv(&self) -> T {
@@ -98,7 +98,7 @@ type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
 /// [park]: std::thread::park
 /// [unpark]: std::thread::Thread::unpark
 /// [`notified().await`]: Notify::notified()
-/// [`notify()`]: Notify::notify()
+/// [`notify_one()`]: Notify::notify_one()
 /// [`Semaphore`]: crate::sync::Semaphore
 #[derive(Debug)]
 pub struct Notify {
@@ -173,11 +173,11 @@ impl Notify {
     /// Wait for a notification.
     ///
     /// Each `Notify` value holds a single permit. If a permit is available from
-    /// an earlier call to [`notify()`], then `notified().await` will complete
+    /// an earlier call to [`notify_one()`], then `notified().await` will complete
     /// immediately, consuming that permit. Otherwise, `notified().await` waits
-    /// for a permit to be made available by the next call to `notify()`.
+    /// for a permit to be made available by the next call to `notify_one()`.
     ///
-    /// [`notify()`]: Notify::notify
+    /// [`notify_one()`]: Notify::notify_one
     ///
     /// # Examples
     ///
@@ -196,7 +196,7 @@ impl Notify {
     ///     });
     ///
     ///     println!("sending notification");
-    ///     notify.notify();
+    ///     notify.notify_one();
     /// }
     /// ```
     pub async fn notified(&self) {
@@ -218,10 +218,10 @@ impl Notify {
     /// If a task is currently waiting, that task is notified. Otherwise, a
     /// permit is stored in this `Notify` value and the **next** call to
     /// [`notified().await`] will complete immediately consuming the permit made
-    /// available by this call to `notify()`.
+    /// available by this call to `notify_one()`.
     ///
     /// At most one permit may be stored by `Notify`. Many sequential calls to
-    /// `notify` will result in a single permit being stored. The next call to
+    /// `notify_one` will result in a single permit being stored. The next call to
     /// `notified().await` will complete immediately, but the one after that
     /// will wait.
     ///
@@ -244,10 +244,10 @@ impl Notify {
     ///     });
     ///
     ///     println!("sending notification");
-    ///     notify.notify();
+    ///     notify.notify_one();
     /// }
     /// ```
-    pub fn notify(&self) {
+    pub fn notify_one(&self) {
         // Load the current state
         let mut curr = self.state.load(SeqCst);
 
@@ -490,7 +490,7 @@ impl Drop for Notified<'_> {
             // `Notify.state` may be in any of the three states (Empty, Waiting,
             // Notified). It doesn't actually matter what the atomic is set to
             // at this point. We hold the lock and will ensure the atomic is in
-            // the correct state once th elock is dropped.
+            // the correct state once the lock is dropped.
             //
             // Because the atomic state is not checked, at first glance, it may
             // seem like this routine does not handle the case where the

--- a/tokio/src/sync/tests/loom_notify.rs
+++ b/tokio/src/sync/tests/loom_notify.rs
@@ -16,7 +16,7 @@ fn notify_one() {
             });
         });
 
-        tx.notify();
+        tx.notify_one();
         th.join().unwrap();
     });
 }
@@ -34,12 +34,12 @@ fn notify_multi() {
             ths.push(thread::spawn(move || {
                 block_on(async {
                     notify.notified().await;
-                    notify.notify();
+                    notify.notify_one();
                 })
             }));
         }
 
-        notify.notify();
+        notify.notify_one();
 
         for th in ths.drain(..) {
             th.join().unwrap();
@@ -67,7 +67,7 @@ fn notify_drop() {
 
             block_on(poll_fn(|cx| {
                 if recv.as_mut().poll(cx).is_ready() {
-                    rx1.notify();
+                    rx1.notify_one();
                 }
                 Poll::Ready(())
             }));
@@ -77,12 +77,12 @@ fn notify_drop() {
             block_on(async {
                 rx2.notified().await;
                 // Trigger second notification
-                rx2.notify();
+                rx2.notify_one();
                 rx2.notified().await;
             });
         });
 
-        notify.notify();
+        notify.notify_one();
 
         th1.join().unwrap();
         th2.join().unwrap();

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -13,7 +13,7 @@ fn notify_notified_one() {
     let notify = Notify::new();
     let mut notified = spawn(async { notify.notified().await });
 
-    notify.notify();
+    notify.notify_one();
     assert_ready!(notified.poll());
 }
 
@@ -24,7 +24,7 @@ fn notified_one_notify() {
 
     assert_pending!(notified.poll());
 
-    notify.notify();
+    notify.notify_one();
     assert!(notified.is_woken());
     assert_ready!(notified.poll());
 }
@@ -38,7 +38,7 @@ fn notified_multi_notify() {
     assert_pending!(notified1.poll());
     assert_pending!(notified2.poll());
 
-    notify.notify();
+    notify.notify_one();
     assert!(notified1.is_woken());
     assert!(!notified2.is_woken());
 
@@ -50,7 +50,7 @@ fn notified_multi_notify() {
 fn notify_notified_multi() {
     let notify = Notify::new();
 
-    notify.notify();
+    notify.notify_one();
 
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -58,7 +58,7 @@ fn notify_notified_multi() {
     assert_ready!(notified1.poll());
     assert_pending!(notified2.poll());
 
-    notify.notify();
+    notify.notify_one();
 
     assert!(notified2.is_woken());
     assert_ready!(notified2.poll());
@@ -76,7 +76,7 @@ fn notified_drop_notified_notify() {
 
     assert_pending!(notified2.poll());
 
-    notify.notify();
+    notify.notify_one();
     assert!(notified2.is_woken());
     assert_ready!(notified2.poll());
 }
@@ -90,7 +90,7 @@ fn notified_multi_notify_drop_one() {
     assert_pending!(notified1.poll());
     assert_pending!(notified2.poll());
 
-    notify.notify();
+    notify.notify_one();
 
     assert!(notified1.is_woken());
     assert!(!notified2.is_woken());


### PR DESCRIPTION
closes https://github.com/tokio-rs/tokio/issues/2813
