### PR TITLE
Fix panics on updating DelayQueue entries

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -36,14 +36,14 @@ use std::task::{self, Poll, Waker};
 /// # `Stream` implementation
 ///
 /// Items are retrieved from the queue via [`DelayQueue::poll_expired`]. If no delays have
-/// expired, no items are returned. In this case, `NotReady` is returned and the
+/// expired, no items are returned. In this case, `Pending` is returned and the
 /// current task is registered to be notified once the next item's delay has
 /// expired.
 ///
 /// If no items are in the queue, i.e. `is_empty()` returns `true`, then `poll`
 /// returns `Ready(None)`. This indicates that the stream has reached an end.
 /// However, if a new item is inserted *after*, `poll` will once again start
-/// returning items or `NotReady.
+/// returning items or `Pending.
 ///
 /// Items are returned ordered by their expirations. Items that are configured
 /// to expire first will be returned first. There are no ordering guarantees
@@ -713,7 +713,7 @@ impl<T> DelayQueue<T> {
     /// Returns `true` if there are no items in the queue.
     ///
     /// Note that this function returns `false` even if all items have not yet
-    /// expired and a call to `poll` will return `NotReady`.
+    /// expired and a call to `poll` will return `Pending`.
     ///
     /// # Examples
     ///

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -538,7 +538,7 @@ impl<T> DelayQueue<T> {
     ///
     ///     delay_queue.reset_at(&key, Instant::now() + Duration::from_secs(10));
     ///
-    ///     // "foo"is now scheduled to be returned in 10 seconds
+    ///     // "foo" is now scheduled to be returned in 10 seconds
     /// # }
     /// ```
     pub fn reset_at(&mut self, key: &Key, when: Instant) {
@@ -548,6 +548,8 @@ impl<T> DelayQueue<T> {
         let when = self.normalize_deadline(when);
 
         self.slab[key.index].when = when;
+        self.slab[key.index].expired = false;
+
         self.insert_idx(when, key.index);
 
         let next_deadline = self.next_deadline();

--- a/tokio-util/src/time/wheel/level.rs
+++ b/tokio-util/src/time/wheel/level.rs
@@ -233,14 +233,13 @@ fn slot_for(duration: u64, level: usize) -> usize {
     ((duration >> (level * 6)) % LEVEL_MULT as u64) as usize
 }
 
-/*
 #[cfg(all(test, not(loom)))]
 mod test {
     use super::*;
 
     #[test]
     fn test_slot_for() {
-        for pos in 1..64 {
+        for pos in 0..64 {
             assert_eq!(pos as usize, slot_for(pos, 0));
         }
 
@@ -252,4 +251,3 @@ mod test {
         }
     }
 }
-*/

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -116,9 +116,17 @@ where
         Ok(())
     }
 
-    /// Remove `item` from thee timing wheel.
+    /// Remove `item` from the timing wheel.
     pub(crate) fn remove(&mut self, item: &T::Borrowed, store: &mut T::Store) {
         let when = T::when(item, store);
+
+        assert!(
+            self.elapsed <= when,
+            "elapsed={}; when={}",
+            self.elapsed,
+            when
+        );
+
         let level = self.level_for(when);
 
         self.levels[level].remove_entry(when, item, store);
@@ -240,9 +248,9 @@ where
 }
 
 fn level_for(elapsed: u64, when: u64) -> usize {
-    let masked = elapsed ^ when;
-
-    assert!(masked != 0, "elapsed={}; when={}", elapsed, when);
+    // Mask in the trailing bits ignored by the level calculation in order to cap
+    // the possible leading zeros
+    let masked = elapsed ^ when | 0x3f;
 
     let leading_zeros = masked.leading_zeros() as usize;
     let significant = 63 - leading_zeros;
@@ -255,7 +263,7 @@ mod test {
 
     #[test]
     fn test_level_for() {
-        for pos in 1..64 {
+        for pos in 0..64 {
             assert_eq!(
                 0,
                 level_for(0, pos),

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -248,9 +248,11 @@ where
 }
 
 fn level_for(elapsed: u64, when: u64) -> usize {
+    const SLOT_MASK: u64 = (1 << 6) - 1;
+
     // Mask in the trailing bits ignored by the level calculation in order to cap
     // the possible leading zeros
-    let masked = elapsed ^ when | 0x3f;
+    let masked = elapsed ^ when | SLOT_MASK;
 
     let leading_zeros = masked.leading_zeros() as usize;
     let significant = 63 - leading_zeros;

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -245,6 +245,11 @@ async fn reset_twice() {
     assert!(queue.is_woken());
 }
 
+/// Regression test: Given an entry inserted with a deadline in the past, so
+/// that it is placed directly on the expired queue, reset the entry to a
+/// deadline in the future. Validate that this leaves the entry and queue in an
+/// internally consistent state by running an additional reset on the entry
+/// before polling it to completion.
 #[tokio::test]
 async fn repeatedly_reset_entry_inserted_as_expired() {
     time::pause();

--- a/tokio/src/time/driver/wheel/level.rs
+++ b/tokio/src/time/driver/wheel/level.rs
@@ -255,14 +255,13 @@ fn slot_for(duration: u64, level: usize) -> usize {
     ((duration >> (level * 6)) % LEVEL_MULT as u64) as usize
 }
 
-/*
 #[cfg(all(test, not(loom)))]
 mod test {
     use super::*;
 
     #[test]
     fn test_slot_for() {
-        for pos in 1..64 {
+        for pos in 0..64 {
             assert_eq!(pos as usize, slot_for(pos, 0));
         }
 
@@ -274,4 +273,3 @@ mod test {
         }
     }
 }
-*/

--- a/tokio/src/time/driver/wheel/mod.rs
+++ b/tokio/src/time/driver/wheel/mod.rs
@@ -288,16 +288,16 @@ impl Wheel {
 }
 
 fn level_for(elapsed: u64, when: u64) -> usize {
+    const SLOT_MASK: u64 = (1 << 6) - 1;
+
     // Mask in the trailing bits ignored by the level calculation in order to cap
     // the possible leading zeros
-    let mut masked = elapsed ^ when | 0x3f;
+    let mut masked = elapsed ^ when | SLOT_MASK;
 
     if masked >= MAX_DURATION {
         // Fudge the timer into the top level
         masked = MAX_DURATION - 1;
     }
-
-    assert!(masked != 0, "elapsed={}; when={}", elapsed, when);
 
     let leading_zeros = masked.leading_zeros() as usize;
     let significant = 63 - leading_zeros;


### PR DESCRIPTION
## Motivation

This PR addresses two related bugs related to edge cases in `tokio_util::time::DelayQueue`.

1. When an entry is inserted into the queue with a deadline that has already elapsed it is flagged and put on a special-cased subqueue. If the entry's key is subsequently reset with a deadline in the future, the expired flag is not cleared. Trying to use `DelayQueue::{reset, reset_at, remove}` with the same key a second time will either cause a debug assert or trigger various kinds of breakage in builds without debug assertions—the key may be left in the timer wheel after a `remove` call and then reused for a separate storage entry, etc.

2. Under specific circumstances, calling `DelayQueue::{reset, reset_at, remove}` with an entry which has expired but has not yet been retrieved with `DelayQueue::poll_expiration` will cause a panic. For this to occur multiple entries need to be inserted with a deadline that happens to be mapped to slot 0 of a level in the timer wheel. When the first of these entries expires and is retrieved the wheel's internal time offset is set to the entries' deadline. Trying to look up another of these entries by key then causes the timer wheel to panic because the call to compute the wheel level for the entry incidentally relies on either the entry's expiration being in the future or the slot index being non-zero.

## Solution

1. Clear the `expired` flag in `DelayQueue::reset_at` before re-inserting the entry into the queue, which will set the flag again if needed.

2. I believe the `Wheel::remove` method is the only point where the wheel implementation does not gracefully handle there being an entry that expires at the current time offset. All the logic which can run from within the wheel's poll method already has to handle that at least transiently being the case, which accounts for pretty much all of the wheel's surface area apart from the insert and remove methods. There is nothing special about slot 0 in a wheel level, so this PR modifies the level computation to work at the current time offset with any slot value.

   I ported the change in the level computation back to the tokio core timer wheel, but both the current core timer implementation and the 0.2 time driver, which shared its `Wheel` implementation with `DelayQueue`, remove expired entries from the wheel all at once in a non-preemptive loop, so neither can hit the panic. (Although PR #3229 recently addressed a bug in the core timer which is very similar to these.)