### PR TITLE
Use a sealed trait to constrain VecWithInitialized

### DIFF
--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -28,7 +28,6 @@ pub(crate) fn read_to_end<'a, R>(reader: &'a mut R, buffer: &'a mut Vec<u8>) -> 
 where
     R: AsyncRead + Unpin + ?Sized,
 {
-    // SAFETY: The generic type on VecWithInitialized is &mut Vec<u8>.
     ReadToEnd {
         reader,
         buf: VecWithInitialized::new(buffer),

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -1,4 +1,4 @@
-use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecWithInitialized, VecU8};
+use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecU8, VecWithInitialized};
 use crate::io::AsyncRead;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -1,4 +1,4 @@
-use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecWithInitialized};
+use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecWithInitialized, VecU8};
 use crate::io::AsyncRead;
 
 use pin_project_lite::pin_project;
@@ -31,13 +31,13 @@ where
     // SAFETY: The generic type on VecWithInitialized is &mut Vec<u8>.
     ReadToEnd {
         reader,
-        buf: unsafe { VecWithInitialized::new(buffer) },
+        buf: VecWithInitialized::new(buffer),
         read: 0,
         _pin: PhantomPinned,
     }
 }
 
-pub(super) fn read_to_end_internal<V: AsMut<Vec<u8>>, R: AsyncRead + ?Sized>(
+pub(super) fn read_to_end_internal<V: VecU8, R: AsyncRead + ?Sized>(
     buf: &mut VecWithInitialized<V>,
     mut reader: Pin<&mut R>,
     num_read: &mut usize,
@@ -58,7 +58,7 @@ pub(super) fn read_to_end_internal<V: AsMut<Vec<u8>>, R: AsyncRead + ?Sized>(
 /// Tries to read from the provided AsyncRead.
 ///
 /// The length of the buffer is increased by the number of bytes read.
-fn poll_read_to_end<V: AsMut<Vec<u8>>, R: AsyncRead + ?Sized>(
+fn poll_read_to_end<V: VecU8, R: AsyncRead + ?Sized>(
     buf: &mut VecWithInitialized<V>,
     read: Pin<&mut R>,
     cx: &mut Context<'_>,

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -41,7 +41,7 @@ where
     // SAFETY: The generic type of the VecWithInitialized is Vec<u8>.
     ReadToString {
         reader,
-        buf: unsafe { VecWithInitialized::new(buf) },
+        buf: VecWithInitialized::new(buf),
         output: string,
         read: 0,
         _pin: PhantomPinned,

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -38,7 +38,6 @@ where
     R: AsyncRead + ?Sized + Unpin,
 {
     let buf = mem::replace(string, String::new()).into_bytes();
-    // SAFETY: The generic type of the VecWithInitialized is Vec<u8>.
     ReadToString {
         reader,
         buf: VecWithInitialized::new(buf),

--- a/tokio/src/io/util/vec_with_initialized.rs
+++ b/tokio/src/io/util/vec_with_initialized.rs
@@ -68,7 +68,7 @@ where
         self.vec.as_mut().is_empty()
     }
 
-    pub(crate) fn get_read_buf(&mut self) -> ReadBuf<'_> {
+    pub(crate) fn get_read_buf<'a>(&'a mut self) -> ReadBuf<'a> {
         let num_initialized = self.num_initialized;
 
         // SAFETY: Creating the slice is safe because of the safety invariants
@@ -78,7 +78,7 @@ where
         let len = vec.len();
         let cap = vec.capacity();
         let ptr = vec.as_mut_ptr().cast::<MaybeUninit<u8>>();
-        let slice = unsafe { std::slice::from_raw_parts_mut::<'_, MaybeUninit<u8>>(ptr, cap) };
+        let slice = unsafe { std::slice::from_raw_parts_mut::<'a, MaybeUninit<u8>>(ptr, cap) };
 
         // SAFETY: This is safe because the safety invariants of
         // VecWithInitialized say that the first num_initialized bytes must be


### PR DESCRIPTION
Use a sealed trait to constrain `VecWithInitialized`'s generic type parameter.  The safety of that struct relies on invariants upheld by `Vec<u8>`.  The struct currently has an `unsafe new` associated fn where `V: AsMut<Vec<u8>>`.
## Motivation
Avoids a bit of `unsafe`.

## Solution
This PR defines a crate private `VecU8` trait and implements it for `Vec<u8>` and `&mut Vec<u8>`.

cc @Darksonn as we discussed this a bit in https://github.com/tokio-rs/tokio/pull/3426