### PR TITLE
doc: fix some typos

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -793,7 +793,7 @@ where
     /// This is useful for a flavor of "optimistic check" before deciding to
     /// await on a receiver.
     ///
-    /// Compared with [`recv`], this function has three failure cases instead of one
+    /// Compared with [`recv`], this function has three failure cases instead of two
     /// (one for closed, one for an empty buffer, one for a lagging receiver).
     ///
     /// `Err(TryRecvError::Closed)` is returned when all `Sender` halves have

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -20,7 +20,7 @@
 //! few flavors of channels provided by Tokio. Each channel flavor supports
 //! different message passing patterns. When a channel supports multiple
 //! producers, many separate tasks may **send** messages. When a channel
-//! supports muliple consumers, many different separate tasks may **receive**
+//! supports multiple consumers, many different separate tasks may **receive**
 //! messages.
 //!
 //! Tokio provides many different channel flavors as different message passing

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1,7 +1,7 @@
 use super::batch_semaphore as ll; // low level implementation
 use std::sync::Arc;
 
-/// Counting semaphore performing asynchronous permit aquisition.
+/// Counting semaphore performing asynchronous permit acquisition.
 ///
 /// A semaphore maintains a set of permits. Permits are used to synchronize
 /// access to a shared resource. A semaphore differs from a mutex in that it

--- a/tokio/src/sync/semaphore_ll.rs
+++ b/tokio/src/sync/semaphore_ll.rs
@@ -910,7 +910,7 @@ impl Waiter {
     }
 
     /// Try to decrement the number of permits to acquire. This returns the
-    /// actual number of permits that were decremented. The delta betweeen `n`
+    /// actual number of permits that were decremented. The delta between `n`
     /// and the return has been assigned to the permit and the caller must
     /// assign these back to the semaphore.
     fn try_dec_permits_to_acquire(&self, n: usize) -> usize {


### PR DESCRIPTION
Fixed some typos in sync module.

Fixes  #2781