### PR TITLE
meta: combine `net` and `dns`, use `parking_lot`

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -30,12 +30,12 @@ default = []
 
 # enable everything
 full = [
-  "dns",
   "fs",
   "io-util",
   "io-std",
   "macros",
   "net",
+  "parking_lot",
   "process",
   "rt",
   "rt-multi-thread",
@@ -45,14 +45,12 @@ full = [
   "time",
 ]
 
-dns = []
 fs = []
 io-util = ["memchr"]
 # stdin, stdout, stderr
 io-std = []
 macros = ["tokio-macros"]
 net = [
-  "dns",
   "lazy_static",
   "libc",
   "mio/os-poll",

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -17,7 +17,7 @@
 ))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-//! A runtime for writing reliable, asynchronous, and slim applications.
+//! A runtime for writing reliable network applications without compromising speed.
 //!
 //! Tokio is an event-driven, non-blocking I/O platform for writing asynchronous
 //! applications with the Rust programming language. At a high level, it
@@ -59,52 +59,6 @@
 //! ```toml
 //! tokio = { version = "0.2", features = ["full"] }
 //! ```
-//!
-//! ## Feature flags
-//!
-//! Tokio uses a set of [feature flags] to reduce the amount of compiled code. It
-//! is possible to just enable certain features over others. By default, Tokio
-//! does not enable any features but allows one to enable a subset for their use
-//! case. Below is a list of the available feature flags. You may also notice
-//! above each function, struct and trait there is listed one or more feature flags
-//! that are required for that item to be used. If you are new to Tokio it is
-//! recommended that you use the `full` feature flag which will enable all public APIs.
-//! Beware though that this will pull in many extra dependencies that you may not
-//! need.
-//!
-//! - `full`: Enables all Tokio public API features listed below.
-//! - `rt-core`: Enables `tokio::spawn`, the basic (current thread) scheduler,
-//! and non-scheduler utilities.
-//! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
-//! - `io-util`: Enables the IO based `Ext` traits.
-//! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
-//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`.
-//! - `time`: Enables `tokio::time` types and allows the schedulers to enable
-//! the built in timer.
-//! - `process`: Enables `tokio::process` types.
-//! - `macros`: Enables `#[tokio::main]` and `#[tokio::test]` macros.
-//! - `sync`: Enables all `tokio::sync` types.
-//! - `stream`: Enables optional `Stream` implementations for types within Tokio.
-//! - `signal`: Enables all `tokio::signal` types.
-//! - `fs`: Enables `tokio::fs` types.
-//! - `dns`: Enables async `tokio::net::ToSocketAddrs`.
-//! - `test-util`: Enables testing based infrastructure for the Tokio runtime.
-//! - `blocking`: Enables `block_in_place` and `spawn_blocking`.
-//!
-//! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are
-//! always available._
-//!
-//! ### Internal features
-//!
-//! These features do not expose any new API, but influence internal
-//! implementation aspects of Tokio, and can pull in additional
-//! dependencies. They are not included in `full`:
-//!
-//! - `parking_lot`: As a potential optimization, use the _parking_lot_ crate's
-//! synchronization primitives internally. MSRV may increase according to the
-//! _parking_lot_ release in use.
-//!
-//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //!
 //! ### Authoring applications
 //!
@@ -332,6 +286,50 @@
 //!     }
 //! }
 //! ```
+//!
+//! ## Feature flags
+//!
+//! Tokio uses a set of [feature flags] to reduce the amount of compiled code. It
+//! is possible to just enable certain features over others. By default, Tokio
+//! does not enable any features but allows one to enable a subset for their use
+//! case. Below is a list of the available feature flags. You may also notice
+//! above each function, struct and trait there is listed one or more feature flags
+//! that are required for that item to be used. If you are new to Tokio it is
+//! recommended that you use the `full` feature flag which will enable all public APIs.
+//! Beware though that this will pull in many extra dependencies that you may not
+//! need.
+//!
+//! - `full`: Enables all Tokio public API features listed below.
+//! - `rt`: Enables `tokio::spawn`, the basic (current thread) scheduler,
+//!         and non-scheduler utilities.
+//! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
+//! - `io-util`: Enables the IO based `Ext` traits.
+//! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
+//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`.
+//! - `time`: Enables `tokio::time` types and allows the schedulers to enable
+//!           the built in timer.
+//! - `process`: Enables `tokio::process` types.
+//! - `macros`: Enables `#[tokio::main]` and `#[tokio::test]` macros.
+//! - `sync`: Enables all `tokio::sync` types.
+//! - `stream`: Enables optional `Stream` implementations for types within Tokio.
+//! - `signal`: Enables all `tokio::signal` types.
+//! - `fs`: Enables `tokio::fs` types.
+//! - `test-util`: Enables testing based infrastructure for the Tokio runtime.
+//!
+//! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are
+//! always available._
+//!
+//! ### Internal features
+//!
+//! These features do not expose any new API, but influence internal
+//! implementation aspects of Tokio, and can pull in additional
+//! dependencies.
+//!
+//! - `parking_lot`: As a potential optimization, use the _parking_lot_ crate's
+//! synchronization primitives internally. MSRV may increase according to the
+//! _parking_lot_ release in use.
+//!
+//! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
 // Includes re-exports used by macros.
 //
@@ -359,7 +357,7 @@ cfg_process! {
     pub mod process;
 }
 
-#[cfg(any(feature = "dns", feature = "fs", feature = "io-std"))]
+#[cfg(any(feature = "net", feature = "fs", feature = "io-std"))]
 mod blocking;
 
 cfg_rt! {

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -6,7 +6,7 @@ macro_rules! cfg_block_on {
         $(
             #[cfg(any(
                     feature = "fs",
-                    feature = "dns",
+                    feature = "net",
                     feature = "io-std",
                     feature = "rt",
                     ))]
@@ -27,16 +27,6 @@ macro_rules! cfg_atomic_waker_impl {
                 feature = "time",
             ))]
             #[cfg(not(loom))]
-            $item
-        )*
-    }
-}
-
-macro_rules! cfg_dns {
-    ($($item:item)*) => {
-        $(
-            #[cfg(feature = "dns")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "dns")))]
             $item
         )*
     }
@@ -338,7 +328,6 @@ macro_rules! cfg_coop {
     ($($item:item)*) => {
         $(
             #[cfg(any(
-                    feature = "dns",
                     feature = "fs",
                     feature = "io-std",
                     feature = "net",

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -9,7 +9,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV
 ///
 /// Implementations of `ToSocketAddrs` for string types require a DNS lookup.
 /// These implementations are only provided when Tokio is used with the
-/// **`dns`** feature flag.
+/// **`net`** feature flag.
 ///
 /// # Calling
 ///
@@ -23,12 +23,13 @@ pub trait ToSocketAddrs: sealed::ToSocketAddrsPriv {}
 
 type ReadyFuture<T> = future::Ready<io::Result<T>>;
 
-#[cfg(any(feature = "dns", feature = "net"))]
-pub(crate) fn to_socket_addrs<T>(arg: T) -> T::Future
-where
-    T: ToSocketAddrs,
-{
-    arg.to_socket_addrs(sealed::Internal)
+cfg_net! {
+    pub(crate) fn to_socket_addrs<T>(arg: T) -> T::Future
+    where
+        T: ToSocketAddrs,
+    {
+        arg.to_socket_addrs(sealed::Internal)
+    }
 }
 
 // ===== impl &impl ToSocketAddrs =====
@@ -143,7 +144,7 @@ impl sealed::ToSocketAddrsPriv for &[SocketAddr] {
     }
 }
 
-cfg_dns! {
+cfg_net! {
     // ===== impl str =====
 
     impl ToSocketAddrs for str {}
@@ -256,7 +257,7 @@ pub(crate) mod sealed {
     #[allow(missing_debug_implementations)]
     pub struct Internal;
 
-    cfg_dns! {
+    cfg_net! {
         use crate::blocking::JoinHandle;
 
         use std::option;

--- a/tokio/src/net/lookup_host.rs
+++ b/tokio/src/net/lookup_host.rs
@@ -1,4 +1,4 @@
-cfg_dns! {
+cfg_net! {
     use crate::net::addr::{self, ToSocketAddrs};
 
     use std::io;

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -27,12 +27,10 @@ mod addr;
 pub(crate) use addr::to_socket_addrs;
 pub use addr::ToSocketAddrs;
 
-cfg_dns! {
+cfg_net! {
     mod lookup_host;
     pub use lookup_host::lookup_host;
-}
 
-cfg_net! {
     pub mod tcp;
     pub use tcp::listener::TcpListener;
     pub use tcp::socket::TcpSocket;

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -80,7 +80,7 @@ impl TcpListener {
     /// method.
     ///
     /// The address type can be any implementor of the [`ToSocketAddrs`] trait.
-    /// Note that strings only implement this trait when the **`dns`** feature
+    /// Note that strings only implement this trait when the **`net`** feature
     /// is enabled, as strings may contain domain names that need to be resolved.
     ///
     /// If `addr` yields multiple addresses, bind will be attempted with each of
@@ -102,25 +102,6 @@ impl TcpListener {
     /// #[tokio::main]
     /// async fn main() -> io::Result<()> {
     ///     let listener = TcpListener::bind("127.0.0.1:2345").await?;
-    ///
-    ///     // use the listener
-    ///
-    ///     # let _ = listener;
-    ///     Ok(())
-    /// }
-    /// ```
-    ///
-    /// Without the `dns` feature:
-    ///
-    /// ```no_run
-    /// use tokio::net::TcpListener;
-    /// use std::net::Ipv4Addr;
-    ///
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> io::Result<()> {
-    ///     let listener = TcpListener::bind((Ipv4Addr::new(127, 0, 0, 1), 2345)).await?;
     ///
     ///     // use the listener
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -61,7 +61,7 @@ impl TcpStream {
     ///
     /// `addr` is an address of the remote host. Anything which implements the
     /// [`ToSocketAddrs`] trait can be supplied as the address. Note that
-    /// strings only implement this trait when the **`dns`** feature is enabled,
+    /// strings only implement this trait when the **`net`** feature is enabled,
     /// as strings may contain domain names that need to be resolved.
     ///
     /// If `addr` yields multiple addresses, connect will be attempted with each
@@ -82,26 +82,6 @@ impl TcpStream {
     /// async fn main() -> Result<(), Box<dyn Error>> {
     ///     // Connect to a peer
     ///     let mut stream = TcpStream::connect("127.0.0.1:8080").await?;
-    ///
-    ///     // Write some data.
-    ///     stream.write_all(b"hello world!").await?;
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    ///
-    /// Without the `dns` feature:
-    ///
-    /// ```no_run
-    /// use tokio::net::TcpStream;
-    /// use tokio::prelude::*;
-    /// use std::error::Error;
-    /// use std::net::Ipv4Addr;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     // Connect to a peer
-    ///     let mut stream = TcpStream::connect((Ipv4Addr::new(127, 0, 0, 1), 8080)).await?;
     ///
     ///     // Write some data.
     ///     stream.write_all(b"hello world!").await?;


### PR DESCRIPTION
This combines the `dns` and `net` feature flags. Previously, `dns` was
included as part of `net`. Given that is is rare that one would want
`dns` without `net`, DNS is now entirely gated w/ `net`.

The `parking_lot` feature is included as part of `full`.

Some misc docs are tweaked to reflect feature flag changes.