### PR TITLE
Adjust buffering in examples

### DIFF
--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -92,7 +92,7 @@ mod tcp {
 
 mod udp {
     use bytes::Bytes;
-    use futures::{future, Sink, SinkExt, Stream, StreamExt};
+    use futures::{Sink, SinkExt, Stream, StreamExt};
     use std::error::Error;
     use std::io;
     use std::net::SocketAddr;
@@ -114,7 +114,7 @@ mod udp {
         let socket = UdpSocket::bind(&bind_addr).await?;
         socket.connect(addr).await?;
 
-        future::try_join(send(stdin, &socket), recv(stdout, &socket)).await?;
+        tokio::try_join!(send(stdin, &socket), recv(stdout, &socket))?;
 
         Ok(())
     }

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -97,12 +97,11 @@ mod udp {
     use std::io;
     use std::net::SocketAddr;
     use tokio::net::UdpSocket;
-    use tokio_util::{codec::BytesCodec, udp::UdpFramed};
 
     pub async fn connect(
         addr: &SocketAddr,
         stdin: impl Stream<Item = Result<Bytes, io::Error>> + Unpin,
-        mut stdout: impl Sink<Bytes, Error = io::Error> + Unpin,
+        stdout: impl Sink<Bytes, Error = io::Error> + Unpin,
     ) -> Result<(), Box<dyn Error>> {
         // We'll bind our UDP socket to a local IP/port, but for now we
         // basically let the OS pick both of those.
@@ -113,26 +112,36 @@ mod udp {
         };
 
         let socket = UdpSocket::bind(&bind_addr).await?;
-        let (mut sink, stream) = UdpFramed::new(socket, BytesCodec::new()).split();
+        socket.connect(addr).await?;
 
-        // Map stdin's Result<Bytes, Error> stream into a
-        // Results<(Bytes, SocketAddr), Error> stream to match UdpFramed's Sink.
-        let mut stdin = stdin.map(|i| i.map(|b| (b, *addr)));
+        future::try_join(send(stdin, &socket), recv(stdout, &socket)).await?;
 
-        // Filter and map UdpFramed's Results<(BytesMut, SocketAddr), Error>
-        // stream into a stream of Results<Bytes, Error> from only our target.
-        let mut stream = stream.filter_map(|i| {
-            future::ready(match i {
-                Ok((data, peer)) if peer == *addr => Some(Ok(data.freeze())),
-                Ok(_) => None,
-                Err(e) => {
-                    println!("failed to read from socket; error={}", e);
-                    Some(Err(e))
-                }
-            })
-        });
-
-        future::try_join(sink.send_all(&mut stdin), stdout.send_all(&mut stream)).await?;
         Ok(())
+    }
+
+    async fn send(
+        mut stdin: impl Stream<Item = Result<Bytes, io::Error>> + Unpin,
+        writer: &UdpSocket,
+    ) -> Result<(), io::Error> {
+        while let Some(item) = stdin.next().await {
+            let buf = item?;
+            writer.send(&buf[..]).await?;
+        }
+
+        Ok(())
+    }
+
+    async fn recv(
+        mut stdout: impl Sink<Bytes, Error = io::Error> + Unpin,
+        reader: &UdpSocket,
+    ) -> Result<(), io::Error> {
+        loop {
+            let mut buf = vec![0; 1024];
+            let n = reader.recv(&mut buf[..]).await?;
+
+            if n > 0 {
+                stdout.send(Bytes::from(buf)).await?;
+            }
+        }
     }
 }

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -55,7 +55,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // which will allow all of our clients to be processed concurrently.
 
         tokio::spawn(async move {
-            let mut buf = [0; 1024];
+            let mut buf = vec![0; 1024];
 
             // In a loop, read data from the socket and write the data back.
             loop {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -26,7 +26,6 @@ use tokio::io;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 
-use futures::future::try_join;
 use futures::FutureExt;
 use std::env;
 use std::error::Error;
@@ -74,7 +73,7 @@ async fn transfer(mut inbound: TcpStream, proxy_addr: String) -> Result<(), Box<
         wi.shutdown().await
     };
 
-    try_join(client_to_server, server_to_client).await?;
+    tokio::try_join!(client_to_server, server_to_client)?;
 
     Ok(())
 }

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let b = pong(&mut b);
 
     // Run both futures simultaneously of `a` and `b` sending messages back and forth.
-    match futures::future::try_join(a, b).await {
+    match tokio::try_join!(a, b) {
         Err(e) => println!("an error occurred; error = {:?}", e),
         _ => println!("done!"),
     }


### PR DESCRIPTION
## Motivation

#2444 identified an example (`echo.rs`) which uses a stack-based buffer and suggests it would be improved by using a heap-based buffer instead.

## Solution

`echo.rs` is a straightforward switch from array to `Vec`. `BytesMut` was also suggested in discussion on #2444, but I chose `Vec` because it matches the approach in [the website tutorial](https://tokio.rs/tokio/tutorial/io).