### PR TITLE
docs: remove `max_threads` mentions in tokio-macros

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -179,7 +179,7 @@ fn parse_knobs(
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
                     name => {
-                        let msg = format!("Unknown attribute {} is specified; expected one of: `flavor`, `worker_threads`, `max_threads`", name);
+                        let msg = format!("Unknown attribute {} is specified; expected one of: `flavor`, `worker_threads`", name);
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
                 }

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -231,10 +231,6 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Marks async function to be executed by runtime, suitable to test environment
 ///
-/// ## Options:
-///
-/// - `max_threads=n` - Sets max threads to `n`.
-///
 /// ## Usage
 ///
 /// ```no_run


### PR DESCRIPTION
## Motivation
The macro argument `max_threads`  was removed by #2876 but is still mentioned in an error message and `test_rt` docs.