### PR TITLE
sync: add_permits does not panic with usize::MAX >> 3

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -253,7 +253,7 @@ impl Semaphore {
             }
 
             if rem > 0 && is_empty {
-                let permits = rem << Self::PERMIT_SHIFT;
+                let permits = rem >> Self::PERMIT_SHIFT;
                 assert!(
                     permits < Self::MAX_PERMITS,
                     "cannot add more than MAX_PERMITS permits ({})",

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -253,9 +253,9 @@ impl Semaphore {
             }
 
             if rem > 0 && is_empty {
-                let permits = rem >> Self::PERMIT_SHIFT;
+                let permits = rem;
                 assert!(
-                    permits < Self::MAX_PERMITS,
+                    permits <= Self::MAX_PERMITS,
                     "cannot add more than MAX_PERMITS permits ({})",
                     Self::MAX_PERMITS
                 );

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -92,6 +92,11 @@ impl Semaphore {
     ///
     /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.
     pub fn add_permits(&self, n: usize) {
+        assert!(
+            self.ll_sem.available_permits() + n <= ll::Semaphore::MAX_PERMITS,
+            "Reached more than max {} permits",
+            ll::Semaphore::MAX_PERMITS
+        );
         self.ll_sem.release(n);
     }
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -92,11 +92,6 @@ impl Semaphore {
     ///
     /// The maximum number of permits is `usize::MAX >> 3`, and this function will panic if the limit is exceeded.
     pub fn add_permits(&self, n: usize) {
-        assert!(
-            self.ll_sem.available_permits() + n <= ll::Semaphore::MAX_PERMITS,
-            "Reached more than max {} permits",
-            ll::Semaphore::MAX_PERMITS
-        );
         self.ll_sem.release(n);
     }
 

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -84,6 +84,7 @@ async fn stresstest() {
 fn add_max_amount_permits() {
     let s = tokio::sync::Semaphore::new(0);
     s.add_permits(usize::MAX >> 3);
+    assert_eq!(s.available_permits(), usize::MAX >> 3);
 }
 
 #[test]

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -79,3 +79,9 @@ async fn stresstest() {
     let _p5 = sem.try_acquire().unwrap();
     assert!(sem.try_acquire().is_err());
 }
+
+#[test]
+fn add_max_amount_permits() {
+    let s = tokio::sync::Semaphore::new(0);
+    s.add_permits(usize::MAX >> 3);
+}

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -85,3 +85,10 @@ fn add_max_amount_permits() {
     let s = tokio::sync::Semaphore::new(0);
     s.add_permits(usize::MAX >> 3);
 }
+
+#[test]
+#[should_panic]
+fn add_more_than_max_amount_permits() {
+    let s = tokio::sync::Semaphore::new(1);
+    s.add_permits(usize::MAX >> 3);
+}


### PR DESCRIPTION
Fixed incorrect shift in the assignment of permits on batch_semaphore.rs

Fixes: #3095
