### PR TITLE
chore: format with latest stable rustfmt

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -193,17 +193,23 @@ fn parse_knobs(
                 let name = ident.unwrap().to_string().to_lowercase();
                 let msg = match name.as_str() {
                     "threaded_scheduler" | "multi_thread" => {
-                        format!("Set the runtime flavor with #[{}(flavor = \"multi_thread\")].", macro_name)
-                    },
+                        format!(
+                            "Set the runtime flavor with #[{}(flavor = \"multi_thread\")].",
+                            macro_name
+                        )
+                    }
                     "basic_scheduler" | "current_thread" | "single_threaded" => {
-                        format!("Set the runtime flavor with #[{}(flavor = \"current_thread\")].", macro_name)
-                    },
+                        format!(
+                            "Set the runtime flavor with #[{}(flavor = \"current_thread\")].",
+                            macro_name
+                        )
+                    }
                     "flavor" | "worker_threads" => {
                         format!("The `{}` attribute requires an argument.", name)
-                    },
+                    }
                     name => {
                         format!("Unknown attribute {} is specified; expected one of: `flavor`, `worker_threads`", name)
-                    },
+                    }
                 };
                 return Err(syn::Error::new_spanned(path, msg));
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

rustfmt check currently failing on master.

https://github.com/tokio-rs/tokio/pull/3156#issuecomment-730875228

> Probably something was fixed in Rust 1.48 stable. (It looks like modules that were not previously formatted correctly are now formatted.)

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
