### PR TITLE
io: Add AsyncFd

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -53,6 +53,7 @@ net = [
   "lazy_static",
   "libc",
   "mio/os-poll",
+  "mio/os-util",
   "mio/tcp",
   "mio/udp",
   "mio/uds",
@@ -77,6 +78,7 @@ signal = [
   "libc",
   "mio/os-poll",
   "mio/uds",
+  "mio/os-util",
   "signal-hook-registry",
   "winapi/consoleapi",
 ]
@@ -105,6 +107,10 @@ tracing = { version = "0.1.16", default-features = false, features = ["std"], op
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
+
+[target.'cfg(unix)'.dev-dependencies]
+libc = { version = "0.2.42" }
+nix = { version = "0.18.0" }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -1,0 +1,320 @@
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::{task::Context, task::Poll};
+
+use std::io;
+
+use mio::unix::SourceFd;
+
+use crate::io::driver::{Direction, Handle, ReadyEvent, ScheduledIo};
+use crate::util::slab;
+
+/// Associates an IO object backed by a Unix file descriptor with the tokio
+/// reactor, allowing for readiness to be polled.
+///
+/// Creating an AsyncFd registers the file descriptor with the current tokio
+/// Reactor, allowing you to directly await the file descriptor being readable
+/// or writable. Once registered, the file descriptor remains registered until
+/// the AsyncFd is dropped.
+///
+/// The AsyncFd takes ownership of an arbitrary object to represent the IO
+/// object. It is intended that this object will handle closing the file
+/// descriptor when it is dropped, avoiding resource leaks and ensuring that the
+/// AsyncFd can clean up the registration before closing the file descriptor.
+/// The [`AsyncFd::into_inner`] function can be used to extract the inner object
+/// to retake control from the tokio IO reactor.
+///
+/// Polling for readiness is done by calling the async functions [`readable`]
+/// and [`writable`]. These functions complete when the associated readiness
+/// condition is observed. Any number of tasks can query the same `AsyncFd` in
+/// parallel, on the same or different conditions.
+///
+/// On some platforms, the readiness detecting mechanism relies on
+/// edge-triggered notifications. This means that the OS will only notify Tokio
+/// when the file descriptor transitions from not-ready to ready. Tokio
+/// internally tracks when it has received a ready notification, and when
+/// readiness checking functions like [`readable`] and [`writable`] are called,
+/// if the readiness flag is set, these async functions will complete
+/// immediately.
+///
+/// This however does mean that it is critical to ensure that this ready flag is
+/// cleared when (and only when) the file descriptor ceases to be ready. The
+/// [`ReadyGuard`] returned from readiness checking functions serves this
+/// function; after calling a readiness-checking async function, you must use
+/// this [`ReadyGuard`] to signal to tokio whether the file descriptor is no
+/// longer in a ready state.
+///
+/// ## Use with to a poll-based API
+///
+/// In some cases it may be desirable to use `AsyncFd` from APIs similar to
+/// [`TcpStream::poll_read_ready`]. The [`AsyncFd::poll_read_ready`] and
+/// [`AsyncFd::poll_write_ready`] functions are provided for this purpose.
+/// Because these functions don't create a future to hold their state, they have
+/// the limitation that only one task can wait on each direction (read or write)
+/// at a time.
+
+/// [`readable`]: method@Self::readable
+/// [`writable`]: method@Self::writable
+/// [`ReadyGuard`]: struct@self::ReadyGuard
+/// [`TcpStream::poll_read_ready`]: struct@crate::net::TcpStream
+pub struct AsyncFd<T> {
+    handle: Handle,
+    fd: RawFd,
+    shared: slab::Ref<ScheduledIo>,
+    inner: Option<T>,
+}
+
+impl<T> AsRawFd for AsyncFd<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for AsyncFd<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AsyncFd")
+            .field("fd", &self.fd)
+            .field("inner", &self.inner)
+            .finish()
+    }
+}
+
+const fn all_interest() -> mio::Interest {
+    mio::Interest::READABLE.add(mio::Interest::WRITABLE)
+}
+
+/// Represents an IO-ready event detected on a particular file descriptor, which
+/// has not yet been acknowledged. This is a `must_use` structure to help ensure
+/// that you do not forget to explicitly clear (or not clear) the event.
+#[must_use = "You must explicitly choose whether to clear the readiness state by calling a method on ReadyGuard"]
+pub struct ReadyGuard<'a, T> {
+    async_fd: &'a AsyncFd<T>,
+    event: Option<ReadyEvent>,
+}
+
+impl<'a, T: std::fmt::Debug> std::fmt::Debug for ReadyGuard<'a, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClearReady")
+            .field("async_fd", self.async_fd)
+            .finish()
+    }
+}
+
+impl<'a, T> ReadyGuard<'a, T> {
+    /// Indicates to tokio that the file descriptor is no longer ready. The
+    /// internal readiness flag will be cleared, and tokio will wait for the
+    /// next edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the file descriptor is _not_ ready. Do not call
+    /// it simply because, for example, a read succeeded; it should be called
+    /// when a read is observed to block.
+    ///
+    /// [`drop`]: method@std::mem::drop
+    pub fn clear_ready(&mut self) {
+        if let Some(event) = self.event.take() {
+            self.async_fd.shared.clear_readiness(event);
+        }
+    }
+
+    /// This function should be invoked when you intentionally want to keep the
+    /// ready flag asserted.
+    ///
+    /// While this function is itself a no-op, it satisfies the `#[must_use]`
+    /// constraint on the [`ReadyGuard`] type.
+    pub fn retain_ready(&mut self) {
+        // no-op
+    }
+
+    /// Performs the IO operation `f`; if `f` returns a [`WouldBlock`] error,
+    /// the readiness state associated with this file descriptor is cleared.
+    ///
+    /// This method helps ensure that the readiness state of the underlying file
+    /// descriptor remains in sync with the tokio-side readiness state, by
+    /// clearing the tokio-side state only when a [`WouldBlock`] condition
+    /// occurs. It is the responsibility of the caller to ensure that `f`
+    /// returns [`WouldBlock`] only if the file descriptor that originated this
+    /// `ReadyGuard` no longer expresses the readiness state that was queried to
+    /// create this `ReadyGuard`.
+    ///
+    /// [`WouldBlock`]: std::io::ErrorKind::WouldBlock
+    pub fn with_io<R, E>(&mut self, f: impl FnOnce() -> Result<R, E>) -> Result<R, E>
+    where
+        E: std::error::Error + 'static,
+    {
+        use std::error::Error;
+
+        let result = f();
+
+        if let Err(e) = result.as_ref() {
+            // Is this a WouldBlock error?
+            let mut error_ref: Option<&(dyn Error + 'static)> = Some(e);
+
+            while let Some(current) = error_ref {
+                if let Some(e) = Error::downcast_ref::<std::io::Error>(current) {
+                    if e.kind() == std::io::ErrorKind::WouldBlock {
+                        self.clear_ready();
+                        break;
+                    }
+                }
+                error_ref = current.source();
+            }
+        }
+
+        result
+    }
+
+    /// Performs the IO operation `f`; if `f` returns [`Pending`], the readiness
+    /// state associated with this file descriptor is cleared.
+    ///
+    /// This method helps ensure that the readiness state of the underlying file
+    /// descriptor remains in sync with the tokio-side readiness state, by
+    /// clearing the tokio-side state only when a [`Pending`] condition occurs.
+    /// It is the responsibility of the caller to ensure that `f` returns
+    /// [`Pending`] only if the file descriptor that originated this
+    /// `ReadyGuard` no longer expresses the readiness state that was queried to
+    /// create this `ReadyGuard`.
+    ///
+    /// [`Pending`]: std::task::Poll::Pending
+    pub fn with_poll<R>(&mut self, f: impl FnOnce() -> std::task::Poll<R>) -> std::task::Poll<R> {
+        let result = f();
+
+        if result.is_pending() {
+            self.clear_ready();
+        }
+
+        result
+    }
+}
+
+impl<T> Drop for AsyncFd<T> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.handle.inner() {
+            let _ = inner.deregister_source(&mut SourceFd(&self.fd));
+        }
+    }
+}
+
+impl<T> AsyncFd<T> {
+    /// Creates an AsyncFd backed by (and taking ownership of) an object
+    /// implementing [`AsRawFd`]. The backing file descriptor is cached at the
+    /// time of creation.
+    ///
+    /// This function must be called in the context of a tokio runtime.
+    pub fn new(inner: T) -> io::Result<Self>
+    where
+        T: AsRawFd,
+    {
+        let fd = inner.as_raw_fd();
+        Self::new_with_fd(inner, fd)
+    }
+
+    /// Constructs a new AsyncFd, explicitly specifying the backing file
+    /// descriptor.
+    ///
+    /// This function must be called in the context of a tokio runtime.
+    pub fn new_with_fd(inner: T, fd: RawFd) -> io::Result<Self> {
+        Self::new_with_handle(inner, fd, Handle::current())
+    }
+
+    pub(crate) fn new_with_handle(inner: T, fd: RawFd, handle: Handle) -> io::Result<Self> {
+        let shared = if let Some(inner) = handle.inner() {
+            inner.add_source(&mut SourceFd(&fd), all_interest())?
+        } else {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to find event loop",
+            ));
+        };
+
+        Ok(AsyncFd {
+            handle,
+            fd,
+            shared,
+            inner: Some(inner),
+        })
+    }
+
+    /// Returns a shared reference to the backing object of this [`AsyncFd`]
+    #[inline]
+    pub fn inner(&self) -> &T {
+        self.inner.as_ref().unwrap()
+    }
+
+    /// Returns a mutable reference to the backing object of this [`AsyncFd`]
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut T {
+        self.inner.as_mut().unwrap()
+    }
+
+    /// Deregisters this file descriptor, and returns ownership of the backing
+    /// object.
+    pub fn into_inner(mut self) -> T {
+        self.inner.take().unwrap()
+    }
+
+    /// Polls for read readiness. This function retains the waker for the last
+    /// context that called [`poll_read_ready`]; it therefore can only be used
+    /// by a single task at a time (however, [`poll_write_ready`] retains a
+    /// second, independent waker).
+    ///
+    /// This function is intended for cases where creating and pinning a future
+    /// via [`readable`] is not feasible. Where possible, using [`readable`] is
+    /// preferred, as this supports polling from multiple tasks at once.
+    pub fn poll_read_ready<'a, 'cx>(
+        &'a self,
+        cx: &mut Context<'cx>,
+    ) -> Poll<io::Result<ReadyGuard<'a, T>>> {
+        let event = ready!(self.shared.poll_readiness(cx, Direction::Read));
+
+        Ok(ReadyGuard {
+            async_fd: self,
+            event: Some(event),
+        })
+        .into()
+    }
+
+    /// Polls for write readiness. This function retains the waker for the last
+    /// context that called [`poll_write_ready`]; it therefore can only be used
+    /// by a single task at a time (however, [`poll_read_ready`] retains a
+    /// second, independent waker).
+    ///
+    /// This function is intended for cases where creating and pinning a future
+    /// via [`writable`] is not feasible. Where possible, using [`writable`] is
+    /// preferred, as this supports polling from multiple tasks at once.
+    pub fn poll_write_ready<'a, 'cx>(
+        &'a self,
+        cx: &mut Context<'cx>,
+    ) -> Poll<io::Result<ReadyGuard<'a, T>>> {
+        let event = ready!(self.shared.poll_readiness(cx, Direction::Write));
+
+        Ok(ReadyGuard {
+            async_fd: self,
+            event: Some(event),
+        })
+        .into()
+    }
+
+    async fn readiness(&self, interest: mio::Interest) -> io::Result<ReadyGuard<'_, T>> {
+        let event = self.shared.readiness(interest).await;
+        Ok(ReadyGuard {
+            async_fd: self,
+            event: Some(event),
+        })
+    }
+
+    /// Waits for the file descriptor to become readable, returning a
+    /// [`ReadyGuard`] that must be dropped to resume read-readiness polling.
+    ///
+    /// [`ReadyGuard`]: struct@self::ReadyGuard
+    pub async fn readable(&self) -> io::Result<ReadyGuard<'_, T>> {
+        self.readiness(mio::Interest::READABLE).await
+    }
+
+    /// Waits for the file descriptor to become writable, returning a
+    /// [`ReadyGuard`] that must be dropped to resume write-readiness polling.
+    ///
+    /// [`ReadyGuard`]: struct@self::ReadyGuard
+    pub async fn writable(&self) -> io::Result<ReadyGuard<'_, T>> {
+        self.readiness(mio::Interest::WRITABLE).await
+    }
+}

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -78,9 +78,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for AsyncFd<T> {
     }
 }
 
-const fn all_interest() -> mio::Interest {
-    mio::Interest::READABLE.add(mio::Interest::WRITABLE)
-}
+const ALL_INTEREST: mio::Interest = mio::Interest::READABLE.add(mio::Interest::WRITABLE);
 
 /// Represents an IO-ready event detected on a particular file descriptor, which
 /// has not yet been acknowledged. This is a `must_use` structure to help ensure
@@ -93,7 +91,7 @@ pub struct ReadyGuard<'a, T> {
 
 impl<'a, T: std::fmt::Debug> std::fmt::Debug for ReadyGuard<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ClearReady")
+        f.debug_struct("ReadyGuard")
             .field("async_fd", self.async_fd)
             .finish()
     }
@@ -218,7 +216,7 @@ impl<T> AsyncFd<T> {
 
     pub(crate) fn new_with_handle(inner: T, fd: RawFd, handle: Handle) -> io::Result<Self> {
         let shared = if let Some(inner) = handle.inner() {
-            inner.add_source(&mut SourceFd(&fd), all_interest())?
+            inner.add_source(&mut SourceFd(&fd), ALL_INTEREST)?
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::Other,

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -266,6 +266,14 @@ impl<T> AsyncFd<T> {
     ) -> Poll<io::Result<ReadyGuard<'a, T>>> {
         let event = ready!(self.shared.poll_readiness(cx, Direction::Read));
 
+        if !self.handle.is_alive() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "IO driver has terminated",
+            ))
+            .into();
+        }
+
         Ok(ReadyGuard {
             async_fd: self,
             event: Some(event),
@@ -286,6 +294,14 @@ impl<T> AsyncFd<T> {
         cx: &mut Context<'cx>,
     ) -> Poll<io::Result<ReadyGuard<'a, T>>> {
         let event = ready!(self.shared.poll_readiness(cx, Direction::Write));
+
+        if !self.handle.is_alive() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "IO driver has terminated",
+            ))
+            .into();
+        }
 
         Ok(ReadyGuard {
             async_fd: self,

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -258,6 +258,10 @@ impl<T> AsyncFd<T> {
     /// This function is intended for cases where creating and pinning a future
     /// via [`readable`] is not feasible. Where possible, using [`readable`] is
     /// preferred, as this supports polling from multiple tasks at once.
+    ///
+    /// [`poll_read_ready`]: method@self::poll_read_ready
+    /// [`poll_write_ready`]: method@self::poll_write_ready
+    /// [`readable`]: method@self::readable
     pub fn poll_read_ready<'a, 'cx>(
         &'a self,
         cx: &mut Context<'cx>,
@@ -287,6 +291,10 @@ impl<T> AsyncFd<T> {
     /// This function is intended for cases where creating and pinning a future
     /// via [`writable`] is not feasible. Where possible, using [`writable`] is
     /// preferred, as this supports polling from multiple tasks at once.
+    ///
+    /// [`poll_read_ready`]: method@self::poll_read_ready
+    /// [`poll_write_ready`]: method@self::poll_write_ready
+    /// [`writable`]: method@self::writable
     pub fn poll_write_ready<'a, 'cx>(
         &'a self,
         cx: &mut Context<'cx>,

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -9,7 +9,9 @@ use crate::io::driver::{Direction, Handle, ReadyEvent, ScheduledIo};
 use crate::util::slab;
 
 /// Associates an IO object backed by a Unix file descriptor with the tokio
-/// reactor, allowing for readiness to be polled.
+/// reactor, allowing for readiness to be polled. The file descriptor must be of
+/// a type that can be used with the OS polling facilities (ie, `poll`, `epoll`,
+/// `kqueue`, etc), such as a network socket or pipe.
 ///
 /// Creating an AsyncFd registers the file descriptor with the current tokio
 /// Reactor, allowing you to directly await the file descriptor being readable

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -259,9 +259,9 @@ impl<T> AsyncFd<T> {
     /// via [`readable`] is not feasible. Where possible, using [`readable`] is
     /// preferred, as this supports polling from multiple tasks at once.
     ///
-    /// [`poll_read_ready`]: method@self::poll_read_ready
-    /// [`poll_write_ready`]: method@self::poll_write_ready
-    /// [`readable`]: method@self::readable
+    /// [`poll_read_ready`]: method@Self::poll_read_ready
+    /// [`poll_write_ready`]: method@Self::poll_write_ready
+    /// [`readable`]: method@Self::readable
     pub fn poll_read_ready<'a, 'cx>(
         &'a self,
         cx: &mut Context<'cx>,
@@ -292,9 +292,9 @@ impl<T> AsyncFd<T> {
     /// via [`writable`] is not feasible. Where possible, using [`writable`] is
     /// preferred, as this supports polling from multiple tasks at once.
     ///
-    /// [`poll_read_ready`]: method@self::poll_read_ready
-    /// [`poll_write_ready`]: method@self::poll_write_ready
-    /// [`writable`]: method@self::writable
+    /// [`poll_read_ready`]: method@Self::poll_read_ready
+    /// [`poll_write_ready`]: method@Self::poll_write_ready
+    /// [`writable`]: method@Self::writable
     pub fn poll_write_ready<'a, 'cx>(
         &'a self,
         cx: &mut Context<'cx>,

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -202,14 +202,14 @@ impl Drop for Inner {
     fn drop(&mut self) {
         let resources = self.resources.lock().take();
 
-        resources.map(|mut slab| {
+        if let Some(mut slab) = resources {
             slab.for_each(|io| {
                 // If a task is waiting on the I/O resource, notify it. The task
                 // will then attempt to use the I/O resource and fail due to the
                 // driver being shutdown.
                 io.shutdown();
-            })
-        });
+            });
+        }
     }
 }
 

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -291,8 +291,10 @@ impl Handle {
         self.inner.upgrade()
     }
 
-    pub(super) fn is_alive(&self) -> bool {
-        self.inner.strong_count() > 0
+    cfg_net_unix! {
+        pub(super) fn is_alive(&self) -> bool {
+            self.inner.strong_count() > 0
+        }
     }
 }
 

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -7,8 +7,8 @@ mod scheduled_io;
 pub(crate) use scheduled_io::ScheduledIo; // pub(crate) for tests
 
 use crate::park::{Park, Unpark};
-use crate::util::bit;
 use crate::util::slab::{self, Slab};
+use crate::{loom::sync::Mutex, util::bit};
 
 use std::fmt;
 use std::io;
@@ -25,8 +25,10 @@ pub(crate) struct Driver {
     events: Option<mio::Events>,
 
     /// Primary slab handle containing the state for each resource registered
-    /// with this driver.
-    resources: Slab<ScheduledIo>,
+    /// with this driver. During Drop this is moved into the Inner structure, so
+    /// this is an Option to allow it to be vacated (until Drop this is always
+    /// Some)
+    resources: Option<Slab<ScheduledIo>>,
 
     /// The system event queue
     poll: mio::Poll,
@@ -47,6 +49,14 @@ pub(crate) struct ReadyEvent {
 }
 
 pub(super) struct Inner {
+    /// Primary slab handle containing the state for each resource registered
+    /// with this driver.
+    ///
+    /// The ownership of this slab is moved into this structure during
+    /// `Driver::drop`, so that `Inner::drop` can notify all outstanding handles
+    /// without risking new ones being registered in the meantime.
+    resources: Mutex<Option<Slab<ScheduledIo>>>,
+
     /// Registers I/O resources
     registry: mio::Registry,
 
@@ -104,9 +114,10 @@ impl Driver {
         Ok(Driver {
             tick: 0,
             events: Some(mio::Events::with_capacity(1024)),
-            resources: slab,
             poll,
+            resources: Some(slab),
             inner: Arc::new(Inner {
+                resources: Mutex::new(None),
                 registry,
                 io_dispatch: allocator,
                 waker,
@@ -133,7 +144,7 @@ impl Driver {
         self.tick = self.tick.wrapping_add(1);
 
         if self.tick == COMPACT_INTERVAL {
-            self.resources.compact();
+            self.resources.as_mut().unwrap().compact()
         }
 
         let mut events = self.events.take().expect("i/o driver event store missing");
@@ -163,7 +174,9 @@ impl Driver {
     fn dispatch(&mut self, token: mio::Token, ready: Ready) {
         let addr = slab::Address::from_usize(ADDRESS.unpack(token.0));
 
-        let io = match self.resources.get(addr) {
+        let resources = self.resources.as_mut().unwrap();
+
+        let io = match resources.get(addr) {
             Some(io) => io,
             None => return,
         };
@@ -181,12 +194,22 @@ impl Driver {
 
 impl Drop for Driver {
     fn drop(&mut self) {
-        self.resources.for_each(|io| {
-            // If a task is waiting on the I/O resource, notify it. The task
-            // will then attempt to use the I/O resource and fail due to the
-            // driver being shutdown.
-            io.wake(Ready::ALL);
-        })
+        (*self.inner.resources.lock()) = self.resources.take();
+    }
+}
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        let resources = self.resources.lock().take();
+
+        resources.map(|mut slab| {
+            slab.for_each(|io| {
+                // If a task is waiting on the I/O resource, notify it. The task
+                // will then attempt to use the I/O resource and fail due to the
+                // driver being shutdown.
+                io.shutdown();
+            })
+        });
     }
 }
 
@@ -266,6 +289,10 @@ impl Handle {
 
     pub(super) fn inner(&self) -> Option<Arc<Inner>> {
         self.inner.upgrade()
+    }
+
+    pub(super) fn is_alive(&self) -> bool {
+        self.inner.strong_count() > 0
     }
 }
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -218,7 +218,10 @@ cfg_io_driver! {
 cfg_net_unix! {
     mod async_fd;
 
-    pub use self::async_fd::{AsyncFd, ReadyGuard};
+    pub mod unix {
+        //! Asynchronous IO structures specific to Unix-like operating systems.
+        pub use super::async_fd::{AsyncFd, ReadyGuard};
+    }
 }
 
 cfg_io_std! {

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -220,7 +220,7 @@ cfg_net_unix! {
 
     pub mod unix {
         //! Asynchronous IO structures specific to Unix-like operating systems.
-        pub use super::async_fd::{AsyncFd, ReadyGuard};
+        pub use super::async_fd::{AsyncFd, AsyncFdReadyGuard};
     }
 }
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -207,11 +207,18 @@ pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 cfg_io_driver! {
     pub(crate) mod driver;
 
+    mod registration;
+
     mod poll_evented;
+
     #[cfg(not(loom))]
     pub(crate) use poll_evented::PollEvented;
+}
 
-    mod registration;
+cfg_net_unix! {
+    mod async_fd;
+
+    pub use self::async_fd::{AsyncFd, ReadyGuard};
 }
 
 cfg_io_std! {

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -305,7 +305,8 @@
 //! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
 //! - `io-util`: Enables the IO based `Ext` traits.
 //! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
-//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`.
+//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`,
+//!          as well as (on Unix-like systems) `AsyncFd`
 //! - `time`: Enables `tokio::time` types and allows the schedulers to enable
 //!           the built in timer.
 //! - `process`: Enables `tokio::process` types.

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -74,7 +74,7 @@ pub(crate) mod sync {
         pub(crate) use crate::loom::std::atomic_u8::AtomicU8;
         pub(crate) use crate::loom::std::atomic_usize::AtomicUsize;
 
-        pub(crate) use std::sync::atomic::{spin_loop_hint, AtomicBool};
+        pub(crate) use std::sync::atomic::{fence, spin_loop_hint, AtomicBool, Ordering};
     }
 }
 

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -43,6 +43,11 @@ impl<T> Mutex<T> {
         self.0.try_lock()
     }
 
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        self.0.get_mut()
+    }
+
     // Note: Additional methods `is_poisoned` and `into_inner`, can be
     // provided here as needed.
 }

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -51,7 +51,7 @@ impl TestWaker {
         self.inner.awoken.swap(false, Ordering::SeqCst)
     }
 
-    fn context<'a>(&'a self) -> Context<'a> {
+    fn context(&self) -> Context<'_> {
         Context::from_waker(&self.waker)
     }
 }
@@ -226,7 +226,7 @@ async fn reset_readable() {
 
 #[tokio::test]
 async fn reset_writable() {
-    let (a, mut b) = socketpair();
+    let (a, b) = socketpair();
 
     let afd_a = AsyncFd::new(a).unwrap();
 
@@ -250,7 +250,7 @@ async fn reset_writable() {
     }
 
     // Read from the other side; we should become writable now.
-    drain(&mut b);
+    drain(&b);
 
     let _ = writable.await.unwrap();
 }

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -1,0 +1,449 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(unix, feature = "full"))]
+
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use std::{
+    io::{self, ErrorKind, Read, Write},
+    task::{Context, Waker},
+};
+
+use nix::errno::Errno;
+use nix::unistd::{close, read, write};
+
+use futures::{poll, FutureExt};
+
+use tokio::io::AsyncFd;
+use tokio_test::assert_pending;
+
+struct TestWaker {
+    inner: Arc<TestWakerInner>,
+    waker: Waker,
+}
+
+#[derive(Default)]
+struct TestWakerInner {
+    awoken: AtomicBool,
+}
+
+impl futures::task::ArcWake for TestWakerInner {
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.awoken.store(true, Ordering::SeqCst);
+    }
+}
+
+impl TestWaker {
+    fn new() -> Self {
+        let inner: Arc<TestWakerInner> = Default::default();
+
+        Self {
+            inner: inner.clone(),
+            waker: futures::task::waker(inner),
+        }
+    }
+
+    fn awoken(&self) -> bool {
+        self.inner.awoken.swap(false, Ordering::SeqCst)
+    }
+
+    fn context<'a>(&'a self) -> Context<'a> {
+        Context::from_waker(&self.waker)
+    }
+}
+
+fn is_blocking(e: &nix::Error) -> bool {
+    Some(Errno::EAGAIN) == e.as_errno()
+}
+
+#[derive(Debug)]
+struct FileDescriptor {
+    fd: RawFd,
+}
+
+impl AsRawFd for FileDescriptor {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl Read for &FileDescriptor {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match read(self.fd, buf) {
+            Ok(n) => Ok(n),
+            Err(e) if is_blocking(&e) => Err(ErrorKind::WouldBlock.into()),
+            Err(e) => Err(io::Error::new(ErrorKind::Other, e)),
+        }
+    }
+}
+
+impl Read for FileDescriptor {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        (self as &Self).read(buf)
+    }
+}
+
+impl Write for &FileDescriptor {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match write(self.fd, buf) {
+            Ok(n) => Ok(n),
+            Err(e) if is_blocking(&e) => Err(ErrorKind::WouldBlock.into()),
+            Err(e) => Err(io::Error::new(ErrorKind::Other, e)),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl Write for FileDescriptor {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        (self as &Self).write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        (self as &Self).flush()
+    }
+}
+
+impl Drop for FileDescriptor {
+    fn drop(&mut self) {
+        let _ = close(self.fd);
+    }
+}
+
+fn set_nonblocking(fd: RawFd) {
+    use nix::fcntl::{OFlag, F_GETFL, F_SETFL};
+
+    let flags = nix::fcntl::fcntl(fd, F_GETFL).expect("fcntl(F_GETFD)");
+
+    if flags < 0 {
+        panic!(
+            "bad return value from fcntl(F_GETFL): {} ({:?})",
+            flags,
+            nix::Error::last()
+        );
+    }
+
+    let flags = OFlag::from_bits_truncate(flags) | OFlag::O_NONBLOCK;
+
+    nix::fcntl::fcntl(fd, F_SETFL(flags)).expect("fcntl(F_SETFD)");
+}
+
+fn socketpair() -> (FileDescriptor, FileDescriptor) {
+    use nix::sys::socket::{self, AddressFamily, SockFlag, SockType};
+
+    let (fd_a, fd_b) = socket::socketpair(
+        AddressFamily::Unix,
+        SockType::Stream,
+        None,
+        SockFlag::empty(),
+    )
+    .expect("socketpair");
+    let fds = (FileDescriptor { fd: fd_a }, FileDescriptor { fd: fd_b });
+
+    set_nonblocking(fds.0.fd);
+    set_nonblocking(fds.1.fd);
+
+    fds
+}
+
+fn drain(mut fd: &FileDescriptor) {
+    let mut buf = [0u8; 512];
+
+    loop {
+        match fd.read(&mut buf[..]) {
+            Err(e) if e.kind() == ErrorKind::WouldBlock => break,
+            Ok(0) => panic!("unexpected EOF"),
+            Err(e) => panic!("unexpected error: {:?}", e),
+            Ok(_) => continue,
+        }
+    }
+}
+
+#[tokio::test]
+async fn initially_writable() {
+    let (a, b) = socketpair();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+    let afd_b = AsyncFd::new(b).unwrap();
+
+    afd_a.writable().await.unwrap().clear_ready();
+    afd_b.writable().await.unwrap().clear_ready();
+
+    futures::select_biased! {
+        _ = tokio::time::sleep(Duration::from_millis(10)).fuse() => {},
+        _ = afd_a.readable().fuse() => panic!("Unexpected readable state"),
+        _ = afd_b.readable().fuse() => panic!("Unexpected readable state"),
+    }
+}
+
+#[tokio::test]
+async fn reset_readable() {
+    let (a, mut b) = socketpair();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+
+    let readable = afd_a.readable();
+    tokio::pin!(readable);
+
+    tokio::select! {
+        _ = readable.as_mut() => panic!(),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
+
+    b.write_all(b"0").unwrap();
+
+    let mut guard = readable.await.unwrap();
+
+    guard.with_io(|| afd_a.inner().read(&mut [0])).unwrap();
+
+    // `a` is not readable, but the reactor still thinks it is
+    // (because we have not observed a not-ready error yet)
+    afd_a.readable().await.unwrap().retain_ready();
+
+    // Explicitly clear the ready state
+    guard.clear_ready();
+
+    let readable = afd_a.readable();
+    tokio::pin!(readable);
+
+    tokio::select! {
+        _ = readable.as_mut() => panic!(),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
+
+    b.write_all(b"0").unwrap();
+
+    // We can observe the new readable event
+    afd_a.readable().await.unwrap().clear_ready();
+}
+
+#[tokio::test]
+async fn reset_writable() {
+    let (a, mut b) = socketpair();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+
+    let mut guard = afd_a.writable().await.unwrap();
+
+    // Write until we get a WouldBlock. This also clears the ready state.
+    loop {
+        if let Err(e) = guard.with_io(|| afd_a.inner().write(&[0; 512][..])) {
+            assert_eq!(ErrorKind::WouldBlock, e.kind());
+            break;
+        }
+    }
+
+    // Writable state should be cleared now.
+    let writable = afd_a.writable();
+    tokio::pin!(writable);
+
+    tokio::select! {
+        _ = writable.as_mut() => panic!(),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
+
+    // Read from the other side; we should become writable now.
+    drain(&mut b);
+
+    let _ = writable.await.unwrap();
+}
+
+#[tokio::test]
+async fn drop_closes() {
+    let (a, mut b) = socketpair();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+
+    assert_eq!(
+        ErrorKind::WouldBlock,
+        b.read(&mut [0]).err().unwrap().kind()
+    );
+
+    std::mem::drop(afd_a);
+
+    assert_eq!(0, b.read(&mut [0]).unwrap());
+
+    // into_inner does not close the fd
+
+    let (a, mut b) = socketpair();
+    let afd_a = AsyncFd::new(a).unwrap();
+    let _a: FileDescriptor = afd_a.into_inner();
+
+    assert_eq!(
+        ErrorKind::WouldBlock,
+        b.read(&mut [0]).err().unwrap().kind()
+    );
+
+    // Drop closure behavior is delegated to the inner object
+    let (a, mut b) = socketpair();
+    let afd_a = AsyncFd::new_with_fd((), a.fd).unwrap();
+    std::mem::drop(afd_a);
+
+    assert_eq!(
+        ErrorKind::WouldBlock,
+        b.read(&mut [0]).err().unwrap().kind()
+    );
+}
+
+#[tokio::test]
+async fn with_poll() {
+    use std::task::Poll;
+
+    let (a, mut b) = socketpair();
+
+    b.write_all(b"0").unwrap();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+
+    let mut guard = afd_a.readable().await.unwrap();
+
+    afd_a.inner().read_exact(&mut [0]).unwrap();
+
+    // Should not clear the readable state
+    let _ = guard.with_poll(|| Poll::Ready(()));
+
+    // Still readable...
+    let _ = afd_a.readable().await.unwrap();
+
+    // Should clear the readable state
+    let _ = guard.with_poll(|| Poll::Pending::<()>);
+
+    // Assert not readable
+    let readable = afd_a.readable();
+    tokio::pin!(readable);
+
+    tokio::select! {
+        _ = readable.as_mut() => panic!(),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
+
+    // Write something down b again and make sure we're reawoken
+    b.write_all(b"0").unwrap();
+    let _ = readable.await.unwrap();
+}
+
+#[tokio::test]
+async fn multiple_waiters() {
+    let (a, mut b) = socketpair();
+    let afd_a = Arc::new(AsyncFd::new(a).unwrap());
+
+    let barrier = Arc::new(tokio::sync::Barrier::new(11));
+
+    let mut tasks = Vec::new();
+    for _ in 0..10 {
+        let afd_a = afd_a.clone();
+        let barrier = barrier.clone();
+
+        let f = async move {
+            let notify_barrier = async {
+                barrier.wait().await;
+                futures::future::pending::<()>().await;
+            };
+
+            futures::select_biased! {
+                guard = afd_a.readable().fuse() => {
+                    tokio::task::yield_now().await;
+                    guard.unwrap().clear_ready()
+                },
+                _ = notify_barrier.fuse() => unreachable!(),
+            }
+
+            std::mem::drop(afd_a);
+        };
+
+        tasks.push(tokio::spawn(f));
+    }
+
+    let mut all_tasks = futures::future::try_join_all(tasks);
+
+    tokio::select! {
+        r = std::pin::Pin::new(&mut all_tasks) => {
+            r.unwrap(); // propagate panic
+            panic!("Tasks exited unexpectedly")
+        },
+        _ = barrier.wait() => {}
+    };
+
+    b.write_all(b"0").unwrap();
+
+    all_tasks.await.unwrap();
+}
+
+#[tokio::test]
+async fn poll_fns() {
+    let (a, b) = socketpair();
+    let afd_a = Arc::new(AsyncFd::new(a).unwrap());
+    let afd_b = Arc::new(AsyncFd::new(b).unwrap());
+
+    // Fill up the write side of A
+    while afd_a.inner().write(&[0; 512]).is_ok() {}
+
+    let waker = TestWaker::new();
+
+    assert_pending!(afd_a.as_ref().poll_read_ready(&mut waker.context()));
+
+    let afd_a_2 = afd_a.clone();
+    let r_barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let barrier_clone = r_barrier.clone();
+
+    let read_fut = tokio::spawn(async move {
+        // Move waker onto this task first
+        assert_pending!(poll!(futures::future::poll_fn(|cx| afd_a_2
+            .as_ref()
+            .poll_read_ready(cx))));
+        barrier_clone.wait().await;
+
+        let _ = futures::future::poll_fn(|cx| afd_a_2.as_ref().poll_read_ready(cx)).await;
+    });
+
+    let afd_a_2 = afd_a.clone();
+    let w_barrier = Arc::new(tokio::sync::Barrier::new(2));
+    let barrier_clone = w_barrier.clone();
+
+    let mut write_fut = tokio::spawn(async move {
+        // Move waker onto this task first
+        assert_pending!(poll!(futures::future::poll_fn(|cx| afd_a_2
+            .as_ref()
+            .poll_write_ready(cx))));
+        barrier_clone.wait().await;
+
+        let _ = futures::future::poll_fn(|cx| afd_a_2.as_ref().poll_write_ready(cx)).await;
+    });
+
+    r_barrier.wait().await;
+    w_barrier.wait().await;
+
+    let readable = afd_a.readable();
+    tokio::pin!(readable);
+
+    tokio::select! {
+        _ = &mut readable => unreachable!(),
+        _ = tokio::task::yield_now() => {}
+    }
+
+    // Make A readable. We expect that 'readable' and 'read_fut' will both complete quickly
+    afd_b.inner().write_all(b"0").unwrap();
+
+    let _ = tokio::join!(readable, read_fut);
+
+    // Our original waker should _not_ be awoken (poll_read_ready retains only the last context)
+    assert!(!waker.awoken());
+
+    // The writable side should not be awoken
+    tokio::select! {
+        _ = &mut write_fut => unreachable!(),
+        _ = tokio::time::sleep(Duration::from_millis(5)) => {}
+    }
+
+    // Make it writable now
+    drain(afd_b.inner());
+
+    // now we should be writable (ie - the waker for poll_write should still be registered after we wake the read side)
+    let _ = write_fut.await;
+}


### PR DESCRIPTION
This adds AsyncFd, a unix-only structure to allow for read/writability states
to be monitored for arbitrary file descriptors.

Issue: #2728

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

See #2728 for the motivation for this change.

## Solution

This introduces a new `AsyncFd` type which can be used to monitor arbitrary file descriptors for readability and writability. I've chosen not to expose a `poll_*` API as callers can emulate such an API on their own (an example is given in the rustdocs). I've also avoided exposing specific `Ready`/`Interest`-like types (this could be added in the future in a backwards-compatible way).

I'm a little bit uncomfortable with how the cfg-macros work out here - I had to touch quite a few places to add the `async-fd` feature flag. That feels like a refactor for another PR however.