### PR TITLE
chore: prepare tokio-macros v0.3.2

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.2 (December 19, 2020)
+
+### Fixed
+
+- fix outdated macro documentation ([#3180])
+- add portability note to `tokio::main` ([#3199])
+
 # 0.3.1 (October 25, 2020)
 
 ### Fixed
@@ -51,3 +58,5 @@
 [#2177]: https://github.com/tokio-rs/tokio/pull/2177
 [#2225]: https://github.com/tokio-rs/tokio/pull/2225
 [#3038]: https://github.com/tokio-rs/tokio/pull/3038
+[#3180]: https://github.com/tokio-rs/tokio/pull/3180
+[#3199]: https://github.com/tokio-rs/tokio/pull/3199

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/0.3.1/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/0.3.2/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/0.3.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-macros/0.3.2")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
# 0.3.2 (December 19, 2020)

### Fixed

- fix outdated macro documentation (#3180)
- add portability note to `tokio::main` (#3199)



Closes: #3290