### PR TITLE
net: reintroduce getter/setter for SO_LINGER to tokio::net::tcp::stream

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -98,7 +98,7 @@ bytes = { version = "0.6.0", optional = true }
 futures-core = { version = "0.3.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 memchr = { version = "2.2", optional = true }
-mio = { version = "0.7.5", optional = true }
+mio = { version = "0.7.6", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
 slab = { version = "0.4.1", optional = true }

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -690,13 +690,9 @@ impl TcpStream {
     /// # }
     /// ```
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        let mio_socket = self.to_mio();
+        let mio_socket = std::mem::ManuallyDrop::new(self.to_mio());
 
-        let result = mio_socket.get_linger();
-
-        std::mem::forget(mio_socket);
-
-        result
+        mio_socket.get_linger()
     }
 
     /// Sets the linger duration of this socket by setting the SO_LINGER option.
@@ -721,12 +717,9 @@ impl TcpStream {
     /// # }
     /// ```
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
-        let mio_socket = self.to_mio();
+        let mio_socket = std::mem::ManuallyDrop::new(self.to_mio());
 
-        let result = mio_socket.set_linger(dur);
-
-        std::mem::forget(mio_socket);
-        result
+        mio_socket.set_linger(dur)
     }
 
     fn to_mio(&self) -> mio::net::TcpSocket {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -732,12 +732,12 @@ impl TcpStream {
     fn to_mio(&self) -> mio::net::TcpSocket {
         #[cfg(windows)]
         {
-            return unsafe { mio::net::TcpSocket::from_raw_socket(self.as_raw_socket()) };
+           unsafe { mio::net::TcpSocket::from_raw_socket(self.as_raw_socket()) }
         }
 
         #[cfg(unix)]
         {
-            return unsafe { mio::net::TcpSocket::from_raw_fd(self.as_raw_fd()) };
+            unsafe { mio::net::TcpSocket::from_raw_fd(self.as_raw_fd()) }
         }
     }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -732,7 +732,7 @@ impl TcpStream {
     fn to_mio(&self) -> mio::net::TcpSocket {
         #[cfg(windows)]
         {
-           unsafe { mio::net::TcpSocket::from_raw_socket(self.as_raw_socket()) }
+            unsafe { mio::net::TcpSocket::from_raw_socket(self.as_raw_socket()) }
         }
 
         #[cfg(unix)]

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -9,8 +9,24 @@ use tokio_test::{assert_ok, assert_pending, assert_ready_ok};
 
 use std::io;
 use std::task::Poll;
+use std::time::Duration;
 
 use futures::future::poll_fn;
+
+#[tokio::test]
+async fn set_linger() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    let stream = TcpStream::connect(listener.local_addr().unwrap())
+        .await
+        .unwrap();
+
+    assert_ok!(stream.set_linger(Some(Duration::from_secs(1))));
+    assert_eq!(stream.linger().unwrap().unwrap().as_secs(), 1);
+
+    assert_ok!(stream.set_linger(None));
+    assert!(stream.linger().unwrap().is_none());
+}
 
 #[tokio::test]
 async fn try_read_write() {


### PR DESCRIPTION
## Motivation
The ability to set_linger option on a TcpStream was removed in v0.3 so that TcpStream could be similar to std. I wasn't able to find the reason for why this `set_linger` was removed from std's TcpStream.

This PR reintroduces this option.

## Solution

Convert the stream using it's raw fd to get a mio TcpSocket and set the option.
