### PR TITLE
chore: prepare tokio-macros v0.2.6

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,9 +1,17 @@
-# 0.2.5 (February 27, 2019)
+# 0.2.6 (November 11, 2020)
+
+### Changes
+
+ - disambiguate the built-in `#[test]` attribute in macro expansion ([#2503])
+ - warn about renaming the Tokio dependency ([#2521])
+ - various documentation changes ([#2683], [#2697])
+
+# 0.2.5 (February 27, 2020)
 
 ### Fixed
 - doc improvements ([#2225]).
 
-# 0.2.4 (January 27, 2019)
+# 0.2.4 (January 27, 2020)
 
 ### Fixed
 - generics on `#[tokio::main]` function ([#2177]).
@@ -11,12 +19,12 @@
 ### Added
 - support for `tokio::select!` ([#2152]).
 
-# 0.2.3 (January 7, 2019)
+# 0.2.3 (January 7, 2020)
 
 ### Fixed
 - Revert breaking change.
 
-# 0.2.2 (January 7, 2019)
+# 0.2.2 (January 7, 2020)
 
 ### Added
 - General refactoring and inclusion of additional runtime options ([#2022] and [#2038])
@@ -30,6 +38,10 @@
 
 - Initial release
 
+[#2697]: https://github.com/tokio-rs/tokio/pull/2697
+[#2683]: https://github.com/tokio-rs/tokio/pull/2683
+[#2521]: https://github.com/tokio-rs/tokio/pull/2521
+[#2503]: https://github.com/tokio-rs/tokio/pull/2503
 [#2225]: https://github.com/tokio-rs/tokio/pull/2225
 [#2177]: https://github.com/tokio-rs/tokio/pull/2177
 [#2152]: https://github.com/tokio-rs/tokio/pull/2152

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,14 +6,14 @@ name = "tokio-macros"
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.
-# - Create "v0.1.x" git tag.
-version = "0.2.5"
+# - Create "v0.2.x" git tag.
+version = "0.2.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.2.5/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.2.6/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.5")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.2.6")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
# 0.2.6 (November 11, 2020)

### Changes

 - disambiguate the built-in `#[test]` attribute in macro expansion (#2503)
 - warn about renaming the Tokio dependency (#2521)
 - various documentation changes (#2683, #2697)