### PR TITLE
Make #[doc(hidden)] apis private

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -55,8 +55,7 @@ impl ReadDir {
         poll_fn(|cx| self.poll_next_entry(cx)).await
     }
 
-    #[doc(hidden)]
-    pub fn poll_next_entry(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<DirEntry>>> {
+    fn poll_next_entry(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<Option<DirEntry>>> {
         loop {
             match self.0 {
                 State::Idle(ref mut std) => {

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -83,8 +83,7 @@ impl<R> Lines<R>
 where
     R: AsyncBufRead,
 {
-    #[doc(hidden)]
-    pub fn poll_next_line(
+    fn poll_next_line(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<Option<String>>> {

--- a/tokio/src/io/util/split.rs
+++ b/tokio/src/io/util/split.rs
@@ -65,8 +65,7 @@ impl<R> Split<R>
 where
     R: AsyncBufRead,
 {
-    #[doc(hidden)]
-    pub fn poll_next_segment(
+    fn poll_next_segment(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<io::Result<Option<Vec<u8>>>> {

--- a/tokio/src/macros/scoped_tls.rs
+++ b/tokio/src/macros/scoped_tls.rs
@@ -23,9 +23,7 @@ macro_rules! scoped_thread_local {
 /// Type representing a thread local storage key corresponding to a reference
 /// to the type parameter `T`.
 pub(crate) struct ScopedKey<T> {
-    #[doc(hidden)]
     pub(crate) inner: &'static LocalKey<Cell<*const ()>>,
-    #[doc(hidden)]
     pub(crate) _marker: marker::PhantomData<T>,
 }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -192,9 +192,13 @@ impl TcpStream {
         Ok(TcpStream { io })
     }
 
-    // Connects `TcpStream` asynchronously that may be built with a net2 `TcpBuilder`.
-    //
-    // This should be removed in favor of some in-crate TcpSocket builder API.
+    /// Connects `TcpStream` asynchronously that may be built with a net2 `TcpBuilder`.
+    ///
+    /// This function is intended to be replaced with some sort of TcpSocket builder.
+    /// See https://github.com/tokio-rs/tokio/issues/2902
+    ///
+    /// Despite being hidden, this function is part of the public API of Tokio v0.3, but
+    /// will be removed in v1.0 in favor of a better design.
     #[doc(hidden)]
     pub async fn connect_std(stream: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
         let io = mio::net::TcpStream::connect_stream(stream, addr)?;

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -192,30 +192,6 @@ impl TcpStream {
         Ok(TcpStream { io })
     }
 
-    // Connects `TcpStream` asynchronously that may be built with a net2 `TcpBuilder`.
-    //
-    // This should be removed in favor of some in-crate TcpSocket builder API.
-    #[doc(hidden)]
-    pub async fn connect_std(stream: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
-        let io = mio::net::TcpStream::connect_stream(stream, addr)?;
-        let io = PollEvented::new(io)?;
-        let stream = TcpStream { io };
-
-        // Once we've connected, wait for the stream to be writable as
-        // that's when the actual connection has been initiated. Once we're
-        // writable we check for `take_socket_error` to see if the connect
-        // actually hit an error or not.
-        //
-        // If all that succeeded then we ship everything on up.
-        poll_fn(|cx| stream.io.poll_write_ready(cx)).await?;
-
-        if let Some(e) = stream.io.get_ref().take_error()? {
-            return Err(e);
-        }
-
-        Ok(stream)
-    }
-
     /// Returns the local address that this stream is bound to.
     ///
     /// # Examples

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -192,6 +192,30 @@ impl TcpStream {
         Ok(TcpStream { io })
     }
 
+    // Connects `TcpStream` asynchronously that may be built with a net2 `TcpBuilder`.
+    //
+    // This should be removed in favor of some in-crate TcpSocket builder API.
+    #[doc(hidden)]
+    pub async fn connect_std(stream: net::TcpStream, addr: &SocketAddr) -> io::Result<TcpStream> {
+        let io = mio::net::TcpStream::connect_stream(stream, addr)?;
+        let io = PollEvented::new(io)?;
+        let stream = TcpStream { io };
+
+        // Once we've connected, wait for the stream to be writable as
+        // that's when the actual connection has been initiated. Once we're
+        // writable we check for `take_socket_error` to see if the connect
+        // actually hit an error or not.
+        //
+        // If all that succeeded then we ship everything on up.
+        poll_fn(|cx| stream.io.poll_write_ready(cx)).await?;
+
+        if let Some(e) = stream.io.get_ref().take_error()? {
+            return Err(e);
+        }
+
+        Ok(stream)
+    }
+
     /// Returns the local address that this stream is bound to.
     ///
     /// # Examples

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -197,8 +197,7 @@ impl<T> Sender<T> {
         Ok(())
     }
 
-    #[doc(hidden)] // TODO: remove
-    pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
         // Keep track of task budget
         let coop = ready!(crate::coop::poll_proceed(cx));
 

--- a/tokio/src/sync/tests/loom_oneshot.rs
+++ b/tokio/src/sync/tests/loom_oneshot.rs
@@ -75,8 +75,10 @@ impl Future for OnClose<'_> {
     type Output = bool;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<bool> {
-        let res = self.get_mut().tx.poll_closed(cx);
-        Ready(res.is_ready())
+        let fut = self.get_mut().tx.closed();
+        crate::pin!(fut);
+
+        Ready(fut.poll(cx).is_ready())
     }
 }
 

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -122,8 +122,7 @@ pub struct Interval {
 }
 
 impl Interval {
-    #[doc(hidden)] // TODO: document
-    pub fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<Instant> {
+    fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<Instant> {
         // Wait for the delay to be done
         ready!(Pin::new(&mut self.delay).poll(cx));
 

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -4,8 +4,8 @@
 use tokio::time::{self, Duration, Instant};
 use tokio_test::{assert_pending, assert_ready_eq, task};
 
-use std::task::Poll;
 use std::future::Future;
+use std::task::Poll;
 
 #[tokio::test]
 #[should_panic]

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -5,6 +5,7 @@ use tokio::time::{self, Duration, Instant};
 use tokio_test::{assert_pending, assert_ready_eq, task};
 
 use std::task::Poll;
+use std::future::Future;
 
 #[tokio::test]
 #[should_panic]
@@ -58,7 +59,12 @@ async fn usage_stream() {
 }
 
 fn poll_next(interval: &mut task::Spawn<time::Interval>) -> Poll<Instant> {
-    interval.enter(|cx, mut interval| interval.poll_tick(cx))
+    interval.enter(|cx, mut interval| {
+        tokio::pin! {
+            let fut = interval.tick();
+        }
+        fut.poll(cx)
+    })
 }
 
 fn ms(n: u64) -> Duration {


### PR DESCRIPTION
This PR makes many `#[doc(hidden)]` apis private. The remaining `#[doc(hidden)]` apis are either necessary due to e.g. macros, or covered by #2900 or #2898.

Some of the APIs should probably be considered more closely:

1. `TcpStream::connect_std` By experience answering questions, this is something I'd like to have.
2. `oneshot::Sender::poll_closed` Oneshot channels are not intrusive and would not make much sense? Consider keeping?
3. `Interval::poll_tick` Unsure whether intrusive makes sense.

The other changes were either on non-public items or had a readily available alternative in the `Stream` impl that just calls the hidden method.

Please voice your opinions about the three listed APIs below.