### PR TITLE
chore: prepare tokio-stream 0.1.2

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.2 (January 12, 2021)
+
+Fixed
+
+ - docs: fix some wrappers missing in documentation (#3378)
+
 # 0.1.1 (January 4, 2021)
 
 Added

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-stream"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-stream/0.1.1/tokio_stream"
+documentation = "https://docs.rs/tokio-stream/0.1.2/tokio_stream"
 description = """
 Utilities to work with `Stream` and `tokio`.
 """

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-stream/0.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-stream/0.1.2")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
This just fixes the documentation. We should have done this a week ago honestly.