### PR TITLE
Suppress deprecated warnings for spin_loop_hint

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -75,7 +75,8 @@ pub(crate) mod sync {
         pub(crate) use crate::loom::std::atomic_usize::AtomicUsize;
 
         pub(crate) use std::sync::atomic::{fence, AtomicBool, Ordering};
-        #[allow(deprecated)] // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
+        // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
+        #[allow(deprecated)]
         pub(crate) use std::sync::atomic::spin_loop_hint;
     }
 }

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -75,7 +75,7 @@ pub(crate) mod sync {
         pub(crate) use crate::loom::std::atomic_usize::AtomicUsize;
 
         pub(crate) use std::sync::atomic::{fence, AtomicBool, Ordering};
-        #[allow(deprecated)]
+        #[allow(deprecated)] // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
         pub(crate) use std::sync::atomic::spin_loop_hint;
     }
 }

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -74,7 +74,9 @@ pub(crate) mod sync {
         pub(crate) use crate::loom::std::atomic_u8::AtomicU8;
         pub(crate) use crate::loom::std::atomic_usize::AtomicUsize;
 
-        pub(crate) use std::sync::atomic::{fence, spin_loop_hint, AtomicBool, Ordering};
+        pub(crate) use std::sync::atomic::{fence, AtomicBool, Ordering};
+        #[allow(deprecated)]
+        pub(crate) use std::sync::atomic::spin_loop_hint;
     }
 }
 

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -223,6 +223,7 @@ impl AtomicWaker {
                 waker.wake();
 
                 // This is equivalent to a spin lock, so use a spin hint.
+                #[allow(deprecated)]
                 atomic::spin_loop_hint();
             }
             state => {

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -223,7 +223,7 @@ impl AtomicWaker {
                 waker.wake();
 
                 // This is equivalent to a spin lock, so use a spin hint.
-                #[allow(deprecated)]
+                #[allow(deprecated)] // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
                 atomic::spin_loop_hint();
             }
             state => {

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -223,7 +223,8 @@ impl AtomicWaker {
                 waker.wake();
 
                 // This is equivalent to a spin lock, so use a spin hint.
-                #[allow(deprecated)] // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
+                // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
+                #[allow(deprecated)]
                 atomic::spin_loop_hint();
             }
             state => {


### PR DESCRIPTION
Replaces #3496 as that's ahead of its time due to MSRV policy.