### PR TITLE
chore: prepare v0.3.1 release

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.3.1 (October 21, 2020)
 
 ### Fixed
+- net: fix use-after-free (#3019).
 - fs: ensure buffered data is written on shutdown (#3009).
 
 ### Added

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.3.1 (October 21, 2020)
+
+### Fixed
+- fs: ensure buffered data is written on shutdown (#3009).
+
+### Added
+- io: `copy_buf()` (#2884).
+- io: `AsyncReadExt::read_buf()`, `AsyncReadExt::write_buf()` for working with
+  `Buf`/`BufMut` (#3003).
+- rt: `Runtime::spawn_blocking()` (#2980).
+- sync: `watch::Sender::is_closed()` (#2991).
+
 # 0.3.0 (October 15, 2020)
 
 This represents a 1.0 beta release. APIs are polished and future-proofed. APIs

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 0.3.1 (October 21, 2020)
 
+This release fixes an use-after-free in the IO driver. Additionally, the `read_buf`
+and `write_buf` methods have been added back to the IO traits, as the bytes crate
+is now on track to reach version 1.0 together with Tokio.
+
 ### Fixed
 - net: fix use-after-free (#3019).
 - fs: ensure buffered data is written on shutdown (#3009).

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.3.0/tokio/"
+documentation = "https://docs.rs/tokio/0.3.1/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.3.1")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
Fix the use-after-free.

Depends on #3020