### PR TITLE
time: rename `Delay` future to `Sleep`

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -20,7 +20,7 @@
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc;
-use tokio::time::{self, Delay, Duration, Instant};
+use tokio::time::{self, Duration, Instant, Sleep};
 
 use futures_core::ready;
 use std::collections::VecDeque;
@@ -67,7 +67,7 @@ enum Action {
 struct Inner {
     actions: VecDeque<Action>,
     waiting: Option<Instant>,
-    sleep: Option<Delay>,
+    sleep: Option<Sleep>,
     read_wait: Option<Waker>,
     rx: mpsc::UnboundedReceiver<Action>,
 }

--- a/tokio-test/tests/block_on.rs
+++ b/tokio-test/tests/block_on.rs
@@ -18,7 +18,7 @@ fn async_fn() {
 }
 
 #[test]
-fn test_delay() {
+fn test_sleep() {
     let deadline = Instant::now() + Duration::from_millis(100);
 
     block_on(async {

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -7,7 +7,7 @@
 use crate::time::wheel::{self, Wheel};
 
 use futures_core::ready;
-use tokio::time::{sleep_until, Delay, Duration, Error, Instant};
+use tokio::time::{sleep_until, Duration, Error, Instant, Sleep};
 
 use slab::Slab;
 use std::cmp;
@@ -138,7 +138,7 @@ pub struct DelayQueue<T> {
     expired: Stack<T>,
 
     /// Delay expiring when the *first* item in the queue expires
-    delay: Option<Delay>,
+    delay: Option<Sleep>,
 
     /// Wheel polling state
     wheel_now: u64,

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -25,7 +25,7 @@
 //! provides a few major components:
 //!
 //! * Tools for [working with asynchronous tasks][tasks], including
-//!   [synchronization primitives and channels][sync] and [timeouts, delays, and
+//!   [synchronization primitives and channels][sync] and [timeouts, sleeps, and
 //!   intervals][time].
 //! * APIs for [performing asynchronous I/O][io], including [TCP and UDP][net] sockets,
 //!   [filesystem][fs] operations, and [process] and [signal] management.
@@ -183,13 +183,13 @@
 //!
 //! The [`tokio::time`] module provides utilities for tracking time and
 //! scheduling work. This includes functions for setting [timeouts][timeout] for
-//! tasks, [delaying][delay] work to run in the future, or [repeating an operation at an
+//! tasks, [sleeping][sleep] work to run in the future, or [repeating an operation at an
 //! interval][interval].
 //!
 //! In order to use `tokio::time`, the "time" feature flag must be enabled.
 //!
 //! [`tokio::time`]: crate::time
-//! [delay]: crate::time::sleep()
+//! [sleep]: crate::time::sleep()
 //! [interval]: crate::time::interval()
 //! [timeout]: crate::time::timeout()
 //!

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -63,9 +63,9 @@
 /// Given that `if` preconditions are used to disable `select!` branches, some
 /// caution must be used to avoid missing values.
 ///
-/// For example, here is **incorrect** usage of `delay` with `if`. The objective
+/// For example, here is **incorrect** usage of `sleep` with `if`. The objective
 /// is to repeatedly run an asynchronous task for up to 50 milliseconds.
-/// However, there is a potential for the `delay` completion to be missed.
+/// However, there is a potential for the `sleep` completion to be missed.
 ///
 /// ```no_run
 /// use tokio::time::{self, Duration};
@@ -76,11 +76,11 @@
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let mut delay = time::sleep(Duration::from_millis(50));
+///     let mut sleep = time::sleep(Duration::from_millis(50));
 ///
-///     while !delay.is_elapsed() {
+///     while !sleep.is_elapsed() {
 ///         tokio::select! {
-///             _ = &mut delay, if !delay.is_elapsed() => {
+///             _ = &mut sleep, if !sleep.is_elapsed() => {
 ///                 println!("operation timed out");
 ///             }
 ///             _ = some_async_work() => {
@@ -91,11 +91,11 @@
 /// }
 /// ```
 ///
-/// In the above example, `delay.is_elapsed()` may return `true` even if
-/// `delay.poll()` never returned `Ready`. This opens up a potential race
-/// condition where `delay` expires between the `while !delay.is_elapsed()`
+/// In the above example, `sleep.is_elapsed()` may return `true` even if
+/// `sleep.poll()` never returned `Ready`. This opens up a potential race
+/// condition where `sleep` expires between the `while !sleep.is_elapsed()`
 /// check and the call to `select!` resulting in the `some_async_work()` call to
-/// run uninterrupted despite the delay having elapsed.
+/// run uninterrupted despite the sleep having elapsed.
 ///
 /// One way to write the above example without the race would be:
 ///
@@ -109,11 +109,11 @@
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let mut delay = time::sleep(Duration::from_millis(50));
+///     let mut sleep = time::sleep(Duration::from_millis(50));
 ///
 ///     loop {
 ///         tokio::select! {
-///             _ = &mut delay => {
+///             _ = &mut sleep => {
 ///                 println!("operation timed out");
 ///                 break;
 ///             }
@@ -226,7 +226,7 @@
 /// #[tokio::main]
 /// async fn main() {
 ///     let mut stream = stream::iter(vec![1, 2, 3]);
-///     let mut delay = time::sleep(Duration::from_secs(1));
+///     let mut sleep = time::sleep(Duration::from_secs(1));
 ///
 ///     loop {
 ///         tokio::select! {
@@ -237,7 +237,7 @@
 ///                     break;
 ///                 }
 ///             }
-///             _ = &mut delay => {
+///             _ = &mut sleep => {
 ///                 println!("timeout");
 ///                 break;
 ///             }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -28,7 +28,7 @@ pub(crate) struct Handle {
 
 impl Handle {
     /// Enter the runtime context. This allows you to construct types that must
-    /// have an executor available on creation such as [`Delay`] or [`TcpStream`].
+    /// have an executor available on creation such as [`Sleep`] or [`TcpStream`].
     /// It will also allow you to call methods such as [`tokio::spawn`].
     pub(crate) fn enter<F, R>(&self, f: F) -> R
     where

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -450,10 +450,10 @@ impl Runtime {
     }
 
     /// Enter the runtime context. This allows you to construct types that must
-    /// have an executor available on creation such as [`Delay`] or [`TcpStream`].
+    /// have an executor available on creation such as [`Sleep`] or [`TcpStream`].
     /// It will also allow you to call methods such as [`tokio::spawn`].
     ///
-    /// [`Delay`]: struct@crate::time::Delay
+    /// [`Sleep`]: struct@crate::time::Sleep
     /// [`TcpStream`]: struct@crate::net::TcpStream
     /// [`tokio::spawn`]: fn@crate::spawn
     ///

--- a/tokio/src/stream/throttle.rs
+++ b/tokio/src/stream/throttle.rs
@@ -1,7 +1,7 @@
 //! Slow down a stream by enforcing a delay between items.
 
 use crate::stream::Stream;
-use crate::time::{Delay, Duration, Instant};
+use crate::time::{Duration, Instant, Sleep};
 
 use std::future::Future;
 use std::marker::Unpin;
@@ -17,7 +17,7 @@ where
     let delay = if duration == Duration::from_millis(0) {
         None
     } else {
-        Some(Delay::new_timeout(Instant::now() + duration, duration))
+        Some(Sleep::new_timeout(Instant::now() + duration, duration))
     };
 
     Throttle {
@@ -34,7 +34,7 @@ pin_project! {
     #[must_use = "streams do nothing unless polled"]
     pub struct Throttle<T> {
         // `None` when duration is zero.
-        delay: Option<Delay>,
+        delay: Option<Sleep>,
         duration: Duration,
 
         // Set to true when `delay` has returned ready, but `stream` hasn't.

--- a/tokio/src/stream/timeout.rs
+++ b/tokio/src/stream/timeout.rs
@@ -1,5 +1,5 @@
 use crate::stream::{Fuse, Stream};
-use crate::time::{Delay, Elapsed, Instant};
+use crate::time::{Elapsed, Instant, Sleep};
 
 use core::future::Future;
 use core::pin::Pin;
@@ -14,7 +14,7 @@ pin_project! {
     pub struct Timeout<S> {
         #[pin]
         stream: Fuse<S>,
-        deadline: Delay,
+        deadline: Sleep,
         duration: Duration,
         poll_deadline: bool,
     }
@@ -23,7 +23,7 @@ pin_project! {
 impl<S: Stream> Timeout<S> {
     pub(super) fn new(stream: S, duration: Duration) -> Self {
         let next = Instant::now() + duration;
-        let deadline = Delay::new_timeout(next, duration);
+        let deadline = Sleep::new_timeout(next, duration);
 
         Timeout {
             stream: Fuse::new(stream),

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -359,11 +359,11 @@
 //!             let mut conf = rx.borrow().clone();
 //!
 //!             let mut op_start = Instant::now();
-//!             let mut delay = time::sleep_until(op_start + conf.timeout);
+//!             let mut sleep = time::sleep_until(op_start + conf.timeout);
 //!
 //!             loop {
 //!                 tokio::select! {
-//!                     _ = &mut delay => {
+//!                     _ = &mut sleep => {
 //!                         // The operation elapsed. Restart it
 //!                         op.set(my_async_operation());
 //!
@@ -371,14 +371,14 @@
 //!                         op_start = Instant::now();
 //!
 //!                         // Restart the timeout
-//!                         delay = time::sleep_until(op_start + conf.timeout);
+//!                         sleep = time::sleep_until(op_start + conf.timeout);
 //!                     }
 //!                     _ = rx.changed() => {
 //!                         conf = rx.borrow().clone();
 //!
 //!                         // The configuration has been updated. Update the
-//!                         // `delay` using the new `timeout` value.
-//!                         delay.reset(op_start + conf.timeout);
+//!                         // `sleep` using the new `timeout` value.
+//!                         sleep.reset(op_start + conf.timeout);
 //!                     }
 //!                     _ = &mut op => {
 //!                         // The operation completed!

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -58,7 +58,7 @@ cfg_test_util! {
     /// The current value of `Instant::now()` is saved and all subsequent calls
     /// to `Instant::now()` until the timer wheel is checked again will return the saved value.
     /// Once the timer wheel is checked, time will immediately advance to the next registered
-    /// `Delay`. This is useful for running tests that depend on time.
+    /// `Sleep`. This is useful for running tests that depend on time.
     ///
     /// # Panics
     ///

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Weak};
 use std::task::{self, Poll};
 use std::u64;
 
-/// Internal state shared between a `Delay` instance and the timer.
+/// Internal state shared between a `Sleep` instance and the timer.
 ///
 /// This struct is used as a node in two intrusive data structures:
 ///
@@ -28,7 +28,7 @@ pub(crate) struct Entry {
     time: CachePadded<UnsafeCell<Time>>,
 
     /// Timer internals. Using a weak pointer allows the timer to shutdown
-    /// without all `Delay` instances having completed.
+    /// without all `Sleep` instances having completed.
     ///
     /// When empty, it means that the entry has not yet been linked with a
     /// timer instance.
@@ -69,8 +69,8 @@ pub(crate) struct Entry {
     /// When the entry expires, relative to the `start` of the timer
     /// (Inner::start). This is only used by the timer.
     ///
-    /// A `Delay` instance can be reset to a different deadline by the thread
-    /// that owns the `Delay` instance. In this case, the timer thread will not
+    /// A `Sleep` instance can be reset to a different deadline by the thread
+    /// that owns the `Sleep` instance. In this case, the timer thread will not
     /// immediately know that this has happened. The timer thread must know the
     /// last deadline that it saw as it uses this value to locate the entry in
     /// its wheel.
@@ -94,7 +94,7 @@ pub(crate) struct Entry {
     pub(crate) prev_stack: UnsafeCell<*const Entry>,
 }
 
-/// Stores the info for `Delay`.
+/// Stores the info for `Sleep`.
 #[derive(Debug)]
 pub(crate) struct Time {
     pub(crate) deadline: Instant,

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -20,12 +20,12 @@ use std::sync::Arc;
 use std::usize;
 use std::{cmp, fmt};
 
-/// Time implementation that drives [`Delay`][delay], [`Interval`][interval], and [`Timeout`][timeout].
+/// Time implementation that drives [`Sleep`][sleep], [`Interval`][interval], and [`Timeout`][timeout].
 ///
 /// A `Driver` instance tracks the state necessary for managing time and
-/// notifying the [`Delay`][delay] instances once their deadlines are reached.
+/// notifying the [`Sleep`][sleep] instances once their deadlines are reached.
 ///
-/// It is expected that a single instance manages many individual [`Delay`][delay]
+/// It is expected that a single instance manages many individual [`Sleep`][sleep]
 /// instances. The `Driver` implementation is thread-safe and, as such, is able
 /// to handle callers from across threads.
 ///
@@ -36,9 +36,9 @@ use std::{cmp, fmt};
 /// The driver has a resolution of one millisecond. Any unit of time that falls
 /// between milliseconds are rounded up to the next millisecond.
 ///
-/// When an instance is dropped, any outstanding [`Delay`][delay] instance that has not
+/// When an instance is dropped, any outstanding [`Sleep`][sleep] instance that has not
 /// elapsed will be notified with an error. At this point, calling `poll` on the
-/// [`Delay`][delay] instance will result in panic.
+/// [`Sleep`][sleep] instance will result in panic.
 ///
 /// # Implementation
 ///
@@ -65,14 +65,14 @@ use std::{cmp, fmt};
 /// * Level 5: 64 x ~12 day slots.
 ///
 /// When the timer processes entries at level zero, it will notify all the
-/// `Delay` instances as their deadlines have been reached. For all higher
+/// `Sleep` instances as their deadlines have been reached. For all higher
 /// levels, all entries will be redistributed across the wheel at the next level
-/// down. Eventually, as time progresses, entries with [`Delay`][delay] instances will
+/// down. Eventually, as time progresses, entries with [`Sleep`][sleep] instances will
 /// either be canceled (dropped) or their associated entries will reach level
 /// zero and be notified.
 ///
 /// [paper]: http://www.cs.columbia.edu/~nahum/w6998/papers/ton97-timing-wheels.pdf
-/// [delay]: crate::time::Delay
+/// [sleep]: crate::time::Sleep
 /// [timeout]: crate::time::Timeout
 /// [interval]: crate::time::Interval
 #[derive(Debug)]
@@ -138,7 +138,7 @@ where
 
     /// Returns a handle to the timer.
     ///
-    /// The `Handle` is how `Delay` instances are created. The `Delay` instances
+    /// The `Handle` is how `Sleep` instances are created. The `Sleep` instances
     /// can either be created directly or the `Handle` instance can be passed to
     /// `with_default`, setting the timer as the default timer for the execution
     /// context.

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -13,7 +13,7 @@ use std::fmt;
 ///   succeed in the future.
 ///
 /// * `at_capacity` occurs when a timer operation is attempted, but the timer
-///   instance is currently handling its maximum number of outstanding delays.
+///   instance is currently handling its maximum number of outstanding sleep instances.
 ///   In this case, the operation is not able to be performed at the current
 ///   moment, and `at_capacity` is returned. This is a transient error, i.e., at
 ///   some point in the future, if the operation is attempted again, it might

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -1,5 +1,5 @@
 use crate::future::poll_fn;
-use crate::time::{sleep_until, Delay, Duration, Instant};
+use crate::time::{sleep_until, Duration, Instant, Sleep};
 
 use std::future::Future;
 use std::pin::Pin;
@@ -115,7 +115,7 @@ pub fn interval_at(start: Instant, period: Duration) -> Interval {
 #[derive(Debug)]
 pub struct Interval {
     /// Future that completes the next time the `Interval` yields a value.
-    delay: Delay,
+    delay: Sleep,
 
     /// The duration between values yielded by `Interval`.
     period: Duration,

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides a number of types for executing code after a set period
 //! of time.
 //!
-//! * `Delay` is a future that does no work and completes at a specific `Instant`
+//! * `Sleep` is a future that does no work and completes at a specific `Instant`
 //!   in time.
 //!
 //! * `Interval` is a stream yielding a value at a fixed period. It is
@@ -93,8 +93,8 @@ pub(crate) use self::clock::Clock;
 #[cfg(feature = "test-util")]
 pub use clock::{advance, pause, resume};
 
-mod delay;
-pub use delay::{sleep, sleep_until, Delay};
+mod sleep;
+pub use sleep::{sleep, sleep_until, Sleep};
 
 pub(crate) mod driver;
 

--- a/tokio/src/time/tests/mod.rs
+++ b/tokio/src/time/tests/mod.rs
@@ -1,4 +1,4 @@
-mod test_delay;
+mod test_sleep;
 
 use crate::time::{self, Instant};
 use std::time::Duration;
@@ -8,15 +8,15 @@ fn assert_sync<T: Sync>() {}
 
 #[test]
 fn registration_is_send_and_sync() {
-    use crate::time::delay::Delay;
+    use crate::time::sleep::Sleep;
 
-    assert_send::<Delay>();
-    assert_sync::<Delay>();
+    assert_send::<Sleep>();
+    assert_sync::<Sleep>();
 }
 
 #[test]
 #[should_panic]
-fn delay_is_eager() {
+fn sleep_is_eager() {
     let when = Instant::now() + Duration::from_millis(100);
     let _ = time::sleep_until(when);
 }

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -4,7 +4,7 @@
 //!
 //! [`Timeout`]: struct@Timeout
 
-use crate::time::{sleep_until, Delay, Duration, Instant};
+use crate::time::{sleep_until, Duration, Instant, Sleep};
 
 use pin_project_lite::pin_project;
 use std::fmt;
@@ -50,7 +50,7 @@ pub fn timeout<T>(duration: Duration, future: T) -> Timeout<T>
 where
     T: Future,
 {
-    let delay = Delay::new_timeout(Instant::now() + duration, duration);
+    let delay = Sleep::new_timeout(Instant::now() + duration, duration);
     Timeout::new_with_delay(future, delay)
 }
 
@@ -108,7 +108,7 @@ pin_project! {
         #[pin]
         value: T,
         #[pin]
-        delay: Delay,
+        delay: Sleep,
     }
 }
 
@@ -125,7 +125,7 @@ impl Elapsed {
 }
 
 impl<T> Timeout<T> {
-    pub(crate) fn new_with_delay(value: T, delay: Delay) -> Timeout<T> {
+    pub(crate) fn new_with_delay(value: T, delay: Sleep) -> Timeout<T> {
         Timeout { value, delay }
     }
 

--- a/tokio/src/time/wheel/mod.rs
+++ b/tokio/src/time/wheel/mod.rs
@@ -47,7 +47,7 @@ pub(crate) struct Wheel {
 /// precision of 1 millisecond.
 const NUM_LEVELS: usize = 6;
 
-/// The maximum duration of a delay
+/// The maximum duration of a `Sleep`
 const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
 
 #[derive(Debug)]

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -359,10 +359,10 @@ async fn join_with_select() {
 async fn use_future_in_if_condition() {
     use tokio::time::{self, Duration};
 
-    let mut delay = time::sleep(Duration::from_millis(50));
+    let mut sleep = time::sleep(Duration::from_millis(50));
 
     tokio::select! {
-        _ = &mut delay, if !delay.is_elapsed() => {
+        _ = &mut sleep, if !sleep.is_elapsed() => {
         }
         _ = async { 1 } => {
         }

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -430,7 +430,7 @@ rt_test! {
     }
 
     #[test]
-    fn delay_at_root() {
+    fn sleep_at_root() {
         let rt = rt();
 
         let now = Instant::now();
@@ -444,7 +444,7 @@ rt_test! {
     }
 
     #[test]
-    fn delay_in_spawn() {
+    fn sleep_in_spawn() {
         let rt = rt();
 
         let now = Instant::now();
@@ -515,7 +515,7 @@ rt_test! {
     }
 
     #[test]
-    fn delay_from_blocking() {
+    fn sleep_from_blocking() {
         let rt = rt();
 
         rt.block_on(async move {

--- a/tokio/tests/stream_timeout.rs
+++ b/tokio/tests/stream_timeout.rs
@@ -6,7 +6,7 @@ use tokio_test::*;
 
 use futures::StreamExt as _;
 
-async fn maybe_delay(idx: i32) -> i32 {
+async fn maybe_sleep(idx: i32) -> i32 {
     if idx % 2 == 0 {
         sleep(ms(200)).await;
     }
@@ -26,7 +26,7 @@ async fn basic_usage() {
     //
     // [Ok(1), Err(Elapsed), Ok(2), Ok(3), Err(Elapsed), Ok(4)]
 
-    let stream = stream::iter(1..=4).then(maybe_delay).timeout(ms(100));
+    let stream = stream::iter(1..=4).then(maybe_sleep).timeout(ms(100));
     let mut stream = task::spawn(stream);
 
     // First item completes immediately
@@ -68,7 +68,7 @@ async fn basic_usage() {
 async fn return_elapsed_errors_only_once() {
     time::pause();
 
-    let stream = stream::iter(1..=3).then(maybe_delay).timeout(ms(50));
+    let stream = stream::iter(1..=3).then(maybe_sleep).timeout(ms(50));
     let mut stream = task::spawn(stream);
 
     // First item completes immediately
@@ -97,7 +97,7 @@ async fn return_elapsed_errors_only_once() {
 #[tokio::test]
 async fn no_timeouts() {
     let stream = stream::iter(vec![1, 3, 5])
-        .then(maybe_delay)
+        .then(maybe_sleep)
         .timeout(ms(100));
 
     let mut stream = task::spawn(stream);

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -20,7 +20,7 @@ macro_rules! assert_elapsed {
 }
 
 #[tokio::test]
-async fn immediate_delay() {
+async fn immediate_sleep() {
     time::pause();
 
     let now = Instant::now();
@@ -31,7 +31,7 @@ async fn immediate_delay() {
 }
 
 #[tokio::test]
-async fn delayed_delay_level_0() {
+async fn delayed_sleep_level_0() {
     time::pause();
 
     for &i in &[1, 10, 60] {
@@ -44,7 +44,7 @@ async fn delayed_delay_level_0() {
 }
 
 #[tokio::test]
-async fn sub_ms_delayed_delay() {
+async fn sub_ms_delayed_sleep() {
     time::pause();
 
     for _ in 0..5 {
@@ -58,7 +58,7 @@ async fn sub_ms_delayed_delay() {
 }
 
 #[tokio::test]
-async fn delayed_delay_wrapping_level_0() {
+async fn delayed_sleep_wrapping_level_0() {
     time::pause();
 
     time::sleep(ms(5)).await;
@@ -70,96 +70,96 @@ async fn delayed_delay_wrapping_level_0() {
 }
 
 #[tokio::test]
-async fn reset_future_delay_before_fire() {
+async fn reset_future_sleep_before_fire() {
     time::pause();
 
     let now = Instant::now();
 
-    let mut delay = task::spawn(time::sleep_until(now + ms(100)));
-    assert_pending!(delay.poll());
+    let mut sleep = task::spawn(time::sleep_until(now + ms(100)));
+    assert_pending!(sleep.poll());
 
-    let mut delay = delay.into_inner();
+    let mut sleep = sleep.into_inner();
 
-    delay.reset(Instant::now() + ms(200));
-    delay.await;
+    sleep.reset(Instant::now() + ms(200));
+    sleep.await;
 
     assert_elapsed!(now, 200);
 }
 
 #[tokio::test]
-async fn reset_past_delay_before_turn() {
+async fn reset_past_sleep_before_turn() {
     time::pause();
 
     let now = Instant::now();
 
-    let mut delay = task::spawn(time::sleep_until(now + ms(100)));
-    assert_pending!(delay.poll());
+    let mut sleep = task::spawn(time::sleep_until(now + ms(100)));
+    assert_pending!(sleep.poll());
 
-    let mut delay = delay.into_inner();
+    let mut sleep = sleep.into_inner();
 
-    delay.reset(now + ms(80));
-    delay.await;
+    sleep.reset(now + ms(80));
+    sleep.await;
 
     assert_elapsed!(now, 80);
 }
 
 #[tokio::test]
-async fn reset_past_delay_before_fire() {
+async fn reset_past_sleep_before_fire() {
     time::pause();
 
     let now = Instant::now();
 
-    let mut delay = task::spawn(time::sleep_until(now + ms(100)));
-    assert_pending!(delay.poll());
+    let mut sleep = task::spawn(time::sleep_until(now + ms(100)));
+    assert_pending!(sleep.poll());
 
-    let mut delay = delay.into_inner();
+    let mut sleep = sleep.into_inner();
 
     time::sleep(ms(10)).await;
 
-    delay.reset(now + ms(80));
-    delay.await;
+    sleep.reset(now + ms(80));
+    sleep.await;
 
     assert_elapsed!(now, 80);
 }
 
 #[tokio::test]
-async fn reset_future_delay_after_fire() {
+async fn reset_future_sleep_after_fire() {
     time::pause();
 
     let now = Instant::now();
-    let mut delay = time::sleep_until(now + ms(100));
+    let mut sleep = time::sleep_until(now + ms(100));
 
-    (&mut delay).await;
+    (&mut sleep).await;
     assert_elapsed!(now, 100);
 
-    delay.reset(now + ms(110));
-    delay.await;
+    sleep.reset(now + ms(110));
+    sleep.await;
     assert_elapsed!(now, 110);
 }
 
 #[tokio::test]
-async fn reset_delay_to_past() {
+async fn reset_sleep_to_past() {
     time::pause();
 
     let now = Instant::now();
 
-    let mut delay = task::spawn(time::sleep_until(now + ms(100)));
-    assert_pending!(delay.poll());
+    let mut sleep = task::spawn(time::sleep_until(now + ms(100)));
+    assert_pending!(sleep.poll());
 
     time::sleep(ms(50)).await;
 
-    assert!(!delay.is_woken());
+    assert!(!sleep.is_woken());
 
-    delay.reset(now + ms(40));
+    sleep.reset(now + ms(40));
 
-    assert!(delay.is_woken());
+    assert!(sleep.is_woken());
 
-    assert_ready!(delay.poll());
+    assert_ready!(sleep.poll());
 }
 
 #[test]
 #[should_panic]
-fn creating_delay_outside_of_context() {
+fn creating_sleep_outside_of_context() {
     let now = Instant::now();
 
     // This creates a delay outside of the context of a mock timer. This tests


### PR DESCRIPTION
Most usages of, and references to `delay` and `Delay` are also removed from docs, tests and comments, except for places where I believe it makes sense to keep referring to  instances of `Sleep` as `delays`.

Examples of this are `time::Interval`, `time::Timeout` and `stream::Throttle`. `DelayQueue` also remains mostly unchanged.  

follow-up to #2826, part of #2928



