### PR TITLE
async_fd: make into_inner() deregister the fd

### DIFF
--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -304,6 +304,15 @@ async fn drop_closes() {
 }
 
 #[tokio::test]
+async fn reregister() {
+    let (a, _b) = socketpair();
+
+    let afd_a = AsyncFd::new(a).unwrap();
+    let a = afd_a.into_inner();
+    AsyncFd::new(a).unwrap();
+}
+
+#[tokio::test]
 async fn with_poll() {
     use std::task::Poll;
 


### PR DESCRIPTION
Fixes: #3103
