### PR TITLE
chore: update pin-project-lite to 0.2.0

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -41,7 +41,7 @@ futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }
 log = "0.4"
-pin-project-lite = "0.1.4"
+pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -91,7 +91,7 @@ time = []
 [dependencies]
 tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }
 
-pin-project-lite = "0.1.1"
+pin-project-lite = "0.2.0"
 
 # Everything else is optional...
 bytes = { version = "0.6.0", optional = true }


### PR DESCRIPTION
This release added support for enum, but all enums that require pin-projection used in tokio/tokio-util have tuple variants and are also public APIs. So, unfortunately, we cannot use pin-project-lite for these enums.