### PR TITLE
Runtime::block_on should NOT be called from async context

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -415,7 +415,7 @@ cfg_rt! {
         ///
         /// # Panics
         ///
-        /// This function panics if the provided future panics, or if not called within an
+        /// This function panics if the provided future panics, or if called within an
         /// asynchronous execution context.
         ///
         /// # Examples


### PR DESCRIPTION
I assume this is a documentation mistake. It doesn't panic if "not called from async context".