### PR TITLE
docs: Improve documentation about blocking threads timeout

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -173,16 +173,18 @@
 //! combat this, Tokio provides two kinds of threads: Core threads and blocking
 //! threads. The core threads are where all asynchronous code runs, and Tokio
 //! will by default spawn one for each CPU core. The blocking threads are
-//! spawned on demand, and can be used to run blocking code that would otherwise
-//! block other tasks from running. Since it is not possible for Tokio to swap
-//! out blocking tasks, like it can do with asynchronous code, the upper limit
-//! on the number of blocking threads is very large. These limits can be
-//! configured on the [`Builder`].
+//! spawned on demand, can be used to run blocking code that would otherwise
+//! block other tasks from running and are kept alive when not used for a certain
+//! amount of time which can be configured with [`thread_keep_alive`].
+//! Since it is not possible for Tokio to swap out blocking tasks, like it
+//! can do with asynchronous code, the upper limit on the number of blocking
+//! threads is very large. These limits can be configured on the [`Builder`].
 //!
 //! To spawn a blocking task, you should use the [`spawn_blocking`] function.
 //!
 //! [`Builder`]: crate::runtime::Builder
 //! [`spawn_blocking`]: crate::task::spawn_blocking()
+//! [`thread_keep_alive`]: crate::runtime::Builder::thread_keep_alive()
 //!
 //! ```
 //! #[tokio::main]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The documentation is not clear about the lifetime of the threads of the blocking threadpool (https://github.com/tokio-rs/tokio/discussions/3251).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I Added link which explains that blocking threads have a timeout which can be configured.

The modification is in the sentence:
```
spawned on demand, can be used to run blocking code that would otherwise
block other tasks from running and are kept alive when not used for a certain
amount of time which can be configured with [`thread_keep_alive`].
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
