### PR TITLE
Add UCred::new(uid, gid).

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -10,6 +10,11 @@ pub struct UCred {
 }
 
 impl UCred {
+    /// Creates a new credentials struct from a user ID and a group ID.
+    pub fn new(uid: uid_t, gid: gid_t) -> Self {
+        Self { uid, gid }
+    }
+
     /// Gets UID (user ID) of the process.
     pub fn uid(&self) -> uid_t {
         self.uid


### PR DESCRIPTION
Without a constructor, third party libraries can not create `UCred` objects. That also means that third party libraries that add support for new socket types can't implement `peer_cred()`.

I ran into this when trying to update `tokio-seqpacket` to current master.
