### PR TITLE
Make futures returned by extension traits !Unpin

### DIFF
--- a/tokio/src/io/seek.rs
+++ b/tokio/src/io/seek.rs
@@ -1,16 +1,22 @@
 use crate::io::AsyncSeek;
+
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::io::{self, SeekFrom};
+use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_io_util! {
+pin_project! {
     /// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Seek<'a, S: ?Sized> {
         seek: &'a mut S,
         pos: Option<SeekFrom>,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
     }
 }
 
@@ -21,6 +27,7 @@ where
     Seek {
         seek,
         pos: Some(pos),
+        _pin: PhantomPinned,
     }
 }
 
@@ -30,29 +37,18 @@ where
 {
     type Output = io::Result<u64>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let me = &mut *self;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
         match me.pos {
-            Some(pos) => match Pin::new(&mut me.seek).start_seek(cx, pos) {
+            Some(pos) => match Pin::new(&mut *me.seek).start_seek(cx, *pos) {
                 Poll::Ready(Ok(())) => {
-                    me.pos = None;
-                    Pin::new(&mut me.seek).poll_complete(cx)
+                    *me.pos = None;
+                    Pin::new(&mut *me.seek).poll_complete(cx)
                 }
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
                 Poll::Pending => Poll::Pending,
             },
-            None => Pin::new(&mut me.seek).poll_complete(cx),
+            None => Pin::new(&mut *me.seek).poll_complete(cx),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn assert_unpin() {
-        use std::marker::PhantomPinned;
-        crate::is_unpin::<Seek<'_, PhantomPinned>>();
     }
 }

--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -37,6 +37,12 @@ cfg_io_util! {
         /// Creates a future which will seek an IO object, and then yield the
         /// new position in the object and the object itself.
         ///
+        /// Equivalent to:
+        ///
+        /// ```ignore
+        /// async fn seek(&mut self, pos: SeekFrom) -> io::Result<u64>;
+        /// ```
+        ///
         /// In the case of an error the buffer and the object will be discarded, with
         /// the error yielded.
         ///

--- a/tokio/src/io/util/write.rs
+++ b/tokio/src/io/util/write.rs
@@ -1,17 +1,22 @@
 use crate::io::AsyncWrite;
 
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::io;
+use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_io_util! {
+pin_project! {
     /// A future to write some of the buffer to an `AsyncWrite`.
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Write<'a, W: ?Sized> {
         writer: &'a mut W,
         buf: &'a [u8],
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
     }
 }
 
@@ -21,7 +26,11 @@ pub(crate) fn write<'a, W>(writer: &'a mut W, buf: &'a [u8]) -> Write<'a, W>
 where
     W: AsyncWrite + Unpin + ?Sized,
 {
-    Write { writer, buf }
+    Write {
+        writer,
+        buf,
+        _pin: PhantomPinned,
+    }
 }
 
 impl<W> Future for Write<'_, W>
@@ -30,8 +39,8 @@ where
 {
     type Output = io::Result<usize>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
-        let me = &mut *self;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        let me = self.project();
         Pin::new(&mut *me.writer).poll_write(cx, me.buf)
     }
 }

--- a/tokio/src/io/util/write_all.rs
+++ b/tokio/src/io/util/write_all.rs
@@ -1,17 +1,22 @@
 use crate::io::AsyncWrite;
 
+use pin_project_lite::pin_project;
 use std::future::Future;
 use std::io;
+use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_io_util! {
+pin_project! {
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct WriteAll<'a, W: ?Sized> {
         writer: &'a mut W,
         buf: &'a [u8],
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
     }
 }
 
@@ -19,7 +24,11 @@ pub(crate) fn write_all<'a, W>(writer: &'a mut W, buf: &'a [u8]) -> WriteAll<'a,
 where
     W: AsyncWrite + Unpin + ?Sized,
 {
-    WriteAll { writer, buf }
+    WriteAll {
+        writer,
+        buf,
+        _pin: PhantomPinned,
+    }
 }
 
 impl<W> Future for WriteAll<'_, W>
@@ -28,13 +37,13 @@ where
 {
     type Output = io::Result<()>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let me = &mut *self;
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let me = self.project();
         while !me.buf.is_empty() {
-            let n = ready!(Pin::new(&mut me.writer).poll_write(cx, me.buf))?;
+            let n = ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf))?;
             {
-                let (_, rest) = mem::replace(&mut me.buf, &[]).split_at(n);
-                me.buf = rest;
+                let (_, rest) = mem::replace(&mut *me.buf, &[]).split_at(n);
+                *me.buf = rest;
             }
             if n == 0 {
                 return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
@@ -42,16 +51,5 @@ where
         }
 
         Poll::Ready(Ok(()))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn assert_unpin() {
-        use std::marker::PhantomPinned;
-        crate::is_unpin::<WriteAll<'_, PhantomPinned>>();
     }
 }

--- a/tokio/src/stream/all.rs
+++ b/tokio/src/stream/all.rs
@@ -1,24 +1,33 @@
 use crate::stream::Stream;
 
 use core::future::Future;
+use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
 
-/// Future for the [`all`](super::StreamExt::all) method.
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct AllFuture<'a, St: ?Sized, F> {
-    stream: &'a mut St,
-    f: F,
+pin_project! {
+    /// Future for the [`all`](super::StreamExt::all) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct AllFuture<'a, St: ?Sized, F> {
+        stream: &'a mut St,
+        f: F,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
 }
 
 impl<'a, St: ?Sized, F> AllFuture<'a, St, F> {
     pub(super) fn new(stream: &'a mut St, f: F) -> Self {
-        Self { stream, f }
+        Self {
+            stream,
+            f,
+            _pin: PhantomPinned,
+        }
     }
 }
-
-impl<St: ?Sized + Unpin, F> Unpin for AllFuture<'_, St, F> {}
 
 impl<St, F> Future for AllFuture<'_, St, F>
 where
@@ -27,12 +36,13 @@ where
 {
     type Output = bool;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let next = futures_core::ready!(Pin::new(&mut self.stream).poll_next(cx));
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
+        let next = futures_core::ready!(Pin::new(me.stream).poll_next(cx));
 
         match next {
             Some(v) => {
-                if !(&mut self.f)(v) {
+                if !(me.f)(v) {
                     Poll::Ready(false)
                 } else {
                     cx.waker().wake_by_ref();

--- a/tokio/src/stream/fold.rs
+++ b/tokio/src/stream/fold.rs
@@ -1,6 +1,7 @@
 use crate::stream::Stream;
 
 use core::future::Future;
+use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use pin_project_lite::pin_project;
@@ -8,11 +9,15 @@ use pin_project_lite::pin_project;
 pin_project! {
     /// Future returned by the [`fold`](super::StreamExt::fold) method.
     #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct FoldFuture<St, B, F> {
         #[pin]
         stream: St,
         acc: Option<B>,
         f: F,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
     }
 }
 
@@ -22,6 +27,7 @@ impl<St, B, F> FoldFuture<St, B, F> {
             stream,
             acc: Some(init),
             f,
+            _pin: PhantomPinned,
         }
     }
 }

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -572,6 +572,12 @@ pub trait StreamExt: Stream {
 
     /// Tests if every element of the stream matches a predicate.
     ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// async fn all<F>(&mut self, f: F) -> bool;
+    /// ```
+    ///
     /// `all()` takes a closure that returns `true` or `false`. It applies
     /// this closure to each element of the stream, and if they all return
     /// `true`, then so does `all`. If any of them return `false`, it
@@ -626,6 +632,12 @@ pub trait StreamExt: Stream {
     }
 
     /// Tests if any element of the stream matches a predicate.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// async fn any<F>(&mut self, f: F) -> bool;
+    /// ```
     ///
     /// `any()` takes a closure that returns `true` or `false`. It applies
     /// this closure to each element of the stream, and if any of them return
@@ -716,6 +728,12 @@ pub trait StreamExt: Stream {
     /// A combinator that applies a function to every element in a stream
     /// producing a single, final value.
     ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// async fn fold<B, F>(self, init: B, f: F) -> B;
+    /// ```
+    ///
     /// # Examples
     /// Basic usage:
     /// ```
@@ -738,6 +756,12 @@ pub trait StreamExt: Stream {
     }
 
     /// Drain stream pushing all emitted values into a collection.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// async fn collect<T>(self) -> T;
+    /// ```
     ///
     /// `collect` streams all values, awaiting as needed. Values are pushed into
     /// a collection. A number of different target collection types are
@@ -871,6 +895,7 @@ pub trait StreamExt: Stream {
     {
         Timeout::new(self, duration)
     }
+
     /// Slows down a stream by enforcing a delay between items.
     ///
     /// # Example

--- a/tokio/src/stream/try_next.rs
+++ b/tokio/src/stream/try_next.rs
@@ -1,22 +1,29 @@
 use crate::stream::{Next, Stream};
 
 use core::future::Future;
+use core::marker::PhantomPinned;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
 
-/// Future for the [`try_next`](super::StreamExt::try_next) method.
-#[derive(Debug)]
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct TryNext<'a, St: ?Sized> {
-    inner: Next<'a, St>,
+pin_project! {
+    /// Future for the [`try_next`](super::StreamExt::try_next) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TryNext<'a, St: ?Sized> {
+        #[pin]
+        inner: Next<'a, St>,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
 }
-
-impl<St: ?Sized + Unpin> Unpin for TryNext<'_, St> {}
 
 impl<'a, St: ?Sized> TryNext<'a, St> {
     pub(super) fn new(stream: &'a mut St) -> Self {
         Self {
             inner: Next::new(stream),
+            _pin: PhantomPinned,
         }
     }
 }
@@ -24,7 +31,8 @@ impl<'a, St: ?Sized> TryNext<'a, St> {
 impl<T, E, St: ?Sized + Stream<Item = Result<T, E>> + Unpin> Future for TryNext<'_, St> {
     type Output = Result<Option<T>, E>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        Pin::new(&mut self.inner).poll(cx).map(Option::transpose)
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
+        me.inner.poll(cx).map(Option::transpose)
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

As described in https://github.com/tokio-rs/tokio/pull/2538#issuecomment-654272701, currently, these methods are not `!Unpin`, so switching to async trait methods is a breaking change.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Make these future `!Unpin` for compatibility with async trait methods. This can implement this by adding a *pinned* `PhantomPinned` field, [as described in the pin-project documentation](https://docs.rs/pin-project/0.4.26/pin_project/attr.pin_project.html#unpin).

Related: #2723, #2259

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
