### PR TITLE
Add portability note to tokio::main

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -35,9 +35,11 @@ use proc_macro::TokenStream;
 /// [Builder](../tokio/runtime/struct.Builder.html), which provides a more
 /// powerful interface.
 ///
-/// Note: This macro can be used in any functions and not just `main` function.
-/// It may be useful to add it to another function if one only wants to use
-/// async code from another thread while keeping main synchronous.
+/// Note: This macro can be used on any function and not just the `main`
+/// function. Using it on a non-main function makes the function behave
+/// as if it was synchronous by starting a new runtime each time it is called.
+/// If the function is called often, it is preferable to create the runtime using
+/// the runtime builder so the runtime can be reused across calls.
 ///
 /// # Multi-threaded runtime
 ///

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -35,6 +35,10 @@ use proc_macro::TokenStream;
 /// [Builder](../tokio/runtime/struct.Builder.html), which provides a more
 /// powerful interface.
 ///
+/// Note: This macro can be used in any functions and not just `main` function.
+/// It may be useful to add it to another function if one only wants to use
+/// async code from another thread while keeping main synchronous.
+///
 /// # Multi-threaded runtime
 ///
 /// To use the multi-threaded runtime, the macro can be configured using


### PR DESCRIPTION
Mention that tokio::main could be use in any function.

Fix #3195

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

It is not easy to discover that `#[tokio::main]` could be used for non-main functions.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Explain this in docs, maybe it would be better to show an example.