### PR TITLE
util: update to bytes 0.6

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,7 @@ tokio = { version = "0.3.0", path = "../tokio", features = ["full", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
 tokio-util = { version = "0.4.0", path = "../tokio-util", features = ["full"] }
-bytes = "0.5"
+bytes = "0.6"
 futures = "0.3.0"
 http = "0.2"
 serde = "1.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -35,7 +35,7 @@ rt = ["tokio/rt"]
 [dependencies]
 tokio = { version = "0.3.0", path = "../tokio" }
 
-bytes = "0.5.0"
+bytes = "0.6.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }


### PR DESCRIPTION
Copies the implementation of poll_read_buf() from tokio::io::util::read_buf.