### PR TITLE
chore: prepare for Tokio 1.0 work

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -5,7 +5,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
 bencher = "0.1.5"
 
 [target.'cfg(unix)'.dependencies]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead.
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full", "tracing"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
-tokio-util = { version = "0.5.0", path = "../tokio-util", features = ["full"] }
+tokio-util = { version = "0.6.0", path = "../tokio-util", features = ["full"] }
 bytes = "0.6"
 futures = "0.3.0"
 http = "0.2"

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = {path = "../tokio/", features = ["full"]}
+tokio = { path = "../tokio/", features = ["full"] }
 
 [dev-dependencies]
 rand = "0.7.3"

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,8 +6,8 @@ name = "tokio-macros"
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.
-# - Create "v0.3.x" git tag.
-version = "0.3.1"
+# - Create "tokio-macros-1.0.x" git tag.
+version = "1.0.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
@@ -18,6 +18,7 @@ description = """
 Tokio's proc macros.
 """
 categories = ["asynchronous"]
+publish = false
 
 [lib]
 proc-macro = true
@@ -30,7 +31,7 @@ quote = "1"
 syn = { version = "1.0.3", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/1.0.0")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,27 +6,28 @@ name = "tokio-test"
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.
-# - Create "v0.3.x" git tag.
-version = "0.3.0"
+# - Create "tokio-test-0.4.x" git tag.
+version = "0.4.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-test/0.3.0/tokio_test"
+documentation = "https://docs.rs/tokio-test/0.4.0/tokio_test"
 description = """
 Testing utilities for Tokio- and futures-based code
 """
 categories = ["asynchronous", "testing"]
+publish = false
 
 [dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["rt", "stream", "sync", "time", "test-util"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["rt", "stream", "sync", "time", "test-util"] }
 
 bytes = "0.6.0"
 futures-core = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
 futures-util = "0.3.0"
 
 [package.metadata.docs.rs]

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-test/0.3.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-test/0.4.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,8 +6,8 @@ name = "tokio-util"
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.
-# - Create "v0.2.x" git tag.
-version = "0.5.1"
+# - Create "tokio-util-0.6.x" git tag.
+version = "0.6.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
@@ -18,6 +18,7 @@ description = """
 Additional utilities for working with Tokio.
 """
 categories = ["asynchronous"]
+publish = false
 
 [features]
 # No features on by default
@@ -34,7 +35,7 @@ io = []
 rt = ["tokio/rt"]
 
 [dependencies]
-tokio = { version = "0.3.4", path = "../tokio" }
+tokio = { version = "1.0.0", path = "../tokio" }
 
 bytes = "0.6.0"
 futures-core = "0.3.0"
@@ -45,8 +46,8 @@ pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]
-tokio = { version = "0.3.0", path = "../tokio", features = ["full"] }
-tokio-test = { version = "0.3.0", path = "../tokio-test" }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
 
 futures = "0.3.0"
 futures-test = "0.3.5"

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.5.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.0")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio"
 #   - Cargo.toml
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v0.3.x" git tag.
-version = "0.3.5"
+# - Create "v1.0.x" git tag.
+version = "1.0.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.3.5/tokio/"
+documentation = "https://docs.rs/tokio/1.0.0/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """
@@ -22,6 +22,7 @@ backed applications.
 """
 categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures"]
+publish = false
 
 [features]
 # Include nothing by default
@@ -88,7 +89,7 @@ test-util = []
 time = []
 
 [dependencies]
-tokio-macros = { version = "0.3.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "1.0.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.0"
 
@@ -117,7 +118,7 @@ default-features = false
 optional = true
 
 [dev-dependencies]
-tokio-test = { version = "0.3.0", path = "../tokio-test" }
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
 futures = { version = "0.3.0", features = ["async-await"] }
 proptest = "0.10.0"
 tempfile = "3.1.0"

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.3.5")]
+#![doc(html_root_url = "https://docs.rs/tokio/1.0.0")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
Updates the Cargo.toml files to disable publishing and set versions for 1.0.