### PR TITLE
util: add back public poll_read_buf() function

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,10 +1,10 @@
+### Added
+- io: `poll_read_buf` util fn (#2972).
+
 # 0.5.0 (October 30, 2020)
 
 ### Changed
 - io: update `bytes` to 0.6 (#3071).
-
-### Added
-- io: `poll_read_buf` util fn (#2972).
 
 # 0.4.0 (October 15, 2020)
 

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -150,7 +150,7 @@ where
             // got room for at least one byte to read to ensure that we don't
             // get a spurious 0 that looks like EOF
             state.buffer.reserve(1);
-            let bytect = match poll_read_buf(cx, pinned.inner.as_mut(), &mut state.buffer)? {
+            let bytect = match poll_read_buf(pinned.inner.as_mut(), cx, &mut state.buffer)? {
                 Poll::Ready(ct) => ct,
                 Poll::Pending => return Poll::Pending,
             };

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -10,6 +10,7 @@ mod read_buf;
 mod reader_stream;
 mod stream_reader;
 
+pub use crate::util::poll_read_buf;
 pub use self::read_buf::read_buf;
 pub use self::reader_stream::ReaderStream;
 pub use self::stream_reader::StreamReader;

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -10,7 +10,7 @@ mod read_buf;
 mod reader_stream;
 mod stream_reader;
 
-pub use crate::util::poll_read_buf;
 pub use self::read_buf::read_buf;
 pub use self::reader_stream::ReaderStream;
 pub use self::stream_reader::StreamReader;
+pub use crate::util::poll_read_buf;

--- a/tokio-util/src/io/read_buf.rs
+++ b/tokio-util/src/io/read_buf.rs
@@ -59,7 +59,7 @@ where
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
             let this = &mut *self;
-            crate::util::poll_read_buf(cx, Pin::new(this.0), this.1)
+            crate::util::poll_read_buf(Pin::new(this.0), cx, this.1)
         }
     }
 }

--- a/tokio-util/src/io/reader_stream.rs
+++ b/tokio-util/src/io/reader_stream.rs
@@ -83,7 +83,7 @@ impl<R: AsyncRead> Stream for ReaderStream<R> {
             this.buf.reserve(CAPACITY);
         }
 
-        match poll_read_buf(cx, reader, &mut this.buf) {
+        match poll_read_buf(reader, cx, &mut this.buf) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(err)) => {
                 self.project().reader.set(None);

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -108,10 +108,10 @@ mod util {
     /// # }
     /// ```
     #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
-    pub fn poll_read_buf<T: AsyncRead>(
-        cx: &mut Context<'_>,
+    pub fn poll_read_buf<T: AsyncRead, B: BufMut>(
         io: Pin<&mut T>,
-        buf: &mut impl BufMut,
+        cx: &mut Context<'_>,
+        buf: &mut B,
     ) -> Poll<io::Result<usize>> {
         if !buf.has_remaining_mut() {
             return Poll::Ready(Ok(0));

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -94,7 +94,7 @@ mod util {
     ///
     /// loop {
     ///     reads += 1;
-    ///     let n = poll_fn(|cx| poll_read_buf(cx, Pin::new(&mut read), &mut buf)).await?;
+    ///     let n = poll_fn(|cx| poll_read_buf(Pin::new(&mut read), cx, &mut buf)).await?;
     ///
     ///     if n == 0 {
     ///         break;

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -107,6 +107,7 @@ mod util {
     /// # Ok(())
     /// # }
     /// ```
+    #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
     pub fn poll_read_buf<T: AsyncRead>(
         cx: &mut Context<'_>,
         io: Pin<&mut T>,


### PR DESCRIPTION
This was accidentally removed in #3064.