### PR TITLE
tokio: Add back poll_* for udp

### DIFF
--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -277,7 +277,7 @@ impl UdpSocket {
     /// `connect`ed.
     ///
     /// The [`connect`] method will connect this socket to a remote address. The future
-    /// will resolve to an error if the socket is not connected..
+    /// will resolve to an error if the socket is not connected.
     ///
     /// Note that on multiple calls to a `poll_*` method in the send direction, only the
     /// `Waker` from the `Context` passed to the most recent call will be scheduled to
@@ -345,7 +345,7 @@ impl UdpSocket {
     /// address to which it is `connect`ed.
     ///
     /// The [`connect`] method will connect this socket to a remote address. The future
-    /// will resolve to an error if the socket is not connected..
+    /// will resolve to an error if the socket is not connected.
     ///
     /// Note that on multiple calls to a `poll_*` method in the recv direction, only the
     /// `Waker` from the `Context` passed to the most recent call will be scheduled to
@@ -532,7 +532,7 @@ impl UdpSocket {
     ///
     /// Note that on multiple calls to a `poll_*` method in the recv direction, only the
     /// `Waker` from the `Context` passed to the most recent call will be scheduled to
-    /// receive a wakeup
+    /// receive a wakeup.
     ///
     /// # Return value
     ///

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -344,8 +344,8 @@ impl UdpSocket {
     /// Attempts to receive a single datagram message on the socket from the remote
     /// address to which it is `connect`ed.
     ///
-    /// The [`connect`] method will connect this socket to a remote address. The future
-    /// will resolve to an error if the socket is not connected.
+    /// The [`connect`] method will connect this socket to a remote address. This method
+    /// resolves to an error if the socket is not connected.
     ///
     /// Note that on multiple calls to a `poll_*` method in the recv direction, only the
     /// `Waker` from the `Context` passed to the most recent call will be scheduled to


### PR DESCRIPTION
As discussed in #2830 the first step to getting `UdpFramed` back is the poll functions. I've added these back, following the new style.

I could have just re-enabled `UdpFramed` on this PR too, but I thought we might take the opportunity to discuss any changes that we may want to make to that. In it's current state it still requires a split-like API to do concurrent send/recv