### PR TITLE
util: prepare v0.5.1 release

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,5 +1,8 @@
+# 0.5.1 (December 3, 2020)
+
 ### Added
 - io: `poll_read_buf` util fn (#2972).
+- io: `poll_write_buf` util fn with vectored write support (#3156).
 
 # 0.5.0 (October 30, 2020)
 

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.5.0/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.5.1/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ io = []
 rt = ["tokio/rt"]
 
 [dependencies]
-tokio = { version = "0.3.4", path = "../tokio" }
+tokio = "0.3.5"
 
 bytes = "0.6.0"
 futures-core = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ io = []
 rt = ["tokio/rt"]
 
 [dependencies]
-tokio = "0.3.5"
+tokio = { version = "0.3.4", path = "../tokio" }
 
 bytes = "0.6.0"
 futures-core = "0.3.0"
@@ -45,8 +45,8 @@ pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]
-tokio = { version = "0.3.0", features = ["full"] }
-tokio-test = { version = "0.3.0" }
+tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
+tokio-test = { version = "0.3.0", path = "../tokio-test" }
 
 futures = "0.3.0"
 futures-test = "0.3.5"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -45,8 +45,8 @@ pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
-tokio-test = { version = "0.3.0", path = "../tokio-test" }
+tokio = { version = "0.3.0", features = ["full"] }
+tokio-test = { version = "0.3.0" }
 
 futures = "0.3.0"
 futures-test = "0.3.5"

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-util/0.5.1")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
### Added

- io: `poll_read_buf` util fn (#2972).
- io: `poll_write_buf` util fn with vectored write support (#3156).