### PR TITLE
chore: remove internal io-readiness cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,11 +150,11 @@ jobs:
         run: cargo install cargo-hack
 
       - name: check --each-feature
-        run: cargo hack check --all --each-feature --skip io-driver,io-readiness -Z avoid-dev-deps
+        run: cargo hack check --all --each-feature --skip io-driver -Z avoid-dev-deps
 
       # Try with unstable feature flags
       - name: check --each-feature --unstable
-        run: cargo hack check --all --each-feature --skip io-driver,io-readiness -Z avoid-dev-deps
+        run: cargo hack check --all --each-feature --skip io-driver -Z avoid-dev-deps
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -51,7 +51,6 @@ blocking = ["rt-core"]
 dns = ["rt-core"]
 fs = ["rt-core", "io-util"]
 io-driver = ["mio", "lazy_static"] # internal only
-io-readiness = [] # internal only
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
@@ -86,8 +85,8 @@ sync = ["fnv"]
 test-util = []
 tcp = ["io-driver", "iovec"]
 time = ["slab"]
-udp = ["io-driver", "io-readiness"]
-uds = ["io-driver", "io-readiness", "mio-uds", "libc"]
+udp = ["io-driver"]
+uds = ["io-driver", "mio-uds", "libc"]
 
 [dependencies]
 tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -26,12 +26,13 @@ pub(crate) struct ScheduledIo {
     waiters: Mutex<Waiters>,
 }
 
-#[cfg(feature = "io-readiness")]
-type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
+cfg_io_readiness! {
+    type WaitList = LinkedList<Waiter, <Waiter as linked_list::Link>::Target>;
+}
 
 #[derive(Debug, Default)]
 struct Waiters {
-    #[cfg(feature = "io-readiness")]
+    #[cfg(any(feature = "udp", feature = "uds"))]
     /// List of all current waiters
     list: WaitList,
 
@@ -208,7 +209,7 @@ impl ScheduledIo {
             }
         }
 
-        #[cfg(feature = "io-readiness")]
+        #[cfg(any(feature = "udp", feature = "uds"))]
         {
             // check list of waiters
             for waiter in waiters

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -146,7 +146,7 @@ macro_rules! cfg_not_io_driver {
 macro_rules! cfg_io_readiness {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "io-readiness")]
+            #[cfg(any(feature = "udp", feature = "uds"))]
             $item
         )*
     }


### PR DESCRIPTION
Starts the work of removing our "internal" build flags from being public to Cargo.

Refs #2869 
