### PR TITLE
Update tokio-macros to new builder

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -4,7 +4,7 @@ error: the async keyword is missing from the function declaration
 4 | fn main_is_not_async() {}
   | ^^
 
-error: Unknown attribute foo is specified; expected `basic_scheduler` or `threaded_scheduler`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `num_workers`
  --> $DIR/macros_invalid_input.rs:6:15
   |
 6 | #[tokio::main(foo)]
@@ -28,7 +28,7 @@ error: the test function cannot accept arguments
 16 | async fn test_fn_has_args(_x: u8) {}
    |                           ^^^^^^
 
-error: Unknown attribute foo is specified; expected `basic_scheduler` or `threaded_scheduler`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `num_workers`
   --> $DIR/macros_invalid_input.rs:18:15
    |
 18 | #[tokio::test(foo)]

--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "macros")]
+#![cfg(all(feature = "macros", feature = "rt-core"))]
 
 #[tokio::main]
 async fn basic_main() -> usize {
@@ -10,18 +10,15 @@ async fn generic_fun<T: Default>() -> T {
     T::default()
 }
 
-#[cfg(feature = "rt-core")]
-mod spawn {
-    #[tokio::main]
-    async fn spawning() -> usize {
-        let join = tokio::spawn(async { 1 });
-        join.await.unwrap()
-    }
+#[tokio::main]
+async fn spawning() -> usize {
+    let join = tokio::spawn(async { 1 });
+    join.await.unwrap()
+}
 
-    #[test]
-    fn main_with_spawn() {
-        assert_eq!(1, spawning());
-    }
+#[test]
+fn main_with_spawn() {
+    assert_eq!(1, spawning());
 }
 
 #[test]

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -1,11 +1,171 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
 use quote::quote;
-use std::num::NonZeroUsize;
+use syn::spanned::Spanned;
 
 #[derive(Clone, Copy, PartialEq)]
-enum Runtime {
-    Basic,
-    Threaded,
+enum RuntimeFlavor {
+    InPlace,
+    WorkStealing,
+}
+
+impl RuntimeFlavor {
+    fn from_str(s: &str) -> Result<RuntimeFlavor, String> {
+        match s {
+            "in_place" => Ok(RuntimeFlavor::InPlace),
+            "work_stealing" => Ok(RuntimeFlavor::WorkStealing),
+            "single_threaded" => Err(format!("The single threaded runtime flavor is called `in_place`.")),
+            "basic_scheduler" => Err(format!("The `basic_scheduler` runtime flavor has been renamed to `in_place`.")),
+            "threaded_scheduler" => Err(format!("The `threaded_scheduler` runtime flavor has been renamed to `work_stealing`.")),
+            _ => Err(format!("No such runtime flavor `{}`.", s)),
+        }
+    }
+}
+
+struct FinalConfig {
+    flavor: RuntimeFlavor,
+    num_workers: Option<usize>,
+    max_threads: Option<usize>,
+}
+
+struct Configuration {
+    rt_threaded_available: bool,
+    default_flavor: RuntimeFlavor,
+    flavor: Option<RuntimeFlavor>,
+    num_workers: Option<(usize, Span)>,
+    max_threads: Option<(usize, Span)>,
+}
+impl Configuration {
+    fn new(is_test: bool, rt_threaded: bool) -> Self {
+        Configuration {
+            rt_threaded_available: rt_threaded,
+            default_flavor: match is_test {
+                true => RuntimeFlavor::InPlace,
+                false => RuntimeFlavor::WorkStealing,
+            },
+            flavor: None,
+            num_workers: None,
+            max_threads: None,
+        }
+    }
+    fn set_flavor(
+        &mut self,
+        runtime: syn::Lit,
+        span: Span,
+    ) -> Result<(), syn::Error> {
+        if self.flavor.is_some() {
+            return Err(syn::Error::new(span, "`flavor` set multiple times."));
+        }
+
+        let runtime_str = parse_string(runtime, span, "flavor")?;
+        let runtime = RuntimeFlavor::from_str(&runtime_str)
+            .map_err(|err| syn::Error::new(span, err))?;
+        self.flavor = Some(runtime);
+        Ok(())
+    }
+    fn set_num_workers(
+        &mut self,
+        num_workers: syn::Lit,
+        span: Span,
+    ) -> Result<(), syn::Error> {
+        if self.num_workers.is_some() {
+            return Err(syn::Error::new(span, "`num_workers` set multiple times."));
+        }
+
+        let num_workers = parse_int(num_workers, span, "num_workers")?;
+        if num_workers == 0 {
+            return Err(syn::Error::new(span, "`num_workers` may not be 0."));
+        }
+        self.num_workers = Some((num_workers, span));
+        Ok(())
+    }
+    fn set_max_threads(
+        &mut self,
+        max_threads: syn::Lit,
+        span: Span,
+    ) -> Result<(), syn::Error> {
+        if self.max_threads.is_some() {
+            return Err(syn::Error::new(span, "`max_threads` set multiple times."));
+        }
+
+        let max_threads = parse_int(max_threads, span, "max_threads")?;
+        if max_threads == 0 {
+            return Err(syn::Error::new(span, "`max_threads` may not be 0."));
+        }
+        self.max_threads = Some((max_threads, span));
+        Ok(())
+    }
+    fn build(&self) -> Result<FinalConfig, syn::Error> {
+        let flavor = self.flavor.unwrap_or(self.default_flavor);
+        match flavor {
+            RuntimeFlavor::InPlace => {
+                if let Some((_, num_workers_span)) = &self.num_workers {
+                    return Err(syn::Error::new(
+                        num_workers_span.clone(),
+                        "The `num_workers` option requires the `work_stealing` runtime flavor."
+                    ));
+                }
+                assert!(self.num_workers.is_none());
+                Ok(FinalConfig {
+                    flavor,
+                    num_workers: None,
+                    max_threads: self.max_threads.map(|(val, _span)| val),
+                })
+            },
+            RuntimeFlavor::WorkStealing => {
+                if !self.rt_threaded_available {
+                    let msg = if self.flavor.is_none() {
+                        "The default runtime flavor is `work_stealing`, but the `rt-threaded` feature is disabled."
+                    } else {
+                        "The runtime flavor `work_stealing` requires the `rt-threaded` feature."
+                    };
+                    return Err(syn::Error::new(Span::call_site(), msg));
+                }
+                match (self.num_workers, self.max_threads) {
+                    (None, Some((_, span))) => {
+                        return Err(syn::Error::new(
+                                span,
+                                "`num_workers` must also be set when using `max_threads`"
+                        ));
+                    },
+                    (Some((num_workers, _)), Some((max_threads, span))) if max_threads <= num_workers => {
+                        return Err(syn::Error::new(
+                                span,
+                                "`max_threads` must be larger than `num_workers`",
+                        ));
+                    },
+                    _ => {},
+                }
+                Ok(FinalConfig {
+                    flavor,
+                    num_workers: self.num_workers.map(|(val, _span)| val),
+                    max_threads: self.max_threads.map(|(val, _span)| val),
+                })
+            },
+        }
+    }
+}
+
+fn parse_int(int: syn::Lit, span: Span, field: &str) -> Result<usize, syn::Error> {
+    match int {
+        syn::Lit::Int(lit) => {
+            match lit.base10_parse::<usize>() {
+                Ok(value) => Ok(value),
+                Err(e) => Err(syn::Error::new(
+                    span,
+                    format!("Failed to parse {} as integer: {}", field, e),
+                )),
+            }
+        },
+        _ => Err(syn::Error::new(span, format!("Failed to parse {} as integer.", field))),
+    }
+}
+fn parse_string(int: syn::Lit, span: Span, field: &str) -> Result<String, syn::Error> {
+    match int {
+        syn::Lit::Str(s) => Ok(s.value()),
+        syn::Lit::Verbatim(s) => Ok(s.to_string()),
+        _ => Err(syn::Error::new(span, format!("Failed to parse {} as string.", field))),
+    }
 }
 
 fn parse_knobs(
@@ -26,9 +186,8 @@ fn parse_knobs(
 
     sig.asyncness = None;
 
-    let mut runtime = None;
-    let mut core_threads = None;
-    let mut max_threads = None;
+    let macro_name = if is_test { "tokio::test" } else { "tokio::main" };
+    let mut config = Configuration::new(is_test, rt_threaded);
 
     for arg in args {
         match arg {
@@ -39,65 +198,21 @@ fn parse_knobs(
                     return Err(syn::Error::new_spanned(namevalue, msg));
                 }
                 match ident.unwrap().to_string().to_lowercase().as_str() {
-                    "core_threads" => {
-                        if rt_threaded {
-                            match &namevalue.lit {
-                                syn::Lit::Int(expr) => {
-                                    let num = expr.base10_parse::<NonZeroUsize>().unwrap();
-                                    if num.get() > 1 {
-                                        runtime = Some(Runtime::Threaded);
-                                    } else {
-                                        runtime = Some(Runtime::Basic);
-                                    }
-
-                                    if let Some(v) = max_threads {
-                                        if v < num {
-                                            return Err(syn::Error::new_spanned(
-                                                namevalue,
-                                                "max_threads cannot be less than core_threads",
-                                            ));
-                                        }
-                                    }
-
-                                    core_threads = Some(num);
-                                }
-                                _ => {
-                                    return Err(syn::Error::new_spanned(
-                                        namevalue,
-                                        "core_threads argument must be an int",
-                                    ))
-                                }
-                            }
-                        } else {
-                            return Err(syn::Error::new_spanned(
-                                namevalue,
-                                "core_threads can only be set with rt-threaded feature flag enabled",
-                            ));
-                        }
+                    "num_workers" => {
+                        config.set_num_workers(namevalue.lit.clone(), namevalue.span())?;
                     }
-                    "max_threads" => match &namevalue.lit {
-                        syn::Lit::Int(expr) => {
-                            let num = expr.base10_parse::<NonZeroUsize>().unwrap();
-
-                            if let Some(v) = core_threads {
-                                if num < v {
-                                    return Err(syn::Error::new_spanned(
-                                        namevalue,
-                                        "max_threads cannot be less than core_threads",
-                                    ));
-                                }
-                            }
-                            max_threads = Some(num);
-                        }
-                        _ => {
-                            return Err(syn::Error::new_spanned(
-                                namevalue,
-                                "max_threads argument must be an int",
-                            ))
-                        }
+                    "max_threads" => {
+                        config.set_max_threads(namevalue.lit.clone(), namevalue.span())?;
                     },
+                    "flavor" => {
+                        config.set_flavor(namevalue.lit.clone(), namevalue.span())?;
+                    },
+                    "core_threads" => {
+                        let msg = "Attribute `core_threads` is renamed to `num_workers`";
+                        return Err(syn::Error::new_spanned(namevalue, msg));
+                    }
                     name => {
-                        let msg = format!("Unknown attribute pair {} is specified; expected one of: `core_threads`, `max_threads`", name);
+                        let msg = format!("Unknown attribute {} is specified; expected one of: `flavor`, `num_workers`, `max_threads`", name);
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
                 }
@@ -108,16 +223,22 @@ fn parse_knobs(
                     let msg = "Must have specified ident";
                     return Err(syn::Error::new_spanned(path, msg));
                 }
-                match ident.unwrap().to_string().to_lowercase().as_str() {
-                    "threaded_scheduler" => {
-                        runtime = Some(runtime.unwrap_or_else(|| Runtime::Threaded))
-                    }
-                    "basic_scheduler" => runtime = Some(runtime.unwrap_or_else(|| Runtime::Basic)),
+                let name = ident.unwrap().to_string().to_lowercase();
+                let msg = match name.as_str() {
+                    "threaded_scheduler" | "work_stealing" => {
+                        format!("Set the runtime flavor with #[{}(flavor = \"work_stealing\")].", macro_name)
+                    },
+                    "basic_scheduler" | "in_place" => {
+                        format!("Set the runtime flavor with #[{}(flavor = \"in_place\")].", macro_name)
+                    },
+                    "flavor" | "num_workers" | "max_threads" => {
+                        format!("The `{}` attribute requires an argument.", name)
+                    },
                     name => {
-                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
-                        return Err(syn::Error::new_spanned(path, msg));
-                    }
-                }
+                        format!("Unkown attribute {} is specified; expected one of: `flavor`, `num_workers`, `max_threads`", name)
+                    },
+                };
+                return Err(syn::Error::new_spanned(path, msg));
             }
             other => {
                 return Err(syn::Error::new_spanned(
@@ -128,14 +249,20 @@ fn parse_knobs(
         }
     }
 
-    let mut rt = quote! { tokio::runtime::Builder::new().basic_scheduler() };
-    if rt_threaded && (runtime == Some(Runtime::Threaded) || (runtime.is_none() && !is_test)) {
-        rt = quote! { #rt.threaded_scheduler() };
-    }
-    if let Some(v) = core_threads.map(|v| v.get()) {
+    let config = config.build()?;
+
+    let mut rt = match config.flavor {
+        RuntimeFlavor::InPlace => quote! {
+            tokio::runtime::Builder::new().basic_scheduler()
+        },
+        RuntimeFlavor::WorkStealing => quote! {
+            tokio::runtime::Builder::new().threaded_scheduler()
+        },
+    };
+    if let Some(v) = config.num_workers {
         rt = quote! { #rt.core_threads(#v) };
     }
-    if let Some(v) = max_threads.map(|v| v.get()) {
+    if let Some(v) = config.max_threads {
         rt = quote! { #rt.max_threads(#v) };
     }
 
@@ -171,12 +298,13 @@ pub(crate) fn main(args: TokenStream, item: TokenStream, rt_threaded: bool) -> T
 
     if input.sig.ident == "main" && !input.sig.inputs.is_empty() {
         let msg = "the main function cannot accept arguments";
-        return syn::Error::new_spanned(&input.sig.inputs, msg)
+        return syn::Error::new_spanned(&input.sig.ident, msg)
             .to_compile_error()
             .into();
     }
 
-    parse_knobs(input, args, false, rt_threaded).unwrap_or_else(|e| e.to_compile_error().into())
+    parse_knobs(input, args, false, rt_threaded)
+        .unwrap_or_else(|e| e.to_compile_error().into())
 }
 
 pub(crate) fn test(args: TokenStream, item: TokenStream, rt_threaded: bool) -> TokenStream {
@@ -199,161 +327,6 @@ pub(crate) fn test(args: TokenStream, item: TokenStream, rt_threaded: bool) -> T
             .into();
     }
 
-    parse_knobs(input, args, true, rt_threaded).unwrap_or_else(|e| e.to_compile_error().into())
-}
-
-pub(crate) mod old {
-    use proc_macro::TokenStream;
-    use quote::quote;
-
-    enum Runtime {
-        Basic,
-        Threaded,
-        Auto,
-    }
-
-    #[cfg(not(test))] // Work around for rust-lang/rust#62127
-    pub(crate) fn main(args: TokenStream, item: TokenStream) -> TokenStream {
-        let mut input = syn::parse_macro_input!(item as syn::ItemFn);
-        let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-        let sig = &mut input.sig;
-        let name = &sig.ident;
-        let inputs = &sig.inputs;
-        let body = &input.block;
-        let attrs = &input.attrs;
-        let vis = input.vis;
-
-        if sig.asyncness.is_none() {
-            let msg = "the async keyword is missing from the function declaration";
-            return syn::Error::new_spanned(sig.fn_token, msg)
-                .to_compile_error()
-                .into();
-        } else if name == "main" && !inputs.is_empty() {
-            let msg = "the main function cannot accept arguments";
-            return syn::Error::new_spanned(&sig.inputs, msg)
-                .to_compile_error()
-                .into();
-        }
-
-        sig.asyncness = None;
-
-        let mut runtime = Runtime::Auto;
-
-        for arg in args {
-            if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
-                let ident = path.get_ident();
-                if ident.is_none() {
-                    let msg = "Must have specified ident";
-                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                }
-                match ident.unwrap().to_string().to_lowercase().as_str() {
-                    "threaded_scheduler" => runtime = Runtime::Threaded,
-                    "basic_scheduler" => runtime = Runtime::Basic,
-                    name => {
-                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
-                        return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                    }
-                }
-            }
-        }
-
-        let result = match runtime {
-            Runtime::Threaded | Runtime::Auto => quote! {
-                #(#attrs)*
-                #vis #sig {
-                    tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
-                }
-            },
-            Runtime::Basic => quote! {
-                #(#attrs)*
-                #vis #sig {
-                    tokio::runtime::Builder::new()
-                        .basic_scheduler()
-                        .enable_all()
-                        .build()
-                        .unwrap()
-                        .block_on(async { #body })
-                }
-            },
-        };
-
-        result.into()
-    }
-
-    pub(crate) fn test(args: TokenStream, item: TokenStream) -> TokenStream {
-        let input = syn::parse_macro_input!(item as syn::ItemFn);
-        let args = syn::parse_macro_input!(args as syn::AttributeArgs);
-
-        let ret = &input.sig.output;
-        let name = &input.sig.ident;
-        let body = &input.block;
-        let attrs = &input.attrs;
-        let vis = input.vis;
-
-        for attr in attrs {
-            if attr.path.is_ident("test") {
-                let msg = "second test attribute is supplied";
-                return syn::Error::new_spanned(&attr, msg)
-                    .to_compile_error()
-                    .into();
-            }
-        }
-
-        if input.sig.asyncness.is_none() {
-            let msg = "the async keyword is missing from the function declaration";
-            return syn::Error::new_spanned(&input.sig.fn_token, msg)
-                .to_compile_error()
-                .into();
-        } else if !input.sig.inputs.is_empty() {
-            let msg = "the test function cannot accept arguments";
-            return syn::Error::new_spanned(&input.sig.inputs, msg)
-                .to_compile_error()
-                .into();
-        }
-
-        let mut runtime = Runtime::Auto;
-
-        for arg in args {
-            if let syn::NestedMeta::Meta(syn::Meta::Path(path)) = arg {
-                let ident = path.get_ident();
-                if ident.is_none() {
-                    let msg = "Must have specified ident";
-                    return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                }
-                match ident.unwrap().to_string().to_lowercase().as_str() {
-                    "threaded_scheduler" => runtime = Runtime::Threaded,
-                    "basic_scheduler" => runtime = Runtime::Basic,
-                    name => {
-                        let msg = format!("Unknown attribute {} is specified; expected `basic_scheduler` or `threaded_scheduler`", name);
-                        return syn::Error::new_spanned(path, msg).to_compile_error().into();
-                    }
-                }
-            }
-        }
-
-        let result = match runtime {
-            Runtime::Threaded => quote! {
-                #[::core::prelude::v1::test]
-                #(#attrs)*
-                #vis fn #name() #ret {
-                    tokio::runtime::Runtime::new().unwrap().block_on(async { #body })
-                }
-            },
-            Runtime::Basic | Runtime::Auto => quote! {
-                #[::core::prelude::v1::test]
-                #(#attrs)*
-                #vis fn #name() #ret {
-                    tokio::runtime::Builder::new()
-                        .basic_scheduler()
-                        .enable_all()
-                        .build()
-                        .unwrap()
-                        .block_on(async { #body })
-                }
-            },
-        };
-
-        result.into()
-    }
+    parse_knobs(input, args, true, rt_threaded)
+        .unwrap_or_else(|e| e.to_compile_error().into())
 }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -14,9 +14,9 @@ impl RuntimeFlavor {
         match s {
             "current_thread" => Ok(RuntimeFlavor::CurrentThread),
             "threaded" => Ok(RuntimeFlavor::Threaded),
-            "single_threaded" => Err(format!("The single threaded runtime flavor is called `current_thread`.")),
-            "basic_scheduler" => Err(format!("The `basic_scheduler` runtime flavor has been renamed to `current_thread`.")),
-            "threaded_scheduler" => Err(format!("The `threaded_scheduler` runtime flavor has been renamed to `threaded`.")),
+            "single_threaded" => Err("The single threaded runtime flavor is called `current_thread`.".to_string()),
+            "basic_scheduler" => Err("The `basic_scheduler` runtime flavor has been renamed to `current_thread`.".to_string()),
+            "threaded_scheduler" => Err("The `threaded_scheduler` runtime flavor has been renamed to `threaded`.".to_string()),
             _ => Err(format!("No such runtime flavor `{}`. The runtime flavors are `current_thread` and `threaded`.", s)),
         }
     }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -201,7 +201,7 @@ fn parse_knobs(
                         format!("The `{}` attribute requires an argument.", name)
                     },
                     name => {
-                        format!("Unkown attribute {} is specified; expected one of: `flavor`, `num_workers`", name)
+                        format!("Unknown attribute {} is specified; expected one of: `flavor`, `num_workers`", name)
                     },
                 };
                 return Err(syn::Error::new_spanned(path, msg));

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -262,7 +262,9 @@ pub fn main_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
         "The #[tokio::main] macro requires rt-core or rt-threaded.",
-    ).to_compile_error().into()
+    )
+    .to_compile_error()
+    .into()
 }
 
 /// Always fails with the error message below.
@@ -274,7 +276,9 @@ pub fn test_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
         "The #[tokio::test] macro requires rt-core or rt-threaded.",
-    ).to_compile_error().into()
+    )
+    .to_compile_error()
+    .into()
 }
 
 /// Implementation detail of the `select!` macro. This macro is **not** intended

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -33,14 +33,23 @@ use proc_macro::TokenStream;
 /// using [Builder](../tokio/runtime/struct.Builder.html), which provides a more powerful
 /// interface.
 ///
-/// ## Options:
+/// # Multi-threaded runtime
+/// To use the multi-threaded runtime, the macro can be configured using
+/// ```
+/// #[tokio::main(flavor = "threaded", num_workers = 10)]
+/// # async fn main() {}
+/// ```
+/// The `num_workers` option configures the number of worker threads, and defaults to the number of
+/// cpus on the system. This is the default flavor.
 ///
-/// If you want to set the number of worker threads used for asynchronous code, use the
-/// `core_threads` option.
+/// # Current thread runtime
 ///
-/// - `core_threads=n` - Sets core threads to `n` (requires `rt-threaded` feature).
-/// - `max_threads=n` - Sets max threads to `n` (requires `rt-core` or `rt-threaded` feature).
-/// - `basic_scheduler` - Use the basic schduler (requires `rt-core`).
+/// To use the single-threaded runtime known as the `current_thread` runtime, the macro can be
+/// configured using
+/// ```
+/// #[tokio::main(flavor = "current_thread")]
+/// # async fn main() {}
+/// ```
 ///
 /// ## Function arguments:
 ///
@@ -48,7 +57,7 @@ use proc_macro::TokenStream;
 ///
 /// ## Usage
 ///
-/// ### Using default
+/// ### Using threaded runtime
 ///
 /// ```rust
 /// #[tokio::main]
@@ -72,12 +81,12 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
-/// ### Using basic scheduler
+/// ### Using current thread runtime
 ///
 /// The basic scheduler is single-threaded.
 ///
 /// ```rust
-/// #[tokio::main(basic_scheduler)]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() {
 ///     println!("Hello world");
 /// }
@@ -98,7 +107,7 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 ///
-/// ### Set number of core threads
+/// ### Set number of worker threads
 ///
 /// ```rust
 /// #[tokio::main(num_workers = 2)]
@@ -139,10 +148,6 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// Marks async function to be executed by selected runtime. This macro helps set up a `Runtime`
 /// without requiring the user to use [Runtime](../tokio/runtime/struct.Runtime.html) or
 /// [Builder](../tokio/runtime/struct.builder.html) directly.
-///
-/// ## Options:
-///
-/// - `max_threads=n` - Sets max threads to `n`.
 ///
 /// ## Function arguments:
 ///
@@ -189,23 +194,20 @@ pub fn main_rt_core(args: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Marks async function to be executed by runtime, suitable to test environment
 ///
-/// ## Options:
-///
-/// - `core_threads=n` - Sets core threads to `n` (requires `rt-threaded` feature).
-/// - `max_threads=n` - Sets max threads to `n` (requires `rt-core` or `rt-threaded` feature).
-///
 /// ## Usage
 ///
-/// ### Select runtime
+/// ### Threaded runtime
 ///
 /// ```no_run
-/// #[tokio::test(core_threads = 1)]
+/// #[tokio::test(flavor = "threaded", num_workers = 1)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
 /// ```
 ///
 /// ### Using default
+///
+/// The default test runtime is single-threaded.
 ///
 /// ```no_run
 /// #[tokio::test]

--- a/tokio-util/src/codec/bytes_codec.rs
+++ b/tokio-util/src/codec/bytes_codec.rs
@@ -33,7 +33,7 @@ use std::io;
 /// #     }
 /// # }
 /// #
-/// # #[tokio::main(core_threads = 1)]
+/// # #[tokio::main(flavor = "current_thread")]
 /// # async fn main() -> Result<(), std::io::Error> {
 /// let my_async_read = File::open("filename.txt").await?;
 /// let my_stream_of_bytes = FramedRead::new(my_async_read, BytesCodec::new());

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -432,7 +432,7 @@ cfg_macros! {
     cfg_not_rt_core! {
         #[cfg(not(test))]
         pub use tokio_macros::main_fail as main;
-        pub use tokio_macros::test_fail as main;
+        pub use tokio_macros::test_fail as test;
     }
 }
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -415,24 +415,24 @@ cfg_macros! {
 
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
             #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-            pub use tokio_macros::main_threaded as main;
+            pub use tokio_macros::main;
 
             #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-            pub use tokio_macros::test_threaded as test;
+            pub use tokio_macros::test;
         }
 
         cfg_not_rt_threaded! {
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
-            pub use tokio_macros::main_basic as main;
-            pub use tokio_macros::test_basic as test;
+            pub use tokio_macros::main_rt_core as main;
+            pub use tokio_macros::test_rt_core as test;
         }
     }
 
-    // Maintains old behavior
+    // Always fail if rt-core is not enabled.
     cfg_not_rt_core! {
         #[cfg(not(test))]
-        pub use tokio_macros::main;
-        pub use tokio_macros::test;
+        pub use tokio_macros::main_fail as main;
+        pub use tokio_macros::test_fail as main;
     }
 }
 

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -267,7 +267,7 @@ pub trait StreamExt: Stream {
     /// # /*
     /// #[tokio::main]
     /// # */
-    /// # #[tokio::main(basic_scheduler)]
+    /// # #[tokio::main(flavor = "in_place")]
     /// async fn main() {
     /// # time::pause();
     ///     let (tx1, rx1) = mpsc::channel(10);

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -267,7 +267,7 @@ pub trait StreamExt: Stream {
     /// # /*
     /// #[tokio::main]
     /// # */
-    /// # #[tokio::main(flavor = "in_place")]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// async fn main() {
     /// # time::pause();
     ///     let (tx1, rx1) = mpsc::channel(10);

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -166,7 +166,7 @@ async fn write_order() {
 }
 
 // A single RwLock is contested by tasks in multiple threads
-#[tokio::test(flavor = "work_stealing", num_workers = 8)]
+#[tokio::test(flavor = "threaded", num_workers = 8)]
 async fn multithreaded() {
     let barrier = Arc::new(Barrier::new(5));
     let rwlock = Arc::new(RwLock::<u32>::new(0));

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -166,7 +166,7 @@ async fn write_order() {
 }
 
 // A single RwLock is contested by tasks in multiple threads
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing", num_workers = 8)]
 async fn multithreaded() {
     let barrier = Arc::new(Barrier::new(5));
     let rwlock = Arc::new(RwLock::<u32>::new(0));

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -28,7 +28,7 @@ async fn basic_blocking() {
     }
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn block_in_blocking() {
     // Run a few times
     for _ in 0..100 {
@@ -51,7 +51,7 @@ async fn block_in_blocking() {
     }
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn block_in_block() {
     // Run a few times
     for _ in 0..100 {
@@ -71,7 +71,7 @@ async fn block_in_block() {
     }
 }
 
-#[tokio::test(flavor = "in_place")]
+#[tokio::test(flavor = "current_thread")]
 #[should_panic]
 async fn no_block_in_basic_scheduler() {
     task::block_in_place(|| {});

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -28,7 +28,7 @@ async fn basic_blocking() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn block_in_blocking() {
     // Run a few times
     for _ in 0..100 {
@@ -51,7 +51,7 @@ async fn block_in_blocking() {
     }
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn block_in_block() {
     // Run a few times
     for _ in 0..100 {
@@ -71,7 +71,7 @@ async fn block_in_block() {
     }
 }
 
-#[tokio::test(basic_scheduler)]
+#[tokio::test(flavor = "in_place")]
 #[should_panic]
 async fn no_block_in_basic_scheduler() {
     task::block_in_place(|| {});

--- a/tokio/tests/task_local.rs
+++ b/tokio/tests/task_local.rs
@@ -3,7 +3,7 @@ tokio::task_local! {
     pub static FOO: bool;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn local() {
     let j1 = tokio::spawn(REQ_ID.scope(1, async move {
         assert_eq!(REQ_ID.get(), 1);

--- a/tokio/tests/task_local.rs
+++ b/tokio/tests/task_local.rs
@@ -3,7 +3,7 @@ tokio::task_local! {
     pub static FOO: bool;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn local() {
     let j1 = tokio::spawn(REQ_ID.scope(1, async move {
         assert_eq!(REQ_ID.get(), 1);

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering::{self, SeqCst};
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 
-#[tokio::test(basic_scheduler)]
+#[tokio::test(flavor = "in_place")]
 async fn local_basic_scheduler() {
     LocalSet::new()
         .run_until(async {
@@ -20,7 +20,7 @@ async fn local_basic_scheduler() {
         .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn local_threadpool() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);
@@ -40,7 +40,7 @@ async fn local_threadpool() {
         .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn localset_future_threadpool() {
     thread_local! {
         static ON_LOCAL_THREAD: Cell<bool> = Cell::new(false);
@@ -55,7 +55,7 @@ async fn localset_future_threadpool() {
     local.await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn localset_future_timers() {
     static RAN1: AtomicBool = AtomicBool::new(false);
     static RAN2: AtomicBool = AtomicBool::new(false);
@@ -99,7 +99,7 @@ async fn localset_future_drives_all_local_futs() {
     assert!(RAN3.load(Ordering::SeqCst));
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn local_threadpool_timer() {
     // This test ensures that runtime services like the timer are properly
     // set for the local task set.
@@ -149,7 +149,7 @@ fn local_threadpool_blocking_in_place() {
     });
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn local_threadpool_blocking_run() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);
@@ -177,7 +177,7 @@ async fn local_threadpool_blocking_run() {
         .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn all_spawns_are_local() {
     use futures::future;
     thread_local! {
@@ -203,7 +203,7 @@ async fn all_spawns_are_local() {
         .await;
 }
 
-#[tokio::test(threaded_scheduler)]
+#[tokio::test(flavor = "work_stealing")]
 async fn nested_spawn_is_local() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -11,7 +11,7 @@ use std::sync::atomic::Ordering::{self, SeqCst};
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 
-#[tokio::test(flavor = "in_place")]
+#[tokio::test(flavor = "current_thread")]
 async fn local_basic_scheduler() {
     LocalSet::new()
         .run_until(async {
@@ -20,7 +20,7 @@ async fn local_basic_scheduler() {
         .await;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn local_threadpool() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);
@@ -40,7 +40,7 @@ async fn local_threadpool() {
         .await;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn localset_future_threadpool() {
     thread_local! {
         static ON_LOCAL_THREAD: Cell<bool> = Cell::new(false);
@@ -55,7 +55,7 @@ async fn localset_future_threadpool() {
     local.await;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn localset_future_timers() {
     static RAN1: AtomicBool = AtomicBool::new(false);
     static RAN2: AtomicBool = AtomicBool::new(false);
@@ -99,7 +99,7 @@ async fn localset_future_drives_all_local_futs() {
     assert!(RAN3.load(Ordering::SeqCst));
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn local_threadpool_timer() {
     // This test ensures that runtime services like the timer are properly
     // set for the local task set.
@@ -149,7 +149,7 @@ fn local_threadpool_blocking_in_place() {
     });
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn local_threadpool_blocking_run() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);
@@ -177,7 +177,7 @@ async fn local_threadpool_blocking_run() {
         .await;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn all_spawns_are_local() {
     use futures::future;
     thread_local! {
@@ -203,7 +203,7 @@ async fn all_spawns_are_local() {
         .await;
 }
 
-#[tokio::test(flavor = "work_stealing")]
+#[tokio::test(flavor = "threaded")]
 async fn nested_spawn_is_local() {
     thread_local! {
         static ON_RT_THREAD: Cell<bool> = Cell::new(false);


### PR DESCRIPTION
Macro part of https://github.com/tokio-rs/tokio/issues/2720#issuecomment-702310198.

Since the builder is not yet fully updated, this still generates code with the old builder syntax, but this is easily changed later. The `rt-threaded` feature is also not renamed to `rt-work-stealing`, but this is also easily changed later. Documentation is still a TODO.