### PR TITLE
Fix new clippy warning

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -133,7 +133,7 @@ impl Semaphore {
     pub(crate) const fn const_new(mut permits: usize) -> Self {
         // NOTE: assertions and by extension panics are still being worked on: https://github.com/rust-lang/rust/issues/74925
         // currently we just clamp the permit count when it exceeds the max
-        permits = permits & Self::MAX_PERMITS;
+        permits &= Self::MAX_PERMITS;
 
         Self {
             permits: AtomicUsize::new(permits << Self::PERMIT_SHIFT),

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -124,7 +124,6 @@ struct State(usize);
 /// }
 /// ```
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
-    #[allow(deprecated)]
     let inner = Arc::new(Inner {
         state: AtomicUsize::new(State::new().as_usize()),
         value: UnsafeCell::new(None),


### PR DESCRIPTION
```
warning: manual implementation of an assign operation
   --> tokio/src/sync/batch_semaphore.rs:136:9
    |
136 |         permits = permits & Self::MAX_PERMITS;
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `permits &= Self::MAX_PERMITS`
    |
    = note: `#[warn(clippy::assign_op_pattern)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assign_op_pattern
```