### PR TITLE
tokio-macros: disambiguate name resolution for "tokio::runtime::Builder"

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -226,10 +226,10 @@ fn parse_knobs(
 
     let mut rt = match config.flavor {
         RuntimeFlavor::CurrentThread => quote! {
-            tokio::runtime::Builder::new_current_thread()
+            ::tokio::runtime::Builder::new_current_thread()
         },
         RuntimeFlavor::Threaded => quote! {
-            tokio::runtime::Builder::new_multi_thread()
+            ::tokio::runtime::Builder::new_multi_thread()
         },
     };
     if let Some(v) = config.worker_threads {


### PR DESCRIPTION
The `#[::tokio::main]` macro failed when another thing with the name "tokio" is in scope. In the case I encountered, the problem arose because of a wildcard import like `use foo::bar::*;` which happened to contain a `foo::bar::tokio` submodule. To add insult to injury, the error message is not very helpful:

```
error[E0433]: failed to resolve: could not find `runtime` in `tokio`
  --> src/main.rs:11:1
   |
11 | #[::tokio::main]
   | ^^^^^^^^^^^^^^^^ not found in `tokio::runtime`
   |
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider importing one of these items
   |
7  | use std::thread::Builder;
   |
7  | use tokio::runtime::Builder;
   |

error: aborting due to previous error
```

Fortunately the issue is quite easy to resolve, as seen in the diff. If you want a testcase for this bug, please let me know where best to put it.