### PR TITLE
runtime: Remove the last slab dependency from tokio proper

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -65,7 +65,7 @@ process = [
   "winapi/threadpoollegacyapiset",
 ]
 # Includes basic task execution capabilities
-rt-core = ["slab"]
+rt-core = []
 rt-util = []
 rt-threaded = [
   "num_cpus",
@@ -101,7 +101,6 @@ memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.2", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true } # Not in full
-slab = { version = "0.4.1", optional = true }
 tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Reducing dependency footprint

## Solution

The last usage of slab isn't doing anything that a `Vec` couldn't do instead, so just replace it with an ordinary `Vec`.