### PR TITLE
tokio: wake localset on spawn_local

### DIFF
--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -242,8 +242,6 @@ impl LocalSet {
     ///
     /// This task is guaranteed to be run on the current thread.
     ///
-    /// Calls to this function will result in waking the current localset.
-    ///
     /// Unlike the free function [`spawn_local`], this method may be used to
     /// spawn local tasks when the task set is _not_ running. For example:
     /// ```rust

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -242,6 +242,8 @@ impl LocalSet {
     ///
     /// This task is guaranteed to be run on the current thread.
     ///
+    /// Calls to this function will result in waking the current localset.
+    ///
     /// Unlike the free function [`spawn_local`], this method may be used to
     /// spawn local tasks when the task set is _not_ running. For example:
     /// ```rust
@@ -283,6 +285,7 @@ impl LocalSet {
         let future = crate::util::trace::task(future, "local");
         let (task, handle) = unsafe { task::joinable_local(future) };
         self.context.tasks.borrow_mut().queue.push_back(task);
+        self.context.shared.waker.wake();
         handle
     }
 


### PR DESCRIPTION
Wake the `tokio::task::LocalSet` after
`tokio::task::LocalSet::spawn_local` is called.

Note this side effect in the `tokio::task::LocalSet::spawn_local` docs.

Add test for spawn_local being woke in `task_local_set.rs`

Fixes: #3117

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Fixes #3117 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add call to shared waker in localset after adding future to localset task queue.