### PR TITLE
tcp_stream: implement keepalive/set_keepalive

### DIFF
--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -29,6 +29,22 @@ async fn set_linger() {
 }
 
 #[tokio::test]
+#[cfg(not(windows))]
+async fn set_keepalive() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    let stream = TcpStream::connect(listener.local_addr().unwrap())
+        .await
+        .unwrap();
+
+    assert_ok!(stream.set_keepalive(Some(Duration::from_secs(1))));
+    assert_eq!(stream.keepalive().unwrap().unwrap().as_secs(), 1);
+
+    assert_ok!(stream.set_keepalive(None));
+    assert!(stream.keepalive().unwrap().is_none());
+}
+
+#[tokio::test]
 async fn try_read_write() {
     const DATA: &[u8] = b"this is some data to write to the socket";
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Setting keepalive parameters used to be possible in previous releases, and it would be nice to restore this capability. Long-standing TCP connections could benefit from having keepalive probes enabled. Example use case: https://github.com/scylladb/scylla-rust-driver/issues/132

Refs #3082

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A pair of keepalive()/set_keepalive() functions are implemented on top of mio's keepalive feature (added in https://github.com/tokio-rs/mio/pull/1385). The interface is consistent with the one from Tokio 0.2.9. This patch comes with a simple test which verifies that previously set values are indeed saved.