### PR TITLE
chore: prepare Tokio 0.3.7

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.7 (January 28, 2021)
+
+### Changes
+
+- runtime: update panic messages to include version (#3461)
+
 # 0.3.6 (December 14, 2020)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v0.3.x" git tag.
-version = "0.3.6"
+version = "0.3.7"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/0.3.6/tokio/"
+documentation = "https://docs.rs/tokio/0.3.7/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/0.3.6")]
+#![doc(html_root_url = "https://docs.rs/tokio/0.3.7")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
### Changes

- runtime: update panic messages to include version (#3461)