### PR TITLE
net: add TcpStream::ready and non-blocking ops

### DIFF
--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -61,7 +61,8 @@ impl Interest {
 
     /// Add together two `Interst` values.
     ///
-    /// This function works from a `const` context.
+    /// This method is an alias for the `|` operator that works from a
+    /// `const` context.
     ///
     /// # Examples
     ///

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -1,14 +1,18 @@
-use crate::io::Ready;
+#![cfg_attr(not(feature = "net"), allow(unreachable_pub))]
+
+use crate::io::driver::Ready;
 
 use std::fmt;
 use std::ops;
 
-/// Readiness event interest
-///
-/// Specifies the readiness events the caller is interested in when awaiting on
-/// I/O resource readiness states.
-#[derive(Clone, Copy, Eq, PartialEq)]
-pub struct Interest(mio::Interest);
+cfg_net! {
+    /// Readiness event interest
+    ///
+    /// Specifies the readiness events the caller is interested in when awaiting on
+    /// I/O resource readiness states.
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    pub struct Interest(mio::Interest);
+}
 
 impl Interest {
     /// Interest in all readable events.

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -5,14 +5,13 @@ use crate::io::driver::Ready;
 use std::fmt;
 use std::ops;
 
-cfg_net! {
-    /// Readiness event interest
-    ///
-    /// Specifies the readiness events the caller is interested in when awaiting on
-    /// I/O resource readiness states.
-    #[derive(Clone, Copy, Eq, PartialEq)]
-    pub struct Interest(mio::Interest);
-}
+/// Readiness event interest
+///
+/// Specifies the readiness events the caller is interested in when awaiting on
+/// I/O resource readiness states.
+#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct Interest(mio::Interest);
 
 impl Interest {
     /// Interest in all readable events.
@@ -61,8 +60,7 @@ impl Interest {
 
     /// Add together two `Interst` values.
     ///
-    /// This method is an alias for the `|` operator that works from a
-    /// `const` context.
+    /// This function works from a `const` context.
     ///
     /// # Examples
     ///

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -1,10 +1,12 @@
 #![cfg_attr(not(feature = "rt"), allow(dead_code))]
 
 mod interest;
-pub(crate) use interest::Interest;
+#[allow(unreachable_pub)]
+pub use interest::Interest;
 
 mod ready;
-use ready::Ready;
+#[allow(unreachable_pub)]
+pub use ready::Ready;
 
 mod registration;
 pub(crate) use registration::Registration;
@@ -51,7 +53,7 @@ pub(crate) struct Handle {
 
 pub(crate) struct ReadyEvent {
     tick: u8,
-    ready: Ready,
+    pub(crate) ready: Ready,
 }
 
 pub(super) struct Inner {

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "net"), allow(unreachable_pub))]
+
 use std::fmt;
 use std::ops;
 
@@ -6,11 +8,13 @@ const WRITABLE: usize = 0b0_10;
 const READ_CLOSED: usize = 0b0_0100;
 const WRITE_CLOSED: usize = 0b0_1000;
 
-/// Describes the readiness state of an I/O resources.
-///
-/// `Ready` tracks which operation an I/O resource is ready to perform.
-#[derive(Clone, Copy, PartialEq, PartialOrd)]
-pub struct Ready(usize);
+cfg_net! {
+    /// Describes the readiness state of an I/O resources.
+    ///
+    /// `Ready` tracks which operation an I/O resource is ready to perform.
+    #[derive(Clone, Copy, PartialEq, PartialOrd)]
+    pub struct Ready(usize);
+}
 
 impl Ready {
     /// Returns the empty `Ready` set.

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -80,7 +80,7 @@ impl Ready {
     /// assert!(Ready::READ_CLOSED.is_readable());
     /// assert!(!Ready::WRITABLE.is_readable());
     /// ```
-    pub(crate) fn is_readable(self) -> bool {
+    pub fn is_readable(self) -> bool {
         self.contains(Ready::READABLE) || self.is_read_closed()
     }
 
@@ -96,7 +96,7 @@ impl Ready {
     /// assert!(Ready::WRITABLE.is_writable());
     /// assert!(Ready::WRITE_CLOSED.is_writable());
     /// ```
-    pub(crate) fn is_writable(self) -> bool {
+    pub fn is_writable(self) -> bool {
         self.contains(Ready::WRITABLE) || self.is_write_closed()
     }
 
@@ -111,7 +111,7 @@ impl Ready {
     /// assert!(!Ready::READABLE.is_read_closed());
     /// assert!(Ready::READ_CLOSED.is_read_closed());
     /// ```
-    pub(crate) fn is_read_closed(self) -> bool {
+    pub fn is_read_closed(self) -> bool {
         self.contains(Ready::READ_CLOSED)
     }
 
@@ -126,7 +126,7 @@ impl Ready {
     /// assert!(!Ready::WRITABLE.is_write_closed());
     /// assert!(Ready::WRITE_CLOSED.is_write_closed());
     /// ```
-    pub(crate) fn is_write_closed(self) -> bool {
+    pub fn is_write_closed(self) -> bool {
         self.contains(Ready::WRITE_CLOSED)
     }
 

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -194,37 +194,37 @@ cfg_io_readiness! {
     }
 }
 
-impl<T: Into<Ready>> ops::BitOr<T> for Ready {
+impl ops::BitOr<Ready> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn bitor(self, other: T) -> Ready {
-        Ready(self.0 | other.into().0)
+    fn bitor(self, other: Ready) -> Ready {
+        Ready(self.0 | other.0)
     }
 }
 
-impl<T: Into<Ready>> ops::BitOrAssign<T> for Ready {
+impl ops::BitOrAssign<Ready> for Ready {
     #[inline]
-    fn bitor_assign(&mut self, other: T) {
-        self.0 |= other.into().0;
+    fn bitor_assign(&mut self, other: Ready) {
+        self.0 |= other.0;
     }
 }
 
-impl<T: Into<Ready>> ops::BitAnd<T> for Ready {
+impl ops::BitAnd<Ready> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn bitand(self, other: T) -> Ready {
-        Ready(self.0 & other.into().0)
+    fn bitand(self, other: Ready) -> Ready {
+        Ready(self.0 & other.0)
     }
 }
 
-impl<T: Into<Ready>> ops::Sub<T> for Ready {
+impl ops::Sub<Ready> for Ready {
     type Output = Ready;
 
     #[inline]
-    fn sub(self, other: T) -> Ready {
-        Ready(self.0 & !other.into().0)
+    fn sub(self, other: Ready) -> Ready {
+        Ready(self.0 & !other.0)
     }
 }
 

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -8,13 +8,12 @@ const WRITABLE: usize = 0b0_10;
 const READ_CLOSED: usize = 0b0_0100;
 const WRITE_CLOSED: usize = 0b0_1000;
 
-cfg_net! {
-    /// Describes the readiness state of an I/O resources.
-    ///
-    /// `Ready` tracks which operation an I/O resource is ready to perform.
-    #[derive(Clone, Copy, PartialEq, PartialOrd)]
-    pub struct Ready(usize);
-}
+/// Describes the readiness state of an I/O resources.
+///
+/// `Ready` tracks which operation an I/O resource is ready to perform.
+#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub struct Ready(usize);
 
 impl Ready {
     /// Returns the empty `Ready` set.

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -6,36 +6,32 @@ const WRITABLE: usize = 0b0_10;
 const READ_CLOSED: usize = 0b0_0100;
 const WRITE_CLOSED: usize = 0b0_1000;
 
-/// A set of readiness event kinds.
+/// Describes the readiness state of an I/O resources.
 ///
-/// `Ready` is set of operation descriptors indicating which kind of an
-/// operation is ready to be performed.
-///
-/// This struct only represents portable event kinds. Portable events are
-/// events that can be raised on any platform while guaranteeing no false
-/// positives.
+/// `Ready` tracks which operation an I/O resource is ready to perform.
 #[derive(Clone, Copy, PartialEq, PartialOrd)]
-pub(crate) struct Ready(usize);
+pub struct Ready(usize);
 
 impl Ready {
     /// Returns the empty `Ready` set.
-    pub(crate) const EMPTY: Ready = Ready(0);
+    pub const EMPTY: Ready = Ready(0);
 
     /// Returns a `Ready` representing readable readiness.
-    pub(crate) const READABLE: Ready = Ready(READABLE);
+    pub const READABLE: Ready = Ready(READABLE);
 
     /// Returns a `Ready` representing writable readiness.
-    pub(crate) const WRITABLE: Ready = Ready(WRITABLE);
+    pub const WRITABLE: Ready = Ready(WRITABLE);
 
     /// Returns a `Ready` representing read closed readiness.
-    pub(crate) const READ_CLOSED: Ready = Ready(READ_CLOSED);
+    pub const READ_CLOSED: Ready = Ready(READ_CLOSED);
 
     /// Returns a `Ready` representing write closed readiness.
-    pub(crate) const WRITE_CLOSED: Ready = Ready(WRITE_CLOSED);
+    pub const WRITE_CLOSED: Ready = Ready(WRITE_CLOSED);
 
     /// Returns a `Ready` representing readiness for all operations.
-    pub(crate) const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED);
+    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED);
 
+    // Must remain crate-private to avoid adding a public dependency on Mio.
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {
         let mut ready = Ready::EMPTY;
 
@@ -59,26 +55,77 @@ impl Ready {
     }
 
     /// Returns true if `Ready` is the empty set
-    pub(crate) fn is_empty(self) -> bool {
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(Ready::EMPTY.is_empty());
+    /// assert!(!Ready::READABLE.is_empty());
+    /// ```
+    pub fn is_empty(self) -> bool {
         self == Ready::EMPTY
     }
 
-    /// Returns true if the value includes readable readiness
+    /// Returns `true` if the value includes `readable`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_readable());
+    /// assert!(Ready::READABLE.is_readable());
+    /// assert!(Ready::READ_CLOSED.is_readable());
+    /// assert!(!Ready::WRITABLE.is_readable());
+    /// ```
     pub(crate) fn is_readable(self) -> bool {
         self.contains(Ready::READABLE) || self.is_read_closed()
     }
 
-    /// Returns true if the value includes writable readiness
+    /// Returns `true` if the value includes writable `readiness`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_writable());
+    /// assert!(!Ready::READABLE.is_writable());
+    /// assert!(Ready::WRITABLE.is_writable());
+    /// assert!(Ready::WRITE_CLOSED.is_writable());
+    /// ```
     pub(crate) fn is_writable(self) -> bool {
         self.contains(Ready::WRITABLE) || self.is_write_closed()
     }
 
-    /// Returns true if the value includes read closed readiness
+    /// Returns `true` if the value includes read-closed `readiness`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_read_closed());
+    /// assert!(!Ready::READABLE.is_read_closed());
+    /// assert!(Ready::READ_CLOSED.is_read_closed());
+    /// ```
     pub(crate) fn is_read_closed(self) -> bool {
         self.contains(Ready::READ_CLOSED)
     }
 
-    /// Returns true if the value includes write closed readiness
+    /// Returns `true` if the value includes write-closed `readiness`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_write_closed());
+    /// assert!(!Ready::WRITABLE.is_write_closed());
+    /// assert!(Ready::WRITE_CLOSED.is_write_closed());
+    /// ```
     pub(crate) fn is_write_closed(self) -> bool {
         self.contains(Ready::WRITE_CLOSED)
     }

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -280,6 +280,15 @@ impl ScheduledIo {
         }
     }
 
+    pub(super) fn ready_event(&self, interest: Interest) -> ReadyEvent {
+        let curr = self.readiness.load(Acquire);
+
+        ReadyEvent {
+            tick: TICK.unpack(curr) as u8,
+            ready: interest.mask() & Ready::from_usize(READINESS.unpack(curr)),
+        }
+    }
+
     /// Poll version of checking readiness for a certain direction.
     ///
     /// These are to support `AsyncRead` and `AsyncWrite` polling methods,

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -1,4 +1,4 @@
-use super::{Ready, ReadyEvent, Tick};
+use super::{Interest, Ready, ReadyEvent, Tick};
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Mutex;
 use crate::util::bit;
@@ -49,8 +49,6 @@ struct Waiters {
 }
 
 cfg_io_readiness! {
-    use crate::io::Interest;
-
     #[derive(Debug)]
     struct Waiter {
         pointers: linked_list::Pointers<Waiter>,

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -204,9 +204,12 @@ pub use self::read_buf::ReadBuf;
 #[doc(no_inline)]
 pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 
-cfg_io_driver! {
+cfg_io_driver_impl! {
     pub(crate) mod driver;
-    pub use driver::{Interest, Ready};
+
+    cfg_net! {
+        pub use driver::{Interest, Ready};
+    }
 
     mod poll_evented;
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -206,7 +206,7 @@ pub use std::io::{Error, ErrorKind, Result, SeekFrom};
 
 cfg_io_driver! {
     pub(crate) mod driver;
-    pub(crate) use driver::Interest;
+    pub use driver::{Interest, Ready};
 
     mod poll_evented;
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -79,6 +79,19 @@ macro_rules! cfg_io_driver {
     }
 }
 
+macro_rules! cfg_io_driver_impl {
+    ( $( $item:item )* ) => {
+        $(
+            #[cfg(any(
+                feature = "net",
+                feature = "process",
+                all(unix, feature = "signal"),
+            ))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_not_io_driver {
     ($($item:item)*) => {
         $(

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -366,6 +366,9 @@ impl TcpStream {
     ///
     /// Usually, [`readable()`] or [`ready()`] is used with this function.
     ///
+    /// [`readable()`]: TcpStream::readable()
+    /// [`ready()`]: TcpStream::ready()
+    ///
     /// # Return
     ///
     /// If data is successfully read, `Ok(n)` is returned, where `n` is the

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -270,6 +270,12 @@ impl TcpStream {
         Ok(event.ready)
     }
 
+    /// Wait for the socket to become readable.
+    pub async fn readable(&self) -> io::Result<()> {
+        self.ready(Interest::READABLE).await?;
+        Ok(())
+    }
+
     /// Attempt a non-blocking read.
     pub fn try_read(&self, buf: &mut [u8]) -> io::Result<usize> {
         use std::io::Read;
@@ -277,6 +283,12 @@ impl TcpStream {
         self.io.registration().try_io(Interest::READABLE, || {
             (&*self.io).read(buf)
         })
+    }
+
+    /// Wait for the socket to become writable.
+    pub async fn writable(&self) -> io::Result<()> {
+        self.ready(Interest::WRITABLE).await?;
+        Ok(())
     }
 
     /// Attempt a non-blocking write.

--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -2,8 +2,8 @@
 
 //! Signal driver
 
-use crate::io::driver::Driver as IoDriver;
-use crate::io::{Interest, PollEvented};
+use crate::io::driver::{Driver as IoDriver, Interest};
+use crate::io::PollEvented;
 use crate::park::Park;
 use crate::signal::registry::globals;
 

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -1,0 +1,82 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::Interest;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_test::{assert_pending, assert_ready_ok};
+use tokio_test::task;
+
+use std::io;
+
+#[tokio::test]
+async fn try_read_write() {
+    const DATA: &[u8] = b"this is some data to write to the socket";
+
+    // Create listener
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    // Create socket pair
+    let client = TcpStream::connect(listener.local_addr().unwrap()).await.unwrap();
+    let (server, _) = listener.accept().await.unwrap();
+    let mut written = DATA.to_vec();
+
+    // Track the server receiving data
+    let mut readable = task::spawn(server.readable());
+    assert_pending!(readable.poll());
+
+    // Write data.
+    client.writable().await.unwrap();
+    assert_eq!(DATA.len(), client.try_write(DATA).unwrap());
+
+    // The task should be notified
+    while !readable.is_woken() {
+        tokio::task::yield_now().await;
+    }
+
+    // Fill the write buffer
+    loop {
+        // Still ready
+        let mut writable = task::spawn(client.writable());
+        assert_ready_ok!(writable.poll());
+    
+        match client.try_write(DATA) {
+            Ok(n) => written.extend(&DATA[..n]),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                break;
+            }
+            Err(e) => panic!("error = {:?}", e),
+        }
+    }
+
+    {
+        // Write buffer full
+        let mut writable = task::spawn(client.writable());
+        assert_pending!(writable.poll());
+
+        // Drain the socket from the server end
+        let mut read = vec![0; written.len()];
+        let mut i = 0;
+
+        while i < read.len() {
+            server.readable().await.unwrap();
+
+            let n = server.try_read(&mut read[i..]).unwrap();
+            i += n;
+        }
+
+        assert_eq!(read, written);
+    }
+
+    // Now, we listen for shutdown
+    drop(client);
+
+    loop {
+        let ready = server.ready(Interest::READABLE).await.unwrap();
+
+        if ready.is_read_closed() {
+            return;
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+}

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -3,8 +3,8 @@
 
 use tokio::io::Interest;
 use tokio::net::{TcpListener, TcpStream};
-use tokio_test::{assert_pending, assert_ready_ok};
 use tokio_test::task;
+use tokio_test::{assert_pending, assert_ready_ok};
 
 use std::io;
 
@@ -16,7 +16,9 @@ async fn try_read_write() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
 
     // Create socket pair
-    let client = TcpStream::connect(listener.local_addr().unwrap()).await.unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap())
+        .await
+        .unwrap();
     let (server, _) = listener.accept().await.unwrap();
     let mut written = DATA.to_vec();
 
@@ -38,7 +40,7 @@ async fn try_read_write() {
         // Still ready
         let mut writable = task::spawn(client.writable());
         assert_ready_ok!(writable.poll());
-    
+
         match client.try_write(DATA) {
             Ok(n) => written.extend(&DATA[..n]),
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -62,8 +62,11 @@ async fn try_read_write() {
         while i < read.len() {
             server.readable().await.unwrap();
 
-            let n = server.try_read(&mut read[i..]).unwrap();
-            i += n;
+            match server.try_read(&mut read[i..]) {
+                Ok(n) => i += n,
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => panic!("error = {:?}", e),
+            }
         }
 
         assert_eq!(read, written);

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -82,3 +82,28 @@ async fn try_read_write() {
         }
     }
 }
+
+#[test]
+fn buffer_not_included_in_future() {
+    use std::mem;
+
+    const N: usize = 4096;
+
+    let fut = async {
+        let stream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
+
+        loop {
+            stream.readable().await.unwrap();
+
+            let mut buf = [0; N];
+            let n = stream.try_read(&mut buf[..]).unwrap();
+
+            if n == 0 {
+                break;
+            }
+        }
+    };
+
+    let n = mem::size_of_val(&fut);
+    assert!(n < 1000);
+}


### PR DESCRIPTION
Adds function to await for readiness on the TcpStream and non-blocking read/write functions.

`async fn TcpStream::ready(Interest)` waits for socket readiness satisfying **any** of the specified interest. There are also two shorthand functions, `readable()` and `writable()`.

Once the stream is in a ready state, the caller may perform non-blocking operations on it using `try_read()` and `try_write()`. These function return `WouldBlock` if the stream is not, in fact, ready.

The await readiness function are similar to `AsyncFd`, but do not require a guard. The guard in `AsyncFd` protect against a potential race between receiving the readiness notification and clearing it. The guard is needed as Tokio does not control the operations. With `TcpStream`, the `try_read()` and `try_write()` function handle clearing stream readiness as needed.

This also exposes `Interest` and `Ready`, both defined in Tokio as wrappers for Mio types. These types will also be useful for fixing #3072 .

Other I/O types, such as `TcpListener`, `UdpSocket`, `Unix*` should get similar functions, but this is left for later PRs.

Refs: #3130