### PR TITLE
util: UdpFramed takes Borrow<UdpSocket>

### DIFF
--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -167,7 +167,10 @@ where
     }
 }
 
-impl<T: Borrow<UdpSocket>, C> UdpFramed<T, C> {
+impl<T, C> UdpFramed<T, C>
+where
+    T: Borrow<UdpSocket>,
+{
     /// Create a new `UdpFramed` backed by the given socket and codec.
     ///
     /// See struct level documentation for more details.
@@ -221,5 +224,10 @@ impl<T: Borrow<UdpSocket>, C> UdpFramed<T, C> {
     /// Returns a mutable reference to the read buffer.
     pub fn read_buffer_mut(&mut self) -> &mut BytesMut {
         &mut self.rd
+    }
+
+    /// Consumes the `Framed`, returning its underlying I/O stream.
+    pub fn into_inner(self) -> T {
+        self.socket
     }
 }


### PR DESCRIPTION
## Motivation

This changes `UdpFramed` from holding a `UdpSocket` to a `Borrow<UdpSocket>`.

Often, you will have an `Arc<UdpSocket>` which you want to share among many tasks but also still be able to use the helper functions from `tokio-util`. Unfortunately, `UdpFramed` only takes a `UdpSocket`.

~~The disadvantage of this approach is that `into_inner` and `get_mut` must be removed, does that seem like an acceptable trade-off for the added flexibility?~~

edit: `into_inner` doesn't actually have to be removed, ~~my mistake, only `get_mut`~~ 
edit: `get_mut` now implemented specifically for `UdpFramed<C, UdpSocket>`

## Possible Solution?

Make `UdpFramed` take a `T: Borrow<UdpSocket>` so it can take UdpSocket types generically. 

I'm happy to take any feedback or alternate approach that is suggested. But let me take your temperature first on if you think you'd like this change or not?