### PR TITLE
time: Fix race condition in timer drop

### DIFF
--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -437,6 +437,17 @@ impl TimerShared {
         true_when
     }
 
+    /// Sets the cached time-of-expiration value.
+    ///
+    /// SAFETY: Must be called with the driver lock held, and when this entry is
+    /// not in any timer wheel lists.
+    pub(super) unsafe fn set_cached_when(&self, when: u64) {
+        self.driver_state
+            .0
+            .cached_when
+            .store(when, Ordering::Relaxed);
+    }
+
     /// Returns the true time-of-expiration value, with relaxed memory ordering.
     pub(super) fn true_when(&self) -> u64 {
         self.state.when().expect("Timer already fired")
@@ -618,6 +629,10 @@ impl TimerHandle {
 
     pub(super) unsafe fn sync_when(&self) -> u64 {
         unsafe { self.inner.as_ref().sync_when() }
+    }
+
+    pub(super) unsafe fn set_cached_when(&self, when: u64) {
+        unsafe { self.inner.as_ref().set_cached_when(when) }
     }
 
     pub(super) unsafe fn is_pending(&self) -> bool {

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -441,7 +441,7 @@ impl TimerShared {
     ///
     /// SAFETY: Must be called with the driver lock held, and when this entry is
     /// not in any timer wheel lists.
-    pub(super) unsafe fn set_cached_when(&self, when: u64) {
+    unsafe fn set_cached_when(&self, when: u64) {
         self.driver_state
             .0
             .cached_when

--- a/tokio/src/time/driver/wheel/mod.rs
+++ b/tokio/src/time/driver/wheel/mod.rs
@@ -244,9 +244,6 @@ impl Wheel {
             match unsafe { item.mark_pending(expiration.deadline) } {
                 Ok(()) => {
                     // Item was expired
-                    unsafe {
-                        item.set_cached_when(u64::max_value());
-                    }
                     self.pending.push_front(item);
                 }
                 Err(expiration_tick) => {

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -308,3 +308,73 @@ async fn no_out_of_bounds_close_to_max() {
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }
+
+#[tokio::test]
+async fn drop_after_reschedule_at_new_scheduled_time() {
+    use futures::poll;
+
+    tokio::time::pause();
+
+    let start = tokio::time::Instant::now();
+
+    let mut a = tokio::time::sleep(Duration::from_millis(5));
+    let mut b = tokio::time::sleep(Duration::from_millis(5));
+    let mut c = tokio::time::sleep(Duration::from_millis(10));
+
+    let _ = poll!(&mut a);
+    let _ = poll!(&mut b);
+    let _ = poll!(&mut c);
+
+    b.reset(start + Duration::from_millis(10));
+    a.await;
+
+    drop(b);
+}
+
+#[tokio::test]
+async fn drop_from_wake() {
+    use std::future::Future;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+    use std::task::Context;
+
+    let paniced = Arc::new(AtomicBool::new(false));
+    let list: Arc<Mutex<Vec<tokio::time::Sleep>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let arc_wake = Arc::new(DropWaker(paniced.clone(), list.clone()));
+    let arc_wake = futures::task::waker(arc_wake);
+
+    tokio::time::pause();
+
+    let mut lock = list.lock().unwrap();
+
+    for _ in 0..100 {
+        let mut timer = tokio::time::sleep(Duration::from_millis(10));
+
+        let _ = std::pin::Pin::new(&mut timer).poll(&mut Context::from_waker(&arc_wake));
+
+        lock.push(timer);
+    }
+
+    drop(lock);
+
+    tokio::time::sleep(Duration::from_millis(11)).await;
+
+    assert!(
+        !paniced.load(Ordering::SeqCst),
+        "paniced when dropping timers"
+    );
+
+    #[derive(Clone)]
+    struct DropWaker(Arc<AtomicBool>, Arc<Mutex<Vec<tokio::time::Sleep>>>);
+
+    impl futures::task::ArcWake for DropWaker {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                *arc_self.1.lock().expect("panic in lock") = Vec::new()
+            })) {
+                arc_self.0.store(true, Ordering::SeqCst);
+            }
+        }
+    }
+}

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -370,9 +370,11 @@ async fn drop_from_wake() {
 
     impl futures::task::ArcWake for DropWaker {
         fn wake_by_ref(arc_self: &Arc<Self>) {
-            if let Err(_) = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 *arc_self.1.lock().expect("panic in lock") = Vec::new()
-            })) {
+            }))
+            .is_err()
+            {
                 arc_self.0.store(true, Ordering::SeqCst);
             }
         }

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -338,10 +338,10 @@ async fn drop_from_wake() {
     use std::sync::{Arc, Mutex};
     use std::task::Context;
 
-    let paniced = Arc::new(AtomicBool::new(false));
+    let panicked = Arc::new(AtomicBool::new(false));
     let list: Arc<Mutex<Vec<tokio::time::Sleep>>> = Arc::new(Mutex::new(Vec::new()));
 
-    let arc_wake = Arc::new(DropWaker(paniced.clone(), list.clone()));
+    let arc_wake = Arc::new(DropWaker(panicked.clone(), list.clone()));
     let arc_wake = futures::task::waker(arc_wake);
 
     tokio::time::pause();
@@ -361,7 +361,7 @@ async fn drop_from_wake() {
     tokio::time::sleep(Duration::from_millis(11)).await;
 
     assert!(
-        !paniced.load(Ordering::SeqCst),
+        !panicked.load(Ordering::SeqCst),
         "paniced when dropping timers"
     );
 

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -370,11 +370,11 @@ async fn drop_from_wake() {
 
     impl futures::task::ArcWake for DropWaker {
         fn wake_by_ref(arc_self: &Arc<Self>) {
-            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                 *arc_self.1.lock().expect("panic in lock") = Vec::new()
-            }))
-            .is_err()
-            {
+            }));
+
+            if result.is_err() {
                 arc_self.0.store(true, Ordering::SeqCst);
             }
         }


### PR DESCRIPTION
Dropping a timer on the millisecond that it was scheduled for, when it was on
the pending list, could result in a panic previously, as we did not record the
pending-list state in cached_when.

Hopefully f<!-- -->ixes: ZcashFoundation/zebra#1452

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
