### PR TITLE
udp: Add split/into_split for UdpSocket

### DIFF
--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -36,7 +36,7 @@ cfg_net! {
     pub use tcp::socket::TcpSocket;
     pub use tcp::stream::TcpStream;
 
-    mod udp;
+    pub mod udp;
     pub use udp::socket::UdpSocket;
 }
 

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -37,7 +37,7 @@ cfg_net! {
     pub use tcp::stream::TcpStream;
 
     mod udp;
-    pub use udp::UdpSocket;
+    pub use udp::socket::UdpSocket;
 }
 
 cfg_net_unix! {

--- a/tokio/src/net/udp/mod.rs
+++ b/tokio/src/net/udp/mod.rs
@@ -1,0 +1,9 @@
+//! UDP utility types.
+
+pub(crate) mod socket;
+mod split;
+
+pub use split::{RecvHalf, SendHalf};
+
+mod split_owned;
+pub use split_owned::{OwnedRecvHalf, OwnedSendHalf};

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -1348,7 +1348,7 @@ impl UdpSocket {
     // These lifetime markers also appear in the generated documentation, and make
     // it more clear that this is a *borrowed* split.
     #[allow(clippy::needless_lifetimes)]
-    /// Split a `UnixStream` into a read half and a write half, which can be used
+    /// Split a `UdpSocket` into a read half and a write half, which can be used
     /// to read and write the stream concurrently.
     ///
     /// This method is more efficient than [`into_split`], but the halves cannot be
@@ -1359,17 +1359,13 @@ impl UdpSocket {
         split(self)
     }
 
-    /// Splits a `UnixStream` into a read half and a write half, which can be used
+    /// Splits a `UdpSocket` into a read half and a write half, which can be used
     /// to read and write the stream concurrently.
     ///
     /// Unlike [`split`], the owned halves can be moved to separate tasks, however
     /// this comes at the cost of a heap allocation.
     ///
-    /// **Note:** Dropping the write half will shut down the write half of the
-    /// stream. This is equivalent to calling [`shutdown(Write)`] on the `UnixStream`.
-    ///
     /// [`split`]: Self::split()
-    /// [`shutdown(Write)`]: fn@Self::shutdown
     pub fn into_split(self) -> (OwnedRecvHalf, OwnedSendHalf) {
         split_owned(self)
     }

--- a/tokio/src/net/udp/socket.rs
+++ b/tokio/src/net/udp/socket.rs
@@ -1,6 +1,6 @@
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
-use crate::net::udp::split::{split, ReadHalf, WriteHalf};
-use crate::net::udp::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};
+use crate::net::udp::split::{split, RecvHalf, SendHalf};
+use crate::net::udp::split_owned::{split_owned, OwnedRecvHalf, OwnedSendHalf};
 use crate::net::{to_socket_addrs, ToSocketAddrs};
 
 use std::convert::TryFrom;

--- a/tokio/src/net/udp/split.rs
+++ b/tokio/src/net/udp/split.rs
@@ -1,0 +1,78 @@
+//! `UdpSocket` split support.
+//!
+//! A `UdpSocket` can be split into a read half and a write half with
+//! `UdpSocket::split`.
+//!
+//! This is a special `split` that just borrows `UdpSocket`, meaning
+//! it's not safe to move into tasks. If that functionality is desired,
+//! use the `Owned` variants.
+
+use crate::net::{ToSocketAddrs, UdpSocket};
+
+use std::{io, net::SocketAddr};
+
+/// Borrowed read half of a [`UdpSocket`], created by [`split`].
+///
+///
+/// [`UdpSocket`]: UdpSocket
+/// [`split`]: UdpSocket::split()
+#[derive(Debug)]
+pub struct RecvHalf<'a>(&'a UdpSocket);
+
+/// Borrowed write half of a [`UdpSocket`], created by [`split`].
+///
+/// [`UdpSocket`]: UdpSocket
+/// [`split`]: UdpSocket::split()
+#[derive(Debug)]
+pub struct SendHalf<'a>(&'a UdpSocket);
+
+pub(crate) fn split(stream: &UdpSocket) -> (RecvHalf<'_>, SendHalf<'_>) {
+    (RecvHalf(stream), SendHalf(stream))
+}
+
+impl<'a> RecvHalf<'a> {
+    /// Attempts to receive a single datagram message on the socket from the remote
+    /// address to which it is `connect`ed.
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.recv(buf).await
+    }
+
+    /// Returns a future that receives a single datagram on the socket. On success,
+    /// the future resolves to the number of bytes read and the origin.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size
+    /// to hold the message bytes. If a message is too long to fit in the supplied
+    /// buffer, excess bytes may be discarded.
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.0.recv_from(buf).await
+    }
+}
+
+impl<'a> SendHalf<'a> {
+    /// Returns a future that sends data on the socket to the remote address to which it is connected.
+    /// On success, the future will resolve to the number of bytes written.
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.0.send(buf).await
+    }
+
+    /// Returns a future that sends data on the socket to the given address.
+    /// On success, the future will resolve to the number of bytes written.
+    ///
+    /// The future will resolve to an error if the IP version of the socket does
+    /// not match that of `target`.
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
+        self.0.send_to(buf, addr).await
+    }
+}
+
+impl AsRef<UdpSocket> for RecvHalf<'_> {
+    fn as_ref(&self) -> &UdpSocket {
+        self.0
+    }
+}
+
+impl AsRef<UdpSocket> for SendHalf<'_> {
+    fn as_ref(&self) -> &UdpSocket {
+        self.0
+    }
+}

--- a/tokio/src/net/udp/split_owned.rs
+++ b/tokio/src/net/udp/split_owned.rs
@@ -1,0 +1,127 @@
+//! `UdpSocket` owned split support.
+//!
+//! A `UdpSocket` can be split into an `OwnedRecvHalf` and a `OwnedSendHalf`
+//! with the `UdpSocket::into_split` method.  `OwnedRecvHalf` can call
+//! `recv`/`recv_from` while `OwnedSendHalf` can call `send`/`send_to`
+//!
+//! If you need to use a `UdpSocket` concurrently from more than 2 separate tasks,
+//! you're free to `Arc` the `UdpSocket` yourself and `clone` as much as you
+//! need. All it's async method are safe to use from multiple tasks.
+
+use crate::net::{ToSocketAddrs, UdpSocket};
+
+use std::{error::Error, fmt, io, net::SocketAddr, sync::Arc};
+
+/// Owned read half of a [`UdpSocket`], created by [`into_split`].
+///
+/// Reading from an `OwnedRecvHalf` is done using `recv` or `recv_from`
+///
+/// [`UdpSocket`]: crate::net::UdpSocket
+/// [`into_split`]: crate::net::UdpSocket::into_split()
+#[derive(Debug)]
+pub struct OwnedRecvHalf(Arc<UdpSocket>);
+
+/// Owned write half of a [`UdpSocket`], created by [`into_split`].
+///
+/// Write to `OwnedSendHalf` is done using `send` or `send_to`
+///
+/// [`UdpSocket`]: crate::net::UdpSocket
+/// [`into_split`]: crate::net::UdpSocket::into_split()
+#[derive(Debug)]
+pub struct OwnedSendHalf(Arc<UdpSocket>);
+
+pub(crate) fn split_owned(stream: UdpSocket) -> (OwnedRecvHalf, OwnedSendHalf) {
+    let arc = Arc::new(stream);
+    (OwnedRecvHalf(Arc::clone(&arc)), OwnedSendHalf(arc))
+}
+
+pub(crate) fn reunite(recv: OwnedRecvHalf, send: OwnedSendHalf) -> Result<UdpSocket, ReuniteError> {
+    if Arc::ptr_eq(&recv.0, &send.0) {
+        drop(recv);
+        // This unwrap cannot fail as the api does not allow creating more than two Arcs,
+        // and we just dropped the other half.
+        Ok(Arc::try_unwrap(send.0).expect("UdpSocket: try_unwrap failed in reunite"))
+    } else {
+        Err(ReuniteError(recv, send))
+    }
+}
+
+/// Error indicating that two halves were not from the same socket, and thus could
+/// not be reunited.
+#[derive(Debug)]
+pub struct ReuniteError(pub OwnedRecvHalf, pub OwnedSendHalf);
+
+impl fmt::Display for ReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same socket"
+        )
+    }
+}
+
+impl Error for ReuniteError {}
+
+impl OwnedRecvHalf {
+    /// Attempts to put the two halves of a `UdpSocket` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to [`into_split`].
+    ///
+    /// [`into_split`]: crate::net::UdpSocket::into_split()
+    pub fn reunite(self, other: OwnedSendHalf) -> Result<UdpSocket, ReuniteError> {
+        reunite(self, other)
+    }
+    /// Attempts to receive a single datagram message on the socket from the remote
+    /// address to which it is `connect`ed.
+    pub async fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+        self.0.recv(buf).await
+    }
+
+    /// Returns a future that receives a single datagram on the socket. On success,
+    /// the future resolves to the number of bytes read and the origin.
+    ///
+    /// The function must be called with valid byte array `buf` of sufficient size
+    /// to hold the message bytes. If a message is too long to fit in the supplied
+    /// buffer, excess bytes may be discarded.
+    pub async fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
+        self.0.recv_from(buf).await
+    }
+}
+
+impl OwnedSendHalf {
+    /// Attempts to put the two halves of a `UdpSocket` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to [`into_split`].
+    ///
+    /// [`into_split`]: crate::net::UdpSocket::into_split()
+    pub fn reunite(self, other: OwnedRecvHalf) -> Result<UdpSocket, ReuniteError> {
+        reunite(other, self)
+    }
+
+    /// Returns a future that sends data on the socket to the remote address to which it is connected.
+    /// On success, the future will resolve to the number of bytes written.
+    pub async fn send(&self, buf: &[u8]) -> io::Result<usize> {
+        self.0.send(buf).await
+    }
+
+    /// Returns a future that sends data on the socket to the given address.
+    /// On success, the future will resolve to the number of bytes written.
+    ///
+    /// The future will resolve to an error if the IP version of the socket does
+    /// not match that of `target`.
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
+        self.0.send_to(buf, addr).await
+    }
+}
+
+impl AsRef<UdpSocket> for OwnedRecvHalf {
+    fn as_ref(&self) -> &UdpSocket {
+        &*self.0
+    }
+}
+
+impl AsRef<UdpSocket> for OwnedSendHalf {
+    fn as_ref(&self) -> &UdpSocket {
+        &*self.0
+    }
+}

--- a/tokio/src/net/udp/split_owned.rs
+++ b/tokio/src/net/udp/split_owned.rs
@@ -6,7 +6,7 @@
 //!
 //! If you need to use a `UdpSocket` concurrently from more than 2 separate tasks,
 //! you're free to `Arc` the `UdpSocket` yourself and `clone` as much as you
-//! need. All it's async method are safe to use from multiple tasks.
+//! need. All it's async methods are safe to use from multiple tasks.
 
 use crate::net::{ToSocketAddrs, UdpSocket};
 


### PR DESCRIPTION
## Motivation

With #2779 we don't *need* the split API anymore, however it still exists for `UnixStream` and `TcpStream`. Why not also for `UdpSocket`? It uses regular references or an `Arc` in the same way that the other types do.

## Solution

Write a simple wrapper over regular references for shared split or Arc for owned split. @Darksonn  seemed to be on board for this, thoughts?
