### PR TITLE
docs: fix typos on UdpSocket

### DIFF
--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -11,10 +11,11 @@ cfg_net! {
     ///
     /// UDP is "connectionless", unlike TCP. Meaning, regardless of what address you've bound to, a `UdpSocket`
     /// is free to communicate with many different remotes. In tokio there are basically two main ways to use `UdpSocket`:
-    ///     - one to many: [`bind`](`UdpSocket::bind`) and use [`send_to`](`UdpSocket::send_to`)
-    /// and `[`recv_from`](`UdpSocket::recv_from`) to communicate with many different addresses
-    ///     - one to one: [`connect`](`UdpSocket::connect`) and associate with a single address, using [`send`](`UdpSocket::send`)
-    /// and `[`recv`](`UdpSocket::recv`) to communicate only with that remote address
+    ///
+    /// * one to many: [`bind`](`UdpSocket::bind`) and use [`send_to`](`UdpSocket::send_to`)
+    /// and [`recv_from`](`UdpSocket::recv_from`) to communicate with many different addresses
+    /// * one to one: [`connect`](`UdpSocket::connect`) and associate with a single address, using [`send`](`UdpSocket::send`)
+    /// and [`recv`](`UdpSocket::recv`) to communicate only with that remote address
     ///
     /// `UdpSocket` can also be used concurrently to `send_to` and `recv_from` in different tasks,
     /// all that's required is that you `Arc<UdpSocket>` and clone a reference for each task.

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -13,9 +13,9 @@ cfg_net! {
     /// is free to communicate with many different remotes. In tokio there are basically two main ways to use `UdpSocket`:
     ///
     /// * one to many: [`bind`](`UdpSocket::bind`) and use [`send_to`](`UdpSocket::send_to`)
-    /// and [`recv_from`](`UdpSocket::recv_from`) to communicate with many different addresses
+    ///   and [`recv_from`](`UdpSocket::recv_from`) to communicate with many different addresses
     /// * one to one: [`connect`](`UdpSocket::connect`) and associate with a single address, using [`send`](`UdpSocket::send`)
-    /// and [`recv`](`UdpSocket::recv`) to communicate only with that remote address
+    ///   and [`recv`](`UdpSocket::recv`) to communicate only with that remote address
     ///
     /// `UdpSocket` can also be used concurrently to `send_to` and `recv_from` in different tasks,
     /// all that's required is that you `Arc<UdpSocket>` and clone a reference for each task.


### PR DESCRIPTION

## Motivation
Following up on a previous PR that added docs for `UdpSocket`, I just noticed when viewed in the web UI the first paragraph didn't look right, made a few tweaks to fix that up