### PR TITLE
Reenable CI on FreeBSD i686

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,8 +23,7 @@ task:
     - . $HOME/.cargo/env
     - cargo test --all
     - cargo doc --all --no-deps
-  # TODO: Re-enable
-  # i686_test_script:
-  #   - . $HOME/.cargo/env
-  #   - |
-  #     cargo test --all --exclude tokio-macros --target i686-unknown-freebsd
+  i686_test_script:
+    - . $HOME/.cargo/env
+    - |
+      cargo test --all --target i686-unknown-freebsd


### PR DESCRIPTION
It was temporarily disabled in 06c473e62842d257ed275497ce906710ea3f8e19
and never reenabled.