### PR TITLE
Add tokio 1.0 policies to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -481,7 +481,7 @@ server if you want to know how difficult an issue likely is.
 
 ### Module
 
-The module label provides a more fine grain categorization than **Area**.
+The module label provides a more fine grained categorization than **Area**.
 
  - **M-blocking** Things relevant to `spawn_blocking`, `block_in_place`.
  - **M-codec** The `tokio_util::codec` module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,7 +513,7 @@ Any label not listed here is not in active use.
 
 ## LTS guarantees
 
-Tokio ≥1.0 comes with LTS guarantees:
+Tokio ≥1.0.0 comes with LTS guarantees:
 
  * A minimum of 5 years of maintenance.
  * A minimum of 3 years before a hypothetical 2.0 release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,9 +427,10 @@ _Adapted from the [Node.js contributing guide][node]_.
 
 ## Keeping track of issues and PRs
 
-The Tokio GitHub repository has a lot of issues and PRs, which is not easy to
-keep track of. This section explains the meaning of various labels, as well as
-our [GitHub project][project]. The section is primarily targeted at maintainers.
+The Tokio GitHub repository has a lot of issues and PRs to keep track of. This
+section explains the meaning of various labels, as well as our [GitHub
+project][project]. The section is primarily targeted at maintainers.  Most
+contributors aren't able to set these labels.
 
 ### Area
 
@@ -445,8 +446,6 @@ The area label describes the crates relevant to this issue or PR.
  - **A-ci** This issue concerns our GitHub Actions setup.
 
 ### Category
-
-The category label describes the category.
 
  - **C-bug** This is a bug-report. Bug-fix PRs use `C-enhancement` instead.
  - **C-enhancement** This is a PR that adds a new features.
@@ -476,12 +475,13 @@ The category label describes the category.
  - **E-needs-mvce** This bug is missing a minimal complete and verifiable
    example.
 
-(I don't know why it's called `E-`. Many issues are missing a difficulty rating,
-and you should feel free to add one.)
+The "E-" prefix is the same as used in the Rust compiler repository. Some
+issues are missing a difficulty rating, but feel free to ask on our Discord
+server if you want to know how difficult an issue likely is.
 
 ### Module
 
-A more fine grain categorization than **Area**.
+The module label provides a more fine grain categorization than **Area**.
 
  - **M-blocking** Things relevant to `spawn_blocking`, `block_in_place`.
  - **M-codec** The `tokio_util::codec` module.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -431,7 +431,9 @@ The Tokio GitHub repository has a lot of issues and PRs, which is not easy to
 keep track of. This section explains the meaning of various labels, as well as
 our [GitHub project][project]. The section is primarily targeted at maintainers.
 
-**Area.** The area label describes the crates relevant to this issue or PR.
+### Area
+
+The area label describes the crates relevant to this issue or PR.
 
  - **A-tokio** This issue concerns the main Tokio crate.
  - **A-tokio-util** This issue concerns the `tokio-util` crate.
@@ -442,7 +444,9 @@ our [GitHub project][project]. The section is primarily targeted at maintainers.
    be used for the procedural macros, and not `join!` or `select!`.
  - **A-ci** This issue concerns our GitHub Actions setup.
 
-**Category.** The category label describes the category.
+### Category
+
+The category label describes the category.
 
  - **C-bug** This is a bug-report. Bug-fix PRs use `C-enhancement` instead.
  - **C-enhancement** This is a PR that adds a new features.
@@ -460,8 +464,7 @@ our [GitHub project][project]. The section is primarily targeted at maintainers.
  - **C-request** A non-feature request, e.g. "please add deprecation notices to
    `-alpha.*` versions of crates"
 
-**Call for participation.** I don't know why it's called `E-`. Many issues are
-missing a difficulty rating, and you should feel free to add one.
+### Calls for participation
 
  - **E-help-wanted** Stuff where we want help. Often seen together with `C-bug`
    or `C-feature-accepted`.
@@ -473,7 +476,12 @@ missing a difficulty rating, and you should feel free to add one.
  - **E-needs-mvce** This bug is missing a minimal complete and verifiable
    example.
 
-**Module.** A more fine groaned categorization than area.
+(I don't know why it's called `E-`. Many issues are missing a difficulty rating,
+and you should feel free to add one.)
+
+### Module
+
+A more fine grain categorization than **Area**.
 
  - **M-blocking** Things relevant to `spawn_blocking`, `block_in_place`.
  - **M-codec** The `tokio_util::codec` module.
@@ -491,7 +499,9 @@ missing a difficulty rating, and you should feel free to add one.
  - **M-time** The `tokio::time` module.
  - **M-tracing** Tracing support in Tokio.
 
-**Topic.** Some extra information.
+### Topic
+
+Some extra information.
 
  - **T-docs** This is about documentation.
  - **T-performance** This is about performance.
@@ -500,6 +510,34 @@ missing a difficulty rating, and you should feel free to add one.
 Any label not listed here is not in active use.
 
 [project]: https://github.com/orgs/tokio-rs/projects/1
+
+## LTS guarantees
+
+Tokio ≥1.0 comes with LTS guarantees:
+
+ * A minimum of 5 years of maintenance.
+ * A minimum of 3 years before a hypothetical 2.0 release.
+
+The goal of these guarantees is to provide stability to the ecosystem.
+
+## Mininum Supported Rust Version (MSRV)
+
+ * All Tokio ≥1.0.0 releases will support at least a 6-month old Rust
+   compiler release.
+ * The MSRV will only be increased on 1.x releases.
+
+## Versioning Policy
+
+With Tokio ≥1.0.0:
+
+ * Patch (1.\_.x) releases _should only_ contain bug fixes or documentation
+   changes. Besides this, these releases should not substantially change
+   runtime behavior.
+ * Minor (1.x) releases may contain new functionality, MSRV increases (see
+   above), minor dependency updates, deprecations, and larger internal
+   implementation changes.
+
+This is as defined by [Semantic Versioning 2.0](https://semver.org/).
 
 ## Releasing
 


### PR DESCRIPTION
## Motivation

The 1.0 roadmap of #2718 and the [Announcing Tokio 1.0 blog post](https://tokio.rs/blog/2020-12-tokio-1-0) both contain details of release and versioning policy moving forward. As discussed on discord, its helpful to contributors to have all the policies in one place. 

## Solution

I've tried to consolidate these appropriately in the CONTRIBUTING.md guide, and I also have made few general cosmetic changes. 