### PR TITLE
mpsc: Add `Sender::try_reserve` function

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -611,12 +611,13 @@ impl<T> Sender<T> {
     /// if there is a slot available it will return a [`Permit`] that will then allow you
     /// to [`send`] on the channel with a guaranteed slot. This function is similar to
     /// [`reserve`] execpt it does not await for the slot to become available.
-    //
+    ///
     /// Dropping [`Permit`] without sending a message releases the capacity back
     /// to the channel.
     ///
     /// [`Permit`]: Permit
     /// [`send`]: Permit::send
+    /// [`reserve`]: Sender::reserve
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -603,6 +603,57 @@ impl<T> Sender<T> {
 
         Ok(Permit { chan: &self.chan })
     }
+
+    /// Try to acquire a slot in the channel without waiting for the slot to become
+    /// available.
+    ///
+    //// If the channel is full this function will return [`TrySendError`], otherwise
+    /// if there is a slot available it will return a [`Permit`] that will then allow you
+    /// to [`send`] on the channel with a guaranteed slot. This function is similar to
+    /// [`reserve`] execpt it does not await for the slot to become available.
+    //
+    /// Dropping [`Permit`] without sending a message releases the capacity back
+    /// to the channel.
+    ///
+    /// [`Permit`]: Permit
+    /// [`send`]: Permit::send
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::channel(1);
+    ///
+    ///     // Reserve capacity
+    ///     let permit = tx.try_reserve().unwrap();
+    ///
+    ///     // Trying to send directly on the `tx` will fail due to no
+    ///     // available capacity.
+    ///     assert!(tx.try_send(123).is_err());
+    ///
+    ///     // Trying to reserve an additional slot on the `tx` will
+    ///     // fail because there is no capacity.
+    ///     assert!(tx.try_reserve().is_err());
+    ///
+    ///     // Sending on the permit succeeds
+    ///     permit.send(456);
+    ///
+    ///     // The value sent on the permit is received
+    ///     assert_eq!(rx.recv().await.unwrap(), 456);
+    ///
+    /// }
+    /// ```
+    pub fn try_reserve(&self) -> Result<Permit<'_, T>, TrySendError<()>> {
+        match self.chan.semaphore().0.try_acquire(1) {
+            Ok(_) => {}
+            Err(_) => return Err(TrySendError::Full(())),
+        }
+
+        Ok(Permit { chan: &self.chan })
+    }
 }
 
 impl<T> Clone for Sender<T> {

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -607,7 +607,7 @@ impl<T> Sender<T> {
     /// Try to acquire a slot in the channel without waiting for the slot to become
     /// available.
     ///
-    //// If the channel is full this function will return [`TrySendError`], otherwise
+    /// If the channel is full this function will return [`TrySendError`], otherwise
     /// if there is a slot available it will return a [`Permit`] that will then allow you
     /// to [`send`] on the channel with a guaranteed slot. This function is similar to
     /// [`reserve`] execpt it does not await for the slot to become available.


### PR DESCRIPTION
Add a `try_reserve` function to the mpsc `Sender`. This allows to attempt to query the `Sender` for available send slots without having to materialize the `T` value. 
