### PR TITLE
docs: Clarified the point about changing the file descriptor underlyi…

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -23,12 +23,11 @@ use std::{task::Context, task::Poll};
 /// to retake control from the tokio IO reactor.
 ///
 /// The inner object is required to implement [`AsRawFd`]. This file descriptor
-/// must not change while [`AsyncFd`] owns the inner object. Changing the file
-/// descriptor through the underlying [`AsRawFd::as_raw_fd`] results
+/// must not change while [`AsyncFd`] owns the inner object. The
+/// [`AsRawFd::as_raw_fd`] method on the inner type must always return the same
+/// file descriptor when called multiple times. Failure to uphold this results
 /// in unspecified behavior in the IO driver, which may include breaking
-/// notifications for other sockets/etc. That is not to say that simply using
-/// a clone of the inner object would be problematic if that is a supported
-/// thing to do.
+/// notifications for other sockets/etc.
 ///
 /// Polling for readiness is done by calling the async functions [`readable`]
 /// and [`writable`]. These functions complete when the associated readiness

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -24,8 +24,11 @@ use std::{task::Context, task::Poll};
 ///
 /// The inner object is required to implement [`AsRawFd`]. This file descriptor
 /// must not change while [`AsyncFd`] owns the inner object. Changing the file
-/// descriptor results in unspecified behavior in the IO driver, which may
-/// include breaking notifications for other sockets/etc.
+/// descriptor through the underlying [`AsRawFd::as_raw_fd`] results
+/// in unspecified behavior in the IO driver, which may include breaking
+/// notifications for other sockets/etc. That is not to say that simply using
+/// a clone of the inner object would be problematic if that is a supported
+/// thing to do.
 ///
 /// Polling for readiness is done by calling the async functions [`readable`]
 /// and [`writable`]. These functions complete when the associated readiness

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -23,7 +23,7 @@ use std::{task::Context, task::Poll};
 /// to retake control from the tokio IO reactor.
 ///
 /// The inner object is required to implement [`AsRawFd`]. This file descriptor
-/// must not change while [`AsyncFd`] owns the inner object. The
+/// must not change while [`AsyncFd`] owns the inner object, i.e. the
 /// [`AsRawFd::as_raw_fd`] method on the inner type must always return the same
 /// file descriptor when called multiple times. Failure to uphold this results
 /// in unspecified behavior in the IO driver, which may include breaking


### PR DESCRIPTION
…ng an AsyncFd

## Motivation

The info on when it's appropriate to have a clone of an underlying `File` object when using an `AsyncFd` was not clear to me from the current docs.

## Solution

Adds a clarification point. This may need further clarification, which I'm happy to do.
