### PR TITLE
util: Refactor UdpFramed & add UdpFramedRead/UdpFramedWrite

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -208,16 +208,6 @@ impl<T, U> Framed<T, U> {
         &mut self.inner.state.read.buffer
     }
 
-    /// Returns a reference to the write buffer.
-    pub fn write_buffer(&self) -> &BytesMut {
-        &self.inner.state.write.buffer
-    }
-
-    /// Returns a mutable reference to the write buffer.
-    pub fn write_buffer_mut(&mut self) -> &mut BytesMut {
-        &mut self.inner.state.write.buffer
-    }
-
     /// Consumes the `Framed`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -48,9 +48,8 @@ where
                 inner,
                 codec: decoder,
                 state: ReadFrame {
-                    eof: false,
-                    is_readable: false,
                     buffer: BytesMut::with_capacity(capacity),
+                    ..ReadFrame::default()
                 },
             },
         }

--- a/tokio-util/src/udp/framed_impl.rs
+++ b/tokio-util/src/udp/framed_impl.rs
@@ -14,16 +14,16 @@ use std::{borrow::BorrowMut, net::SocketAddr};
 use std::{io, mem::MaybeUninit};
 
 pin_project! {
-#[derive(Debug)]
-pub(crate) struct UdpFramedImpl<U, State> {
-    #[pin]
-    pub(crate) inner: UdpSocket,
-    pub(crate) state: State,
-    pub(crate) codec: U,
-    pub(crate) current_addr: Option<SocketAddr>,
-    pub(crate) out_addr: SocketAddr,
-    pub(crate) flushed: bool,
-}
+    #[derive(Debug)]
+    pub(crate) struct UdpFramedImpl<U, State> {
+        #[pin]
+        pub(crate) inner: UdpSocket,
+        pub(crate) state: State,
+        pub(crate) codec: U,
+        pub(crate) current_addr: Option<SocketAddr>,
+        pub(crate) out_addr: SocketAddr,
+        pub(crate) flushed: bool,
+    }
 }
 
 pub(crate) const INITIAL_RD_CAPACITY: usize = 64 * 1024;

--- a/tokio-util/src/udp/framed_impl.rs
+++ b/tokio-util/src/udp/framed_impl.rs
@@ -1,0 +1,147 @@
+use crate::codec::{Decoder, ReadFrame};
+use crate::codec::{Encoder, WriteFrame};
+
+use pin_project_lite::pin_project;
+use tokio::{io::ReadBuf, net::UdpSocket};
+use tokio_stream::Stream;
+
+use bytes::BufMut;
+use futures_core::ready;
+use futures_sink::Sink;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::{borrow::BorrowMut, net::SocketAddr};
+use std::{io, mem::MaybeUninit};
+
+pin_project! {
+#[derive(Debug)]
+pub(crate) struct UdpFramedImpl<U, State> {
+    #[pin]
+    pub(crate) inner: UdpSocket,
+    pub(crate) state: State,
+    pub(crate) codec: U,
+    pub(crate) current_addr: Option<SocketAddr>,
+    pub(crate) out_addr: SocketAddr,
+    pub(crate) flushed: bool,
+}
+}
+
+pub(crate) const INITIAL_RD_CAPACITY: usize = 64 * 1024;
+pub(crate) const INITIAL_WR_CAPACITY: usize = 8 * 1024;
+
+impl<C, R> Stream for UdpFramedImpl<C, R>
+where
+    C: Decoder,
+    R: BorrowMut<ReadFrame>,
+{
+    type Item = Result<(C::Item, SocketAddr), C::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut pin = self.project();
+
+        let read_state: &mut ReadFrame = pin.state.borrow_mut();
+        read_state.buffer.reserve(INITIAL_RD_CAPACITY);
+
+        loop {
+            // Are there are still bytes left in the read buffer to decode?
+            if read_state.is_readable {
+                if let Some(frame) = pin.codec.decode_eof(&mut read_state.buffer)? {
+                    let current_addr = pin
+                        .current_addr
+                        .expect("will always be set before this line is called");
+
+                    return Poll::Ready(Some(Ok((frame, current_addr))));
+                }
+
+                // if this line has been reached then decode has returned `None`.
+                read_state.is_readable = false;
+                read_state.buffer.clear();
+            }
+
+            // We're out of data. Try and fetch more data to decode
+            let addr = unsafe {
+                // Convert `&mut [MaybeUnit<u8>]` to `&mut [u8]` because we will be
+                // writing to it via `poll_recv_from` and therefore initializing the memory.
+                let buf =
+                    &mut *(read_state.buffer.bytes_mut() as *mut _ as *mut [MaybeUninit<u8>]);
+                let mut read = ReadBuf::uninit(buf);
+                let ptr = read.filled().as_ptr();
+                let res = ready!(Pin::new(&mut pin.inner).poll_recv_from(cx, &mut read));
+
+                assert_eq!(ptr, read.filled().as_ptr());
+                let addr = res?;
+                read_state.buffer.advance_mut(read.filled().len());
+                addr
+            };
+
+            *pin.current_addr = Some(addr);
+            read_state.is_readable = true;
+        }
+    }
+}
+
+impl<I, C, W> Sink<(I, SocketAddr)> for UdpFramedImpl<C, W>
+where
+    C: Encoder<I>,
+    C::Error: From<io::Error>,
+    W: BorrowMut<WriteFrame>,
+{
+    type Error = C::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        if !self.flushed {
+            match self.poll_flush(cx)? {
+                Poll::Ready(()) => {}
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: (I, SocketAddr)) -> Result<(), Self::Error> {
+        let (frame, out_addr) = item;
+
+        let pin = self.project();
+        let write_state: &mut WriteFrame = pin.state.borrow_mut();
+
+        pin.codec.encode(frame, &mut write_state.buffer)?;
+        *pin.out_addr = out_addr;
+        *pin.flushed = false;
+
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let pin = self.project();
+        if *pin.flushed {
+            return Poll::Ready(Ok(()));
+        }
+
+        let write_state: &mut WriteFrame = pin.state.borrow_mut();
+        let n = ready!(pin
+            .inner
+            .poll_send_to(cx, &write_state.buffer, *pin.out_addr))?;
+
+        let wrote_all = n == write_state.buffer.len();
+        write_state.buffer.clear();
+        *pin.flushed = true;
+
+        let res = if wrote_all {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to write entire datagram to socket",
+            )
+            .into())
+        };
+
+        Poll::Ready(res)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_flush(cx))?;
+        Poll::Ready(Ok(()))
+    }
+}

--- a/tokio-util/src/udp/framed_read.rs
+++ b/tokio-util/src/udp/framed_read.rs
@@ -40,7 +40,7 @@ impl<C> UdpFramedRead<C> {
                 inner: socket,
                 current_addr: None,
                 out_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
-                flushed: false,
+                flushed: true,
             },
         }
     }

--- a/tokio-util/src/udp/framed_read.rs
+++ b/tokio-util/src/udp/framed_read.rs
@@ -14,6 +14,10 @@ use std::{
 };
 
 pin_project! {
+    /// A [`Stream`] of messages decoded from a [`UdpSocket`].
+    ///
+    /// [`Stream`]: tokio::stream::Stream
+    /// [`AsyncRead`]: tokio::udp::UdpSocket
     #[cfg_attr(docsrs, doc(all(feature = "codec", feature = "udp")))]
     pub struct UdpFramedRead<C> {
         #[pin]

--- a/tokio-util/src/udp/framed_read.rs
+++ b/tokio-util/src/udp/framed_read.rs
@@ -1,0 +1,126 @@
+use crate::codec::{Decoder, ReadFrame};
+use crate::udp::framed_impl::UdpFramedImpl;
+
+use pin_project_lite::pin_project;
+use tokio::net::UdpSocket;
+use tokio_stream::Stream;
+
+use bytes::BytesMut;
+use std::{
+    fmt,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    #[cfg_attr(docsrs, doc(all(feature = "codec", feature = "udp")))]
+    pub struct UdpFramedRead<C> {
+        #[pin]
+        inner: UdpFramedImpl<C, ReadFrame>,
+    }
+}
+
+impl<C> UdpFramedRead<C> {
+    /// Create a new `UdpFramed` backed by the given socket and codec.
+    ///
+    /// See struct level documentation for more details.
+    pub fn new(socket: UdpSocket, codec: C) -> UdpFramedRead<C> {
+        Self {
+            inner: UdpFramedImpl {
+                codec,
+                state: ReadFrame {
+                    buffer: BytesMut::with_capacity(crate::udp::framed_impl::INITIAL_RD_CAPACITY),
+                    ..ReadFrame::default()
+                },
+                inner: socket,
+                current_addr: None,
+                out_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
+                flushed: false,
+            },
+        }
+    }
+
+    /// Returns a reference to the underlying I/O stream wrapped by `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_ref(&self) -> &UdpSocket {
+        &self.inner.inner
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `UdpFramed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_mut(&mut self) -> &mut UdpSocket {
+        &mut self.inner.inner
+    }
+
+    /// Returns a reference to the underlying codec wrapped by
+    /// `Framed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec(&self) -> &C {
+        &self.inner.codec
+    }
+
+    /// Returns a mutable reference to the underlying codec wrapped by
+    /// `UdpFramed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn codec_mut(&mut self) -> &mut C {
+        &mut self.inner.codec
+    }
+
+    /// Returns a reference to the read buffer.
+    pub fn read_buffer(&self) -> &BytesMut {
+        &self.inner.state.buffer
+    }
+
+    /// Returns a mutable reference to the read buffer.
+    pub fn read_buffer_mut(&mut self) -> &mut BytesMut {
+        &mut self.inner.state.buffer
+    }
+
+    /// Consumes the `Framed`, returning its underlying I/O stream.
+    pub fn into_inner(self) -> UdpSocket {
+        self.inner.inner
+    }
+}
+
+impl<C> Stream for UdpFramedRead<C>
+where
+    C: Decoder,
+{
+    type Item = Result<(C::Item, SocketAddr), C::Error>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
+    }
+}
+
+impl<C> fmt::Debug for UdpFramedRead<C>
+where
+    C: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UdpFramedRead")
+            .field("io", self.get_ref())
+            .field("codec", self.codec())
+            .field("current_addr", &self.inner.current_addr)
+            .field("is_readable", &self.inner.state.is_readable)
+            .field("eof", &self.inner.state.eof)
+            .field("read_buffer", &self.read_buffer())
+            .finish()
+    }
+}

--- a/tokio-util/src/udp/framed_write.rs
+++ b/tokio-util/src/udp/framed_write.rs
@@ -38,7 +38,7 @@ impl<C> UdpFramedWrite<C> {
                 inner: socket,
                 current_addr: None,
                 out_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
-                flushed: false,
+                flushed: true,
             },
         }
     }

--- a/tokio-util/src/udp/framed_write.rs
+++ b/tokio-util/src/udp/framed_write.rs
@@ -1,0 +1,126 @@
+use crate::codec::{Encoder, WriteFrame};
+use crate::udp::framed_impl::UdpFramedImpl;
+
+use pin_project_lite::pin_project;
+use tokio::net::UdpSocket;
+
+use bytes::BytesMut;
+use futures_sink::Sink;
+use std::{
+    fmt, io,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pin_project! {
+    #[cfg_attr(docsrs, doc(all(feature = "codec", feature = "udp")))]
+    pub struct UdpFramedWrite<C> {
+        #[pin]
+        inner: UdpFramedImpl<C, WriteFrame>,
+    }
+}
+
+impl<C> UdpFramedWrite<C> {
+    /// Create a new `UdpFramed` backed by the given socket and codec.
+    ///
+    /// See struct level documentation for more details.
+    pub fn new(socket: UdpSocket, codec: C) -> UdpFramedWrite<C> {
+        Self {
+            inner: UdpFramedImpl {
+                codec,
+                state: WriteFrame {
+                    buffer: BytesMut::with_capacity(crate::udp::framed_impl::INITIAL_WR_CAPACITY),
+                },
+                inner: socket,
+                current_addr: None,
+                out_addr: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), 0)),
+                flushed: false,
+            },
+        }
+    }
+
+    /// Returns a reference to the underlying I/O stream wrapped by `Framed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_ref(&self) -> &UdpSocket {
+        &self.inner.inner
+    }
+
+    /// Returns a mutable reference to the underlying I/O stream wrapped by
+    /// `UdpFramed`.
+    ///
+    /// # Note
+    ///
+    /// Care should be taken to not tamper with the underlying stream of data
+    /// coming in as it may corrupt the stream of frames otherwise being worked
+    /// with.
+    pub fn get_mut(&mut self) -> &mut UdpSocket {
+        &mut self.inner.inner
+    }
+
+    /// Returns a reference to the underlying codec wrapped by
+    /// `Framed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder(&self) -> &C {
+        &self.inner.codec
+    }
+
+    /// Returns a mutable reference to the underlying codec wrapped by
+    /// `UdpFramed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn encoder_mut(&mut self) -> &mut C {
+        &mut self.inner.codec
+    }
+
+    /// Consumes the `Framed`, returning its underlying I/O stream.
+    pub fn into_inner(self) -> UdpSocket {
+        self.inner.inner
+    }
+}
+
+// This impl just defers to the underlying FramedImpl
+impl<I, U> Sink<(I, SocketAddr)> for UdpFramedWrite<U>
+where
+    U: Encoder<I>,
+    U::Error: From<io::Error>,
+{
+    type Error = U::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_ready(cx)
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: (I, SocketAddr)) -> Result<(), Self::Error> {
+        self.project().inner.start_send(item)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.project().inner.poll_close(cx)
+    }
+}
+
+impl<C> fmt::Debug for UdpFramedWrite<C>
+where
+    C: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UdpFramedWrite")
+            .field("io", self.get_ref())
+            .field("codec", self.encoder())
+            .field("buffer", &self.inner.state.buffer)
+            .finish()
+    }
+}

--- a/tokio-util/src/udp/framed_write.rs
+++ b/tokio-util/src/udp/framed_write.rs
@@ -14,6 +14,9 @@ use std::{
 };
 
 pin_project! {
+    /// A [`Sink`] of frames encoded for udp.
+    ///
+    /// [`Sink`]: futures_sink::Sink
     #[cfg_attr(docsrs, doc(all(feature = "codec", feature = "udp")))]
     pub struct UdpFramedWrite<C> {
         #[pin]

--- a/tokio-util/src/udp/mod.rs
+++ b/tokio-util/src/udp/mod.rs
@@ -1,4 +1,10 @@
 //! UDP framing
 
 mod frame;
+mod framed_impl;
+mod framed_read;
+mod framed_write;
+
 pub use frame::UdpFramed;
+pub use framed_read::UdpFramedRead;
+pub use framed_write::UdpFramedWrite;


### PR DESCRIPTION
## Motivation

`Framed` has both a `FramedRead` and `FramedWrite`, it's split up nicely to use the same underlying implementation. This doesn't exist for udp

## Solution

I basically copied the same style but for `UdpFramed`, so that you can make both a Stream-only or Sink-only. It's not totally cleaned up yet, I wanted to get feedback on if this would be accepted first if I keep working on it.

I would love to make the underlying type generic and not `UdpSocket` or have something generic that bounds over types that implement `poll_send` & `poll_recv`, but unless you're open to adding such a trait, the type will have to be monomorphic, I think.

~~edit: this builds on #3044 so that needs to be merged first~~