### PR TITLE
Add OwnedRwLockReadGuard and OwnedRwLockWriteGuard

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -451,6 +451,9 @@ cfg_sync! {
 
     mod rwlock;
     pub use rwlock::RwLock;
+    pub use rwlock::owned_read_guard::OwnedRwLockReadGuard;
+    pub use rwlock::owned_write_guard::OwnedRwLockWriteGuard;
+    pub use rwlock::owned_write_guard_mapped::OwnedRwLockMappedWriteGuard;
     pub use rwlock::read_guard::RwLockReadGuard;
     pub use rwlock::write_guard::RwLockWriteGuard;
     pub use rwlock::write_guard_mapped::RwLockMappedWriteGuard;

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -2,6 +2,7 @@ use crate::sync::batch_semaphore::{Semaphore, TryAcquireError};
 use crate::sync::mutex::TryLockError;
 use std::cell::UnsafeCell;
 use std::marker;
+use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::sync::Arc;
 
@@ -330,6 +331,7 @@ impl<T: ?Sized> RwLock<T> {
         OwnedRwLockReadGuard {
             data: self.c.get(),
             lock: ManuallyDrop::new(self),
+            _p: PhantomData,
         }
     }
 
@@ -427,6 +429,7 @@ impl<T: ?Sized> RwLock<T> {
         Ok(OwnedRwLockReadGuard {
             data: self.c.get(),
             lock: ManuallyDrop::new(self),
+            _p: PhantomData,
         })
     }
 
@@ -503,6 +506,7 @@ impl<T: ?Sized> RwLock<T> {
         OwnedRwLockWriteGuard {
             data: self.c.get(),
             lock: ManuallyDrop::new(self),
+            _p: PhantomData,
         }
     }
 
@@ -583,6 +587,7 @@ impl<T: ?Sized> RwLock<T> {
         Ok(OwnedRwLockWriteGuard {
             data: self.c.get(),
             lock: ManuallyDrop::new(self),
+            _p: PhantomData,
         })
     }
 

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -2,10 +2,16 @@ use crate::sync::batch_semaphore::{Semaphore, TryAcquireError};
 use crate::sync::mutex::TryLockError;
 use std::cell::UnsafeCell;
 use std::marker;
+use std::mem::ManuallyDrop;
+use std::sync::Arc;
 
+pub(crate) mod owned_read_guard;
+pub(crate) mod owned_write_guard;
 pub(crate) mod read_guard;
 pub(crate) mod write_guard;
 pub(crate) mod write_guard_mapped;
+pub(crate) use owned_read_guard::OwnedRwLockReadGuard;
+pub(crate) use owned_write_guard::OwnedRwLockWriteGuard;
 pub(crate) use read_guard::RwLockReadGuard;
 pub(crate) use write_guard::RwLockWriteGuard;
 pub(crate) use write_guard_mapped::RwLockMappedWriteGuard;
@@ -101,13 +107,23 @@ fn bounds() {
     check_sync::<RwLockReadGuard<'_, u32>>();
     check_unpin::<RwLockReadGuard<'_, u32>>();
 
+    check_send::<OwnedRwLockReadGuard<u32>>();
+    check_sync::<OwnedRwLockReadGuard<u32>>();
+    check_unpin::<OwnedRwLockReadGuard<u32>>();
+
     check_send::<RwLockWriteGuard<'_, u32>>();
     check_sync::<RwLockWriteGuard<'_, u32>>();
     check_unpin::<RwLockWriteGuard<'_, u32>>();
 
-    let rwlock = RwLock::new(0);
+    check_send::<OwnedRwLockWriteGuard<u32>>();
+    check_sync::<OwnedRwLockWriteGuard<u32>>();
+    check_unpin::<OwnedRwLockWriteGuard<u32>>();
+
+    let rwlock = Arc::new(RwLock::new(0));
     check_send_sync_val(rwlock.read());
+    check_send_sync_val(Arc::clone(&rwlock).read_owned());
     check_send_sync_val(rwlock.write());
+    check_send_sync_val(Arc::clone(&rwlock).write_owned());
 }
 
 // As long as T: Send + Sync, it's fine to send and share RwLock<T> between threads.
@@ -120,13 +136,19 @@ unsafe impl<T> Sync for RwLock<T> where T: ?Sized + Send + Sync {}
 // `T` is `Send`.
 unsafe impl<T> Send for RwLockReadGuard<'_, T> where T: ?Sized + Sync {}
 unsafe impl<T> Sync for RwLockReadGuard<'_, T> where T: ?Sized + Send + Sync {}
+// T is required to be `Send` because an OwnedRwLockReadGuard can be used to drop the value held in
+// the RwLock, unlike RwLockReadGuard.
+unsafe impl<T> Send for OwnedRwLockReadGuard<T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for OwnedRwLockReadGuard<T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for RwLockWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Sync for OwnedRwLockWriteGuard<T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Sync for RwLockMappedWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
 // Safety: Stores a raw pointer to `T`, so if `T` is `Sync`, the lock guard over
 // `T` is `Send` - but since this is also provides mutable access, we need to
 // make sure that `T` is `Send` since its value can be sent across thread
 // boundaries.
 unsafe impl<T> Send for RwLockWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
+unsafe impl<T> Send for OwnedRwLockWriteGuard<T> where T: ?Sized + Send + Sync {}
 unsafe impl<T> Send for RwLockMappedWriteGuard<'_, T> where T: ?Sized + Send + Sync {}
 
 impl<T: ?Sized> RwLock<T> {
@@ -222,6 +244,63 @@ impl<T: ?Sized> RwLock<T> {
         }
     }
 
+    /// Locks this `RwLock` with shared read access, causing the current task
+    /// to yield until the lock has been acquired.
+    ///
+    /// The calling task will yield until there are no writers which hold the
+    /// lock. There may be other readers inside the lock when the task resumes.
+    ///
+    /// This method is identical to [`RwLock::read`], except that the returned
+    /// guard references the `RwLock` with an [`Arc`] rather than by borrowing
+    /// it. Therefore, the `RwLock` must be wrapped in an `Arc` to call this
+    /// method, and the guard will live for the `'static` lifetime, as it keeps
+    /// the `RwLock` alive by holding an `Arc`.
+    ///
+    /// Note that under the priority policy of [`RwLock`], read locks are not
+    /// granted until prior write locks, to prevent starvation. Therefore
+    /// deadlock may occur if a read lock is held by the current task, a write
+    /// lock attempt is made, and then a subsequent read lock attempt is made
+    /// by the current task.
+    ///
+    /// Returns an RAII guard which will drop this read access of the `RwLock`
+    /// when dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::RwLock;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let lock = Arc::new(RwLock::new(1));
+    ///     let c_lock = lock.clone();
+    ///
+    ///     let n = lock.read_owned().await;
+    ///     assert_eq!(*n, 1);
+    ///
+    ///     tokio::spawn(async move {
+    ///         // While main has an active read lock, we acquire one too.
+    ///         let r = c_lock.read_owned().await;
+    ///         assert_eq!(*r, 1);
+    ///     }).await.expect("The spawned task has panicked");
+    ///
+    ///     // Drop the guard after the spawned task finishes.
+    ///     drop(n);
+    ///}
+    /// ```
+    pub async fn read_owned(self: Arc<Self>) -> OwnedRwLockReadGuard<T> {
+        self.s.acquire(1).await.unwrap_or_else(|_| {
+            // The semaphore was closed. but, we never explicitly close it, and we have a
+            // handle to it through the Arc, which means that this can never happen.
+            unreachable!()
+        });
+        OwnedRwLockReadGuard {
+            data: self.c.get(),
+            lock: self,
+        }
+    }
+
     /// Attempts to acquire this `RwLock` with shared read access.
     ///
     /// If the access couldn't be acquired immediately, returns [`TryLockError`].
@@ -300,6 +379,47 @@ impl<T: ?Sized> RwLock<T> {
             s: &self.s,
             data: self.c.get(),
             marker: marker::PhantomData,
+        }
+    }
+
+    /// Locks this `RwLock` with exclusive write access, causing the current
+    /// task to yield until the lock has been acquired.
+    ///
+    /// The calling task will yield while other writers or readers currently
+    /// have access to the lock.
+    ///
+    /// This method is identical to [`RwLock::write`], except that the returned
+    /// guard references the `RwLock` with an [`Arc`] rather than by borrowing
+    /// it. Therefore, the `RwLock` must be wrapped in an `Arc` to call this
+    /// method, and the guard will live for the `'static` lifetime, as it keeps
+    /// the `RwLock` alive by holding an `Arc`.
+    ///
+    /// Returns an RAII guard which will drop the write access of this `RwLock`
+    /// when dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::RwLock;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///   let lock = Arc::new(RwLock::new(1));
+    ///
+    ///   let mut n = lock.write_owned().await;
+    ///   *n = 2;
+    ///}
+    /// ```
+    pub async fn write_owned(self: Arc<Self>) -> OwnedRwLockWriteGuard<T> {
+        self.s.acquire(MAX_READS as u32).await.unwrap_or_else(|_| {
+            // The semaphore was closed. but, we never explicitly close it, and we have a
+            // handle to it through the Arc, which means that this can never happen.
+            unreachable!()
+        });
+        OwnedRwLockWriteGuard {
+            data: self.c.get(),
+            lock: ManuallyDrop::new(self),
         }
     }
 

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -567,7 +567,7 @@ impl<T: ?Sized> RwLock<T> {
     /// async fn main() {
     ///     let rw = Arc::new(RwLock::new(1));
     ///
-    ///     let v = rw.read().await;
+    ///     let v = Arc::clone(&rw).read_owned().await;
     ///     assert_eq!(*v, 1);
     ///
     ///     assert!(rw.try_write_owned().is_err());

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -1,0 +1,49 @@
+use crate::sync::rwlock::RwLock;
+use std::fmt;
+use std::ops;
+use std::sync::Arc;
+
+/// Owned RAII structure used to release the shared read access of a lock when
+/// dropped.
+///
+/// This structure is created by the [`read_owned`] method on
+/// [`RwLock`].
+///
+/// [`read_owned`]: method@crate::sync::RwLock::read_owned
+/// [`RwLock`]: struct@crate::sync::RwLock
+pub struct OwnedRwLockReadGuard<T: ?Sized> {
+    pub(super) lock: Arc<RwLock<T>>,
+    pub(super) data: *const T,
+}
+
+impl<T: ?Sized> ops::Deref for OwnedRwLockReadGuard<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.data }
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for OwnedRwLockReadGuard<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> fmt::Display for OwnedRwLockReadGuard<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> Drop for OwnedRwLockReadGuard<T> {
+    fn drop(&mut self) {
+        self.lock.s.release(1);
+    }
+}

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -1,5 +1,7 @@
 use crate::sync::rwlock::RwLock;
 use std::fmt;
+use std::mem;
+use std::mem::ManuallyDrop;
 use std::ops;
 use std::sync::Arc;
 
@@ -11,39 +13,133 @@ use std::sync::Arc;
 ///
 /// [`read_owned`]: method@crate::sync::RwLock::read_owned
 /// [`RwLock`]: struct@crate::sync::RwLock
-pub struct OwnedRwLockReadGuard<T: ?Sized> {
-    pub(super) lock: Arc<RwLock<T>>,
-    pub(super) data: *const T,
+pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
+    // ManuallyDrop allows us to destructure into this field without running the destructor.
+    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) data: *const U,
 }
 
-impl<T: ?Sized> ops::Deref for OwnedRwLockReadGuard<T> {
-    type Target = T;
+impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
+    /// Make a new `OwnedRwLockReadGuard` for a component of the locked data.
+    /// This operation cannot fail as the `OwnedRwLockReadGuard` passed in
+    /// already locked the data.
+    ///
+    /// This is an associated function that needs to be
+    /// used as `OwnedRwLockReadGuard::map(...)`. A method would interfere with
+    /// methods of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockReadGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// let guard = lock.read_owned().await;
+    /// let guard = OwnedRwLockReadGuard::map(guard, |f| &f.0);
+    ///
+    /// assert_eq!(1, *guard);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn map<F, V: ?Sized>(mut this: Self, f: F) -> OwnedRwLockReadGuard<T, V>
+    where
+        F: FnOnce(&U) -> &V,
+    {
+        let data = f(&*this) as *const V;
+        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(this);
+        OwnedRwLockReadGuard {
+            lock: ManuallyDrop::new(lock),
+            data,
+        }
+    }
 
-    fn deref(&self) -> &T {
+    /// Attempts to make a new [`OwnedRwLockReadGuard`] for a component of the
+    /// locked data. The original guard is returned if the closure returns
+    /// `None`.
+    ///
+    /// This operation cannot fail as the `OwnedRwLockReadGuard` passed in
+    /// already locked the data.
+    ///
+    /// This is an associated function that needs to be used as
+    /// `OwnedRwLockReadGuard::try_map(..)`. A method would interfere with
+    /// methods of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockReadGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// let guard = lock.read_owned().await;
+    /// let guard = OwnedRwLockReadGuard::try_map(guard, |f| Some(&f.0)).expect("should not fail");
+    ///
+    /// assert_eq!(1, *guard);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_map<F, V: ?Sized>(mut this: Self, f: F) -> Result<OwnedRwLockReadGuard<T, V>, Self>
+    where
+        F: FnOnce(&U) -> Option<&V>,
+    {
+        let data = match f(&*this) {
+            Some(data) => data as *const V,
+            None => return Err(this),
+        };
+        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(this);
+        Ok(OwnedRwLockReadGuard {
+            lock: ManuallyDrop::new(lock),
+            data,
+        })
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> ops::Deref for OwnedRwLockReadGuard<T, U> {
+    type Target = U;
+
+    fn deref(&self) -> &U {
         unsafe { &*self.data }
     }
 }
 
-impl<T: ?Sized> fmt::Debug for OwnedRwLockReadGuard<T>
+impl<T: ?Sized, U: ?Sized> fmt::Debug for OwnedRwLockReadGuard<T, U>
 where
-    T: fmt::Debug,
+    U: fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&**self, f)
     }
 }
 
-impl<T: ?Sized> fmt::Display for OwnedRwLockReadGuard<T>
+impl<T: ?Sized, U: ?Sized> fmt::Display for OwnedRwLockReadGuard<T, U>
 where
-    T: fmt::Display,
+    U: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&**self, f)
     }
 }
 
-impl<T: ?Sized> Drop for OwnedRwLockReadGuard<T> {
+impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockReadGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(1);
+        unsafe { ManuallyDrop::drop(&mut self.lock) };
     }
 }

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -1,5 +1,6 @@
 use crate::sync::rwlock::RwLock;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem;
 use std::mem::ManuallyDrop;
 use std::ops;
@@ -17,6 +18,7 @@ pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
     // ManuallyDrop allows us to destructure into this field without running the destructor.
     pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
     pub(super) data: *const U,
+    pub(super) _p: PhantomData<T>,
 }
 
 impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
@@ -59,6 +61,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
         OwnedRwLockReadGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         }
     }
 
@@ -107,6 +110,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
         Ok(OwnedRwLockReadGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         })
     }
 }

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -2,6 +2,7 @@ use crate::sync::rwlock::owned_read_guard::OwnedRwLockReadGuard;
 use crate::sync::rwlock::owned_write_guard_mapped::OwnedRwLockMappedWriteGuard;
 use crate::sync::rwlock::RwLock;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::ops;
 use std::sync::Arc;

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -18,6 +18,7 @@ pub struct OwnedRwLockWriteGuard<T: ?Sized> {
     // ManuallyDrop allows us to destructure into this field without running the destructor.
     pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
     pub(super) data: *mut T,
+    pub(super) _p: PhantomData<T>,
 }
 
 impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
@@ -65,6 +66,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         OwnedRwLockMappedWriteGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         }
     }
 
@@ -121,6 +123,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         Ok(OwnedRwLockMappedWriteGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         })
     }
 
@@ -180,6 +183,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         OwnedRwLockReadGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         }
     }
 }

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -1,0 +1,107 @@
+use crate::sync::rwlock::owned_read_guard::OwnedRwLockReadGuard;
+use crate::sync::rwlock::RwLock;
+use std::fmt;
+use std::mem::{self, ManuallyDrop};
+use std::ops;
+use std::sync::Arc;
+
+/// Owned RAII structure used to release the exclusive write access of a lock when
+/// dropped.
+///
+/// This structure is created by the [`write_owned`] method
+/// on [`RwLock`].
+///
+/// [`write_owned`]: method@crate::sync::RwLock::write_owned
+/// [`RwLock`]: struct@crate::sync::RwLock
+pub struct OwnedRwLockWriteGuard<T: ?Sized> {
+    // ManuallyDrop allows us to destructure into this field without running the destructor.
+    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) data: *mut T,
+}
+
+impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
+    /// Atomically downgrades a write lock into a read lock without allowing
+    /// any writers to take exclusive access of the lock in the meantime.
+    ///
+    /// **Note:** This won't *necessarily* allow any additional readers to acquire
+    /// locks, since [`RwLock`] is fair and it is possible that a writer is next
+    /// in line.
+    ///
+    /// Returns an RAII guard which will drop this read access of the `RwLock`
+    /// when dropped.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tokio::sync::RwLock;
+    /// # use std::sync::Arc;
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(1));
+    ///
+    /// let n = lock.clone().write_owned().await;
+    ///
+    /// let cloned_lock = lock.clone();
+    /// let handle = tokio::spawn(async move {
+    ///     *cloned_lock.write_owned().await = 2;
+    /// });
+    ///
+    /// let n = n.downgrade();
+    /// assert_eq!(*n, 1, "downgrade is atomic");
+    ///
+    /// drop(n);
+    /// handle.await.unwrap();
+    /// assert_eq!(*lock.read().await, 2, "second writer obtained write lock");
+    /// # }
+    /// ```
+    pub fn downgrade(mut self) -> OwnedRwLockReadGuard<T> {
+        let lock = unsafe { ManuallyDrop::take(&mut self.lock) };
+        let data = self.data;
+
+        // Release all but one of the permits held by the write guard
+        lock.s.release(super::MAX_READS - 1);
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(self);
+        OwnedRwLockReadGuard { lock, data }
+    }
+}
+
+impl<T: ?Sized> ops::Deref for OwnedRwLockWriteGuard<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        unsafe { &*self.data }
+    }
+}
+
+impl<T: ?Sized> ops::DerefMut for OwnedRwLockWriteGuard<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<T: ?Sized> fmt::Debug for OwnedRwLockWriteGuard<T>
+where
+    T: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> fmt::Display for OwnedRwLockWriteGuard<T>
+where
+    T: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> Drop for OwnedRwLockWriteGuard<T> {
+    fn drop(&mut self) {
+        self.lock.s.release(super::MAX_READS);
+        unsafe { ManuallyDrop::drop(&mut self.lock) };
+    }
+}

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -17,6 +17,7 @@ pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
     // ManuallyDrop allows us to destructure into this field without running the destructor.
     pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
     pub(super) data: *mut U,
+    pub(super) _p: PhantomData<T>,
 }
 
 impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
@@ -64,6 +65,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
         OwnedRwLockMappedWriteGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         }
     }
 
@@ -118,6 +120,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
         Ok(OwnedRwLockMappedWriteGuard {
             lock: ManuallyDrop::new(lock),
             data,
+            _p: PhantomData,
         })
     }
 }

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -1,0 +1,162 @@
+use crate::sync::rwlock::RwLock;
+use std::fmt;
+use std::mem::{self, ManuallyDrop};
+use std::ops;
+use std::sync::Arc;
+
+/// Owned RAII structure used to release the exclusive write access of a lock when
+/// dropped.
+///
+/// This structure is created by [mapping] an [`OwnedRwLockWriteGuard`]. It is a
+/// separate type from `OwnedRwLockWriteGuard` to disallow downgrading a mapped
+/// guard, since doing so can cause undefined behavior.
+///
+/// [mapping]: method@crate::sync::OwnedRwLockWriteGuard::map
+/// [`OwnedRwLockWriteGuard`]: struct@crate::sync::OwnedRwLockWriteGuard
+pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
+    // ManuallyDrop allows us to destructure into this field without running the destructor.
+    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) data: *mut U,
+}
+
+impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
+    /// Make a new `OwnedRwLockMappedWriteGuard` for a component of the locked
+    /// data.
+    ///
+    /// This operation cannot fail as the `OwnedRwLockMappedWriteGuard` passed
+    /// in already locked the data.
+    ///
+    /// This is an associated function that needs to be used as
+    /// `OwnedRwLockWriteGuard::map(..)`. A method would interfere with methods
+    /// of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// {
+    ///     let lock = Arc::clone(&lock);
+    ///     let mut mapped = OwnedRwLockWriteGuard::map(lock.write_owned().await, |f| &mut f.0);
+    ///     *mapped = 2;
+    /// }
+    ///
+    /// assert_eq!(Foo(2), *lock.read().await);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn map<F, V: ?Sized>(mut this: Self, f: F) -> OwnedRwLockMappedWriteGuard<T, V>
+    where
+        F: FnOnce(&mut U) -> &mut V,
+    {
+        let data = f(&mut *this) as *mut V;
+        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(this);
+        OwnedRwLockMappedWriteGuard {
+            lock: ManuallyDrop::new(lock),
+            data,
+        }
+    }
+
+    /// Attempts to make a new `OwnedRwLockMappedWriteGuard` for a component
+    /// of the locked data. The original guard is returned if the closure
+    /// returns `None`.
+    ///
+    /// This operation cannot fail as the `OwnedRwLockMappedWriteGuard` passed
+    /// in already locked the data.
+    ///
+    /// This is an associated function that needs to be
+    /// used as `OwnedRwLockMappedWriteGuard::try_map(...)`. A method would interfere with
+    /// methods of the same name on the contents of the locked data.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// {
+    ///     let guard = Arc::clone(&lock).write_owned().await;
+    ///     let mut guard = OwnedRwLockWriteGuard::try_map(guard, |f| Some(&mut f.0)).expect("should not fail");
+    ///     *guard = 2;
+    /// }
+    ///
+    /// assert_eq!(Foo(2), *lock.read().await);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_map<F, V: ?Sized>(
+        mut this: Self,
+        f: F,
+    ) -> Result<OwnedRwLockMappedWriteGuard<T, V>, Self>
+    where
+        F: FnOnce(&mut U) -> Option<&mut V>,
+    {
+        let data = match f(&mut *this) {
+            Some(data) => data as *mut V,
+            None => return Err(this),
+        };
+        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
+        // NB: Forget to avoid drop impl from being called.
+        mem::forget(this);
+        Ok(OwnedRwLockMappedWriteGuard {
+            lock: ManuallyDrop::new(lock),
+            data,
+        })
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> ops::Deref for OwnedRwLockMappedWriteGuard<T, U> {
+    type Target = U;
+
+    fn deref(&self) -> &U {
+        unsafe { &*self.data }
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> ops::DerefMut for OwnedRwLockMappedWriteGuard<T, U> {
+    fn deref_mut(&mut self) -> &mut U {
+        unsafe { &mut *self.data }
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> fmt::Debug for OwnedRwLockMappedWriteGuard<T, U>
+where
+    U: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> fmt::Display for OwnedRwLockMappedWriteGuard<T, U>
+where
+    U: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockMappedWriteGuard<T, U> {
+    fn drop(&mut self) {
+        self.lock.s.release(super::MAX_READS);
+        unsafe { ManuallyDrop::drop(&mut self.lock) };
+    }
+}

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -1,5 +1,6 @@
 use crate::sync::rwlock::RwLock;
 use std::fmt;
+use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::ops;
 use std::sync::Arc;

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -18,7 +18,7 @@ pub struct RwLockReadGuard<'a, T: ?Sized> {
     pub(super) marker: marker::PhantomData<&'a T>,
 }
 
-impl<'a, T> RwLockReadGuard<'a, T> {
+impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
     /// Make a new `RwLockReadGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `RwLockReadGuard` passed in already

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -9,7 +9,7 @@ use std::ops;
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
 ///
-/// This structure is created by the [`write`] and method
+/// This structure is created by the [`write`] method
 /// on [`RwLock`].
 ///
 /// [`write`]: method@crate::sync::RwLock::write

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -26,8 +26,8 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
     /// locked the data.
     ///
     /// This is an associated function that needs to be used as
-    /// `RwLockWriteGuard::map(..)`. A method would interfere with methods of
-    /// the same name on the contents of the locked data.
+    /// `RwLockMappedWriteGuard::map(..)`. A method would interfere with methods
+    /// of the same name on the contents of the locked data.
     ///
     /// This is an asynchronous version of [`RwLockWriteGuard::map`] from the
     /// [`parking_lot` crate].
@@ -71,7 +71,7 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
         }
     }
 
-    /// Attempts to make  a new [`RwLockMappedWriteGuard`] for a component of
+    /// Attempts to make a new [`RwLockMappedWriteGuard`] for a component of
     /// the locked data. The original guard is returned if the closure returns
     /// `None`.
     ///
@@ -79,8 +79,8 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
     /// locked the data.
     ///
     /// This is an associated function that needs to be
-    /// used as `RwLockWriteGuard::try_map(...)`. A method would interfere with
-    /// methods of the same name on the contents of the locked data.
+    /// used as `RwLockMappedWriteGuard::try_map(...)`. A method would interfere
+    /// with methods of the same name on the contents of the locked data.
     ///
     /// This is an asynchronous version of [`RwLockWriteGuard::try_map`] from
     /// the [`parking_lot` crate].

--- a/tokio/src/sync/tests/loom_rwlock.rs
+++ b/tokio/src/sync/tests/loom_rwlock.rs
@@ -22,7 +22,7 @@ fn concurrent_write() {
         let rwclone = rwlock.clone();
         let t2 = thread::spawn(move || {
             block_on(async {
-                let mut guard = rwclone.write().await;
+                let mut guard = rwclone.write_owned().await;
                 *guard += 5;
             });
         });

--- a/tokio/src/sync/tests/loom_rwlock.rs
+++ b/tokio/src/sync/tests/loom_rwlock.rs
@@ -68,7 +68,7 @@ fn concurrent_read_write() {
         });
 
         {
-            let guard = blcok_on(rwlock.clone().read_owned());
+            let guard = block_on(rwlock.clone().read_owned());
             //at this state the value on the lock may either be 0, 5, or 10
             assert!(*guard == 0 || *guard == 5 || *guard == 10);
         }

--- a/tokio/src/sync/tests/loom_rwlock.rs
+++ b/tokio/src/sync/tests/loom_rwlock.rs
@@ -53,7 +53,7 @@ fn concurrent_read_write() {
         let rwclone = rwlock.clone();
         let t2 = thread::spawn(move || {
             block_on(async {
-                let mut guard = rwclone.write().await;
+                let mut guard = rwclone.write_owned().await;
                 *guard += 5;
             });
         });
@@ -66,6 +66,12 @@ fn concurrent_read_write() {
                 assert!(*guard == 0 || *guard == 5 || *guard == 10);
             });
         });
+
+        {
+            let guard = blcok_on(rwlock.clone().read_owned());
+            //at this state the value on the lock may either be 0, 5, or 10
+            assert!(*guard == 0 || *guard == 5 || *guard == 10);
+        }
 
         t1.join().expect("thread 1 write should not panic");
         t2.join().expect("thread 2 write should not panic");


### PR DESCRIPTION
I did not add mapping functions as it's not possible to implement them soundly without adding another generic parameter to the guards, which I will leave to another PR. I implemented `OwnedRwLockWriteGuard::downgrade` as a method because `RwLockWriteGuard::downgrade` is a method - but that was probably a mistake, so I'm not sure.

Fixes: #3327

## Motivation

The feature is already present for mutexes, and it is useful in some scenarios with `RwLock`s.

## Solution

Add `OwnedRwLockReadGuard` and `OwnedRwLockWriteGuard`, which are variants of `RwLockReadGuard` and `RwLockWriteGuard` that store an `Arc`.