### PR TITLE
Add documentation to process::Child fields

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -844,7 +844,7 @@ pub struct Child {
     /// find it helpful to do:
     ///
     /// ```no_run
-    /// # let child: tokio::process::Child = unreachable!();
+    /// # let mut child = tokio::process::Command::new("echo").spawn().unwrap();
     /// let stdin = child.stdin.take().unwrap();
     /// ```
     pub stdin: Option<ChildStdin>,
@@ -853,7 +853,7 @@ pub struct Child {
     /// has been captured. You might find it helpful to do
     ///
     /// ```no_run
-    /// # let child: tokio::process::Child = unreachable!();
+    /// # let mut child = tokio::process::Command::new("echo").spawn().unwrap();
     /// let stdout = child.stdout.take().unwrap();
     /// ```
     ///
@@ -865,7 +865,7 @@ pub struct Child {
     /// has been captured. You might find it helpful to do
     ///
     /// ```no_run
-    /// # let child: tokio::process::Child = unreachable!();
+    /// # let mut child = tokio::process::Command::new("echo").spawn().unwrap();
     /// let stderr = child.stderr.take().unwrap();
     /// ```
     ///

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -839,15 +839,35 @@ pub struct Child {
     child: FusedChild,
 
     /// The handle for writing to the child's standard input (stdin), if it has
-    /// been captured.
+    /// been captured. To avoid partially moving the `child` and thus blocking
+    /// yourself from calling functions on `child` while using `stdin`, you might
+    /// find it helpful to do:
+    ///
+    /// ```compile_fail,E0425
+    /// let stdin = child.stdin.take().unwrap();
+    /// ```
     pub stdin: Option<ChildStdin>,
 
     /// The handle for reading from the child's standard output (stdout), if it
-    /// has been captured.
+    /// has been captured. You might find it helpful to do
+    ///
+    /// ```compile_fail,E0425
+    /// let stdout = child.stdout.take().unwrap();
+    /// ```
+    ///
+    /// to avoid partially moving the `child` and thus blocking yourself from calling
+    /// functions on `child` while using `stdout`.
     pub stdout: Option<ChildStdout>,
 
     /// The handle for reading from the child's standard error (stderr), if it
-    /// has been captured.
+    /// has been captured. You might find it helpful to do
+    ///
+    /// ```compile_fail,E0425
+    /// let stderr = child.stderr.take().unwrap();
+    /// ```
+    ///
+    /// to avoid partially moving the `child` and thus blocking yourself from calling
+    /// functions on `child` while using `stderr`.
     pub stderr: Option<ChildStderr>,
 }
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -843,7 +843,8 @@ pub struct Child {
     /// yourself from calling functions on `child` while using `stdin`, you might
     /// find it helpful to do:
     ///
-    /// ```compile_fail,E0425
+    /// ```no_run
+    /// # let child: tokio::process::Child = unreachable!();
     /// let stdin = child.stdin.take().unwrap();
     /// ```
     pub stdin: Option<ChildStdin>,
@@ -851,7 +852,8 @@ pub struct Child {
     /// The handle for reading from the child's standard output (stdout), if it
     /// has been captured. You might find it helpful to do
     ///
-    /// ```compile_fail,E0425
+    /// ```no_run
+    /// # let child: tokio::process::Child = unreachable!();
     /// let stdout = child.stdout.take().unwrap();
     /// ```
     ///
@@ -862,7 +864,8 @@ pub struct Child {
     /// The handle for reading from the child's standard error (stderr), if it
     /// has been captured. You might find it helpful to do
     ///
-    /// ```compile_fail,E0425
+    /// ```no_run
+    /// # let child: tokio::process::Child = unreachable!();
     /// let stderr = child.stderr.take().unwrap();
     /// ```
     ///


### PR DESCRIPTION
## Motivation

I was using `tokio::process::Child` without much experience of `std::process::Child` and was reading the tokio docs. I worked out that I needed to use the `child.stdin.take().unwrap()` pattern but it would have saved me some time if it was in the docs. I later discovered that this was added to the rust std lib documentation by https://github.com/rust-lang/rust/pull/74192.

## Solution

Updated the doc comments on the public fields of `Child` to match the changes made by https://github.com/rust-lang/rust/pull/74192.