### PR TITLE
Expose `Semaphore::close`

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -41,8 +41,7 @@ struct Waitlist {
     closed: bool,
 }
 
-/// Error returned from the [`Semaphore::try_acquire`] function.
-/// [`Semaphore::try_acquire`]: Semaphore::try_acquire
+/// Error returned from the `Semaphore::try_acquire` function.
 #[derive(Debug)]
 pub enum TryAcquireError {
     /// The semaphore has been closed and cannot issue new permits
@@ -53,12 +52,8 @@ pub enum TryAcquireError {
 }
 /// Error returned by `Semaphore::acquire`.
 ///
-/// Error returned from the [`Semaphore::acquire`] function.
-///
 /// An `acquire` operation can only fail if the semaphore has been
 /// closed.
-///
-/// [`Semaphore::acquire`]: Semaphore::acquire
 #[derive(Debug)]
 pub struct AcquireError(());
 

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -41,19 +41,26 @@ struct Waitlist {
     closed: bool,
 }
 
-/// Error returned from the `Semaphore::try_acquire` function.
-#[derive(Debug)]
+/// Error returned from the [`Semaphore::try_acquire`] function.
+///
+/// [`Semaphore::try_acquire`]: crate::sync::Semaphore::try_acquire
+#[derive(Debug, PartialEq)]
 pub enum TryAcquireError {
-    /// The semaphore has been closed and cannot issue new permits
+    /// The semaphore has been [closed] and cannot issue new permits.
+    ///
+    /// [closed]: crate::sync::Semaphore::close
     Closed,
 
-    /// The has no available permits.
+    /// The semaphore has no available permits.
     NoPermits,
 }
-/// Error returned by `Semaphore::acquire`.
+/// Error returned from the [`Semaphore::acquire`] function.
 ///
 /// An `acquire` operation can only fail if the semaphore has been
-/// closed.
+/// [closed].
+///
+/// [closed]: crate::sync::Semaphore::close
+/// [`Semaphore::acquire`]: crate::sync::Semaphore::acquire
 #[derive(Debug)]
 pub struct AcquireError(());
 

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -41,15 +41,26 @@ struct Waitlist {
     closed: bool,
 }
 
-/// Error returned by `Semaphore::try_acquire`.
+/// Error returned from the [`Semaphore::try_acquire`] function.
+/// [`Semaphore::try_acquire`]: Semaphore::try_acquire
 #[derive(Debug)]
-pub(crate) enum TryAcquireError {
+pub enum TryAcquireError {
+    /// The semaphore has been closed and cannot issue new permits
     Closed,
+
+    /// The has no available permits.
     NoPermits,
 }
 /// Error returned by `Semaphore::acquire`.
+///
+/// Error returned from the [`Semaphore::acquire`] function.
+///
+/// An `acquire` operation can only fail if the semaphore has been
+/// closed.
+///
+/// [`Semaphore::acquire`]: Semaphore::acquire
 #[derive(Debug)]
-pub(crate) struct AcquireError(());
+pub struct AcquireError(());
 
 pub(crate) struct Acquire<'a> {
     node: Waiter,

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -164,8 +164,6 @@ impl Semaphore {
 
     /// Closes the semaphore. This prevents the semaphore from issuing new
     /// permits and notifies all pending waiters.
-    // This will be used once the bounded MPSC is updated to use the new
-    // semaphore implementation.
     pub(crate) fn close(&self) {
         let mut waiters = self.waiters.lock();
         // If the semaphore's permits counter has enough permits for an

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -443,8 +443,10 @@ cfg_sync! {
     pub mod oneshot;
 
     pub(crate) mod batch_semaphore;
+    pub use batch_semaphore::{AcquireError, TryAcquireError};
+
     mod semaphore;
-    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit, TryAcquireError};
+    pub use semaphore::{Semaphore, SemaphorePermit, OwnedSemaphorePermit};
 
     mod rwlock;
     pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -162,6 +162,13 @@ impl Semaphore {
             Err(_) => Err(TryAcquireError(())),
         }
     }
+
+    /// Closes the semaphore.
+    ///
+    /// This prevents the semaphore from issuing new permits and notifies all pending waiters.
+    pub fn close(&self) {
+        self.ll_sem.close();
+    }
 }
 
 impl<'a> SemaphorePermit<'a> {


### PR DESCRIPTION

## Motivation
The need to expose `Semaphore::close` as explained in #3061. 
## Solution
Expose `Semaphore::close`

