### PR TITLE
doc: add from_std change to CHANGELOG

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -66,7 +66,7 @@ Biggest changes are:
 - fs: `File` operations take `&self` (#2930).
 - rt: runtime API, and `#[tokio::main]` macro polish (#2876)
 - rt: `Runtime::enter` uses an RAII guard instead of a closure (#2954).
-- net: the `from_std` function on all sockets no longer sets `O_NONBLOCK` (#2893)
+- net: the `from_std` function on all sockets no longer sets socket into non-blocking mode (#2893)
 
 ### Added
 - sync: `map` function to lock guards (#2445).

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -66,6 +66,7 @@ Biggest changes are:
 - fs: `File` operations take `&self` (#2930).
 - rt: runtime API, and `#[tokio::main]` macro polish (#2876)
 - rt: `Runtime::enter` uses an RAII guard instead of a closure (#2954).
+- net: the `from_std` function on all sockets no longer sets `O_NONBLOCK` (#2893)
 
 ### Added
 - sync: `map` function to lock guards (#2445).


### PR DESCRIPTION
The behavior of the `from_std` changes was a consequence of the upgrade to mio 0.7, but was not mentioned in the changelog. Since many people have been bitten by this, I think it makes sense to add it to the changelog.

I used #2893 as the PR as it is the update of mio.