### PR TITLE
io: add a into_std method for tokio's TcpStream

### DIFF
--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -124,6 +124,17 @@ impl<E: Source> PollEvented<E> {
     pub(crate) fn registration(&self) -> &Registration {
         &self.registration
     }
+
+    /// Deregister the inner io from the registration and returns a Result containing the inner io
+    #[cfg(feature = "net")]
+    pub(crate) fn into_inner(mut self) -> io::Result<E> {
+        let mut inner = self
+            .io
+            .take()
+            .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+        self.registration.deregister(&mut inner)?;
+        Ok(inner)
+    }
 }
 
 feature! {

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -128,10 +128,7 @@ impl<E: Source> PollEvented<E> {
     /// Deregister the inner io from the registration and returns a Result containing the inner io
     #[cfg(feature = "net")]
     pub(crate) fn into_inner(mut self) -> io::Result<E> {
-        let mut inner = self
-            .io
-            .take()
-            .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
+        let mut inner = self.io.take().unwrap(); // As io shouldn't ever be None, just unwrap here.
         self.registration.deregister(&mut inner)?;
         Ok(inner)
     }

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -197,7 +197,7 @@ impl TcpStream {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     let mut data = [0u8; 50];
+    ///     let mut data = [0u8; 12];
     ///     let listener = TcpListener::bind("127.0.0.1:34254").await?;
     /// #   let handle = tokio::spawn(async {
     /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:34254").await.unwrap();
@@ -206,8 +206,8 @@ impl TcpStream {
     ///     let (tokio_tcp_stream, _) = listener.accept().await?;
     ///     let mut std_tcp_stream = tokio_tcp_stream.into_std()?;
     /// #   handle.await.expect("The task being joined has panicked");
-    ///     let size = std_tcp_stream.read(&mut data)?;
-    /// #   assert_eq!(b"Hello world!", &data[0..size]);
+    ///     std_tcp_stream.read_exact(&mut data)?;
+    /// #   assert_eq!(b"Hello world!", &data);
     ///    Ok(())
     /// }
     /// ```

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -194,24 +194,21 @@ impl TcpStream {
     /// use tokio::net::TcpListener;
     /// # use tokio::net::TcpStream;
     /// # use tokio::io::AsyncWriteExt;
-    /// # use tokio::time::Duration;
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
-    /// #   tokio::spawn(async {
-    /// #       tokio::time::sleep(Duration::from_millis(50)).await;
+    ///     let mut data = [0u8; 50];
+    ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
+    /// #   let handle = tokio::spawn(async {
     /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
     /// #       let _ = stream.write(b"Hello world!").await;
     /// #   });
-    ///     let mut data = [0 as u8; 50];
-    ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
     ///     let (tokio_tcp_stream, _) = listener.accept().await?;
-    ///
     ///     let mut std_tcp_stream = tokio_tcp_stream.into_std()?;
-    /// #   tokio::time::sleep(Duration::from_millis(100)).await;
+    /// #   handle.await.expect("The task being joined has panicked");
     ///     let size = std_tcp_stream.read(&mut data)?;
-    /// #   assert_eq!("Hello world!", std::str::from_utf8(&data[0..size])?);
-    /// #   Ok(())
+    /// #   assert_eq!(b"Hello world!", &data[0..size]);
+    ///    Ok(())
     /// }
     /// ```
     /// [`tokio::net::TcpStream`]: TcpStream

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -186,6 +186,9 @@ impl TcpStream {
 
     /// Turn a [`tokio::net::TcpStream`] into a [`std::net::TcpStream`].
     ///
+    /// The returned [`std::net::TcpStream`] will have `nonblocking mode` set as `true`.
+    /// Use [`set_nonblocking`] to change the blocking mode if needed.
+    ///
     /// # Examples
     ///
     /// ```
@@ -206,6 +209,7 @@ impl TcpStream {
     ///     let (tokio_tcp_stream, _) = listener.accept().await?;
     ///     let mut std_tcp_stream = tokio_tcp_stream.into_std()?;
     /// #   handle.await.expect("The task being joined has panicked");
+    ///     std_tcp_stream.set_nonblocking(false)?;
     ///     std_tcp_stream.read_exact(&mut data)?;
     /// #   assert_eq!(b"Hello world!", &data);
     ///    Ok(())
@@ -213,6 +217,7 @@ impl TcpStream {
     /// ```
     /// [`tokio::net::TcpStream`]: TcpStream
     /// [`std::net::TcpStream`]: std::net::TcpStream
+    /// [`set_nonblocking`]: fn@std::net::TcpStream::set_nonblocking
     pub fn into_std(self) -> io::Result<std::net::TcpStream> {
         #[cfg(unix)]
         {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -198,9 +198,9 @@ impl TcpStream {
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
     ///     let mut data = [0u8; 50];
-    ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
+    ///     let listener = TcpListener::bind("127.0.0.1:34254").await?;
     /// #   let handle = tokio::spawn(async {
-    /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
+    /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:34254").await.unwrap();
     /// #       let _ = stream.write(b"Hello world!").await;
     /// #   });
     ///     let (tokio_tcp_stream, _) = listener.accept().await?;

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -212,7 +212,7 @@ impl TcpStream {
     ///     std_tcp_stream.set_nonblocking(false)?;
     ///     std_tcp_stream.read_exact(&mut data)?;
     /// #   assert_eq!(b"Hello world!", &data);
-    ///    Ok(())
+    ///     Ok(())
     /// }
     /// ```
     /// [`tokio::net::TcpStream`]: TcpStream

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -184,7 +184,38 @@ impl TcpStream {
         Ok(TcpStream { io })
     }
 
-    /// Turn a `TcpStream` into a `std::net::TcpStream`.
+    /// Turn a [`tokio::net::TcpStream`] into a [`std::net::TcpStream`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::error::Error;
+    /// use std::io::Read;
+    /// use tokio::net::TcpListener;
+    /// # use tokio::net::TcpStream;
+    /// # use tokio::io::AsyncWriteExt;
+    /// # use tokio::time::Duration;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    /// #   tokio::spawn(async {
+    /// #       tokio::time::sleep(Duration::from_millis(50)).await;
+    /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
+    /// #       let _ = stream.write(b"Hello world!").await;
+    /// #   });
+    ///     let mut data = [0 as u8; 50];
+    ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
+    ///     let (tokio_tcp_stream, _) = listener.accept().await?;
+    ///
+    ///     let mut std_tcp_stream = tokio_tcp_stream.into_std()?;
+    /// #   tokio::time::sleep(Duration::from_millis(100)).await;
+    ///     let size = std_tcp_stream.read(&mut data)?;
+    /// #   assert_eq!("Hello world!", std::str::from_utf8(&data[0..size])?);
+    /// #   Ok(())
+    /// }
+    /// ```
+    /// [`tokio::net::TcpStream`]: TcpStream
+    /// [`std::net::TcpStream`]: std::net::TcpStream
     pub fn into_std(self) -> io::Result<std::net::TcpStream> {
         #[cfg(unix)]
         {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -204,7 +204,7 @@ impl TcpStream {
     ///     let listener = TcpListener::bind("127.0.0.1:34254").await?;
     /// #   let handle = tokio::spawn(async {
     /// #       let mut stream: TcpStream = TcpStream::connect("127.0.0.1:34254").await.unwrap();
-    /// #       let _ = stream.write(b"Hello world!").await;
+    /// #       stream.write(b"Hello world!").await.unwrap();
     /// #   });
     ///     let (tokio_tcp_stream, _) = listener.accept().await?;
     ///     let mut std_tcp_stream = tokio_tcp_stream.into_std()?;

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -24,7 +24,7 @@ async fn tcp_into_std() -> Result<()> {
         .expect("set_nonblocking call failed");
 
     let mut client = handle.await.expect("The task being joined has panicked");
-    let _ = client.write_all(b"Hello world!").await;
+    client.write_all(b"Hello world!").await?;
 
     std_tcp_stream
         .read_exact(&mut data)
@@ -36,7 +36,7 @@ async fn tcp_into_std() -> Result<()> {
         .set_nonblocking(true)
         .expect("set_nonblocking call failed");
     let mut tokio_tcp_stream = TcpStream::from_std(std_tcp_stream)?;
-    let _ = client.write_all(b"Hello tokio!").await;
+    client.write_all(b"Hello tokio!").await?;
     let _size = tokio_tcp_stream.read_exact(&mut data).await?;
     assert_eq!(b"Hello tokio!", &data);
 

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -1,0 +1,44 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use std::io::Read;
+use std::io::Result;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+
+#[tokio::test]
+async fn tcp_into_std() -> Result<()> {
+    let mut data = [0u8; 12];
+    let listener = TcpListener::bind("127.0.0.1:34254").await?;
+
+    let handle = tokio::spawn(async {
+        let stream: TcpStream = TcpStream::connect("127.0.0.1:34254").await.unwrap();
+        stream
+    });
+
+    let (tokio_tcp_stream, _) = listener.accept().await?;
+    let mut std_tcp_stream = tokio_tcp_stream.into_std()?;
+    std_tcp_stream
+        .set_nonblocking(false)
+        .expect("set_nonblocking call failed");
+
+    let mut client = handle.await.expect("The task being joined has panicked");
+    let _ = client.write_all(b"Hello world!").await;
+
+    std_tcp_stream
+        .read_exact(&mut data)
+        .expect("std TcpStream read failed!");
+    assert_eq!(b"Hello world!", &data);
+
+    // test back to tokio stream
+    std_tcp_stream
+        .set_nonblocking(true)
+        .expect("set_nonblocking call failed");
+    let mut tokio_tcp_stream = TcpStream::from_std(std_tcp_stream)?;
+    let _ = client.write_all(b"Hello tokio!").await;
+    let _size = tokio_tcp_stream.read_exact(&mut data).await?;
+    assert_eq!(b"Hello tokio!", &data);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes https://github.com/tokio-rs/tokio/issues/3031

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Add an `into_inner` method on `PollEvented`. Make sure to deregister the stream from Tokio.
2. Convert the `mio` tcp stream into an std one. Go through mio's `IntoRawFd` to do so.
