### PR TITLE
chore: use #[non_exhaustive] instead of private unit field

### DIFF
--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -224,12 +224,13 @@ mod date {
 
     use time::{self, Duration};
 
-    pub struct Now(());
+    #[non_exhaustive]
+    pub struct Now;
 
     /// Returns a struct, which when formatted, renders an appropriate `Date`
     /// header value.
     pub fn now() -> Now {
-        Now(())
+        Now
     }
 
     // Gee Alex, doesn't this seem like premature optimization. Well you see

--- a/tokio-stream/src/timeout.rs
+++ b/tokio-stream/src/timeout.rs
@@ -24,7 +24,8 @@ pin_project! {
 
 /// Error returned by `Timeout`.
 #[derive(Debug, PartialEq)]
-pub struct Elapsed(());
+#[non_exhaustive]
+pub struct Elapsed;
 
 impl<S: Stream> Timeout<S> {
     pub(super) fn new(stream: S, duration: Duration) -> Self {
@@ -61,7 +62,7 @@ impl<S: Stream> Stream for Timeout<S> {
         if *me.poll_deadline {
             ready!(me.deadline.poll(cx));
             *me.poll_deadline = false;
-            return Poll::Ready(Some(Err(Elapsed::new())));
+            return Poll::Ready(Some(Err(Elapsed)));
         }
 
         Poll::Pending
@@ -73,12 +74,6 @@ impl<S: Stream> Stream for Timeout<S> {
 }
 
 // ===== impl Elapsed =====
-
-impl Elapsed {
-    pub(crate) fn new() -> Self {
-        Elapsed(())
-    }
-}
 
 impl fmt::Display for Elapsed {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio-util/src/codec/bytes_codec.rs
+++ b/tokio-util/src/codec/bytes_codec.rs
@@ -42,12 +42,13 @@ use std::io;
 /// ```
 ///
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-pub struct BytesCodec(());
+#[non_exhaustive]
+pub struct BytesCodec;
 
 impl BytesCodec {
     /// Creates a new `BytesCodec` for shipping around raw bytes.
     pub fn new() -> BytesCodec {
-        BytesCodec(())
+        BytesCodec
     }
 }
 

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -219,7 +219,6 @@ impl<T, U> Framed<T, U> {
             codec: self.inner.codec,
             read_buf: self.inner.state.read.buffer,
             write_buf: self.inner.state.write.buffer,
-            _priv: (),
         }
     }
 }
@@ -282,7 +281,7 @@ where
 ///
 /// [`Framed`]: crate::codec::Framed
 #[derive(Debug)]
-#[allow(clippy::manual_non_exhaustive)]
+#[non_exhaustive]
 pub struct FramedParts<T, U> {
     /// The inner transport used to read bytes to and write bytes to
     pub io: T,
@@ -295,10 +294,6 @@ pub struct FramedParts<T, U> {
 
     /// A buffer with unprocessed data which are not written yet.
     pub write_buf: BytesMut,
-
-    /// This private field allows us to add additional fields in the future in a
-    /// backwards compatible way.
-    _priv: (),
 }
 
 impl<T, U> FramedParts<T, U> {
@@ -312,7 +307,6 @@ impl<T, U> FramedParts<T, U> {
             codec,
             read_buf: BytesMut::new(),
             write_buf: BytesMut::new(),
-            _priv: (),
         }
     }
 }

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -409,9 +409,8 @@ pub struct Builder {
 }
 
 /// An error when the number of bytes read is more than max frame length.
-pub struct LengthDelimitedCodecError {
-    _priv: (),
-}
+#[non_exhaustive]
+pub struct LengthDelimitedCodecError;
 
 /// A codec for frames delimited by a frame head specifying their lengths.
 ///
@@ -496,7 +495,7 @@ impl LengthDelimitedCodec {
             if n > self.builder.max_frame_len as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    LengthDelimitedCodecError { _priv: () },
+                    LengthDelimitedCodecError,
                 ));
             }
 
@@ -586,7 +585,7 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
         if n > self.builder.max_frame_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                LengthDelimitedCodecError { _priv: () },
+                LengthDelimitedCodecError,
             ));
         }
 

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -530,7 +530,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
         }
 
         match result {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError),
             result => Ok(result),
         }
     }
@@ -591,7 +591,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
         }
 
         match result {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError),
             result => Ok(result),
         }
     }
@@ -620,4 +620,5 @@ impl<'a, T: std::fmt::Debug + AsRawFd> std::fmt::Debug for AsyncFdReadyMutGuard<
 /// [`WouldBlock`]: std::io::ErrorKind::WouldBlock
 /// [`try_io`]: method@AsyncFdReadyGuard::try_io
 #[derive(Debug)]
-pub struct TryIoError(());
+#[non_exhaustive]
+pub struct TryIoError;

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -15,9 +15,8 @@ cfg_io_util! {
     ///
     /// [`empty`]: fn@empty
     /// [std]: std::io::empty
-    pub struct Empty {
-        _p: (),
-    }
+    #[non_exhaustive]
+    pub struct Empty;
 
     /// Creates a new empty async reader.
     ///
@@ -42,7 +41,7 @@ cfg_io_util! {
     /// }
     /// ```
     pub fn empty() -> Empty {
-        Empty { _p: () }
+        Empty
     }
 }
 

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -15,9 +15,8 @@ cfg_io_util! {
     ///
     /// [sink]: sink()
     /// [std]: std::io::Sink
-    pub struct Sink {
-        _p: (),
-    }
+    #[non_exhaustive]
+    pub struct Sink;
 
     /// Creates an instance of an async writer which will successfully consume all
     /// data.
@@ -45,7 +44,7 @@ cfg_io_util! {
     /// }
     /// ```
     pub fn sink() -> Sink {
-        Sink { _p: () }
+        Sink
     }
 }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -106,7 +106,7 @@ impl Handle {
     ///
     /// Contrary to `current`, this never panics
     pub fn try_current() -> Result<Self, TryCurrentError> {
-        context::current().ok_or(TryCurrentError(()))
+        context::current().ok_or(TryCurrentError)
     }
 
     /// Spawn a future onto the Tokio runtime.
@@ -203,7 +203,8 @@ impl Handle {
 }
 
 /// Error returned by `try_current` when no Runtime has been started
-pub struct TryCurrentError(());
+#[non_exhaustive]
+pub struct TryCurrentError;
 
 impl fmt::Debug for TryCurrentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -54,6 +54,7 @@ pub enum TryAcquireError {
     /// The semaphore has no available permits.
     NoPermits,
 }
+
 /// Error returned from the [`Semaphore::acquire`] function.
 ///
 /// An `acquire` operation can only fail if the semaphore has been
@@ -62,7 +63,8 @@ pub enum TryAcquireError {
 /// [closed]: crate::sync::Semaphore::close
 /// [`Semaphore::acquire`]: crate::sync::Semaphore::acquire
 #[derive(Debug)]
-pub struct AcquireError(());
+#[non_exhaustive]
+pub struct AcquireError;
 
 pub(crate) struct Acquire<'a> {
     node: Waiter,
@@ -521,7 +523,7 @@ unsafe impl Sync for Acquire<'_> {}
 
 impl AcquireError {
     fn closed() -> AcquireError {
-        AcquireError(())
+        AcquireError
     }
 }
 

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -55,7 +55,8 @@ impl<T> From<SendError<T>> for TrySendError<T> {
 
 /// Error returned by `Receiver`.
 #[derive(Debug)]
-pub struct RecvError(());
+#[non_exhaustive]
+pub struct RecvError;
 
 impl fmt::Display for RecvError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -167,7 +167,8 @@ unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
 ///
 /// [`Mutex::try_lock`]: Mutex::try_lock
 #[derive(Debug)]
-pub struct TryLockError(());
+#[non_exhaustive]
+pub struct TryLockError;
 
 impl fmt::Display for TryLockError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -323,7 +324,7 @@ impl<T: ?Sized> Mutex<T> {
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
             Ok(_) => Ok(MutexGuard { lock: self }),
-            Err(_) => Err(TryLockError(())),
+            Err(_) => Err(TryLockError),
         }
     }
 
@@ -378,7 +379,7 @@ impl<T: ?Sized> Mutex<T> {
     pub fn try_lock_owned(self: Arc<Self>) -> Result<OwnedMutexGuard<T>, TryLockError> {
         match self.s.try_acquire(1) {
             Ok(_) => Ok(OwnedMutexGuard { lock: self }),
-            Err(_) => Err(TryLockError(())),
+            Err(_) => Err(TryLockError),
         }
     }
 

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -156,7 +156,7 @@ impl<T: 'static> LocalKey<T> {
             if let Some(val) = v.borrow().as_ref() {
                 Ok(f(val))
             } else {
-                Err(AccessError { _private: () })
+                Err(AccessError)
             }
         })
     }
@@ -223,9 +223,8 @@ impl<T: 'static> StaticLifetime for T {}
 
 /// An error returned by [`LocalKey::try_with`](method@LocalKey::try_with).
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub struct AccessError {
-    _private: (),
-}
+#[non_exhaustive]
+pub struct AccessError;
 
 impl fmt::Debug for AccessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -42,7 +42,8 @@ impl From<Kind> for Error {
 
 /// Error returned by `Timeout`.
 #[derive(Debug, PartialEq)]
-pub struct Elapsed(());
+#[non_exhaustive]
+pub struct Elapsed;
 
 #[derive(Debug)]
 pub(crate) enum InsertError {
@@ -98,12 +99,6 @@ impl fmt::Display for Error {
 }
 
 // ===== impl Elapsed =====
-
-impl Elapsed {
-    pub(crate) fn new() -> Self {
-        Elapsed(())
-    }
-}
 
 impl fmt::Display for Elapsed {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -148,7 +148,7 @@ where
 
         // Now check the timer
         match me.delay.poll(cx) {
-            Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
+            Poll::Ready(()) => Poll::Ready(Err(Elapsed)),
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
#[non_exhaustive] is the official feature for this pattern and was stable at Rust 1.40.