### PR TITLE
docs: More docs for UdpSocket

### DIFF
--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -30,45 +30,45 @@ cfg_udp! {
     ///
     /// Using `bind` we can create a simple echo server that sends and recv's with many different clients:
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    ///    use std::io;
+    /// use tokio::net::UdpSocket;
+    /// use std::io;
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080").await?;
-    ///        let mut buf = [0; 1024];
-    ///        loop {
-    ///            let (len, addr) = sock.recv_from(&mut buf).await?;
-    ///            println!("{:?} bytes received from {:?}", len, addr);
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let sock = UdpSocket::bind("0.0.0.0:8080").await?;
+    ///     let mut buf = [0; 1024];
+    ///     loop {
+    ///         let (len, addr) = sock.recv_from(&mut buf).await?;
+    ///         println!("{:?} bytes received from {:?}", len, addr);
     ///
-    ///            let len = sock.send_to(&buf[..len], addr).await?;
-    ///            println!("{:?} bytes sent", len);
-    ///        }
-    ///    }
+    ///         let len = sock.send_to(&buf[..len], addr).await?;
+    ///         println!("{:?} bytes sent", len);
+    ///     }
+    /// }
     /// ```
     ///
     /// # Example: one to one (connect)
     ///
     /// Or using `connect` we can echo with a single remote address using `send` and `recv`:
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    ///    use std::io;
+    /// use tokio::net::UdpSocket;
+    /// use std::io;
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080").await?;
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let sock = UdpSocket::bind("0.0.0.0:8080").await?;
     ///
-    ///        let remote_addr = "127.0.0.1:59611";
-    ///        sock.connect(remote_addr).await?;
-    ///        let mut buf = [0; 1024];
-    ///        loop {
-    ///            let len = sock.recv(&mut buf).await?;
-    ///            println!("{:?} bytes received from {:?}", len, remote_addr);
+    ///     let remote_addr = "127.0.0.1:59611";
+    ///     sock.connect(remote_addr).await?;
+    ///     let mut buf = [0; 1024];
+    ///     loop {
+    ///         let len = sock.recv(&mut buf).await?;
+    ///         println!("{:?} bytes received from {:?}", len, remote_addr);
     ///
-    ///            let len = sock.send(&buf[..len]).await?;
-    ///            println!("{:?} bytes sent", len);
-    ///        }
-    ///    }
+    ///         let len = sock.send(&buf[..len]).await?;
+    ///         println!("{:?} bytes sent", len);
+    ///     }
+    /// }
     /// ```
     ///
     /// # Example: Sending/Receiving concurrently
@@ -116,16 +116,16 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    ///    use std::io;
+    /// use tokio::net::UdpSocket;
+    /// use std::io;
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080").await?;
-    ///        // use `sock`
-    /// #      let _ = sock;
-    ///        Ok(())
-    ///    }
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let sock = UdpSocket::bind("0.0.0.0:8080").await?;
+    ///     // use `sock`
+    /// #   let _ = sock;
+    ///     Ok(())
+    /// }
     /// ```
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<UdpSocket> {
         let addrs = addr.to_socket_addrs().await?;
@@ -177,17 +177,17 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    /// #   use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
-    ///        let std_sock = std::net::UdpSocket::bind(addr)?;
-    ///        let sock = UdpSocket::from_std(std_sock)?;
-    ///        // use `sock`
-    /// #       Ok(())
-    /// #   }
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
+    /// let std_sock = std::net::UdpSocket::bind(addr)?;
+    /// let sock = UdpSocket::from_std(std_sock)?;
+    /// // use `sock`
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
@@ -199,17 +199,17 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    /// #   use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
-    ///        let sock = UdpSocket::bind(addr).await?;
-    ///        // the address the socket is bound to
-    ///        let local_addr = sock.local_addr()?;
-    /// #       Ok(())
-    /// #   }
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
+    /// let sock = UdpSocket::bind(addr).await?;
+    /// // the address the socket is bound to
+    /// let local_addr = sock.local_addr()?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().local_addr()
@@ -222,22 +222,22 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    ///    # use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
     ///
-    ///        let remote_addr = "127.0.0.1:59600".parse::<SocketAddr>().unwrap();
-    ///        sock.connect(remote_addr).await?;
-    ///        let mut buf = [0u8; 32];
-    ///        // recv from remote_addr
-    ///        let len = sock.recv(&mut buf).await?;
-    ///        // send to remote_addr
-    ///        let _len = sock.send(&buf[..len]).await?;
-    /// #       Ok(())
-    /// #   }
+    /// let remote_addr = "127.0.0.1:59600".parse::<SocketAddr>().unwrap();
+    /// sock.connect(remote_addr).await?;
+    /// let mut buf = [0u8; 32];
+    /// // recv from remote_addr
+    /// let len = sock.recv(&mut buf).await?;
+    /// // send to remote_addr
+    /// let _len = sock.send(&buf[..len]).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn connect<A: ToSocketAddrs>(&self, addr: A) -> io::Result<()> {
         let addrs = addr.to_socket_addrs().await?;
@@ -312,17 +312,17 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    /// #   use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
-    ///        let buf = b"hello world";
-    ///        let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
-    ///        let _len = sock.send_to(&buf[..], remote_addr).await?;
-    /// #       Ok(())
-    /// #   }
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
+    /// let buf = b"hello world";
+    /// let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
+    /// let _len = sock.send_to(&buf[..], remote_addr).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
         let mut addrs = target.to_socket_addrs().await?;
@@ -350,17 +350,17 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    /// #   use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
-    ///        let buf = b"hello world";
-    ///        let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
-    ///        let _len = sock.try_send_to(&buf[..], remote_addr)?;
-    /// #       Ok(())
-    /// #   }
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
+    /// let buf = b"hello world";
+    /// let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
+    /// let _len = sock.try_send_to(&buf[..], remote_addr)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`ErrorKind::WouldBlock`]: std::io::ErrorKind::WouldBlock
@@ -384,17 +384,17 @@ impl UdpSocket {
     /// # Example
     ///
     /// ```no_run
-    ///    use tokio::net::UdpSocket;
-    ///   # use std::{io, net::SocketAddr};
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
     ///
-    /// #   #[tokio::main]
-    /// #   async fn main() -> io::Result<()> {
-    ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
-    ///        let mut buf = [0u8; 32];
-    ///        let (len, addr) = sock.recv_from(&mut buf).await?;
-    ///        println!("received {:?} bytes from {:?}", len, addr);
-    ///  #      Ok(())
-    ///  #  }
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
+    /// let mut buf = [0u8; 32];
+    /// let (len, addr) = sock.recv_from(&mut buf).await?;
+    /// println!("received {:?} bytes from {:?}", len, addr);
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -78,30 +78,30 @@ cfg_udp! {
     /// a similar "echo" example but that supports concurrent sending/receiving:
     ///
     /// ```no_run
-    ///     use tokio::{net::UdpSocket, sync::mpsc};
-    ///     use std::{io, net::SocketAddr, sync::Arc};
+    /// use tokio::{net::UdpSocket, sync::mpsc};
+    /// use std::{io, net::SocketAddr, sync::Arc};
     ///
-    ///     #[tokio::main]
-    ///     async fn main() -> io::Result<()> {
-    ///         let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
-    ///         let r = Arc::new(sock);
-    ///         let s = r.clone();
-    ///         let (tx, mut rx) = mpsc::channel::<(Vec<u8>, SocketAddr)>(1_000);
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
+    ///     let r = Arc::new(sock);
+    ///     let s = r.clone();
+    ///     let (tx, mut rx) = mpsc::channel::<(Vec<u8>, SocketAddr)>(1_000);
     ///
-    ///         tokio::spawn(async move {
-    ///             while let Some((bytes, addr)) = rx.recv().await {
-    ///                 let len = s.send_to(&bytes, &addr).await.unwrap();
-    ///                 println!("{:?} bytes sent", len);
-    ///             }
-    ///         });
-    ///
-    ///         let mut buf = [0; 1024];
-    ///         loop {
-    ///             let (len, addr) = r.recv_from(&mut buf).await?;
-    ///             println!("{:?} bytes received from {:?}", len, addr);
-    ///             tx.send((buf[..len].to_vec(), addr)).await.unwrap();
+    ///     tokio::spawn(async move {
+    ///         while let Some((bytes, addr)) = rx.recv().await {
+    ///             let len = s.send_to(&bytes, &addr).await.unwrap();
+    ///             println!("{:?} bytes sent", len);
     ///         }
+    ///     });
+    ///
+    ///     let mut buf = [0; 1024];
+    ///     loop {
+    ///         let (len, addr) = r.recv_from(&mut buf).await?;
+    ///         println!("{:?} bytes received from {:?}", len, addr);
+    ///         tx.send((buf[..len].to_vec(), addr)).await.unwrap();
     ///     }
+    /// }
     /// ```
     ///
     pub struct UdpSocket {

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -123,7 +123,7 @@ impl UdpSocket {
     ///    async fn main() -> io::Result<()> {
     ///        let sock = UdpSocket::bind("0.0.0.0:8080").await?;
     ///        // use `sock`
-    ///      # let _ = sock;
+    /// #      let _ = sock;
     ///        Ok(())
     ///    }
     /// ```

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -143,17 +143,16 @@ impl UdpSocket {
     ///
     /// ```no_run
     ///    use tokio::net::UdpSocket;
-    ///    use std::{io, net::SocketAddr};
+    /// #   use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
     ///        let std_sock = std::net::UdpSocket::bind(addr)?;
     ///        let sock = UdpSocket::from_std(std_sock)?;
     ///        // use `sock`
-    ///      # let _ = sock;
-    ///        Ok(())
-    ///    }
+    /// #       Ok(())
+    /// #   }
     /// ```
     pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         let io = mio::net::UdpSocket::from_socket(socket)?;
@@ -166,17 +165,16 @@ impl UdpSocket {
     ///
     /// ```no_run
     ///    use tokio::net::UdpSocket;
-    ///    use std::{io, net::SocketAddr};
+    /// #   use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
     ///        let sock = UdpSocket::bind(addr).await?;
     ///        // the address the socket is bound to
     ///        let local_addr = sock.local_addr()?;
-    ///      # let _ = sock;
-    ///        Ok(())
-    ///    }
+    /// #       Ok(())
+    /// #   }
     /// ```
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.io.get_ref().local_addr()
@@ -192,8 +190,8 @@ impl UdpSocket {
     ///    use tokio::net::UdpSocket;
     ///    # use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
     ///
     ///        let remote_addr = "127.0.0.1:59600".parse::<SocketAddr>().unwrap();
@@ -203,8 +201,8 @@ impl UdpSocket {
     ///        let len = sock.recv(&mut buf).await?;
     ///        // send to remote_addr
     ///        let _len = sock.send(&buf[..len]).await?;
-    ///        Ok(())
-    ///    }
+    /// #       Ok(())
+    /// #   }
     /// ```
     pub async fn connect<A: ToSocketAddrs>(&self, addr: A) -> io::Result<()> {
         let addrs = addr.to_socket_addrs().await?;
@@ -280,16 +278,16 @@ impl UdpSocket {
     ///
     /// ```no_run
     ///    use tokio::net::UdpSocket;
-    ///    use std::{io, net::SocketAddr};
+    /// #   use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
     ///        let buf = b"hello world";
     ///        let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
     ///        let _len = sock.send_to(&buf[..], remote_addr).await?;
-    ///        Ok(())
-    ///    }
+    /// #       Ok(())
+    /// #   }
     /// ```
     pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
         let mut addrs = target.to_socket_addrs().await?;
@@ -318,16 +316,16 @@ impl UdpSocket {
     ///
     /// ```no_run
     ///    use tokio::net::UdpSocket;
-    ///    use std::{io, net::SocketAddr};
+    /// #   use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
     ///        let buf = b"hello world";
     ///        let remote_addr = "127.0.0.1:58000".parse::<SocketAddr>().unwrap();
     ///        let _len = sock.try_send_to(&buf[..], remote_addr)?;
-    ///        Ok(())
-    ///    }
+    /// #       Ok(())
+    /// #   }
     /// ```
     ///
     /// [`ErrorKind::WouldBlock`]: std::io::ErrorKind::WouldBlock
@@ -352,16 +350,16 @@ impl UdpSocket {
     ///
     /// ```no_run
     ///    use tokio::net::UdpSocket;
-    ///    use std::{io, net::SocketAddr};
+    ///   # use std::{io, net::SocketAddr};
     ///
-    ///    #[tokio::main]
-    ///    async fn main() -> io::Result<()> {
+    /// #   #[tokio::main]
+    /// #   async fn main() -> io::Result<()> {
     ///        let sock = UdpSocket::bind("0.0.0.0:8080".parse::<SocketAddr>().unwrap()).await?;
     ///        let mut buf = [0u8; 32];
     ///        let (len, addr) = sock.recv_from(&mut buf).await?;
     ///        println!("received {:?} bytes from {:?}", len, addr);
-    ///        Ok(())
-    ///    }
+    ///  #      Ok(())
+    ///  #  }
     /// ```
     pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io
@@ -453,6 +451,20 @@ impl UdpSocket {
     /// For more information about this option, see [`set_ttl`].
     ///
     /// [`set_ttl`]: method@Self::set_ttl
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UdpSocket;
+    /// # use std::io;
+    ///
+    /// # async fn dox() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("127.0.0.1:8080").await?;
+    ///
+    /// println!("{:?}", sock.ttl()?);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn ttl(&self) -> io::Result<u32> {
         self.io.get_ref().ttl()
     }
@@ -461,6 +473,20 @@ impl UdpSocket {
     ///
     /// This value sets the time-to-live field that is used in every packet sent
     /// from this socket.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UdpSocket;
+    /// # use std::io;
+    ///
+    /// # async fn dox() -> io::Result<()> {
+    /// let sock = UdpSocket::bind("127.0.0.1:8080").await?;
+    /// sock.set_ttl(60)?;
+    ///
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn set_ttl(&self, ttl: u32) -> io::Result<()> {
         self.io.get_ref().set_ttl(ttl)
     }


### PR DESCRIPTION
# Motivation

I always found the udp docs a little lackluster, after using them extensively for some time I thought it might be nice to flesh it out a bit. I asked in the tokio-docs discord and others seemed open to it, so here they are! Would love to hear your thoughts

## Solution

A few small code examples similar to the way the tcp section is set up, with an explanation of the different ways to use `UdpSocket`.

~~I had a full larger example with `split` but found that it's been removed for `UdpSocket` in master, I hope that's temporary, if not is there anything I can do to get similar functionality back? i.e. being able to `send_to`/`recv_from` concurrently~~

~~In writing an example using the new way to share `UdpSocket` concurrently (post-`split`) I think I found a bug~~ this bug was fixed #2886 