### PR TITLE
chore: remove some left over `stream` feature code

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -21,7 +21,7 @@ categories = ["asynchronous", "testing"]
 publish = false
 
 [dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["rt", "stream", "sync", "time", "test-util"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 async-stream = "0.3"
 

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -29,7 +29,7 @@ full = ["codec", "compat", "io", "time", "net", "rt"]
 
 net = ["tokio/net"]
 compat = ["futures-io",]
-codec = ["tokio/stream"]
+codec = []
 time = ["tokio/time","slab"]
 io = []
 rt = ["tokio/rt"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -40,7 +40,6 @@ full = [
   "rt",
   "rt-multi-thread",
   "signal",
-  "stream",
   "sync",
   "time",
 ]
@@ -83,7 +82,6 @@ signal = [
   "signal-hook-registry",
   "winapi/consoleapi",
 ]
-stream = ["futures-core"]
 sync = []
 test-util = []
 time = []
@@ -95,7 +93,6 @@ pin-project-lite = "0.2.0"
 
 # Everything else is optional...
 bytes = { version = "0.6.0", optional = true }
-futures-core = { version = "0.3.0", optional = true }
 once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.6", optional = true }


### PR DESCRIPTION
Removes the `stream` feature flag from `Cargo.toml` and removes the
`futures-core` dependency. Once `Stream` lands in `std`, a feature flag
is most likely not needed.