### PR TITLE
Document `SinkExt` and other futures traits on docs.rs

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,6 +34,8 @@ time = ["tokio/time","slab"]
 io = []
 rt = ["tokio/rt"]
 
+__docs_rs = ["futures-util"]
+
 [dependencies]
 tokio = { version = "1.0.0", path = "../tokio" }
 
@@ -41,6 +43,7 @@ bytes = "0.6.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }
+futures-util = { version = "0.3.0", optional = true }
 log = "0.4"
 pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`SinkExt` and other futures traits are extremely hard to find if you don't already know they exist. They do not appear in docs generated by Rustdoc because tokio-utils doesn't depend on futures-util itself, you have to do that in your downstream crate.

## Solution

Add an optional dependency enabled only on docs.rs, so that it shows up with `cargo doc --all-features`.

Before (https://docs.rs/tokio-util/0.5.1/tokio_util/codec/struct.Framed.html): ![image](https://user-images.githubusercontent.com/23638587/102089829-bbf57780-3dea-11eb-9d4e-541bcc875974.png)

After: 
![image](https://user-images.githubusercontent.com/23638587/102089906-ce6fb100-3dea-11eb-9455-f9a438e4828e.png)