### PR TITLE
Revert "chore: use #[non_exhaustive] instead of private unit field (#3320)"

### DIFF
--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -224,13 +224,12 @@ mod date {
 
     use time::{self, Duration};
 
-    #[non_exhaustive]
-    pub struct Now;
+    pub struct Now(());
 
     /// Returns a struct, which when formatted, renders an appropriate `Date`
     /// header value.
     pub fn now() -> Now {
-        Now
+        Now(())
     }
 
     // Gee Alex, doesn't this seem like premature optimization. Well you see

--- a/tokio-stream/src/timeout.rs
+++ b/tokio-stream/src/timeout.rs
@@ -24,8 +24,7 @@ pin_project! {
 
 /// Error returned by `Timeout`.
 #[derive(Debug, PartialEq)]
-#[non_exhaustive]
-pub struct Elapsed;
+pub struct Elapsed(());
 
 impl<S: Stream> Timeout<S> {
     pub(super) fn new(stream: S, duration: Duration) -> Self {
@@ -62,7 +61,7 @@ impl<S: Stream> Stream for Timeout<S> {
         if *me.poll_deadline {
             ready!(me.deadline.poll(cx));
             *me.poll_deadline = false;
-            return Poll::Ready(Some(Err(Elapsed)));
+            return Poll::Ready(Some(Err(Elapsed::new())));
         }
 
         Poll::Pending
@@ -74,6 +73,12 @@ impl<S: Stream> Stream for Timeout<S> {
 }
 
 // ===== impl Elapsed =====
+
+impl Elapsed {
+    pub(crate) fn new() -> Self {
+        Elapsed(())
+    }
+}
 
 impl fmt::Display for Elapsed {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio-util/src/codec/bytes_codec.rs
+++ b/tokio-util/src/codec/bytes_codec.rs
@@ -42,13 +42,12 @@ use std::io;
 /// ```
 ///
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Default)]
-#[non_exhaustive]
-pub struct BytesCodec;
+pub struct BytesCodec(());
 
 impl BytesCodec {
     /// Creates a new `BytesCodec` for shipping around raw bytes.
     pub fn new() -> BytesCodec {
-        BytesCodec
+        BytesCodec(())
     }
 }
 

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -219,6 +219,7 @@ impl<T, U> Framed<T, U> {
             codec: self.inner.codec,
             read_buf: self.inner.state.read.buffer,
             write_buf: self.inner.state.write.buffer,
+            _priv: (),
         }
     }
 }
@@ -281,7 +282,7 @@ where
 ///
 /// [`Framed`]: crate::codec::Framed
 #[derive(Debug)]
-#[non_exhaustive]
+#[allow(clippy::manual_non_exhaustive)]
 pub struct FramedParts<T, U> {
     /// The inner transport used to read bytes to and write bytes to
     pub io: T,
@@ -294,6 +295,10 @@ pub struct FramedParts<T, U> {
 
     /// A buffer with unprocessed data which are not written yet.
     pub write_buf: BytesMut,
+
+    /// This private field allows us to add additional fields in the future in a
+    /// backwards compatible way.
+    _priv: (),
 }
 
 impl<T, U> FramedParts<T, U> {
@@ -307,6 +312,7 @@ impl<T, U> FramedParts<T, U> {
             codec,
             read_buf: BytesMut::new(),
             write_buf: BytesMut::new(),
+            _priv: (),
         }
     }
 }

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -409,8 +409,9 @@ pub struct Builder {
 }
 
 /// An error when the number of bytes read is more than max frame length.
-#[non_exhaustive]
-pub struct LengthDelimitedCodecError;
+pub struct LengthDelimitedCodecError {
+    _priv: (),
+}
 
 /// A codec for frames delimited by a frame head specifying their lengths.
 ///
@@ -495,7 +496,7 @@ impl LengthDelimitedCodec {
             if n > self.builder.max_frame_len as u64 {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
-                    LengthDelimitedCodecError,
+                    LengthDelimitedCodecError { _priv: () },
                 ));
             }
 
@@ -585,7 +586,7 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
         if n > self.builder.max_frame_len {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
-                LengthDelimitedCodecError,
+                LengthDelimitedCodecError { _priv: () },
             ));
         }
 

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -530,7 +530,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
         }
 
         match result {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
             result => Ok(result),
         }
     }
@@ -591,7 +591,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
         }
 
         match result {
-            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
             result => Ok(result),
         }
     }
@@ -620,5 +620,4 @@ impl<'a, T: std::fmt::Debug + AsRawFd> std::fmt::Debug for AsyncFdReadyMutGuard<
 /// [`WouldBlock`]: std::io::ErrorKind::WouldBlock
 /// [`try_io`]: method@AsyncFdReadyGuard::try_io
 #[derive(Debug)]
-#[non_exhaustive]
-pub struct TryIoError;
+pub struct TryIoError(());

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -15,8 +15,9 @@ cfg_io_util! {
     ///
     /// [`empty`]: fn@empty
     /// [std]: std::io::empty
-    #[non_exhaustive]
-    pub struct Empty;
+    pub struct Empty {
+        _p: (),
+    }
 
     /// Creates a new empty async reader.
     ///
@@ -41,7 +42,7 @@ cfg_io_util! {
     /// }
     /// ```
     pub fn empty() -> Empty {
-        Empty
+        Empty { _p: () }
     }
 }
 

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -15,8 +15,9 @@ cfg_io_util! {
     ///
     /// [sink]: sink()
     /// [std]: std::io::Sink
-    #[non_exhaustive]
-    pub struct Sink;
+    pub struct Sink {
+        _p: (),
+    }
 
     /// Creates an instance of an async writer which will successfully consume all
     /// data.
@@ -44,7 +45,7 @@ cfg_io_util! {
     /// }
     /// ```
     pub fn sink() -> Sink {
-        Sink
+        Sink { _p: () }
     }
 }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -106,7 +106,7 @@ impl Handle {
     ///
     /// Contrary to `current`, this never panics
     pub fn try_current() -> Result<Self, TryCurrentError> {
-        context::current().ok_or(TryCurrentError)
+        context::current().ok_or(TryCurrentError(()))
     }
 
     /// Spawn a future onto the Tokio runtime.
@@ -203,8 +203,7 @@ impl Handle {
 }
 
 /// Error returned by `try_current` when no Runtime has been started
-#[non_exhaustive]
-pub struct TryCurrentError;
+pub struct TryCurrentError(());
 
 impl fmt::Debug for TryCurrentError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -54,7 +54,6 @@ pub enum TryAcquireError {
     /// The semaphore has no available permits.
     NoPermits,
 }
-
 /// Error returned from the [`Semaphore::acquire`] function.
 ///
 /// An `acquire` operation can only fail if the semaphore has been
@@ -63,8 +62,7 @@ pub enum TryAcquireError {
 /// [closed]: crate::sync::Semaphore::close
 /// [`Semaphore::acquire`]: crate::sync::Semaphore::acquire
 #[derive(Debug)]
-#[non_exhaustive]
-pub struct AcquireError;
+pub struct AcquireError(());
 
 pub(crate) struct Acquire<'a> {
     node: Waiter,
@@ -523,7 +521,7 @@ unsafe impl Sync for Acquire<'_> {}
 
 impl AcquireError {
     fn closed() -> AcquireError {
-        AcquireError
+        AcquireError(())
     }
 }
 

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -55,8 +55,7 @@ impl<T> From<SendError<T>> for TrySendError<T> {
 
 /// Error returned by `Receiver`.
 #[derive(Debug)]
-#[non_exhaustive]
-pub struct RecvError;
+pub struct RecvError(());
 
 impl fmt::Display for RecvError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -167,8 +167,7 @@ unsafe impl<T> Sync for OwnedMutexGuard<T> where T: ?Sized + Send + Sync {}
 ///
 /// [`Mutex::try_lock`]: Mutex::try_lock
 #[derive(Debug)]
-#[non_exhaustive]
-pub struct TryLockError;
+pub struct TryLockError(());
 
 impl fmt::Display for TryLockError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -324,7 +323,7 @@ impl<T: ?Sized> Mutex<T> {
     pub fn try_lock(&self) -> Result<MutexGuard<'_, T>, TryLockError> {
         match self.s.try_acquire(1) {
             Ok(_) => Ok(MutexGuard { lock: self }),
-            Err(_) => Err(TryLockError),
+            Err(_) => Err(TryLockError(())),
         }
     }
 
@@ -379,7 +378,7 @@ impl<T: ?Sized> Mutex<T> {
     pub fn try_lock_owned(self: Arc<Self>) -> Result<OwnedMutexGuard<T>, TryLockError> {
         match self.s.try_acquire(1) {
             Ok(_) => Ok(OwnedMutexGuard { lock: self }),
-            Err(_) => Err(TryLockError),
+            Err(_) => Err(TryLockError(())),
         }
     }
 

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -156,7 +156,7 @@ impl<T: 'static> LocalKey<T> {
             if let Some(val) = v.borrow().as_ref() {
                 Ok(f(val))
             } else {
-                Err(AccessError)
+                Err(AccessError { _private: () })
             }
         })
     }
@@ -223,8 +223,9 @@ impl<T: 'static> StaticLifetime for T {}
 
 /// An error returned by [`LocalKey::try_with`](method@LocalKey::try_with).
 #[derive(Clone, Copy, Eq, PartialEq)]
-#[non_exhaustive]
-pub struct AccessError;
+pub struct AccessError {
+    _private: (),
+}
 
 impl fmt::Debug for AccessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -42,8 +42,7 @@ impl From<Kind> for Error {
 
 /// Error returned by `Timeout`.
 #[derive(Debug, PartialEq)]
-#[non_exhaustive]
-pub struct Elapsed;
+pub struct Elapsed(());
 
 #[derive(Debug)]
 pub(crate) enum InsertError {
@@ -99,6 +98,12 @@ impl fmt::Display for Error {
 }
 
 // ===== impl Elapsed =====
+
+impl Elapsed {
+    pub(crate) fn new() -> Self {
+        Elapsed(())
+    }
+}
 
 impl fmt::Display for Elapsed {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -148,7 +148,7 @@ where
 
         // Now check the timer
         match me.delay.poll(cx) {
-            Poll::Ready(()) => Poll::Ready(Err(Elapsed)),
+            Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
             Poll::Pending => Poll::Pending,
         }
     }


### PR DESCRIPTION
This reverts commit 575938d4579e6fe6a89b700aadb0ae2bbab5483b. (#3320)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

For context, see discussion in discord.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
