### PR TITLE
util: add constructors to TokioContext

### DIFF
--- a/tokio-util/src/context.rs
+++ b/tokio-util/src/context.rs
@@ -13,7 +13,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::runtime::{Runtime, Handle};
+use tokio::runtime::{Handle, Runtime};
 
 pin_project! {
     /// `TokioContext` allows running futures that must be inside Tokio's

--- a/tokio-util/src/context.rs
+++ b/tokio-util/src/context.rs
@@ -9,20 +9,169 @@
 use pin_project_lite::pin_project;
 use std::{
     future::Future,
+    marker::PhantomData,
     pin::Pin,
     task::{Context, Poll},
 };
-use tokio::runtime::Runtime;
+use tokio::runtime::{Runtime, Handle};
 
 pin_project! {
-    /// `TokioContext` allows connecting a custom executor with the tokio runtime.
+    /// `TokioContext` allows running futures that must be inside Tokio's
+    /// context on a non-Tokio runtime.
     ///
-    /// It contains a `Handle` to the runtime. A handle to the runtime can be
-    /// obtain by calling the `Runtime::handle()` method.
+    /// It contains a [`Handle`] to the runtime. A handle to the runtime can be
+    /// obtain by calling the [`Runtime::handle()`] method.
+    ///
+    /// Note that the `TokioContext` wrapper only works if the `Runtime` it is
+    /// connected to has not yet been destroyed. The lifetime on this type
+    /// allows the compiler to verify at compile-time that this requirement is
+    /// not violated, but it is possible to opt-out of this check by using the
+    /// [`new_static`] constructor.
+    ///
+    /// **Warning:** If `TokioContext` is used together with a [current thread]
+    /// runtime, that runtime must be inside a call to `block_on` for the
+    /// wrapped future to work. For this reason, it is recommended to use a
+    /// [multi thread] runtime, even if you configure it to only spawn one
+    /// worker thread.
+    ///
+    /// # Examples
+    ///
+    /// This example creates two runtimes, but only [enables time] on one of
+    /// them. It then uses the context of the runtime with the timer enabled to
+    /// execute a [`sleep`] future on the runtime with timing disabled.
+    /// ```
+    /// use tokio::time::{sleep, Duration};
+    /// use tokio_util::context::RuntimeExt;
+    ///
+    /// // This runtime has timers enabled.
+    /// let rt = tokio::runtime::Builder::new_multi_thread()
+    ///     .enable_all()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // This runtime has timers disabled.
+    /// let rt2 = tokio::runtime::Builder::new_multi_thread()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // Wrap the sleep future in the context of rt.
+    /// let fut = rt.wrap(async { sleep(Duration::from_millis(2)).await });
+    ///
+    /// // Execute the future on rt2.
+    /// rt2.block_on(fut);
+    /// ```
+    ///
+    /// [`Handle`]: struct@tokio::runtime::Handle
+    /// [`Runtime::handle()`]: fn@tokio::runtime::Runtime::handle
+    /// [`RuntimeExt`]: trait@crate::context::RuntimeExt
+    /// [`new_static`]: fn@Self::new_static
+    /// [`sleep`]: fn@tokio::time::sleep
+    /// [enables time]: fn@tokio::runtime::Builder::enable_time
+    /// [current thread]: fn@tokio::runtime::Builder::new_current_thread
+    /// [multi thread]: fn@tokio::runtime::Builder::new_multi_thread
     pub struct TokioContext<'a, F> {
         #[pin]
         inner: F,
-        handle: &'a Runtime,
+        handle: Handle,
+        runtime: PhantomData<&'a Runtime>,
+    }
+}
+
+impl<'a, F> TokioContext<'a, F> {
+    /// Associate the provided future with the context of the `Runtime`.
+    ///
+    /// This constructor uses lifetimes to verify at compile time that the Tokio
+    /// runtime is not destroyed until after the wrapped future has finished
+    /// executing.
+    ///
+    /// This is equivalent to [`RuntimeExt::wrap`].
+    ///
+    /// # Examples
+    ///
+    /// The same example as above, but using `new_by_ref` rather than
+    /// `RuntimeExt::wrap`.
+    /// ```
+    /// use tokio::time::{sleep, Duration};
+    /// use tokio_util::context::TokioContext;
+    ///
+    /// // This runtime has timers enabled.
+    /// let rt = tokio::runtime::Builder::new_multi_thread()
+    ///     .enable_all()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // This runtime has timers disabled.
+    /// let rt2 = tokio::runtime::Builder::new_multi_thread()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let fut = TokioContext::new_by_ref(
+    ///     async { sleep(Duration::from_millis(2)).await },
+    ///     &rt,
+    /// );
+    ///
+    /// rt2.block_on(fut);
+    /// ```
+    pub fn new_by_ref(future: F, rt: &'a Runtime) -> TokioContext<'a, F> {
+        TokioContext {
+            inner: future,
+            handle: rt.handle().clone(),
+            runtime: PhantomData,
+        }
+    }
+
+    /// Associate the provided future with the context of the runtime behind
+    /// the provided `Handle`.
+    ///
+    /// This constructor uses a `'static` lifetime to opt-out of checking that
+    /// the runtime still exists.
+    ///
+    /// # Examples
+    ///
+    /// This example spawns the future on the runtime without timers enabled.
+    /// Since spawning requires a `'static` lifetime, we have to opt-out of the
+    /// runtime-liveness check by using `new_static`.
+    /// ```
+    /// use tokio::time::{sleep, Duration};
+    /// use tokio_util::context::TokioContext;
+    ///
+    /// // This runtime has timers enabled.
+    /// let rt = tokio::runtime::Builder::new_multi_thread()
+    ///     .enable_all()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // This runtime has timers disabled.
+    /// let rt2 = tokio::runtime::Builder::new_multi_thread()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// // opt-out of runtime liveness check so we can spawn it
+    /// let fut = TokioContext::new_static(
+    ///     async { sleep(Duration::from_millis(2)).await },
+    ///     rt.handle().clone(),
+    /// );
+    ///
+    /// # let handle =
+    /// rt2.spawn(fut);
+    /// # rt2.block_on(handle).unwrap();
+    /// ```
+    pub fn new_static(future: F, handle: Handle) -> TokioContext<'static, F> {
+        TokioContext {
+            inner: future,
+            handle,
+            runtime: PhantomData,
+        }
+    }
+
+    /// Obtain a reference to the handle inside this `TokioContext`.
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    /// Remove the association between the Tokio runtime and the wrapped future.
+    pub fn into_inner(self) -> F {
+        self.inner
     }
 }
 
@@ -43,28 +192,9 @@ impl<F: Future> Future for TokioContext<'_, F> {
 pub trait RuntimeExt {
     /// Convenience method that takes a Future and returns a `TokioContext`.
     ///
-    /// # Example: calling Tokio Runtime from a custom ThreadPool
+    /// See [`TokioContext`] for examples of using this function.
     ///
-    /// ```no_run
-    /// use tokio_util::context::RuntimeExt;
-    /// use tokio::time::{sleep, Duration};
-    ///
-    /// let rt = tokio::runtime::Builder::new_multi_thread()
-    ///     .enable_all()
-    ///     .build()
-    ///     .unwrap();
-    ///
-    /// let rt2 = tokio::runtime::Builder::new_multi_thread()
-    ///     .build()
-    ///     .unwrap();
-    ///
-    /// let fut = sleep(Duration::from_millis(2));
-    ///
-    /// rt.block_on(
-    ///     rt2
-    ///         .wrap(async { sleep(Duration::from_millis(2)).await }),
-    /// );
-    ///```
+    /// [`TokioContext`]: struct@crate::context::TokioContext
     fn wrap<F: Future>(&self, fut: F) -> TokioContext<'_, F>;
 }
 
@@ -72,7 +202,8 @@ impl RuntimeExt for Runtime {
     fn wrap<F: Future>(&self, fut: F) -> TokioContext<'_, F> {
         TokioContext {
             inner: fut,
-            handle: self,
+            handle: self.handle().clone(),
+            runtime: PhantomData,
         }
     }
 }


### PR DESCRIPTION
This PR changes the following:

1. Change [`TokioContext`][1] to use `Handle` rather than `&'a Runtime`.
2. Add two constructors.
3. Add examples to documentation.

The current design of `TokioContext` uses a `&'a Runtime` field because `Handle` did not exist when `TokioContext` was added to tokio-util, but now that we have a `Handle` type, we can change it to use `Handle` instead. To avoid a breaking change, I have kept the lifetime and defined the struct like this:
```Rust
pub struct TokioContext<'a, F> {
    #[pin]
    inner: F,
    handle: Handle,
    runtime_ref: PhantomData<&'a Runtime>,
}
```
The lifetime can still be used to verify at compile time that the `TokioContext` does not outlive its runtime, so it can be useful to keep it. However I have added a `new_static` constructor that opts-out of this by using a `'static` lifetime. We may want to consider changing this in a later breaking change, e.g. when we release Tokio 1.0.

This PR was written because I feel it can improve the examples in #3198 quite a bit.

[1]: https://docs.rs/tokio-util/0.5/tokio_util/context/struct.TokioContext.html