### PR TITLE
sync: add mem::forget to RwLockWriteGuard::downgrade.

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -375,8 +375,6 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     /// let n = n.downgrade();
     /// assert_eq!(*n, 1, "downgrade is atomic");
     ///
-    /// assert_eq!(*lock.read().await, 1, "additional readers can obtain locks");
-    ///
     /// drop(n);
     /// handle.await.unwrap();
     /// assert_eq!(*lock.read().await, 2, "second writer obtained write lock");
@@ -389,7 +387,8 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
 
         // Release all but one of the permits held by the write guard
         s.release(MAX_READS - 1);
-
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(self);
         RwLockReadGuard {
             s,
             data,

--- a/tokio/src/sync/tests/loom_rwlock.rs
+++ b/tokio/src/sync/tests/loom_rwlock.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 #[test]
 fn concurrent_write() {
-    let mut b = loom::model::Builder::new();
+    let b = loom::model::Builder::new();
 
     b.check(|| {
         let rwlock = Arc::new(RwLock::<u32>::new(0));
@@ -37,7 +37,7 @@ fn concurrent_write() {
 
 #[test]
 fn concurrent_read_write() {
-    let mut b = loom::model::Builder::new();
+    let b = loom::model::Builder::new();
 
     b.check(|| {
         let rwlock = Arc::new(RwLock::<u32>::new(0));

--- a/tokio/src/sync/tests/mod.rs
+++ b/tokio/src/sync/tests/mod.rs
@@ -12,4 +12,5 @@ cfg_loom! {
     mod loom_oneshot;
     mod loom_semaphore_batch;
     mod loom_watch;
+    mod loom_rwlock;
 }


### PR DESCRIPTION
## Motivation
Currently when `RwLockWriteGuard::downgrade` the `MAX_READS - 1`
permits are added to the semaphore. When `RwLockWriteGuard::drop`
gets invoked however another `MAX_READS` permits are added. This
results in releasing more permits that were actually aquired when
downgrading a write to a read lock. 

## Solution

This is why we need to call
`mem::forget` on the `RwLockWriteGuard` in order to avoid
invoking the destructor.


Additionally doc test for `downgrade` was not correct as it can hang in the situation where after downgrading all available permits are assigned to the waiting writer before the additional reader gets the change to obtain a permit.



Fixes: #2941
