### PR TITLE
net: fix use-after-free in slab compaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,21 @@ jobs:
       - name: miri
         run: cargo miri test --features rt,rt-multi-thread,sync task
         working-directory: tokio
+  san:
+    name: san
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          override: true
+      - name: asan
+        run: cargo +nightly test --all-features --target x86_64-unknown-linux-gnu --lib -- --test-threads 1
+        working-directory: tokio
+        env:
+          RUSTFLAGS: -Z sanitizer=address
+          ASAN_OPTIONS: detect_leaks=0
 
   cross:
     name: cross

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           toolchain: ${{ env.nightly }}
           override: true
       - name: asan
-        run: cargo +nightly test --all-features --target x86_64-unknown-linux-gnu --lib -- --test-threads 1
+        run: cargo test --all-features --target x86_64-unknown-linux-gnu --lib -- --test-threads 1
         working-directory: tokio
         env:
           RUSTFLAGS: -Z sanitizer=address

--- a/tokio/src/util/slab.rs
+++ b/tokio/src/util/slab.rs
@@ -304,7 +304,10 @@ impl<T> Slab<T> {
             // Drop the lock so we can drop the vector outside the lock below.
             drop(slots);
 
-            debug_assert!(self.cached[idx].slots.is_null() || self.cached[idx].slots == vec.as_ptr());
+            debug_assert!(
+                self.cached[idx].slots.is_null() || self.cached[idx].slots == vec.as_ptr(),
+                "cached = {:?}; actual = {:?}", self.cached[idx].slots, vec.as_ptr(),
+            );
 
             // Clear cache
             self.cached[idx].slots = ptr::null();
@@ -492,8 +495,11 @@ impl<T> CachedPage<T> {
     /// Refresh the cache
     fn refresh(&mut self, page: &Page<T>) {
         let slots = page.slots.lock();
-        self.slots = slots.slots.as_ptr();
-        self.init = slots.slots.len();
+
+        if !slots.slots.is_empty() {
+            self.slots = slots.slots.as_ptr();
+            self.init = slots.slots.len();
+        }
     }
 
     // Get a value by index

--- a/tokio/src/util/slab.rs
+++ b/tokio/src/util/slab.rs
@@ -272,9 +272,7 @@ impl<T> Slab<T> {
     pub(crate) fn compact(&mut self) {
         // Iterate each page except the very first one. The very first page is
         // never freed.
-        for (n, page) in (&self.pages[1..]).iter().enumerate() {
-            let idx = n + 1;
-
+        for (idx, page) in self.pages.iter().enumerate().skip(1) {
             if page.used.load(Relaxed) != 0 || !page.allocated.load(Relaxed) {
                 // If the page has slots in use or the memory has not been
                 // allocated then it cannot be compacted.
@@ -306,7 +304,9 @@ impl<T> Slab<T> {
 
             debug_assert!(
                 self.cached[idx].slots.is_null() || self.cached[idx].slots == vec.as_ptr(),
-                "cached = {:?}; actual = {:?}", self.cached[idx].slots, vec.as_ptr(),
+                "cached = {:?}; actual = {:?}",
+                self.cached[idx].slots,
+                vec.as_ptr(),
             );
 
             // Clear cache


### PR DESCRIPTION
An off-by-one bug results in freeing the incorrect page.

Fixes: #3014