### PR TITLE
sync: implement Clone for broadcast::Receiver

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -616,22 +616,20 @@ impl<T> Sender<T> {
     }
 }
 
-impl<T> Shared<T> {
-    fn new_receiver(self: Arc<Self>) -> Receiver<T> {
-        let mut tail = self.tail.lock();
+fn new_receiver<T>(shared: Arc<Shared<T>>) -> Receiver<T> {
+    let mut tail = shared.tail.lock();
 
-        if tail.rx_cnt == MAX_RECEIVERS {
-            panic!("max receivers");
-        }
-
-        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
-
-        let next = tail.pos;
-
-        drop(tail);
-
-        Receiver { shared: self, next }
+    if tail.rx_cnt == MAX_RECEIVERS {
+        panic!("max receivers");
     }
+
+    tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
+
+    let next = tail.pos;
+
+    drop(tail);
+
+    Receiver { shared, next }
 }
 
 impl Tail {

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -526,7 +526,7 @@ impl<T> Sender<T> {
     /// ```
     pub fn subscribe(&self) -> Receiver<T> {
         let shared = self.shared.clone();
-        shared.new_receiver()
+        new_receiver(shared)
     }
 
     /// Returns the number of active receivers
@@ -944,7 +944,7 @@ impl<T: Clone> Receiver<T> {
 impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
         let shared = self.shared.clone();
-        shared.new_receiver()
+        new_receiver(shared)
     }
 }
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -936,6 +936,25 @@ impl<T: Clone> Receiver<T> {
     }
 }
 
+impl<T> Clone for Receiver<T> {
+    fn clone(&self) -> Self {
+        let shared = self.shared.clone();
+
+        let mut tail = shared.tail.lock();
+
+        if tail.rx_cnt == MAX_RECEIVERS {
+            panic!("max receivers");
+        }
+
+        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
+        let next = tail.pos;
+
+        drop(tail);
+
+        Receiver { shared, next }
+    }
+}
+
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         let mut tail = self.shared.tail.lock();

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -361,7 +361,8 @@ const MAX_RECEIVERS: usize = usize::MAX >> 2;
 ///
 /// The `Sender` can be cloned to `send` to the same channel from multiple
 /// points in the process or it can be used concurrently from an `Arc`. New
-/// `Receiver` handles are created by calling [`Sender::subscribe`].
+/// `Receiver` handles can be cloned from an existing `Receiver` or created by
+/// calling [`Sender::subscribe`].
 ///
 /// If all [`Receiver`] handles are dropped, the `send` method will return a
 /// [`SendError`]. Similarly, if all [`Sender`] handles are dropped, the [`recv`]

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -526,8 +526,7 @@ impl<T> Sender<T> {
     /// ```
     pub fn subscribe(&self) -> Receiver<T> {
         let shared = self.shared.clone();
-        let next = new_receiver(&shared);
-        Receiver { shared, next }
+        shared.new_receiver()
     }
 
     /// Returns the number of active receivers
@@ -614,6 +613,24 @@ impl<T> Sender<T> {
         drop(tail);
 
         Ok(rem)
+    }
+}
+
+impl<T> Shared<T> {
+    fn new_receiver(self: Arc<Self>) -> Receiver<T> {
+        let mut tail = self.tail.lock();
+
+        if tail.rx_cnt == MAX_RECEIVERS {
+            panic!("max receivers");
+        }
+
+        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
+
+        let next = tail.pos;
+
+        drop(tail);
+
+        Receiver { shared: self, next }
     }
 }
 
@@ -929,8 +946,7 @@ impl<T: Clone> Receiver<T> {
 impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
         let shared = self.shared.clone();
-        let next = new_receiver(&shared);
-        Receiver { shared, next }
+        shared.new_receiver()
     }
 }
 
@@ -1134,17 +1150,3 @@ impl fmt::Display for TryRecvError {
 impl std::error::Error for TryRecvError {}
 
 fn is_unpin<T: Unpin>() {}
-
-/// Updates the Tail of the given "shared" to add a new Receiver to
-/// the count, and returns the current end position of the tail.
-fn new_receiver<T>(shared: &Shared<T>) -> u64 {
-    let mut tail = shared.tail.lock();
-
-    if tail.rx_cnt == MAX_RECEIVERS {
-        panic!("max receivers");
-    }
-
-    tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
-
-    tail.pos
-}

--- a/tokio/src/sync/tests/loom_broadcast.rs
+++ b/tokio/src/sync/tests/loom_broadcast.rs
@@ -92,11 +92,12 @@ fn broadcast_two() {
     });
 }
 
+// Exercise the Receiver Clone impl as well
 #[test]
 fn broadcast_wrap() {
     loom::model(|| {
         let (tx, mut rx1) = broadcast::channel(2);
-        let mut rx2 = tx.subscribe();
+        let mut rx2 = rx1.clone();
 
         let th1 = thread::spawn(move || {
             block_on(async {


### PR DESCRIPTION
Implement `Clone` for the `broadcast::Receiver` type using the same code as is used in `broadcast::Sender::subscribe`.  

## Motivation

I'm working on an API where I need a channel with the "multiple consumer" ability that the broadcast channel has, but I don't need multiple producers. I can't use a watch channel because I would like to at least know when messages have been missed.  Because the producer is singular it makes sense for my API to only expose the broadcast Receiver. However, since the only way to create new Receivers right now is by having a Sender handle, this doesn't work.

On looking at the code it seemed like implementing `Clone` for the Receiver would be pretty trivial, and it makes the API substantially more flexible, especially for my usage.

## Solution

I simply copied and pasted the code used in `Sender::subscribe`. I don't feel great about this, and I considered implementing the details of modifying the Tail count in an `impl Shared` function.  I chose not to because that function would need to return the current position of the tail for use in the new Receiver, which felt very haphazard to me.  I think this still might be worthwhile so that the two implementations don't diverge in the future, either as a method on `Shared` or a free-standing private helper function.

## Notes

I looked to see if there was another way of doing what I want, but I didn't find anything. Hopefully I'm not missing something as to why implementing this is not a good idea.