### PR TITLE
docs: fix typo in runtime module documentation

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -132,7 +132,7 @@
 //!
 //! The current-thread scheduler provides a _single-threaded_ future executor.
 //! All tasks will be created and executed on the current thread. This requires
-//! the `rt-core` feature flag.
+//! the `rt` feature flag.
 //! ```
 //! use tokio::runtime;
 //!


### PR DESCRIPTION
[Current-Thread Scheduler] docs say `rt-core` but it should be`rt`.

[Current-Thread Scheduler]: https://docs.rs/tokio/0.3.0/tokio/runtime/index.html#current-thread-scheduler