### PR TITLE
io: remove `Poll` from the `AsyncSeek::start_seek` return value

### DIFF
--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -125,12 +125,12 @@ where
     L: AsyncSeek,
     R: AsyncSeek,
 {
-    fn start_seek(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        position: SeekFrom,
-    ) -> Poll<Result<()>> {
-        delegate_call!(self.start_seek(cx, position))
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        delegate_call!(self.poll_ready(cx))
+    }
+
+    fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> Result<()> {
+        delegate_call!(self.start_seek(position))
     }
 
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<u64>> {

--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -125,10 +125,6 @@ where
     L: AsyncSeek,
     R: AsyncSeek,
 {
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
-        delegate_call!(self.poll_ready(cx))
-    }
-
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> Result<()> {
         delegate_call!(self.start_seek(position))
     }

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -548,7 +548,7 @@ impl AsyncSeek for File {
     fn start_seek(mut self: Pin<&mut Self>, mut pos: SeekFrom) -> io::Result<()> {
         loop {
             match self.state {
-                Busy(_) => panic!("must wait for poll_ready before calling start_seek"),
+                Busy(_) => panic!("must wait for poll_complete before calling start_seek"),
                 Idle(ref mut buf_cell) => {
                     let mut buf = buf_cell.take().unwrap();
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -337,7 +337,6 @@ impl File {
         match op {
             Operation::Seek(res) => res.map(|pos| {
                 self.pos = pos;
-                ()
             }),
             _ => unreachable!(),
         }

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -86,6 +86,8 @@ pub struct File {
     /// error is observed while performing a read, it is saved until the next
     /// write / flush call.
     last_write_err: Option<io::ErrorKind>,
+
+    pos: u64,
 }
 
 #[derive(Debug)]
@@ -199,6 +201,7 @@ impl File {
             std: Arc::new(std),
             state: State::Idle(Some(Buf::with_capacity(0))),
             last_write_err: None,
+            pos: 0,
         }
     }
 
@@ -332,7 +335,10 @@ impl File {
         self.state = Idle(Some(buf));
 
         match op {
-            Operation::Seek(res) => res.map(|_| ()),
+            Operation::Seek(res) => res.map(|pos| {
+                self.pos = pos;
+                ()
+            }),
             _ => unreachable!(),
         }
     }
@@ -524,9 +530,12 @@ impl AsyncRead for File {
                             self.last_write_err = Some(e.kind());
                             self.state = Idle(Some(buf));
                         }
-                        Operation::Seek(_) => {
+                        Operation::Seek(result) => {
                             assert!(buf.is_empty());
                             self.state = Idle(Some(buf));
+                            if let Ok(pos) = result {
+                                self.pos = pos;
+                            }
                             continue;
                         }
                     }
@@ -537,27 +546,6 @@ impl AsyncRead for File {
 }
 
 impl AsyncSeek for File {
-    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        loop {
-            match self.state {
-                Idle(_) => return Poll::Ready(Ok(())),
-                Busy(ref mut rx) => {
-                    let (op, buf) = ready!(Pin::new(rx).poll(cx))?;
-                    self.state = Idle(Some(buf));
-                    match op {
-                        Operation::Read(_) => {}
-                        Operation::Write(Err(e)) => {
-                            assert!(self.last_write_err.is_none());
-                            self.last_write_err = Some(e.kind());
-                        }
-                        Operation::Write(_) => {}
-                        Operation::Seek(_) => {}
-                    }
-                }
-            }
-        }
-    }
-
     fn start_seek(mut self: Pin<&mut Self>, mut pos: SeekFrom) -> io::Result<()> {
         loop {
             match self.state {
@@ -589,7 +577,7 @@ impl AsyncSeek for File {
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         loop {
             match self.state {
-                Idle(_) => panic!("must call start_seek before calling poll_complete"),
+                Idle(_) => return Poll::Ready(Ok(self.pos)),
                 Busy(ref mut rx) => {
                     let (op, buf) = ready!(Pin::new(rx).poll(cx))?;
                     self.state = Idle(Some(buf));
@@ -601,7 +589,12 @@ impl AsyncSeek for File {
                             self.last_write_err = Some(e.kind());
                         }
                         Operation::Write(_) => {}
-                        Operation::Seek(res) => return Ready(res),
+                        Operation::Seek(res) => {
+                            if let Ok(pos) = res {
+                                self.pos = pos;
+                            }
+                            return Ready(res);
+                        }
                     }
                 }
             }

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -23,21 +23,26 @@ pub trait AsyncSeek {
     ///
     /// If this function returns successfully, then the job has been submitted.
     /// To find out when it completes, call `poll_complete`.
+    ///
+    /// # Errors
+    ///
+    /// This function can return [`ErrorKind::Other`] in case there is another
+    /// seek in progress. To avoid this, it is advisable that any call to
+    /// `start_seek` is preceded by a call to `poll_complete` to ensure all
+    /// pending seeks have completed.
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()>;
 
     /// Waits for a seek operation to complete.
     ///
     /// If the seek operation completed successfully,
     /// this method returns the new position from the start of the stream.
-    /// That position can be used later with [`SeekFrom::Start`].
+    /// That position can be used later with [`SeekFrom::Start`]. Repeatedly
+    /// calling this function without calling `start_seek` might return the
+    /// same result.
     ///
     /// # Errors
     ///
     /// Seeking to a negative offset is considered an error.
-    ///
-    /// # Panics
-    ///
-    /// Calling this method without calling `start_seek` first is an error.
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>>;
 }
 

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -16,23 +16,11 @@ use std::task::{Context, Poll};
 /// [`Seek::seek`]: std::io::Seek::seek()
 /// [`AsyncSeekExt`]: crate::io::AsyncSeekExt
 pub trait AsyncSeek {
-    /// Ensures that the `AsyncSeek` is ready for `start_seek` to be called.
-    ///
-    /// This method must be called and return `Poll::Ready(Ok(()))` prior to
-    /// each call to `start_seek`.
-    ///
-    /// If this method returns `Poll::Pending`, the current task
-    /// is registered to be notified (via `cx.waker().wake_by_ref()`) when `poll_ready`
-    /// should be called again.
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
-
     /// Attempts to seek to an offset, in bytes, in a stream.
     ///
     /// A seek beyond the end of a stream is allowed, but behavior is defined
     /// by the implementation.
     ///
-    /// Each call to this function must be preceded by a successful call to
-    /// `poll_ready` which returned `Poll::Ready(Ok(()))`.
     /// If this function returns successfully, then the job has been submitted.
     /// To find out when it completes, call `poll_complete`.
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()>;
@@ -55,10 +43,6 @@ pub trait AsyncSeek {
 
 macro_rules! deref_async_seek {
     () => {
-        fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            Pin::new(&mut **self).poll_ready(cx)
-        }
-
         fn start_seek(mut self: Pin<&mut Self>, pos: SeekFrom) -> io::Result<()> {
             Pin::new(&mut **self).start_seek(pos)
         }
@@ -82,10 +66,6 @@ where
     P: DerefMut + Unpin,
     P::Target: AsyncSeek,
 {
-    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.get_mut().as_mut().poll_ready(cx)
-    }
-
     fn start_seek(self: Pin<&mut Self>, pos: SeekFrom) -> io::Result<()> {
         self.get_mut().as_mut().start_seek(pos)
     }
@@ -96,10 +76,6 @@ where
 }
 
 impl<T: AsRef<[u8]> + Unpin> AsyncSeek for io::Cursor<T> {
-    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
-    }
-
     fn start_seek(mut self: Pin<&mut Self>, pos: SeekFrom) -> io::Result<()> {
         io::Seek::seek(&mut *self, pos).map(drop)
     }

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -26,9 +26,9 @@ pub trait AsyncSeek {
     ///
     /// # Errors
     ///
-    /// This function can return [`ErrorKind::Other`] in case there is another
-    /// seek in progress. To avoid this, it is advisable that any call to
-    /// `start_seek` is preceded by a call to `poll_complete` to ensure all
+    /// This function can return [`io::ErrorKind::Other`] in case there is
+    /// another seek in progress. To avoid this, it is advisable that any call
+    /// to `start_seek` is preceded by a call to `poll_complete` to ensure all
     /// pending seeks have completed.
     fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()>;
 

--- a/tokio/src/io/seek.rs
+++ b/tokio/src/io/seek.rs
@@ -32,14 +32,14 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = &mut *self;
+        ready!(Pin::new(&mut me.seek).poll_ready(cx))?;
         match me.pos {
-            Some(pos) => match Pin::new(&mut me.seek).start_seek(cx, pos) {
-                Poll::Ready(Ok(())) => {
+            Some(pos) => match Pin::new(&mut me.seek).start_seek(pos) {
+                Ok(()) => {
                     me.pos = None;
                     Pin::new(&mut me.seek).poll_complete(cx)
                 }
-                Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-                Poll::Pending => Poll::Pending,
+                Err(e) => Poll::Ready(Err(e)),
             },
             None => Pin::new(&mut me.seek).poll_complete(cx),
         }


### PR DESCRIPTION
## Motivation
To remove the Poll from `start_seek` and rely on `poll_ready` instead

Fix: #1994

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>