### PR TITLE
docs: `tokio::main` macro also supported on `rt`

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -53,6 +53,8 @@ use proc_macro::TokenStream;
 /// The `worker_threads` option configures the number of worker threads, and
 /// defaults to the number of cpus on the system. This is the default flavor.
 ///
+/// Note: The multi-threaded runtime requires the `rt-multi-thread` feature flag.
+///
 /// # Current thread runtime
 ///
 /// To use the single-threaded runtime known as the `current_thread` runtime,

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -410,13 +410,13 @@ cfg_macros! {
     cfg_rt! {
         cfg_rt_multi_thread! {
             // This is the docs.rs case (with all features) so make sure macros
-            // is included in doc(cfg).
+            // and rt are included in doc(cfg).
 
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
-            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "rt"))))]
             pub use tokio_macros::main;
 
-            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "rt"))))]
             pub use tokio_macros::test;
         }
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -407,21 +407,22 @@ cfg_macros! {
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
 
-    #[cfg(feature = "rt-multi-thread")]
-    #[cfg(not(test))] // Work around for rust-lang/rust#62127
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", any(feature = "rt-multi-thread", feature = "rt")))))]
-    pub use tokio_macros::main;
+    cfg_rt! {
+        #[cfg(feature = "rt-multi-thread")]
+        #[cfg(not(test))] // Work around for rust-lang/rust#62127
+        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        pub use tokio_macros::main;
 
-    #[cfg(feature = "rt-multi-thread")]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", any(feature = "rt-multi-thread", feature = "rt")))))]
-    pub use tokio_macros::test;
+        #[cfg(feature = "rt-multi-thread")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        pub use tokio_macros::test;
 
-    #[cfg(all(feature = "rt", not(feature = "rt-multi-thread")))]
-    #[cfg(not(test))] // Work around for rust-lang/rust#62127
-    pub use tokio_macros::main_rt as main;
-
-    #[cfg(all(feature = "rt", not(feature = "rt-multi-thread")))]
-    pub use tokio_macros::test_rt as test;
+        cfg_not_rt_multi_thread! {
+            #[cfg(not(test))] // Work around for rust-lang/rust#62127
+            pub use tokio_macros::main_rt as main;
+            pub use tokio_macros::test_rt as test;
+        }
+    }
 
     // Always fail if rt is not enabled.
     cfg_not_rt! {

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -407,25 +407,21 @@ cfg_macros! {
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
 
-    cfg_rt! {
-        cfg_rt_multi_thread! {
-            // This is the docs.rs case (with all features) so make sure macros
-            // and rt are included in doc(cfg).
+    #[cfg(feature = "rt-multi-thread")]
+    #[cfg(not(test))] // Work around for rust-lang/rust#62127
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", any(feature = "rt-multi-thread", feature = "rt")))))]
+    pub use tokio_macros::main;
 
-            #[cfg(not(test))] // Work around for rust-lang/rust#62127
-            #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "rt"))))]
-            pub use tokio_macros::main;
+    #[cfg(feature = "rt-multi-thread")]
+    #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", any(feature = "rt-multi-thread", feature = "rt")))))]
+    pub use tokio_macros::test;
 
-            #[cfg_attr(docsrs, doc(cfg(all(feature = "macros", feature = "rt"))))]
-            pub use tokio_macros::test;
-        }
+    #[cfg(all(feature = "rt", not(feature = "rt-multi-thread")))]
+    #[cfg(not(test))] // Work around for rust-lang/rust#62127
+    pub use tokio_macros::main_rt as main;
 
-        cfg_not_rt_multi_thread! {
-            #[cfg(not(test))] // Work around for rust-lang/rust#62127
-            pub use tokio_macros::main_rt as main;
-            pub use tokio_macros::test_rt as test;
-        }
-    }
+    #[cfg(all(feature = "rt", not(feature = "rt-multi-thread")))]
+    pub use tokio_macros::test_rt as test;
 
     // Always fail if rt is not enabled.
     cfg_not_rt! {


### PR DESCRIPTION
Fixes: #3144
Refs: #2225