### PR TITLE
Prepare tokio-util 0.6.2

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.6.2 (January 21, 2020)
+
+### Added
+
+- sync: add pollable `Semaphore` ([#3444])
+
+### Fixed
+
+- time: fix panics on updating `DelayQueue` entries ([#3270])
+
 # 0.6.1 (January 12, 2020)
 
 ### Added
@@ -62,8 +72,10 @@
 
 - Initial release
 
+[#3444]: https://github.com/tokio-rs/tokio/pull/3444
 [#3387]: https://github.com/tokio-rs/tokio/pull/3387
 [#3364]: https://github.com/tokio-rs/tokio/pull/3364
+[#3270]: https://github.com/tokio-rs/tokio/pull/3270
 [#2326]: https://github.com/tokio-rs/tokio/pull/2326
 [#2215]: https://github.com/tokio-rs/tokio/pull/2215
 [#2198]: https://github.com/tokio-rs/tokio/pull/2198

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.6.x" git tag.
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.6.1/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.6.2/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.1")]
+#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.2")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
# 0.6.2 (January 21, 2020)

### Added

- sync: add pollable `Semaphore` (#3444)

### Fixed

- time: fix panics on updating `DelayQueue` entries (#3270)