### PR TITLE
sync: add `mpsc::Sender::closed` future

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -473,6 +473,7 @@ cfg_not_sync! {
     cfg_signal_internal! {
         pub(crate) mod mpsc;
         pub(crate) mod batch_semaphore;
+        pub(crate) mod notify;
     }
 }
 

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -473,7 +473,6 @@ cfg_not_sync! {
     cfg_signal_internal! {
         pub(crate) mod mpsc;
         pub(crate) mod batch_semaphore;
-        pub(crate) mod notify;
     }
 }
 

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -320,6 +320,41 @@ impl<T> Sender<T> {
         }
     }
 
+    /// Completes when the receiver has dropped.
+    ///
+    /// This allows the producers to get notified when interest in the produced
+    /// values is canceled and immediately stop doing work.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut tx1, rx) = mpsc::channel::<()>(1);
+    ///     let mut tx2 = tx1.clone();
+    ///     let mut tx3 = tx1.clone();
+    ///     let mut tx4 = tx1.clone();
+    ///     let mut tx5 = tx1.clone();
+    ///     tokio::spawn(async move {
+    ///         drop(rx);
+    ///     });
+    ///
+    ///     futures::join!(
+    ///         tx1.closed(),
+    ///         tx2.closed(),
+    ///         tx3.closed(),
+    ///         tx4.closed(),
+    ///         tx5.closed()
+    ///     );
+    ////     println!("Receiver dropped");
+    /// }
+    /// ```
+    pub async fn closed(&mut self) {
+        self.chan.closed().await
+    }
+
     /// Attempts to immediately send a message on this `Sender`
     ///
     /// This method differs from [`send`] by returning immediately if the channel's

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -136,6 +136,13 @@ impl<T, S> Tx<T, S> {
         self.inner.send(value);
     }
 
+    /// Wake the receive half
+    pub(crate) fn wake_rx(&self) {
+        self.inner.rx_waker.wake();
+    }
+}
+
+impl<T, S: Semaphore> Tx<T, S> {
     pub(crate) async fn closed(&mut self) {
         use std::future::Future;
         use std::pin::Pin;
@@ -161,11 +168,6 @@ impl<T, S> Tx<T, S> {
             return;
         }
         notified.await;
-    }
-
-    /// Wake the receive half
-    pub(crate) fn wake_rx(&self) {
-        self.inner.rx_waker.wake();
     }
 }
 

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -210,4 +210,39 @@ impl<T> UnboundedSender<T> {
             }
         }
     }
+
+    /// Completes when the receiver has dropped.
+    ///
+    /// This allows the producers to get notified when interest in the produced
+    /// values is canceled and immediately stop doing work.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (mut tx1, rx) = mpsc::unbounded_channel::<()>();
+    ///     let mut tx2 = tx1.clone();
+    ///     let mut tx3 = tx1.clone();
+    ///     let mut tx4 = tx1.clone();
+    ///     let mut tx5 = tx1.clone();
+    ///     tokio::spawn(async move {
+    ///         drop(rx);
+    ///     });
+    ///
+    ///     futures::join!(
+    ///         tx1.closed(),
+    ///         tx2.closed(),
+    ///         tx3.closed(),
+    ///         tx4.closed(),
+    ///         tx5.closed()
+    ///     );
+    ////     println!("Receiver dropped");
+    /// }
+    /// ```
+    pub async fn closed(&mut self) {
+        self.chan.closed().await
+    }
 }

--- a/tokio/src/sync/tests/loom_mpsc.rs
+++ b/tokio/src/sync/tests/loom_mpsc.rs
@@ -41,6 +41,34 @@ fn closing_unbounded_tx() {
 }
 
 #[test]
+fn closing_bounded_rx() {
+    loom::model(|| {
+        let (mut tx1, rx) = mpsc::channel::<()>(16);
+        let mut tx2 = tx1.clone();
+        thread::spawn(move || {
+            drop(rx);
+        });
+
+        block_on(tx1.closed());
+        block_on(tx2.closed());
+    });
+}
+
+#[test]
+fn closing_unbounded_rx() {
+    loom::model(|| {
+        let (mut tx1, rx) = mpsc::unbounded_channel::<()>();
+        let mut tx2 = tx1.clone();
+        thread::spawn(move || {
+            drop(rx);
+        });
+
+        block_on(tx1.closed());
+        block_on(tx2.closed());
+    });
+}
+
+#[test]
 fn dropping_tx() {
     loom::model(|| {
         let (tx, mut rx) = mpsc::channel::<()>(16);


### PR DESCRIPTION
## Motivation
Adding closed future, makes it possible to select over closed and some other work, so that the task is woken when the channel is closed and can proactively cancel itself.

## Solution
Added a mpsc::Sender::closed future that will become ready when the receiver is closed
