### PR TITLE
time: fix panic on multithreaded runtime shutdown

### DIFF
--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -9,6 +9,12 @@ pub(crate) struct Handle {
     inner: Arc<Mutex<super::Inner>>,
 }
 
+impl std::fmt::Debug for Handle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Handle({:?})", &*self.inner as *const _)
+    }
+}
+
 impl Handle {
     /// Creates a new timer `Handle` from a shared `Inner` timer state.
     pub(super) fn new(inner: Arc<Mutex<super::Inner>>) -> Self {
@@ -74,11 +80,5 @@ cfg_not_rt! {
             panic!("there is no timer running, must be called from the context of Tokio runtime or \
             `rt` is not enabled")
         }
-    }
-}
-
-impl fmt::Debug for Handle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Handle")
     }
 }


### PR DESCRIPTION
All core threads share the same park, and invoke park() followed by shutdown -
in parallel.  This is quite possibly a bug in the worker (in that it invokes
shutdown when it's not done with the parker), but for now work around it by
bypassing the timer parker once shutdown is called.

Fixes: #2789

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
