### PR TITLE
watch: fix spurious wakeup

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -54,9 +54,9 @@
 use crate::sync::Notify;
 
 use std::ops;
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::sync::{Arc, RwLock, RwLockReadGuard};
+use crate::loom::sync::atomic::AtomicUsize;
+use crate::loom::sync::atomic::Ordering::{Relaxed, SeqCst};
+use crate::loom::sync::{Arc, RwLock, RwLockReadGuard};
 
 /// Receives values from the associated [`Sender`](struct@Sender).
 ///
@@ -388,5 +388,45 @@ impl<T> ops::Deref for Ref<'_, T> {
 
     fn deref(&self) -> &T {
         self.inner.deref()
+    }
+}
+
+#[cfg(all(test, loom))]
+mod tests {
+    use loom::thread;
+    use futures::future::FutureExt;
+
+    #[test]
+    fn watch_spurious_wakeup() {
+        loom::model(|| {
+            let (send, mut recv) = crate::sync::watch::channel(0i32);
+
+            send.send(1).unwrap();
+
+            let send_thread = thread::spawn(move || {
+                send.send(2).unwrap();
+                send
+            });
+
+            recv.changed().now_or_never();
+
+            let send = send_thread.join().unwrap();
+            let recv_thread = thread::spawn(move || {
+                recv.changed().now_or_never();
+                recv.changed().now_or_never();
+                recv
+            });
+
+            send.send(3).unwrap();
+
+            let mut recv = recv_thread.join().unwrap();
+            let send_thread = thread::spawn(move || {
+                send.send(2).unwrap();
+            });
+
+            recv.changed().now_or_never();
+
+            send_thread.join().unwrap();
+        });
     }
 }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -53,10 +53,10 @@
 
 use crate::sync::Notify;
 
-use std::ops;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::atomic::Ordering::{Relaxed, SeqCst};
 use crate::loom::sync::{Arc, RwLock, RwLockReadGuard};
+use std::ops;
 
 /// Receives values from the associated [`Sender`](struct@Sender).
 ///
@@ -393,8 +393,8 @@ impl<T> ops::Deref for Ref<'_, T> {
 
 #[cfg(all(test, loom))]
 mod tests {
-    use loom::thread;
     use futures::future::FutureExt;
+    use loom::thread;
 
     // test for https://github.com/tokio-rs/tokio/issues/3168
     #[test]

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -396,6 +396,7 @@ mod tests {
     use loom::thread;
     use futures::future::FutureExt;
 
+    // test for https://github.com/tokio-rs/tokio/issues/3168
     #[test]
     fn watch_spurious_wakeup() {
         loom::model(|| {


### PR DESCRIPTION
Closes: #3168

I will push the fix that @tijsvd suggested once I have observed the test failing on CI. It does fix the test locally.
```Rust
loop {
        let notified = self.shared.notify_rx.notified();
        if let Some(ret) = maybe_changed(&self.shared, &mut self.version) {
            return ret;
        }
        notified.await;
}
```
command to run the test:
```
LOOM_MAX_PREEMPTIONS=1 RUSTFLAGS="--cfg loom" cargo test --lib --release --features full -- --test-threads=1 --nocapture watch_spurious_wakeup
```