### PR TITLE
Fix the process_kill_on_drop.rs test on non-Linux systems

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -11,7 +11,7 @@ task:
     LOOM_MAX_PREEMPTIONS: 2
     RUSTFLAGS: -Dwarnings
   setup_script:
-    - pkg install -y curl
+    - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal --default-toolchain stable
     - . $HOME/.cargo/env

--- a/tokio/tests/process_kill_on_drop.rs
+++ b/tokio/tests/process_kill_on_drop.rs
@@ -10,7 +10,7 @@ use tokio_test::assert_ok;
 
 #[tokio::test]
 async fn kill_on_drop() {
-    let mut cmd = Command::new("sh");
+    let mut cmd = Command::new("bash");
     cmd.args(&[
         "-c",
         "


### PR DESCRIPTION
"disown" is a bash builtin, not part of POSIX sh.

## Motivation

While running the tests locally on FreeBSD, I noticed a console message about "disown not found".  The fact that the test passed suggests that there may be something wrong with its logic, but I didn't investigate further.

## Solution

Always execute this script with bash instead of sh.