### PR TITLE
Upgrade mio dependency

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -101,7 +101,7 @@ fnv = { version = "1.0.6", optional = true }
 futures-core = { version = "0.3.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 memchr = { version = "2.2", optional = true }
-mio = { version = "0.6.20", optional = true }
+mio = { version = "0.6.23", optional = true }
 iovec = { version = "0.1.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true } # Not in full


### PR DESCRIPTION
Follow up to https://github.com/tokio-rs/mio/pull/1405. Would probably help greatly with the adoption rate of the fixed versions of `net2` and `miow`. Helps unblock https://github.com/rust-lang/rust/pull/78802. See that PR for more details.