### PR TITLE
chore: prepare v0.3.6 release

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.3.6 (December 14, 2020)
+
+### Fixed
+- rt: fix deadlock in shutdown (#3228)
+- rt: fix panic in task abort when off rt (#3159)
+- sync: make `add_permits` panic with usize::MAX >> 3 permits (#3188)
+- time: Fix race condition in timer drop (#3229)
+- watch: fix spurious wakeup (#3244)
+
+### Added
+- example: add back udp-codec example (#3205)
+- net: add `TcpStream::into_std` (#3189)
+
 # 0.3.5 (November 30, 2020)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.5"
+version = "0.3.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.3.5/tokio/"
+documentation = "https://docs.rs/tokio/0.3.6/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.3.5")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.3.6")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
# 0.3.6 (December 14, 2020)

### Fixed
- rt: fix deadlock in shutdown (#3228)
- rt: fix panic in task abort when off rt (#3159)
- sync: make `add_permits` panic with usize::MAX >> 3 permits (#3188)
- time: Fix race condition in timer drop (#3229)
- watch: fix spurious wakeup (#3244)

### Added
- example: add back udp-codec example (#3205)
- net: add `TcpStream::into_std` (#3189)
