### PR TITLE
Add _mut variants of methods on AsyncFd

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -534,7 +534,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
             }
         }
 
-        result.into()
+        result
     }
 
     /// Performs the IO operation `f`; if `f` returns [`Pending`], the readiness
@@ -613,7 +613,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
             }
         }
 
-        result.into()
+        result
     }
 
     /// Performs the IO operation `f`; if `f` returns [`Pending`], the readiness

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -444,7 +444,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     pub fn with_io<R>(
         &mut self,
         f: impl FnOnce(&AsyncFd<Inner>) -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
+    ) -> io::Result<R> {
         let result = f(self.async_fd);
 
         if let Err(e) = result.as_ref() {
@@ -468,8 +468,11 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     /// create this `AsyncFdReadyGuard`.
     ///
     /// [`Pending`]: std::task::Poll::Pending
-    pub fn with_poll<R>(&mut self, f: impl FnOnce() -> std::task::Poll<R>) -> std::task::Poll<R> {
-        let result = f();
+    pub fn with_poll<R>(
+        &mut self,
+        f: impl FnOnce(&AsyncFd<Inner>) -> std::task::Poll<R>,
+    ) -> std::task::Poll<R> {
+        let result = f(&self.async_fd);
 
         if result.is_pending() {
             self.clear_ready();
@@ -520,7 +523,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     pub fn with_io<R>(
         &mut self,
         f: impl FnOnce(&mut AsyncFd<Inner>) -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
+    ) -> io::Result<R> {
         let result = f(&mut self.async_fd);
 
         if let Err(e) = result.as_ref() {
@@ -544,8 +547,11 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     /// create this `AsyncFdReadyGuard`.
     ///
     /// [`Pending`]: std::task::Poll::Pending
-    pub fn with_poll<R>(&mut self, f: impl FnOnce() -> std::task::Poll<R>) -> std::task::Poll<R> {
-        let result = f();
+    pub fn with_poll<R>(
+        &mut self,
+        f: impl FnOnce(&mut AsyncFd<Inner>) -> std::task::Poll<R>,
+    ) -> std::task::Poll<R> {
+        let result = f(&mut self.async_fd);
 
         if result.is_pending() {
             self.clear_ready();

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -222,7 +222,7 @@ cfg_net_unix! {
 
     pub mod unix {
         //! Asynchronous IO structures specific to Unix-like operating systems.
-        pub use super::async_fd::{AsyncFd, AsyncFdReadyGuard};
+        pub use super::async_fd::{AsyncFd, AsyncFdReadyGuard, AsyncFdReadyMutGuard};
     }
 }
 

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -19,7 +19,7 @@ use nix::unistd::{close, read, write};
 use futures::{poll, FutureExt};
 
 use tokio::io::unix::{AsyncFd, AsyncFdReadyGuard};
-use tokio_test::{assert_err, assert_pending, assert_ready};
+use tokio_test::{assert_err, assert_pending};
 
 struct TestWaker {
     inner: Arc<TestWakerInner>,
@@ -201,7 +201,7 @@ async fn reset_readable() {
 
     let mut guard = readable.await.unwrap();
 
-    assert_ready!(guard.with_io(|_| afd_a.get_ref().read(&mut [0]))).unwrap();
+    guard.with_io(|_| afd_a.get_ref().read(&mut [0])).unwrap();
 
     // `a` is not readable, but the reactor still thinks it is
     // (because we have not observed a not-ready error yet)
@@ -234,7 +234,7 @@ async fn reset_writable() {
 
     // Write until we get a WouldBlock. This also clears the ready state.
     loop {
-        if let Err(e) = assert_ready!(guard.with_io(|_| afd_a.get_ref().write(&[0; 512][..]))) {
+        if let Err(e) = guard.with_io(|_| afd_a.get_ref().write(&[0; 512][..])) {
             assert_eq!(ErrorKind::WouldBlock, e.kind());
             break;
         }
@@ -327,13 +327,13 @@ async fn with_poll() {
     afd_a.get_ref().read_exact(&mut [0]).unwrap();
 
     // Should not clear the readable state
-    let _ = guard.with_poll(|| Poll::Ready(()));
+    let _ = guard.with_poll(|_| Poll::Ready(()));
 
     // Still readable...
     let _ = afd_a.readable().await.unwrap();
 
     // Should clear the readable state
-    let _ = guard.with_poll(|| Poll::Pending::<()>);
+    let _ = guard.with_poll(|_| Poll::Pending::<()>);
 
     // Assert not readable
     let readable = afd_a.readable();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

* https://github.com/rust-lang/rfcs/pull/3014 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
* Update `AsyncFdReadGuard::with_poll` to pass a reference to the underlying
  object to the clousure.
* Create a new `AsyncFdReadMutGuard` to provide mutable APIs on the underlying
  object.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
