### PR TITLE
fs: seal OpenOptionsExt and DirBuilderExt

### DIFF
--- a/tokio/src/fs/os/unix/dir_builder_ext.rs
+++ b/tokio/src/fs/os/unix/dir_builder_ext.rs
@@ -3,7 +3,7 @@ use crate::fs::dir_builder::DirBuilder;
 /// Unix-specific extensions to [`DirBuilder`].
 ///
 /// [`DirBuilder`]: crate::fs::DirBuilder
-pub trait DirBuilderExt {
+pub trait DirBuilderExt: sealed::Sealed {
     /// Sets the mode to create new directories with.
     ///
     /// This option defaults to 0o777.
@@ -26,4 +26,11 @@ impl DirBuilderExt for DirBuilder {
         self.mode = Some(mode);
         self
     }
+}
+
+impl sealed::Sealed for DirBuilder {}
+
+pub(crate) mod sealed {
+    #[doc(hidden)]
+    pub trait Sealed {}
 }

--- a/tokio/src/fs/os/unix/open_options_ext.rs
+++ b/tokio/src/fs/os/unix/open_options_ext.rs
@@ -8,7 +8,7 @@ use std::os::unix::fs::OpenOptionsExt as StdOpenOptionsExt;
 ///
 /// [`fs::OpenOptions`]: crate::fs::OpenOptions
 /// [`std::os::unix::fs::OpenOptionsExt`]: std::os::unix::fs::OpenOptionsExt
-pub trait OpenOptionsExt {
+pub trait OpenOptionsExt: sealed::Sealed {
     /// Sets the mode bits that a new file will be created with.
     ///
     /// If a new file is created as part of an `OpenOptions::open` call then this
@@ -76,4 +76,11 @@ impl OpenOptionsExt for OpenOptions {
         self.as_inner_mut().custom_flags(flags);
         self
     }
+}
+
+impl sealed::Sealed for OpenOptions {}
+
+pub(crate) mod sealed {
+    #[doc(hidden)]
+    pub trait Sealed {}
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

We don't expect users to implement these extension traits. See also https://github.com/tokio-rs/tokio/pull/2515#issuecomment-626640636.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
