### PR TITLE
Add const constructors to `RwLock`, `Notify`, and `Semaphore`.

### DIFF
--- a/tokio/src/loom/std/atomic_u16.rs
+++ b/tokio/src/loom/std/atomic_u16.rs
@@ -11,7 +11,7 @@ unsafe impl Send for AtomicU16 {}
 unsafe impl Sync for AtomicU16 {}
 
 impl AtomicU16 {
-    pub(crate) fn new(val: u16) -> AtomicU16 {
+    pub(crate) const fn new(val: u16) -> AtomicU16 {
         let inner = UnsafeCell::new(std::sync::atomic::AtomicU16::new(val));
         AtomicU16 { inner }
     }

--- a/tokio/src/loom/std/atomic_u32.rs
+++ b/tokio/src/loom/std/atomic_u32.rs
@@ -11,7 +11,7 @@ unsafe impl Send for AtomicU32 {}
 unsafe impl Sync for AtomicU32 {}
 
 impl AtomicU32 {
-    pub(crate) fn new(val: u32) -> AtomicU32 {
+    pub(crate) const fn new(val: u32) -> AtomicU32 {
         let inner = UnsafeCell::new(std::sync::atomic::AtomicU32::new(val));
         AtomicU32 { inner }
     }

--- a/tokio/src/loom/std/atomic_u8.rs
+++ b/tokio/src/loom/std/atomic_u8.rs
@@ -11,7 +11,7 @@ unsafe impl Send for AtomicU8 {}
 unsafe impl Sync for AtomicU8 {}
 
 impl AtomicU8 {
-    pub(crate) fn new(val: u8) -> AtomicU8 {
+    pub(crate) const fn new(val: u8) -> AtomicU8 {
         let inner = UnsafeCell::new(std::sync::atomic::AtomicU8::new(val));
         AtomicU8 { inner }
     }

--- a/tokio/src/loom/std/unsafe_cell.rs
+++ b/tokio/src/loom/std/unsafe_cell.rs
@@ -2,7 +2,7 @@
 pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
 
 impl<T> UnsafeCell<T> {
-    pub(crate) fn new(data: T) -> UnsafeCell<T> {
+    pub(crate) const fn new(data: T) -> UnsafeCell<T> {
         UnsafeCell(std::cell::UnsafeCell::new(data))
     }
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -170,6 +170,23 @@ impl Notify {
         }
     }
 
+    /// Create a new `Notify`, initialized without a permit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Notify;
+    ///
+    /// static NOTIFY: Notify = Notify::const_new();
+    /// ```
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    pub const fn const_new() -> Notify {
+        Notify {
+            state: AtomicU8::new(0),
+            waiters: Mutex::const_new(LinkedList::new()),
+        }
+    }
+
     /// Wait for a notification.
     ///
     /// Equivalent to:

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -180,6 +180,7 @@ impl Notify {
     /// static NOTIFY: Notify = Notify::const_new();
     /// ```
     #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
     pub const fn const_new() -> Notify {
         Notify {
             state: AtomicU8::new(0),

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -495,6 +495,7 @@ impl<T: ?Sized> RwLock<T> {
     /// static LOCK: RwLock<i32> = RwLock::const_new(5);
     /// ```
     #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
     pub const fn const_new(value: T) -> RwLock<T>
     where
         T: Sized,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -485,6 +485,26 @@ impl<T: ?Sized> RwLock<T> {
         }
     }
 
+    /// Creates a new instance of an `RwLock<T>` which is unlocked.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::RwLock;
+    ///
+    /// static LOCK: RwLock<i32> = RwLock::const_new(5);
+    /// ```
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    pub const fn const_new(value: T) -> RwLock<T>
+    where
+        T: Sized,
+    {
+        RwLock {
+            c: UnsafeCell::new(value),
+            s: Semaphore::const_new(MAX_READS),
+        }
+    }
+
     /// Locks this rwlock with shared read access, causing the current task
     /// to yield until the lock has been acquired.
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -76,6 +76,7 @@ impl Semaphore {
 
     /// Creates a new semaphore with the initial number of permits.
     #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
     pub const fn const_new(permits: usize) -> Self {
         Self {
             ll_sem: ll::Semaphore::const_new(permits),

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -74,6 +74,14 @@ impl Semaphore {
         }
     }
 
+    /// Creates a new semaphore with the initial number of permits.
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    pub const fn const_new(permits: usize) -> Self {
+        Self {
+            ll_sem: ll::Semaphore::const_new(permits),
+        }
+    }
+
     /// Returns the current number of available permits.
     pub fn available_permits(&self) -> usize {
         self.ll_sem.available_permits()


### PR DESCRIPTION
Referring to the types in `tokio::sync`.
Also add `const` to `new` for the remaining atomic integers in `src/loom` (except for 64bit which is impossible) and to `UnsafeCell`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation and Solution

Builds upon previous work in #2790.
Closes #2756.

This PR adds `const_new` to `sync::Notify`, `sync::RwLock`, and `sync::Semaphore`, in addition to the previously added one for `sync::Mutex` as they can all be reasonably be used in `static` variables and this saves the need for (and overhead of) something like `lazy_static` in the case that `parking_lot` already is used internally anyways.

Also, upon encountering the problem of missing `const` for `AtomicU8` in `src/loom` (used in `Notify`), I decided (also for consistency) to add `const` to all the constructors for the remaining types in that directory, whereas #2790 only added `const` to `new` for `AtomicUSize`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
