### PR TITLE
Exposing write_buffer on FramedWrite/Framed for consistency with FramedRead

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -208,6 +208,16 @@ impl<T, U> Framed<T, U> {
         &mut self.inner.state.read.buffer
     }
 
+    /// Returns a reference to the write buffer.
+    pub fn write_buffer(&self) -> &BytesMut {
+        &self.inner.state.write.buffer
+    }
+
+    /// Returns a mutable reference to the write buffer.
+    pub fn write_buffer_mut(&mut self) -> &mut BytesMut {
+        &mut self.inner.state.write.buffer
+    }
+
     /// Consumes the `Framed`, returning its underlying I/O stream.
     ///
     /// Note that care should be taken to not tamper with the underlying stream

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -4,6 +4,7 @@ use crate::codec::framed_impl::{FramedImpl, WriteFrame};
 use tokio::io::AsyncWrite;
 use tokio_stream::Stream;
 
+use bytes::BytesMut;
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use std::fmt;
@@ -85,6 +86,16 @@ impl<T, E> FramedWrite<T, E> {
     /// Returns a mutable reference to the underlying encoder.
     pub fn encoder_mut(&mut self) -> &mut E {
         &mut self.inner.codec
+    }
+
+    /// Returns a reference to the write buffer.
+    pub fn write_buffer(&self) -> &BytesMut {
+        &self.inner.state.buffer
+    }
+
+    /// Returns a mutable reference to the write buffer.
+    pub fn write_buffer_mut(&mut self) -> &mut BytesMut {
+        &mut self.inner.state.buffer
     }
 }
 


### PR DESCRIPTION
## Motivation

I have a scenario where given a specific event trigger, I need to consider all data in my Framed object is invalid, and I need to clear all of it. The framed object already exposes the [read_buffer](https://docs.rs/tokio-util/0.6.0/tokio_util/codec/struct.Framed.html#method.read_buffer), I am just exposing the corresponding write buffer, so that I can clear that data as well.

## Solution

Copying the API used for read_buffer in the FramedWrite/Framed files as well.
