### PR TITLE
net: Add get/set reuseport and get_localaddr/reuseaddr for TcpSocket

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -183,6 +183,127 @@ impl TcpSocket {
         self.inner.set_reuseaddr(reuseaddr)
     }
 
+    /// Retrieves the value set for `SO_REUSEADDR` on this socket
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpSocket;
+    ///
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let addr = "127.0.0.1:8080".parse().unwrap();
+    ///
+    ///     let socket = TcpSocket::new_v4()?;
+    ///     socket.set_reuseaddr(true)?;
+    ///     assert!(socket.get_reuseaddr().unwrap());
+    ///     socket.bind(addr)?;
+    ///
+    ///     let listener = socket.listen(1024)?;
+    /// # drop(listener);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_reuseaddr(&self) -> io::Result<bool> {
+        self.inner.get_reuseaddr()
+    }
+
+    /// Allow the socket to bind to an in-use port. Only available for unix systems
+    /// (excluding Solaris).
+    ///
+    /// Behavior is platform specific. Refer to the target platform's
+    /// documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpSocket;
+    ///
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let addr = "127.0.0.1:8080".parse().unwrap();
+    ///
+    ///     let socket = TcpSocket::new_v4()?;
+    ///     socket.set_reuseport(true)?;
+    ///     socket.bind(addr)?;
+    ///
+    ///     let listener = socket.listen(1024)?;
+    /// # drop(listener);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+    pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
+        self.inner.set_reuseport(reuseport)
+    }
+
+    /// Allow the socket to bind to an in-use port. Only available for unix systems
+    /// (excluding Solaris).
+    ///
+    /// Behavior is platform specific. Refer to the target platform's
+    /// documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpSocket;
+    ///
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let addr = "127.0.0.1:8080".parse().unwrap();
+    ///
+    ///     let socket = TcpSocket::new_v4()?;
+    ///     socket.set_reuseport(true)?;
+    ///     assert!(socket.get_reuseport().unwrap());
+    ///     socket.bind(addr)?;
+    ///
+    ///     let listener = socket.listen(1024)?;
+    /// # drop(listener);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+    pub fn get_reuseport(&self) -> io::Result<bool> {
+        self.inner.get_reuseport()
+    }
+
+    /// Get the local address of this socket.
+    ///
+    /// Will `Err` on windows if called before `bind`
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpSocket;
+    ///
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let addr = "127.0.0.1:8080".parse().unwrap();
+    ///
+    ///     let socket = TcpSocket::new_v4()?;
+    ///     socket.bind(addr)?;
+    ///     assert_eq!(socket.get_localaddr().unwrap().to_string(), "127.0.0.1:8080");
+    ///     let listener = socket.listen(1024)?;
+    /// # drop(listener);
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn get_localaddr(&self) -> io::Result<SocketAddr> {
+        self.inner.get_localaddr()
+    }
+
     /// Bind the socket to the given address.
     ///
     /// This calls the `bind(2)` operating-system function. Behavior is

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -198,21 +198,19 @@ impl TcpSocket {
     ///
     ///     let socket = TcpSocket::new_v4()?;
     ///     socket.set_reuseaddr(true)?;
-    ///     assert!(socket.get_reuseaddr().unwrap());
+    ///     assert!(socket.reuseaddr().unwrap());
     ///     socket.bind(addr)?;
     ///
     ///     let listener = socket.listen(1024)?;
-    /// # drop(listener);
-    ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn get_reuseaddr(&self) -> io::Result<bool> {
+    pub fn reuseaddr(&self) -> io::Result<bool> {
         self.inner.get_reuseaddr()
     }
 
     /// Allow the socket to bind to an in-use port. Only available for unix systems
-    /// (excluding Solaris).
+    /// (excluding Solaris & Illumos).
     ///
     /// Behavior is platform specific. Refer to the target platform's
     /// documentation for more details.
@@ -233,18 +231,16 @@ impl TcpSocket {
     ///     socket.bind(addr)?;
     ///
     ///     let listener = socket.listen(1024)?;
-    /// # drop(listener);
-    ///
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
+    #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
         self.inner.set_reuseport(reuseport)
     }
 
     /// Allow the socket to bind to an in-use port. Only available for unix systems
-    /// (excluding Solaris).
+    /// (excluding Solaris & Illumos).
     ///
     /// Behavior is platform specific. Refer to the target platform's
     /// documentation for more details.
@@ -262,23 +258,21 @@ impl TcpSocket {
     ///
     ///     let socket = TcpSocket::new_v4()?;
     ///     socket.set_reuseport(true)?;
-    ///     assert!(socket.get_reuseport().unwrap());
+    ///     assert!(socket.reuseport().unwrap());
     ///     socket.bind(addr)?;
     ///
     ///     let listener = socket.listen(1024)?;
-    /// # drop(listener);
-    ///
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
-    pub fn get_reuseport(&self) -> io::Result<bool> {
+    #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
+    pub fn reuseport(&self) -> io::Result<bool> {
         self.inner.get_reuseport()
     }
 
     /// Get the local address of this socket.
     ///
-    /// Will `Err` on windows if called before `bind`
+    /// Will fail on windows if called before `bind`.
     ///
     /// # Examples
     ///
@@ -293,14 +287,12 @@ impl TcpSocket {
     ///
     ///     let socket = TcpSocket::new_v4()?;
     ///     socket.bind(addr)?;
-    ///     assert_eq!(socket.get_localaddr().unwrap().to_string(), "127.0.0.1:8080");
+    ///     assert_eq!(socket.local_addr().unwrap().to_string(), "127.0.0.1:8080");
     ///     let listener = socket.listen(1024)?;
-    /// # drop(listener);
-    ///
     ///     Ok(())
     /// }
     /// ```
-    pub fn get_localaddr(&self) -> io::Result<SocketAddr> {
+    pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.inner.get_localaddr()
     }
 

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -235,6 +235,7 @@ impl TcpSocket {
     /// }
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
+    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))))]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
         self.inner.set_reuseport(reuseport)
     }
@@ -266,6 +267,7 @@ impl TcpSocket {
     /// }
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
+    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))))]
     pub fn reuseport(&self) -> io::Result<bool> {
         self.inner.get_reuseport()
     }

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -235,7 +235,10 @@ impl TcpSocket {
     /// }
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos"))))
+    )]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
         self.inner.set_reuseport(reuseport)
     }
@@ -267,7 +270,10 @@ impl TcpSocket {
     /// }
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos"))))
+    )]
     pub fn reuseport(&self) -> io::Result<bool> {
         self.inner.get_reuseport()
     }


### PR DESCRIPTION
## Motivation

Recently updated mio tcp sockets with getter/setter for `SO_REUSEPORT` and also added `TcpSocket::get_localaddr` and `TcpSocket::get_reuseaddr`.

This PR is just to make it available for tokio `TcpSocket`
