### PR TITLE
net: Add try_read_buf and try_recv_buf

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -600,8 +600,6 @@ impl TcpStream {
         ///         // Wait for the socket to be readable
         ///         stream.readable().await?;
         ///
-        ///         // Creating the buffer **after** the `await` prevents it from
-        ///         // being stored in the async task.
         ///         let mut buf = Vec::with_capacity(4096);
         ///
         ///         // Try to read data, this may still fail with `WouldBlock`

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -17,6 +17,8 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
+use bytes::BufMut;
+
 cfg_net! {
     /// A TCP stream between a local and a remote socket.
     ///
@@ -557,6 +559,89 @@ impl TcpStream {
         self.io
             .registration()
             .try_io(Interest::READABLE, || (&*self.io).read(buf))
+    }
+
+    /// Try to read data from the stream into the provided buffer, advancing the
+    /// buffer's internal cursor, returning how many bytes were read.
+    ///
+    /// Receives any pending data from the socket but does not wait for new data
+    /// to arrive. On success, returns the number of bytes read. Because
+    /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
+    /// the async task and can exist entirely on the stack.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: TcpStream::readable()
+    /// [`ready()`]: TcpStream::ready()
+    ///
+    /// # Return
+    ///
+    /// If data is successfully read, `Ok(n)` is returned, where `n` is the
+    /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
+    /// and will no longer yield data. If the stream is not ready to read data
+    /// `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpStream;
+    /// use std::error::Error;
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    ///     // Connect to a peer
+    ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
+    ///
+    ///     loop {
+    ///         // Wait for the socket to be readable
+    ///         stream.readable().await?;
+    ///
+    ///         // Creating the buffer **after** the `await` prevents it from
+    ///         // being stored in the async task.
+    ///         let mut buf = Vec::with_capacity(4096);
+    ///
+    ///         // Try to read data, this may still fail with `WouldBlock`
+    ///         // if the readiness event is a false positive.
+    ///         match stream.try_read_buf(&mut buf) {
+    ///             Ok(0) => break,
+    ///             Ok(n) => {
+    ///                 println!("read {} bytes", n);
+    ///             }
+    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+    ///                 continue;
+    ///             }
+    ///             Err(e) => {
+    ///                 return Err(e.into());
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+        if !buf.has_remaining_mut() {
+            return Ok(0);
+        }
+
+        self.io.registration().try_io(Interest::READABLE, || {
+            use std::io::Read;
+
+            let dst = buf.chunk_mut();
+            let dst =
+                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+            // Safety: We trust `TcpStream::read` to have filled up `n` bytes in the
+            // buffer.
+            let n = (&*self.io).read(dst)?;
+
+            unsafe {
+                buf.advance_mut(n);
+            }
+
+            Ok(n)
+        })
     }
 
     /// Wait for the socket to become writable.

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -622,10 +622,6 @@ impl TcpStream {
         /// }
         /// ```
         pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-            if !buf.has_remaining_mut() {
-                return Ok(0);
-            }
-
             self.io.registration().try_io(Interest::READABLE, || {
                 use std::io::Read;
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -17,7 +17,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
 
-use bytes::BufMut;
+cfg_io_util! {
+    use bytes::BufMut;
+}
 
 cfg_net! {
     /// A TCP stream between a local and a remote socket.
@@ -561,87 +563,89 @@ impl TcpStream {
             .try_io(Interest::READABLE, || (&*self.io).read(buf))
     }
 
-    /// Try to read data from the stream into the provided buffer, advancing the
-    /// buffer's internal cursor, returning how many bytes were read.
-    ///
-    /// Receives any pending data from the socket but does not wait for new data
-    /// to arrive. On success, returns the number of bytes read. Because
-    /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
-    /// the async task and can exist entirely on the stack.
-    ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
-    ///
-    /// [`readable()`]: TcpStream::readable()
-    /// [`ready()`]: TcpStream::ready()
-    ///
-    /// # Return
-    ///
-    /// If data is successfully read, `Ok(n)` is returned, where `n` is the
-    /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
-    /// and will no longer yield data. If the stream is not ready to read data
-    /// `Err(io::ErrorKind::WouldBlock)` is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::TcpStream;
-    /// use std::error::Error;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     // Connect to a peer
-    ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         stream.readable().await?;
-    ///
-    ///         // Creating the buffer **after** the `await` prevents it from
-    ///         // being stored in the async task.
-    ///         let mut buf = Vec::with_capacity(4096);
-    ///
-    ///         // Try to read data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match stream.try_read_buf(&mut buf) {
-    ///             Ok(0) => break,
-    ///             Ok(n) => {
-    ///                 println!("read {} bytes", n);
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e.into());
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-        if !buf.has_remaining_mut() {
-            return Ok(0);
-        }
-
-        self.io.registration().try_io(Interest::READABLE, || {
-            use std::io::Read;
-
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `TcpStream::read` to have filled up `n` bytes in the
-            // buffer.
-            let n = (&*self.io).read(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
+    cfg_io_util! {
+        /// Try to read data from the stream into the provided buffer, advancing the
+        /// buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// Receives any pending data from the socket but does not wait for new data
+        /// to arrive. On success, returns the number of bytes read. Because
+        /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
+        /// the async task and can exist entirely on the stack.
+        ///
+        /// Usually, [`readable()`] or [`ready()`] is used with this function.
+        ///
+        /// [`readable()`]: TcpStream::readable()
+        /// [`ready()`]: TcpStream::ready()
+        ///
+        /// # Return
+        ///
+        /// If data is successfully read, `Ok(n)` is returned, where `n` is the
+        /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
+        /// and will no longer yield data. If the stream is not ready to read data
+        /// `Err(io::ErrorKind::WouldBlock)` is returned.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::TcpStream;
+        /// use std::error::Error;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> Result<(), Box<dyn Error>> {
+        ///     // Connect to a peer
+        ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         stream.readable().await?;
+        ///
+        ///         // Creating the buffer **after** the `await` prevents it from
+        ///         // being stored in the async task.
+        ///         let mut buf = Vec::with_capacity(4096);
+        ///
+        ///         // Try to read data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match stream.try_read_buf(&mut buf) {
+        ///             Ok(0) => break,
+        ///             Ok(n) => {
+        ///                 println!("read {} bytes", n);
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e.into());
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+            if !buf.has_remaining_mut() {
+                return Ok(0);
             }
 
-            Ok(n)
-        })
+            self.io.registration().try_io(Interest::READABLE, || {
+                use std::io::Read;
+
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `TcpStream::read` to have filled up `n` bytes in the
+                // buffer.
+                let n = (&*self.io).read(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok(n)
+            })
+        }
     }
 
     /// Wait for the socket to become writable.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -736,10 +736,6 @@ impl UdpSocket {
         /// }
         /// ```
         pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-            if !buf.has_remaining_mut() {
-                return Ok(0);
-            }
-
             self.io.registration().try_io(Interest::READABLE, || {
                 let dst = buf.chunk_mut();
                 let dst =

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -7,7 +7,9 @@ use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::task::{Context, Poll};
 
-use bytes::BufMut;
+cfg_io_util! {
+    use bytes::BufMut;
+}
 
 cfg_net! {
     /// A UDP socket
@@ -685,75 +687,143 @@ impl UdpSocket {
             .try_io(Interest::READABLE, || self.io.recv(buf))
     }
 
-    /// Try to receive data from the stream into the provided buffer, advancing the
-    /// buffer's internal cursor, returning how many bytes were read.
-    ///
-    /// The function must be called with valid byte array buf of sufficient size
-    /// to hold the message bytes. If a message is too long to fit in the
-    /// supplied buffer, excess bytes may be discarded.
-    ///
-    /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
-    /// returned. This function is usually paired with `readable()`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::UdpSocket;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> io::Result<()> {
-    ///     // Connect to a peer
-    ///     let socket = UdpSocket::bind("127.0.0.1:8080").await?;
-    ///     socket.connect("127.0.0.1:8081").await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         socket.readable().await?;
-    ///
-    ///         // The buffer is **not** included in the async task and will
-    ///         // only exist on the stack.
-    ///         let mut buf = Vec::with_capacity(1024);
-    ///
-    ///         // Try to recv data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match socket.try_recv_from(&mut buf) {
-    ///             Ok(n) => {
-    ///                 println!("GOT {:?}", &buf[..n]);
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e);
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-        if !buf.has_remaining_mut() {
-            return Ok(0);
-        }
-
-        self.io.registration().try_io(Interest::READABLE, || {
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
-            // buffer.
-            let n = (&*self.io).recv(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
+    cfg_io_util! {
+        /// Try to receive data from the stream into the provided buffer, advancing the
+        /// buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// The function must be called with valid byte array buf of sufficient size
+        /// to hold the message bytes. If a message is too long to fit in the
+        /// supplied buffer, excess bytes may be discarded.
+        ///
+        /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
+        /// returned. This function is usually paired with `readable()`.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::UdpSocket;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> io::Result<()> {
+        ///     // Connect to a peer
+        ///     let socket = UdpSocket::bind("127.0.0.1:8080").await?;
+        ///     socket.connect("127.0.0.1:8081").await?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         socket.readable().await?;
+        ///
+        ///         // The buffer is **not** included in the async task and will
+        ///         // only exist on the stack.
+        ///         let mut buf = Vec::with_capacity(1024);
+        ///
+        ///         // Try to recv data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match socket.try_recv_from(&mut buf) {
+        ///             Ok(n) => {
+        ///                 println!("GOT {:?}", &buf[..n]);
+        ///                 break;
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e);
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+            if !buf.has_remaining_mut() {
+                return Ok(0);
             }
 
-            Ok(n)
-        })
+            self.io.registration().try_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
+                // buffer.
+                let n = (&*self.io).recv(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok(n)
+            })
+        }
+
+        /// Try to receive a single datagram message on the socket. On success,
+        /// returns the number of bytes read and the origin.
+        ///
+        /// The function must be called with valid byte array buf of sufficient size
+        /// to hold the message bytes. If a message is too long to fit in the
+        /// supplied buffer, excess bytes may be discarded.
+        ///
+        /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
+        /// returned. This function is usually paired with `readable()`.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::UdpSocket;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> io::Result<()> {
+        ///     // Connect to a peer
+        ///     let socket = UdpSocket::bind("127.0.0.1:8080").await?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         socket.readable().await?;
+        ///
+        ///         // The buffer is **not** included in the async task and will
+        ///         // only exist on the stack.
+        ///         let mut buf = Vec::with_capacity(1024);
+        ///
+        ///         // Try to recv data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match socket.try_recv_from(&mut buf) {
+        ///             Ok((n, _addr)) => {
+        ///                 println!("GOT {:?}", &buf[..n]);
+        ///                 break;
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e);
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
+            self.io.registration().try_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
+                // buffer.
+                let (n, addr) = (&*self.io).recv_from(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok((n, addr))
+            })
+        }
     }
 
     /// Sends data on the socket to the given address. On success, returns the
@@ -1009,72 +1079,6 @@ impl UdpSocket {
         self.io
             .registration()
             .try_io(Interest::READABLE, || self.io.recv_from(buf))
-    }
-
-    /// Try to receive a single datagram message on the socket. On success,
-    /// returns the number of bytes read and the origin.
-    ///
-    /// The function must be called with valid byte array buf of sufficient size
-    /// to hold the message bytes. If a message is too long to fit in the
-    /// supplied buffer, excess bytes may be discarded.
-    ///
-    /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
-    /// returned. This function is usually paired with `readable()`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::UdpSocket;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> io::Result<()> {
-    ///     // Connect to a peer
-    ///     let socket = UdpSocket::bind("127.0.0.1:8080").await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         socket.readable().await?;
-    ///
-    ///         // The buffer is **not** included in the async task and will
-    ///         // only exist on the stack.
-    ///         let mut buf = Vec::with_capacity(1024);
-    ///
-    ///         // Try to recv data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match socket.try_recv_from(&mut buf) {
-    ///             Ok((n, _addr)) => {
-    ///                 println!("GOT {:?}", &buf[..n]);
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e);
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
-        self.io.registration().try_io(Interest::READABLE, || {
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
-            // buffer.
-            let (n, addr) = (&*self.io).recv_from(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
-            }
-
-            Ok((n, addr))
-        })
     }
 
     /// Receives data from the socket, without removing it from the input queue.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -720,7 +720,7 @@ impl UdpSocket {
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`
         ///         // if the readiness event is a false positive.
-        ///         match socket.try_recv_from(&mut buf) {
+        ///         match socket.try_recv_buf(&mut buf) {
         ///             Ok(n) => {
         ///                 println!("GOT {:?}", &buf[..n]);
         ///                 break;

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -790,7 +790,7 @@ impl UdpSocket {
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`
         ///         // if the readiness event is a false positive.
-        ///         match socket.try_recv_from(&mut buf) {
+        ///         match socket.try_recv_buf_from(&mut buf) {
         ///             Ok((n, _addr)) => {
         ///                 println!("GOT {:?}", &buf[..n]);
         ///                 break;

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -714,8 +714,6 @@ impl UdpSocket {
         ///         // Wait for the socket to be readable
         ///         socket.readable().await?;
         ///
-        ///         // The buffer is **not** included in the async task and will
-        ///         // only exist on the stack.
         ///         let mut buf = Vec::with_capacity(1024);
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`
@@ -784,8 +782,6 @@ impl UdpSocket {
         ///         // Wait for the socket to be readable
         ///         socket.readable().await?;
         ///
-        ///         // The buffer is **not** included in the async task and will
-        ///         // only exist on the stack.
         ///         let mut buf = Vec::with_capacity(1024);
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -677,8 +677,6 @@ impl UnixDatagram {
         ///         // Wait for the socket to be readable
         ///         socket.readable().await?;
         ///
-        ///         // The buffer is **not** included in the async task and will
-        ///         // only exist on the stack.
         ///         let mut buf = Vec::with_capacity(1024);
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`
@@ -742,8 +740,6 @@ impl UnixDatagram {
         ///         // Wait for the socket to be readable
         ///         socket.readable().await?;
         ///
-        ///         // The buffer is **not** included in the async task and will
-        ///         // only exist on the stack.
         ///         let mut buf = Vec::with_capacity(1024);
         ///
         ///         // Try to recv data, this may still fail with `WouldBlock`

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -762,10 +762,6 @@ impl UnixDatagram {
         /// }
         /// ```
         pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-            if !buf.has_remaining_mut() {
-                return Ok(0);
-            }
-
             self.io.registration().try_io(Interest::READABLE, || {
                 let dst = buf.chunk_mut();
                 let dst =

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -10,6 +10,8 @@ use std::os::unix::net;
 use std::path::Path;
 use std::task::{Context, Poll};
 
+use bytes::BufMut;
+
 cfg_net_unix! {
     /// An I/O object representing a Unix datagram socket.
     ///
@@ -652,6 +654,73 @@ impl UnixDatagram {
             .try_io(Interest::READABLE, || self.io.recv(buf))
     }
 
+    /// Try to read data from the stream into the provided buffer, advancing the
+    /// buffer's internal cursor, returning how many bytes were read.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixDatagram;
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     // Connect to a peer
+    ///     let dir = tempfile::tempdir().unwrap();
+    ///     let client_path = dir.path().join("client.sock");
+    ///     let server_path = dir.path().join("server.sock");
+    ///     let socket = UnixDatagram::bind(&client_path)?;
+    ///     socket.connect(&server_path)?;
+    ///
+    ///     loop {
+    ///         // Wait for the socket to be readable
+    ///         socket.readable().await?;
+    ///
+    ///         // The buffer is **not** included in the async task and will
+    ///         // only exist on the stack.
+    ///         let mut buf = Vec::with_capacity(1024);
+    ///
+    ///         // Try to recv data, this may still fail with `WouldBlock`
+    ///         // if the readiness event is a false positive.
+    ///         match socket.try_recv_buf(&mut buf) {
+    ///             Ok(n) => {
+    ///                 println!("GOT {:?}", &buf[..n]);
+    ///                 break;
+    ///             }
+    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+    ///                 continue;
+    ///             }
+    ///             Err(e) => {
+    ///                 return Err(e);
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+        if !buf.has_remaining_mut() {
+            return Ok(0);
+        }
+
+        self.io.registration().try_io(Interest::READABLE, || {
+            let dst = buf.chunk_mut();
+            let dst =
+                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+            // Safety: We trust `UnixDatagram::recv` to have filled up `n` bytes in the
+            // buffer.
+            let n = (&*self.io).recv(dst)?;
+
+            unsafe {
+                buf.advance_mut(n);
+            }
+
+            Ok(n)
+        })
+    }
+
     /// Sends data on the socket to the specified address.
     ///
     /// # Examples
@@ -926,6 +995,69 @@ impl UnixDatagram {
             .io
             .registration()
             .try_io(Interest::READABLE, || self.io.recv_from(buf))?;
+
+        Ok((n, SocketAddr(addr)))
+    }
+
+    /// Try to receive data from the socket without waiting.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixDatagram;
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     // Connect to a peer
+    ///     let dir = tempfile::tempdir().unwrap();
+    ///     let client_path = dir.path().join("client.sock");
+    ///     let server_path = dir.path().join("server.sock");
+    ///     let socket = UnixDatagram::bind(&client_path)?;
+    ///
+    ///     loop {
+    ///         // Wait for the socket to be readable
+    ///         socket.readable().await?;
+    ///
+    ///         // The buffer is **not** included in the async task and will
+    ///         // only exist on the stack.
+    ///         let mut buf = Vec::with_capacity(1024);
+    ///
+    ///         // Try to recv data, this may still fail with `WouldBlock`
+    ///         // if the readiness event is a false positive.
+    ///         match socket.try_recv_buf_from(&mut buf) {
+    ///             Ok((n, _addr)) => {
+    ///                 println!("GOT {:?}", &buf[..n]);
+    ///                 break;
+    ///             }
+    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+    ///                 continue;
+    ///             }
+    ///             Err(e) => {
+    ///                 return Err(e);
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
+        let (n, addr) = self.io.registration().try_io(Interest::READABLE, || {
+            let dst = buf.chunk_mut();
+            let dst =
+                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+            // Safety: We trust `UnixDatagram::recv_from` to have filled up `n` bytes in the
+            // buffer.
+            let (n, addr) = (&*self.io).recv_from(dst)?;
+
+            unsafe {
+                buf.advance_mut(n);
+            }
+
+            Ok((n, addr))
+        })?;
 
         Ok((n, SocketAddr(addr)))
     }

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -10,7 +10,9 @@ use std::os::unix::net;
 use std::path::Path;
 use std::task::{Context, Poll};
 
-use bytes::BufMut;
+cfg_io_util! {
+    use bytes::BufMut;
+}
 
 cfg_net_unix! {
     /// An I/O object representing a Unix datagram socket.
@@ -654,71 +656,136 @@ impl UnixDatagram {
             .try_io(Interest::READABLE, || self.io.recv(buf))
     }
 
-    /// Try to read data from the stream into the provided buffer, advancing the
-    /// buffer's internal cursor, returning how many bytes were read.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::UnixDatagram;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> io::Result<()> {
-    ///     // Connect to a peer
-    ///     let dir = tempfile::tempdir().unwrap();
-    ///     let client_path = dir.path().join("client.sock");
-    ///     let server_path = dir.path().join("server.sock");
-    ///     let socket = UnixDatagram::bind(&client_path)?;
-    ///     socket.connect(&server_path)?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         socket.readable().await?;
-    ///
-    ///         // The buffer is **not** included in the async task and will
-    ///         // only exist on the stack.
-    ///         let mut buf = Vec::with_capacity(1024);
-    ///
-    ///         // Try to recv data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match socket.try_recv_buf(&mut buf) {
-    ///             Ok(n) => {
-    ///                 println!("GOT {:?}", &buf[..n]);
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e);
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-        if !buf.has_remaining_mut() {
-            return Ok(0);
+    cfg_io_util! {
+        /// Try to receive data from the socket without waiting.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::UnixDatagram;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> io::Result<()> {
+        ///     // Connect to a peer
+        ///     let dir = tempfile::tempdir().unwrap();
+        ///     let client_path = dir.path().join("client.sock");
+        ///     let server_path = dir.path().join("server.sock");
+        ///     let socket = UnixDatagram::bind(&client_path)?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         socket.readable().await?;
+        ///
+        ///         // The buffer is **not** included in the async task and will
+        ///         // only exist on the stack.
+        ///         let mut buf = Vec::with_capacity(1024);
+        ///
+        ///         // Try to recv data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match socket.try_recv_buf_from(&mut buf) {
+        ///             Ok((n, _addr)) => {
+        ///                 println!("GOT {:?}", &buf[..n]);
+        ///                 break;
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e);
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
+            let (n, addr) = self.io.registration().try_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UnixDatagram::recv_from` to have filled up `n` bytes in the
+                // buffer.
+                let (n, addr) = (&*self.io).recv_from(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok((n, addr))
+            })?;
+
+            Ok((n, SocketAddr(addr)))
         }
 
-        self.io.registration().try_io(Interest::READABLE, || {
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `UnixDatagram::recv` to have filled up `n` bytes in the
-            // buffer.
-            let n = (&*self.io).recv(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
+        /// Try to read data from the stream into the provided buffer, advancing the
+        /// buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::UnixDatagram;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> io::Result<()> {
+        ///     // Connect to a peer
+        ///     let dir = tempfile::tempdir().unwrap();
+        ///     let client_path = dir.path().join("client.sock");
+        ///     let server_path = dir.path().join("server.sock");
+        ///     let socket = UnixDatagram::bind(&client_path)?;
+        ///     socket.connect(&server_path)?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         socket.readable().await?;
+        ///
+        ///         // The buffer is **not** included in the async task and will
+        ///         // only exist on the stack.
+        ///         let mut buf = Vec::with_capacity(1024);
+        ///
+        ///         // Try to recv data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match socket.try_recv_buf(&mut buf) {
+        ///             Ok(n) => {
+        ///                 println!("GOT {:?}", &buf[..n]);
+        ///                 break;
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e);
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+            if !buf.has_remaining_mut() {
+                return Ok(0);
             }
 
-            Ok(n)
-        })
+            self.io.registration().try_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UnixDatagram::recv` to have filled up `n` bytes in the
+                // buffer.
+                let n = (&*self.io).recv(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok(n)
+            })
+        }
     }
 
     /// Sends data on the socket to the specified address.
@@ -995,69 +1062,6 @@ impl UnixDatagram {
             .io
             .registration()
             .try_io(Interest::READABLE, || self.io.recv_from(buf))?;
-
-        Ok((n, SocketAddr(addr)))
-    }
-
-    /// Try to receive data from the socket without waiting.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::UnixDatagram;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> io::Result<()> {
-    ///     // Connect to a peer
-    ///     let dir = tempfile::tempdir().unwrap();
-    ///     let client_path = dir.path().join("client.sock");
-    ///     let server_path = dir.path().join("server.sock");
-    ///     let socket = UnixDatagram::bind(&client_path)?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         socket.readable().await?;
-    ///
-    ///         // The buffer is **not** included in the async task and will
-    ///         // only exist on the stack.
-    ///         let mut buf = Vec::with_capacity(1024);
-    ///
-    ///         // Try to recv data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match socket.try_recv_buf_from(&mut buf) {
-    ///             Ok((n, _addr)) => {
-    ///                 println!("GOT {:?}", &buf[..n]);
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e);
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
-        let (n, addr) = self.io.registration().try_io(Interest::READABLE, || {
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `UnixDatagram::recv_from` to have filled up `n` bytes in the
-            // buffer.
-            let (n, addr) = (&*self.io).recv_from(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
-            }
-
-            Ok((n, addr))
-        })?;
 
         Ok((n, SocketAddr(addr)))
     }

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -15,7 +15,9 @@ use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use bytes::BufMut;
+cfg_io_util! {
+    use bytes::BufMut;
+}
 
 cfg_net_unix! {
     /// A structure representing a connected Unix socket.
@@ -269,89 +271,91 @@ impl UnixStream {
             .try_io(Interest::READABLE, || (&*self.io).read(buf))
     }
 
-    /// Try to read data from the stream into the provided buffer, advancing the
-    /// buffer's internal cursor, returning how many bytes were read.
-    ///
-    /// Receives any pending data from the socket but does not wait for new data
-    /// to arrive. On success, returns the number of bytes read. Because
-    /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
-    /// the async task and can exist entirely on the stack.
-    ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
-    ///
-    /// [`readable()`]: UnixStream::readable()
-    /// [`ready()`]: UnixStream::ready()
-    ///
-    /// # Return
-    ///
-    /// If data is successfully read, `Ok(n)` is returned, where `n` is the
-    /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
-    /// and will no longer yield data. If the stream is not ready to read data
-    /// `Err(io::ErrorKind::WouldBlock)` is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::UnixStream;
-    /// use std::error::Error;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     // Connect to a peer
-    ///     let dir = tempfile::tempdir().unwrap();
-    ///     let bind_path = dir.path().join("bind_path");
-    ///     let stream = UnixStream::connect(bind_path).await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be readable
-    ///         stream.readable().await?;
-    ///
-    ///         // Creating the buffer **after** the `await` prevents it from
-    ///         // being stored in the async task.
-    ///         let mut buf = Vec::with_capacity(4096);
-    ///
-    ///         // Try to read data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match stream.try_read_buf(&mut buf) {
-    ///             Ok(0) => break,
-    ///             Ok(n) => {
-    ///                 println!("read {} bytes", n);
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e.into());
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-        if !buf.has_remaining_mut() {
-            return Ok(0);
-        }
-
-        self.io.registration().try_io(Interest::READABLE, || {
-            use std::io::Read;
-
-            let dst = buf.chunk_mut();
-            let dst =
-                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
-
-            // Safety: We trust `UnixStream::read` to have filled up `n` bytes in the
-            // buffer.
-            let n = (&*self.io).read(dst)?;
-
-            unsafe {
-                buf.advance_mut(n);
+    cfg_io_util! {
+        /// Try to read data from the stream into the provided buffer, advancing the
+        /// buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// Receives any pending data from the socket but does not wait for new data
+        /// to arrive. On success, returns the number of bytes read. Because
+        /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
+        /// the async task and can exist entirely on the stack.
+        ///
+        /// Usually, [`readable()`] or [`ready()`] is used with this function.
+        ///
+        /// [`readable()`]: UnixStream::readable()
+        /// [`ready()`]: UnixStream::ready()
+        ///
+        /// # Return
+        ///
+        /// If data is successfully read, `Ok(n)` is returned, where `n` is the
+        /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
+        /// and will no longer yield data. If the stream is not ready to read data
+        /// `Err(io::ErrorKind::WouldBlock)` is returned.
+        ///
+        /// # Examples
+        ///
+        /// ```no_run
+        /// use tokio::net::UnixStream;
+        /// use std::error::Error;
+        /// use std::io;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> Result<(), Box<dyn Error>> {
+        ///     // Connect to a peer
+        ///     let dir = tempfile::tempdir().unwrap();
+        ///     let bind_path = dir.path().join("bind_path");
+        ///     let stream = UnixStream::connect(bind_path).await?;
+        ///
+        ///     loop {
+        ///         // Wait for the socket to be readable
+        ///         stream.readable().await?;
+        ///
+        ///         // Creating the buffer **after** the `await` prevents it from
+        ///         // being stored in the async task.
+        ///         let mut buf = Vec::with_capacity(4096);
+        ///
+        ///         // Try to read data, this may still fail with `WouldBlock`
+        ///         // if the readiness event is a false positive.
+        ///         match stream.try_read_buf(&mut buf) {
+        ///             Ok(0) => break,
+        ///             Ok(n) => {
+        ///                 println!("read {} bytes", n);
+        ///             }
+        ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+        ///                 continue;
+        ///             }
+        ///             Err(e) => {
+        ///                 return Err(e.into());
+        ///             }
+        ///         }
+        ///     }
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+            if !buf.has_remaining_mut() {
+                return Ok(0);
             }
 
-            Ok(n)
-        })
+            self.io.registration().try_io(Interest::READABLE, || {
+                use std::io::Read;
+
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UnixStream::read` to have filled up `n` bytes in the
+                // buffer.
+                let n = (&*self.io).read(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+
+                Ok(n)
+            })
+        }
     }
 
     /// Wait for the socket to become writable.

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -332,10 +332,6 @@ impl UnixStream {
         /// }
         /// ```
         pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-            if !buf.has_remaining_mut() {
-                return Ok(0);
-            }
-
             self.io.registration().try_io(Interest::READABLE, || {
                 use std::io::Read;
 

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -310,8 +310,6 @@ impl UnixStream {
         ///         // Wait for the socket to be readable
         ///         stream.readable().await?;
         ///
-        ///         // Creating the buffer **after** the `await` prevents it from
-        ///         // being stored in the async task.
         ///         let mut buf = Vec::with_capacity(4096);
         ///
         ///         // Try to read data, this may still fail with `WouldBlock`

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -15,6 +15,8 @@ use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use bytes::BufMut;
+
 cfg_net_unix! {
     /// A structure representing a connected Unix socket.
     ///
@@ -265,6 +267,91 @@ impl UnixStream {
         self.io
             .registration()
             .try_io(Interest::READABLE, || (&*self.io).read(buf))
+    }
+
+    /// Try to read data from the stream into the provided buffer, advancing the
+    /// buffer's internal cursor, returning how many bytes were read.
+    ///
+    /// Receives any pending data from the socket but does not wait for new data
+    /// to arrive. On success, returns the number of bytes read. Because
+    /// `try_read_buf()` is non-blocking, the buffer does not have to be stored by
+    /// the async task and can exist entirely on the stack.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: UnixStream::readable()
+    /// [`ready()`]: UnixStream::ready()
+    ///
+    /// # Return
+    ///
+    /// If data is successfully read, `Ok(n)` is returned, where `n` is the
+    /// number of bytes read. `Ok(0)` indicates the stream's read half is closed
+    /// and will no longer yield data. If the stream is not ready to read data
+    /// `Err(io::ErrorKind::WouldBlock)` is returned.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixStream;
+    /// use std::error::Error;
+    /// use std::io;
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> Result<(), Box<dyn Error>> {
+    ///     // Connect to a peer
+    ///     let dir = tempfile::tempdir().unwrap();
+    ///     let bind_path = dir.path().join("bind_path");
+    ///     let stream = UnixStream::connect(bind_path).await?;
+    ///
+    ///     loop {
+    ///         // Wait for the socket to be readable
+    ///         stream.readable().await?;
+    ///
+    ///         // Creating the buffer **after** the `await` prevents it from
+    ///         // being stored in the async task.
+    ///         let mut buf = Vec::with_capacity(4096);
+    ///
+    ///         // Try to read data, this may still fail with `WouldBlock`
+    ///         // if the readiness event is a false positive.
+    ///         match stream.try_read_buf(&mut buf) {
+    ///             Ok(0) => break,
+    ///             Ok(n) => {
+    ///                 println!("read {} bytes", n);
+    ///             }
+    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+    ///                 continue;
+    ///             }
+    ///             Err(e) => {
+    ///                 return Err(e.into());
+    ///             }
+    ///         }
+    ///     }
+    ///
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn try_read_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+        if !buf.has_remaining_mut() {
+            return Ok(0);
+        }
+
+        self.io.registration().try_io(Interest::READABLE, || {
+            use std::io::Read;
+
+            let dst = buf.chunk_mut();
+            let dst =
+                unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+            // Safety: We trust `UnixStream::read` to have filled up `n` bytes in the
+            // buffer.
+            let n = (&*self.io).read(dst)?;
+
+            unsafe {
+                buf.advance_mut(n);
+            }
+
+            Ok(n)
+        })
     }
 
     /// Wait for the socket to become writable.

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -234,3 +234,81 @@ fn write_until_pending(stream: &mut TcpStream) {
         }
     }
 }
+
+#[tokio::test]
+async fn try_read_buf() {
+    const DATA: &[u8] = b"this is some data to write to the socket";
+
+    // Create listener
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+
+    // Create socket pair
+    let client = TcpStream::connect(listener.local_addr().unwrap())
+        .await
+        .unwrap();
+    let (server, _) = listener.accept().await.unwrap();
+    let mut written = DATA.to_vec();
+
+    // Track the server receiving data
+    let mut readable = task::spawn(server.readable());
+    assert_pending!(readable.poll());
+
+    // Write data.
+    client.writable().await.unwrap();
+    assert_eq!(DATA.len(), client.try_write(DATA).unwrap());
+
+    // The task should be notified
+    while !readable.is_woken() {
+        tokio::task::yield_now().await;
+    }
+
+    // Fill the write buffer
+    loop {
+        // Still ready
+        let mut writable = task::spawn(client.writable());
+        assert_ready_ok!(writable.poll());
+
+        match client.try_write(DATA) {
+            Ok(n) => written.extend(&DATA[..n]),
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                break;
+            }
+            Err(e) => panic!("error = {:?}", e),
+        }
+    }
+
+    {
+        // Write buffer full
+        let mut writable = task::spawn(client.writable());
+        assert_pending!(writable.poll());
+
+        // Drain the socket from the server end
+        let mut read = Vec::with_capacity(written.len());
+        let mut i = 0;
+
+        while i < read.capacity() {
+            server.readable().await.unwrap();
+
+            match server.try_read_buf(&mut read) {
+                Ok(n) => i += n,
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                Err(e) => panic!("error = {:?}", e),
+            }
+        }
+
+        assert_eq!(read, written);
+    }
+
+    // Now, we listen for shutdown
+    drop(client);
+
+    loop {
+        let ready = server.ready(Interest::READABLE).await.unwrap();
+
+        if ready.is_read_closed() {
+            return;
+        } else {
+            tokio::task::yield_now().await;
+        }
+    }
+}


### PR DESCRIPTION
Refs: https://github.com/tokio-rs/tokio/issues/3313

two questions:

- what i have done was in the right direction? 
- what a `vectored read` function should look like?
function signature like below?
```rust
pub fn try_read_vectored<B: BufMut>(&self, buf: &mut [B]) -> io::Result<usize>;
```