### PR TITLE
Enable `test-util` feature for the playground

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -133,4 +133,4 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.playground]
-features = ["full"]
+features = ["full", "test-util"]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

this allows using e.g. `tokio::time::pause();`, which is useful for timing-related tests to be shared via the playground

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Like PR #1960 (issue #1932), this simply adds metadata to Cargo.toml to tell Playground how to compile tokio.