### PR TITLE
Fix unsoundness in read_to_end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: ["master"]
+    branches: ["tokio-1.0.x"]
   pull_request:
-    branches: ["master"]
+    branches: ["tokio-1.0.x"]
 
 name: CI
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: ["tokio-1.0.x"]
+    branches: ["master", "tokio-*.x"]
   pull_request:
-    branches: ["tokio-1.0.x"]
+    branches: ["master", "tokio-*.x"]
 
 name: CI
 

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -72,14 +72,13 @@ fn poll_read_to_end<R: AsyncRead + ?Sized>(
 
     let mut unused_capacity = ReadBuf::uninit(get_unused_capacity(buf));
 
+    let ptr = unused_capacity.filled().as_ptr();
     ready!(read.poll_read(cx, &mut unused_capacity))?;
+    assert_eq!(ptr, unused_capacity.filled().as_ptr());
 
     let n = unused_capacity.filled().len();
     let new_len = buf.len() + n;
 
-    // This should no longer even be possible in safe Rust. An implementor
-    // would need to have unsafely *replaced* the buffer inside `ReadBuf`,
-    // which... yolo?
     assert!(new_len <= buf.capacity());
     unsafe {
         buf.set_len(new_len);


### PR DESCRIPTION
This is a companion of #3426 that contains just the unsoundness fix so we can release it in a patch release.