### PR TITLE
chore: fix stress test

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -18,7 +18,7 @@ jobs:
         run: rustup update stable
 
       - name: Install Valgrind
-        run: sudo apt install -y valgrind
+        run: sudo apt-get install -y valgrind
 
       # Compiles each of the stress test examples.
       - name: Compile stress test examples

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -1,5 +1,6 @@
 name: Stress Test
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -18,7 +18,7 @@ jobs:
         run: rustup update stable
 
       - name: Install Valgrind
-        run: apt install -y valgrind
+        run: sudo apt install -y valgrind
 
       # Compiles each of the stress test examples.
       - name: Compile stress test examples

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -23,7 +23,7 @@ jobs:
 
       # Compiles each of the stress test examples.
       - name: Compile stress test examples
-        run: cargo build -p stress-test --release --examples ${{ matrix.stress-test }}
+        run: cargo build -p stress-test --release --example ${{ matrix.stress-test }}
 
       # Runs each of the examples using Valgrind. Detects leaks and displays them.
       - name: Run valgrind

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -27,4 +27,4 @@ jobs:
 
       # Runs each of the examples using Valgrind. Detects leaks and displays them.
       - name: Run valgrind
-        run: valgrind  --leak-check=full --show-leak-kinds=all ./target/release/${{ matrix.stress-test }}
+        run: valgrind  --leak-check=full --show-leak-kinds=all ./target/release/examples/${{ matrix.stress-test }}

--- a/stress-test/examples/simple_echo_tcp.rs
+++ b/stress-test/examples/simple_echo_tcp.rs
@@ -9,7 +9,7 @@ use tokio::{
 };
 
 const TCP_ENDPOINT: &str = "127.0.0.1:8080";
-const NUM_MSGS: usize = 10_000;
+const NUM_MSGS: usize = 100;
 const MSG_SIZE: usize = 1024;
 
 fn main() {


### PR DESCRIPTION
CI run 1515308234 reported that the command
Run apt install -y valgrind failed due to missing root permissions.
This patch adds sudo before the apt install to overcome this.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
