### PR TITLE
Add simple hard cancellation

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -1,8 +1,6 @@
 //! An asynchronously awaitable `CancellationToken`.
 //! The token allows to signal a cancellation request to one or more tasks.
-mod wrapped;
-
-pub use wrapped::{Aborted, Wrapped};
+pub(crate) mod wrapped;
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Mutex;
@@ -284,8 +282,8 @@ impl CancellationToken {
     /// scenarios, which don't require asynchronous cleanup.
     /// If such cleanup is desired, you should take CancellationToken
     /// and manually monitor for cancellations.
-    pub fn wrap_future<F>(&self, fut: F) -> Wrapped<F> {
-        Wrapped {
+    pub fn wrap_future<F>(&self, fut: F) -> wrapped::Wrapped<F> {
+        wrapped::Wrapped {
             cancelled: self.clone().into_cancelled(),
             fut: Some(fut),
         }

--- a/tokio-util/src/sync/cancellation_token/wrapped.rs
+++ b/tokio-util/src/sync/cancellation_token/wrapped.rs
@@ -1,0 +1,61 @@
+//! Defines Wrapped future.
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Error returned when future was aborted
+#[derive(Debug)]
+pub struct Aborted(());
+
+impl std::fmt::Display for Aborted {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        "operation was aborted".fmt(f)
+    }
+}
+
+impl std::error::Error for Aborted {}
+pin_project! {
+    /// Future with lifetime is bound to a [`CancellationToken`].
+    /// When token is cancelled, on next poll this future will resolve with
+    /// Err([`Aborted`]),
+    /// and inner future will be dropped.
+    /// This future can be constructed using [`wrap_future`] method
+    /// on [`CancellationToken`]
+    ///
+    /// [`CancellationToken`]: crate::sync::CancellationToken
+    /// [`Aborted`]: crate::sync::Aborted
+    #[derive(Debug)]
+    pub struct Wrapped<F> {
+        #[pin]
+        pub(super) cancelled: super::WaitForCancellationFuture<'static>,
+        #[pin]
+        pub(super) fut: Option<F>,
+    }
+}
+
+impl<F> Future for Wrapped<F>
+where
+    F: Future,
+{
+    type Output = Result<F::Output, Aborted>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+        // if `fut` is None, then operation was cancelled long-long ago,
+        // i.e. before previous poll.
+        let fut = match this.fut.as_mut().as_pin_mut() {
+            Some(fut) => fut,
+            None => return Poll::Ready(Err(Aborted(()))),
+        };
+        if this.cancelled.poll(cx).is_ready() {
+            // cancellation was requested.
+            this.fut.set(None);
+            Poll::Ready(Err(Aborted(())))
+        } else {
+            // we are still allowed to work.
+            fut.poll(cx).map(Ok)
+        }
+    }
+}

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,6 +1,6 @@
 //! Synchronization primitives
 
 mod cancellation_token;
-pub use cancellation_token::{CancellationToken, WaitForCancellationFuture, Aborted, Wrapped};
+pub use cancellation_token::{Aborted, CancellationToken, WaitForCancellationFuture, Wrapped};
 
 mod intrusive_double_linked_list;

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,6 +1,9 @@
 //! Synchronization primitives
 
 mod cancellation_token;
-pub use cancellation_token::{Aborted, CancellationToken, WaitForCancellationFuture, Wrapped};
+pub use cancellation_token::{
+    wrapped::{Aborted, Wrapped},
+    CancellationToken, WaitForCancellationFuture,
+};
 
 mod intrusive_double_linked_list;

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,6 +1,6 @@
 //! Synchronization primitives
 
 mod cancellation_token;
-pub use cancellation_token::{CancellationToken, WaitForCancellationFuture};
+pub use cancellation_token::{CancellationToken, WaitForCancellationFuture, Aborted, Wrapped};
 
 mod intrusive_double_linked_list;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

For hard cancellation one typically uses `select!` + `oneshot`/`CancellationToken`. However `select` adds one more indent
level, and it creates some troubles for IDE (it is very hard to provide completion inside proc macro).

Alternatively, one can use `AbortHandle` from `futures-util`. However, since `AbortRegistration` is not `Clone`-able, user has
to manage e.g. `Vec<AbortHandle>` if they want to cancel multiple tasks.

That's why I propose implementing something similar to `Abortable` on top of `CancellationToken` (where token itself acts
as abort handle).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
(Better naming appreciated, of course).
This PR adds new `Wrapped` future adapter that can be roughly defined as 
`Wrapped(fut) := select(token.cancelled(), fut)`.
This adapter is constructed using `wrap_future` method of CancellationToken.

Additionally, I provided `into_cancelled` method on CancellationToken, which returns `'static` future.
`WaitForCancellationFuture` now stores Cow<'_, CancellationToken>. Unfortunately, it made it size 8 bytes larger.
It is possible avoid this memory usage loss, because both CancellationToken and &CancellationToken are non-null
aligned pointers. Therefore, we can use it's lower bit as an enum discriminant. However, it requires some unsafe code
(or using some `crates.io` dependency), so I'd like to see maintainers opinion.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
