### PR TITLE
chore: merge 1.0.x changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 on:
   push:
-    branches: ["master"]
+    branches: ["master", "tokio-*.x"]
   pull_request:
-    branches: ["master"]
+    branches: ["master", "tokio-*.x"]
 
 name: CI
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.0.2 (January 14, 2020)
+
+### Fixed
+- io: soundness in `read_to_end` (#3428).
+
 # 1.0.1 (December 25, 2020)
 
 This release fixes a soundness hole caused by the combination of `RwLockWriteGuard::map`

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/1.0.1/tokio/"
+documentation = "https://docs.rs/tokio/1.0.2/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -72,14 +72,13 @@ fn poll_read_to_end<R: AsyncRead + ?Sized>(
 
     let mut unused_capacity = ReadBuf::uninit(get_unused_capacity(buf));
 
+    let ptr = unused_capacity.filled().as_ptr();
     ready!(read.poll_read(cx, &mut unused_capacity))?;
+    assert_eq!(ptr, unused_capacity.filled().as_ptr());
 
     let n = unused_capacity.filled().len();
     let new_len = buf.len() + n;
 
-    // This should no longer even be possible in safe Rust. An implementor
-    // would need to have unsafely *replaced* the buffer inside `ReadBuf`,
-    // which... yolo?
     assert!(new_len <= buf.capacity());
     unsafe {
         buf.set_len(new_len);

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/tokio/1.0.2")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
Merges `tokio-1.0.x` changes into master.

This PR should be merged w/ the git CLI tool and not the Github UI.