### PR TITLE
Efficient implementation of vectored writes for BufWriter

### DIFF
--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -2,7 +2,7 @@ use crate::io::util::DEFAULT_BUF_SIZE;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use pin_project_lite::pin_project;
-use std::io::{self, SeekFrom};
+use std::io::{self, IoSlice, SeekFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{cmp, fmt, mem};
@@ -266,6 +266,18 @@ impl<R: AsyncRead + AsyncWrite> AsyncWrite for BufReader<R> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         self.get_pin_mut().poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.get_pin_mut().poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.get_ref().is_write_vectored()
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/tokio/src/io/util/buf_stream.rs
+++ b/tokio/src/io/util/buf_stream.rs
@@ -2,7 +2,7 @@ use crate::io::util::{BufReader, BufWriter};
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use pin_project_lite::pin_project;
-use std::io::{self, SeekFrom};
+use std::io::{self, IoSlice, SeekFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -125,6 +125,18 @@ impl<RW: AsyncRead + AsyncWrite> AsyncWrite for BufStream<RW> {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         self.project().inner.poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -174,6 +174,7 @@ impl<W: AsyncWrite> AsyncWrite for BufWriter<W> {
             if first_len >= me.buf.capacity() {
                 // The slice is at least as large as the buffering capacity,
                 // so it's better to write it directly, bypassing the buffer.
+                debug_assert!(me.buf.is_empty());
                 return me.inner.poll_write(cx, &bufs[0]);
             } else {
                 me.buf.extend_from_slice(&bufs[0]);

--- a/tokio/tests/support/io_vec.rs
+++ b/tokio/tests/support/io_vec.rs
@@ -1,0 +1,45 @@
+use std::io::IoSlice;
+use std::ops::Deref;
+use std::slice;
+
+pub struct IoBufs<'a, 'b>(&'b mut [IoSlice<'a>]);
+
+impl<'a, 'b> IoBufs<'a, 'b> {
+    pub fn new(slices: &'b mut [IoSlice<'a>]) -> Self {
+        IoBufs(slices)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn advance(mut self, n: usize) -> IoBufs<'a, 'b> {
+        let mut to_remove = 0;
+        let mut remaining_len = n;
+        for slice in self.0.iter() {
+            if remaining_len < slice.len() {
+                break;
+            } else {
+                remaining_len -= slice.len();
+                to_remove += 1;
+            }
+        }
+        self.0 = self.0.split_at_mut(to_remove).1;
+        if let Some(slice) = self.0.first_mut() {
+            let tail = &slice[remaining_len..];
+            // Safety: recasts slice to the original lifetime
+            let tail = unsafe { slice::from_raw_parts(tail.as_ptr(), tail.len()) };
+            *slice = IoSlice::new(tail);
+        } else if remaining_len != 0 {
+            panic!("advance past the end of the slice vector");
+        }
+        self
+    }
+}
+
+impl<'a, 'b> Deref for IoBufs<'a, 'b> {
+    type Target = [IoSlice<'a>];
+    fn deref(&self) -> &[IoSlice<'a>] {
+        self.0
+    }
+}


### PR DESCRIPTION
## Motivation

With vectored writes reintroduced in #3149, `BufWriter` can provide an efficient implementation both with or without vectored write support in the underlying writer, and advertise it with `is_write_vectored`.

## Solution

Provide a custom implementation of `AsyncWrite::poll_write_vectored` by coalescing data from the slices in the buffer, unless it is more efficient to pass one or all of them directly to the underlying writer. This needs to be optimized differently depending on whether the underlying writer supports efficient vectored output.