### PR TITLE
chore: prepare 0.2.24 release

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.24 (December 7, 2020)
+
+### Fixes
+
+ - sync: fix mpsc bug related to closing the channel (#3215)
+
 # 0.2.23 (November 12, 2020)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -122,7 +122,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.2.0" }
+tokio-test = { version = "0.2.0", path = "../tokio-test" }
 futures = { version = "0.3.0", features = ["async-await"] }
 futures-test = "0.3.0"
 proptest = "0.9.4"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.23"
+version = "0.2.24"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.23/tokio/"
+documentation = "https://docs.rs/tokio/0.2.24/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -122,7 +122,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.2.0", path = "../tokio-test" }
+tokio-test = { version = "0.2.0" }
 futures = { version = "0.3.0", features = ["async-await"] }
 futures-test = "0.3.0"
 proptest = "0.9.4"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.23")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.24")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
# 0.2.24 (December 7, 2020)

### Fixes

 - sync: fix mpsc bug related to closing the channel (#3215)

