### PR TITLE
io: add ReadBuf::inner_mut

### DIFF
--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -113,6 +113,25 @@ impl<'a> ReadBuf<'a> {
         unsafe { mem::transmute::<&mut [MaybeUninit<u8>], &mut [u8]>(slice) }
     }
 
+    /// Returns a mutable reference to the entire buffer, without ensuring that it has been fully
+    /// initialized.
+    ///
+    /// The elements between 0 and `self.filled().len()` are filled, and those between 0 and
+    /// `self.initialized().len()` are initialized (and so can be transmuted to a `&mut [u8]`).
+    ///
+    /// The caller of this method must ensure that these invariants are upheld. For example, if the
+    /// caller initializes some of the uninitialized section of the buffer, it must call
+    /// [`assume_init`](Self::assume_init) with the number of bytes initialized.
+    ///
+    /// # Safety
+    ///
+    /// The caller must not de-initialize portions of the buffer that have already been initialized.
+    /// This includes any bytes in the region marked as uninitialized by `ReadBuf`.
+    #[inline]
+    pub unsafe fn inner_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        self.buf
+    }
+
     /// Returns a mutable reference to the unfilled part of the buffer without ensuring that it has been fully
     /// initialized.
     ///


### PR DESCRIPTION
This returns the entire buffer as a `&mut [MaybeUninit<u8>]`, which may
be useful for building abstractions on top.

## Motivation

It looks like `ReadBuf` doesn't have a way to get the entire buffer, only various sections of it. Being able to work with the entire buffer is useful in some situations, such as while building testing tools that limit the size of the buffer (similar to `BufMut::limit` in tokio 0.2).

## Solution

Add `ReadBuf::inner_mut` which returns the entire inner buffer.

This is unsafe for the same reason that `unfilled_mut` is: the caller must not deinitialize portions of the buffer that have already been initialized.

I've used this method in `partial-io`: https://github.com/facebookincubator/rust-partial-io/pull/33#discussion_r559884801 and it looks like it does the job.

I'm not sure if any tests for this make sense, given the fact that the implementation is one line long.

Thank you!