### PR TITLE
net: change mention of net2

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -203,7 +203,7 @@ impl TcpListener {
     /// about the underlying listener; it is left up to the user to set it in
     /// non-blocking mode.
     ///
-    /// This API is typically paired with the `net2` crate and the `TcpBuilder`
+    /// This API is typically paired with the `socket2` crate and the `Socket`
     /// type to build up and customize a listener before it's shipped off to the
     /// backing event loop. This allows configuration of options like
     /// `SO_REUSEPORT`, binding to multiple addresses, etc.

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -165,7 +165,7 @@ impl UdpSocket {
     /// about the underlying socket; it is left up to the user to set it in
     /// non-blocking mode.
     ///
-    /// This can be used in conjunction with net2's `UdpBuilder` interface to
+    /// This can be used in conjunction with socket2's `Socket` interface to
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
     ///


### PR DESCRIPTION
Fixes: #3034

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
## Motivation
net2 is deprecated
## Solution
change mention of net2 to socket2

