### PR TITLE
Add async-spawner support.

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -30,6 +30,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
+async-spawner = "1.0.0"
 tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -246,10 +246,24 @@ fn parse_knobs(
         }
     };
 
+    let spawner = if is_test {
+        quote! {}
+    } else {
+        quote! {
+            use core::future::Future;
+            use core::pin::Pin;
+            fn spawn(future: Pin<Box<dyn Future<Output = ()> + Send>>) {
+                tokio::spawn(future);
+            }
+            tokio::register_spawner(spawn);
+        }
+    };
+
     let result = quote! {
         #header
         #(#attrs)*
         #vis #sig {
+            #spawner
             #rt
                 .enable_all()
                 .build()

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -48,7 +48,7 @@ fs = []
 io-util = ["memchr", "bytes"]
 # stdin, stdout, stderr
 io-std = []
-macros = ["tokio-macros"]
+macros = ["async-spawner", "tokio-macros"]
 net = [
   "lazy_static",
   "libc",
@@ -94,6 +94,7 @@ tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }
 pin-project-lite = "0.2.0"
 
 # Everything else is optional...
+async-spawner = { version = "1.0.0", optional = true }
 bytes = { version = "0.6.0", optional = true }
 futures-core = { version = "0.3.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -416,6 +416,10 @@ cfg_macros! {
             #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
             pub use tokio_macros::main;
 
+            #[cfg(not(test))] // Work around for rust-lang/rust#62127
+            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+            pub use async_spawner::register_spawner;
+
             #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
             pub use tokio_macros::test;
         }


### PR DESCRIPTION
This allows spawning tasks independent of the executor. So now the only thing you have to do to change your executor is change the `#[async_std::main]` to `#[tokio::main]` and vice versa. This is very useful for library authors that want their code to just work.