### PR TITLE
chore: prepare v0.3.5 release

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.3.5 (November 30, 2020)
+
+### Fixed
+- rt: fix `shutdown_timeout(0)` (#3196).
+- time: fixed race condition with small sleeps (#3069).
+
+### Added
+- io: `AsyncFd::with_interest()` (#3167).
+- signal: `CtrlC` stream on windows (#3186).
+
 # 0.3.4 (November 18, 2020)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.3.4/tokio/"
+documentation = "https://docs.rs/tokio/0.3.5/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.3.4")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.3.5")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
# 0.3.5 (November 30, 2020)

### Fixed
- rt: fix `shutdown_timeout(0)` (#3196).
- time: fixed race condition with small sleeps (#3069).

### Added
- io: `AsyncFd::with_interest()` (#3167).
- signal: `CtrlC` stream on windows (#3186).