### PR TITLE
Support aborting a task remotely in a multithreaded runtime without panicking

### DIFF
--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -1,0 +1,26 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+/// Checks that a suspended task can be aborted without panicking as reported in
+/// issue #3157: <https://github.com/tokio-rs/tokio/issues/3157>.
+#[test]
+fn test_abort_without_panic_3157() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_time()
+        .worker_threads(1)
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        let handle = tokio::spawn(async move {
+            println!("task started");
+            tokio::time::sleep(std::time::Duration::new(100, 0)).await
+        });
+
+        // wait for task to sleep.
+        tokio::time::sleep(std::time::Duration::new(1, 0)).await;
+
+        handle.abort();
+        let _ = handle.await;
+    });
+}


### PR DESCRIPTION
We have an issue in #3157 where a call to `JoinHandle::abort` releases a task, causing a panic because the current implementation of `release` for a thread pool requires it to be called from within a worker context.

This change makes access of  the thread-local context optional under release, by falling back to remotely marking a task remotely as dropped. Behaving the same as if the core was stolen by another worker.

Needs a review by someone familiar with the scheduler, cause I'm not entirely sure I've grok:ed the internals well enough.
