### PR TITLE
Keep track of initialized bytes in read_to_end

### DIFF
--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -48,6 +48,7 @@ cfg_io_util! {
     mod read_line;
 
     mod read_to_end;
+    mod vec_with_initialized;
     cfg_process! {
         pub(crate) use read_to_end::read_to_end;
     }

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -83,6 +83,7 @@ cfg_io_util! {
 
 cfg_not_io_util! {
     cfg_process! {
+        mod vec_with_initialized;
         mod read_to_end;
         // Used by process
         pub(crate) use read_to_end::read_to_end;

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -1,10 +1,11 @@
-use crate::io::{AsyncRead, ReadBuf};
+use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecWithInitialized};
+use crate::io::AsyncRead;
 
 use pin_project_lite::pin_project;
 use std::future::Future;
 use std::io;
 use std::marker::PhantomPinned;
-use std::mem::{self, MaybeUninit};
+use std::mem;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -13,13 +14,10 @@ pin_project! {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct ReadToEnd<'a, R: ?Sized> {
         reader: &'a mut R,
-        buf: &'a mut Vec<u8>,
+        buf: VecWithInitialized<&'a mut Vec<u8>>,
         // The number of bytes appended to buf. This can be less than buf.len() if
         // the buffer was not empty when the operation was started.
         read: usize,
-        // The number of initialized bytes in the unused capacity of the vector.
-        // Always between 0 and `buf.capacity() - buf.len()`.
-        initialized: usize,
         // Make this future `!Unpin` for compatibility with async trait methods.
         #[pin]
         _pin: PhantomPinned,
@@ -30,32 +28,23 @@ pub(crate) fn read_to_end<'a, R>(reader: &'a mut R, buffer: &'a mut Vec<u8>) -> 
 where
     R: AsyncRead + Unpin + ?Sized,
 {
+    // SAFETY: The generic type on VecWithInitialized is &mut Vec<u8>.
     ReadToEnd {
         reader,
-        buf: buffer,
+        buf: unsafe { VecWithInitialized::new(buffer) },
         read: 0,
-        initialized: 0,
         _pin: PhantomPinned,
     }
 }
 
-/// # Safety:
-///
-/// The first `num_initialized` bytes of the unused capacity of the vector must be
-/// initialized.
-///
-/// This function guarantees that the above invariant still holds when the function
-/// returns.
-pub(super) unsafe fn read_to_end_internal<R: AsyncRead + ?Sized>(
-    buf: &mut Vec<u8>,
+pub(super) fn read_to_end_internal<V: AsMut<Vec<u8>>, R: AsyncRead + ?Sized>(
+    buf: &mut VecWithInitialized<V>,
     mut reader: Pin<&mut R>,
     num_read: &mut usize,
-    num_initialized: &mut usize,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<usize>> {
     loop {
-        // safety: The caller promised to prepare the buffer.
-        let ret = ready!(poll_read_to_end(buf, reader.as_mut(), num_initialized, cx));
+        let ret = ready!(poll_read_to_end(buf, reader.as_mut(), cx));
         match ret {
             Err(err) => return Poll::Ready(Err(err)),
             Ok(0) => return Poll::Ready(Ok(mem::replace(num_read, 0))),
@@ -69,18 +58,9 @@ pub(super) unsafe fn read_to_end_internal<R: AsyncRead + ?Sized>(
 /// Tries to read from the provided AsyncRead.
 ///
 /// The length of the buffer is increased by the number of bytes read.
-///
-/// # Safety:
-///
-/// The first `num_initialized` bytes of the unused capacity of the vector must be
-/// initialized.
-///
-/// This function guarantees that the above invariant still holds when the function
-/// returns.
-fn poll_read_to_end<R: AsyncRead + ?Sized>(
-    buf: &mut Vec<u8>,
+fn poll_read_to_end<V: AsMut<Vec<u8>>, R: AsyncRead + ?Sized>(
+    buf: &mut VecWithInitialized<V>,
     read: Pin<&mut R>,
-    num_initialized: &mut usize,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<usize>> {
     // This uses an adaptive system to extend the vector when it fills. We want to
@@ -89,54 +69,34 @@ fn poll_read_to_end<R: AsyncRead + ?Sized>(
     // of data to return. Simply tacking on an extra DEFAULT_BUF_SIZE space every
     // time is 4,500 times (!) slower than this if the reader has a very small
     // amount of data to return.
-    reserve(buf, 32, num_initialized);
+    buf.reserve(32);
 
-    let mut unused_capacity = ReadBuf::uninit(get_unused_capacity(buf));
-    unsafe {
-        unused_capacity.assume_init(*num_initialized);
+    // Get a ReadBuf into the vector.
+    let mut read_buf = buf.get_read_buf();
+
+    let filled_before = read_buf.filled().len();
+    let poll_result = read.poll_read(cx, &mut read_buf);
+    let filled_after = read_buf.filled().len();
+    let n = filled_after - filled_before;
+
+    // Update the length of the vector using the result of poll_read.
+    let read_buf_parts = into_read_buf_parts(read_buf);
+    buf.apply_read_buf(read_buf_parts);
+
+    match poll_result {
+        Poll::Pending => {
+            // In this case, nothing should have been read. However we still
+            // update the vector in case the poll_read call initialized parts of
+            // the vector's unused capacity.
+            debug_assert_eq!(filled_before, filled_after);
+            Poll::Pending
+        }
+        Poll::Ready(Err(err)) => {
+            debug_assert_eq!(filled_before, filled_after);
+            Poll::Ready(Err(err))
+        }
+        Poll::Ready(Ok(())) => Poll::Ready(Ok(n)),
     }
-
-    let ptr = unused_capacity.filled().as_ptr();
-    // If poll_read returns Poll::Pending, the value of `num_initialized` is
-    // still correct as the vector's length is unchanged, and `poll_read` cannot
-    // de-initialize any bytes in `unused_capacity`.
-    ready!(read.poll_read(cx, &mut unused_capacity))?;
-
-    // Ensure that the pointer does not change from under us.
-    if ptr != unused_capacity.filled().as_ptr() {
-        *num_initialized = 0;
-        panic!("The poll_read call has mem::swapped the ReadBuf.");
-    }
-
-    let n = unused_capacity.filled().len();
-    let new_initialized = unused_capacity.initialized().len() - n;
-    let new_len = buf.len() + n;
-
-    // Safety: The safety invariants of ReadBuf guarantees that the new bytes have
-    // been initialized.
-    assert!(new_len <= buf.capacity());
-    unsafe {
-        *num_initialized = new_initialized;
-        buf.set_len(new_len);
-    }
-
-    Poll::Ready(Ok(n))
-}
-
-/// Allocates more memory and ensures that the unused capacity is prepared for use
-/// with the `AsyncRead`.
-fn reserve(buf: &mut Vec<u8>, bytes: usize, num_initialized: &mut usize) {
-    if buf.capacity() - buf.len() >= bytes {
-        return;
-    }
-    *num_initialized = 0;
-    buf.reserve(bytes);
-}
-
-/// Returns the unused capacity of the provided vector.
-fn get_unused_capacity(buf: &mut Vec<u8>) -> &mut [MaybeUninit<u8>] {
-    let uninit = bytes::BufMut::chunk_mut(buf);
-    unsafe { &mut *(uninit as *mut _ as *mut [MaybeUninit<u8>]) }
 }
 
 impl<A> Future for ReadToEnd<'_, A>
@@ -148,9 +108,6 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
 
-        // Safety: initialized is initially zero, which is always correct, and
-        // `read_to_string_internal` guarantees that its invariant still holds
-        // when it returns.
-        unsafe { read_to_end_internal(me.buf, Pin::new(*me.reader), me.read, me.initialized, cx) }
+        read_to_end_internal(me.buf, Pin::new(*me.reader), me.read, cx)
     }
 }

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -17,6 +17,9 @@ pin_project! {
         // The number of bytes appended to buf. This can be less than buf.len() if
         // the buffer was not empty when the operation was started.
         read: usize,
+        // The number of initialized bytes in the unused capacity of the vector.
+        // Always between 0 and `buf.capacity() - buf.len()`.
+        initialized: usize,
         // Make this future `!Unpin` for compatibility with async trait methods.
         #[pin]
         _pin: PhantomPinned,
@@ -31,19 +34,28 @@ where
         reader,
         buf: buffer,
         read: 0,
+        initialized: 0,
         _pin: PhantomPinned,
     }
 }
 
-pub(super) fn read_to_end_internal<R: AsyncRead + ?Sized>(
+/// # Safety:
+///
+/// The first `num_initialized` bytes of the unused capacity of the vector must be
+/// initialized.
+///
+/// This function guarantees that the above invariant still holds when the function
+/// returns.
+pub(super) unsafe fn read_to_end_internal<R: AsyncRead + ?Sized>(
     buf: &mut Vec<u8>,
     mut reader: Pin<&mut R>,
     num_read: &mut usize,
+    num_initialized: &mut usize,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<usize>> {
     loop {
         // safety: The caller promised to prepare the buffer.
-        let ret = ready!(poll_read_to_end(buf, reader.as_mut(), cx));
+        let ret = ready!(poll_read_to_end(buf, reader.as_mut(), num_initialized, cx));
         match ret {
             Err(err) => return Poll::Ready(Err(err)),
             Ok(0) => return Poll::Ready(Ok(mem::replace(num_read, 0))),
@@ -57,9 +69,18 @@ pub(super) fn read_to_end_internal<R: AsyncRead + ?Sized>(
 /// Tries to read from the provided AsyncRead.
 ///
 /// The length of the buffer is increased by the number of bytes read.
+///
+/// # Safety:
+///
+/// The first `num_initialized` bytes of the unused capacity of the vector must be
+/// initialized.
+///
+/// This function guarantees that the above invariant still holds when the function
+/// returns.
 fn poll_read_to_end<R: AsyncRead + ?Sized>(
     buf: &mut Vec<u8>,
     read: Pin<&mut R>,
+    num_initialized: &mut usize,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<usize>> {
     // This uses an adaptive system to extend the vector when it fills. We want to
@@ -68,31 +89,47 @@ fn poll_read_to_end<R: AsyncRead + ?Sized>(
     // of data to return. Simply tacking on an extra DEFAULT_BUF_SIZE space every
     // time is 4,500 times (!) slower than this if the reader has a very small
     // amount of data to return.
-    reserve(buf, 32);
+    reserve(buf, 32, num_initialized);
 
     let mut unused_capacity = ReadBuf::uninit(get_unused_capacity(buf));
+    unsafe {
+        unused_capacity.assume_init(*num_initialized);
+    }
 
+    let ptr = unused_capacity.filled().as_ptr();
+    // If poll_read returns Poll::Pending, the value of `num_initialized` is
+    // still correct as the vector's length is unchanged, and `poll_read` cannot
+    // de-initialize any bytes in `unused_capacity`.
     ready!(read.poll_read(cx, &mut unused_capacity))?;
 
+    // Ensure that the pointer does not change from under us.
+    if ptr != unused_capacity.filled().as_ptr() {
+        *num_initialized = 0;
+        panic!("The poll_read call has mem::swapped the ReadBuf.");
+    }
+
     let n = unused_capacity.filled().len();
+    let new_initialized = unused_capacity.initialized().len() - n;
     let new_len = buf.len() + n;
 
-    // This should no longer even be possible in safe Rust. An implementor
-    // would need to have unsafely *replaced* the buffer inside `ReadBuf`,
-    // which... yolo?
+    // Safety: The safety invariants of ReadBuf guarantees that the new bytes have
+    // been initialized.
     assert!(new_len <= buf.capacity());
     unsafe {
+        *num_initialized = new_initialized;
         buf.set_len(new_len);
     }
+
     Poll::Ready(Ok(n))
 }
 
 /// Allocates more memory and ensures that the unused capacity is prepared for use
 /// with the `AsyncRead`.
-fn reserve(buf: &mut Vec<u8>, bytes: usize) {
+fn reserve(buf: &mut Vec<u8>, bytes: usize, num_initialized: &mut usize) {
     if buf.capacity() - buf.len() >= bytes {
         return;
     }
+    *num_initialized = 0;
     buf.reserve(bytes);
 }
 
@@ -111,6 +148,9 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
 
-        read_to_end_internal(me.buf, Pin::new(*me.reader), me.read, cx)
+        // Safety: initialized is initially zero, which is always correct, and
+        // `read_to_string_internal` guarantees that its invariant still holds
+        // when it returns.
+        unsafe { read_to_end_internal(me.buf, Pin::new(*me.reader), me.read, me.initialized, cx) }
     }
 }

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -1,5 +1,6 @@
 use crate::io::util::read_line::finish_string_read;
 use crate::io::util::read_to_end::read_to_end_internal;
+use crate::io::util::vec_with_initialized::VecWithInitialized;
 use crate::io::AsyncRead;
 
 use pin_project_lite::pin_project;
@@ -19,13 +20,10 @@ pin_project! {
         // while reading to postpone utf-8 handling until after reading.
         output: &'a mut String,
         // The actual allocation of the string is moved into this vector instead.
-        buf: Vec<u8>,
+        buf: VecWithInitialized<Vec<u8>>,
         // The number of bytes appended to buf. This can be less than buf.len() if
         // the buffer was not empty when the operation was started.
         read: usize,
-        // The number of initialized bytes in the unused capacity of the vector.
-        // Always between 0 and `buf.capacity() - buf.len()`.
-        initialized: usize,
         // Make this future `!Unpin` for compatibility with async trait methods.
         #[pin]
         _pin: PhantomPinned,
@@ -40,33 +38,25 @@ where
     R: AsyncRead + ?Sized + Unpin,
 {
     let buf = mem::replace(string, String::new()).into_bytes();
+    // SAFETY: The generic type of the VecWithInitialized is Vec<u8>.
     ReadToString {
         reader,
-        buf,
+        buf: unsafe { VecWithInitialized::new(buf) },
         output: string,
         read: 0,
-        initialized: 0,
         _pin: PhantomPinned,
     }
 }
 
-/// # Safety
-///
-/// The first `num_initialized` bytes of the unused capacity of the vector must be
-/// initialized.
-///
-/// This function guarantees that the above invariant still holds when the function
-/// returns.
-unsafe fn read_to_string_internal<R: AsyncRead + ?Sized>(
+fn read_to_string_internal<R: AsyncRead + ?Sized>(
     reader: Pin<&mut R>,
     output: &mut String,
-    buf: &mut Vec<u8>,
+    buf: &mut VecWithInitialized<Vec<u8>>,
     read: &mut usize,
-    initialized: &mut usize,
     cx: &mut Context<'_>,
 ) -> Poll<io::Result<usize>> {
-    let io_res = ready!(read_to_end_internal(buf, reader, read, initialized, cx));
-    let utf8_res = String::from_utf8(mem::replace(buf, Vec::new()));
+    let io_res = ready!(read_to_end_internal(buf, reader, read, cx));
+    let utf8_res = String::from_utf8(buf.take());
 
     // At this point both buf and output are empty. The allocation is in utf8_res.
 
@@ -84,18 +74,6 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
 
-        // Safety: initialized is initially zero, which is always correct, and
-        // `read_to_string_internal` guarantees that its invariant still holds
-        // when it returns.
-        unsafe {
-            read_to_string_internal(
-                Pin::new(*me.reader),
-                me.output,
-                me.buf,
-                me.read,
-                me.initialized,
-                cx,
-            )
-        }
+        read_to_string_internal(Pin::new(*me.reader), me.output, me.buf, me.read, cx)
     }
 }

--- a/tokio/src/io/util/vec_with_initialized.rs
+++ b/tokio/src/io/util/vec_with_initialized.rs
@@ -1,0 +1,118 @@
+use crate::io::ReadBuf;
+use std::mem::MaybeUninit;
+
+/// This struct wraps a `Vec<u8>` or `&mut Vec<u8>`, combining it with a
+/// `num_initialized`, which keeps track of the number of initialized bytes
+/// in the unused capacity.
+///
+/// The purpose of this struct is to remember how many bytes were initialized
+/// through a `ReadBuf` from call to call.
+///
+/// This struct has the safety invariant that the first `num_initialized` of the
+/// vector's allocation must be initialized at any time.
+#[derive(Debug)]
+pub(crate) struct VecWithInitialized<V> {
+    vec: V,
+    // The number of initialized bytes in the vector.
+    // Always between `vec.len()` and `vec.capacity()`.
+    num_initialized: usize,
+}
+
+impl VecWithInitialized<Vec<u8>> {
+    pub(crate) fn take(&mut self) -> Vec<u8> {
+        self.num_initialized = 0;
+        std::mem::take(&mut self.vec)
+    }
+}
+
+impl<V> VecWithInitialized<V>
+where
+    V: AsMut<Vec<u8>>,
+{
+    /// Safety: The generic parameter `V` must be either `Vec<u8>` or `&mut Vec<u8>`.
+    pub(crate) unsafe fn new(mut vec: V) -> Self {
+        // SAFETY: The safety invariants of vector guarantee that the bytes up
+        // to its length are initialized.
+        Self {
+            num_initialized: vec.as_mut().len(),
+            vec,
+        }
+    }
+
+    pub(crate) fn reserve(&mut self, num_bytes: usize) {
+        let vec = self.vec.as_mut();
+        if vec.capacity() - vec.len() >= num_bytes {
+            return;
+        }
+        // SAFETY: Setting num_initialized to `vec.len()` is correct as
+        // `reserve` does not change the length of the vector.
+        self.num_initialized = vec.len();
+        vec.reserve(num_bytes);
+    }
+
+    pub(crate) fn is_empty(&mut self) -> bool {
+        self.vec.as_mut().is_empty()
+    }
+
+    pub(crate) fn get_read_buf<'a>(&'a mut self) -> ReadBuf<'a> {
+        let num_initialized = self.num_initialized;
+
+        // SAFETY: Creating the slice is safe because of the safety invariants
+        // on Vec<u8>. The safety invariants of `ReadBuf` will further guarantee
+        // that no bytes in the slice are de-initialized.
+        let vec = self.vec.as_mut();
+        let len = vec.len();
+        let cap = vec.capacity();
+        let ptr = vec.as_mut_ptr().cast::<MaybeUninit<u8>>();
+        let slice = unsafe { std::slice::from_raw_parts_mut::<'a, MaybeUninit<u8>>(ptr, cap) };
+
+        // SAFETY: This is safe because the safety invariants of
+        // VecWithInitialized say that the first num_initialized bytes must be
+        // initialized.
+        let mut read_buf = ReadBuf::uninit(slice);
+        unsafe {
+            read_buf.assume_init(num_initialized);
+        }
+        read_buf.set_filled(len);
+
+        read_buf
+    }
+
+    pub(crate) fn apply_read_buf(&mut self, parts: ReadBufParts) {
+        let vec = self.vec.as_mut();
+        assert_eq!(vec.as_ptr(), parts.ptr);
+
+        // SAFETY:
+        // The ReadBufParts really does point inside `self.vec` due to the above
+        // check, and the safety invariants of `ReadBuf` guarantee that the
+        // first `parts.initialized` bytes of `self.vec` really have been
+        // initialized. Additionally, `ReadBuf` guarantees that `parts.len` is
+        // at most `parts.initialized`, so the first `parts.len` bytes are also
+        // initialized.
+        //
+        // Note that this relies on the fact that `V` is either `Vec<u8>` or
+        // `&mut Vec<u8>`, so the vector returned by `self.vec.as_mut()` cannot
+        // change from call to call.
+        unsafe {
+            self.num_initialized = parts.initialized;
+            vec.set_len(parts.len);
+        }
+    }
+}
+
+pub(crate) struct ReadBufParts {
+    // Pointer is only used to check that the ReadBuf actually came from the
+    // right VecWithInitialized.
+    ptr: *const u8,
+    len: usize,
+    initialized: usize,
+}
+
+// This is needed to release the borrow on `VecWithInitialized<V>`.
+pub(crate) fn into_read_buf_parts(rb: ReadBuf<'_>) -> ReadBufParts {
+    ReadBufParts {
+        ptr: rb.filled().as_ptr(),
+        len: rb.filled().len(),
+        initialized: rb.initialized().len(),
+    }
+}

--- a/tokio/src/io/util/vec_with_initialized.rs
+++ b/tokio/src/io/util/vec_with_initialized.rs
@@ -19,6 +19,7 @@ pub(crate) struct VecWithInitialized<V> {
 }
 
 impl VecWithInitialized<Vec<u8>> {
+    #[cfg(feature = "io-util")]
     pub(crate) fn take(&mut self) -> Vec<u8> {
         self.num_initialized = 0;
         std::mem::take(&mut self.vec)
@@ -50,6 +51,7 @@ where
         vec.reserve(num_bytes);
     }
 
+    #[cfg(feature = "io-util")]
     pub(crate) fn is_empty(&mut self) -> bool {
         self.vec.as_mut().is_empty()
     }

--- a/tokio/tests/io_read_to_end.rs
+++ b/tokio/tests/io_read_to_end.rs
@@ -1,7 +1,9 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::io::AsyncReadExt;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_test::assert_ok;
 
 #[tokio::test]
@@ -12,4 +14,64 @@ async fn read_to_end() {
     let n = assert_ok!(rd.read_to_end(&mut buf).await);
     assert_eq!(n, 11);
     assert_eq!(buf[..], b"hello world"[..]);
+}
+
+#[derive(Copy, Clone, Debug)]
+enum State {
+    Initializing,
+    JustFilling,
+    Done,
+}
+
+struct UninitTest {
+    num_init: usize,
+    state: State,
+}
+
+impl AsyncRead for UninitTest {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        let me = Pin::into_inner(self);
+        assert_eq!(buf.initialized().len(), me.num_init, "{:?}", me.state);
+
+        match me.state {
+            State::Initializing => {
+                buf.initialize_unfilled_to(me.num_init + 2);
+                buf.advance(1);
+                me.num_init += 1;
+
+                if me.num_init == 24 {
+                    me.state = State::JustFilling;
+                }
+            }
+            State::JustFilling => {
+                buf.advance(1);
+                me.num_init -= 1;
+
+                if me.num_init == 15 {
+                    // The buffer is resized on next call.
+                    me.num_init = 0;
+                    me.state = State::Done;
+                }
+            }
+            State::Done => { /* .. do nothing .. */ }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[tokio::test]
+async fn read_to_end_uninit() {
+    let mut buf = Vec::with_capacity(64);
+    let mut test = UninitTest {
+        num_init: 0,
+        state: State::Initializing,
+    };
+
+    test.read_to_end(&mut buf).await.unwrap();
+    assert_eq!(buf.len(), 33);
 }

--- a/tokio/tests/io_read_to_end.rs
+++ b/tokio/tests/io_read_to_end.rs
@@ -35,7 +35,8 @@ impl AsyncRead for UninitTest {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
         let me = Pin::into_inner(self);
-        assert_eq!(buf.initialized().len(), me.num_init, "{:?}", me.state);
+        let real_num_init = buf.initialized().len() - buf.filled().len();
+        assert_eq!(real_num_init, me.num_init, "{:?}", me.state);
 
         match me.state {
             State::Initializing => {


### PR DESCRIPTION
This keeps track of the number of initialized bytes inside `read_to_end`.

Note that old implementation is actually unsound as replacing the buffer inside `ReadBuf` does not require unsafe, and it does not check whether the pointer has been changed.
```Rust
// This should no longer even be possible in safe Rust. An implementor
// would need to have unsafely *replaced* the buffer inside `ReadBuf`,
// which... yolo?
assert!(new_len <= buf.capacity());
```