### PR TITLE
Optimize writing large buffers to windows stdio

### DIFF
--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -19,6 +19,12 @@ impl<W> SplitByUtf8BoundaryIfWindows<W> {
     }
 }
 
+// this constant is defined by Unicode standard.
+const MAX_BYTES_PER_CHAR: usize = 4;
+
+// Subject for tweaking here
+const MAGIC_CONST: usize = 8;
+
 impl<W> crate::io::AsyncWrite for SplitByUtf8BoundaryIfWindows<W>
 where
     W: AsyncWrite + Unpin,
@@ -39,7 +45,8 @@ where
         // 2. If buffer is small, it will not be shrinked.
         // That's why, it's "textness" will not change, so we don't have
         // to fixup it.
-        if cfg!(not(any(target_os = "windows", test))) || buf.len() <= crate::io::blocking::MAX_BUF
+        if cfg!(not(any(target_os = "windows", test)))
+            || buf.len() <= crate::io::blocking::MAX_BUF
         {
             return call_inner(buf);
         }
@@ -54,27 +61,15 @@ where
         // that's why check we will perform now is allowed to have
         // false-positive.
 
-        // this constant is defined by Unicode standard.
-        const MAX_BYTES_PER_CHAR: usize = 4;
-
-        // Subject for tweaking here
-        const MAGIC_CONST: usize = 8;
-
         // Now let's look at the first MAX_BYTES_PER_CHAR * MAGIC_CONST bytes.
         // if they are (possibly incomplete) utf8, then we can be quite sure
         // that input buffer was utf8.
 
         let have_to_fix_up = match std::str::from_utf8(&buf[..MAX_BYTES_PER_CHAR * MAGIC_CONST]) {
-            Ok(_) => {
-                // We do not need to shrink this buffer:
-                // we were lucky enough and it didn't broke
-                // during shrinking
-                false
-            }
+            Ok(_) => true,
             Err(err) => {
-                let bad_bytes = (MAX_BYTES_PER_CHAR * MAGIC_CONST) - err.valid_up_to();
-                // this must hold for any shrinked utf8 buffer.
-                bad_bytes < MAX_BYTES_PER_CHAR
+                let incomplete_bytes = MAX_BYTES_PER_CHAR * MAGIC_CONST - err.valid_up_to();
+                incomplete_bytes < MAX_BYTES_PER_CHAR
             }
         };
 
@@ -86,8 +81,9 @@ where
             let trailing_incomplete_char_size = buf
                 .iter()
                 .rev()
+                .take(MAX_BYTES_PER_CHAR)
                 .position(|byte| *byte < 0b1000_0000 || *byte >= 0b1100_0000)
-                .unwrap()
+                .unwrap_or(0)
                 + 1;
             buf = &buf[..buf.len() - trailing_incomplete_char_size];
         }
@@ -120,8 +116,10 @@ mod tests {
     use std::task::Poll;
 
     const MAX_BUF: usize = 16 * 1024;
-    struct MockWriter;
-    impl crate::io::AsyncWrite for MockWriter {
+
+    struct TextMockWriter;
+
+    impl crate::io::AsyncWrite for TextMockWriter {
         fn poll_write(
             self: Pin<&mut Self>,
             _cx: &mut Context<'_>,
@@ -144,10 +142,45 @@ mod tests {
         }
     }
 
+    struct LoggingMockWriter {
+        write_history: Vec<usize>,
+    }
+
+    impl LoggingMockWriter {
+        fn new() -> Self {
+            LoggingMockWriter {
+                write_history: Vec::new(),
+            }
+        }
+    }
+
+    impl crate::io::AsyncWrite for LoggingMockWriter {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            assert!(buf.len() <= MAX_BUF);
+            self.write_history.push(buf.len());
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
     #[test]
     fn test_splitter() {
         let data = str::repeat("█", MAX_BUF);
-        let mut wr = super::SplitByUtf8BoundaryIfWindows::new(MockWriter);
+        let mut wr = super::SplitByUtf8BoundaryIfWindows::new(TextMockWriter);
         let fut = async move {
             wr.write_all(data.as_bytes()).await.unwrap();
         };
@@ -156,5 +189,35 @@ mod tests {
             .build()
             .unwrap()
             .block_on(fut);
+    }
+
+    #[test]
+    fn test_pseudo_text() {
+        // In this test we write a piece of binary data, whose beginning is
+        // text though. We then validate that even in this corner case buffer
+        // was not shrinked too much.
+        let checked_count = super::MAGIC_CONST * super::MAX_BYTES_PER_CHAR;
+        let mut data: Vec<u8> = str::repeat("a", checked_count).into();
+        data.extend(std::iter::repeat(0b1010_1010).take(MAX_BUF - checked_count + 1));
+        let mut writer = LoggingMockWriter::new();
+        let mut splitter = super::SplitByUtf8BoundaryIfWindows::new(&mut writer);
+        crate::runtime::Builder::new()
+            .basic_scheduler()
+            .build()
+            .unwrap()
+            .block_on(async {
+                splitter.write_all(&data).await.unwrap();
+            });
+        // Check that at most two writes were performed
+        assert!(writer.write_history.len() <= 2);
+        // Check that all has been written
+        assert_eq!(
+            writer.write_history.iter().copied().sum::<usize>(),
+            data.len()
+        );
+        // Check that at most MAX_BYTES_PER_CHAR + 1 (i.e. 5) bytes were shrinked
+        // from the buffer: one because it was outside of MAX_BUF boundary, and
+        // up to one "utf8 code point".
+        assert!(data.len() - writer.write_history[0] <= super::MAX_BYTES_PER_CHAR + 1);
     }
 }

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -72,7 +72,7 @@ where
                 false
             }
             Err(err) => {
-                let bad_bytes = buf.len() - err.valid_up_to();
+                let bad_bytes = (MAX_BYTES_PER_CHAR * MAGIC_CONST) - err.valid_up_to();
                 // this must hold for any shrinked utf8 buffer.
                 bad_bytes < MAX_BYTES_PER_CHAR
             }
@@ -87,7 +87,7 @@ where
                 .iter()
                 .rev()
                 .position(|byte| *byte < 0b1000_0000 || *byte >= 0b1100_0000)
-                .unwrap();
+                .unwrap()+1;
             buf = &buf[..buf.len() - trailing_incomplete_char_size];
         }
 

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -87,7 +87,8 @@ where
                 .iter()
                 .rev()
                 .position(|byte| *byte < 0b1000_0000 || *byte >= 0b1100_0000)
-                .unwrap()+1;
+                .unwrap()
+                + 1;
             buf = &buf[..buf.len() - trailing_incomplete_char_size];
         }
 

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -23,6 +23,7 @@ impl<W> crate::io::AsyncWrite for SplitByUtf8BoundaryIfWindows<W>
 where
     W: AsyncWrite + Unpin,
 {
+    #[cfg_attr(not(any(target_os = "windows", test)), allow(unreachable_code))]
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -36,7 +37,7 @@ where
         // for further code. Since `AsyncWrite` can always shrink
         // buffer at its discretion, excessive (i.e. in tests) shrinking
         // does not break correctness.
-        #[cfg(not(any(target_os = "windows", test, target_os = "linux" /*TODO(mb): remove this dbg clause*/)))]
+        #[cfg(not(any(target_os = "windows", test)))]
         return call_inner(buf);
 
         // If buffer is small, it will not be shrinked.

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -91,7 +91,7 @@ where
             buf = &buf[..buf.len() - trailing_incomplete_char_size];
         }
 
-        return call_inner(buf);
+        call_inner(buf)
     }
 
     fn poll_flush(

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -45,8 +45,7 @@ where
         // 2. If buffer is small, it will not be shrinked.
         // That's why, it's "textness" will not change, so we don't have
         // to fixup it.
-        if cfg!(not(any(target_os = "windows", test)))
-            || buf.len() <= crate::io::blocking::MAX_BUF
+        if cfg!(not(any(target_os = "windows", test))) || buf.len() <= crate::io::blocking::MAX_BUF
         {
             return call_inner(buf);
         }

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -23,7 +23,6 @@ impl<W> crate::io::AsyncWrite for SplitByUtf8BoundaryIfWindows<W>
 where
     W: AsyncWrite + Unpin,
 {
-    //#[cfg_attr(not(any(target_os = "windows", test)), allow(unreachable_code))]
     fn poll_write(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->
(I hope i did not messed up during rebasing)
## Motivation
Performance is cool.
Fixes #2863
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Propose algorithm that shrinks text buffers efficiently (now only 32 instead of 16*1024 bytes are checked for utf8)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
