### PR TITLE
Seal AsyncBufRead and make implementation methods private

### DIFF
--- a/tokio/src/io/async_buf_read.rs
+++ b/tokio/src/io/async_buf_read.rs
@@ -1,5 +1,3 @@
-use crate::io::AsyncRead;
-
 use std::io;
 use std::ops::DerefMut;
 use std::pin::Pin;
@@ -20,66 +18,52 @@ use std::task::{Context, Poll};
 /// [`poll_fill_buf`]: AsyncBufRead::poll_fill_buf
 /// [`BufRead::fill_buf`]: std::io::BufRead::fill_buf
 /// [`AsyncBufReadExt`]: crate::io::AsyncBufReadExt
-pub trait AsyncBufRead: AsyncRead {
-    /// Attempts to return the contents of the internal buffer, filling it with more data
-    /// from the inner reader if it is empty.
-    ///
-    /// On success, returns `Poll::Ready(Ok(buf))`.
-    ///
-    /// If no data is available for reading, the method returns
-    /// `Poll::Pending` and arranges for the current task (via
-    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
-    /// readable or is closed.
-    ///
-    /// This function is a lower-level call. It needs to be paired with the
-    /// [`consume`] method to function properly. When calling this
-    /// method, none of the contents will be "read" in the sense that later
-    /// calling [`poll_read`] may return the same contents. As such, [`consume`] must
-    /// be called with the number of bytes that are consumed from this buffer to
-    /// ensure that the bytes are never returned twice.
-    ///
-    /// An empty buffer returned indicates that the stream has reached EOF.
-    ///
-    /// [`poll_read`]: AsyncRead::poll_read
-    /// [`consume`]: AsyncBufRead::consume
-    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>>;
-
-    /// Tells this buffer that `amt` bytes have been consumed from the buffer,
-    /// so they should no longer be returned in calls to [`poll_read`].
-    ///
-    /// This function is a lower-level call. It needs to be paired with the
-    /// [`poll_fill_buf`] method to function properly. This function does
-    /// not perform any I/O, it simply informs this object that some amount of
-    /// its buffer, returned from [`poll_fill_buf`], has been consumed and should
-    /// no longer be returned. As such, this function may do odd things if
-    /// [`poll_fill_buf`] isn't called before calling it.
-    ///
-    /// The `amt` must be `<=` the number of bytes in the buffer returned by
-    /// [`poll_fill_buf`].
-    ///
-    /// [`poll_read`]: AsyncRead::poll_read
-    /// [`poll_fill_buf`]: AsyncBufRead::poll_fill_buf
-    fn consume(self: Pin<&mut Self>, amt: usize);
-}
+pub trait AsyncBufRead: sealed::AsyncBufReadPriv {}
 
 macro_rules! deref_async_buf_read {
     () => {
-        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-            Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
+        fn poll_fill_buf(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            _: sealed::Internal,
+        ) -> Poll<io::Result<&[u8]>> {
+            Pin::new(&mut **self.get_mut()).poll_fill_buf(cx, sealed::Internal)
         }
 
-        fn consume(mut self: Pin<&mut Self>, amt: usize) {
-            Pin::new(&mut **self).consume(amt)
+        fn consume(mut self: Pin<&mut Self>, _: sealed::Internal, amt: usize) {
+            Pin::new(&mut **self).consume(sealed::Internal, amt)
         }
     };
 }
 
-impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
+impl<T: ?Sized + AsyncBufRead + Unpin> sealed::AsyncBufReadPriv for Box<T> {
     deref_async_buf_read!();
 }
 
-impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for &mut T {
+impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {}
+
+impl<T: ?Sized + AsyncBufRead + Unpin> sealed::AsyncBufReadPriv for &mut T {
     deref_async_buf_read!();
+}
+
+impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for &mut T {}
+
+impl<P> sealed::AsyncBufReadPriv for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: AsyncBufRead,
+{
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        _: sealed::Internal,
+    ) -> Poll<io::Result<&[u8]>> {
+        self.get_mut().as_mut().poll_fill_buf(cx, sealed::Internal)
+    }
+
+    fn consume(self: Pin<&mut Self>, _: sealed::Internal, amt: usize) {
+        self.get_mut().as_mut().consume(sealed::Internal, amt)
+    }
 }
 
 impl<P> AsyncBufRead for Pin<P>
@@ -87,31 +71,94 @@ where
     P: DerefMut + Unpin,
     P::Target: AsyncBufRead,
 {
-    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        self.get_mut().as_mut().poll_fill_buf(cx)
-    }
-
-    fn consume(self: Pin<&mut Self>, amt: usize) {
-        self.get_mut().as_mut().consume(amt)
-    }
 }
 
-impl AsyncBufRead for &[u8] {
-    fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+impl sealed::AsyncBufReadPriv for &[u8] {
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _: sealed::Internal,
+    ) -> Poll<io::Result<&[u8]>> {
         Poll::Ready(Ok(*self))
     }
 
-    fn consume(mut self: Pin<&mut Self>, amt: usize) {
+    fn consume(mut self: Pin<&mut Self>, _: sealed::Internal, amt: usize) {
         *self = &self[amt..];
     }
 }
 
-impl<T: AsRef<[u8]> + Unpin> AsyncBufRead for io::Cursor<T> {
-    fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+impl AsyncBufRead for &[u8] {}
+
+impl<T: AsRef<[u8]> + Unpin> sealed::AsyncBufReadPriv for io::Cursor<T> {
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _: sealed::Internal,
+    ) -> Poll<io::Result<&[u8]>> {
         Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
     }
 
-    fn consume(self: Pin<&mut Self>, amt: usize) {
+    fn consume(self: Pin<&mut Self>, _: sealed::Internal, amt: usize) {
         io::BufRead::consume(self.get_mut(), amt)
     }
+}
+
+impl<T: AsRef<[u8]> + Unpin> AsyncBufRead for io::Cursor<T> {}
+
+pub(super) mod sealed {
+    use crate::io::AsyncRead;
+
+    use std::io;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    #[doc(hidden)]
+    pub trait AsyncBufReadPriv: AsyncRead {
+        /// Attempts to return the contents of the internal buffer, filling it with more data
+        /// from the inner reader if it is empty.
+        ///
+        /// On success, returns `Poll::Ready(Ok(buf))`.
+        ///
+        /// If no data is available for reading, the method returns
+        /// `Poll::Pending` and arranges for the current task (via
+        /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+        /// readable or is closed.
+        ///
+        /// This function is a lower-level call. It needs to be paired with the
+        /// [`consume`] method to function properly. When calling this
+        /// method, none of the contents will be "read" in the sense that later
+        /// calling [`poll_read`] may return the same contents. As such, [`consume`] must
+        /// be called with the number of bytes that are consumed from this buffer to
+        /// ensure that the bytes are never returned twice.
+        ///
+        /// An empty buffer returned indicates that the stream has reached EOF.
+        ///
+        /// [`poll_read`]: AsyncRead::poll_read
+        /// [`consume`]: AsyncBufRead::consume
+        fn poll_fill_buf(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            internal: Internal,
+        ) -> Poll<io::Result<&[u8]>>;
+
+        /// Tells this buffer that `amt` bytes have been consumed from the buffer,
+        /// so they should no longer be returned in calls to [`poll_read`].
+        ///
+        /// This function is a lower-level call. It needs to be paired with the
+        /// [`poll_fill_buf`] method to function properly. This function does
+        /// not perform any I/O, it simply informs this object that some amount of
+        /// its buffer, returned from [`poll_fill_buf`], has been consumed and should
+        /// no longer be returned. As such, this function may do odd things if
+        /// [`poll_fill_buf`] isn't called before calling it.
+        ///
+        /// The `amt` must be `<=` the number of bytes in the buffer returned by
+        /// [`poll_fill_buf`].
+        ///
+        /// [`poll_read`]: AsyncRead::poll_read
+        /// [`poll_fill_buf`]: AsyncBufRead::poll_fill_buf
+        fn consume(self: Pin<&mut Self>, internal: Internal, amt: usize);
+    }
+
+    #[allow(missing_debug_implementations)]
+    pub struct Internal;
 }

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -1,4 +1,4 @@
-use crate::io::{AsyncBufRead, AsyncRead, ReadBuf};
+use crate::io::{async_buf_read, AsyncBufRead, AsyncRead, ReadBuf};
 
 use std::fmt;
 use std::io;
@@ -57,15 +57,21 @@ impl AsyncRead for Empty {
     }
 }
 
-impl AsyncBufRead for Empty {
+impl async_buf_read::sealed::AsyncBufReadPriv for Empty {
     #[inline]
-    fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+    fn poll_fill_buf(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        _: async_buf_read::sealed::Internal,
+    ) -> Poll<io::Result<&[u8]>> {
         Poll::Ready(Ok(&[]))
     }
 
     #[inline]
-    fn consume(self: Pin<&mut Self>, _: usize) {}
+    fn consume(self: Pin<&mut Self>, _: async_buf_read::sealed::Internal, _: usize) {}
 }
+
+impl AsyncBufRead for Empty {}
 
 impl fmt::Debug for Empty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
The extension methods still exist (`lines`, `read_until`, etc). The implementation details are now private, so we can consider changing things later (post 1.0) without breaking users.

cc #2428 