### PR TITLE
tokio: add Runtime::spawn_blocking

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -187,6 +187,7 @@ cfg_rt! {
 
     mod blocking;
     use blocking::BlockingPool;
+    use blocking::task::BlockingTask;
     pub(crate) use blocking::spawn_blocking;
 
     mod builder;
@@ -369,6 +370,31 @@ cfg_rt! {
                 Kind::ThreadPool(exec) => exec.spawn(future),
                 Kind::CurrentThread(exec) => exec.spawn(future),
             }
+        }
+
+        /// Run the provided function on an executor dedicated to blocking operations.
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Runtime;
+        ///
+        /// # fn dox() {
+        /// // Create the runtime
+        /// let rt = Runtime::new().unwrap();
+        ///
+        /// // Spawn a blocking function onto the runtime
+        /// rt.spawn_blocking(|| {
+        ///     println!("now running on a worker thread");
+        /// });
+        /// # }
+        #[cfg(feature = "rt")]
+        pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
+        where
+            F: FnOnce() -> R + Send + 'static,
+        {
+            let (task, handle) = task::joinable(BlockingTask::new(func));
+            let _ = self.handle.blocking_spawner.spawn(task, &self.handle);
+            handle
         }
 
         /// Run a future to completion on the Tokio runtime. This is the

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -373,6 +373,7 @@ cfg_rt! {
         }
 
         /// Run the provided function on an executor dedicated to blocking operations.
+        ///
         /// # Examples
         ///
         /// ```


### PR DESCRIPTION
This allows writing

```
rt.spawn_blocking(f);
```

instead of

```
let _enter = rt.enter();
tokio::task::spawn_blocking(f);
```
