### PR TITLE
Trait AsyncVectoredWrite and related utilities

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -199,6 +199,8 @@ pub use self::async_write::AsyncWrite;
 mod read_buf;
 pub use self::read_buf::ReadBuf;
 
+pub mod vec;
+
 // Re-export some types from `std::io` so that users don't have to deal
 // with conflicts when `use`ing `tokio::io` and `std::io`.
 #[doc(no_inline)]

--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -1,8 +1,9 @@
 use crate::io::util::DEFAULT_BUF_SIZE;
+use crate::io::vec::AsyncVectoredWrite;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 use pin_project_lite::pin_project;
-use std::io;
+use std::io::{self, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{cmp, fmt};
@@ -156,6 +157,16 @@ impl<R: AsyncRead + AsyncWrite> AsyncWrite for BufReader<R> {
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.get_pin_mut().poll_shutdown(cx)
+    }
+}
+
+impl<R: AsyncRead + AsyncVectoredWrite> AsyncVectoredWrite for BufReader<R> {
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.get_pin_mut().poll_write_vectored(cx, bufs)
     }
 }
 

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -1,7 +1,8 @@
+use crate::io::vec::AsyncVectoredWrite;
 use crate::io::AsyncWrite;
 
 use std::fmt;
-use std::io;
+use std::io::{self, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -67,6 +68,17 @@ impl AsyncWrite for Sink {
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncVectoredWrite for Sink {
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        slices: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let total_len = slices.iter().map(|s| s.len()).sum();
+        Poll::Ready(Ok(total_len))
     }
 }
 

--- a/tokio/src/io/vec/async_vectored_write.rs
+++ b/tokio/src/io/vec/async_vectored_write.rs
@@ -1,0 +1,33 @@
+use crate::io::AsyncWrite;
+use std::io::{self, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+/// Writes bytes from a slice of buffers asynchronously.
+///
+/// This trait extends [`AsyncWrite`], providing
+/// the functionality of [`std::io::Write::write_vectored`]
+/// in a non-blocking way, and indicates that an I/O object has an efficient
+/// implementation for vectored writes.
+pub trait AsyncVectoredWrite: AsyncWrite {
+    /// Attempt to write bytes from `slices` into the object.
+    ///
+    /// Data is copied from each buffer in order, with the final buffer
+    /// copied from possibly being only partially consumed.
+    /// This method must behave as a call to [`poll_write`]
+    /// with the buffers concatenated would.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_written))`.
+    ///
+    /// If the object is not ready for writing, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker()`) to receive a notification when the object becomes
+    /// writable or is closed.
+    ///
+    /// [`poll_write`]: AsyncWrite::poll_write()
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        slices: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>>;
+}

--- a/tokio/src/io/vec/async_vectored_write.rs
+++ b/tokio/src/io/vec/async_vectored_write.rs
@@ -66,3 +66,36 @@ where
         self.get_mut().as_mut().poll_write_vectored(cx, slices)
     }
 }
+
+macro_rules! delegate_async_vectored_write_to_std {
+    () => {
+        #[inline]
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            slices: &[IoSlice<'_>],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(io::Write::write_vectored(self.get_mut(), slices))
+        }
+    };
+}
+
+impl AsyncVectoredWrite for Vec<u8> {
+    delegate_async_vectored_write_to_std!();
+}
+
+impl AsyncVectoredWrite for io::Cursor<&mut [u8]> {
+    delegate_async_vectored_write_to_std!();
+}
+
+impl AsyncVectoredWrite for io::Cursor<&mut Vec<u8>> {
+    delegate_async_vectored_write_to_std!();
+}
+
+impl AsyncVectoredWrite for io::Cursor<Vec<u8>> {
+    delegate_async_vectored_write_to_std!();
+}
+
+impl AsyncVectoredWrite for io::Cursor<Box<[u8]>> {
+    delegate_async_vectored_write_to_std!();
+}

--- a/tokio/src/io/vec/mod.rs
+++ b/tokio/src/io/vec/mod.rs
@@ -1,0 +1,7 @@
+//! Asynchronous vectored I/O.
+//!
+//! This module provides traits, helpers, and type definitions for efficient
+//! asynchronous vectored I/O.
+
+mod async_vectored_write;
+pub use async_vectored_write::AsyncVectoredWrite;

--- a/tokio/src/io/vec/mod.rs
+++ b/tokio/src/io/vec/mod.rs
@@ -5,3 +5,6 @@
 
 mod async_vectored_write;
 pub use async_vectored_write::AsyncVectoredWrite;
+
+mod util;
+pub use util::{AsyncVectoredWriteExt, WriteVectored};

--- a/tokio/src/io/vec/mod.rs
+++ b/tokio/src/io/vec/mod.rs
@@ -6,5 +6,9 @@
 mod async_vectored_write;
 pub use async_vectored_write::AsyncVectoredWrite;
 
-mod util;
-pub use util::{AsyncVectoredWriteExt, WriteVectored};
+cfg_io_util! {
+
+    mod util;
+    pub use util::{AsyncVectoredWriteExt, WriteVectored};
+
+}

--- a/tokio/src/io/vec/util/async_vectored_write_ext.rs
+++ b/tokio/src/io/vec/util/async_vectored_write_ext.rs
@@ -1,0 +1,30 @@
+use super::write_vectored::{write_vectored, WriteVectored};
+use crate::io::vec::AsyncVectoredWrite;
+
+use std::io::IoSlice;
+
+/// Vectored output with an async method.
+///
+/// Implemented as an extention trait, adding the `write_vectored`
+/// utility method to all [`AsyncVectoredWrite`] types. Callers will
+/// tend to import this trait instead of [`AsyncVectoredWrite`].
+pub trait AsyncVectoredWriteExt: AsyncVectoredWrite {
+    /// Like [`AsyncWriteExt::write`], except that it writes from
+    /// a slice of buffers.
+    ///
+    /// Equivalent to:
+    ///
+    /// ```ignore
+    /// async fn write_vectored(&mut self, slices: &[IoSlice<'_>]) -> io::Result<usize>;
+    /// ```
+    ///
+    /// [`AsyncWriteExt::write`]: crate::io::AsyncWriteExt::write
+    fn write_vectored<'a>(&'a mut self, slices: &'a [IoSlice<'a>]) -> WriteVectored<'a, Self>
+    where
+        Self: Unpin,
+    {
+        write_vectored(self, slices)
+    }
+}
+
+impl<W: AsyncVectoredWrite + ?Sized> AsyncVectoredWriteExt for W {}

--- a/tokio/src/io/vec/util/mod.rs
+++ b/tokio/src/io/vec/util/mod.rs
@@ -1,0 +1,9 @@
+#![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+
+cfg_io_util! {
+    mod async_vectored_write_ext;
+    pub use async_vectored_write_ext::AsyncVectoredWriteExt;
+
+    mod write_vectored;
+    pub use write_vectored::WriteVectored;
+}

--- a/tokio/src/io/vec/util/write_vectored.rs
+++ b/tokio/src/io/vec/util/write_vectored.rs
@@ -1,0 +1,50 @@
+use crate::io::vec::AsyncVectoredWrite;
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io::{self, IoSlice};
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// A future to write some data from the slice of buffers
+    /// to an `AsyncVectoredWrite`.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct WriteVectored<'a, W: ?Sized> {
+        writer: &'a mut W,
+        bufs: &'a [IoSlice<'a>],
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+/// Tries to write some bytes from the given `bufs` to the writer in an
+/// asynchronous manner, returning a future.
+pub(crate) fn write_vectored<'a, W>(
+    writer: &'a mut W,
+    bufs: &'a [IoSlice<'a>],
+) -> WriteVectored<'a, W>
+where
+    W: AsyncVectoredWrite + Unpin + ?Sized,
+{
+    WriteVectored {
+        writer,
+        bufs,
+        _pin: PhantomPinned,
+    }
+}
+
+impl<W> Future for WriteVectored<'_, W>
+where
+    W: AsyncVectoredWrite + Unpin + ?Sized,
+{
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
+        let me = self.project();
+        Pin::new(me.writer).poll_write_vectored(cx, me.bufs)
+    }
+}

--- a/tokio/src/net/tcp/split_owned.rs
+++ b/tokio/src/net/tcp/split_owned.rs
@@ -9,15 +9,17 @@
 //! level.
 
 use crate::future::poll_fn;
+use crate::io::vec::AsyncVectoredWrite;
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::net::TcpStream;
 
 use std::error::Error;
+use std::fmt;
+use std::io::{self, IoSlice};
 use std::net::Shutdown;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
-use std::{fmt, io};
 
 /// Owned read half of a [`TcpStream`], created by [`into_split`].
 ///
@@ -242,6 +244,16 @@ impl AsyncWrite for OwnedWriteHalf {
             Pin::into_inner(self).shutdown_on_drop = false;
         }
         res.into()
+    }
+}
+
+impl AsyncVectoredWrite for OwnedWriteHalf {
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        slices: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.inner.poll_write_vectored_priv(cx, slices)
     }
 }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -512,7 +512,7 @@ impl TcpStream {
         }
     }
 
-    fn poll_write_vectored_priv(
+    pub(super) fn poll_write_vectored_priv(
         &self,
         cx: &mut Context<'_>,
         slices: &[IoSlice<'_>],

--- a/tokio/src/net/unix/split.rs
+++ b/tokio/src/net/unix/split.rs
@@ -8,10 +8,11 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+use crate::io::vec::AsyncVectoredWrite;
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::net::UnixStream;
 
-use std::io;
+use std::io::{self, IoSlice};
 use std::net::Shutdown;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -74,6 +75,16 @@ impl AsyncWrite for WriteHalf<'_> {
 
     fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.0.shutdown(Shutdown::Write).into()
+    }
+}
+
+impl AsyncVectoredWrite for WriteHalf<'_> {
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        slices: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.0.poll_write_vectored_priv(cx, slices)
     }
 }
 

--- a/tokio/tests/io_buf_writer.rs
+++ b/tokio/tests/io_buf_writer.rs
@@ -1,0 +1,118 @@
+use tokio::io::vec::AsyncVectoredWriteExt;
+use tokio::io::BufWriter;
+use tokio::prelude::*;
+
+use tokio_test::assert_ok;
+
+use std::io::IoSlice;
+
+mod support {
+    pub(crate) mod io_vec;
+}
+use support::io_vec::IoBufs;
+
+#[tokio::test]
+async fn write_vectored_empty() {
+    let mut w = BufWriter::new(Vec::new());
+    let n = assert_ok!(w.write_vectored(&[]).await);
+    assert_eq!(n, 0);
+
+    let io_vec = [IoSlice::new(&[]); 3];
+    let n = assert_ok!(w.write_vectored(&io_vec).await);
+    assert_eq!(n, 0);
+
+    assert_ok!(w.flush().await);
+    assert!(w.get_ref().is_empty());
+}
+
+#[tokio::test]
+async fn write_vectored_basic() {
+    let msg = b"foo bar baz";
+    let bufs = [
+        IoSlice::new(&msg[0..4]),
+        IoSlice::new(&msg[4..8]),
+        IoSlice::new(&msg[8..]),
+    ];
+    let mut w = BufWriter::new(Vec::new());
+    let n = assert_ok!(w.write_vectored(&bufs).await);
+    assert_eq!(n, msg.len());
+    assert!(w.buffer() == &msg[..]);
+    assert_ok!(w.flush().await);
+    assert_eq!(w.get_ref(), msg);
+
+    let mut bufs = [
+        IoSlice::new(&msg[0..4]),
+        IoSlice::new(&msg[4..8]),
+        IoSlice::new(&msg[8..]),
+    ];
+    let io_vec = IoBufs::new(&mut bufs);
+    let mut w = BufWriter::with_capacity(8, Vec::new());
+    let n = assert_ok!(w.write_vectored(&io_vec).await);
+    assert_eq!(n, 8);
+    assert!(w.buffer() == &msg[..8]);
+    let io_vec = io_vec.advance(n);
+    let n = assert_ok!(w.write_vectored(&io_vec).await);
+    assert_eq!(n, 3);
+    assert!(w.get_ref().as_slice() == &msg[..8]);
+    assert!(w.buffer() == &msg[8..]);
+}
+
+struct VectoredWriteHarness {
+    writer: BufWriter<Vec<u8>>,
+    buf_capacity: usize,
+}
+
+impl VectoredWriteHarness {
+    fn new(buf_capacity: usize) -> Self {
+        VectoredWriteHarness {
+            writer: BufWriter::with_capacity(buf_capacity, Vec::new()),
+            buf_capacity,
+        }
+    }
+
+    async fn write_all<'a, 'b>(&mut self, mut io_vec: IoBufs<'a, 'b>) -> usize {
+        let mut total_written = 0;
+        while !io_vec.is_empty() {
+            let n = assert_ok!(self.writer.write_vectored(&io_vec).await);
+            assert!(n != 0);
+            assert!(self.writer.buffer().len() <= self.buf_capacity);
+            total_written += n;
+            io_vec = io_vec.advance(n);
+        }
+        total_written
+    }
+
+    async fn flush(&mut self) -> &[u8] {
+        assert_ok!(self.writer.flush().await);
+        self.writer.get_ref()
+    }
+}
+
+#[tokio::test]
+async fn write_vectored_odd() {
+    let msg = b"foo bar baz";
+    let mut bufs = [
+        IoSlice::new(&msg[0..4]),
+        IoSlice::new(&[]),
+        IoSlice::new(&msg[4..9]),
+        IoSlice::new(&msg[9..]),
+    ];
+    let mut h = VectoredWriteHarness::new(8);
+    let bytes_written = h.write_all(IoBufs::new(&mut bufs)).await;
+    assert_eq!(bytes_written, msg.len());
+    assert_eq!(h.flush().await, msg);
+}
+
+#[tokio::test]
+async fn write_vectored_large() {
+    let msg = b"foo bar baz";
+    let mut bufs = [
+        IoSlice::new(&[]),
+        IoSlice::new(&msg[..9]),
+        IoSlice::new(&msg[9..]),
+    ];
+    let mut h = VectoredWriteHarness::new(8);
+    let bytes_written = h.write_all(IoBufs::new(&mut bufs)).await;
+    assert_eq!(bytes_written, msg.len());
+    assert_eq!(h.flush().await, msg);
+}

--- a/tokio/tests/support/io_vec.rs
+++ b/tokio/tests/support/io_vec.rs
@@ -1,0 +1,45 @@
+use std::io::IoSlice;
+use std::ops::Deref;
+use std::slice;
+
+pub struct IoBufs<'a, 'b>(&'b mut [IoSlice<'a>]);
+
+impl<'a, 'b> IoBufs<'a, 'b> {
+    pub fn new(slices: &'b mut [IoSlice<'a>]) -> Self {
+        IoBufs(slices)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn advance(mut self, n: usize) -> IoBufs<'a, 'b> {
+        let mut to_remove = 0;
+        let mut remaining_len = n;
+        for slice in self.0.iter() {
+            if remaining_len < slice.len() {
+                break;
+            } else {
+                remaining_len -= slice.len();
+                to_remove += 1;
+            }
+        }
+        self.0 = self.0.split_at_mut(to_remove).1;
+        if let Some(slice) = self.0.first_mut() {
+            let tail = &slice[remaining_len..];
+            // Safety: recasts slice to the original lifetime
+            let tail = unsafe { slice::from_raw_parts(tail.as_ptr(), tail.len()) };
+            *slice = IoSlice::new(tail);
+        } else if remaining_len != 0 {
+            panic!("advance past the end of the slice vector");
+        }
+        self
+    }
+}
+
+impl<'a, 'b> Deref for IoBufs<'a, 'b> {
+    type Target = [IoSlice<'a>];
+    fn deref(&self) -> &[IoSlice<'a>] {
+        self.0
+    }
+}

--- a/tokio/tests/vectored.rs
+++ b/tokio/tests/vectored.rs
@@ -1,0 +1,55 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::vec::AsyncVectoredWriteExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::prelude::*;
+use tokio_test::assert_ok;
+
+use std::io::IoSlice;
+
+#[tokio::test]
+async fn echo_server() {
+    const N: usize = 1024;
+
+    let srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
+    let addr = assert_ok!(srv.local_addr());
+
+    let msg = b"foo bar baz";
+
+    let t = tokio::spawn(async move {
+        let mut s = assert_ok!(TcpStream::connect(&addr).await);
+
+        let t2 = tokio::spawn(async move {
+            let mut s = assert_ok!(TcpStream::connect(&addr).await);
+            let mut b = vec![0; msg.len() * N];
+            assert_ok!(s.read_exact(&mut b).await);
+            b
+        });
+
+        let mut expected = Vec::<u8>::new();
+        for _i in 0..N {
+            expected.extend(msg);
+            let io_vec = [
+                IoSlice::new(&msg[0..4]),
+                IoSlice::new(&msg[4..8]),
+                IoSlice::new(&msg[8..]),
+            ];
+            let res = assert_ok!(s.write_vectored(&io_vec).await);
+            assert_eq!(res, msg.len());
+        }
+
+        (expected, t2)
+    });
+
+    let (mut a, _) = assert_ok!(srv.accept().await);
+    let (mut b, _) = assert_ok!(srv.accept().await);
+
+    let n = assert_ok!(io::copy(&mut a, &mut b).await);
+
+    let (expected, t2) = t.await.unwrap();
+    let actual = t2.await.unwrap();
+
+    assert!(expected == actual);
+    assert_eq!(n, (msg.len() * N) as u64);
+}


### PR DESCRIPTION
## Motivation

#2882 removed the `poll_write_buf` method in `AsyncWrite` that could be implemented as a vectored write.
There is still a desire to use vectored I/O facilities on objects that support them efficiently, especially on the writing side.

## Solution

Introduce a new trait, `AsyncVectoredWrite`, providing the `poll_write_vectored` method.
In contrast to the earlier `poll_write_buf`, the method is object-safe.

`AsyncVectoredWrite` is implemented for:

- `Sink`;
- `TcpStream`, `UnixStream`, their write halves;
- standard in-memory containers;
- generic pointer types that deref to an `AsyncVectoredWrite` types;
- `io::WriteHalf` of an `AsyncVectoredWrite` object;
- `BufWriter`, as well as write-through delegations on `BufStream` and `BufReader`.

The latter implementation allows using `BufWriter` and friends as buffering adapters in cases when generic code requires `AsyncVectoredWrite`.

The `AsyncVectoredWriteExt` utility trait provides the async-friendly method `write_vectored` for all types implementing `AsyncVectoredWrite`.