### PR TITLE
Minimize the amount of duplicated code in the task harness

### DIFF
--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -296,6 +296,26 @@ cfg_rt_multi_thread! {
     }
 }
 
+impl Trailer {
+    pub(crate) unsafe fn set_waker(&self, waker: Option<Waker>) {
+        self.waker.with_mut(|ptr| {
+            *ptr = waker;
+        });
+    }
+
+    pub(crate) unsafe fn will_wake(&self, waker: &Waker) -> bool {
+        self.waker
+            .with(|ptr| (*ptr).as_ref().unwrap().will_wake(waker))
+    }
+
+    pub(crate) fn wake_join(&self) {
+        self.waker.with(|ptr| match unsafe { &*ptr } {
+            Some(waker) => waker.wake_by_ref(),
+            None => panic!("waker missing"),
+        });
+    }
+}
+
 #[test]
 #[cfg(not(loom))]
 fn header_lte_cache_line() {

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -210,6 +210,7 @@ where
         unsafe { Task::from_raw(self.header.into()) }
     }
 
+    /// Returns true if the task should be deallocated.
     fn transition_to_terminal(&self, is_join_interested: bool) -> bool {
         let ref_dec = if self.scheduler.is_bound() {
             if let Some(task) = self.scheduler.release(self.to_task()) {

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -1,4 +1,4 @@
-use crate::runtime::task::core::{Cell, Core, CoreStage, Header, Trailer};
+use crate::runtime::task::core::{Cell, Core, CoreStage, Header, Scheduler, Trailer};
 use crate::runtime::task::state::Snapshot;
 use crate::runtime::task::waker::waker_ref;
 use crate::runtime::task::{JoinError, Notified, Schedule, Task};
@@ -36,6 +36,13 @@ where
     fn core(&self) -> &Core<T, S> {
         unsafe { &self.cell.as_ref().core }
     }
+
+    fn scheduler_view(&self) -> SchedulerView<'_, S> {
+        SchedulerView {
+            header: self.header(),
+            scheduler: &self.core().scheduler,
+        }
+    }
 }
 
 impl<T, S> Harness<T, S>
@@ -49,49 +56,7 @@ where
     ///
     /// Panics raised while polling the future are handled.
     pub(super) fn poll(self) {
-        // If this is the first time the task is polled, the task will be bound
-        // to the scheduler, in which case the task ref count must be
-        // incremented.
-        let is_not_bound = !self.core().scheduler.is_bound();
-
-        // Transition the task to the running state.
-        //
-        // A failure to transition here indicates the task has been cancelled
-        // while in the run queue pending execution.
-        let snapshot = match self.header().state.transition_to_running(is_not_bound) {
-            Ok(snapshot) => snapshot,
-            Err(_) => {
-                // The task was shutdown while in the run queue. At this point,
-                // we just hold a ref counted reference. Drop it here.
-                self.drop_reference();
-                return;
-            }
-        };
-
-        if is_not_bound {
-            // Ensure the task is bound to a scheduler instance. Since this is
-            // the first time polling the task, a scheduler instance is pulled
-            // from the local context and assigned to the task.
-            //
-            // The scheduler maintains ownership of the task and responds to
-            // `wake` calls.
-            //
-            // The task reference count has been incremented.
-            //
-            // Safety: Since we have unique access to the task so that we can
-            // safely call `bind_scheduler`.
-            self.core().scheduler.bind_scheduler(self.to_task());
-        }
-
-        // The transition to `Running` done above ensures that a lock on the
-        // future has been obtained. This also ensures the `*mut T` pointer
-        // contains the future (as opposed to the output) and is initialized.
-
-        let waker_ref = waker_ref::<T, S>(self.header());
-        let cx = Context::from_waker(&*waker_ref);
-        let res = poll_future(self.header(), &self.core().stage, snapshot, cx);
-
-        match res {
+        match self.poll_inner() {
             PollFuture::Notified => {
                 // Signal yield
                 self.core().scheduler.yield_now(Notified(self.to_task()));
@@ -99,11 +64,29 @@ where
                 // `transition_to_idle`.
                 self.drop_reference();
             }
-            PollFuture::Complete(out) => {
-                self.complete(out, snapshot.is_join_interested());
+            PollFuture::DropReference => {
+                self.drop_reference();
+            }
+            PollFuture::Complete(out, is_join_interested) => {
+                self.complete(out, is_join_interested);
             }
             PollFuture::None => (),
         }
+    }
+
+    fn poll_inner(&self) -> PollFuture<T::Output> {
+        let snapshot = match self.scheduler_view().transition_to_running() {
+            Ok(snapshot) => snapshot,
+            Err(()) => return PollFuture::DropReference,
+        };
+
+        // The transition to `Running` done above ensures that a lock on the
+        // future has been obtained. This also ensures the `*mut T` pointer
+        // contains the future (as opposed to the output) and is initialized.
+
+        let waker_ref = waker_ref::<T, S>(self.header());
+        let cx = Context::from_waker(&*waker_ref);
+        poll_future(self.header(), &self.core().stage, snapshot, cx)
     }
 
     pub(super) fn dealloc(self) {
@@ -227,7 +210,58 @@ where
     }
 
     fn to_task(&self) -> Task<S> {
-        unsafe { Task::from_raw(self.header().into()) }
+        self.scheduler_view().to_task()
+    }
+}
+
+struct SchedulerView<'a, S> {
+    header: &'a Header,
+    scheduler: &'a Scheduler<S>,
+}
+
+impl<'a, S> SchedulerView<'a, S>
+where
+    S: Schedule,
+{
+    fn to_task(&self) -> Task<S> {
+        // SAFETY The header is from the same struct containing the scheduler `S` so  the cast is safe
+        unsafe { Task::from_raw(self.header.into()) }
+    }
+
+    fn transition_to_running(&self) -> Result<Snapshot, ()> {
+        // If this is the first time the task is polled, the task will be bound
+        // to the scheduler, in which case the task ref count must be
+        // incremented.
+        let is_not_bound = !self.scheduler.is_bound();
+
+        // Transition the task to the running state.
+        //
+        // A failure to transition here indicates the task has been cancelled
+        // while in the run queue pending execution.
+        let snapshot = match self.header.state.transition_to_running(is_not_bound) {
+            Ok(snapshot) => snapshot,
+            Err(_) => {
+                // The task was shutdown while in the run queue. At this point,
+                // we just hold a ref counted reference. Drop it here.
+                return Err(());
+            }
+        };
+
+        if is_not_bound {
+            // Ensure the task is bound to a scheduler instance. Since this is
+            // the first time polling the task, a scheduler instance is pulled
+            // from the local context and assigned to the task.
+            //
+            // The scheduler maintains ownership of the task and responds to
+            // `wake` calls.
+            //
+            // The task reference count has been incremented.
+            //
+            // Safety: Since we have unique access to the task so that we can
+            // safely call `bind_scheduler`.
+            self.scheduler.bind_scheduler(self.to_task());
+        }
+        Ok(snapshot)
     }
 }
 
@@ -351,7 +385,8 @@ fn set_join_waker(
 }
 
 enum PollFuture<T> {
-    Complete(Result<T, JoinError>),
+    Complete(Result<T, JoinError>, bool),
+    DropReference,
     Notified,
     None,
 }
@@ -413,9 +448,9 @@ fn poll_future<T: Future>(
                     PollFuture::None
                 }
             }
-            Err(_) => PollFuture::Complete(Err(cancel_task(core))),
+            Err(_) => PollFuture::Complete(Err(cancel_task(core)), true),
         },
-        Ok(Poll::Ready(ok)) => PollFuture::Complete(ok),
-        Err(err) => PollFuture::Complete(Err(JoinError::panic(err))),
+        Ok(Poll::Ready(ok)) => PollFuture::Complete(ok, snapshot.is_join_interested()),
+        Err(err) => PollFuture::Complete(Err(JoinError::panic(err)), snapshot.is_join_interested()),
     }
 }


### PR DESCRIPTION
## Motivation

Task spawning is a common operation which results in a lot of instantiations of the task code. Reducing the amount of generated code should lead to faster compile times overall.

## Solution

This extracts code that does not depend on a type parameter into functions with less or no type parameters at all. Reducing the amount of duplicated code.
