### PR TITLE
chore: remove use of doc_alias feature

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -16,7 +16,6 @@
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! A runtime for writing reliable, asynchronous, and slim applications.
 //!


### PR DESCRIPTION
This is no longer used.