### PR TITLE
Update documentation to mention possibility of deadlock

### DIFF
--- a/tokio-util/src/time/wheel/level.rs
+++ b/tokio-util/src/time/wheel/level.rs
@@ -46,7 +46,7 @@ impl<T: Stack> Level<T> {
             () => {
                 T::default()
             };
-        };
+        }
 
         Level {
             level,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -403,10 +403,11 @@ impl<T: ?Sized> RwLock<T> {
     /// The calling task will yield until there are no writers which hold the
     /// lock. There may be other readers inside the lock when the task resumes.
     ///
-    /// Note that deadlock may occur if a read lock is held by the current
-    /// task, a write lock attempt is made, and then a further read lock
-    /// attempt is made. Under the priority policy of [`RwLock`], read locks
-    /// are not granted until prior write locks, to prevent starvation.
+    /// Note that under the priority policy of [`RwLock`], read locks are not
+    /// granted until prior write locks, to prevent starvation. Therefore
+    /// deadlock may occur if a read lock is held by the current task, a write
+    /// lock attempt is made, and then a subsequent read lock attempt is made
+    /// by the current task.
     ///
     /// Returns an RAII guard which will drop this read access of the `RwLock`
     /// when dropped.


### PR DESCRIPTION
## Motivation

Add detail about why deadlocks might be encountered when a read lock attempt is made following a successful read lock followed by a write lock attempt by the same task.

## Solution

Update documentation in #2849
