### PR TITLE
Re-allow zero blocking threads with warnings, panic in blocking spawner

### DIFF
--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -6,14 +6,22 @@
 mod pool;
 pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
 
+cfg_rt_multi_thread! {
+    pub(crate) use pool::spawn_core;
+}
+
 mod schedule;
 mod shutdown;
 pub(crate) mod task;
 
 use crate::runtime::Builder;
 
-pub(crate) fn create_blocking_pool(builder: &Builder, thread_cap: usize) -> BlockingPool {
-    BlockingPool::new(builder, thread_cap)
+pub(crate) fn create_blocking_pool(
+    builder: &Builder,
+    core_cap: usize,
+    extra_cap: usize,
+) -> BlockingPool {
+    BlockingPool::new(builder, core_cap, extra_cap)
 }
 
 /*

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -156,7 +156,7 @@ impl Builder {
 
     /// Sets the number of worker threads the `Runtime` will use.
     ///
-    /// This should be a number between 0 and 32,768 though it is advised to
+    /// This should be a number between 1 and 32,768 though it is advised to
     /// keep this value on the smaller side.
     ///
     /// # Default
@@ -165,9 +165,10 @@ impl Builder {
     ///
     /// # Panic
     ///
-    /// When using the `current_thread` runtime this method will panic, since
-    /// those variants do not allow setting worker thread counts.
+    /// * Panics if used via [`Builder::new_current_thread`], since those
+    ///   runtimes do not have distinct worker threads.
     ///
+    /// * Panics if set to zero (`0`).
     ///
     /// # Examples
     ///
@@ -200,9 +201,6 @@ impl Builder {
     /// rt.block_on(async move {});
     /// ```
     ///
-    /// # Panic
-    ///
-    /// This will panic if `val` is not larger than `0`.
     pub fn worker_threads(&mut self, val: usize) -> &mut Self {
         assert!(val > 0, "Worker threads cannot be set to 0");
         self.worker_threads = Some(val);

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -206,7 +206,9 @@ cfg_rt! {
 
 cfg_rt_multi_thread! {
     mod park;
+
     use park::Parker;
+    pub(crate) use blocking::spawn_core;
 }
 
 cfg_rt_multi_thread! {

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -248,7 +248,8 @@ where
         cx.worker.core.set(core);
 
         // Next, clone the worker handle and send it to a new thread for
-        // processing.
+        // processing. Use spawn_blocking because this is no longer a "core"
+        // thread.
         //
         // Once the blocking task is done executing, we will attempt to
         // steal the core back.
@@ -276,7 +277,7 @@ const GLOBAL_POLL_INTERVAL: u8 = 61;
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
-            runtime::spawn_blocking(move || run(worker));
+            runtime::spawn_core(move || run(worker));
         }
     }
 }


### PR DESCRIPTION
## Motivation

I'm of the development school favoring a fixed, small number of threads per process. Its the _raison d'être_ for the additional effort of asynchronous code. Such applications are more predictable in terms of memory usage and performance. With tokio 0.2-0.3 I was able to configure a fixed number of "core" worker threads and, with some careful other choices, _know_ that no (zero) "extra" threads were needed; in tokio terms, neither `spawn_blocking` nor `block_in_place` were in use.

Note that the existing _blocking_ facilities are really just workarounds for OS gaps which we should expect to become less favored as alternatives become available, e.g. rust-native fully asynchronous DNS resolvers and Linux `io_uring`.

As of tokio-1.0.0, #3287 disallowed configuring zero (0) "extra" threads (`max_blocking_threads`) on tokio's threaded runtime pool. Previously, if one configured zero extra threads, testing showed that any application tasks needing extra blocking threads would simply fail to complete. That was too subtle a failure, but on the other hand, #3287 may be too prescriptive as it stands, not matching other parts of tokio, which allows selecting only the features needed for the application.

With #3287 as released, configuring just one "extra" thread (`max_blocking_threads(1)`) may still be a silent and hard to diagnose performance liability, for example serializing DNS lookups with file reads/writes.  Runtime (as opposed to config time) panic on calls to `spawn_blocking` may be more educational to the end user than simply forcing them to use a small positive number, which may still be inadequate for good performance.

## Solution

* Introduce `spawn_core` to separate the call path for "core" worker thread launching.

* Make the pool aware of "core" and "extra" thread capacity.  If there is zero "extra" capacity, panic with an informative message when `spawn_blocking` or `block_in_place` is called.

* Improve rustdoc in general for `max_blocking_threads`

This logically preserves the "fix" for #2802 in that instead of never completing, tokio will panic with an informative runtime error message (and stack trace) as to the mis-configuration:

```text
panicked at '`spawn_blocking` or `block_in_place` called,
but `runtime::Builder::max_blocking_threads(0)` was configured!',
```

## Alternatives

### Configurable workaround

With tokio 1.0.0-1.0.1, we can effectively obtain the same panics and backtrace on the first use of a blocking "extra" thread:

```rust
    use std::sync::atomic::{AtomicUsize, Ordering};

    let rt = tokio::runtime::Builder::new_multi_thread()
        .worker_threads(2)
        .max_blocking_threads(1)
        .thread_name_fn(|| {
            static CNT: AtomicUsize = AtomicUsize::new(0);
            let c = CNT.fetch_add(1, Ordering::SeqCst);
            if c >= 2 {
                panic!("spawn_blocking/block_in_place must have been used!");
            } else {
                format!("worker-{}", c)
            }
        })
        .build()
        .unwrap();
```

This isn't terribly bad as a workaround, but consider that many users whom might have initially configured zero (0) blocking threads, thinking they don't need it, might next choose one (1) blocking thread, and not be aware of the significant performance implications to effectively serializing all blocking operations, e.g. DNS lookups and file operations, on one thread.

### Feature gates

We _could_ place `spawn_blocking` and `block_in_place` functions under _spawn-blocking_ and _block-in-place_ feature gates, respectively. (Previously there was the `blocking` feature gate.) These would be included by _full_.  Also tokio features like _fs_ could depend on _spawn-blocking_ to ensure continued compatibility.

A start of a prototype for this is here:

https://github.com/tokio-rs/tokio/compare/master...dekellum:opt-in-blocking-features

An advantage for this alternative is that libraries (not using `full`) will need to explicitly opt-in to the features or will fail to compile (rather then deferring to a runtime panic).

However, this alternative will frequently not be sufficient without associated down stream changes, and these may be an up hill battle for users. For example, `hyper` currently includes a [`client::connect::dns::GaiResolver`](https://docs.rs/hyper/0.14.2/hyper/client/connect/dns/struct.GaiResolver.html) which uses _spawn_blocking_. However, currently the only way to disable this resolver is to disable hyper's _tcp_ feature, which disables too much: the entire `HttpConnector` and all its tokio integration.

### Add `runtime::Builder::enable_blocking(false)`

This adds an additional safety/hurdle to configuring no capacity for blocking, but would result in the same runtime panics as the preferred solution above. Here the user would additionally need to add the following to `runtime::Builder` configuration:

```rust
    let rt = tokio::runtime::Builder::new_multi_thread()
        .enable_blocking(false)
        .max_blocking_threads(0) // optional, but now allowed
        .build()
        .unwrap();
```

Note that as a user, I would still want to explicitly set `max_blocking_threads(0)`.

Prototype for this is as follows, with explicit warnings in rustdoc:

https://github.com/tokio-rs/tokio/compare/master...dekellum:allow-disable-blocking
```rust
    /// Enable or disable support for spawning of blocking operations.
    ///
    /// The default value is `true` (enabled).
    ///
    /// **Warning: Setting this to `false` (disabled) will result in runtime
    /// panics as described below.** Doing so is only possibly useful as
    /// _either_ a temporary way to find calls to `spawn_blocking` or as a
    /// testing/runtime assertion that an application does not use
    /// `spawn_blocking` either directly or indirectly via tokio or other
    /// libraries.
    ///
    /// # Panic
    ///
    /// If set to `false` (disabled), any calls to [`Runtime::spawn_blocking`]
    /// or [`task::block_in_place`](crate::task::block_in_place), including
    /// internal use such as in `tokio::fs` or via other libraries, will result
    /// in a panic.
    pub fn enable_blocking(&mut self, val: bool) -> &mut Self {
        /*…*/
    }
```

IMO this alternative amounts to an unnecessary additional hurdle, but I'm willing to add this to the preferred solution of this PR, if it remains desired.

#### Or `disable_blocking`

Another alternative interface is to add `disable_blocking` for the same purpose. In terms of consistency of the builder interface, there is already `enable_*` methods (e.g. `enable_time`) so a `disable_*` method, without a parameter, is more consistent in some sense.
