### PR TITLE
[WIP] ci: improve cross testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
             os: ubuntu-latest
           - target: powerpc64-unknown-linux-gnu
             os: ubuntu-latest
+            subcmd: check # cross does not provide a Docker image for powerpc64-unknown-linux-gnu
           - target: mips-unknown-linux-gnu
             os: ubuntu-latest
           - target: arm-linux-androideabi
@@ -150,15 +151,15 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
-      - name: cross test --target ${{ matrix.target }}
+      - name: cross --target ${{ matrix.target }}
         run: |
           cargo install cross
-          cross test --workspace --all-features --target ${{ matrix.target }}
+          cross ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }}
         if: startsWith(matrix.os, 'ubuntu')
-      - name: cargo test --target ${{ matrix.target }}
+      - name: cargo --target ${{ matrix.target }}
         run: |
           rustup target add ${{ matrix.target }}
-          cargo test --workspace --all-features --target ${{ matrix.target }}
+          cargo ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }}
         if: startsWith(matrix.os, 'windows')
 
   features:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-pc-windows-msvc
             os: windows-latest
+            subcmd: build # cross does not provide a Docker image for aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
     name: cross
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,12 +156,14 @@ jobs:
       - name: cross --target ${{ matrix.target }}
         run: |
           cargo install cross
-          cross ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }}
+          # tests-integration is excluded because it runs executable
+          cross ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }} --exclude tests-integration
         if: startsWith(matrix.os, 'ubuntu')
       - name: cargo --target ${{ matrix.target }}
         run: |
           rustup target add ${{ matrix.target }}
-          cargo ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }}
+          # tests-integration is excluded because it runs executable
+          cargo ${{ matrix.subcmd || 'test' }} --workspace --all-features --target ${{ matrix.target }} --exclude tests-integration
         if: startsWith(matrix.os, 'windows')
 
   features:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,15 +125,24 @@ jobs:
 
   cross:
     name: cross
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target:
-          - i686-unknown-linux-gnu
-          - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
-          - arm-linux-androideabi
+        include:
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: i686-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: powerpc-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: powerpc64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: mips-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: arm-linux-androideabi
+            os: ubuntu-latest
+          - target: aarch64-pc-windows-msvc
+            os: windows-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -141,11 +150,16 @@ jobs:
           toolchain: stable
           target: ${{ matrix.target }}
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: check
-          args: --workspace --target ${{ matrix.target }}
+      - name: cross test --target ${{ matrix.target }}
+        run: |
+          cargo install cross
+          cross test --workspace --all-features --target ${{ matrix.target }}
+        if: startsWith(matrix.os, 'ubuntu')
+      - name: cargo test --target ${{ matrix.target }}
+        run: |
+          rustup target add ${{ matrix.target }}
+          cargo test --workspace --all-features --target ${{ matrix.target }}
+        if: startsWith(matrix.os, 'windows')
 
   features:
     name: features


### PR DESCRIPTION
Currently, we run `cross check` on these platforms. Try to run `cross test`.

This also tries whether `aarch64-unknown-linux-gnu`, which was recently promoted to tier1, and `aarch64-pc-windows-msvc`, which was proposed in #2985, can be added to the matrix.
