### PR TITLE
Prepare tokio-util v0.6.3

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - sync: use `ReusableBoxFuture` for `PollSemaphore` ([#3463])
+- deps: remove `async-stream` dependency ([#3463])
 - deps: remove `tokio-stream` dependency ([#3487])
 
 # 0.6.2 (January 21, 2021)

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,4 +1,15 @@
-# 0.6.2 (January 21, 2020)
+# 0.6.3 (January 31, 2021)
+
+### Added
+
+- sync: add `ReusableBoxFuture` utility ([#3464])
+
+### Changed
+
+- sync: use `ReusableBoxFuture` for `PollSemaphore` ([#3463])
+- deps: remove `tokio-stream` dependency ([#3487])
+
+# 0.6.2 (January 21, 2021)
 
 ### Added
 
@@ -8,7 +19,7 @@
 
 - time: fix panics on updating `DelayQueue` entries ([#3270])
 
-# 0.6.1 (January 12, 2020)
+# 0.6.1 (January 12, 2021)
 
 ### Added
 
@@ -72,6 +83,9 @@
 
 - Initial release
 
+[#3487]: https://github.com/tokio-rs/tokio/pull/3487
+[#3464]: https://github.com/tokio-rs/tokio/pull/3464
+[#3463]: https://github.com/tokio-rs/tokio/pull/3463
 [#3444]: https://github.com/tokio-rs/tokio/pull/3444
 [#3387]: https://github.com/tokio-rs/tokio/pull/3387
 [#3364]: https://github.com/tokio-rs/tokio/pull/3364

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -7,13 +7,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.6.x" git tag.
-version = "0.6.2"
+version = "0.6.3"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.6.2/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.6.3/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.2")]
+#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.3")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,


### PR DESCRIPTION
### Added

- sync: add `ReusableBoxFuture` utility (#3464)

### Changed

- sync: use `ReusableBoxFuture` for `PollSemaphore` (#3463)
- deps: remove `async-stream` dependency (#3463)
- deps: remove `tokio-stream` dependency (#3487)