### PR TITLE
Add IntoStream for all Iterator<_>

### DIFF
--- a/tokio/src/stream/mod.rs
+++ b/tokio/src/stream/mod.rs
@@ -926,6 +926,18 @@ pub trait StreamExt: Stream {
 
 impl<St: ?Sized> StreamExt for St where St: Stream {}
 
+pub trait IntoStream<T>: std::iter::Iterator<Item = T> + Sized {
+    fn into_stream(self) -> Iter<Self>;
+}
+
+impl<I, T> IntoStream<T> for I
+    where I: std::iter::Iterator<Item = T> + Sized
+{
+    fn into_stream(self) -> Iter<Self> {
+        iter(self)
+    }
+}
+
 /// Merge the size hints from two streams.
 fn merge_size_hints(
     (left_low, left_high): (usize, Option<usize>),


### PR DESCRIPTION
## Motivation

I just started recently using tokio (or writing async-await rust), and I found it very inconvenient (and slightly harder to read) to write

```
let i = collection.iter()
    .map(something);

tokio::stream::iter(i)
    .map(something_else)
    //...
```

But instead I wanted to write 

```
collection.iter()
    .map(something)
    .into_stream()
    .map(something_else)
    // ...
```

Which is the problem I try to solve with this PR.


## Solution

This PR thus implements an extension trait for all `std::iter::Iterator`s which adds the `into_stream()` conveniance function.

## Note

Please note that this is my first PR to this project and although I've read the contribution guidelines, I want to apologize in advance for any mistakes made.

Thank you for this awesome library!