### PR TITLE
ci: run clippy on MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update stable
+        run: rustup update ${{ env.minrust }} && rustup default ${{ env.minrust }}
       - name: Install clippy
         run: rustup component add clippy
 


### PR DESCRIPTION
clippy does not consider our MSRV. And sometimes add new lints and block unrelated PR.
As discussed in discord, these issues should be workaround by running clippy on MSRV.
