### PR TITLE
io: fix doc-cfg on AsyncSeekExt

### DIFF
--- a/tokio/src/io/seek.rs
+++ b/tokio/src/io/seek.rs
@@ -4,12 +4,14 @@ use std::io::{self, SeekFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-/// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct Seek<'a, S: ?Sized> {
-    seek: &'a mut S,
-    pos: Option<SeekFrom>,
+cfg_io_util! {
+    /// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct Seek<'a, S: ?Sized> {
+        seek: &'a mut S,
+        pos: Option<SeekFrom>,
+    }
 }
 
 pub(crate) fn seek<S>(seek: &mut S, pos: SeekFrom) -> Seek<'_, S>

--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -2,65 +2,67 @@ use crate::io::seek::{seek, Seek};
 use crate::io::AsyncSeek;
 use std::io::SeekFrom;
 
-/// An extension trait which adds utility methods to [`AsyncSeek`] types.
-///
-/// As a convenience, this trait may be imported using the [`prelude`]:
-///
-/// # Examples
-///
-/// ```
-/// use std::io::{Cursor, SeekFrom};
-/// use tokio::prelude::*;
-///
-/// #[tokio::main]
-/// async fn main() -> io::Result<()> {
-///     let mut cursor = Cursor::new(b"abcdefg");
-///
-///     // the `seek` method is defined by this trait
-///     cursor.seek(SeekFrom::Start(3)).await?;
-///
-///     let mut buf = [0; 1];
-///     let n = cursor.read(&mut buf).await?;
-///     assert_eq!(n, 1);
-///     assert_eq!(buf, [b'd']);
-///
-///     Ok(())
-/// }
-/// ```
-///
-/// See [module][crate::io] documentation for more details.
-///
-/// [`AsyncSeek`]: AsyncSeek
-/// [`prelude`]: crate::prelude
-pub trait AsyncSeekExt: AsyncSeek {
-    /// Creates a future which will seek an IO object, and then yield the
-    /// new position in the object and the object itself.
+cfg_io_util! {
+    /// An extension trait which adds utility methods to [`AsyncSeek`] types.
     ///
-    /// In the case of an error the buffer and the object will be discarded, with
-    /// the error yielded.
+    /// As a convenience, this trait may be imported using the [`prelude`]:
     ///
     /// # Examples
     ///
-    /// ```no_run
-    /// use tokio::fs::File;
+    /// ```
+    /// use std::io::{Cursor, SeekFrom};
     /// use tokio::prelude::*;
     ///
-    /// use std::io::SeekFrom;
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let mut cursor = Cursor::new(b"abcdefg");
     ///
-    /// # async fn dox() -> std::io::Result<()> {
-    /// let mut file = File::open("foo.txt").await?;
-    /// file.seek(SeekFrom::Start(6)).await?;
+    ///     // the `seek` method is defined by this trait
+    ///     cursor.seek(SeekFrom::Start(3)).await?;
     ///
-    /// let mut contents = vec![0u8; 10];
-    /// file.read_exact(&mut contents).await?;
-    /// # Ok(())
-    /// # }
+    ///     let mut buf = [0; 1];
+    ///     let n = cursor.read(&mut buf).await?;
+    ///     assert_eq!(n, 1);
+    ///     assert_eq!(buf, [b'd']);
+    ///
+    ///     Ok(())
+    /// }
     /// ```
-    fn seek(&mut self, pos: SeekFrom) -> Seek<'_, Self>
-    where
-        Self: Unpin,
-    {
-        seek(self, pos)
+    ///
+    /// See [module][crate::io] documentation for more details.
+    ///
+    /// [`AsyncSeek`]: AsyncSeek
+    /// [`prelude`]: crate::prelude
+    pub trait AsyncSeekExt: AsyncSeek {
+        /// Creates a future which will seek an IO object, and then yield the
+        /// new position in the object and the object itself.
+        ///
+        /// In the case of an error the buffer and the object will be discarded, with
+        /// the error yielded.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::fs::File;
+        /// use tokio::prelude::*;
+        ///
+        /// use std::io::SeekFrom;
+        ///
+        /// # async fn dox() -> std::io::Result<()> {
+        /// let mut file = File::open("foo.txt").await?;
+        /// file.seek(SeekFrom::Start(6)).await?;
+        ///
+        /// let mut contents = vec![0u8; 10];
+        /// file.read_exact(&mut contents).await?;
+        /// # Ok(())
+        /// # }
+        /// ```
+        fn seek(&mut self, pos: SeekFrom) -> Seek<'_, Self>
+        where
+            Self: Unpin,
+        {
+            seek(self, pos)
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

[`AsyncSeekExt` requires `io-util` feature](https://github.com/tokio-rs/tokio/blob/207320dbbbacb4e7c8c12f6e94f5e78eb0f055a5/tokio/src/io/mod.rs#L227-L239
), but [doesn't display on docs](https://docs.rs/tokio/0.2.22/tokio/io/index.html#traits).


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
