### PR TITLE
Add link to PollSemaphore

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -13,6 +13,11 @@ use std::sync::Arc;
 /// function immediately returns a permit. However, if no remaining permits are
 /// available, `acquire` (asynchronously) waits until an outstanding permit is
 /// dropped. At this point, the freed permit is assigned to the caller.
+///
+/// To use the `Semaphore` in a poll function, you can use the [`PollSemaphore`]
+/// utility.
+///
+/// [`PollSemaphore`]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSemaphore.html
 #[derive(Debug)]
 pub struct Semaphore {
     /// The low level semaphore


### PR DESCRIPTION
This links to [`PollSemaphore`][1] from [`Semaphore`][2].

[1]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSemaphore.html
[2]: https://docs.rs/tokio/1/tokio/sync/struct.Semaphore.html