### PR TITLE
signal: make Signal::poll_recv method public

### DIFF
--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -397,7 +397,41 @@ impl Signal {
         poll_fn(|cx| self.poll_recv(cx)).await
     }
 
-    pub(crate) fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
+    /// Polls to receive the next signal notification event, outside of an
+    /// `async` context.
+    ///
+    /// This method returns:
+    ///
+    ///  * `Poll::Pending` if no signals are available but the channel is not
+    ///    closed.
+    ///  * `Poll::Ready(Some(()))` if a signal is available.
+    ///  * `Poll::Ready(None)` if the channel has been closed and all signals
+    ///    sent before it was closed have been received.
+    ///
+    /// # Examples
+    ///
+    /// Polling from a manually implemented future
+    ///
+    /// ```rust,no_run
+    /// use std::pin::Pin;
+    /// use std::future::Future;
+    /// use std::task::{Context, Poll};
+    /// use tokio::signal::unix::Signal;
+    ///
+    /// struct MyFuture {
+    ///     signal: Signal,
+    /// }
+    ///
+    /// impl Future for MyFuture {
+    ///     type Output = Option<()>;
+    ///
+    ///     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    ///         println!("polling MyFuture");
+    ///         self.signal.poll_recv(cx)
+    ///     }
+    /// }
+    /// ```
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
         self.rx.poll_recv(cx)
     }
 


### PR DESCRIPTION
Signed-off-by: Fuyang Liu <liufuyang@users.noreply.github.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

make the `poll_recv` method public,  So we can add a wrapper to `tokio_stream::wrappers` for them.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
