### PR TITLE
Add a poll_read_buf shim to tokio-util to mimic now deprecated AsyncRead API

### DIFF
--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -8,6 +8,8 @@
 
 mod reader_stream;
 mod stream_reader;
+mod poll_read_buf;
 
+pub use self::poll_read_buf::poll_read_buf;
 pub use self::reader_stream::ReaderStream;
 pub use self::stream_reader::StreamReader;

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -7,9 +7,11 @@
 //! [`AsyncRead`]: tokio::io::AsyncRead
 
 mod poll_read_buf;
+mod read_buf;
 mod reader_stream;
 mod stream_reader;
 
 pub use self::poll_read_buf::poll_read_buf;
+pub use self::read_buf::read_buf;
 pub use self::reader_stream::ReaderStream;
 pub use self::stream_reader::StreamReader;

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -6,9 +6,9 @@
 //! [`Body`]: https://docs.rs/hyper/0.13/hyper/struct.Body.html
 //! [`AsyncRead`]: tokio::io::AsyncRead
 
+mod poll_read_buf;
 mod reader_stream;
 mod stream_reader;
-mod poll_read_buf;
 
 pub use self::poll_read_buf::poll_read_buf;
 pub use self::reader_stream::ReaderStream;

--- a/tokio-util/src/io/poll_read_buf.rs
+++ b/tokio-util/src/io/poll_read_buf.rs
@@ -5,9 +5,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
 
-/// Adapter function which implements the now deprecated
-/// `AsyncRead::poll_read_buf` API to ease the process of moving projects to
-/// Tokio 0.3.x.
+/// Try to read data from an `AsyncRead` into an implementer of the [`Buf`] trait.
+///
+/// [`Buf`]: bytes::Buf
 ///
 /// # Example
 ///

--- a/tokio-util/src/io/poll_read_buf.rs
+++ b/tokio-util/src/io/poll_read_buf.rs
@@ -52,14 +52,18 @@ where
     R: AsyncRead,
     B: BufMut,
 {
+    if !buf.has_remaining_mut() {
+        return Poll::Ready(Ok(0));
+    }
+
     let n = {
         let mut buf = ReadBuf::uninit(buf.bytes_mut());
         ready!(read.poll_read(cx, &mut buf)?);
         buf.filled().len()
     };
 
-    // Safety: This is guaranteed to be the number of initialized bytes due to
-    // the invariants guaranteed by `ReadBuf`.
+    // Safety: This is guaranteed to be the number of initialized (and read)
+    // bytes due to the invariants provided by `ReadBuf::filled`.
     unsafe {
         buf.advance_mut(n);
     }

--- a/tokio-util/src/io/poll_read_buf.rs
+++ b/tokio-util/src/io/poll_read_buf.rs
@@ -1,0 +1,68 @@
+use bytes::BufMut;
+use futures_core::ready;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, ReadBuf};
+
+/// Adapter function which implements the now deprecated
+/// `AsyncRead::poll_read_buf` API to ease when moving projects to Tokio
+/// 0.3.x.
+///
+/// # Example
+///
+/// ```
+/// use bytes::{Bytes, BytesMut};
+/// use tokio::stream;
+/// use tokio::io::Result;
+/// use tokio_util::io::{StreamReader, poll_read_buf};
+/// use futures::future::poll_fn;
+/// use std::pin::Pin;
+/// # #[tokio::main]
+/// # async fn main() -> std::io::Result<()> {
+///
+/// // Create a reader from an iterator. This particular reader will always be
+/// // ready.
+/// let mut read = StreamReader::new(stream::iter(vec![Result::Ok(Bytes::from_static(&[0, 1, 2, 3]))]));
+///
+/// let mut buf = BytesMut::new();
+/// let mut reads = 0;
+///
+/// loop {
+///     reads += 1;
+///     let n = poll_fn(|cx| poll_read_buf(Pin::new(&mut read), cx, &mut buf)).await?;
+///
+///     if n == 0 {
+///         break;
+///     }
+/// }
+///
+/// // one or more reads might be necessary.
+/// assert!(reads >= 1);
+/// assert_eq!(&buf[..], &[0, 1, 2, 3]);
+/// # Ok(())
+/// # }
+/// ```
+pub fn poll_read_buf<R, B>(
+    read: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    buf: &mut B,
+) -> Poll<io::Result<usize>>
+where
+    R: AsyncRead,
+    B: BufMut,
+{
+    let n = {
+        let mut buf = ReadBuf::uninit(buf.bytes_mut());
+        ready!(read.poll_read(cx, &mut buf)?);
+        buf.filled().len()
+    };
+
+    // Safety: This is guaranteed to be the number of initialized bytes due to
+    // the invariants guaranteed by `ReadBuf`.
+    unsafe {
+        buf.advance_mut(n);
+    }
+
+    Poll::Ready(Ok(n))
+}

--- a/tokio-util/src/io/poll_read_buf.rs
+++ b/tokio-util/src/io/poll_read_buf.rs
@@ -6,8 +6,8 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, ReadBuf};
 
 /// Adapter function which implements the now deprecated
-/// `AsyncRead::poll_read_buf` API to ease when moving projects to Tokio
-/// 0.3.x.
+/// `AsyncRead::poll_read_buf` API to ease the process of moving projects to
+/// Tokio 0.3.x.
 ///
 /// # Example
 ///

--- a/tokio-util/src/io/read_buf.rs
+++ b/tokio-util/src/io/read_buf.rs
@@ -1,0 +1,65 @@
+use bytes::BufMut;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncRead;
+
+/// Adapter function which implements the now deprecated
+/// `AsyncReadExt::read_buf` API to ease the process of moving projects to Tokio
+/// 0.3.x.
+///
+/// # Example
+///
+/// ```
+/// use bytes::{Bytes, BytesMut};
+/// use tokio::stream;
+/// use tokio::io::Result;
+/// use tokio_util::io::{StreamReader, read_buf};
+/// # #[tokio::main]
+/// # async fn main() -> std::io::Result<()> {
+///
+/// // Create a reader from an iterator. This particular reader will always be
+/// // ready.
+/// let mut read = StreamReader::new(stream::iter(vec![Result::Ok(Bytes::from_static(&[0, 1, 2, 3]))]));
+///
+/// let mut buf = BytesMut::new();
+/// let mut reads = 0;
+///
+/// loop {
+///     reads += 1;
+///     let n = read_buf(&mut read, &mut buf).await?;
+///
+///     if n == 0 {
+///         break;
+///     }
+/// }
+///
+/// // one or more reads might be necessary.
+/// assert!(reads >= 1);
+/// assert_eq!(&buf[..], &[0, 1, 2, 3]);
+/// # Ok(())
+/// # }
+/// ```
+pub async fn read_buf<R, B>(read: &mut R, buf: &mut B) -> io::Result<usize>
+where
+    R: AsyncRead + Unpin,
+    B: BufMut,
+{
+    return ReadBufFn(read, buf).await;
+
+    struct ReadBufFn<'a, R, B>(&'a mut R, &'a mut B);
+
+    impl<'a, R, B> Future for ReadBufFn<'a, R, B>
+    where
+        R: AsyncRead + Unpin,
+        B: BufMut,
+    {
+        type Output = io::Result<usize>;
+
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let this = &mut *self;
+            super::poll_read_buf(Pin::new(this.0), cx, this.1)
+        }
+    }
+}

--- a/tokio-util/src/io/read_buf.rs
+++ b/tokio-util/src/io/read_buf.rs
@@ -5,9 +5,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::AsyncRead;
 
-/// Adapter function which implements the now deprecated
-/// `AsyncReadExt::read_buf` API to ease the process of moving projects to Tokio
-/// 0.3.x.
+/// Read data from an `AsyncRead` into an implementer of the [`Buf`] trait.
+///
+/// [`Buf`]: bytes::Buf
 ///
 /// # Example
 ///


### PR DESCRIPTION
While working to migrate a project to `0.3.0` I found uses of the now deprecated `poll_read_buf` API that needed to be migrated. This turned out to be nontrivial for types implementing `BufMut` which does not immediately provide an API to access an underlying contiguous buffer like [Chain](https://docs.rs/bytes/0.5.6/bytes/buf/ext/struct.Chain.html).

This adds a shim for it which provides the old API to ease migrations to `0.3.0`. The naming and shape of the API is preliminary and I'll happily move and rename it to whatever is appropriate if it warrants inclusion. At the very least I'm putting it here in the hope so that people who are currently migrating might find it. It might also be a good idea to provide it as a library function since the generic implementation involves a sprinkle of `unsafe` it would be a shame for people to have to replicate.