### PR TITLE
Add assert callback

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -47,7 +47,7 @@ pub struct Handle {
 }
 
 /// Builds `Mock` instances.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Builder {
     // Sequence of actions for the Mock to take
     actions: VecDeque<Action>,
@@ -76,7 +76,9 @@ struct Inner {
 impl Builder {
     /// Return a new, empty `Builder.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            actions: VecDeque::new(),
+        }
     }
 
     /// Sequence a `read` operation.

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -84,3 +84,17 @@ async fn mock_panics_write_data_left() {
     use tokio_test::io::Builder;
     Builder::new().write(b"write").build();
 }
+
+#[tokio::test]
+async fn write_with_failing_assert_callback() {
+    static mut CALLED: bool = false;
+
+    let mut mock = Builder::new()
+        .write(b"test")
+        .set_assert_callback(|_, _| unsafe { CALLED = true })
+        .build();
+
+    mock.write_all(b"test").await.expect("write 1");
+
+    assert!(unsafe { CALLED }, "assert_callback should be called");
+}


### PR DESCRIPTION
Adds an assert_callback to tokio-test Builder and Inner. 
  
## Motivation

Quality of life improvement. Copying and decoding byte slices on test failures is tedious.

## Solution

This callback will allow overriding the assert_eq! on the expected and actual u8 slices in actions (pretty_assert or decoding to human friendly strings).