### PR TITLE
rt: bring back a public Handle type

### DIFF
--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -125,15 +125,6 @@ impl<P: Park> BasicScheduler<P> {
         &self.spawner
     }
 
-    /// Spawns a future onto the thread pool
-    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        self.spawner.spawn(future)
-    }
-
     pub(crate) fn block_on<F: Future>(&self, future: F) -> F::Output {
         pin!(future);
 

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -70,6 +70,7 @@ const KEEP_ALIVE: Duration = Duration::from_secs(10);
 pub(crate) fn spawn_blocking<F, R>(func: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
 {
     let rt = context::current().expect("not currently running on the Tokio runtime.");
     rt.spawn_blocking(func)

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -33,7 +33,7 @@ pub struct Handle {
 
 /// Runtime context guard.
 ///
-/// Returned by [`Runtime::enter`] and [^Handle::enter^], the context guard exits
+/// Returned by [`Runtime::enter`] and [`Handle::enter`], the context guard exits
 /// the runtime context on drop.
 #[derive(Debug)]
 pub struct EnterGuard<'a> {

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -1,4 +1,5 @@
 use crate::runtime::blocking::task::BlockingTask;
+use crate::runtime::context::{self, EnterGuard};
 use crate::runtime::task::{self, JoinHandle};
 use crate::runtime::{blocking, driver, Spawner};
 
@@ -28,16 +29,16 @@ pub struct Handle {
     pub(super) blocking_spawner: blocking::Spawner,
 }
 
+#[derive(Debug)]
+pub struct HandleEnterGuard(EnterGuard);
+
 impl Handle {
-    // /// Enter the runtime context. This allows you to construct types that must
-    // /// have an executor available on creation such as [`Sleep`] or [`TcpStream`].
-    // /// It will also allow you to call methods such as [`tokio::spawn`].
-    // pub(crate) fn enter<F, R>(&self, f: F) -> R
-    // where
-    //     F: FnOnce() -> R,
-    // {
-    //     context::enter(self.clone(), f)
-    // }
+    /// Enter the runtime context. This allows you to construct types that must
+    /// have an executor available on creation such as [`Sleep`] or [`TcpStream`].
+    /// It will also allow you to call methods such as [`tokio::spawn`].
+    pub fn enter(&self) -> HandleEnterGuard {
+        HandleEnterGuard(context::enter(self.clone()))
+    }
 
     /// Run the provided function on an executor dedicated to blocking operations.
     ///

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -168,6 +168,7 @@ impl Handle {
     pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
     {
         #[cfg(feature = "tracing")]
         let func = {

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -35,6 +35,8 @@ pub struct Handle {
 ///
 /// Returned by [`Runtime::enter`] and [`Handle::enter`], the context guard exits
 /// the runtime context on drop.
+///
+/// [`Runtime::enter`]: fn@crate::runtime::Runtime::enter
 #[derive(Debug)]
 pub struct EnterGuard<'a> {
     handle: &'a Handle,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -9,7 +9,7 @@ use crate::runtime::{blocking, driver, Spawner};
 ///
 /// [`Runtime::handle`]: crate::runtime::Runtime::handle()
 #[derive(Debug, Clone)]
-pub(crate) struct Handle {
+pub struct Handle {
     pub(super) spawner: Spawner,
 
     /// Handles to the I/O drivers

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -40,7 +40,24 @@ impl Handle {
     // }
 
     /// Run the provided function on an executor dedicated to blocking operations.
-    pub(crate) fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime::Runtime;
+    ///
+    /// # fn dox() {
+    /// // Create the runtime
+    /// let rt = Runtime::new().unwrap();
+    /// // Get a handle from this runtime
+    /// let handle = rt.handle();
+    ///
+    /// // Spawn a blocking function onto the runtime using the handle
+    /// handle.spawn_blocking(|| {
+    ///     println!("now running on a worker thread");
+    /// });
+    /// # }
+    pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
     {

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -383,11 +383,7 @@ cfg_rt! {
             F: Future + Send + 'static,
             F::Output: Send + 'static,
         {
-            match &self.kind {
-                #[cfg(feature = "rt-multi-thread")]
-                Kind::ThreadPool(exec) => exec.spawn(future),
-                Kind::CurrentThread(exec) => exec.spawn(future),
-            }
+            self.handle.spawn(future)
         }
 
         /// Run the provided function on an executor dedicated to blocking operations.

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -198,7 +198,7 @@ cfg_rt! {
     use self::enter::enter;
 
     mod handle;
-    use handle::Handle;
+    pub use handle::Handle;
 
     mod spawner;
     use self::spawner::Spawner;
@@ -330,6 +330,27 @@ cfg_rt! {
         #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
         pub fn new() -> std::io::Result<Runtime> {
             Builder::new_multi_thread().enable_all().build()
+        }
+
+        /// Return a handle to the runtime's spawner.
+        ///
+        /// The returned handle can be used to spawn tasks that run on this runtime, and can
+        /// be cloned to allow moving the `Handle` to other threads.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Runtime;
+        ///
+        /// let rt = Runtime::new()
+        ///     .unwrap();
+        ///
+        /// let handle = rt.handle();
+        ///
+        /// // Use the handle...
+        /// ```
+        pub fn handle(&self) -> &Handle {
+            &self.handle
         }
 
         /// Spawn a future onto the Tokio runtime.

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -198,7 +198,7 @@ cfg_rt! {
     use self::enter::enter;
 
     mod handle;
-    pub use handle::Handle;
+    pub use handle::{EnterGuard, Handle};
 
     mod spawner;
     use self::spawner::Spawner;
@@ -270,16 +270,6 @@ cfg_rt! {
 
         /// Blocking pool handle, used to signal shutdown
         blocking_pool: BlockingPool,
-    }
-
-    /// Runtime context guard.
-    ///
-    /// Returned by [`Runtime::enter`], the context guard exits the runtime
-    /// context on drop.
-    #[derive(Debug)]
-    pub struct EnterGuard<'a> {
-        rt: &'a Runtime,
-        guard: context::EnterGuard,
     }
 
     /// The runtime executor is either a thread-pool or a current-thread executor.
@@ -495,10 +485,7 @@ cfg_rt! {
         /// }
         /// ```
         pub fn enter(&self) -> EnterGuard<'_> {
-            EnterGuard {
-                rt: self,
-                guard: context::enter(self.handle.clone()),
-            }
+            self.handle.enter()
         }
 
         /// Shutdown the runtime, waiting for at most `duration` for all spawned

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -397,6 +397,7 @@ cfg_rt! {
         pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
         where
             F: FnOnce() -> R + Send + 'static,
+            R: Send + 'static,
         {
             self.handle.spawn_blocking(func)
         }

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -59,15 +59,6 @@ impl ThreadPool {
         &self.spawner
     }
 
-    /// Spawns a task
-    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
-    where
-        F: Future + Send + 'static,
-        F::Output: Send + 'static,
-    {
-        self.spawner.spawn(future)
-    }
-
     /// Blocks the current thread waiting for the future to complete.
     ///
     /// The future will execute on the current thread, but all spawned tasks


### PR DESCRIPTION
- make the `Handle` type public
- make `Runtime::spawn` and `Runtime::spawn_blocking` just thin wrappers around new public methods from `Handle`
- introduce `handleEnterGuard` to bring back `Handle::enter` (not sure if it's the right call here)
- didn't bring back `Handle::block_on` (not sure if that's something we want, feels less trivial to do, and maybe not that useful)
- brought back `Handle::current` and `Handle::try_current`

Fixes #2965 
