### PR TITLE
docs: use #[doc(no_inline)] on re-exports

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -201,6 +201,7 @@ pub use self::read_buf::ReadBuf;
 
 // Re-export some types from `std::io` so that users don't have to deal
 // with conflicts when `use`ing `tokio::io` and `std::io`.
+#[doc(no_inline)]
 pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 
 cfg_io_driver! {

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -125,6 +125,7 @@ cfg_time! {
     use crate::stream::throttle::{throttle, Throttle};
 }
 
+#[doc(no_inline)]
 pub use futures_core::Stream;
 
 /// An extension trait for `Stream`s that provides a variety of convenient

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -125,6 +125,7 @@ mod wheel;
 mod tests;
 
 // Re-export for convenience
+#[doc(no_inline)]
 pub use std::time::Duration;
 
 // ===== Internal utils =====


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Probably easier to understand. #2873 

before: https://docs.rs/tokio/0.2.22/tokio/io/index.html#structs

after: 
![tokio-doc1](https://user-images.githubusercontent.com/43724913/94147321-1a781d00-feb0-11ea-8599-7045c6ce5852.png)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
