### PR TITLE
Remove html_root_url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -571,9 +571,8 @@ When releasing a new version of a crate, follow these steps:
 2. **Update Cargo metadata.** After releasing any path dependencies, update the
    `version` field in `Cargo.toml` to the new version, and the `documentation`
    field to the docs.rs URL of the new version.
-3. **Update other documentation links.** Update the `#![doc(html_root_url)]`
-   attribute in the crate's `lib.rs` and the "Documentation" link in the crate's
-   `README.md` to point to the docs.rs URL of the new version.
+3. **Update other documentation links.** Update the "Documentation" link in the
+   crate's `README.md` to point to the docs.rs URL of the new version.
 4. **Update the changelog for the crate.** Each crate in the Tokio repository
    has its own `CHANGELOG.md` in that crate's subdirectory. Any changes to that
    crate since the last release should be added to the changelog. Change

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tokio-macros"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tokio-macros/1.0.0")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tokio-stream"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tokio-stream/0.1.2")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tokio-test"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tokio-test/0.4.0")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tokio-util"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 # - Update CHANGELOG.md.

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tokio-util/0.6.2")]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -2,7 +2,6 @@
 name = "tokio"
 # When releasing to crates.io:
 # - Remove path dependencies
-# - Update html_root_url.
 # - Update doc url
 #   - Cargo.toml
 #   - README.md

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/tokio/1.1.1")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
AFAIK, `html_root_url` is not needed in most cases. And api-guidelines no longer recommends this. See https://github.com/rust-lang/api-guidelines/issues/229 for more.

This allows us to remove one of the easy-to-forget release steps.