### PR TITLE
Implement a test scheduler that propagates panics

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -38,6 +38,7 @@ full = [
   "process",
   "rt",
   "rt-multi-thread",
+  "rt-test",
   "signal",
   "stream",
   "sync",
@@ -73,6 +74,7 @@ rt-multi-thread = [
   "num_cpus",
   "rt",
 ]
+rt-test = ["rt"]
 signal = [
   "once_cell",
   "libc",

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -299,6 +299,22 @@ macro_rules! cfg_not_rt_multi_thread {
     }
 }
 
+macro_rules! cfg_rt_test {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "rt-test")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt-test")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_rt_test {
+    ($($item:item)*) => {
+        $( #[cfg(not(feature = "rt-test"))] $item )*
+    }
+}
+
 macro_rules! cfg_test_util {
     ($($item:item)*) => {
         $(

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -216,6 +216,11 @@ cfg_rt_multi_thread! {
     use self::thread_pool::ThreadPool;
 }
 
+cfg_rt_test! {
+    pub(crate) mod test_scheduler;
+    use self::test_scheduler::TestScheduler;
+}
+
 cfg_rt! {
     use crate::task::JoinHandle;
 
@@ -281,6 +286,10 @@ cfg_rt! {
         /// Execute tasks across multiple threads.
         #[cfg(feature = "rt-multi-thread")]
         ThreadPool(ThreadPool),
+
+        /// Execute all tasks on the current-thread. Do not capture panics.
+        #[cfg(feature = "rt-test")]
+        TestScheduler(TestScheduler<driver::Driver>),
     }
 
     /// After thread starts / before thread stops
@@ -450,6 +459,8 @@ cfg_rt! {
                 Kind::CurrentThread(exec) => exec.block_on(future),
                 #[cfg(feature = "rt-multi-thread")]
                 Kind::ThreadPool(exec) => exec.block_on(future),
+                #[cfg(feature = "rt-test")]
+                Kind::TestScheduler(exec) => exec.block_on(future),
             }
         }
 

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -9,12 +9,18 @@ cfg_rt_multi_thread! {
     use crate::runtime::thread_pool;
 }
 
+cfg_rt_test! {
+    use crate::runtime::test_scheduler;
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum Spawner {
     #[cfg(feature = "rt")]
     Basic(basic_scheduler::Spawner),
     #[cfg(feature = "rt-multi-thread")]
     ThreadPool(thread_pool::Spawner),
+    #[cfg(feature = "rt-test")]
+    TestScheduler(test_scheduler::Spawner),
 }
 
 impl Spawner {
@@ -40,6 +46,8 @@ cfg_rt! {
                 Spawner::Basic(spawner) => spawner.spawn(future),
                 #[cfg(feature = "rt-multi-thread")]
                 Spawner::ThreadPool(spawner) => spawner.spawn(future),
+                #[cfg(feature = "rt-test")]
+                Spawner::TestScheduler(spawner) => spawner.spawn(future),
             }
         }
     }

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -103,6 +103,29 @@ impl<T: Future, S: Schedule> Cell<T, S> {
             },
         })
     }
+
+    cfg_rt_test! {
+        /// Allocates a new task cell, containing the header, trailer, and core
+        /// structures.
+        pub(super) fn new_test(future: T, state: State) -> Box<Cell<T, S>> {
+            Box::new(Cell {
+                header: Header {
+                    state,
+                    owned: UnsafeCell::new(linked_list::Pointers::new()),
+                    queue_next: UnsafeCell::new(None),
+                    stack_next: UnsafeCell::new(None),
+                    vtable: raw::vtable_test::<T, S>(),
+                },
+                core: Core {
+                    scheduler: UnsafeCell::new(None),
+                    stage: UnsafeCell::new(Stage::Running(future)),
+                },
+                trailer: Trailer {
+                    waker: UnsafeCell::new(None),
+                },
+            })
+        }
+    }
 }
 
 impl<T: Future, S: Schedule> Core<T, S> {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -119,6 +119,26 @@ cfg_rt! {
     }
 }
 
+cfg_rt_test! {
+    /// Create a new task with an associated join handle
+    pub(crate) fn joinable_test<T, S>(task: T) -> (Notified<S>, JoinHandle<T::Output>)
+    where
+        T: Future + Send + 'static,
+        S: Schedule,
+    {
+        let raw = RawTask::new_test::<_, S>(task);
+
+        let task = Task {
+            raw,
+            _p: PhantomData,
+        };
+
+        let join = JoinHandle::new(raw);
+
+        (Notified(task), join)
+    }
+}
+
 impl<S: 'static> Task<S> {
     pub(crate) unsafe fn from_raw(ptr: NonNull<Header>) -> Task<S> {
         Task {

--- a/tokio/src/runtime/test_scheduler.rs
+++ b/tokio/src/runtime/test_scheduler.rs
@@ -1,0 +1,423 @@
+use crate::future::poll_fn;
+use crate::loom::sync::Mutex;
+use crate::park::{Park, Unpark};
+use crate::runtime::task::{self, JoinHandle, Schedule, Task};
+use crate::sync::notify::Notify;
+use crate::util::linked_list::{Link, LinkedList};
+use crate::util::{waker_ref, Wake, WakerRef};
+
+use std::cell::RefCell;
+use std::collections::VecDeque;
+use std::fmt;
+use std::future::Future;
+use std::sync::Arc;
+use std::task::Poll::{Pending, Ready};
+use std::time::Duration;
+
+/// Executes tasks on the current thread
+pub(crate) struct TestScheduler<P: Park> {
+    /// Inner state guarded by a mutex that is shared
+    /// between all `block_on` calls.
+    inner: Mutex<Option<Inner<P>>>,
+
+    /// Notifier for waking up other threads to steal the
+    /// parker.
+    notify: Notify,
+
+    /// Sendable task spawner
+    spawner: Spawner,
+}
+
+/// The inner scheduler that owns the task queue and the main parker P.
+struct Inner<P: Park> {
+    /// Scheduler run queue
+    ///
+    /// When the scheduler is executed, the queue is removed from `self` and
+    /// moved into `Context`.
+    ///
+    /// This indirection is to allow `TestScheduler` to be `Send`.
+    tasks: Option<Tasks>,
+
+    /// Sendable task spawner
+    spawner: Spawner,
+
+    /// Current tick
+    tick: u8,
+
+    /// Thread park handle
+    park: P,
+}
+
+#[derive(Clone)]
+pub(crate) struct Spawner {
+    shared: Arc<Shared>,
+}
+
+struct Tasks {
+    /// Collection of all active tasks spawned onto this executor.
+    owned: LinkedList<Task<Arc<Shared>>, <Task<Arc<Shared>> as Link>::Target>,
+
+    /// Local run queue.
+    ///
+    /// Tasks notified from the current thread are pushed into this queue.
+    queue: VecDeque<task::Notified<Arc<Shared>>>,
+}
+
+/// Scheduler state shared between threads.
+struct Shared {
+    /// Remote run queue
+    queue: Mutex<VecDeque<task::Notified<Arc<Shared>>>>,
+
+    /// Unpark the blocked thread
+    unpark: Box<dyn Unpark>,
+}
+
+/// Thread-local context.
+struct Context {
+    /// Shared scheduler state
+    shared: Arc<Shared>,
+
+    /// Local queue
+    tasks: RefCell<Tasks>,
+}
+
+/// Initial queue capacity.
+const INITIAL_CAPACITY: usize = 64;
+
+/// Max number of tasks to poll per tick.
+const MAX_TASKS_PER_TICK: usize = 61;
+
+/// How often to check the remote queue first.
+const REMOTE_FIRST_INTERVAL: u8 = 31;
+
+// Tracks the current TestScheduler.
+scoped_thread_local!(static CURRENT: Context);
+
+impl<P: Park> TestScheduler<P> {
+    pub(crate) fn new(park: P) -> TestScheduler<P> {
+        let unpark = Box::new(park.unpark());
+
+        let spawner = Spawner {
+            shared: Arc::new(Shared {
+                queue: Mutex::new(VecDeque::with_capacity(INITIAL_CAPACITY)),
+                unpark: unpark as Box<dyn Unpark>,
+            }),
+        };
+
+        let inner = Mutex::new(Some(Inner {
+            tasks: Some(Tasks {
+                owned: LinkedList::new(),
+                queue: VecDeque::with_capacity(INITIAL_CAPACITY),
+            }),
+            spawner: spawner.clone(),
+            tick: 0,
+            park,
+        }));
+
+        TestScheduler {
+            inner,
+            notify: Notify::new(),
+            spawner,
+        }
+    }
+
+    pub(crate) fn spawner(&self) -> &Spawner {
+        &self.spawner
+    }
+
+    pub(crate) fn block_on<F: Future>(&self, future: F) -> F::Output {
+        pin!(future);
+
+        // Attempt to steal the dedicated parker and block_on the future if we can there,
+        // othwerwise, lets select on a notification that the parker is available
+        // or the future is complete.
+        loop {
+            if let Some(inner) = &mut self.take_inner() {
+                return inner.block_on(future);
+            } else {
+                let mut enter = crate::runtime::enter(false);
+
+                let notified = self.notify.notified();
+                pin!(notified);
+
+                if let Some(out) = enter
+                    .block_on(poll_fn(|cx| {
+                        if notified.as_mut().poll(cx).is_ready() {
+                            return Ready(None);
+                        }
+
+                        if let Ready(out) = future.as_mut().poll(cx) {
+                            return Ready(Some(out));
+                        }
+
+                        Pending
+                    }))
+                    .expect("Failed to `Enter::block_on`")
+                {
+                    return out;
+                }
+            }
+        }
+    }
+
+    fn take_inner(&self) -> Option<InnerGuard<'_, P>> {
+        let inner = self.inner.lock().take()?;
+
+        Some(InnerGuard {
+            inner: Some(inner),
+            test_scheduler: &self,
+        })
+    }
+}
+
+impl<P: Park> Inner<P> {
+    /// Block on the future provided and drive the runtime's driver.
+    fn block_on<F: Future>(&mut self, future: F) -> F::Output {
+        enter(self, |scheduler, context| {
+            let _enter = crate::runtime::enter(false);
+            let waker = scheduler.spawner.waker_ref();
+            let mut cx = std::task::Context::from_waker(&waker);
+
+            pin!(future);
+
+            'outer: loop {
+                if let Ready(v) = crate::coop::budget(|| future.as_mut().poll(&mut cx)) {
+                    return v;
+                }
+
+                for _ in 0..MAX_TASKS_PER_TICK {
+                    // Get and increment the current tick
+                    let tick = scheduler.tick;
+                    scheduler.tick = scheduler.tick.wrapping_add(1);
+
+                    let next = if tick % REMOTE_FIRST_INTERVAL == 0 {
+                        scheduler
+                            .spawner
+                            .pop()
+                            .or_else(|| context.tasks.borrow_mut().queue.pop_front())
+                    } else {
+                        context
+                            .tasks
+                            .borrow_mut()
+                            .queue
+                            .pop_front()
+                            .or_else(|| scheduler.spawner.pop())
+                    };
+
+                    match next {
+                        Some(task) => crate::coop::budget(|| task.run()),
+                        None => {
+                            // Park until the thread is signaled
+                            scheduler.park.park().ok().expect("failed to park");
+
+                            // Try polling the `block_on` future next
+                            continue 'outer;
+                        }
+                    }
+                }
+
+                // Yield to the park, this drives the timer and pulls any pending
+                // I/O events.
+                scheduler
+                    .park
+                    .park_timeout(Duration::from_millis(0))
+                    .ok()
+                    .expect("failed to park");
+            }
+        })
+    }
+}
+
+/// Enter the scheduler context. This sets the queue and other necessary
+/// scheduler state in the thread-local
+fn enter<F, R, P>(scheduler: &mut Inner<P>, f: F) -> R
+where
+    F: FnOnce(&mut Inner<P>, &Context) -> R,
+    P: Park,
+{
+    // Ensures the run queue is placed back in the `TestScheduler` instance
+    // once `block_on` returns.`
+    struct Guard<'a, P: Park> {
+        context: Option<Context>,
+        scheduler: &'a mut Inner<P>,
+    }
+
+    impl<P: Park> Drop for Guard<'_, P> {
+        fn drop(&mut self) {
+            let Context { tasks, .. } = self.context.take().expect("context missing");
+            self.scheduler.tasks = Some(tasks.into_inner());
+        }
+    }
+
+    // Remove `tasks` from `self` and place it in a `Context`.
+    let tasks = scheduler.tasks.take().expect("invalid state");
+
+    let guard = Guard {
+        context: Some(Context {
+            shared: scheduler.spawner.shared.clone(),
+            tasks: RefCell::new(tasks),
+        }),
+        scheduler,
+    };
+
+    let context = guard.context.as_ref().unwrap();
+    let scheduler = &mut *guard.scheduler;
+
+    CURRENT.set(context, || f(scheduler, context))
+}
+
+impl<P: Park> Drop for TestScheduler<P> {
+    fn drop(&mut self) {
+        // Avoid a double panic if we are currently panicking and
+        // the lock may be poisoned.
+
+        let mut inner = match self.inner.lock().take() {
+            Some(inner) => inner,
+            None if std::thread::panicking() => return,
+            None => panic!("Oh no! We never placed the Inner state back, this is a bug!"),
+        };
+
+        enter(&mut inner, |scheduler, context| {
+            // Loop required here to ensure borrow is dropped between iterations
+            #[allow(clippy::while_let_loop)]
+            loop {
+                let task = match context.tasks.borrow_mut().owned.pop_back() {
+                    Some(task) => task,
+                    None => break,
+                };
+
+                task.shutdown();
+            }
+
+            // Drain local queue
+            for task in context.tasks.borrow_mut().queue.drain(..) {
+                task.shutdown();
+            }
+
+            // Drain remote queue
+            for task in scheduler.spawner.shared.queue.lock().drain(..) {
+                task.shutdown();
+            }
+
+            assert!(context.tasks.borrow().owned.is_empty());
+        });
+    }
+}
+
+impl<P: Park> fmt::Debug for TestScheduler<P> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("TestScheduler").finish()
+    }
+}
+
+// ===== impl Spawner =====
+
+impl Spawner {
+    /// Spawns a future onto the thread pool
+    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        let (task, handle) = task::joinable_test(future);
+        self.shared.schedule(task);
+        handle
+    }
+
+    fn pop(&self) -> Option<task::Notified<Arc<Shared>>> {
+        self.shared.queue.lock().pop_front()
+    }
+
+    fn waker_ref(&self) -> WakerRef<'_> {
+        waker_ref(&self.shared)
+    }
+}
+
+impl fmt::Debug for Spawner {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Spawner").finish()
+    }
+}
+
+// ===== impl Shared =====
+
+impl Schedule for Arc<Shared> {
+    fn bind(task: Task<Self>) -> Arc<Shared> {
+        CURRENT.with(|maybe_cx| {
+            let cx = maybe_cx.expect("scheduler context missing");
+            cx.tasks.borrow_mut().owned.push_front(task);
+            cx.shared.clone()
+        })
+    }
+
+    fn release(&self, task: &Task<Self>) -> Option<Task<Self>> {
+        use std::ptr::NonNull;
+
+        CURRENT.with(|maybe_cx| {
+            let cx = maybe_cx.expect("scheduler context missing");
+
+            // safety: the task is inserted in the list in `bind`.
+            unsafe {
+                let ptr = NonNull::from(task.header());
+                cx.tasks.borrow_mut().owned.remove(ptr)
+            }
+        })
+    }
+
+    fn schedule(&self, task: task::Notified<Self>) {
+        CURRENT.with(|maybe_cx| match maybe_cx {
+            Some(cx) if Arc::ptr_eq(self, &cx.shared) => {
+                cx.tasks.borrow_mut().queue.push_back(task);
+            }
+            _ => {
+                self.queue.lock().push_back(task);
+                self.unpark.unpark();
+            }
+        });
+    }
+}
+
+impl Wake for Shared {
+    fn wake(self: Arc<Self>) {
+        Wake::wake_by_ref(&self)
+    }
+
+    /// Wake by reference
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.unpark.unpark();
+    }
+}
+
+// ===== InnerGuard =====
+
+/// Used to ensure we always place the Inner value
+/// back into its slot in `TestScheduler`, even if the
+/// future panics.
+struct InnerGuard<'a, P: Park> {
+    inner: Option<Inner<P>>,
+    test_scheduler: &'a TestScheduler<P>,
+}
+
+impl<P: Park> InnerGuard<'_, P> {
+    fn block_on<F: Future>(&mut self, future: F) -> F::Output {
+        // The only time inner gets set to `None` is if we have dropped
+        // already so this unwrap is safe.
+        self.inner.as_mut().unwrap().block_on(future)
+    }
+}
+
+impl<P: Park> Drop for InnerGuard<'_, P> {
+    fn drop(&mut self) {
+        if let Some(scheduler) = self.inner.take() {
+            let mut lock = self.test_scheduler.inner.lock();
+
+            // Replace old scheduler back into the state to allow
+            // other threads to pick it up and drive it.
+            lock.replace(scheduler);
+
+            // Wake up other possible threads that could steal
+            // the dedicated parker P.
+            self.test_scheduler.notify.notify_one()
+        }
+    }
+}


### PR DESCRIPTION
This patch implements a new scheduler that does not capture unwinds. It
instead lets unwinds bubble up.

This is useful in test cases where we might be interested in detached
tasks' panics. Not all applications are interested in letting tasks
fail, so this scheduler makes the implementation of testing such
applications or libraries much easier.

Tentative solution to:

https://github.com/tokio-rs/tokio/issues/3217