### PR TITLE
test: fix spelling error in documentation

### DIFF
--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -11,7 +11,7 @@ use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 
 use tokio::stream::Stream;
 
-/// TOOD: dox
+/// TODO: dox
 pub fn spawn<T>(task: T) -> Spawn<T> {
     Spawn {
         task: MockTask::new(),


### PR DESCRIPTION
## Motivation
Fix a spelling error in the documentation.

Fixes: #2754 

