### PR TITLE
chore: prepare tokio v1.2.0

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,9 +1,27 @@
+# 1.2.0 (February 5, 2021)
+
+### Added
+
+- signal: make `Signal::poll_recv` method public ([#3383])
+
+### Fixed
+
+- time: make `test-util` paused time fully deterministic ([#3492])
+
+### Documented
+
+- sync: link to new broadcast and watch wrappers ([#3504])
+
+[#3383]: https://github.com/tokio-rs/tokio/pull/3383
+[#3492]: https://github.com/tokio-rs/tokio/pull/3492
+[#3504]: https://github.com/tokio-rs/tokio/pull/3504
+
 # 1.1.1 (January 29, 2021)
 
 Forward ports 1.0.3 fix.
 
 ### Fixed
-- io: memory leak during shutdown (#3477).
+- io: memory leak during shutdown ([#3477]).
 
 # 1.1.0 (January 22, 2021)
 
@@ -58,7 +76,9 @@ Forward ports 1.0.3 fix.
 # 1.0.3 (January 28, 2021)
 
 ### Fixed
-- io: memory leak during shutdown (#3477).
+- io: memory leak during shutdown ([#3477]).
+
+[#3477]: https://github.com/tokio-rs/tokio/pull/3477
 
 # 1.0.2 (January 14, 2021)
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,12 +8,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.1.1"
+version = "1.2.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/1.1.1/tokio/"
+documentation = "https://docs.rs/tokio/1.2.0/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -86,7 +86,7 @@ test-util = []
 time = []
 
 [dependencies]
-tokio-macros = { version = "1.0.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "1.1.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.0"
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/tokio/1.1.1")]
+#![doc(html_root_url = "https://docs.rs/tokio/1.2.0")]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,


### PR DESCRIPTION
### Added

- signal: make `Signal::poll_recv` method public (#3383)

### Fixed

- time: make `test-util` paused time fully deterministic (#3492)

### Documented

- sync: link to new broadcast and watch wrappers (#3504)