### PR TITLE
util: remove stream feature flag from DelayQueue

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -771,7 +771,6 @@ impl<T> Default for DelayQueue<T> {
     }
 }
 
-#[cfg(feature = "stream")]
 impl<T> futures_core::Stream for DelayQueue<T> {
     // DelayQueue seems much more specific, where a user may care that it
     // has reached capacity, so return those errors instead of panicking.


### PR DESCRIPTION
## Motivation

In tokio 0.3, `DelayQueue` is moved to tokio-util. However, stream flag is forgotten to expose.

```
[features]
# No features on by default
default = []

# Shorthand for enabling everything
full = ["codec", "compat", "io", "time"]

compat = ["futures-io",]
codec = ["tokio/stream"]
time = ["tokio/time","slab"]
io = []
rt = ["tokio/rt"]

[dependencies]
```

Then it is not possible to unlock `Stream` impl for `DelayQueue`.

```rust
#[cfg(feature = "stream")]
impl<T> futures_core::Stream for DelayQueue<T> {
```

## Solution

This PR removes stream feature lock from `DelayQueue`. As future_cores is linked with tokio-util by default there is no reason to hide the impl by a feature flag.
