### PR TITLE
sync: Remove readiness assertion in `watch::Receiver::changed()

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -105,6 +105,13 @@ pub struct Notify {
     state: AtomicU8,
     waiters: Mutex<WaitList>,
 }
+#[derive(Debug, Clone, Copy)]
+enum NotificationType {
+    // Notification trigerred by calling `notify_waiters`
+    AllWaiters,
+    // Notification trigerred by calling `notify_one`
+    OneWaiter,
+}
 
 #[derive(Debug)]
 struct Waiter {
@@ -115,7 +122,7 @@ struct Waiter {
     waker: Option<Waker>,
 
     /// `true` if the notification has been assigned to this waiter.
-    notified: bool,
+    notified: Option<NotificationType>,
 
     /// Should not be `Unpin`.
     _p: PhantomPinned,
@@ -230,7 +237,7 @@ impl Notify {
             waiter: UnsafeCell::new(Waiter {
                 pointers: linked_list::Pointers::new(),
                 waker: None,
-                notified: false,
+                notified: None,
                 _p: PhantomPinned,
             }),
         }
@@ -327,9 +334,9 @@ impl Notify {
             // Safety: `waiters` lock is still held.
             let waiter = unsafe { waiter.as_mut() };
 
-            assert!(!waiter.notified);
+            assert!(waiter.notified.is_none());
 
-            waiter.notified = true;
+            waiter.notified = Some(NotificationType::AllWaiters);
 
             if let Some(waker) = waiter.waker.take() {
                 waker.wake();
@@ -375,9 +382,9 @@ fn notify_locked(waiters: &mut WaitList, state: &AtomicU8, curr: u8) -> Option<W
                 // Safety: `waiters` lock is still held.
                 let waiter = unsafe { waiter.as_mut() };
 
-                assert!(!waiter.notified);
+                assert!(waiter.notified.is_none());
 
-                waiter.notified = true;
+                waiter.notified = Some(NotificationType::OneWaiter);
                 let waker = waiter.waker.take();
 
                 if waiters.is_empty() {
@@ -506,11 +513,11 @@ impl Future for Notified<'_> {
                     // Safety: called while locked
                     let w = unsafe { &mut *waiter.get() };
 
-                    if w.notified {
+                    if w.notified.is_some() {
                         // Our waker has been notified. Reset the fields and
                         // remove it from the list.
                         w.waker = None;
-                        w.notified = false;
+                        w.notified = None;
 
                         *state = Done;
                     } else {
@@ -583,13 +590,12 @@ impl Drop for Notified<'_> {
             }
 
             // See if the node was notified but not received. In this case, the
-            // notification must be sent to another waiter.
+            // notification must be sent to another waiter, only if it was
+            // triggered via `notify_one`
             //
             // Safety: with the entry removed from the linked list, there can be
             // no concurrent access to the entry
-            let notified = unsafe { (*waiter.get()).notified };
-
-            if notified {
+            if let Some(NotificationType::OneWaiter) = unsafe { (*waiter.get()).notified } {
                 if let Some(waker) = notify_locked(&mut waiters, &notify.state, notify_state) {
                     drop(waiters);
                     waker.wake();

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -105,11 +105,12 @@ pub struct Notify {
     state: AtomicU8,
     waiters: Mutex<WaitList>,
 }
+
 #[derive(Debug, Clone, Copy)]
 enum NotificationType {
-    // Notification trigerred by calling `notify_waiters`
+    // Notification triggered by calling `notify_waiters`
     AllWaiters,
-    // Notification trigerred by calling `notify_one`
+    // Notification triggered by calling `notify_one`
     OneWaiter,
 }
 
@@ -589,9 +590,9 @@ impl Drop for Notified<'_> {
                 notify.state.store(EMPTY, SeqCst);
             }
 
-            // See if the node was notified but not received. In this case, the
-            // notification must be sent to another waiter, only if it was
-            // triggered via `notify_one`
+            // See if the node was notified but not received. In this case, if
+            // the notification was triggered via `notify_one`, it must be sent
+            // to the next waiter.
             //
             // Safety: with the entry removed from the linked list, there can be
             // no concurrent access to the entry

--- a/tokio/src/sync/tests/loom_watch.rs
+++ b/tokio/src/sync/tests/loom_watch.rs
@@ -6,14 +6,30 @@ use loom::thread;
 #[test]
 fn smoke() {
     loom::model(|| {
-        let (tx, mut rx) = watch::channel(1);
+        let (tx, mut rx1) = watch::channel(1);
+        let mut rx2 = rx1.clone();
+        let mut rx3 = rx1.clone();
+        let mut rx4 = rx1.clone();
+        let mut rx5 = rx1.clone();
 
         let th = thread::spawn(move || {
             tx.send(2).unwrap();
         });
 
-        block_on(rx.changed()).unwrap();
-        assert_eq!(*rx.borrow(), 2);
+        block_on(rx1.changed()).unwrap();
+        assert_eq!(*rx1.borrow(), 2);
+
+        block_on(rx2.changed()).unwrap();
+        assert_eq!(*rx2.borrow(), 2);
+
+        block_on(rx3.changed()).unwrap();
+        assert_eq!(*rx3.borrow(), 2);
+
+        block_on(rx4.changed()).unwrap();
+        assert_eq!(*rx4.borrow(), 2);
+
+        block_on(rx5.changed()).unwrap();
+        assert_eq!(*rx5.borrow(), 2);
 
         th.join().unwrap();
     })

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -251,22 +251,14 @@ impl<T> Receiver<T> {
         let notified = self.shared.notify_rx.notified();
         pin!(notified);
 
-        // Polling the future here has dual purpose. The first one is to register
-        // the waiter so when `notify_waiters` is called it is notified. The second
-        // is to cover the case where another instance of `Notiified` has been dropped
-        // without receiving its notification. If that was the case polling the
-        // future for the first time will use this "lost" notification and return
-        // `Ready` immediatelly without registering any waiter
-        let aquired_lost_notification =
-            crate::future::poll_fn(|cx| match Pin::new(&mut notified).poll(cx) {
-                Poll::Ready(()) => Poll::Ready(true),
-                Poll::Pending => Poll::Ready(false),
-            })
-            .await;
-
-        if aquired_lost_notification {
-            return Ok(());
-        }
+        // Polling the future once is guaranteed to return `Pending` as `watch`
+        // only notifies using `notify_waiters`.
+        crate::future::poll_fn(|cx| {
+            let res = Pin::new(&mut notified).poll(cx);
+            assert!(!res.is_ready());
+            Poll::Ready(())
+        })
+        .await;
 
         if let Some(ret) = maybe_changed(&self.shared, &mut self.version) {
             return ret;


### PR DESCRIPTION
## Motivation

After chatting with @hawkw I decided to try and tackle #2800. They pointed me to a[ bit of code](https://github.com/tokio-rs/tokio/pull/2814#discussion_r483794400) that might be useful when learning about how the `Notify` type works. I decided to play with loom and see how it works by writing a few tests. Then came around a problem with the `Watch` type. The current loom smoke test for `Watch` exercises only one receiver. Changing the test to have more than one will result in a panic: 

```
running 1 test
test sync::tests::loom_watch::smoke ... thread 'main' panicked at 'assertion failed: !res.is_ready()', tokio/src/sync/watch.rs:258:13
stack backtrace:
   0: std::panicking::begin_panic
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:505
   1: tokio::sync::watch::Receiver<T>::changed::{{closure}}::{{closure}}
             at ./src/sync/watch.rs:258
   2: <tokio::future::poll_fn::PollFn<F> as core::future::future::Future>::poll
             at ./src/future/poll_fn.rs:36
   3: tokio::sync::watch::Receiver<T>::changed::{{closure}}
             at ./src/sync/watch.rs:256
   4: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:79
   5: loom::future::block_on
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/loom-0.3.5/src/future/mod.rs:34
   6: tokio::sync::tests::loom_watch::smoke::{{closure}}
             at ./src/sync/tests/loom_watch.rs:18
   7: loom::model::Builder::check::{{closure}}
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/loom-0.3.5/src/model.rs:198
   8: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227
   9: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1042
  10: loom::rt::scheduler::spawn_threads::{{closure}}::{{closure}}
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/loom-0.3.5/src/rt/scheduler.rs:140
  11: generator::gen_impl::GeneratorImpl<A,T>::init_code::{{closure}}
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/generator-0.6.21/src/gen_impl.rs:308
  12: generator::stack::StackBox<F>::call_once
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/generator-0.6.21/src/stack/mod.rs:135
  13: generator::stack::Func::call_once
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/generator-0.6.21/src/stack/mod.rs:117
  14: generator::gen_impl::gen_init::{{closure}}
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/generator-0.6.21/src/gen_impl.rs:513
  15: core::ops::function::FnOnce::call_once
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227
  16: std::panicking::try::do_call
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:381
  17: ___rust_try
  18: std::panicking::try
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:345
  19: std::panic::catch_unwind
             at /Users/zaharidichev/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:382
  20: generator::gen_impl::gen_init
             at /Users/zaharidichev/.cargo/registry/src/github.com-1ecc6299db9ec823/generator-0.6.21/src/gen_impl.rs:527
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
FAILED

failures:

failures:
    sync::tests::loom_watch::smoke

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 69 filtered out

error: test failed, to rerun pass '--lib'

```

This happens because in `watch::Receiver::changed` `Notified` was polled for the firt time to ensure that we register the waiter. The problem is that when there are more than one `Notified` instances tied to one `Notify`, it is possible for a `Notified` to be dropped without receiving its notification. If that happens this notification is left for another `Notified` instance to consume it. This means that it is not safe to assume that calling Notified::poll() for the first time shall always result in returning `Pending`, even if we are never calling `notify_one`.  

## Solution

We handle the case where polling the `Notified` future returns `Ready` right away.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>