### PR TITLE
docs: fix typo in signal module documentation

### DIFF
--- a/tokio/src/signal/mod.rs
+++ b/tokio/src/signal/mod.rs
@@ -5,7 +5,7 @@
 //! signal handling, but it should be evaluated for your own applications' needs
 //! to see if it's suitable.
 //!
-//! The are some fundamental limitations of this crate documented on the OS
+//! There are some fundamental limitations of this crate documented on the OS
 //! specific structures, as well.
 //!
 //! # Examples


### PR DESCRIPTION
Hi, I've found there is typo in [tokio::signal](https://docs.rs/tokio/0.3.5/tokio/signal/index.html).
It seems like the sentence `The are some fundamental limitations ...` should be started with `There are ...`.