### PR TITLE
stream: add stream extend function

### DIFF
--- a/tokio/src/stream/extend.rs
+++ b/tokio/src/stream/extend.rs
@@ -1,5 +1,5 @@
 use crate::stream::{Stream, StreamExt};
-use std::marker::Unpin;
+use std::{iter::Extend, marker::Unpin};
 /// Extends a slice from a Stream
 /// # Example
 /// `rust,no_run`
@@ -10,11 +10,12 @@ use std::marker::Unpin;
 ///
 /// stream::extend(&mut buff, s).await;
 /// assert_eq!(vec![-2, 0, 2, 4, 6], buff);
-pub async fn extend<T, S>(buff: &mut Vec<T>, mut b: S)
+pub async fn extend<E, S, T>(buff: &mut E, mut b: S)
 where
     S: Stream<Item = T> + Unpin,
+    E: Extend<T>,
 {
     while let Some(item) = b.next().await {
-        buff.push(item)
+        buff.extend(std::iter::once(item))
     }
 }

--- a/tokio/src/stream/extend.rs
+++ b/tokio/src/stream/extend.rs
@@ -5,11 +5,11 @@ use std::marker::Unpin;
 /// `rust,no_run`
 /// use tokio::stream;
 ///
-/// let mut b = vec![0, 0, 0, 0];
+/// let mut b = vec![-2];
 /// let stream = stream::iter(vec![0, 2, 4, 6]);
 ///
 /// stream::extend(&mut buff, s).await;
-/// assert_eq!(vec![0, 2, 4, 6], buff);
+/// assert_eq!(vec![-2, 0, 2, 4, 6], buff);
 pub async fn extend<T, S>(buff: &mut Vec<T>, mut b: S)
 where
     S: Stream<Item = T> + Unpin,

--- a/tokio/src/stream/extend.rs
+++ b/tokio/src/stream/extend.rs
@@ -1,16 +1,16 @@
 use crate::stream::{Stream, StreamExt};
-use std::{iter::Extend, marker::Unpin};
+use std::iter::Extend;
 /// Extends a slice from a Stream
 /// # Example
 /// `rust,no_run`
 /// use tokio::stream;
 ///
-/// let mut b = vec![-2];
-/// let stream = stream::iter(vec![0, 2, 4, 6]);
+/// let buff = vec![-2];
+/// let s = stream::iter(vec![0, 2, 4, 6]);
 ///
 /// stream::extend(&mut buff, s).await;
 /// assert_eq!(vec![-2, 0, 2, 4, 6], buff);
-pub async fn extend<E, S>(buff: &mut E, mut b: S)
+pub async fn extend<E, S>(buff: &mut E, b: S)
 where
     S: Stream,
     E: Extend<S::Item>,

--- a/tokio/src/stream/extend.rs
+++ b/tokio/src/stream/extend.rs
@@ -10,11 +10,12 @@ use std::{iter::Extend, marker::Unpin};
 ///
 /// stream::extend(&mut buff, s).await;
 /// assert_eq!(vec![-2, 0, 2, 4, 6], buff);
-pub async fn extend<E, S, T>(buff: &mut E, mut b: S)
+pub async fn extend<E, S>(buff: &mut E, mut b: S)
 where
-    S: Stream<Item = T> + Unpin,
-    E: Extend<T>,
+    S: Stream,
+    E: Extend<S::Item>,
 {
+    crate::pin!(b);
     while let Some(item) = b.next().await {
         buff.extend(std::iter::once(item))
     }

--- a/tokio/src/stream/extend.rs
+++ b/tokio/src/stream/extend.rs
@@ -1,0 +1,20 @@
+use crate::stream::{Stream, StreamExt};
+use std::marker::Unpin;
+/// Extends a slice from a Stream
+/// # Example
+/// `rust,no_run`
+/// use tokio::stream;
+///
+/// let mut b = vec![0, 0, 0, 0];
+/// let stream = stream::iter(vec![0, 2, 4, 6]);
+///
+/// stream::extend(&mut buff, s).await;
+/// assert_eq!(vec![0, 2, 4, 6], buff);
+pub async fn extend<T, S>(buff: &mut Vec<T>, mut b: S)
+where
+    S: Stream<Item = T> + Unpin,
+{
+    while let Some(item) = b.next().await {
+        buff.push(item)
+    }
+}

--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -66,6 +66,8 @@ mod collect;
 use collect::Collect;
 pub use collect::FromStream;
 
+mod extend;
+pub use extend::extend;
 mod empty;
 pub use empty::{empty, Empty};
 

--- a/tokio/tests/stream_extend.rs
+++ b/tokio/tests/stream_extend.rs
@@ -1,0 +1,9 @@
+use tokio::stream;
+
+#[tokio::test]
+async fn extend_stream() {
+    let s = stream::iter(vec![0, 2, 4, 6]);
+    let mut buff = vec![-2];
+    stream::extend(&mut buff, s).await;
+    assert_eq!(buff, vec![-2, 0, 2, 4, 6]);
+}

--- a/tokio/tests/stream_extend.rs
+++ b/tokio/tests/stream_extend.rs
@@ -1,9 +1,26 @@
+use std::collections::HashMap;
+
 use tokio::stream;
 
 #[tokio::test]
-async fn extend_stream() {
+async fn vec_extend_stream() {
     let s = stream::iter(vec![0, 2, 4, 6]);
     let mut buff = vec![-2];
     stream::extend(&mut buff, s).await;
     assert_eq!(buff, vec![-2, 0, 2, 4, 6]);
+}
+
+#[tokio::test]
+async fn hash_map_extend_stream() {
+    let hm: HashMap<String, i32> = vec![("one".to_string(), 1)].into_iter().collect();
+    let s = stream::iter(hm);
+
+    let mut buff: HashMap<String, i32> = vec![("zero".to_string(), 0)].into_iter().collect();
+    buff.insert("zero".to_string(), 0);
+    stream::extend(&mut buff, s).await;
+
+    let hm_expected: HashMap<_, _> = vec![("zero".to_string(), 0), ("one".to_string(), 1)]
+        .into_iter()
+        .collect();
+    assert_eq!(hm_expected, buff);
 }


### PR DESCRIPTION
Allows extending a Vec<T> with a Stream<Item=T>.

Ref: #2842

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
