### PR TITLE
rt: simplify rt-* features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           rm -rf tokio/tests
 
       - name: miri
-        run: cargo miri test --features rt-core,rt-threaded,rt-util,sync task
+        run: cargo miri test --features rt,rt-threaded,sync task
         working-directory: tokio
 
   cross:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           rm -rf tokio/tests
 
       - name: miri
-        run: cargo miri test --features rt,rt-threaded,sync task
+        run: cargo miri test --features rt,rt-multi-thread,sync task
         working-directory: tokio
 
   cross:

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [features]
 full = ["tokio/full"]
-rt-core = ["tokio/rt-core", "tokio/macros"]
+rt = ["tokio/rt", "tokio/macros"]
 
 [dependencies]
 tokio = { path = "../tokio", optional = true }

--- a/tests-build/tests/fail/macros_core_no_default.stderr
+++ b/tests-build/tests/fail/macros_core_no_default.stderr
@@ -1,4 +1,4 @@
-error: The default runtime flavor is `multi_thread`, but the `rt-threaded` feature is disabled.
+error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
  --> $DIR/macros_core_no_default.rs:3:1
   |
 3 | #[tokio::main]

--- a/tests-build/tests/macros.rs
+++ b/tests-build/tests/macros.rs
@@ -5,7 +5,7 @@ fn compile_fail_full() {
     #[cfg(feature = "full")]
     t.compile_fail("tests/fail/macros_invalid_input.rs");
 
-    #[cfg(all(feature = "rt-core", not(feature = "full")))]
+    #[cfg(all(feature = "rt", not(feature = "full")))]
     t.compile_fail("tests/fail/macros_core_no_default.rs");
 
     drop(t);

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 full = [
     "macros",
     "rt",
-    "rt-threaded",
+    "rt-multi-thread",
 
     "tokio/full",
     "tokio-test"
@@ -17,7 +17,7 @@ full = [
 macros = ["tokio/macros"]
 sync = ["tokio/sync"]
 rt = ["tokio/rt"]
-rt-threaded = ["rt", "tokio/rt-threaded"]
+rt-multi-thread = ["rt", "tokio/rt-multi-thread"]
 
 [dependencies]
 tokio = { path = "../tokio" }

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [features]
 full = [
     "macros",
-    "rt-core",
+    "rt",
     "rt-threaded",
 
     "tokio/full",
@@ -16,8 +16,8 @@ full = [
 ]
 macros = ["tokio/macros"]
 sync = ["tokio/sync"]
-rt-core = ["tokio/rt-core"]
-rt-threaded = ["rt-core", "tokio/rt-threaded"]
+rt = ["tokio/rt"]
+rt-threaded = ["rt", "tokio/rt-threaded"]
 
 [dependencies]
 tokio = { path = "../tokio" }

--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "macros", feature = "rt-core"))]
+#![cfg(all(feature = "macros", feature = "rt"))]
 
 #[tokio::main]
 async fn basic_main() -> usize {

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -258,13 +258,13 @@ pub fn test_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Always fails with the error message below.
 /// ```text
-/// The #[tokio::main] macro requires rt or rt-threaded.
+/// The #[tokio::main] macro requires rt or rt-multi-thread.
 /// ```
 #[proc_macro_attribute]
 pub fn main_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "The #[tokio::main] macro requires rt or rt-threaded.",
+        "The #[tokio::main] macro requires rt or rt-multi-thread.",
     )
     .to_compile_error()
     .into()
@@ -272,13 +272,13 @@ pub fn main_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
 
 /// Always fails with the error message below.
 /// ```text
-/// The #[tokio::test] macro requires rt or rt-threaded.
+/// The #[tokio::test] macro requires rt or rt-multi-thread.
 /// ```
 #[proc_macro_attribute]
 pub fn test_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "The #[tokio::test] macro requires rt or rt-threaded.",
+        "The #[tokio::test] macro requires rt or rt-multi-thread.",
     )
     .to_compile_error()
     .into()

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -189,7 +189,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// macro is expanded.
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
-pub fn main_rt_core(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::main(args, item, false)
 }
 
@@ -252,19 +252,19 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 /// tokio 0.2 crate available as `tokio` in the module where this
 /// macro is expanded.
 #[proc_macro_attribute]
-pub fn test_rt_core(args: TokenStream, item: TokenStream) -> TokenStream {
+pub fn test_rt(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::test(args, item, false)
 }
 
 /// Always fails with the error message below.
 /// ```text
-/// The #[tokio::main] macro requires rt-core or rt-threaded.
+/// The #[tokio::main] macro requires rt or rt-threaded.
 /// ```
 #[proc_macro_attribute]
 pub fn main_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "The #[tokio::main] macro requires rt-core or rt-threaded.",
+        "The #[tokio::main] macro requires rt or rt-threaded.",
     )
     .to_compile_error()
     .into()
@@ -272,13 +272,13 @@ pub fn main_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
 
 /// Always fails with the error message below.
 /// ```text
-/// The #[tokio::test] macro requires rt-core or rt-threaded.
+/// The #[tokio::test] macro requires rt or rt-threaded.
 /// ```
 #[proc_macro_attribute]
 pub fn test_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
     syn::Error::new(
         proc_macro2::Span::call_site(),
-        "The #[tokio::test] macro requires rt-core or rt-threaded.",
+        "The #[tokio::test] macro requires rt or rt-threaded.",
     )
     .to_compile_error()
     .into()

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["asynchronous", "testing"]
 publish = false
 
 [dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["rt-core", "stream", "sync", "time", "test-util"] }
+tokio = { version = "0.3.0", path = "../tokio", features = ["rt", "stream", "sync", "time", "test-util"] }
 
 bytes = "0.5.0"
 futures-core = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -31,7 +31,7 @@ compat = ["futures-io",]
 codec = ["tokio/stream"]
 time = ["tokio/time","slab"]
 io = []
-rt-core = ["tokio/rt-core"]
+rt = ["tokio/rt"]
 
 [dependencies]
 tokio = { version = "0.3.0", path = "../tokio" }

--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -40,11 +40,11 @@ macro_rules! cfg_io {
     }
 }
 
-macro_rules! cfg_rt_core {
+macro_rules! cfg_rt {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "rt-core")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-core")))]
+            #[cfg(feature = "rt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -47,7 +47,7 @@ cfg_io! {
     pub mod io;
 }
 
-cfg_rt_core! {
+cfg_rt! {
     pub mod context;
 }
 

--- a/tokio-util/tests/context.rs
+++ b/tokio-util/tests/context.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rt-core")]
+#![cfg(feature = "rt")]
 #![warn(rust_2018_idioms)]
 
 use tokio::runtime::Builder;

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -38,7 +38,7 @@ full = [
   "net",
   "process",
   "rt",
-  "rt-threaded",
+  "rt-multi-thread",
   "signal",
   "stream",
   "sync",
@@ -71,7 +71,7 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt = ["slab"]
-rt-threaded = [
+rt-multi-thread = [
   "num_cpus",
   "rt",
 ]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -37,8 +37,7 @@ full = [
   "macros",
   "net",
   "process",
-  "rt-core",
-  "rt-util",
+  "rt",
   "rt-threaded",
   "signal",
   "stream",
@@ -71,11 +70,10 @@ process = [
   "winapi/threadpoollegacyapiset",
 ]
 # Includes basic task execution capabilities
-rt-core = ["slab"]
-rt-util = []
+rt = ["slab"]
 rt-threaded = [
   "num_cpus",
-  "rt-core",
+  "rt",
 ]
 signal = [
   "lazy_static",

--- a/tokio/src/blocking.rs
+++ b/tokio/src/blocking.rs
@@ -1,9 +1,9 @@
-cfg_rt_core! {
+cfg_rt! {
     pub(crate) use crate::runtime::spawn_blocking;
     pub(crate) use crate::task::JoinHandle;
 }
 
-cfg_not_rt_core! {
+cfg_not_rt! {
     use std::fmt;
     use std::future::Future;
     use std::pin::Pin;
@@ -15,7 +15,7 @@ cfg_not_rt_core! {
         R: Send + 'static,
     {
         assert_send_sync::<JoinHandle<std::cell::Cell<()>>>();
-        panic!("requires the `rt-core` Tokio feature flag")
+        panic!("requires the `rt` Tokio feature flag")
 
     }
 

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -134,7 +134,7 @@ cfg_rt_threaded! {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     /// Forcibly remove the budgeting constraints early.
     ///
     /// Returns the remaining budget

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -83,7 +83,7 @@ impl Budget {
     }
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     impl Budget {
         fn has_remaining(self) -> bool {
             self.0.map(|budget| budget > 0).unwrap_or(true)
@@ -122,7 +122,7 @@ fn with_budget<R>(budget: Budget, f: impl FnOnce() -> R) -> R {
     })
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     /// Set the current task's budget
     pub(crate) fn set(budget: Budget) {
         CURRENT.with(|cell| cell.set(budget))

--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -1,13 +1,13 @@
 use std::future::Future;
 
-cfg_rt_core! {
+cfg_rt! {
     pub(crate) fn block_on<F: Future>(f: F) -> F::Output {
         let mut e = crate::runtime::enter::enter(false);
         e.block_on(f).unwrap()
     }
 }
 
-cfg_not_rt_core! {
+cfg_not_rt! {
     pub(crate) fn block_on<F: Future>(f: F) -> F::Output {
         let mut park = crate::park::thread::CachedParkThread::new();
         park.block_on(f).unwrap()

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 mod ready;
 use ready::Ready;
@@ -219,13 +219,13 @@ impl fmt::Debug for Driver {
 
 // ===== impl Handle =====
 
-cfg_rt_core! {
+cfg_rt! {
     impl Handle {
         /// Returns a handle to the current reactor
         ///
         /// # Panics
         ///
-        /// This function panics if there is no current reactor set and `rt-core` feature
+        /// This function panics if there is no current reactor set and `rt` feature
         /// flag is not enabled.
         pub(super) fn current() -> Self {
             crate::runtime::context::io_handle()
@@ -234,16 +234,16 @@ cfg_rt_core! {
     }
 }
 
-cfg_not_rt_core! {
+cfg_not_rt! {
     impl Handle {
         /// Returns a handle to the current reactor
         ///
         /// # Panics
         ///
-        /// This function panics if there is no current reactor set, or if the `rt-core`
+        /// This function panics if there is no current reactor set, or if the `rt`
         /// feature flag is not enabled.
         pub(super) fn current() -> Self {
-            panic!("there is no reactor running, must be called from the context of Tokio runtime with `rt-core` enabled.")
+            panic!("there is no reactor running, must be called from the context of Tokio runtime with `rt` enabled.")
         }
     }
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -75,7 +75,7 @@
 //! - `full`: Enables all Tokio public API features listed below.
 //! - `rt-core`: Enables `tokio::spawn`, the basic (single-threaded) scheduler,
 //! and non-scheduler utilities.
-//! - `rt-threaded`: Enables the heavier, multi-threaded, work-stealing scheduler.
+//! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
 //! - `io-util`: Enables the IO based `Ext` traits.
 //! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
 //! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`.
@@ -196,9 +196,9 @@
 //! and managing runtimes. You should use that module if the `#[tokio::main]` macro doesn't
 //! provide the functionality you need.
 //!
-//! Using the runtime requires the "rt" or "rt-threaded" feature flags, to
+//! Using the runtime requires the "rt" or "rt-multi-thread" feature flags, to
 //! enable the basic [single-threaded scheduler][rt] and the [thread-pool
-//! scheduler][rt-threaded], respectively. See the [`runtime` module
+//! scheduler][rt-multi-thread], respectively. See the [`runtime` module
 //! documentation][rt-features] for details. In addition, the "macros" feature
 //! flag enables the `#[tokio::main]` and `#[tokio::test]` attributes.
 //!
@@ -207,7 +207,7 @@
 //! [`Builder`]: crate::runtime::Builder
 //! [`Runtime`]: crate::runtime::Runtime
 //! [rt]: runtime/index.html#basic-scheduler
-//! [rt-threaded]: runtime/index.html#threaded-scheduler
+//! [rt-multi-thread]: runtime/index.html#threaded-scheduler
 //! [rt-features]: runtime/index.html#runtime-scheduler
 //!
 //! ## CPU-bound tasks and blocking code
@@ -409,7 +409,7 @@ cfg_macros! {
     pub use tokio_macros::select_priv_declare_output_enum;
 
     cfg_rt! {
-        cfg_rt_threaded! {
+        cfg_rt_multi_thread! {
             // This is the docs.rs case (with all features) so make sure macros
             // is included in doc(cfg).
 
@@ -421,7 +421,7 @@ cfg_macros! {
             pub use tokio_macros::test;
         }
 
-        cfg_not_rt_threaded! {
+        cfg_not_rt_multi_thread! {
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
             pub use tokio_macros::main_rt as main;
             pub use tokio_macros::test_rt as test;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -73,9 +73,9 @@
 //! need.
 //!
 //! - `full`: Enables all Tokio public API features listed below.
-//! - `rt-core`: Enables `tokio::spawn` and the basic (single-threaded) scheduler.
+//! - `rt-core`: Enables `tokio::spawn`, the basic (single-threaded) scheduler,
+//! and non-scheduler utilities.
 //! - `rt-threaded`: Enables the heavier, multi-threaded, work-stealing scheduler.
-//! - `rt-util`: Enables non-scheduler utilities.
 //! - `io-util`: Enables the IO based `Ext` traits.
 //! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
 //! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`.
@@ -134,7 +134,7 @@
 //! needs to `tokio::spawn` and use a `TcpStream`.
 //!
 //! ```toml
-//! tokio = { version = "0.2", features = ["rt-core", "net"] }
+//! tokio = { version = "0.2", features = ["rt", "net"] }
 //! ```
 //!
 //! ## Working With Tasks
@@ -148,7 +148,7 @@
 //! * Functions for [running blocking operations][blocking] in an asynchronous
 //!   task context.
 //!
-//! The [`tokio::task`] module is present only when the "rt-core" feature flag
+//! The [`tokio::task`] module is present only when the "rt" feature flag
 //! is enabled.
 //!
 //! [tasks]: task/index.html#what-are-tasks
@@ -196,8 +196,8 @@
 //! and managing runtimes. You should use that module if the `#[tokio::main]` macro doesn't
 //! provide the functionality you need.
 //!
-//! Using the runtime requires the "rt-core" or "rt-threaded" feature flags, to
-//! enable the basic [single-threaded scheduler][rt-core] and the [thread-pool
+//! Using the runtime requires the "rt" or "rt-threaded" feature flags, to
+//! enable the basic [single-threaded scheduler][rt] and the [thread-pool
 //! scheduler][rt-threaded], respectively. See the [`runtime` module
 //! documentation][rt-features] for details. In addition, the "macros" feature
 //! flag enables the `#[tokio::main]` and `#[tokio::test]` attributes.
@@ -206,7 +206,7 @@
 //! [`tokio::runtime`]: crate::runtime
 //! [`Builder`]: crate::runtime::Builder
 //! [`Runtime`]: crate::runtime::Runtime
-//! [rt-core]: runtime/index.html#basic-scheduler
+//! [rt]: runtime/index.html#basic-scheduler
 //! [rt-threaded]: runtime/index.html#threaded-scheduler
 //! [rt-features]: runtime/index.html#runtime-scheduler
 //!
@@ -362,11 +362,9 @@ cfg_process! {
 #[cfg(any(feature = "dns", feature = "fs", feature = "io-std"))]
 mod blocking;
 
-cfg_rt_core! {
+cfg_rt! {
     pub mod runtime;
 }
-#[cfg(all(not(feature = "rt-core"), feature = "rt-util"))]
-mod runtime;
 
 pub(crate) mod coop;
 
@@ -393,7 +391,7 @@ cfg_not_sync! {
 }
 
 pub mod task;
-cfg_rt_core! {
+cfg_rt! {
     pub use task::spawn;
 }
 
@@ -410,7 +408,7 @@ cfg_macros! {
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
 
-    doc_rt_core! {
+    doc_rt! {
         cfg_rt_threaded! {
             // This is the docs.rs case (with all features) so make sure macros
             // is included in doc(cfg).
@@ -425,13 +423,13 @@ cfg_macros! {
 
         cfg_not_rt_threaded! {
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
-            pub use tokio_macros::main_rt_core as main;
-            pub use tokio_macros::test_rt_core as test;
+            pub use tokio_macros::main_rt as main;
+            pub use tokio_macros::test_rt as test;
         }
     }
 
-    // Always fail if rt-core is not enabled.
-    cfg_not_rt_core! {
+    // Always fail if rt is not enabled.
+    cfg_not_rt! {
         #[cfg(not(test))]
         pub use tokio_macros::main_fail as main;
         pub use tokio_macros::test_fail as test;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -73,7 +73,7 @@
 //! need.
 //!
 //! - `full`: Enables all Tokio public API features listed below.
-//! - `rt-core`: Enables `tokio::spawn`, the basic (single-threaded) scheduler,
+//! - `rt-core`: Enables `tokio::spawn`, the basic (current thread) scheduler,
 //! and non-scheduler utilities.
 //! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
 //! - `io-util`: Enables the IO based `Ext` traits.

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -408,7 +408,7 @@ cfg_macros! {
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
 
-    doc_rt! {
+    cfg_rt! {
         cfg_rt_threaded! {
             // This is the docs.rs case (with all features) so make sure macros
             // is included in doc(cfg).

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -79,12 +79,12 @@ pub(crate) mod sync {
 }
 
 pub(crate) mod sys {
-    #[cfg(feature = "rt-threaded")]
+    #[cfg(feature = "rt-multi-thread")]
     pub(crate) fn num_cpus() -> usize {
         usize::max(1, num_cpus::get())
     }
 
-    #[cfg(not(feature = "rt-threaded"))]
+    #[cfg(not(feature = "rt-multi-thread"))]
     pub(crate) fn num_cpus() -> usize {
         1
     }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -261,26 +261,6 @@ macro_rules! cfg_rt {
     }
 }
 
-macro_rules! cfg_task {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "rt")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! doc_rt {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "rt")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
-            $item
-        )*
-    }
-}
-
 macro_rules! cfg_not_rt {
     ($($item:item)*) => {
         $( #[cfg(not(feature = "rt"))] $item )*

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -8,7 +8,7 @@ macro_rules! cfg_block_on {
                     feature = "fs",
                     feature = "dns",
                     feature = "io-std",
-                    feature = "rt-core",
+                    feature = "rt",
                     ))]
             $item
         )*
@@ -22,7 +22,7 @@ macro_rules! cfg_atomic_waker_impl {
             #[cfg(any(
                 feature = "net",
                 feature = "process",
-                feature = "rt-util",
+                feature = "rt",
                 feature = "signal",
                 feature = "time",
             ))]
@@ -251,10 +251,11 @@ macro_rules! cfg_not_sync {
     }
 }
 
-macro_rules! cfg_rt_core {
+macro_rules! cfg_rt {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "rt-core")]
+            #[cfg(feature = "rt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }
@@ -263,26 +264,26 @@ macro_rules! cfg_rt_core {
 macro_rules! cfg_task {
     ($($item:item)*) => {
         $(
-            #[cfg(any(feature = "rt-core", feature = "rt-util"))]
-            #[cfg_attr(docsrs, doc(cfg(any(feature = "rt-core", feature = "rt-util"))))]
+            #[cfg(feature = "rt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }
 }
 
-macro_rules! doc_rt_core {
+macro_rules! doc_rt {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "rt-core")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-core")))]
+            #[cfg(feature = "rt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }
 }
 
-macro_rules! cfg_not_rt_core {
+macro_rules! cfg_not_rt {
     ($($item:item)*) => {
-        $( #[cfg(not(feature = "rt-core"))] $item )*
+        $( #[cfg(not(feature = "rt"))] $item )*
     }
 }
 
@@ -291,16 +292,6 @@ macro_rules! cfg_rt_threaded {
         $(
             #[cfg(feature = "rt-threaded")]
             #[cfg_attr(docsrs, doc(cfg(feature = "rt-threaded")))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_rt_util {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "rt-util")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-util")))]
             $item
         )*
     }
@@ -372,8 +363,7 @@ macro_rules! cfg_coop {
                     feature = "io-std",
                     feature = "net",
                     feature = "process",
-                    feature = "rt-core",
-                    feature = "rt-util",
+                    feature = "rt",
                     feature = "signal",
                     feature = "sync",
                     feature = "stream",

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -267,19 +267,19 @@ macro_rules! cfg_not_rt {
     }
 }
 
-macro_rules! cfg_rt_threaded {
+macro_rules! cfg_rt_multi_thread {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "rt-threaded")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-threaded")))]
+            #[cfg(feature = "rt-multi-thread")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
             $item
         )*
     }
 }
 
-macro_rules! cfg_not_rt_threaded {
+macro_rules! cfg_not_rt_multi_thread {
     ($($item:item)*) => {
-        $( #[cfg(not(feature = "rt-threaded"))] $item )*
+        $( #[cfg(not(feature = "rt-multi-thread"))] $item )*
     }
 }
 

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -16,7 +16,7 @@ mod ready;
 mod thread_local;
 
 #[macro_use]
-#[cfg(any(feature = "rt-core", feature = "rt-util"))]
+#[cfg(feature = "rt")]
 pub(crate) mod scoped_tls;
 
 cfg_macros! {

--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -34,11 +34,11 @@
 //! * `park_timeout` does the same as `park` but allows specifying a maximum
 //!   time to block the thread for.
 
-cfg_rt_core! {
+cfg_rt! {
     pub(crate) mod either;
 }
 
-#[cfg(any(feature = "rt-core", feature = "rt-util", feature = "sync"))]
+#[cfg(any(feature = "rt", feature = "sync"))]
 pub(crate) mod thread;
 
 use std::sync::Arc;

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Process driver
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -73,7 +73,7 @@ pub(crate) type ThreadNameFn = std::sync::Arc<dyn Fn() -> String + Send + Sync +
 
 pub(crate) enum Kind {
     CurrentThread,
-    #[cfg(feature = "rt-threaded")]
+    #[cfg(feature = "rt-multi-thread")]
     MultiThread,
 }
 
@@ -84,7 +84,7 @@ impl Builder {
     }
 
     /// TODO
-    #[cfg(feature = "rt-threaded")]
+    #[cfg(feature = "rt-multi-thread")]
     pub fn new_multi_thread() -> Builder {
         Builder::new(Kind::MultiThread)
     }
@@ -360,7 +360,7 @@ impl Builder {
     pub fn build(&mut self) -> io::Result<Runtime> {
         match &self.kind {
             Kind::CurrentThread => self.build_basic_runtime(),
-            #[cfg(feature = "rt-threaded")]
+            #[cfg(feature = "rt-multi-thread")]
             Kind::MultiThread => self.build_threaded_runtime(),
         }
     }
@@ -472,7 +472,7 @@ cfg_time! {
     }
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     impl Builder {
         fn build_threaded_runtime(&mut self) -> io::Result<Runtime> {
             use crate::loom::sys::num_cpus;

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -48,7 +48,7 @@ cfg_time! {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     pub(crate) fn spawn_handle() -> Option<crate::runtime::Spawner> {
         CONTEXT.with(|ctx| match *ctx.borrow() {
             Some(ref ctx) => Some(ctx.spawner.clone()),

--- a/tokio/src/runtime/enter.rs
+++ b/tokio/src/runtime/enter.rs
@@ -65,7 +65,7 @@ cfg_rt! {
 //
 // This is hidden for a reason. Do not use without fully understanding
 // executors. Misuing can easily cause your program to deadlock.
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     pub(crate) fn exit<F: FnOnce() -> R, R>(f: F) -> R {
         // Reset in case the closure panics
         struct Reset(EnterContext);
@@ -130,7 +130,7 @@ cfg_rt! {
     }
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     /// Returns true if in a runtime context.
     pub(crate) fn context() -> EnterContext {
         ENTERED.with(|c| c.get())

--- a/tokio/src/runtime/enter.rs
+++ b/tokio/src/runtime/enter.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) enum EnterContext {
-    #[cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+    #[cfg_attr(not(feature = "rt"), allow(dead_code))]
     Entered {
         allow_blocking: bool,
     },
@@ -24,7 +24,7 @@ pub(crate) struct Enter {
     _p: PhantomData<RefCell<()>>,
 }
 
-cfg_rt_core! {
+cfg_rt! {
     use crate::park::thread::ParkError;
 
     use std::time::Duration;
@@ -91,7 +91,7 @@ cfg_rt_threaded! {
     }
 }
 
-cfg_rt_util! {
+cfg_rt! {
     /// Disallow blocking in the current runtime context until the guard is dropped.
     pub(crate) fn disallow_blocking() -> DisallowBlockingGuard {
         let reset = ENTERED.with(|c| {
@@ -137,7 +137,7 @@ cfg_rt_threaded! {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     impl Enter {
         /// Blocks the thread on the specified future, returning the value with
         /// which that future completes.

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -114,7 +114,7 @@
 //!
 //! The current-thread scheduler provides a _single-threaded_ future executor.
 //! All tasks will be created and executed on the current thread. This requires
-//! the `rt-core` feature flag.
+//! the `rt` feature flag.
 //! ```
 //! use tokio::runtime;
 //!
@@ -181,7 +181,7 @@ pub(crate) mod enter;
 
 pub(crate) mod task;
 
-cfg_rt_core! {
+cfg_rt! {
     mod basic_scheduler;
     use basic_scheduler::BasicScheduler;
 
@@ -216,7 +216,7 @@ cfg_rt_threaded! {
     use self::thread_pool::ThreadPool;
 }
 
-cfg_rt_core! {
+cfg_rt! {
     use crate::task::JoinHandle;
 
     use std::future::Future;
@@ -266,7 +266,7 @@ cfg_rt_core! {
     #[derive(Debug)]
     enum Kind {
         /// Execute all tasks on the current-thread.
-        #[cfg(feature = "rt-core")]
+        #[cfg(feature = "rt")]
         CurrentThread(BasicScheduler<driver::Driver>),
 
         /// Execute tasks across multiple threads.
@@ -283,7 +283,7 @@ cfg_rt_core! {
         /// This results in a scheduler, I/O driver, and time driver being
         /// initialized. The type of scheduler used depends on what feature flags
         /// are enabled: if the `rt-threaded` feature is enabled, the [threaded
-        /// scheduler] is used, while if only the `rt-core` feature is enabled, the
+        /// scheduler] is used, while if only the `rt` feature is enabled, the
         /// [basic scheduler] is used instead.
         ///
         /// If the threaded scheduler is selected, it will not spawn
@@ -343,7 +343,7 @@ cfg_rt_core! {
         /// });
         /// # }
         /// ```
-        #[cfg(feature = "rt-core")]
+        #[cfg(feature = "rt")]
         pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,
@@ -393,7 +393,7 @@ cfg_rt_core! {
         /// [handle]: fn@Handle::block_on
         pub fn block_on<F: Future>(&self, future: F) -> F::Output {
             self.handle.enter(|| match &self.kind {
-                #[cfg(feature = "rt-core")]
+                #[cfg(feature = "rt")]
                 Kind::CurrentThread(exec) => exec.block_on(future),
                 #[cfg(feature = "rt-threaded")]
                 Kind::ThreadPool(exec) => exec.block_on(future),

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -129,7 +129,7 @@
 //! The multi-thread scheduler executes futures on a _thread pool_, using a
 //! work-stealing strategy. By default, it will start a worker thread for each
 //! CPU core available on the system. This tends to be the ideal configurations
-//! for most applications. The multi-thread scheduler requires the `rt-threaded`
+//! for most applications. The multi-thread scheduler requires the `rt-multi-thread`
 //! feature flag, and is selected by default:
 //! ```
 //! use tokio::runtime;
@@ -204,12 +204,12 @@ cfg_rt! {
     use self::spawner::Spawner;
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     mod park;
     use park::Parker;
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     mod queue;
 
     pub(crate) mod thread_pool;
@@ -270,7 +270,7 @@ cfg_rt! {
         CurrentThread(BasicScheduler<driver::Driver>),
 
         /// Execute tasks across multiple threads.
-        #[cfg(feature = "rt-threaded")]
+        #[cfg(feature = "rt-multi-thread")]
         ThreadPool(ThreadPool),
     }
 
@@ -282,7 +282,7 @@ cfg_rt! {
         ///
         /// This results in a scheduler, I/O driver, and time driver being
         /// initialized. The type of scheduler used depends on what feature flags
-        /// are enabled: if the `rt-threaded` feature is enabled, the [threaded
+        /// are enabled: if the `rt-multi-thread` feature is enabled, the [threaded
         /// scheduler] is used, while if only the `rt` feature is enabled, the
         /// [basic scheduler] is used instead.
         ///
@@ -313,7 +313,7 @@ cfg_rt! {
         /// [threaded scheduler]: index.html#threaded-scheduler
         /// [basic scheduler]: index.html#basic-scheduler
         /// [runtime builder]: crate::runtime::Builder
-        #[cfg(feature = "rt-threaded")]
+        #[cfg(feature = "rt-multi-thread")]
         pub fn new() -> std::io::Result<Runtime> {
             Builder::new_multi_thread().enable_all().build()
         }
@@ -350,7 +350,7 @@ cfg_rt! {
             F::Output: Send + 'static,
         {
             match &self.kind {
-                #[cfg(feature = "rt-threaded")]
+                #[cfg(feature = "rt-multi-thread")]
                 Kind::ThreadPool(exec) => exec.spawn(future),
                 Kind::CurrentThread(exec) => exec.spawn(future),
             }
@@ -395,7 +395,7 @@ cfg_rt! {
             self.handle.enter(|| match &self.kind {
                 #[cfg(feature = "rt")]
                 Kind::CurrentThread(exec) => exec.block_on(future),
-                #[cfg(feature = "rt-threaded")]
+                #[cfg(feature = "rt-multi-thread")]
                 Kind::ThreadPool(exec) => exec.block_on(future),
             })
         }

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -5,7 +5,7 @@ cfg_rt! {
     use std::future::Future;
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     use crate::runtime::thread_pool;
 }
 
@@ -13,13 +13,13 @@ cfg_rt_threaded! {
 pub(crate) enum Spawner {
     #[cfg(feature = "rt")]
     Basic(basic_scheduler::Spawner),
-    #[cfg(feature = "rt-threaded")]
+    #[cfg(feature = "rt-multi-thread")]
     ThreadPool(thread_pool::Spawner),
 }
 
 impl Spawner {
     pub(crate) fn shutdown(&mut self) {
-        #[cfg(feature = "rt-threaded")]
+        #[cfg(feature = "rt-multi-thread")]
         {
             if let Spawner::ThreadPool(spawner) = self {
                 spawner.shutdown();
@@ -38,7 +38,7 @@ cfg_rt! {
             match self {
                 #[cfg(feature = "rt")]
                 Spawner::Basic(spawner) => spawner.spawn(future),
-                #[cfg(feature = "rt-threaded")]
+                #[cfg(feature = "rt-multi-thread")]
                 Spawner::ThreadPool(spawner) => spawner.spawn(future),
             }
         }

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -1,4 +1,4 @@
-cfg_rt_core! {
+cfg_rt! {
     use crate::runtime::basic_scheduler;
     use crate::task::JoinHandle;
 
@@ -11,7 +11,7 @@ cfg_rt_threaded! {
 
 #[derive(Debug, Clone)]
 pub(crate) enum Spawner {
-    #[cfg(feature = "rt-core")]
+    #[cfg(feature = "rt")]
     Basic(basic_scheduler::Spawner),
     #[cfg(feature = "rt-threaded")]
     ThreadPool(thread_pool::Spawner),
@@ -28,7 +28,7 @@ impl Spawner {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     impl Spawner {
         pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
         where
@@ -36,7 +36,7 @@ cfg_rt_core! {
             F::Output: Send + 'static,
         {
             match self {
-                #[cfg(feature = "rt-core")]
+                #[cfg(feature = "rt")]
                 Spawner::Basic(spawner) => spawner.spawn(future),
                 #[cfg(feature = "rt-threaded")]
                 Spawner::ThreadPool(spawner) => spawner.spawn(future),

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -269,7 +269,7 @@ impl<T: Future, S: Schedule> Core<T, S> {
     }
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     impl Header {
         pub(crate) fn shutdown(&self) {
             use crate::runtime::task::RawTask;

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::io;
 use std::sync::Mutex;
 
-cfg_task! {
+cfg_rt! {
     /// Task failed to execute to completion.
     pub struct JoinError {
         repr: Repr,

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -6,7 +6,7 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_task! {
+cfg_rt! {
     /// An owned permission to join on a task (await its termination).
     ///
     /// This can be thought of as the equivalent of [`std::thread::JoinHandle`] for

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -21,7 +21,7 @@ use self::state::State;
 
 mod waker;
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     mod stack;
     pub(crate) use self::stack::TransferStack;
 }
@@ -132,7 +132,7 @@ impl<S: 'static> Task<S> {
     }
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     impl<S: 'static> Notified<S> {
         pub(crate) unsafe fn from_raw(ptr: NonNull<Header>) -> Notified<S> {
             Notified(Task::from_raw(ptr))

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -79,7 +79,7 @@ pub(crate) trait Schedule: Sync + Sized + 'static {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     /// Create a new task with an associated join handle
     pub(crate) fn joinable<T, S>(task: T) -> (Notified<S>, JoinHandle<T::Output>)
     where
@@ -99,7 +99,7 @@ cfg_rt_core! {
     }
 }
 
-cfg_rt_util! {
+cfg_rt! {
     /// Create a new `!Send` task with an associated join handle
     pub(crate) unsafe fn joinable_local<T, S>(task: T) -> (Notified<S>, JoinHandle<T::Output>)
     where

--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Signal driver
 
@@ -175,7 +175,7 @@ impl Handle {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     impl Handle {
         /// Returns a handle to the current driver
         ///
@@ -190,7 +190,7 @@ cfg_rt_core! {
     }
 }
 
-cfg_not_rt_core! {
+cfg_not_rt! {
     impl Handle {
         /// Returns a handle to the current driver
         ///
@@ -200,7 +200,7 @@ cfg_not_rt_core! {
         pub(super) fn current() -> Self {
             panic!(
                 "there is no signal driver running, must be called from the context of Tokio runtime or with\
-                `rt-core` enabled.",
+                `rt` enabled.",
             )
         }
     }

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -464,7 +464,7 @@ cfg_not_sync! {
         pub(crate) use mutex::Mutex;
     }
 
-    #[cfg(any(feature = "rt-core", feature = "signal", all(unix, feature = "process")))]
+    #[cfg(any(feature = "rt", feature = "signal", all(unix, feature = "process")))]
     pub(crate) mod notify;
 
     cfg_atomic_waker_impl! {
@@ -473,7 +473,7 @@ cfg_not_sync! {
     }
 
     #[cfg(any(
-            feature = "rt-core",
+            feature = "rt",
             feature = "process",
             feature = "signal"))]
     pub(crate) mod oneshot;

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1,7 +1,7 @@
 // Allow `unreachable_pub` warnings when sync is not enabled
-// due to the usage of `Notify` within the `rt-core` feature set.
+// due to the usage of `Notify` within the `rt` feature set.
 // When this module is compiled with `sync` enabled we will warn on
-// this lint. When `rt-core` is enabled we use `pub(crate)` which
+// this lint. When `rt` is enabled we use `pub(crate)` which
 // triggers this warning but it is safe to ignore in this case.
 #![cfg_attr(not(feature = "sync"), allow(unreachable_pub, dead_code))]
 

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -1,6 +1,6 @@
 use crate::task::JoinHandle;
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     /// Runs the provided blocking function on the current thread without
     /// blocking the executor.
     ///

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -14,7 +14,7 @@ use std::task::Poll;
 
 use pin_project_lite::pin_project;
 
-cfg_rt_util! {
+cfg_rt! {
     /// A set of tasks which are executed on the same thread.
     ///
     /// In some cases, it is necessary to run one or more futures that do not
@@ -158,7 +158,7 @@ pin_project! {
 
 scoped_thread_local!(static CURRENT: Context);
 
-cfg_rt_util! {
+cfg_rt! {
     /// Spawns a `!Send` future on the local task set.
     ///
     /// The spawned future will be run on the same thread that called `spawn_local.`
@@ -346,8 +346,8 @@ impl LocalSet {
     /// [`Runtime::block_on`]: method@crate::runtime::Runtime::block_on
     /// [in-place blocking]: fn@crate::task::block_in_place
     /// [`spawn_blocking`]: fn@crate::task::spawn_blocking
-    #[cfg(feature = "rt-core")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt-core")))]
+    #[cfg(feature = "rt")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
     pub fn block_on<F>(&self, rt: &crate::runtime::Runtime, future: F) -> F::Output
     where
         F: Future,

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -215,7 +215,7 @@
 //! [`task::yield_now`]: crate::task::yield_now()
 //! [`thread::yield_now`]: std::thread::yield_now
 
-cfg_task! {
+cfg_rt! {
     pub use crate::runtime::task::{JoinError, JoinHandle};
 }
 

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -159,7 +159,7 @@
 //!
 //! #### block_in_place
 //!
-//! When using the [threaded runtime][rt-threaded], the [`task::block_in_place`]
+//! When using the [multi-threaded runtime][rt-multi-thread], the [`task::block_in_place`]
 //! function is also available. Like `task::spawn_blocking`, this function
 //! allows running a blocking operation from an asynchronous context. Unlike
 //! `spawn_blocking`, however, `block_in_place` works by transitioning the
@@ -211,27 +211,23 @@
 //!
 //! [`task::spawn_blocking`]: crate::task::spawn_blocking
 //! [`task::block_in_place`]: crate::task::block_in_place
-//! [rt-threaded]: ../runtime/index.html#threaded-scheduler
+//! [rt-multi-thread]: ../runtime/index.html#threaded-scheduler
 //! [`task::yield_now`]: crate::task::yield_now()
 //! [`thread::yield_now`]: std::thread::yield_now
 
 cfg_rt! {
     pub use crate::runtime::task::{JoinError, JoinHandle};
-}
 
-cfg_rt! {
     mod blocking;
     pub use blocking::spawn_blocking;
 
     mod spawn;
     pub use spawn::spawn;
 
-    cfg_rt_threaded! {
+    cfg_rt_multi_thread! {
         pub use blocking::block_in_place;
     }
-}
 
-cfg_rt! {
     mod yield_now;
     pub use yield_now::yield_now;
 

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -102,7 +102,7 @@
 //! # }
 //! ```
 //!
-//! `spawn`, `JoinHandle`, and `JoinError` are present when the "rt-core"
+//! `spawn`, `JoinHandle`, and `JoinError` are present when the "rt"
 //! feature flag is enabled.
 //!
 //! [`task::spawn`]: crate::task::spawn()
@@ -219,7 +219,7 @@ cfg_task! {
     pub use crate::runtime::task::{JoinError, JoinHandle};
 }
 
-cfg_rt_core! {
+cfg_rt! {
     mod blocking;
     pub use blocking::spawn_blocking;
 
@@ -231,7 +231,7 @@ cfg_rt_core! {
     }
 }
 
-cfg_rt_util! {
+cfg_rt! {
     mod yield_now;
     pub use yield_now::yield_now;
 

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -3,7 +3,7 @@ use crate::task::JoinHandle;
 
 use std::future::Future;
 
-doc_rt! {
+cfg_rt! {
     /// Spawns a new asynchronous task, returning a
     /// [`JoinHandle`](super::JoinHandle) for it.
     ///

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -3,7 +3,7 @@ use crate::task::JoinHandle;
 
 use std::future::Future;
 
-doc_rt_core! {
+doc_rt! {
     /// Spawns a new asynchronous task, returning a
     /// [`JoinHandle`](super::JoinHandle) for it.
     ///

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_rt_util! {
+cfg_rt! {
     /// Yields execution back to the Tokio runtime.
     ///
     /// A task yields by awaiting on `yield_now()`, and may resume when that

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Source of time abstraction.
 //!
@@ -39,13 +39,13 @@ cfg_test_util! {
     use crate::time::{Duration, Instant};
     use std::sync::{Arc, Mutex};
 
-    cfg_rt_core! {
+    cfg_rt! {
         fn clock() -> Option<Clock> {
             crate::runtime::context::clock()
         }
     }
 
-    cfg_not_rt_core! {
+    cfg_not_rt! {
         fn clock() -> Option<Clock> {
             None
         }

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -20,7 +20,7 @@ impl Handle {
     }
 }
 
-cfg_rt_core! {
+cfg_rt! {
     impl Handle {
         /// Tries to get a handle to the current timer.
         ///
@@ -45,7 +45,7 @@ cfg_rt_core! {
     }
 }
 
-cfg_not_rt_core! {
+cfg_not_rt! {
     impl Handle {
         /// Tries to get a handle to the current timer.
         ///
@@ -65,7 +65,7 @@ cfg_not_rt_core! {
         /// panicking.
         pub(crate) fn current() -> Self {
             panic!("there is no timer running, must be called from the context of Tokio runtime or \
-            `rt-core` is not enabled")
+            `rt` is not enabled")
         }
     }
 }

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 //! Time driver
 

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -203,7 +203,7 @@ impl<L: Link> Default for LinkedList<L, L::Target> {
 
 // ===== impl Iter =====
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     pub(crate) struct Iter<'a, T: Link> {
         curr: Option<NonNull<T::Target>>,
         _p: core::marker::PhantomData<&'a T>,

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -7,8 +7,7 @@ cfg_io_driver! {
     feature = "fs",
     feature = "net",
     feature = "process",
-    feature = "rt-core",
-    feature = "rt-util",
+    feature = "rt",
     feature = "sync",
     feature = "signal",
 ))]
@@ -17,7 +16,7 @@ pub(crate) mod linked_list;
 #[cfg(any(feature = "rt-threaded", feature = "macros", feature = "stream"))]
 mod rand;
 
-cfg_rt_core! {
+cfg_rt! {
     mod wake;
     pub(crate) use wake::WakerRef;
     pub(crate) use wake::{waker_ref, Wake};

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -13,7 +13,7 @@ cfg_io_driver! {
 ))]
 pub(crate) mod linked_list;
 
-#[cfg(any(feature = "rt-threaded", feature = "macros", feature = "stream"))]
+#[cfg(any(feature = "rt-multi-thread", feature = "macros", feature = "stream"))]
 mod rand;
 
 cfg_rt! {
@@ -22,7 +22,7 @@ cfg_rt! {
     pub(crate) use wake::{waker_ref, Wake};
 }
 
-cfg_rt_threaded! {
+cfg_rt_multi_thread! {
     pub(crate) use rand::FastRand;
 
     mod try_lock;

--- a/tokio/src/util/slab.rs
+++ b/tokio/src/util/slab.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "rt-core"), allow(dead_code))]
+#![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::{AtomicBool, AtomicUsize};

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,5 +1,5 @@
 cfg_trace! {
-    cfg_task! {
+    cfg_rt! {
         use std::future::Future;
         use std::pin::Pin;
         use std::task::{Context, Poll};
@@ -47,7 +47,7 @@ cfg_trace! {
 }
 
 cfg_not_trace! {
-    cfg_task! {
+    cfg_rt! {
         #[inline]
         pub(crate) fn task<F>(task: F, _: &'static str) -> F {
             // nop


### PR DESCRIPTION
tokio:
* merge `rt-core` and `rt-util` as `rt`
* rename `rt-threaded` to `rt-multi-thread`

tokio-util:
* rename `rt-core` to `rt`

Closes #2942