### PR TITLE
Prepare tokio-macros 0.3.1

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.1 (October 25, 2020)
+
+### Fixed
+
+- fix incorrect docs regarding `max_threads` option ([#3038])
+
 # 0.3.0 (October 15, 2020)
 
 - Track `tokio` 0.3 release.
@@ -38,9 +44,10 @@
 
 - Initial release
 
-[#2225]: https://github.com/tokio-rs/tokio/pull/2225
-[#2177]: https://github.com/tokio-rs/tokio/pull/2177
-[#2152]: https://github.com/tokio-rs/tokio/pull/2152
-[#2038]: https://github.com/tokio-rs/tokio/pull/2038
-[#2022]: https://github.com/tokio-rs/tokio/pull/2022
 [#1954]: https://github.com/tokio-rs/tokio/pull/1954
+[#2022]: https://github.com/tokio-rs/tokio/pull/2022
+[#2038]: https://github.com/tokio-rs/tokio/pull/2038
+[#2152]: https://github.com/tokio-rs/tokio/pull/2152
+[#2177]: https://github.com/tokio-rs/tokio/pull/2177
+[#2225]: https://github.com/tokio-rs/tokio/pull/2225
+[#3038]: https://github.com/tokio-rs/tokio/pull/3038

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -30,7 +30,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "0.3.0", features = ["full"] }
+tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.0"
+version = "0.3.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.3.0/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.3.1/tokio_macros"
 description = """
 Tokio's proc macros.
 """
@@ -30,7 +30,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
+tokio = { version = "0.3.0", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.3.1")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
# 0.3.1 (October 25, 2020)

### Fixed

- fix incorrect docs regarding `max_threads` option (#3038)
