### PR TITLE
Add unwind feature flag

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,6 +87,7 @@ stream = ["futures-core"]
 sync = []
 test-util = []
 time = []
+unwind = []
 
 [dependencies]
 tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }

--- a/tokio/tests/panics.rs
+++ b/tokio/tests/panics.rs
@@ -1,0 +1,18 @@
+#[cfg(feature = "unwind")]
+#[tokio::test]
+#[should_panic]
+async fn panic_propagated() {
+    tokio::spawn(async {
+        panic!();
+    });
+    tokio::task::yield_now().await;
+}
+
+#[cfg(not(feature = "unwind"))]
+#[tokio::test]
+async fn panic_not_propagated() {
+    tokio::spawn(async {
+        panic!();
+    });
+    tokio::task::yield_now().await;
+}

--- a/tokio/tests/process_issue_2174.rs
+++ b/tokio/tests/process_issue_2174.rs
@@ -16,6 +16,7 @@ use tokio::process::Command;
 use tokio::time;
 use tokio_test::assert_err;
 
+#[cfg(not(feature = "unwind"))]
 #[tokio::test]
 async fn issue_2174() {
     let mut child = Command::new("sleep")

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -646,6 +646,7 @@ rt_test! {
         assert_err!(rx.try_recv());
     }
 
+    #[cfg(not(feature = "unwind"))]
     #[test]
     fn panic_in_task() {
         let rt = rt();


### PR DESCRIPTION
Specifying the `unwind` feature flag removes the catch_unwind from
the task harness. This is especially useful for testing a program with
detached joinhandles.

## Motivation

Solving https://github.com/tokio-rs/tokio/issues/2699 to make testing easier to perform. Especially system tests where we have no control over spawned and detached tasks. Not all systems are going to be running with catch_unwind on each task. Some want to fail fast.

## Solution

Adds a feature `unwind` to disable the usage of catch_unwind.