### PR TITLE
tracing: replace future names with spawn locations in task spans

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -70,7 +70,10 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt = ["slab"]
-rt-multi-thread = ["num_cpus", "rt"]
+rt-multi-thread = [
+  "num_cpus",
+  "rt"
+]
 signal = [
   "lazy_static",
   "libc",
@@ -97,9 +100,9 @@ lazy_static = { version = "1.0.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.3", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
-parking_lot = { version = "0.11.0", optional = true }# Not in full
+parking_lot = { version = "0.11.0", optional = true } # Not in full
 slab = { version = "0.4.1", optional = true }
-tracing = { version = "0.1.21", default-features = false, features = ["std"], optional = true }# Not in full
+tracing = { version = "0.1.21", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -126,6 +126,9 @@ tempfile = "3.1.0"
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.3.5", features = ["futures", "checkpoint"] }
 
+[build-dependencies]
+autocfg = "1" # Needed for conditionally enabling `track-caller`
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -72,7 +72,7 @@ process = [
 rt = ["slab"]
 rt-multi-thread = [
   "num_cpus",
-  "rt"
+  "rt",
 ]
 signal = [
   "lazy_static",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -70,10 +70,7 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt = ["slab"]
-rt-multi-thread = [
-  "num_cpus",
-  "rt",
-]
+rt-multi-thread = ["num_cpus", "rt"]
 signal = [
   "lazy_static",
   "libc",
@@ -100,9 +97,9 @@ lazy_static = { version = "1.0.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.3", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
-parking_lot = { version = "0.11.0", optional = true } # Not in full
+parking_lot = { version = "0.11.0", optional = true }# Not in full
 slab = { version = "0.4.1", optional = true }
-tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # Not in full
+tracing = { version = "0.1.21", default-features = false, features = ["std"], optional = true }# Not in full
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -1,0 +1,43 @@
+use std::{env, ffi::OsString, process::Command};
+
+fn main() {
+    match rustc_minor_version() {
+        // If rustc >= 1.47.0, we can enable `track_caller`.
+        Ok(minor) if minor >= 47 => println!("cargo:rustc-cfg=tokio_track_caller"),
+        Err(e) => println!("cargo:warning=could not parse rustc version: {}", e),
+        _ => {}
+    }
+}
+
+fn rustc_minor_version() -> Result<usize, Box<dyn std::error::Error>> {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let out = Command::new(rustc).arg("-V").output()?;
+    let version_str = std::str::from_utf8(&out.stdout)?;
+    let mut parts = version_str.split(' ');
+    if parts.next() != Some("rustc") {
+        Err(format!(
+            "weird rustc version: {:?} (missing 'rustc') ",
+            version_str
+        ))?;
+    }
+    if let Some(part) = parts.next() {
+        let mut parts = part.split('.');
+        if parts.next() != Some("1") {
+            Err(format!(
+                "weird rustc version: {:?} (does not start with 1)",
+                version_str
+            ))?;
+        }
+        if let Some(middle) = parts.next() {
+            Ok(middle.parse()?)
+        } else {
+            Err(format!("weird rustc version: {:?} (no minor version)", version_str).into())
+        }
+    } else {
+        Err(format!(
+            "weird rustc version: {:?} (missing version entirely?) ",
+            version_str,
+        )
+        .into())
+    }
+}

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -15,10 +15,7 @@ fn rustc_minor_version() -> Result<usize, Box<dyn std::error::Error>> {
     let version_str = std::str::from_utf8(&out.stdout)?;
     let mut parts = version_str.split(' ');
     if parts.next() != Some("rustc") {
-        Err(format!(
-            "weird rustc version: {:?} (missing 'rustc') ",
-            version_str
-        ))?;
+        return Err(format!("weird rustc version: {:?} (missing 'rustc') ", version_str).into());
     }
     if let Some(part) = parts.next() {
         let mut parts = part.split('.');

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -20,10 +20,11 @@ fn rustc_minor_version() -> Result<usize, Box<dyn std::error::Error>> {
     if let Some(part) = parts.next() {
         let mut parts = part.split('.');
         if parts.next() != Some("1") {
-            Err(format!(
+            return Err(format!(
                 "weird rustc version: {:?} (does not start with 1)",
                 version_str
-            ))?;
+            )
+            .into());
         }
         if let Some(middle) = parts.next() {
             Ok(middle.parse()?)

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -1,41 +1,22 @@
-use std::{env, ffi::OsString, process::Command};
+use autocfg::AutoCfg;
 
 fn main() {
-    match rustc_minor_version() {
-        // If rustc >= 1.47.0, we can enable `track_caller`.
-        Ok(minor) if minor >= 47 => println!("cargo:rustc-cfg=tokio_track_caller"),
-        Err(e) => println!("cargo:warning=could not parse rustc version: {}", e),
-        _ => {}
-    }
-}
+    match AutoCfg::new() {
+        Ok(ac) => {
+            // The #[track_caller] attribute was stabilized in rustc 1.46.0.
+            if ac.probe_rustc_version(1, 46) {
+                autocfg::emit("tokio_track_caller")
+            }
+        }
 
-fn rustc_minor_version() -> Result<usize, Box<dyn std::error::Error>> {
-    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
-    let out = Command::new(rustc).arg("-V").output()?;
-    let version_str = std::str::from_utf8(&out.stdout)?;
-    let mut parts = version_str.split(' ');
-    if parts.next() != Some("rustc") {
-        return Err(format!("weird rustc version: {:?} (missing 'rustc') ", version_str).into());
-    }
-    if let Some(part) = parts.next() {
-        let mut parts = part.split('.');
-        if parts.next() != Some("1") {
-            return Err(format!(
-                "weird rustc version: {:?} (does not start with 1)",
-                version_str
-            )
-            .into());
+        Err(e) => {
+            // If we couldn't detect the compiler version and features, just
+            // print a warning. This isn't a fatal error: we can still build
+            // Tokio, we just can't enable cfgs automatically.
+            println!(
+                "cargo:warning=tokio: failed to detect compiler features: {}",
+                e
+            );
         }
-        if let Some(middle) = parts.next() {
-            Ok(middle.parse()?)
-        } else {
-            Err(format!("weird rustc version: {:?} (no minor version)", version_str).into())
-        }
-    } else {
-        Err(format!(
-            "weird rustc version: {:?} (missing version entirely?) ",
-            version_str,
-        )
-        .into())
     }
 }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -357,11 +357,14 @@ cfg_rt! {
         /// });
         /// # }
         /// ```
+        #[cfg_attr(tokio_track_caller, track_caller)]
         pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,
             F::Output: Send + 'static,
         {
+            #[cfg(feature = "tracing")]
+            let future = crate::util::trace::task(future, "task");
             match &self.kind {
                 #[cfg(feature = "rt-multi-thread")]
                 Kind::ThreadPool(exec) => exec.spawn(future),
@@ -385,6 +388,7 @@ cfg_rt! {
         ///     println!("now running on a worker thread");
         /// });
         /// # }
+        #[cfg_attr(tokio_track_caller, track_caller)]
         pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
         where
             F: FnOnce() -> R + Send + 'static,

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -104,6 +104,7 @@ cfg_rt_multi_thread! {
 /// # Ok(())
 /// # }
 /// ```
+#[cfg_attr(tokio_track_caller, track_caller)]
 pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -190,6 +190,7 @@ cfg_rt! {
     ///     }).await;
     /// }
     /// ```
+    #[cfg_attr(tokio_track_caller, track_caller)]
     pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
@@ -273,6 +274,7 @@ impl LocalSet {
     /// }
     /// ```
     /// [`spawn_local`]: fn@spawn_local
+    #[cfg_attr(tokio_track_caller, track_caller)]
     pub fn spawn_local<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -122,6 +122,7 @@ cfg_rt! {
     /// ```text
     /// error[E0391]: cycle detected when processing `main`
     /// ```
+    #[cfg_attr(tokio_track_caller, track_caller)]
     pub fn spawn<T>(task: T) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -9,7 +9,6 @@ cfg_trace! {
                 target: "tokio::task",
                 "task",
                 %kind,
-                future = %std::any::type_name::<F>(),
             ))
         }
     }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,47 +1,16 @@
 cfg_trace! {
     cfg_rt! {
-        use std::future::Future;
-        use std::pin::Pin;
-        use std::task::{Context, Poll};
-        use pin_project_lite::pin_project;
-
-        use tracing::Span;
-
-        pin_project! {
-            /// A future that has been instrumented with a `tracing` span.
-            #[derive(Debug, Clone)]
-            pub(crate) struct Instrumented<T> {
-                #[pin]
-                inner: T,
-                span: Span,
-            }
-        }
-
-        impl<T: Future> Future for Instrumented<T> {
-            type Output = T::Output;
-
-            fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-                let this = self.project();
-                let _enter = this.span.enter();
-                this.inner.poll(cx)
-            }
-        }
-
-        impl<T> Instrumented<T> {
-            pub(crate) fn new(inner: T, span: Span) -> Self {
-                Self { inner, span }
-            }
-        }
+        pub(crate) use tracing::instrument::Instrumented;
 
         #[inline]
         pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
-            let span = tracing::trace_span!(
+            use tracing::instrument::Instrument;
+            task.instrument(tracing::trace_span!(
                 target: "tokio::task",
                 "task",
                 %kind,
                 future = %std::any::type_name::<F>(),
-            );
-            Instrumented::new(task, span)
+            ))
         }
     }
 }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -3,13 +3,25 @@ cfg_trace! {
         pub(crate) use tracing::instrument::Instrumented;
 
         #[inline]
+        #[cfg_attr(tokio_track_caller, track_caller)]
         pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
             use tracing::instrument::Instrument;
-            task.instrument(tracing::trace_span!(
+            #[cfg(tokio_track_caller)]
+            let location = std::panic::Location::caller();
+            #[cfg(tokio_track_caller)]
+            let span = tracing::trace_span!(
                 target: "tokio::task",
                 "task",
                 %kind,
-            ))
+                spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
+            );
+            #[cfg(not(tokio_track_caller))]
+            let span = tracing::trace_span!(
+                target: "tokio::task",
+                "task",
+                %kind,
+            );
+            task.instrument(span)
         }
     }
 }


### PR DESCRIPTION
## Motivation

Currently, the per-task `tracing` spans generated by tokio's `tracing`
feature flag include the `std::any::type_name` of the future that was
spawned. When future combinators and/or libraries like Tower are in use,
these future names can get _quite_ long. Furthermore, when formatting
the `tracing` spans with their parent spans as context, any other task
spans in the span context where the future was spawned from can _also_
include extremely long future names.

In some cases, this can result in extremely high memory use just to
store the future names. For example, in Linkerd, when we enable
`tokio=trace` to enable the task spans, there's a spawned task whose
future name is _232990 characters long_. A proxy with only 14 spawned
tasks generates a task list that's over 690 KB. Enabling task spans
under load results in the process getting OOM killed very quickly.

## Solution

This branch removes future type names from the spans generated by
`spawn`. As a replacement, to allow identifying which `spawn` call a
span corresponds to, the task span now contains the source code location
where `spawn` was called, when the compiler supports the
`#[track_caller]` attribute. Since `track_caller` was stabilized in Rust
1.46.0, and our minimum supported Rust version is 1.45.0, we can't
assume that `#[track_caller]` is always available. Instead, we have a
RUSTFLAGS cfg, `tokio_track_caller`, that guards whether or not we use
it. I've also added a `build.rs` that detects the compiler minor
version, and sets the cfg flag automatically if the current compiler
version is >= 1.46. This means users shouldn't have to enable
`tokio_track_caller` manually.

Here's the trace output from the `chat` example, before this change:
![Screenshot_20201030_110157](https://user-images.githubusercontent.com/2796466/97741071-6d408800-1a9f-11eb-9ed6-b25e72f58c7b.png)
...and after:
![Screenshot_20201030_110303](https://user-images.githubusercontent.com/2796466/97741112-7e899480-1a9f-11eb-9197-c5a3f9ea1c05.png)


Closes #3073