### PR TITLE
tokio: add document annotation for missing timer panics

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -135,6 +135,12 @@ impl Builder {
     /// individually. If additional components are added to Tokio in the future,
     /// `enable_all` will include these future components.
     ///
+    /// # Panics
+    ///
+    /// When creating runtime by Builder we need to call `Builder::enable_time()`
+    /// or `Builder::enable_all()` to set current timer.
+    /// Otherwise we will get a missing timer panic when trying to get a handle to the current timer.
+    ///
     /// # Examples
     ///
     /// ```

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -135,13 +135,6 @@ impl Builder {
     /// individually. If additional components are added to Tokio in the future,
     /// `enable_all` will include these future components.
     ///
-    /// # Panics
-    ///
-    /// When creating runtime by Builder we need to call `Builder::enable_time()`
-    /// or `Builder::enable_all()` to set current timer.
-    /// Otherwise we will get a missing timer panic when trying to get a handle
-    /// to the current timer.
-    ///
     /// # Examples
     ///
     /// ```

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -139,7 +139,8 @@ impl Builder {
     ///
     /// When creating runtime by Builder we need to call `Builder::enable_time()`
     /// or `Builder::enable_all()` to set current timer.
-    /// Otherwise we will get a missing timer panic when trying to get a handle to the current timer.
+    /// Otherwise we will get a missing timer panic when trying to get a handle
+    /// to the current timer.
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -298,8 +298,6 @@ cfg_rt! {
         ///
         /// See [module level][mod] documentation for more details.
         ///
-        /// # Panics
-        ///
         /// When creating runtime by Builder we need to call `Builder::enable_time()`
         /// or `Builder::enable_all()` to set current timer.
         /// Otherwise we will get a missing timer panic when trying to get a handle

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -298,6 +298,13 @@ cfg_rt! {
         ///
         /// See [module level][mod] documentation for more details.
         ///
+        /// # Panics
+        ///
+        /// When creating runtime by Builder we need to call `Builder::enable_time()`
+        /// or `Builder::enable_all()` to set current timer.
+        /// Otherwise we will get a missing timer panic when trying to get a handle
+        /// to the current timer.
+        ///
         /// # Examples
         ///
         /// Creating a new `Runtime` with default configuration values.


### PR DESCRIPTION
Add document annotation for missing timer panics in runtime/builder.rs

Fixes: tokio-rs#2696
