### PR TITLE
docs: update docs for `from_std` functions

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -196,7 +196,7 @@ impl TcpListener {
         }
     }
 
-    /// Creates a new TCP listener from the standard library's TCP listener.
+    /// Creates new `TcpListener` from a `std::net::TcpListener`.
     ///
     /// This function is intended to be used to wrap a TCP listener from the
     /// standard library in the Tokio equivalent. The conversion assumes nothing

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -145,8 +145,10 @@ impl TcpStream {
 
     /// Creates new `TcpStream` from a `std::net::TcpStream`.
     ///
-    /// This function will convert a TCP stream created by the standard library
-    /// to a TCP stream ready to be used with the provided event loop handle.
+    /// This function is intended to be used to wrap a TCP stream from the
+    /// standard library in the Tokio equivalent. The conversion assumes nothing
+    /// about the underlying stream; it is left up to the user to set it in
+    /// non-blocking mode.
     ///
     /// # Examples
     ///

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -157,11 +157,12 @@ impl UdpSocket {
         Ok(UdpSocket { io })
     }
 
-    /// Creates a new `UdpSocket` from the previously bound socket provided.
+    /// Creates new `UdpSocket` from a previously bound `std::net::UdpSocket`.
     ///
-    /// The socket given will be registered with the event loop that `handle`
-    /// is associated with. This function requires that `socket` has previously
-    /// been bound to an address to work correctly.
+    /// This function is intended to be used to wrap a UDP socket from the
+    /// standard library in the Tokio equivalent. The conversion assumes nothing
+    /// about the underlying socket; it is left up to the user to set it in
+    /// non-blocking mode.
     ///
     /// This can be used in conjunction with net2's `UdpBuilder` interface to
     /// configure a socket before it's handed off, such as setting options like

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -149,11 +149,12 @@ impl UnixDatagram {
         Ok((a, b))
     }
 
-    /// Consumes a `UnixDatagram` in the standard library and returns a
-    /// nonblocking `UnixDatagram` from this crate.
+    /// Creates new `UnixDatagram` from a `std::os::unix::net::UnixDatagram`.
     ///
-    /// The returned datagram will be associated with the given event loop
-    /// specified by `handle` and is ready to perform I/O.
+    /// This function is intended to be used to wrap a UnixDatagram from the
+    /// standard library in the Tokio equivalent. The conversion assumes
+    /// nothing about the underlying datagram; it is left up to the user to set
+    /// it in non-blocking mode.
     ///
     /// # Panics
     ///

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -68,11 +68,12 @@ impl UnixListener {
         Ok(UnixListener { io })
     }
 
-    /// Consumes a `UnixListener` in the standard library and returns a
-    /// nonblocking `UnixListener` from this crate.
+    /// Creates new `UnixListener` from a `std::os::unix::net::UnixListener `.
     ///
-    /// The returned listener will be associated with the given event loop
-    /// specified by `handle` and is ready to perform I/O.
+    /// This function is intended to be used to wrap a UnixListener from the
+    /// standard library in the Tokio equivalent. The conversion assumes
+    /// nothing about the underlying listener; it is left up to the user to set
+    /// it in non-blocking mode.
     ///
     /// # Panics
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -43,11 +43,12 @@ impl UnixStream {
         Ok(stream)
     }
 
-    /// Consumes a `UnixStream` in the standard library and returns a
-    /// nonblocking `UnixStream` from this crate.
+    /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.
     ///
-    /// The returned stream will be associated with the given event loop
-    /// specified by `handle` and is ready to perform I/O.
+    /// This function is intended to be used to wrap a UnixStream from the
+    /// standard library in the Tokio equivalent. The conversion assumes
+    /// nothing about the underlying stream; it is left up to the user to set
+    /// it in non-blocking mode.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Fixes: #3007

## Motivation
Some of the docs for `from_std` methods are outdated.
## Solution
Update and unify docs.
