### PR TITLE
chore: update proptest and nix

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -110,7 +110,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.42" }
-nix = { version = "0.18.0" }
+nix = { version = "0.19.0" }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
@@ -120,7 +120,7 @@ optional = true
 [dev-dependencies]
 tokio-test = { version = "0.3.0", path = "../tokio-test" }
 futures = { version = "0.3.0", features = ["async-await"] }
-proptest = "0.9.4"
+proptest = "0.10.0"
 tempfile = "3.1.0"
 
 [target.'cfg(loom)'.dev-dependencies]


### PR DESCRIPTION
nix 0.18 -> 0.19
proptest 0.9 -> 0.10

(Note: both are dev-deps)