### PR TITLE
io: Rename `ReadBuf` methods

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -212,7 +212,7 @@ impl Inner {
                 let n = cmp::min(dst.remaining(), data.len());
 
                 // Copy the data into the `dst` slice
-                dst.append(&data[..n]);
+                dst.put_slice(&data[..n]);
 
                 // Drain the data from the source
                 data.drain(..n);

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -118,7 +118,7 @@ where
             cx,
             slice
         ))?;
-        buf.add_filled(n);
+        buf.advance(n);
         Poll::Ready(Ok(()))
     }
 }

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -114,7 +114,7 @@ where
             Poll::Pending => return Poll::Pending,
         };
         let len = std::cmp::min(inner_buf.len(), buf.remaining());
-        buf.append(&inner_buf[..len]);
+        buf.put_slice(&inner_buf[..len]);
 
         self.consume(len);
         Poll::Ready(Ok(()))

--- a/tokio-util/tests/framed_read.rs
+++ b/tokio-util/tests/framed_read.rs
@@ -271,7 +271,7 @@ impl AsyncRead for Mock {
         match self.calls.pop_front() {
             Some(Ok(data)) => {
                 debug_assert!(buf.remaining() >= data.len());
-                buf.append(&data);
+                buf.put_slice(&data);
                 Ready(Ok(()))
             }
             Some(Err(ref e)) if e.kind() == WouldBlock => Pending,

--- a/tokio-util/tests/io_reader_stream.rs
+++ b/tokio-util/tests/io_reader_stream.rs
@@ -25,7 +25,7 @@ impl AsyncRead for Reader {
             for x in &mut buf.initialize_unfilled_to(n)[..n] {
                 *x = 0;
             }
-            buf.add_filled(n);
+            buf.advance(n);
             this.remaining -= n;
             Poll::Ready(Ok(()))
         } else {

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -712,7 +712,7 @@ impl AsyncRead for Mock {
         match self.calls.pop_front() {
             Some(Ready(Ok(Op::Data(data)))) => {
                 debug_assert!(dst.remaining() >= data.len());
-                dst.append(&data);
+                dst.put_slice(&data);
                 Ready(Ok(()))
             }
             Some(Ready(Ok(_))) => panic!(),

--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -97,7 +97,7 @@ impl AsyncRead for &[u8] {
     ) -> Poll<io::Result<()>> {
         let amt = std::cmp::min(self.len(), buf.remaining());
         let (a, b) = self.split_at(amt);
-        buf.append(a);
+        buf.put_slice(a);
         *self = b;
         Poll::Ready(Ok(()))
     }
@@ -121,7 +121,7 @@ impl<T: AsRef<[u8]> + Unpin> AsyncRead for io::Cursor<T> {
         let amt = std::cmp::min(slice.len() - start, buf.remaining());
         // Add won't overflow because of pos check above.
         let end = start + amt;
-        buf.append(&slice[start..end]);
+        buf.put_slice(&slice[start..end]);
         self.set_position(end as u64);
 
         Poll::Ready(Ok(()))

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -205,7 +205,7 @@ impl Buf {
 
     pub(crate) fn copy_to(&mut self, dst: &mut ReadBuf<'_>) -> usize {
         let n = cmp::min(self.len(), dst.remaining());
-        dst.append(&self.bytes()[..n]);
+        dst.put_slice(&self.bytes()[..n]);
         self.pos += n;
 
         if self.pos == self.buf.len() {

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -249,7 +249,7 @@ impl<E: Source + Read + Unpin> AsyncRead for PollEvented<E> {
             }
 
             return Poll::Ready(r.map(|n| {
-                buf.add_filled(n);
+                buf.advance(n);
             }));
         }
     }

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -171,7 +171,7 @@ impl<'a> ReadBuf<'a> {
         self.filled = 0;
     }
 
-    /// Increases the size of the filled region of the buffer.
+    /// Advances the size of the filled region of the buffer.
     ///
     /// The number of initialized bytes is not changed.
     ///
@@ -179,7 +179,7 @@ impl<'a> ReadBuf<'a> {
     ///
     /// Panics if the filled region of the buffer would become larger than the initialized region.
     #[inline]
-    pub fn add_filled(&mut self, n: usize) {
+    pub fn advance(&mut self, n: usize) {
         let new = self.filled.checked_add(n).expect("filled overflow");
         self.set_filled(new);
     }
@@ -225,7 +225,7 @@ impl<'a> ReadBuf<'a> {
     ///
     /// Panics if `self.remaining()` is less than `buf.len()`.
     #[inline]
-    pub fn append(&mut self, buf: &[u8]) {
+    pub fn put_slice(&mut self, buf: &[u8]) {
         assert!(
             self.remaining() >= buf.len(),
             "buf.len() must fit in remaining()"

--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -111,7 +111,7 @@ impl<R: AsyncRead> AsyncRead for BufReader<R> {
         }
         let rem = ready!(self.as_mut().poll_fill_buf(cx))?;
         let amt = std::cmp::min(rem.len(), buf.remaining());
-        buf.append(&rem[..amt]);
+        buf.put_slice(&rem[..amt]);
         self.consume(amt);
         Poll::Ready(Ok(()))
     }

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -167,7 +167,7 @@ impl AsyncRead for Pipe {
     ) -> Poll<std::io::Result<()>> {
         if self.buffer.has_remaining() {
             let max = self.buffer.remaining().min(buf.remaining());
-            buf.append(&self.buffer[..max]);
+            buf.put_slice(&self.buffer[..max]);
             self.buffer.advance(max);
             if max > 0 {
                 // The passed `buf` might have been empty, don't wake up if

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -55,7 +55,7 @@ impl AsyncRead for Repeat {
     ) -> Poll<io::Result<()>> {
         // TODO: could be faster, but should we unsafe it?
         while buf.remaining() != 0 {
-            buf.append(&[self.byte]);
+            buf.put_slice(&[self.byte]);
         }
         Poll::Ready(Ok(()))
     }

--- a/tokio/src/io/util/take.rs
+++ b/tokio/src/io/util/take.rs
@@ -93,7 +93,7 @@ impl<R: AsyncRead> AsyncRead for Take<R> {
         unsafe {
             buf.assume_init(n);
         }
-        buf.add_filled(n);
+        buf.advance(n);
         *me.limit_ -= n as u64;
         Poll::Ready(Ok(()))
     }

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -503,7 +503,7 @@ impl TcpStream {
                     unsafe {
                         buf.assume_init(n);
                     }
-                    buf.add_filled(n);
+                    buf.advance(n);
                     return Poll::Ready(Ok(()));
                 }
                 Err(e) => return Poll::Ready(Err(e)),

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -215,7 +215,7 @@ impl UnixStream {
                     unsafe {
                         buf.assume_init(n);
                     }
-                    buf.add_filled(n);
+                    buf.advance(n);
                     return Poll::Ready(Ok(()));
                 }
                 Err(e) => return Poll::Ready(Err(e)),

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -18,7 +18,7 @@ async fn copy() {
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
             if self.0 {
-                buf.append(b"hello world");
+                buf.put_slice(b"hello world");
                 self.0 = false;
                 Poll::Ready(Ok(()))
             } else {

--- a/tokio/tests/io_read.rs
+++ b/tokio/tests/io_read.rs
@@ -24,7 +24,7 @@ async fn read() {
             assert_eq!(0, self.poll_cnt);
             self.poll_cnt += 1;
 
-            buf.append(b"hello world");
+            buf.put_slice(b"hello world");
             Poll::Ready(Ok(()))
         }
     }

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -15,7 +15,7 @@ impl AsyncRead for RW {
         _cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        buf.append(&[b'z']);
+        buf.put_slice(&[b'z']);
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
This changes `ReadBuf::add_filled` to `ReadBuf::advance` and
`ReadBuf::append` to `ReadBuf::put_slice`. This is just a
mechanical change.

Closes #2769
