### PR TITLE
ci: minimal version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,13 @@ jobs:
           toolchain: ${{ env.nightly }}
           override: true
       - name: "check --all-features -Z minimal-versions"
-        run: cargo check --all-features -Z minimal-versions
+        run: |
+          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+          # from determining minimal versions based on dev-dependencies.
+          cargo hack --remove-dev-deps --workspace
+          # Update Cargo.lock to minimal version dependencies.
+          cargo update -Z minimal-versions
+          cargo check --all-features
 
   fmt:
     name: fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,18 @@ jobs:
       - name: "test --workspace --all-features"
         run: cargo check --workspace --all-features
 
+  minimal-versions:
+    name: minimal-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          override: true
+      - name: "check --all-features -Z minimal-versions"
+        run: cargo check --all-features -Z minimal-versions
+
   fmt:
     name: fmt
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,8 @@ jobs:
         with:
           toolchain: ${{ env.nightly }}
           override: true
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
       - name: "check --all-features -Z minimal-versions"
         run: |
           # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -96,7 +96,7 @@ pin-project-lite = "0.1.1"
 # Everything else is optional...
 bytes = { version = "0.6.0", optional = true }
 futures-core = { version = "0.3.0", optional = true }
-lazy_static = { version = "1.0.2", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.5", optional = true }
 num_cpus = { version = "1.8.0", optional = true }


### PR DESCRIPTION
This checks that crates compile with the minimum allowed version of each dependency.