### PR TITLE
feat: Expose the Notified future

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -439,7 +439,7 @@ cfg_sync! {
     pub use mutex::{Mutex, MutexGuard, TryLockError, OwnedMutexGuard};
 
     pub(crate) mod notify;
-    pub use notify::Notify;
+    pub use notify::{Notify, Notified};
 
     pub mod oneshot;
 


### PR DESCRIPTION
## Motivation

I would like to avoid boxing the `Notified` future when storing it a struct in https://github.com/fede1024/rust-rdkafka/pull/320 .

## Solution

Exporting the type allows it to be named