### PR TITLE
Use triomphe to optimize sync primitives

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -35,6 +35,7 @@ full = [
   "macros",
   "net",
   "parking_lot",
+  "triomphe",
   "process",
   "rt",
   "rt-multi-thread",
@@ -97,6 +98,7 @@ memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.6", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
+triomphe = { version = "0.1.2", optional = true }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.

--- a/tokio/src/loom/mocked.rs
+++ b/tokio/src/loom/mocked.rs
@@ -25,6 +25,7 @@ pub(crate) mod sync {
         }
     }
     pub(crate) use loom::sync::*;
+    pub(crate) type SmallArc<T> = Arc<T>;
 }
 
 pub(crate) mod rand {

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -9,6 +9,7 @@ mod atomic_usize;
 mod mutex;
 #[cfg(feature = "parking_lot")]
 mod parking_lot;
+mod small_arc;
 mod unsafe_cell;
 
 pub(crate) mod cell {
@@ -47,6 +48,9 @@ pub(crate) mod rand {
 }
 
 pub(crate) mod sync {
+    /// Faster but limited version of Arc
+    pub(crate) use super::small_arc::SmallArc; 
+
     pub(crate) use std::sync::{Arc, Weak};
 
     // Below, make sure all the feature-influenced types are exported for

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -49,7 +49,7 @@ pub(crate) mod rand {
 
 pub(crate) mod sync {
     /// Faster but limited version of Arc
-    pub(crate) use super::small_arc::SmallArc; 
+    pub(crate) use super::small_arc::SmallArc;
 
     pub(crate) use std::sync::{Arc, Weak};
 

--- a/tokio/src/loom/std/small_arc.rs
+++ b/tokio/src/loom/std/small_arc.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "triomphe")]
+use triomphe::Arc as Inner;
+#[cfg(not(feature = "triomphe"))]
+use std::sync::Arc as Inner;
+
+/// Faster but more limited version of Arc
+#[derive(Debug)]
+pub(crate) struct SmallArc<T>(Inner<T>);
+
+impl<T> SmallArc<T> {
+    pub (crate) fn new(val: T) -> Self {
+        Self(Inner::new(val))
+    }
+}
+
+// triomphe::Arc has too strict Unpin bounds
+impl<T> std::marker::Unpin for SmallArc<T> {}
+
+impl<T> Clone for SmallArc<T> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T> std::ops::Deref for SmallArc<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        <Inner<T> as std::ops::Deref>::deref(&self.0)
+    }
+}

--- a/tokio/src/loom/std/small_arc.rs
+++ b/tokio/src/loom/std/small_arc.rs
@@ -1,14 +1,14 @@
-#[cfg(feature = "triomphe")]
-use triomphe::Arc as Inner;
 #[cfg(not(feature = "triomphe"))]
 use std::sync::Arc as Inner;
+#[cfg(feature = "triomphe")]
+use triomphe::Arc as Inner;
 
 /// Faster but more limited version of Arc
 #[derive(Debug)]
 pub(crate) struct SmallArc<T>(Inner<T>);
 
 impl<T> SmallArc<T> {
-    pub (crate) fn new(val: T) -> Self {
+    pub(crate) fn new(val: T) -> Self {
         Self(Inner::new(val))
     }
 }

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -111,7 +111,7 @@
 
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
-use crate::loom::sync::{SmallArc, Mutex, RwLock, RwLockReadGuard};
+use crate::loom::sync::{Mutex, RwLock, RwLockReadGuard, SmallArc};
 use crate::util::linked_list::{self, LinkedList};
 
 use std::fmt;

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -4,7 +4,7 @@
 
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
-use crate::loom::sync::Arc;
+use crate::loom::sync::SmallArc;
 
 use std::fmt;
 use std::future::Future;
@@ -19,7 +19,7 @@ use std::task::{Context, Poll, Waker};
 /// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Sender<T> {
-    inner: Option<Arc<Inner<T>>>,
+    inner: Option<SmallArc<Inner<T>>>,
 }
 
 /// Receive a value from the associated `Sender`.
@@ -27,7 +27,7 @@ pub struct Sender<T> {
 /// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Receiver<T> {
-    inner: Option<Arc<Inner<T>>>,
+    inner: Option<SmallArc<Inner<T>>>,
 }
 
 pub mod error {
@@ -124,7 +124,7 @@ struct State(usize);
 /// }
 /// ```
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
-    let inner = Arc::new(Inner {
+    let inner = SmallArc::new(Inner {
         state: AtomicUsize::new(State::new().as_usize()),
         value: UnsafeCell::new(None),
         tx_task: UnsafeCell::new(MaybeUninit::uninit()),

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -55,7 +55,7 @@ use crate::sync::Notify;
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::atomic::Ordering::{Relaxed, SeqCst};
-use crate::loom::sync::{Arc, RwLock, RwLockReadGuard};
+use crate::loom::sync::{SmallArc, RwLock, RwLockReadGuard};
 use std::ops;
 
 /// Receives values from the associated [`Sender`](struct@Sender).
@@ -64,7 +64,7 @@ use std::ops;
 #[derive(Debug)]
 pub struct Receiver<T> {
     /// Pointer to the shared state
-    shared: Arc<Shared<T>>,
+    shared: SmallArc<Shared<T>>,
 
     /// Last observed version
     version: usize,
@@ -75,7 +75,7 @@ pub struct Receiver<T> {
 /// Instances are created by the [`channel`](fn@channel) function.
 #[derive(Debug)]
 pub struct Sender<T> {
-    shared: Arc<Shared<T>>,
+    shared: SmallArc<Shared<T>>,
 }
 
 /// Returns a reference to the inner value
@@ -175,7 +175,7 @@ const CLOSED: usize = 1;
 /// [`Sender`]: struct@Sender
 /// [`Receiver`]: struct@Receiver
 pub fn channel<T>(init: T) -> (Sender<T>, Receiver<T>) {
-    let shared = Arc::new(Shared {
+    let shared = SmallArc::new(Shared {
         value: RwLock::new(init),
         version: AtomicUsize::new(0),
         ref_count_rx: AtomicUsize::new(1),

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -55,7 +55,7 @@ use crate::sync::Notify;
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::atomic::Ordering::{Relaxed, SeqCst};
-use crate::loom::sync::{SmallArc, RwLock, RwLockReadGuard};
+use crate::loom::sync::{RwLock, RwLockReadGuard, SmallArc};
 use std::ops;
 
 /// Receives values from the associated [`Sender`](struct@Sender).


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`triomphe::Arc` uses less memory. Also, it should be more efficient because maintaining weak_count is hard.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases, there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add a wrapper type that delegates to either `std::sync::Arc` or `triomphe::Arc` depending on whether the `triomphe` feature is enabled. Triomphe is a private dependency of Tokio and API is not changed, so in the future, it is possible to:
 - use other versions of triomphe
 - use other crates
 - deprecate this feature (and make it no-op)

in a backward-compatible way.


<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
