### PR TITLE
fs: flush on shutdown

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -682,9 +682,8 @@ impl AsyncWrite for File {
         inner.poll_flush(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        // Flush is a noop for files so it's fine not to call it.
-        Poll::Ready(Ok(()))
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.poll_flush(cx)
     }
 }
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -38,6 +38,19 @@ async fn basic_write() {
 }
 
 #[tokio::test]
+async fn basic_write_and_shutdown() {
+    let tempfile = tempfile();
+
+    let mut file = File::create(tempfile.path()).await.unwrap();
+
+    file.write_all(HELLO).await.unwrap();
+    file.shutdown().await.unwrap();
+
+    let file = std::fs::read(tempfile.path()).unwrap();
+    assert_eq!(file, HELLO);
+}
+
+#[tokio::test]
 async fn coop() {
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();


### PR DESCRIPTION
Fixes: #2950

## Motivation
file should be flushed on shutdown.

## Solution
call `poll_flush` on shutdown
