### PR TITLE
net: Avoid race during io driver shutdown

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -203,7 +203,7 @@ impl Drop for Driver {
                 .is_ok()
             {
                 drop(inner);
-                /// we drop the arc first
+                // we drop the arc first
                 self.resources.for_each(|io| {
                     // If a task is waiting on the I/O resource, notify it. The task
                     // will then attempt to use the I/O resource and fail due to the


### PR DESCRIPTION
To avoid IO resources getting registered while the driver
is shutting down,`state: AtomicUsize` is introduced.

## Motivation

As described in #2924 IO resources can be added while the driver is shutting down, resulting in these resources never being woken.

## Solution
An atomic state is added that should ensure no IO resources are added while the driver is shutting down. ]

Fix #2924
