### PR TITLE
chore: refactor runtime driver useage of `Either` and cfgs

### DIFF
--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -8,34 +8,38 @@ use std::time::Duration;
 // ===== io driver =====
 
 cfg_io_driver! {
-    type IoDriver = crate::park::either::Either<crate::io::driver::Driver, ParkThread>;
+    type IoDriver = crate::io::driver::Driver;
+    type IoStack = crate::park::either::Either<ProcessDriver, ParkThread>;
     pub(crate) type IoHandle = Option<crate::io::driver::Handle>;
 
-    fn create_io_driver(enable: bool) -> io::Result<(IoDriver, IoHandle)> {
+    fn create_io_stack(enabled: bool) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
         use crate::park::either::Either;
 
         #[cfg(loom)]
-        assert!(!enable);
+        assert!(!enabled);
 
-        if enable {
-            let driver = crate::io::driver::Driver::new()?;
-            let handle = driver.handle();
+        let ret = if enabled {
+            let io_driver = crate::io::driver::Driver::new()?;
+            let io_handle = io_driver.handle();
 
-            Ok((Either::A(driver), Some(handle)))
+            let (signal_driver, signal_handle) = create_signal_driver(io_driver)?;
+            let process_driver = create_process_driver(signal_driver)?;
+
+            (Either::A(process_driver), Some(io_handle), signal_handle)
         } else {
-            let driver = ParkThread::new();
-            Ok((Either::B(driver), None))
-        }
+            (Either::B(ParkThread::new()), Default::default(), Default::default())
+        };
+
+        Ok(ret)
     }
 }
 
 cfg_not_io_driver! {
-    type IoDriver = ParkThread;
     pub(crate) type IoHandle = ();
+    type IoStack = ParkThread;
 
-    fn create_io_driver(_enable: bool) -> io::Result<(IoDriver, IoHandle)> {
-        let driver = ParkThread::new();
-        Ok((driver, ()))
+    fn create_io_stack(_enabled: bool) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
+        Ok((ParkThread::new(), Default::default(), Default::default()))
     }
 }
 
@@ -49,64 +53,52 @@ macro_rules! cfg_signal_internal_and_unix {
 }
 
 cfg_signal_internal_and_unix! {
-    type SignalDriver = crate::park::either::Either<crate::signal::unix::driver::Driver, IoDriver>;
+    type SignalDriver = crate::signal::unix::driver::Driver;
     pub(crate) type SignalHandle = Option<crate::signal::unix::driver::Handle>;
 
     fn create_signal_driver(io_driver: IoDriver) -> io::Result<(SignalDriver, SignalHandle)> {
-        use crate::park::either::Either;
-
-        // Enable the signal driver if IO is also enabled
-        match io_driver {
-            Either::A(io_driver) => {
-                let driver = crate::signal::unix::driver::Driver::new(io_driver)?;
-                let handle = driver.handle();
-                Ok((Either::A(driver), Some(handle)))
-            }
-            Either::B(_) => Ok((Either::B(io_driver), None)),
-        }
+        let driver = crate::signal::unix::driver::Driver::new(io_driver)?;
+        let handle = driver.handle();
+        Ok((driver, Some(handle)))
     }
 }
 
 cfg_not_signal_internal! {
-    type SignalDriver = IoDriver;
     pub(crate) type SignalHandle = ();
 
-    fn create_signal_driver(io_driver: IoDriver) -> io::Result<(SignalDriver, SignalHandle)> {
-        Ok((io_driver, ()))
+    cfg_io_driver! {
+        type SignalDriver = IoDriver;
+
+        fn create_signal_driver(io_driver: IoDriver) -> io::Result<(SignalDriver, SignalHandle)> {
+            Ok((io_driver, ()))
+        }
     }
 }
 
 // ===== process driver =====
 
 cfg_process_driver! {
-    type ProcessDriver = crate::park::either::Either<crate::process::unix::driver::Driver, SignalDriver>;
+    type ProcessDriver = crate::process::unix::driver::Driver;
 
     fn create_process_driver(signal_driver: SignalDriver) -> io::Result<ProcessDriver> {
-        use crate::park::either::Either;
-
-        // Enable the signal driver if IO is also enabled
-        match signal_driver {
-            Either::A(signal_driver) => {
-                let driver = crate::process::unix::driver::Driver::new(signal_driver)?;
-                Ok(Either::A(driver))
-            }
-            Either::B(_) => Ok(Either::B(signal_driver)),
-        }
+        crate::process::unix::driver::Driver::new(signal_driver)
     }
 }
 
 cfg_not_process_driver! {
-    type ProcessDriver = SignalDriver;
+    cfg_io_driver! {
+        type ProcessDriver = SignalDriver;
 
-    fn create_process_driver(signal_driver: SignalDriver) -> io::Result<ProcessDriver> {
-        Ok(signal_driver)
+        fn create_process_driver(signal_driver: SignalDriver) -> io::Result<ProcessDriver> {
+            Ok(signal_driver)
+        }
     }
 }
 
 // ===== time driver =====
 
 cfg_time! {
-    type TimeDriver = crate::park::either::Either<crate::time::driver::Driver<ProcessDriver>, ProcessDriver>;
+    type TimeDriver = crate::park::either::Either<crate::time::driver::Driver<IoStack>, IoStack>;
 
     pub(crate) type Clock = crate::time::Clock;
     pub(crate) type TimeHandle = Option<crate::time::driver::Handle>;
@@ -117,24 +109,24 @@ cfg_time! {
 
     fn create_time_driver(
         enable: bool,
-        process_driver: ProcessDriver,
+        io_stack: IoStack,
         clock: Clock,
     ) -> (TimeDriver, TimeHandle) {
         use crate::park::either::Either;
 
         if enable {
-            let driver = crate::time::driver::Driver::new(process_driver, clock);
+            let driver = crate::time::driver::Driver::new(io_stack, clock);
             let handle = driver.handle();
 
             (Either::A(driver), Some(handle))
         } else {
-            (Either::B(process_driver), None)
+            (Either::B(io_stack), None)
         }
     }
 }
 
 cfg_not_time! {
-    type TimeDriver = ProcessDriver;
+    type TimeDriver = IoStack;
 
     pub(crate) type Clock = ();
     pub(crate) type TimeHandle = ();
@@ -145,10 +137,10 @@ cfg_not_time! {
 
     fn create_time_driver(
         _enable: bool,
-        process_driver: ProcessDriver,
+        io_stack: IoStack,
         _clock: Clock,
     ) -> (TimeDriver, TimeHandle) {
-        (process_driver, ())
+        (io_stack, ())
     }
 }
 
@@ -173,13 +165,11 @@ pub(crate) struct Cfg {
 
 impl Driver {
     pub(crate) fn new(cfg: Cfg) -> io::Result<(Self, Resources)> {
-        let clock = create_clock();
+        let (io_stack, io_handle, signal_handle) = create_io_stack(cfg.enable_io)?;
 
-        let (io_driver, io_handle) = create_io_driver(cfg.enable_io)?;
-        let (signal_driver, signal_handle) = create_signal_driver(io_driver)?;
-        let process_driver = create_process_driver(signal_driver)?;
+        let clock = create_clock();
         let (time_driver, time_handle) =
-            create_time_driver(cfg.enable_time, process_driver, clock.clone());
+            create_time_driver(cfg.enable_time, io_stack, clock.clone());
 
         Ok((
             Self { inner: time_driver },

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -184,9 +184,9 @@ impl<L: Link> fmt::Debug for LinkedList<L, L::Target> {
 
 #[cfg(any(
     feature = "fs",
-    feature = "sync",
+    all(unix, feature = "process"),
     feature = "signal",
-    feature = "process"
+    feature = "sync",
 ))]
 impl<L: Link> LinkedList<L, L::Target> {
     pub(crate) fn last(&self) -> Option<&L::Target> {


### PR DESCRIPTION
* rt: optimize usage of either when creating a runtime::Driver
* chore: fix unused warning for LinkedList::last on Windows

Fixes #2916 