### PR TITLE
io: Explain how to determine number of bytes read in `AsyncRead`

### DIFF
--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -16,8 +16,9 @@ use std::task::{Context, Poll};
 /// the following:
 ///
 /// * `Poll::Ready(Ok(()))` means that data was immediately read and placed into
-///   the output buffer. If no data was read (`buf.filled().is_empty()`) it
-///   implies that EOF has been reached.
+///   the output buffer. The amount of data read can be determined by the
+///   increase in the lenght of the slice returned by `ReadBuf::filled`. If the
+///   difference is 0, EOF has been reached.
 ///
 /// * `Poll::Pending` means that no data was read into the buffer
 ///   provided. The I/O object is not currently readable but may become readable


### PR DESCRIPTION
## Motivation
As indicated in #2999 it is useful to explain how to find out the number of bytes read. by `AsyncRead` as this is not returned in the result anymore.

## Solution
tweak the docs
