### PR TITLE
tests: fix ping pong saturation

### DIFF
--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1021,7 +1021,7 @@ rt_test! {
     // other tasks.
     #[test]
     fn ping_pong_saturation() {
-        use std::{sync::atomic::{Ordering, AtomicBool}};
+        use std::sync::atomic::{Ordering, AtomicBool};
         use tokio::sync::mpsc;
 
         const NUM: usize = 100;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1021,7 +1021,7 @@ rt_test! {
     // other tasks.
     #[test]
     fn ping_pong_saturation() {
-        use std::{mem::drop, sync::atomic::{Ordering, AtomicBool}};
+        use std::{sync::atomic::{Ordering, AtomicBool}};
         use tokio::sync::mpsc;
 
         const NUM: usize = 100;
@@ -1040,12 +1040,12 @@ rt_test! {
                 let (tx1, mut rx1) = mpsc::unbounded_channel();
                 let (tx2, mut rx2) = mpsc::unbounded_channel();
                 let spawned_tx = spawned_tx.clone();
-                let running_cloned = running.clone();
+                let running = running.clone();
                 tasks.push(task::spawn(async move {
                     spawned_tx.send(()).unwrap();
 
 
-                    while running_cloned.load(Ordering::Relaxed) {
+                    while running.load(Ordering::Relaxed) {
                         tx1.send(()).unwrap();
                         rx2.recv().await.unwrap();
                     }
@@ -1056,7 +1056,7 @@ rt_test! {
                 }));
 
                 tasks.push(task::spawn(async move {
-                    while rx1.recv().await.is_some(){
+                    while rx1.recv().await.is_some() {
                         tx2.send(()).unwrap();
                     }
                 }));

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1021,39 +1021,45 @@ rt_test! {
     // other tasks.
     #[test]
     fn ping_pong_saturation() {
+        use std::{mem::drop, sync::atomic::{Ordering, AtomicBool}};
         use tokio::sync::mpsc;
 
         const NUM: usize = 100;
 
         let rt = rt();
 
+        let running = Arc::new(AtomicBool::new(true));
+
         rt.block_on(async {
             let (spawned_tx, mut spawned_rx) = mpsc::unbounded_channel();
 
+            let mut tasks = vec![];
             // Spawn a bunch of tasks that ping ping between each other to
             // saturate the runtime.
             for _ in 0..NUM {
                 let (tx1, mut rx1) = mpsc::unbounded_channel();
                 let (tx2, mut rx2) = mpsc::unbounded_channel();
                 let spawned_tx = spawned_tx.clone();
-
-                task::spawn(async move {
+                let running_cloned = running.clone();
+                tasks.push(task::spawn(async move {
                     spawned_tx.send(()).unwrap();
 
-                    tx1.send(()).unwrap();
 
-                    loop {
-                        rx2.recv().await.unwrap();
+                    while running_cloned.load(Ordering::Relaxed) {
                         tx1.send(()).unwrap();
+                        rx2.recv().await.unwrap();
                     }
-                });
 
-                task::spawn(async move {
-                    loop {
-                        rx1.recv().await.unwrap();
+                    // Close the channel and wait for the other task to exit.
+                    drop(tx1);
+                    assert!(rx2.recv().await.is_none());
+                }));
+
+                tasks.push(task::spawn(async move {
+                    while rx1.recv().await.is_some(){
                         tx2.send(()).unwrap();
                     }
-                });
+                }));
             }
 
             for _ in 0..NUM {
@@ -1068,6 +1074,10 @@ rt_test! {
                 }
             });
             handle.await.unwrap();
+            running.store(false, Ordering::Relaxed);
+            for t in tasks {
+                t.await.unwrap();
+            }
         });
     }
 }


### PR DESCRIPTION
Signal the tasks driving the ping pong to stop running after spawning
a few others. After that, awaits for each of them to ensure that all ran properly.

Fixes #3305

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
