### PR TITLE
Broadcast channel breaking changes

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -107,6 +107,7 @@
 //!     assert_eq!(20, rx.recv().await.unwrap());
 //!     assert_eq!(30, rx.recv().await.unwrap());
 //! }
+//! ```
 
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
@@ -844,6 +845,7 @@ impl<T: Clone> Receiver<T> {
     ///     assert_eq!(20, rx.recv().await.unwrap());
     ///     assert_eq!(30, rx.recv().await.unwrap());
     /// }
+    /// ```
     pub async fn recv(&mut self) -> Result<T, RecvError> {
         let fut = Recv::<_, T>::new(Borrow(self));
         fut.await
@@ -915,7 +917,7 @@ impl<T: Clone> Receiver<T> {
     ///         }
     ///     });
     ///
-    ///    // Streams must be pinned to iterate.
+    ///     // Streams must be pinned to iterate.
     ///     tokio::pin! {
     ///         let stream = rx
     ///             .into_stream()

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -952,28 +952,6 @@ impl<T: Clone> Receiver<T> {
     }
 }
 
-#[cfg(feature = "stream")]
-#[doc(hidden)]
-#[deprecated(since = "0.2.21", note = "use `into_stream()`")]
-impl<T> crate::stream::Stream for Receiver<T>
-where
-    T: Clone,
-{
-    type Item = Result<T, RecvError>;
-
-    fn poll_next(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Option<Result<T, RecvError>>> {
-        #[allow(deprecated)]
-        self.poll_recv(cx).map(|v| match v {
-            Ok(v) => Some(Ok(v)),
-            lag @ Err(RecvError::Lagged(_)) => Some(lag),
-            Err(RecvError::Closed) => None,
-        })
-    }
-}
-
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         let mut tail = self.shared.tail.lock();

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -537,10 +537,7 @@ impl<T> Sender<T> {
 
         drop(tail);
 
-        Receiver {
-            shared,
-            next,
-        }
+        Receiver { shared, next }
     }
 
     /// Returns the number of active receivers

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -400,7 +400,7 @@ const MAX_RECEIVERS: usize = usize::MAX >> 2;
 ///     tx.send(20).unwrap();
 /// }
 /// ```
-pub fn channel<T>(mut capacity: usize) -> (Sender<T>, Receiver<T>) {
+pub fn channel<T: Clone>(mut capacity: usize) -> (Sender<T>, Receiver<T>) {
     assert!(capacity > 0, "capacity is empty");
     assert!(capacity <= usize::MAX >> 1, "requested capacity too large");
 
@@ -784,10 +784,7 @@ impl<T> Receiver<T> {
     }
 }
 
-impl<T> Receiver<T>
-where
-    T: Clone,
-{
+impl<T: Clone> Receiver<T> {
     /// Attempts to return a pending value on this receiver without awaiting.
     ///
     /// This is useful for a flavor of "optimistic check" before deciding to

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -950,6 +950,48 @@ impl<T: Clone> Receiver<T> {
         let fut = Recv::<_, T>::new(Borrow(self));
         fut.await
     }
+
+    /// Convert the receiver into a `Stream`.
+    ///
+    /// The conversion allows using `Receiver` with APIs that require stream
+    /// values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::stream::StreamExt;
+    /// use tokio::sync::broadcast;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = broadcast::channel(128);
+    ///
+    ///     tokio::spawn(async move {
+    ///         for i in 0..10_i32 {
+    ///             tx.send(i).unwrap();
+    ///         }
+    ///     });
+    ///
+    ///    // Streams must be pinned to iterate.
+    ///     tokio::pin! {
+    ///         let stream = rx
+    ///             .into_stream()
+    ///             .filter(Result::is_ok)
+    ///             .map(Result::unwrap)
+    ///             .filter(|v| v % 2 == 0)
+    ///             .map(|v| v + 1);
+    ///     }
+    ///
+    ///     while let Some(i) = stream.next().await {
+    ///         println!("{}", i);
+    ///     }
+    /// }
+    /// ```
+    #[cfg(feature = "stream")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "stream")))]
+    pub fn into_stream(self) -> impl Stream<Item = Result<T, RecvError>> {
+        Recv::new(Borrow(self))
+    }
 }
 
 impl<T> Drop for Receiver<T> {
@@ -1045,48 +1087,6 @@ where
 
 cfg_stream! {
     use futures_core::Stream;
-
-    impl<T: Clone> Receiver<T> {
-        /// Convert the receiver into a `Stream`.
-        ///
-        /// The conversion allows using `Receiver` with APIs that require stream
-        /// values.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use tokio::stream::StreamExt;
-        /// use tokio::sync::broadcast;
-        ///
-        /// #[tokio::main]
-        /// async fn main() {
-        ///     let (tx, rx) = broadcast::channel(128);
-        ///
-        ///     tokio::spawn(async move {
-        ///         for i in 0..10_i32 {
-        ///             tx.send(i).unwrap();
-        ///         }
-        ///     });
-        ///
-        ///    // Streams must be pinned to iterate.
-        ///     tokio::pin! {
-        ///         let stream = rx
-        ///             .into_stream()
-        ///             .filter(Result::is_ok)
-        ///             .map(Result::unwrap)
-        ///             .filter(|v| v % 2 == 0)
-        ///             .map(|v| v + 1);
-        ///     }
-        ///
-        ///     while let Some(i) = stream.next().await {
-        ///         println!("{}", i);
-        ///     }
-        /// }
-        /// ```
-        pub fn into_stream(self) -> impl Stream<Item = Result<T, RecvError>> {
-            Recv::new(Borrow(self))
-        }
-    }
 
     impl<R, T: Clone> Stream for Recv<R, T>
     where

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -491,39 +491,6 @@ fn lagging_receiver_recovers_after_wrap_open() {
     assert_empty!(rx);
 }
 
-#[tokio::test]
-async fn send_recv_stream_ready_deprecated() {
-    use tokio::stream::StreamExt;
-
-    let (tx, mut rx) = broadcast::channel::<i32>(8);
-
-    assert_ok!(tx.send(1));
-    assert_ok!(tx.send(2));
-
-    assert_eq!(Some(Ok(1)), rx.next().await);
-    assert_eq!(Some(Ok(2)), rx.next().await);
-
-    drop(tx);
-
-    assert_eq!(None, rx.next().await);
-}
-
-#[tokio::test]
-async fn send_recv_stream_pending_deprecated() {
-    use tokio::stream::StreamExt;
-
-    let (tx, mut rx) = broadcast::channel::<i32>(8);
-
-    let mut recv = task::spawn(rx.next());
-    assert_pending!(recv.poll());
-
-    assert_ok!(tx.send(1));
-
-    assert!(recv.is_woken());
-    let val = assert_ready!(recv.poll());
-    assert_eq!(val, Some(Ok(1)));
-}
-
 fn is_closed(err: broadcast::RecvError) -> bool {
     match err {
         broadcast::RecvError::Closed => true,


### PR DESCRIPTION
This PR performs breaking changes to the broadcast channel. Additionally it moves around some functions to make them appear in the right order in the documentation. It may be easier to read the changes one commit at the time.

Fixes: #2261