### PR TITLE
feat: add mutable buffer api to FramedRead

### DIFF
--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -100,6 +100,11 @@ impl<T, D> FramedRead<T, D> {
     pub fn read_buffer(&self) -> &BytesMut {
         &self.inner.state.buffer
     }
+
+    /// Returns a mutable reference to the read buffer.
+    pub fn read_buffer_mut(&mut self) -> &mut BytesMut {
+        &mut self.inner.state.buffer
+    }
 }
 
 // This impl just defers to the underlying FramedImpl


### PR DESCRIPTION
fix #3165 

Can this PR also be patched to the 0.3.x version of `tokio-util`?