### PR TITLE
chore: prepare tokio 1.0.1 release

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,23 @@
+# 1.0.1 (December 25, 2020)
+
+This release fixes a soundness hole caused by the combination of `RwLockWriteGuard::map`
+and `RwLockWriteGuard::downgrade` by removing the `map` function. This is a breaking
+change, but breaking changes are allowed under our semver policy when they are required
+to fix a soundness hole.
+
+Note that we have chosen not to do a deprecation cycle or similar because Tokio 1.0.0 was
+released two days ago, and therefore the impact should be minimal.
+
+Due to the soundness hole, we have also yanked Tokio version 1.0.0.
+
+### Removed
+
+ - sync: remove `RwLockWriteGuard::map` and `RwLockWriteGuard::try_map` (#3345)
+
+### Fixed
+
+ - docs: remove stream feature from docs (#3335)
+
 # 1.0.0 (December 23, 2020)
 
 Commit to the API and long-term support.

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -3,7 +3,7 @@
 This release fixes a soundness hole caused by the combination of `RwLockWriteGuard::map`
 and `RwLockWriteGuard::downgrade` by removing the `map` function. This is a breaking
 change, but breaking changes are allowed under our semver policy when they are required
-to fix a soundness hole.
+to fix a soundness hole. (See [this RFC][semver] for more.)
 
 Note that we have chosen not to do a deprecation cycle or similar because Tokio 1.0.0 was
 released two days ago, and therefore the impact should be minimal.
@@ -17,6 +17,8 @@ Due to the soundness hole, we have also yanked Tokio version 1.0.0.
 ### Fixed
 
  - docs: remove stream feature from docs (#3335)
+
+[semver]: https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md#soundness-changes
 
 # 1.0.0 (December 23, 2020)
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.0.0"
+version = "1.0.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/1.0.0/tokio/"
+documentation = "https://docs.rs/tokio/1.0.1/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -29,7 +29,6 @@ the Rust programming language. It is:
 [Website](https://tokio.rs) |
 [Guides](https://tokio.rs/tokio/tutorial) |
 [API Docs](https://docs.rs/tokio/latest/tokio) |
-[Roadmap](https://github.com/tokio-rs/tokio/blob/master/ROADMAP.md) |
 [Chat](https://discord.gg/tokio)
 
 ## Overview

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/tokio/1.0.1")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
# 1.0.1 (December 25, 2020)

This release fixes a soundness hole caused by the combination of `RwLockWriteGuard::map` and `RwLockWriteGuard::downgrade` by removing the `map` function. This is a breaking change, but breaking changes are allowed under our semver policy when they are required to fix a soundness hole. (See [this RFC][semver] for more.)

Note that we have chosen not to do a deprecation cycle or similar because Tokio 1.0.0 was released two days ago, and therefore the impact should be minimal.

Due to the soundness hole, we have also yanked Tokio version 1.0.0.

### Removed

 - sync: remove `RwLockWriteGuard::map` and `RwLockWriteGuard::try_map` (#3345)

### Fixed

 - docs: remove stream feature from docs (#3335)

[semver]: https://github.com/rust-lang/rfcs/blob/master/text/1122-language-semver.md#soundness-changes