### PR TITLE
net: ref argument for {join,leave}_multicast_v4 method

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1289,8 +1289,8 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
-        self.io.join_multicast_v4(&multiaddr, &interface)
+    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.io.join_multicast_v4(multiaddr, interface)
     }
 
     /// Executes an operation of the `IPV6_ADD_MEMBERSHIP` type.
@@ -1307,8 +1307,8 @@ impl UdpSocket {
     /// For more information about this option, see [`join_multicast_v4`].
     ///
     /// [`join_multicast_v4`]: method@Self::join_multicast_v4
-    pub fn leave_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
-        self.io.leave_multicast_v4(&multiaddr, &interface)
+    pub fn leave_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.io.leave_multicast_v4(multiaddr, interface)
     }
 
     /// Executes an operation of the `IPV6_DROP_MEMBERSHIP` type.


### PR DESCRIPTION

## Motivation

Small change for consistent code.
Changed argument to reference for the `{join,leave}_multicast_v4` method because
`{join,leave}_multicast_v6` method uses reference argument.
same methods in `std::net::UdpSocket`, `socket2::net::Socket` use reference argument.

## Solution

Solution is use reference
