### PR TITLE
chore: prepare Tokio 0.2.25

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.2.25 (January 28, 2021)
+
+### Changes
+
+- chore: upgrade mio dependency (#3207)
+- runtime: update panic messages to include version (#3460)
+
+### Fixes
+
+- task: add missing feature flags for `task_local` (#3236)
+
 # 0.2.24 (December 7, 2020)
 
 ### Fixes

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.2.x" git tag.
-version = "0.2.24"
+version = "0.2.25"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.2.24/tokio/"
+documentation = "https://docs.rs/tokio/0.2.25/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.2.24")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.2.25")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
### Changes

- chore: upgrade mio dependency (#3207)
- runtime: update panic messages to include version (#3460)

### Fixes

- task: add missing feature flags for `task_local` (#3236)