### PR TITLE
process: do not publicly turn on `signal` when enabled

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -59,10 +59,11 @@ macros = ["tokio-macros"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
   "io-driver",
+  "lazy_static",
   "libc",
   "mio-named-pipes",
-  "signal",
-  "winapi/consoleapi",
+  "mio-uds",
+  "signal-hook-registry",
   "winapi/threadpoollegacyapiset",
 ]
 # Includes basic task execution capabilities

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -372,6 +372,13 @@ cfg_signal! {
     pub mod signal;
 }
 
+cfg_signal_internal! {
+    #[cfg(not(feature = "signal"))]
+    #[allow(dead_code)]
+    #[allow(unreachable_pub)]
+    pub(crate) mod signal;
+}
+
 cfg_stream! {
     pub mod stream;
 }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -223,6 +223,25 @@ macro_rules! cfg_signal {
     }
 }
 
+macro_rules! cfg_signal_internal {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(feature = "signal", all(unix, feature = "process")))]
+            #[cfg(not(loom))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_signal_internal {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(loom, not(unix), not(any(feature = "signal", all(unix, feature = "process")))))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_stream {
     ($($item:item)*) => {
         $(

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -22,7 +22,7 @@ cfg_io_driver! {
     }
 }
 
-cfg_signal! {
+cfg_signal_internal! {
     #[cfg(unix)]
     pub(crate) fn signal_handle() -> crate::runtime::driver::SignalHandle {
         CONTEXT.with(|ctx| match *ctx.borrow() {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -38,26 +38,14 @@ cfg_not_io_driver! {
 }
 
 // ===== signal driver =====
-
-macro_rules! cfg_unix_and_signal {
+macro_rules! cfg_signal_internal_and_unix {
     ($($item:item)*) => {
-        $(
-            #[cfg(all(not(loom), unix, feature = "signal"))]
-            $item
-        )*
+        #[cfg(unix)]
+        cfg_signal_internal! { $($item)* }
     }
 }
 
-macro_rules! cfg_neither_unix_nor_windows {
-    ($($item:item)*) => {
-        $(
-            #[cfg(any(loom, not(all(unix, feature = "signal"))))]
-            $item
-        )*
-    }
-}
-
-cfg_unix_and_signal! {
+cfg_signal_internal_and_unix! {
     type SignalDriver = crate::park::Either<crate::signal::unix::driver::Driver, IoDriver>;
     pub(crate) type SignalHandle = Option<crate::signal::unix::driver::Handle>;
 
@@ -76,7 +64,7 @@ cfg_unix_and_signal! {
     }
 }
 
-cfg_neither_unix_nor_windows! {
+cfg_not_signal_internal! {
     type SignalDriver = IoDriver;
     pub(crate) type SignalHandle = ();
 

--- a/tokio/src/signal/windows.rs
+++ b/tokio/src/signal/windows.rs
@@ -14,9 +14,9 @@ use std::convert::TryFrom;
 use std::io;
 use std::sync::Once;
 use std::task::{Context, Poll};
-use winapi::shared::minwindef::*;
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
 use winapi::um::consoleapi::SetConsoleCtrlHandler;
-use winapi::um::wincon::*;
+use winapi::um::wincon::{CTRL_BREAK_EVENT, CTRL_C_EVENT};
 
 #[derive(Debug)]
 pub(crate) struct OsStorage {

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -475,7 +475,7 @@ cfg_not_sync! {
             feature = "signal"))]
     pub(crate) mod oneshot;
 
-    cfg_signal! {
+    cfg_signal_internal! {
         pub(crate) mod mpsc;
         pub(crate) mod semaphore_ll;
     }


### PR DESCRIPTION
* This change will still internally compile any `signal` resources
  required when `process` is enabled on unix systems, but it will not
  publicly turn on the cargo feature

Fixes #2862 