### PR TITLE
StreamMap: fix Default bound

### DIFF
--- a/tokio/src/stream/stream_map.rs
+++ b/tokio/src/stream/stream_map.rs
@@ -156,7 +156,7 @@ use std::task::{Context, Poll};
 ///     }
 /// }
 /// ```
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct StreamMap<K, V> {
     /// Streams stored in the map
     entries: Vec<(K, V)>,
@@ -510,6 +510,12 @@ where
         } else {
             Pending
         }
+    }
+}
+
+impl<K, V> Default for StreamMap<K, V> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
Right now `StreamMap` implements `Default` only if both the stream and the key do too. This doesn't make sense, but is enforced because of deriving. This PR replaces this with manual `Default` implementation that is an alias for `StreamMap::new`.