### PR TITLE
ci: minimal version check (v0.2.x)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,9 +180,16 @@ jobs:
         with:
           toolchain: ${{ env.nightly }}
           override: true
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
       - name: "check --all-features -Z minimal-versions"
-        run: cargo check --all-features -Z minimal-versions
-
+        run: |
+          # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
+          # from determining minimal versions based on dev-dependencies.
+          cargo hack --remove-dev-deps --workspace
+          # Update Cargo.lock to minimal version dependencies.
+          cargo update -Z minimal-versions
+          cargo check --all-features
 
   fmt:
     name: fmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,19 @@ jobs:
       - name: "test --workspace --all-features"
         run: cargo check --workspace --all-features
 
+  minimal-versions:
+    name: minimal-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          override: true
+      - name: "check --all-features -Z minimal-versions"
+        run: cargo check --all-features -Z minimal-versions
+
+
   fmt:
     name: fmt
     runs-on: ubuntu-latest

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -38,7 +38,7 @@ bytes = "0.5.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }
-log = "0.4"
+log = "0.4.6"
 pin-project-lite = "0.1.4"
 
 [dev-dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -99,7 +99,7 @@ pin-project-lite = "0.1.1"
 # Everything else is optional...
 fnv = { version = "1.0.6", optional = true }
 futures-core = { version = "0.3.0", optional = true }
-lazy_static = { version = "1.0.2", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.6.20", optional = true }
 iovec = { version = "0.1.4", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -105,7 +105,7 @@ mio = { version = "0.6.20", optional = true }
 iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true } # Not in full
-slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
+slab = { version = "0.4.2", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This checks that crates compile with the minimum allowed version of each dependency.

Backport of #3131