### PR TITLE
util: add more `get_{ref,mut,pin_mut}` methods

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -170,6 +170,16 @@ impl<T, U> Framed<T, U> {
         &mut self.inner.inner
     }
 
+    /// Returns a pinned mutable reference to the underlying I/O stream wrapped by
+    /// `Framed`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner.project().inner
+    }
+
     /// Returns a reference to the underlying codec wrapped by
     /// `Framed`.
     ///

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -78,6 +78,16 @@ impl<T, D> FramedRead<T, D> {
         &mut self.inner.inner
     }
 
+    /// Returns a pinned mutable reference to the underlying I/O stream wrapped by
+    /// `FramedRead`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner.project().inner
+    }
+
     /// Consumes the `FramedRead`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -58,6 +58,16 @@ impl<T, E> FramedWrite<T, E> {
         &mut self.inner.inner
     }
 
+    /// Returns a pinned mutable reference to the underlying I/O stream wrapped by
+    /// `FramedWrite`.
+    ///
+    /// Note that care should be taken to not tamper with the underlying stream
+    /// of data coming in as it may corrupt the stream of frames otherwise
+    /// being worked with.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut T> {
+        self.project().inner.project().inner
+    }
+
     /// Consumes the `FramedWrite`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -93,6 +93,29 @@ where
     }
 }
 
+impl<S, B> StreamReader<S, B> {
+    /// Gets a reference to the underlying stream.
+    ///
+    /// It is inadvisable to directly read from the underlying stream.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying stream.
+    ///
+    /// It is inadvisable to directly read from the underlying stream.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying stream.
+    ///
+    /// It is inadvisable to directly read from the underlying stream.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut S> {
+        self.project().inner
+    }
+}
+
 impl<S, B, E> AsyncRead for StreamReader<S, B>
 where
     S: Stream<Item = Result<B, E>>,

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -114,6 +114,13 @@ impl<S, B> StreamReader<S, B> {
     pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut S> {
         self.project().inner
     }
+
+    /// Consumes this `BufWriter`, returning the underlying stream.
+    ///
+    /// Note that any leftover data in the internal buffer is lost.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
 }
 
 impl<S, B, E> AsyncRead for StreamReader<S, B>


### PR DESCRIPTION
## Motivation

Many wrapper types under `tokio::io` like `BufReader` have `get_ref`, `get_mut` and `get_pin_mut` methods and they seem to be good to have for `tokio-util` types as well.

## Solution

This commit adds:

- `Framed::get_pin_mut`
- `FramedRead::get_pin_mut`
- `FramedWrite::get_pin_mut`
- `StreamReader::get_ref`
- `StreamReader::get_mut`
- `StreamReader::get_pin_mut`
- `StreamReader::into_inner`