### PR TITLE
process: add ProcessDriver to handle orphan reaping

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -242,6 +242,23 @@ macro_rules! cfg_process {
     }
 }
 
+macro_rules! cfg_process_driver {
+    ($($item:item)*) => {
+        #[cfg(unix)]
+        #[cfg(not(loom))]
+        cfg_process! { $($item)* }
+    }
+}
+
+macro_rules! cfg_not_process_driver {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(all(unix, not(loom), feature = "process")))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_signal {
     ($($item:item)*) => {
         $(

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -113,6 +113,11 @@
 #[cfg(unix)]
 mod imp;
 
+#[cfg(unix)]
+pub(crate) mod unix {
+    pub(crate) use super::imp::*;
+}
+
 #[path = "windows.rs"]
 #[cfg(windows)]
 mod imp;

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -1,0 +1,154 @@
+//! Process driver
+
+use crate::park::Park;
+use crate::process::unix::orphan::ReapOrphanQueue;
+use crate::process::unix::GlobalOrphanQueue;
+use crate::signal::unix::driver::Driver as SignalDriver;
+use crate::signal::unix::{signal_with_handle, InternalStream, Signal, SignalKind};
+use crate::sync::mpsc::error::TryRecvError;
+
+use std::io;
+use std::time::Duration;
+
+/// Responsible for cleaning up orphaned child processes on Unix platforms.
+#[derive(Debug)]
+pub(crate) struct Driver {
+    park: SignalDriver,
+    inner: CoreDriver<Signal, GlobalOrphanQueue>,
+}
+
+#[derive(Debug)]
+struct CoreDriver<S, Q> {
+    sigchild: S,
+    orphan_queue: Q,
+}
+
+// ===== impl CoreDriver =====
+
+impl<S, Q> CoreDriver<S, Q>
+where
+    S: InternalStream,
+    Q: ReapOrphanQueue,
+{
+    fn got_signal(&mut self) -> bool {
+        match self.sigchild.try_recv() {
+            Ok(()) => true,
+            Err(TryRecvError::Empty) => false,
+            Err(TryRecvError::Closed) => panic!("signal was deregistered"),
+        }
+    }
+
+    fn process(&mut self) {
+        if self.got_signal() {
+            // Drain all notifications which may have been buffered
+            // so we can try to reap all orphans in one batch
+            while self.got_signal() {}
+
+            self.orphan_queue.reap_orphans();
+        }
+    }
+}
+
+// ===== impl Driver =====
+
+impl Driver {
+    /// Creates a new signal `Driver` instance that delegates wakeups to `park`.
+    pub(crate) fn new(park: SignalDriver) -> io::Result<Self> {
+        let sigchild = signal_with_handle(SignalKind::child(), park.handle())?;
+        let inner = CoreDriver {
+            sigchild,
+            orphan_queue: GlobalOrphanQueue,
+        };
+
+        Ok(Self { park, inner })
+    }
+}
+
+// ===== impl Park for Driver =====
+
+impl Park for Driver {
+    type Unpark = <SignalDriver as Park>::Unpark;
+    type Error = io::Error;
+
+    fn unpark(&self) -> Self::Unpark {
+        self.park.unpark()
+    }
+
+    fn park(&mut self) -> Result<(), Self::Error> {
+        self.park.park()?;
+        self.inner.process();
+        Ok(())
+    }
+
+    fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
+        self.park.park_timeout(duration)?;
+        self.inner.process();
+        Ok(())
+    }
+
+    fn shutdown(&mut self) {
+        self.park.shutdown()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::process::unix::orphan::test::MockQueue;
+    use crate::sync::mpsc::error::TryRecvError;
+    use std::task::{Context, Poll};
+
+    struct MockStream {
+        total_try_recv: usize,
+        values: Vec<Option<()>>,
+    }
+
+    impl MockStream {
+        fn new(values: Vec<Option<()>>) -> Self {
+            Self {
+                total_try_recv: 0,
+                values,
+            }
+        }
+    }
+
+    impl InternalStream for MockStream {
+        fn poll_recv(&mut self, _cx: &mut Context<'_>) -> Poll<Option<()>> {
+            unimplemented!();
+        }
+
+        fn try_recv(&mut self) -> Result<(), TryRecvError> {
+            self.total_try_recv += 1;
+            match self.values.remove(0) {
+                Some(()) => Ok(()),
+                None => Err(TryRecvError::Empty),
+            }
+        }
+    }
+
+    #[test]
+    fn no_reap_if_no_signal() {
+        let mut driver = CoreDriver {
+            sigchild: MockStream::new(vec![None]),
+            orphan_queue: MockQueue::<()>::new(),
+        };
+
+        driver.process();
+
+        assert_eq!(1, driver.sigchild.total_try_recv);
+        assert_eq!(0, driver.orphan_queue.total_reaps.get());
+    }
+
+    #[test]
+    fn coalesce_signals_before_reaping() {
+        let mut driver = CoreDriver {
+            sigchild: MockStream::new(vec![Some(()), Some(()), None]),
+            orphan_queue: MockQueue::<()>::new(),
+        };
+
+        driver.process();
+
+        assert_eq!(3, driver.sigchild.total_try_recv);
+        assert_eq!(1, driver.orphan_queue.total_reaps.get());
+    }
+}

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -6,6 +6,7 @@
 #![cfg(unix)]
 
 use crate::signal::registry::{globals, EventId, EventInfo, Globals, Init, Storage};
+use crate::sync::mpsc::error::TryRecvError;
 use crate::sync::mpsc::{channel, Receiver};
 
 use libc::c_int;
@@ -17,6 +18,7 @@ use std::sync::Once;
 use std::task::{Context, Poll};
 
 pub(crate) mod driver;
+use self::driver::Handle;
 
 pub(crate) type OsStorage = Vec<SignalInfo>;
 
@@ -220,7 +222,7 @@ fn action(globals: Pin<&'static Globals>, signal: c_int) {
 ///
 /// This will register the signal handler if it hasn't already been registered,
 /// returning any error along the way if that fails.
-fn signal_enable(signal: c_int) -> io::Result<()> {
+fn signal_enable(signal: c_int, handle: Handle) -> io::Result<()> {
     if signal < 0 || signal_hook_registry::FORBIDDEN.contains(&signal) {
         return Err(Error::new(
             ErrorKind::Other,
@@ -229,7 +231,7 @@ fn signal_enable(signal: c_int) -> io::Result<()> {
     }
 
     // Check that we have a signal driver running
-    driver::Handle::current().check_inner()?;
+    handle.check_inner()?;
 
     let globals = globals();
     let siginfo = match globals.storage().get(signal as EventId) {
@@ -349,10 +351,14 @@ pub struct Signal {
 /// * If the signal is one of
 ///   [`signal_hook::FORBIDDEN`](fn@signal_hook_registry::register#panics)
 pub fn signal(kind: SignalKind) -> io::Result<Signal> {
+    signal_with_handle(kind, Handle::current())
+}
+
+pub(crate) fn signal_with_handle(kind: SignalKind, handle: Handle) -> io::Result<Signal> {
     let signal = kind.0;
 
     // Turn the signal delivery on once we are ready for it
-    signal_enable(signal)?;
+    signal_enable(signal, handle)?;
 
     // One wakeup in a queue is enough, no need for us to buffer up any
     // more.
@@ -394,6 +400,11 @@ impl Signal {
     pub(crate) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
         self.rx.poll_recv(cx)
     }
+
+    /// Try to receive a signal notification without blocking or registering a waker.
+    pub(crate) fn try_recv(&mut self) -> Result<(), TryRecvError> {
+        self.rx.try_recv()
+    }
 }
 
 cfg_stream! {
@@ -403,6 +414,22 @@ cfg_stream! {
         fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<()>> {
             self.poll_recv(cx)
         }
+    }
+}
+
+// Work around for abstracting streams internally
+pub(crate) trait InternalStream: Unpin {
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>>;
+    fn try_recv(&mut self) -> Result<(), TryRecvError>;
+}
+
+impl InternalStream for Signal {
+    fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
+        self.poll_recv(cx)
+    }
+
+    fn try_recv(&mut self) -> Result<(), TryRecvError> {
+        self.try_recv()
     }
 }
 
@@ -416,11 +443,11 @@ mod tests {
 
     #[test]
     fn signal_enable_error_on_invalid_input() {
-        signal_enable(-1).unwrap_err();
+        signal_enable(-1, Handle::default()).unwrap_err();
     }
 
     #[test]
     fn signal_enable_error_on_forbidden_input() {
-        signal_enable(signal_hook_registry::FORBIDDEN[0]).unwrap_err();
+        signal_enable(signal_hook_registry::FORBIDDEN[0], Handle::default()).unwrap_err();
     }
 }

--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -30,7 +30,7 @@ pub(crate) struct Driver {
     inner: Arc<Inner>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct Handle {
     inner: Weak<Inner>,
 }


### PR DESCRIPTION
## Motivation

* Dropping/canceling child processes cannot be done cleanly since we can neither afford to perform a blocking `wait` call in the destructor, nor do we have something like async-destructors to perform the clean up for us
* Although the `kill_on_drop` flag will terminate the child process on drop, there is no guarantee that the caller will call `child.await` which will leave a zombie process floating around and can lead to exhaustion of the pid space
* We do try to clean up orphaned processes on a best-effort-basis, as long as additional child processes are being spawned/polled, but this isn't good enough since enough zombie processes can accumulate through one way or another

## Solution

* Introduce a `ProcessDriver` (only on Unix platforms) which will reap the orphaned processes spawned by tokio, gradually eliminating them as they finally exit.
* This also avoids having every child process wrapper attempt to drain the orphan queue, which should lead to faster poll times and fewer contentions for the orphan queue lock.

Refs #2685
Refs #2841
