### PR TITLE
chore: prepare tokio-stream 0.1.1

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.1.1 (January 4, 2021)
+
+Added
+
+ - add `Stream` wrappers ([#3343])
+
+Fixed
+
+ - move `async-stream` to `dev-dependencies` ([#3366])
+
+[#3366]: https://github.com/tokio-rs/tokio/pull/3366
+[#3343]: https://github.com/tokio-rs/tokio/pull/3343
+
 # 0.1.0 (December 23, 2020)
 
-- Initial release
+ - Initial release

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-stream"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-stream/0.1.0/tokio_stream"
+documentation = "https://docs.rs/tokio-stream/0.1.1/tokio_stream"
 description = """
 Utilities to work with `Stream` and `tokio`.
 """

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-stream/0.1.0")]
+#![doc(html_root_url = "https://docs.rs/tokio-stream/0.1.1")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
Added

 - add `Stream` wrappers (#3343)

Fixed

 - move `async-stream` to `dev-dependencies` (#3366)