### PR TITLE
fs: switch to our own DirEntryExt trait

### DIFF
--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -383,7 +383,7 @@ impl OpenOptions {
         Ok(File::from_std(std))
     }
 
-    /// Returns a mutable reference to the the underlying std::fs::OpenOptions
+    /// Returns a mutable reference to the underlying `std::fs::OpenOptions`
     #[cfg(unix)]
     pub(super) fn as_inner_mut(&mut self) -> &mut std::fs::OpenOptions {
         &mut self.0

--- a/tokio/src/fs/os/unix/dir_entry_ext.rs
+++ b/tokio/src/fs/os/unix/dir_entry_ext.rs
@@ -1,0 +1,44 @@
+use crate::fs::DirEntry;
+use std::os::unix::fs::DirEntryExt as _;
+
+/// Unix-specific extension methods for [`fs::DirEntry`].
+///
+/// This mirrors the definition of [`std::os::unix::fs::DirEntryExt`].
+///
+/// [`fs::DirEntry`]: crate::fs::DirEntry
+/// [`std::os::unix::fs::DirEntryExt`]: std::os::unix::fs::DirEntryExt
+pub trait DirEntryExt: sealed::Sealed {
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::fs;
+    /// use tokio::fs::os::unix::DirEntryExt;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> std::io::Result<()> {
+    /// let mut entries = fs::read_dir(".").await?;
+    /// while let Some(entry) = entries.next_entry().await? {
+    ///     // Here, `entry` is a `DirEntry`.
+    ///     println!("{:?}: {}", entry.file_name(), entry.ino());
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn ino(&self) -> u64;
+}
+
+impl DirEntryExt for DirEntry {
+    fn ino(&self) -> u64 {
+        self.as_inner().ino()
+    }
+}
+
+impl sealed::Sealed for DirEntry {}
+
+pub(crate) mod sealed {
+    #[doc(hidden)]
+    pub trait Sealed {}
+}

--- a/tokio/src/fs/os/unix/mod.rs
+++ b/tokio/src/fs/os/unix/mod.rs
@@ -8,3 +8,6 @@ pub use self::open_options_ext::OpenOptionsExt;
 
 mod dir_builder_ext;
 pub use self::dir_builder_ext::DirBuilderExt;
+
+mod dir_entry_ext;
+pub use self::dir_entry_ext::DirEntryExt;

--- a/tokio/src/fs/os/unix/open_options_ext.rs
+++ b/tokio/src/fs/os/unix/open_options_ext.rs
@@ -1,10 +1,9 @@
 use crate::fs::open_options::OpenOptions;
-use std::os::unix::fs::OpenOptionsExt as StdOpenOptionsExt;
+use std::os::unix::fs::OpenOptionsExt as _;
 
 /// Unix-specific extensions to [`fs::OpenOptions`].
 ///
 /// This mirrors the definition of [`std::os::unix::fs::OpenOptionsExt`].
-///
 ///
 /// [`fs::OpenOptions`]: crate::fs::OpenOptions
 /// [`std::os::unix::fs::OpenOptionsExt`]: std::os::unix::fs::OpenOptionsExt

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -4,8 +4,6 @@ use std::ffi::OsString;
 use std::fs::{FileType, Metadata};
 use std::future::Future;
 use std::io;
-#[cfg(unix)]
-use std::os::unix::fs::DirEntryExt;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -233,11 +231,10 @@ impl DirEntry {
         let std = self.0.clone();
         asyncify(move || std.file_type()).await
     }
-}
 
-#[cfg(unix)]
-impl DirEntryExt for DirEntry {
-    fn ino(&self) -> u64 {
-        self.0.ino()
+    /// Returns a reference to the underlying `std::fs::DirEntry`
+    #[cfg(unix)]
+    pub(super) fn as_inner(&self) -> &std::fs::DirEntry {
+        &self.0
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #2912

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Refs: [std's `DirEntryExt`](https://doc.rust-lang.org/nightly/std/os/unix/fs/trait.DirEntryExt.html)
