### PR TITLE
readme: update the MSRV to 1.45

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
-Tokio is built against the latest stable release. The minimum supported version is 1.45.2.
+Tokio is built against the latest stable release. The minimum supported version is 1.45.
 The current Tokio version is not guaranteed to build on Rust versions earlier than the
 minimum supported version.
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
-Tokio is built against the latest stable release. The minimum supported version is 1.39.
+Tokio is built against the latest stable release. The minimum supported version is 1.45.2.
 The current Tokio version is not guaranteed to build on Rust versions earlier than the
 minimum supported version.
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -157,7 +157,7 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
-Tokio is built against the latest stable release. The minimum supported version is 1.45.2.
+Tokio is built against the latest stable release. The minimum supported version is 1.45.
 The current Tokio version is not guaranteed to build on Rust versions earlier than the
 minimum supported version.
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -157,7 +157,7 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
-Tokio is built against the latest stable release. The minimum supported version is 1.39.
+Tokio is built against the latest stable release. The minimum supported version is 1.45.2.
 The current Tokio version is not guaranteed to build on Rust versions earlier than the
 minimum supported version.
 


### PR DESCRIPTION
## Motivation

MSRV is 1.45.2 for CI but readme says 1.39

closes: #3047 