### PR TITLE
chore: remove internal io-driver cargo feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,11 +150,11 @@ jobs:
         run: cargo install cargo-hack
 
       - name: check --each-feature
-        run: cargo hack check --all --each-feature --skip io-driver -Z avoid-dev-deps
+        run: cargo hack check --all --each-feature -Z avoid-dev-deps
 
       # Try with unstable feature flags
       - name: check --each-feature --unstable
-        run: cargo hack check --all --each-feature --skip io-driver -Z avoid-dev-deps
+        run: cargo hack check --all --each-feature -Z avoid-dev-deps
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -50,16 +50,15 @@ full = [
 blocking = ["rt-core"]
 dns = ["rt-core"]
 fs = ["rt-core", "io-util"]
-io-driver = ["mio", "lazy_static"] # internal only
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = ["rt-core"]
 macros = ["tokio-macros"]
 net = ["dns", "tcp", "udp", "uds"]
 process = [
-  "io-driver",
   "lazy_static",
   "libc",
+  "mio",
   "mio-named-pipes",
   "mio-uds",
   "signal-hook-registry",
@@ -73,9 +72,9 @@ rt-threaded = [
   "rt-core",
 ]
 signal = [
-  "io-driver",
   "lazy_static",
   "libc",
+  "mio",
   "mio-uds",
   "signal-hook-registry",
   "winapi/consoleapi",
@@ -83,10 +82,10 @@ signal = [
 stream = ["futures-core"]
 sync = ["fnv"]
 test-util = []
-tcp = ["io-driver", "iovec"]
+tcp = ["iovec", "lazy_static", "mio"]
 time = ["slab"]
-udp = ["io-driver"]
-uds = ["io-driver", "mio-uds", "libc"]
+udp = ["lazy_static", "mio"]
+uds = ["lazy_static", "libc", "mio", "mio-uds"]
 
 [dependencies]
 tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -14,7 +14,14 @@ pub(crate) mod cell {
     pub(crate) use super::unsafe_cell::UnsafeCell;
 }
 
-#[cfg(any(feature = "sync", feature = "io-driver"))]
+#[cfg(any(
+    feature = "process",
+    feature = "signal",
+    feature = "sync",
+    feature = "tcp",
+    feature = "udp",
+    feature = "uds",
+))]
 pub(crate) mod future {
     pub(crate) use crate::sync::AtomicWaker;
 }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -3,7 +3,14 @@
 macro_rules! cfg_resource_drivers {
     ($($item:item)*) => {
         $(
-            #[cfg(any(feature = "io-driver", feature = "time"))]
+            #[cfg(any(
+                feature = "process",
+                all(unix, feature = "signal"),
+                all(not(loom), feature = "tcp"),
+                feature = "time",
+                all(not(loom), feature = "udp"),
+                all(not(loom), feature = "uds"),
+            ))]
             $item
         )*
     }
@@ -89,9 +96,13 @@ macro_rules! cfg_atomic_waker_impl {
     ($($item:item)*) => {
         $(
             #[cfg(any(
-                feature = "io-driver",
+                feature = "process",
+                all(feature = "rt-core", feature = "rt-util"),
+                feature = "signal",
+                feature = "tcp",
                 feature = "time",
-                all(feature = "rt-core", feature = "rt-util")
+                feature = "udp",
+                feature = "uds",
             ))]
             #[cfg(not(loom))]
             $item
@@ -128,7 +139,20 @@ macro_rules! cfg_io_blocking {
 macro_rules! cfg_io_driver {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "io-driver")]
+            #[cfg(any(
+                feature = "process",
+                all(unix, feature = "signal"),
+                feature = "tcp",
+                feature = "udp",
+                feature = "uds",
+            ))]
+            #[cfg_attr(docsrs, doc(cfg(any(
+                feature = "process",
+                all(unix, feature = "signal"),
+                feature = "tcp",
+                feature = "udp",
+                feature = "uds",
+            ))))]
             $item
         )*
     }
@@ -137,7 +161,13 @@ macro_rules! cfg_io_driver {
 macro_rules! cfg_not_io_driver {
     ($($item:item)*) => {
         $(
-            #[cfg(not(feature = "io-driver"))]
+            #[cfg(not(any(
+                feature = "process",
+                all(unix, feature = "signal"),
+                feature = "tcp",
+                feature = "udp",
+                feature = "uds",
+            )))]
             $item
         )*
     }
@@ -407,13 +437,16 @@ macro_rules! cfg_coop {
                     feature = "blocking",
                     feature = "dns",
                     feature = "fs",
-                    feature = "io-driver",
                     feature = "io-std",
                     feature = "process",
                     feature = "rt-core",
+                    feature = "signal",
                     feature = "sync",
                     feature = "stream",
-                    feature = "time"
+                    feature = "tcp",
+                    feature = "time",
+                    feature = "udp",
+                    feature = "uds",
                     ))]
             $item
         )*

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -138,7 +138,13 @@ impl Builder {
     ///     .unwrap();
     /// ```
     pub fn enable_all(&mut self) -> &mut Self {
-        #[cfg(feature = "io-driver")]
+        #[cfg(any(
+            feature = "process",
+            all(unix, feature = "signal"),
+            feature = "tcp",
+            feature = "udp",
+            feature = "uds",
+        ))]
         self.enable_io();
         #[cfg(feature = "time")]
         self.enable_time();


### PR DESCRIPTION
Completes the work of removing our "internal" build flags from being public to Cargo.

Fixes #2869