### PR TITLE
tokio-stream: add wrapper for broadcast and watch

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # [dependencies] instead.
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["full", "tracing"] }
-tokio-util = { version = "0.6.1", features = ["full"] }
+tokio-util = { version = "0.6.3", features = ["full"] }
 tokio-stream = { version = "0.1" }
 
 async-stream = "0.3"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -28,13 +28,13 @@ fs = ["tokio/fs"]
 
 [dependencies]
 futures-core = { version = "0.3.0" }
+async-stream = "0.3"
 pin-project-lite = "0.2.0"
 tokio = { version = "1.0", features = ["sync"] }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tokio-test = { path = "../tokio-test" }
-async-stream = "0.3"
 futures = { version = "0.3", default-features = false }
 
 proptest = "0.10.0"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -34,6 +34,7 @@ tokio-util = { version = "0.6.3" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full", "test-util"] }
+async-stream = "0.3"
 tokio-test = { path = "../tokio-test" }
 futures = { version = "0.3", default-features = false }
 

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -30,7 +30,7 @@ fs = ["tokio/fs"]
 futures-core = { version = "0.3.0" }
 pin-project-lite = "0.2.0"
 tokio = { version = "1.0", features = ["sync"] }
-tokio-util = { path = "../tokio-util" }
+tokio-util = { version = "0.6.3" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full", "test-util"] }

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -28,9 +28,9 @@ fs = ["tokio/fs"]
 
 [dependencies]
 futures-core = { version = "0.3.0" }
-async-stream = "0.3"
 pin-project-lite = "0.2.0"
 tokio = { version = "1.0", features = ["sync"] }
+tokio-util = { path = "../tokio-util" }
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["full", "test-util"] }

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -8,6 +8,7 @@ pub use mpsc_unbounded::UnboundedReceiverStream;
 
 mod broadcast;
 pub use broadcast::BroadcastStream;
+pub use broadcast::BroadcastStreamRecvError;
 
 cfg_time! {
     mod interval;

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -10,6 +10,9 @@ mod broadcast;
 pub use broadcast::BroadcastStream;
 pub use broadcast::BroadcastStreamRecvError;
 
+mod watch;
+pub use watch::WatchStream;
+
 cfg_time! {
     mod interval;
     pub use interval::IntervalStream;

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -6,6 +6,9 @@ pub use mpsc_bounded::ReceiverStream;
 mod mpsc_unbounded;
 pub use mpsc_unbounded::UnboundedReceiverStream;
 
+mod broadcast;
+pub use broadcast::BroadcastStream;
+
 cfg_time! {
     mod interval;
     pub use interval::IntervalStream;

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -11,6 +11,7 @@ use std::task::{Context, Poll};
 /// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
 /// [`async-stream`]: https://docs.rs/async-stream
+#[derive(Debug)]
 pub struct BroadcastStream<T: Clone> {
     inner: Pin<Box<dyn Stream<Item = Result<T, RecvError>> + Send + Sync >>,
 }

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -1,0 +1,38 @@
+use crate::Stream;
+use async_stream::try_stream;
+use std::pin::Pin;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::Receiver;
+
+use std::task::{Context, Poll};
+
+/// A wrapper around [`Receiver`] that implements [`Stream`]. Achieved by using the [`async-stream`] crate.
+///
+/// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
+/// [`Stream`]: trait@crate::Stream
+/// [`async-stream`]: https://docs.rs/async-stream
+#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+pub struct BroadcastStream<T: Clone> {
+    inner: Pin<Box<dyn Stream<Item = Result<T, RecvError>>>>,
+}
+
+impl<T: Clone + Unpin + 'static> BroadcastStream<T> {
+    /// Create a new `BroadcastStream`.
+    pub fn new(mut rx: Receiver<T>) -> Self {
+        let stream = try_stream! {
+            loop {
+                let item = rx.recv().await?;
+                yield item;
+            }
+        };
+        Self { inner: Box::pin(stream) }
+    }
+}
+
+impl<T: Clone> Stream for BroadcastStream<T> {
+    type Item = T;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.poll_next(cx)
+    }
+}

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -31,13 +31,11 @@ impl<T: Clone + Unpin + 'static + Send + Sync> BroadcastStream<T> {
         let stream = stream! {
             loop {
                 match rx.recv().await {
-                Ok(item) => yield Ok(item),
-                Err(err) =>
-                    match err {
-                         RecvError::Closed => break,
-                         RecvError::Lagged(n) =>
-                             yield Err(BroadcastStreamRecvError::Lagged(n))
-                    }
+                    Ok(item) => yield Ok(item),
+                    Err(err) => match err {
+                        RecvError::Closed => break,
+                        RecvError::Lagged(n) => yield Err(BroadcastStreamRecvError::Lagged(n)),
+                    },
                 }
             }
         };

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -11,7 +11,6 @@ use std::task::{Context, Poll};
 /// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
 /// [`async-stream`]: https://docs.rs/async-stream
-#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
 pub struct BroadcastStream<T: Clone> {
     inner: Pin<Box<dyn Stream<Item = Result<T, RecvError>> + Send + Sync >>,
 }

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -11,7 +11,7 @@ use std::task::{Context, Poll};
 ///
 /// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
-pub struct BroadcastStream<T: Clone> {
+pub struct BroadcastStream<T> {
     inner: Pin<Box<dyn Stream<Item = Result<T, BroadcastStreamRecvError>> + Send + Sync>>,
 }
 
@@ -35,7 +35,8 @@ impl<T: Clone + Unpin + 'static + Send + Sync> BroadcastStream<T> {
                 Err(err) =>
                     match err {
                          RecvError::Closed => break,
-                         RecvError::Lagged(n) => yield Err(BroadcastStreamRecvError::Lagged(n))
+                         RecvError::Lagged(n) =>
+                             yield Err(BroadcastStreamRecvError::Lagged(n))
                     }
                 }
             }

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -1,37 +1,61 @@
 use crate::Stream;
-use async_stream::try_stream;
+use async_stream::stream;
 use std::pin::Pin;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::sync::broadcast::Receiver;
 
+use std::fmt;
 use std::task::{Context, Poll};
 
 /// A wrapper around [`Receiver`] that implements [`Stream`].
 ///
 /// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
-#[derive(Debug)]
 pub struct BroadcastStream<T: Clone> {
-    inner: Pin<Box<dyn Stream<Item = Result<T, RecvError>> + Send + Sync >>,
+    inner: Pin<Box<dyn Stream<Item = Result<T, BroadcastStreamRecvError>> + Send + Sync>>,
+}
+
+/// An error returned from the inner stream of a [`BroadcastStream`].
+#[derive(Debug, PartialEq)]
+pub enum BroadcastStreamRecvError {
+    /// The receiver lagged too far behind. Attempting to receive again will
+    /// return the oldest message still retained by the channel.
+    ///
+    /// Includes the number of skipped messages.
+    Lagged(u64),
 }
 
 impl<T: Clone + Unpin + 'static + Send + Sync> BroadcastStream<T> {
     /// Create a new `BroadcastStream`.
     pub fn new(mut rx: Receiver<T>) -> Self {
-        let stream = try_stream! {
+        let stream = stream! {
             loop {
-                let item = rx.recv().await?;
-                yield item;
+                match rx.recv().await {
+                Ok(item) => yield Ok(item),
+                Err(err) =>
+                    match err {
+                         RecvError::Closed => break,
+                         RecvError::Lagged(n) => yield Err(BroadcastStreamRecvError::Lagged(n))
+                    }
+                }
             }
         };
-        Self { inner: Box::pin(stream) }
+        Self {
+            inner: Box::pin(stream),
+        }
     }
 }
 
 impl<T: Clone> Stream for BroadcastStream<T> {
-    type Item =  Result<T, RecvError>;
+    type Item = Result<T, BroadcastStreamRecvError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<T: Clone> fmt::Debug for BroadcastStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BroadcastStream").finish()
     }
 }

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -6,11 +6,10 @@ use tokio::sync::broadcast::Receiver;
 
 use std::task::{Context, Poll};
 
-/// A wrapper around [`Receiver`] that implements [`Stream`]. Achieved by using the [`async-stream`] crate.
+/// A wrapper around [`Receiver`] that implements [`Stream`].
 ///
 /// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
-/// [`async-stream`]: https://docs.rs/async-stream
 #[derive(Debug)]
 pub struct BroadcastStream<T: Clone> {
     inner: Pin<Box<dyn Stream<Item = Result<T, RecvError>> + Send + Sync >>,

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -7,9 +7,9 @@ use tokio::sync::broadcast::Receiver;
 use std::fmt;
 use std::task::{Context, Poll};
 
-/// A wrapper around [`Receiver`] that implements [`Stream`].
+/// A wrapper around [`tokio::sync::broadcast::Receiver`] that implements [`Stream`].
 ///
-/// [`Receiver`]: struct@tokio::sync::broadcast::Receiver
+/// [`tokio::sync::broadcast::Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
 pub struct BroadcastStream<T> {
     inner: Pin<Box<dyn Stream<Item = Result<T, BroadcastStreamRecvError>> + Send + Sync>>,

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -47,15 +47,15 @@ impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
         self.inner.set(make_future(rx));
         match result {
             Ok(item) => Poll::Ready(Some(Ok(item))),
-            Err(err) => match err {
-                RecvError::Closed => Poll::Ready(None),
-                RecvError::Lagged(n) => Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n)))),
-            },
+            Err(RecvError::Closed) => Poll::Ready(None),
+            Err(RecvError::Lagged(n)) => {
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n))))
+            }
         }
     }
 }
 
-impl<T: Clone> fmt::Debug for BroadcastStream<T> {
+impl<T> fmt::Debug for BroadcastStream<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BroadcastStream").finish()
     }

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -1,0 +1,50 @@
+use crate::Stream;
+use async_stream::stream;
+use std::pin::Pin;
+use tokio::sync::watch::Receiver;
+
+use std::fmt;
+use std::task::{Context, Poll};
+
+/// A wrapper around [`tokio::sync::watch::Receiver`] that implements [`Stream`].
+///
+/// [`tokio::sync::watch::Receiver`]: struct@tokio::sync::watch::Receiver
+/// [`Stream`]: trait@crate::Stream
+pub struct WatchStream<T> {
+    inner: Pin<Box<dyn Stream<Item = ()>>>,
+    _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: 'static> WatchStream<T> {
+    /// Create a new `WatchStream`.
+    pub fn new(mut rx: Receiver<T>) -> Self {
+        let stream = stream! {
+            loop {
+                match rx.changed().await {
+                    Ok(item) => yield item,
+                    Err(_) => break,
+                }
+            }
+        };
+        Self {
+            inner: Box::pin(stream),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<T> Stream for WatchStream<T> {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.inner).poll_next(cx)
+    }
+}
+
+impl<T> Unpin for WatchStream<T> {}
+
+impl<T> fmt::Debug for WatchStream<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WatchStream").finish()
+    }
+}

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -13,14 +13,14 @@ use tokio::sync::watch::error::RecvError;
 /// [`tokio::sync::watch::Receiver`]: struct@tokio::sync::watch::Receiver
 /// [`Stream`]: trait@crate::Stream
 pub struct WatchStream<T> {
-    inner: ReusableBoxFuture<Result<((), Receiver<T>), RecvError>>,
+    inner: ReusableBoxFuture<(Result<(), RecvError>, Receiver<T>)>,
 }
 
 async fn make_future<T: Clone + Send + Sync>(
     mut rx: Receiver<T>,
-) -> Result<((), Receiver<T>), RecvError> {
+) -> (Result<(), RecvError>, Receiver<T>) {
     let signal = rx.changed().await?;
-    Ok((signal, rx))
+    (Ok(signal), rx)
 }
 
 impl<T: 'static + Clone + Unpin + Send + Sync> WatchStream<T> {
@@ -36,10 +36,11 @@ impl<T: Clone + 'static + Send + Sync> Stream for WatchStream<T> {
     type Item = T;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match ready!(self.inner.poll(cx)) {
-            Ok((_, rx)) => {
+        let (result, rx) = ready!(self.inner.poll(cx));
+        self.inner.set(make_future(rx));
+        match result {
+            Ok(_) => {
                 let received = (*rx.borrow()).clone();
-                self.inner.set(make_future(rx));
                 Poll::Ready(Some(received))
             }
             Err(_) => Poll::Ready(None),


### PR DESCRIPTION
Signed-off-by: Fuyang Liu <liufuyang@users.noreply.github.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #3382 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The basic sketch is going to be:

* Make the constructor takes a broadcast receiver
* Then it uses async-stream to turn that into an `impl Stream`
* Still inside the constructor, call `Box::pin` on that stream, the put the pinned box into the struct
* Then your `impl Stream on Wrapper` just forwards calls to `poll_next` to the pinned box
