### PR TITLE
Improve Sleep documentation for !Unpin

### DIFF
--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -101,6 +101,14 @@ macro_rules! assert_value {
             require_unpin(&f);
         };
     };
+    ($type:ty: !Unpin) => {
+        #[allow(unreachable_code)]
+        #[allow(unused_variables)]
+        const _: fn() = || {
+            let f: $type = todo!();
+            AmbiguousIfUnpin::some_item(&f);
+        };
+    };
 }
 macro_rules! async_assert_fn {
     ($($f:ident $(< $($generic:ty),* > )? )::+($($arg:ty),*): Send & Sync) => {
@@ -289,6 +297,7 @@ async_assert_fn!(tokio::time::timeout_at(Instant, BoxFuture<()>): !Send & !Sync)
 async_assert_fn!(tokio::time::Interval::tick(_): Send & Sync);
 
 assert_value!(tokio::time::Interval: Unpin);
+assert_value!(tokio::time::Sleep: !Unpin);
 async_assert_fn!(tokio::time::sleep(Duration): !Unpin);
 async_assert_fn!(tokio::time::sleep_until(Instant): !Unpin);
 async_assert_fn!(tokio::time::timeout(Duration, BoxFuture<()>): !Unpin);


### PR DESCRIPTION
Currently the documentation for `Sleep` renders like this:

![scr](https://user-images.githubusercontent.com/928074/103076890-02a75680-45cf-11eb-9ce0-23e8f120774b.png)
![scr](https://user-images.githubusercontent.com/928074/103076905-0e931880-45cf-11eb-8c04-610a2e2c2541.png)

It is not exactly clear from this documentation that `Sleep` is `!Unpin`. This PR manually implements the `project` method on `Sleep` so that the documentation is improved to this:

![scr](https://user-images.githubusercontent.com/928074/103076981-35514f00-45cf-11eb-8f6a-547501c15e2c.png)
![scr](https://user-images.githubusercontent.com/928074/103077003-3e422080-45cf-11eb-8626-318aa868cd99.png)

I will let it be up to the rest of the team to decide if this is worth the extra unsafe block.