### PR TITLE
ci: deny warnings on '--cfg tokio_unstable' tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         run: cargo test --features full
         working-directory: tokio
         env:
-          RUSTFLAGS: '--cfg tokio_unstable'
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
   miri:
     name: miri
@@ -156,7 +156,7 @@ jobs:
       - name: check --each-feature --unstable
         run: cargo hack check --all --each-feature -Z avoid-dev-deps
         env:
-          RUSTFLAGS: --cfg tokio_unstable
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
   minrust:
     name: minrust
@@ -239,6 +239,6 @@ jobs:
         run: cargo test --lib --release --features full -- --nocapture $SCOPE
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg loom --cfg tokio_unstable
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
           LOOM_MAX_PREEMPTIONS: 2
           SCOPE: ${{ matrix.scope }}

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,4 +1,4 @@
-use crate::loom::sync::{Arc, Mutex};
+use crate::loom::sync::Mutex;
 use crate::runtime::handle::Handle;
 use crate::runtime::shell::Shell;
 use crate::runtime::{blocking, io, time, Callback, Runtime, Spawner};
@@ -330,7 +330,7 @@ impl Builder {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        self.before_stop = Some(Arc::new(f));
+        self.before_stop = Some(std::sync::Arc::new(f));
         self
     }
 

--- a/tokio/src/runtime/tests/loom_pool.rs
+++ b/tokio/src/runtime/tests/loom_pool.rs
@@ -209,7 +209,7 @@ mod group_b {
     #[test]
     fn complete_block_on_under_load() {
         loom::model(|| {
-            let mut pool = mk_pool(1);
+            let pool = mk_pool(1);
 
             pool.block_on(async {
                 // Trigger a re-schedule

--- a/tokio/src/util/bit.rs
+++ b/tokio/src/util/bit.rs
@@ -22,12 +22,6 @@ impl Pack {
         Pack { mask, shift }
     }
 
-    /// Mask used to unpack value
-    #[cfg(all(test, loom))]
-    pub(crate) const fn mask(&self) -> usize {
-        self.mask
-    }
-
     /// Width, in bits, dedicated to storing the value.
     pub(crate) const fn width(&self) -> u32 {
         pointer_width() - (self.mask >> self.shift).leading_zeros()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
https://github.com/tokio-rs/tokio/pull/2858#discussion_r492979753
Seems `RUSTFLAGS: --cfg tokio_unstable` overwriting global `RUSTFLAGS`.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
