### PR TITLE
Replace deprecated compare_and_swap with compare_exchange

### DIFF
--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -131,7 +131,11 @@ impl<T: AsyncWrite> AsyncWrite for WriteHalf<T> {
 
 impl<T> Inner<T> {
     fn poll_lock(&self, cx: &mut Context<'_>) -> Poll<Guard<'_, T>> {
-        if !self.locked.compare_and_swap(false, true, Acquire) {
+        if self
+            .locked
+            .compare_exchange(false, true, Acquire, Acquire)
+            .is_ok()
+        {
             Poll::Ready(Guard { inner: self })
         } else {
             // Spin... but investigate a better strategy

--- a/tokio/src/runtime/queue.rs
+++ b/tokio/src/runtime/queue.rs
@@ -194,13 +194,14 @@ impl<T> Local<T> {
         // work. This is because all tasks are pushed into the queue from the
         // current thread (or memory has been acquired if the local queue handle
         // moved).
-        let actual = self.inner.head.compare_and_swap(
+        let actual = self.inner.head.compare_exchange(
             prev,
             pack(head.wrapping_add(n), head.wrapping_add(n)),
             Release,
+            Release,
         );
 
-        if actual != prev {
+        if actual.is_err() {
             // We failed to claim the tasks, losing the race. Return out of
             // this function and try the full `push` routine again. The queue
             // may not be full anymore.

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -6,7 +6,7 @@ use crate::sync::mpsc::block::{self, Block};
 
 use std::fmt;
 use std::ptr::NonNull;
-use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
+use std::sync::atomic::Ordering::{Acquire, Relaxed, Release};
 
 /// List queue transmit handle
 pub(crate) struct Tx<T> {
@@ -140,11 +140,14 @@ impl<T> Tx<T> {
                 //
                 // Acquire is not needed as any "actual" value is not accessed.
                 // At this point, the linked list is walked to acquire blocks.
-                let actual =
-                    self.block_tail
-                        .compare_and_swap(block_ptr, next_block.as_ptr(), Release);
+                let actual = self.block_tail.compare_exchange(
+                    block_ptr,
+                    next_block.as_ptr(),
+                    Release,
+                    Release,
+                );
 
-                if actual == block_ptr {
+                if actual.is_ok() {
                     // Synchronize with any senders
                     let tail_position = self.tail_position.fetch_add(0, Release);
 
@@ -191,7 +194,7 @@ impl<T> Tx<T> {
 
         // TODO: Unify this logic with Block::grow
         for _ in 0..3 {
-            match curr.as_ref().try_push(&mut block, AcqRel) {
+            match curr.as_ref().try_push(&mut block) {
                 Ok(_) => {
                     reused = true;
                     break;


### PR DESCRIPTION
compare_and_swap is deprecated in 1.50. (rust-lang/rust#79261) This PR replaces the usage of  `compare_and_swap` with `compare_exchange`.

migration docs: https://doc.rust-lang.org/nightly/core/sync/atomic/struct.AtomicUsize.html#migrating-to-compare_exchange-and-compare_exchange_weak