### PR TITLE
Remove stream feature from docs

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -314,7 +314,6 @@
 //! - `process`: Enables `tokio::process` types.
 //! - `macros`: Enables `#[tokio::main]` and `#[tokio::test]` macros.
 //! - `sync`: Enables all `tokio::sync` types.
-//! - `stream`: Enables optional `Stream` implementations for types within Tokio.
 //! - `signal`: Enables all `tokio::signal` types.
 //! - `fs`: Enables `tokio::fs` types.
 //! - `test-util`: Enables testing based infrastructure for the Tokio runtime.


### PR DESCRIPTION
## Motivation

The streams haven't been stabilized yet, but the crate docs still mention their feature.

## Solution

Remove the feature for now.

Fixes #3333