### PR TITLE
chore: update to `bytes` 1.0 git branch

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -14,7 +14,7 @@ tokio-stream = { version = "0.1", path = "../tokio-stream" }
 async-stream = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
-bytes = "0.6"
+bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures = "0.3.0"
 http = "0.2"
 serde = "1.0"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -25,7 +25,7 @@ tokio = { version = "1.0.0", path = "../tokio", features = ["rt", "sync", "time"
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 async-stream = "0.3"
 
-bytes = "0.6.0"
+bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures-core = "0.3.0"
 
 [dev-dependencies]

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -40,7 +40,7 @@ __docs_rs = ["futures-util"]
 tokio = { version = "1.0.0", path = "../tokio" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
-bytes = "0.6.0"
+bytes = { git = "https://github.com/tokio-rs/bytes" }
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -131,7 +131,7 @@ where
         loop {
             if self.as_mut().has_chunk() {
                 // This unwrap is very sad, but it can't be avoided.
-                let buf = self.project().chunk.as_ref().unwrap().bytes();
+                let buf = self.project().chunk.as_ref().unwrap().chunk();
                 return Poll::Ready(Ok(buf));
             } else {
                 match self.as_mut().project().inner.poll_next(cx) {

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -113,7 +113,7 @@ mod util {
         }
 
         let n = {
-            let dst = buf.bytes_mut();
+            let dst = buf.chunk_mut();
             let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
             let mut buf = ReadBuf::uninit(dst);
             let ptr = buf.filled().as_ptr();
@@ -187,10 +187,10 @@ mod util {
 
         let n = if io.is_write_vectored() {
             let mut slices = [IoSlice::new(&[]); MAX_BUFS];
-            let cnt = buf.bytes_vectored(&mut slices);
+            let cnt = buf.chunks_vectored(&mut slices);
             ready!(io.poll_write_vectored(cx, &slices[..cnt]))?
         } else {
-            ready!(io.poll_write(cx, buf.bytes()))?
+            ready!(io.poll_write(cx, buf.chunk()))?
         };
 
         buf.advance(n);

--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -76,7 +76,7 @@ impl<C: Decoder + Unpin> Stream for UdpFramed<C> {
             let addr = unsafe {
                 // Convert `&mut [MaybeUnit<u8>]` to `&mut [u8]` because we will be
                 // writing to it via `poll_recv_from` and therefore initializing the memory.
-                let buf = &mut *(pin.rd.bytes_mut() as *mut _ as *mut [MaybeUninit<u8>]);
+                let buf = &mut *(pin.rd.chunk_mut() as *mut _ as *mut [MaybeUninit<u8>]);
                 let mut read = ReadBuf::uninit(buf);
                 let ptr = read.filled().as_ptr();
                 let res = ready!(Pin::new(&mut pin.socket).poll_recv_from(cx, &mut read));

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,7 @@ tokio-macros = { version = "1.0.0", path = "../tokio-macros", optional = true }
 pin-project-lite = "0.2.0"
 
 # Everything else is optional...
-bytes = { version = "0.6.0", optional = true }
+bytes = { git = "https://github.com/tokio-rs/bytes", optional = true }
 once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.6", optional = true }

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -50,7 +50,7 @@ where
         }
 
         let n = {
-            let dst = me.buf.bytes_mut();
+            let dst = me.buf.chunk_mut();
             let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
             let mut buf = ReadBuf::uninit(dst);
             let ptr = buf.filled().as_ptr();

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -98,7 +98,7 @@ fn reserve(buf: &mut Vec<u8>, bytes: usize) {
 
 /// Returns the unused capacity of the provided vector.
 fn get_unused_capacity(buf: &mut Vec<u8>) -> &mut [MaybeUninit<u8>] {
-    let uninit = bytes::BufMut::bytes_mut(buf);
+    let uninit = bytes::BufMut::chunk_mut(buf);
     unsafe { &mut *(uninit as *mut _ as *mut [MaybeUninit<u8>]) }
 }
 

--- a/tokio/src/io/util/write_buf.rs
+++ b/tokio/src/io/util/write_buf.rs
@@ -48,7 +48,7 @@ where
             return Poll::Ready(Ok(0));
         }
 
-        let n = ready!(Pin::new(me.writer).poll_write(cx, me.buf.bytes()))?;
+        let n = ready!(Pin::new(me.writer).poll_write(cx, me.buf.chunk()))?;
         me.buf.advance(n);
         Poll::Ready(Ok(n))
     }


### PR DESCRIPTION
Updates the codebase to track the `bytes` git branch. This is in
preparation for the 1.0 release.

Closes #3058