### PR TITLE
Add `fs::exists` function

### DIFF
--- a/tokio/src/fs/exists.rs
+++ b/tokio/src/fs/exists.rs
@@ -1,0 +1,27 @@
+use std::path::Path;
+
+/// Returns `true` if the path points at an existing entity.
+///
+/// This function will traverse symbolic links to query information about the
+/// destination file.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use tokio::fs;
+///
+/// # #[tokio::main]
+/// # async fn main() {
+/// let exists = fs::exists("/some/file/path.txt").await;
+/// // in case the `/some/file/path.txt` points to existing path
+/// assert_eq!(exists, true);
+/// # }
+/// ```
+///
+/// # Note
+///
+/// This method returns false in case of errors thus ignoring them. Use [`fs::metadata`][super::metadata()]
+/// if you want to check for errors.
+pub async fn exists(path: impl AsRef<Path>) -> bool {
+    super::metadata(&path).await.is_ok()
+}

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -36,6 +36,9 @@ pub use self::create_dir_all::create_dir_all;
 mod dir_builder;
 pub use self::dir_builder::DirBuilder;
 
+mod exists;
+pub use self::exists::exists;
+
 mod file;
 pub use self::file::File;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The std lib implements `exists` while there's no tokio equivalent. This is possible with `metadata` function but a wrapper is nice to have.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `fs::exists` function.

Fixes: #3373

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
