### PR TITLE
Replace lazy_static with once_cell

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -50,7 +50,6 @@ io-util = ["memchr", "bytes"]
 io-std = []
 macros = ["tokio-macros"]
 net = [
-  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/os-util",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -50,7 +50,7 @@ io-util = ["memchr", "bytes"]
 io-std = []
 macros = ["tokio-macros"]
 net = [
-  "lazy_static",
+  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/os-util",
@@ -60,7 +60,7 @@ net = [
 ]
 process = [
   "bytes",
-  "lazy_static",
+  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/os-util",
@@ -75,7 +75,7 @@ rt-multi-thread = [
   "rt",
 ]
 signal = [
-  "lazy_static",
+  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/uds",
@@ -96,7 +96,7 @@ pin-project-lite = "0.2.0"
 # Everything else is optional...
 bytes = { version = "0.6.0", optional = true }
 futures-core = { version = "0.3.0", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
+once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.6", optional = true }
 num_cpus = { version = "1.8.0", optional = true }

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -36,6 +36,7 @@ use crate::signal::unix::{signal, Signal, SignalKind};
 
 use mio::event::Source;
 use mio::unix::SourceFd;
+use once_cell::sync::Lazy;
 use std::fmt;
 use std::fs::File;
 use std::future::Future;
@@ -62,9 +63,7 @@ impl Kill for StdChild {
     }
 }
 
-lazy_static::lazy_static! {
-    static ref ORPHAN_QUEUE: OrphanQueueImpl<StdChild> = OrphanQueueImpl::new();
-}
+static ORPHAN_QUEUE: Lazy<OrphanQueueImpl<StdChild>> = Lazy::new(|| OrphanQueueImpl::new());
 
 pub(crate) struct GlobalOrphanQueue;
 

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -63,7 +63,7 @@ impl Kill for StdChild {
     }
 }
 
-static ORPHAN_QUEUE: Lazy<OrphanQueueImpl<StdChild>> = Lazy::new(|| OrphanQueueImpl::new());
+static ORPHAN_QUEUE: Lazy<OrphanQueueImpl<StdChild>> = Lazy::new(OrphanQueueImpl::new);
 
 pub(crate) struct GlobalOrphanQueue;
 

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -4,7 +4,7 @@ use crate::signal::os::{OsExtraData, OsStorage};
 
 use crate::sync::mpsc::Sender;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use std::ops;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -165,12 +165,10 @@ where
     OsExtraData: 'static + Send + Sync + Init,
     OsStorage: 'static + Send + Sync + Init,
 {
-    lazy_static! {
-        static ref GLOBALS: Pin<Box<Globals>> = Box::pin(Globals {
-            extra: OsExtraData::init(),
-            registry: Registry::new(OsStorage::init()),
-        });
-    }
+    static GLOBALS: Lazy<Pin<Box<Globals>>> = Lazy::new(|| Box::pin(Globals {
+        extra: OsExtraData::init(),
+        registry: Registry::new(OsStorage::init()),
+    }));
 
     GLOBALS.as_ref()
 }

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -165,10 +165,12 @@ where
     OsExtraData: 'static + Send + Sync + Init,
     OsStorage: 'static + Send + Sync + Init,
 {
-    static GLOBALS: Lazy<Pin<Box<Globals>>> = Lazy::new(|| Box::pin(Globals {
-        extra: OsExtraData::init(),
-        registry: Registry::new(OsStorage::init()),
-    }));
+    static GLOBALS: Lazy<Pin<Box<Globals>>> = Lazy::new(|| {
+        Box::pin(Globals {
+            extra: OsExtraData::init(),
+            registry: Registry::new(OsStorage::init()),
+        })
+    });
 
     GLOBALS.as_ref()
 }


### PR DESCRIPTION
##  Motivation

`once_cell` is a macro-free alternative to `lazy_static`. Its `Lazy` type has the same API as `lazy_static`, but it will not use any "macro magic" and it might be more clear to read by non-experienced Rust developers.

This solution is being proposed to be implemented at the Rust standard library level with an [RFC](https://github.com/rust-lang/rfcs/pull/2788). This could be an opportunity to migrate to the new solution and to check that everything is working correctly in Tokio.

Furthermore, as per [this](https://github.com/async-rs/async-std/issues/406#issuecomment-547286625) comment, it seems that due to a possible compiler bug, using `once_cell` is noticeably faster than `lazy_static` in certain hot get operations.

## Solution

This PR replaces all mentions to `lazy_static` by `once_cell` using the built-in `Lazy` type.