### PR TITLE
Add OnceCell and Lazy

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -458,7 +458,7 @@ cfg_sync! {
     pub mod watch;
 
     mod once_cell;
-    pub use self::once_cell::{OnceCell, OnceCellError, Lazy};
+    pub use self::once_cell::{OnceCell, NotInitializedError, AlreadyInitializedError, Lazy};
 }
 
 cfg_not_sync! {

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -456,6 +456,9 @@ cfg_sync! {
     pub(crate) use task::AtomicWaker;
 
     pub mod watch;
+
+    mod once_cell;
+    pub use self::once_cell::{OnceCell, OnceCellError, Lazy};
 }
 
 cfg_not_sync! {

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -17,8 +17,6 @@ use std::sync::atomic::{AtomicBool, Ordering};
 /// # Examples
 /// ```
 /// use tokio::sync::OnceCell;
-/// use std::pin::Pin;
-/// use std::future::Future;
 ///
 /// async fn some_computation() -> u32 {
 ///     1 + 1
@@ -259,8 +257,6 @@ impl Error for NotInitializedError {}
 /// # Examples
 /// ```
 /// use tokio::sync::Lazy;
-/// use std::pin::Pin;
-/// use std::future::Future;
 ///
 ///
 /// async fn some_computation() -> u32 {

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -1,0 +1,300 @@
+#![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
+
+use super::Semaphore;
+use crate::loom::cell::UnsafeCell;
+use std::cell::Cell;
+use std::fmt;
+use std::future::Future;
+use std::mem::MaybeUninit;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A thread-safe cell which can be written to only once.
+///
+/// Provides the functionality to set the value by using an async
+/// function via [`OnceCell::get_or_init`]
+///
+/// [`OnceCell::get_or_init`]: crate::sync::OnceCell::get_or_init
+///
+/// # Examples
+/// ```
+/// use tokio::sync::OnceCell;
+/// use std::pin::Pin;
+/// use std::future::Future;
+///
+/// async fn some_computation() -> u32 {
+///     1 + 1
+/// }
+///
+/// fn call_async_fn() -> Pin<Box<dyn Future<Output = u32> + Send>> {
+///     Box::pin(some_computation())
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     static ONCE: OnceCell<u32> = OnceCell::new();
+///     let result1 = tokio::spawn(async {
+///         ONCE.get_or_init(call_async_fn).await
+///     }).await.unwrap();
+///     assert_eq!(*result1, 2);
+/// }
+pub struct OnceCell<T> {
+    value_set: AtomicBool,
+    value: UnsafeCell<MaybeUninit<T>>,
+    sema: Semaphore,
+}
+
+impl<T> Default for OnceCell<T> {
+    fn default() -> OnceCell<T> {
+        OnceCell::new()
+    }
+}
+
+impl<T> fmt::Debug for OnceCell<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("OnceCell")
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl<T: Clone> Clone for OnceCell<T> {
+    fn clone(&self) -> OnceCell<T> {
+        let new_cell = OnceCell::new();
+        if let Ok(value) = self.get() {
+            match new_cell.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            }
+        }
+        new_cell
+    }
+}
+
+impl<T: PartialEq> PartialEq for OnceCell<T> {
+    fn eq(&self, other: &OnceCell<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T: Eq> Eq for OnceCell<T> {}
+
+impl<T> OnceCell<T> {
+    /// Creates a new uninitialized OnceCell instance.
+    pub const fn new() -> Self {
+        OnceCell {
+            value_set: AtomicBool::new(false),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+            sema: Semaphore::const_new(1),
+        }
+    }
+
+    fn initialized(&self) -> bool {
+        self.value_set.load(Ordering::Acquire)
+    }
+
+    fn set_to_initialized(&self) {
+        self.value_set.store(true, Ordering::Release);
+    }
+
+    unsafe fn get_unchecked(&self) -> &T {
+        &*self.value.with(|ptr| (*ptr).as_ptr())
+    }
+
+    unsafe fn set_value(&self, value: T) {
+        self.value.with_mut(|ptr| (*ptr).as_mut_ptr().write(value));
+    }
+
+    /// Tries to get a reference to the value of the OnceCell.
+    ///
+    /// Returns [`OnceCellError::NotInitialized`] if the value of the OnceCell
+    /// hasn't previously been initialized
+    ///
+    /// [`OnceCellError::NotInitialized`]: crate::sync::OnceCellError::NotInitialized
+    pub fn get(&self) -> Result<&T, OnceCellError> {
+        if self.initialized() {
+            Ok(unsafe { self.get_unchecked() })
+        } else {
+            Err(OnceCellError::NotInitialized)
+        }
+    }
+
+    /// Sets the value of the OnceCell to the argument value.
+    ///
+    /// If the value of the OnceCell was already set prior to this call, then
+    /// [`OnceCellError::AlreadyInitialized`] is returned
+    ///
+    /// [`OnceCellError::AlreadyInitialized`]: crate::sync::OnceCellError::AlreadyInitialized
+    pub fn set(&self, value: T) -> Result<(), OnceCellError> {
+        if !self.initialized() {
+            // After acquire().await we have either acquired a permit while self.value
+            // is still uninitialized, or another thread has intialized the value and
+            // closed the semaphore, in which case self.initialized is true and we
+            // don't set the value
+            match self.sema.try_acquire() {
+                Ok(_permit) => {
+                    if !self.initialized() {
+                        // SAFETY: There is only one permit on the semaphore, hence only one
+                        // mutable reference is created
+                        unsafe { self.set_value(value) };
+
+                        self.set_to_initialized();
+                        self.sema.close();
+                        return Ok(());
+                    } else {
+                        panic!("acquired the permit after OnceCell value was already initialized");
+                    }
+                }
+                _ => {
+                    if !self.initialized() {
+                        panic!(
+                            "couldn't acquire a permit even though OnceCell value is uninitialized"
+                        );
+                    }
+                }
+            }
+        }
+
+        Err(OnceCellError::AlreadyInitialized)
+    }
+
+    /// Tries to initialize the value of the OnceCell using the async function `f`.
+    /// If the value of the OnceCell had already been initialized prior to this call
+    /// a reference to that initialized value is returned
+    ///
+    /// This will deadlock if `f` tries to initialize the cell itself.
+    pub async fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: Fn() -> Pin<Box<dyn Future<Output = T> + Send>>,
+    {
+        if self.initialized() {
+            // SAFETY: once the value is initialized, no mutable references are given out, so
+            // we can give out arbitrarily many immutable references
+            return unsafe { self.get_unchecked() };
+        } else {
+            // After acquire().await we have either acquired a permit while self.value
+            // is still uninitialized, or current thread is awoken after another thread
+            // has intialized the value and closed the semaphore, in which case self.initialized
+            // is true and we don't set the value here
+            match self.sema.acquire().await {
+                Ok(_permit) => {
+                    if !self.initialized() {
+                        let value = f().await;
+
+                        // SAFETY: There is only one permit on the semaphore, hence only one
+                        // mutable reference is created
+                        unsafe { self.set_value(value) };
+
+                        // It's important that we close the semaphore only after set_to_initialized call
+                        // otherwise a waiting thread would be woken up and find an uninitialized
+                        // state after failing to acquire a permit, which causes a panic
+                        self.set_to_initialized();
+                        self.sema.close();
+
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        return unsafe { self.get_unchecked() };
+                    } else {
+                        panic!("acquired semaphore after value was already initialized");
+                    }
+                }
+                Err(_) => {
+                    if self.initialized() {
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        return unsafe { self.get_unchecked() };
+                    } else {
+                        panic!("semaphore acquire call failed when value not already intialized");
+                    }
+                }
+            }
+        }
+    }
+}
+
+unsafe impl<T: Sync + Send> Sync for OnceCell<T> {}
+unsafe impl<T: Send> Send for OnceCell<T> {}
+
+/// Error returned from the [`OnceCell::get`] and [`OnceCell::set`] methods
+///
+/// [`OnceCell::get`]: crate::sync::OnceCell::get
+/// [`OnceCell::set`]: crate::sync::OnceCell::set
+#[derive(Debug, PartialEq)]
+pub enum OnceCellError {
+    /// The value in OnceCell was already initialized
+    AlreadyInitialized,
+
+    /// The value in OnceCell was not previously initialized
+    NotInitialized,
+}
+
+/// Allows one to lazily call an async function
+///
+/// # Examples
+/// ```
+/// use tokio::sync::Lazy;
+/// use std::pin::Pin;
+/// use std::future::Future;
+///
+///
+/// async fn some_computation() -> u32 {
+///     1 + 1
+/// }
+///
+/// fn call_async_fn() -> Pin<Box<dyn Future<Output = u32> + Send>> {
+///     Box::pin(some_computation())
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     static LAZY : Lazy<u32> = Lazy::new(call_async_fn);
+///
+///     let result = tokio::spawn(async {
+///         LAZY.get().await
+///     }).await.unwrap();
+///     assert_eq!(*result, 2);
+/// }
+/// ```
+pub struct Lazy<T, F = fn() -> Pin<Box<dyn Future<Output = T> + Send>>> {
+    cell: OnceCell<T>,
+    init: Cell<Option<F>>,
+}
+
+impl<T, F> Lazy<T, F> {
+    /// Creates a new lazy value with the given initializing
+    /// async function.
+    pub const fn new(init: F) -> Lazy<T, F> {
+        Lazy {
+            cell: OnceCell::new(),
+            init: Cell::new(Some(init)),
+        }
+    }
+}
+
+impl<T, F: Fn() -> Pin<Box<dyn Future<Output = T> + Send>>> Lazy<T, F> {
+    /// On first call runs the function stored in Lazy and stores its return value.
+    /// Each subsequent call only returns the stored value.
+    pub async fn get(&self) -> &T {
+        let get_f = || match self.init.take() {
+            Some(f) => f(),
+            None => panic!(),
+        };
+
+        self.cell.get_or_init(get_f).await
+    }
+}
+
+impl<T: fmt::Debug, F> fmt::Debug for Lazy<T, F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Lazy")
+            .field("cell", &self.cell)
+            .field("init", &"..")
+            .finish()
+    }
+}
+
+// We never create a `&F` from a `&Lazy<T, F>` so it is fine
+// to not require a `Sync` bound on `F`
+unsafe impl<T, F: Send> Sync for Lazy<T, F> where OnceCell<T>: Sync {}
+
+unsafe impl<T, F: Send> Send for Lazy<T, F> where OnceCell<T>: Send {}

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -267,8 +267,8 @@ async_assert_fn!(tokio::sync::watch::Sender<u8>::closed(_): Send & Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Cell<u8>>::closed(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Rc<u8>>::closed(_): !Send & !Sync);
 
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
 async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
     _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -267,10 +267,10 @@ async_assert_fn!(tokio::sync::watch::Sender<u8>::closed(_): Send & Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Cell<u8>>::closed(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Rc<u8>>::closed(_): !Send & !Sync);
 
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
 async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
     _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
     _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::Lazy<u8>::get(_): Send & !Sync);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -271,11 +271,16 @@ async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
     _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
     _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::Lazy<u8>::get(_): Send & !Sync);
 async_assert_fn!(tokio::sync::Lazy<Cell<u8>>::get(_): !Send & !Sync);
+async_assert_fn!(tokio::sync::Lazy<Rc<u8>>::get(_): !Send & !Sync);
 assert_value!(tokio::sync::OnceCell<u8>: Send & Sync);
+assert_value!(tokio::sync::OnceCell<Cell<u8>>: Send & !Sync);
 assert_value!(tokio::sync::OnceCell<Rc<u8>>: !Send & !Sync);
 assert_value!(tokio::sync::Lazy<u8>: Send & Sync);
+assert_value!(tokio::sync::Lazy<Cell<u8>>: Send & !Sync);
 assert_value!(tokio::sync::Lazy<Rc<u8>>: !Send & !Sync);
 
 async_assert_fn!(tokio::task::LocalKey<u32>::scope(_, u32, BoxFutureSync<()>): Send & Sync);

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -3,7 +3,7 @@
 
 use tokio::runtime::Runtime;
 use tokio::sync::{AlreadyInitializedError, Lazy, NotInitializedError, OnceCell};
-use tokio::time::{pause, sleep, Duration, Instant};
+use tokio::time::{sleep, Duration, Instant};
 
 use std::future::Future;
 use std::pin::Pin;

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -1,0 +1,97 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::runtime::Runtime;
+use tokio::sync::{Lazy, OnceCell, OnceCellError};
+use tokio::time::sleep;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::time::{Duration, Instant};
+
+fn func1() -> Pin<Box<dyn Future<Output = u32> + Send>> {
+    async fn f() -> u32 {
+        5
+    }
+    Box::pin(f())
+}
+
+fn func2() -> Pin<Box<dyn Future<Output = u32> + Send>> {
+    async fn f() -> u32 {
+        sleep(Duration::from_secs(1)).await;
+        10
+    }
+    Box::pin(f())
+}
+
+#[test]
+fn get_or_init() {
+    let rt = Runtime::new().unwrap();
+
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    rt.block_on(async {
+        let result1 = rt
+            .spawn(async { ONCE.get_or_init(func1).await })
+            .await
+            .unwrap();
+
+        let result2 = rt
+            .spawn(async { ONCE.get_or_init(func2).await })
+            .await
+            .unwrap();
+
+        assert_eq!(*result1, 5);
+        assert_eq!(*result2, 5);
+    });
+}
+
+#[test]
+fn set_and_get() {
+    let rt = Runtime::new().unwrap();
+
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    rt.block_on(async {
+        let _ = rt.spawn(async { ONCE.set(5) }).await;
+        let value = ONCE.get().unwrap();
+        assert_eq!(*value, 5);
+    });
+}
+
+#[test]
+fn get_uninit() {
+    static ONCE: OnceCell<u32> = OnceCell::new();
+    let uninit = ONCE.get();
+    assert_eq!(uninit, Err(OnceCellError::NotInitialized));
+}
+
+#[test]
+fn set_twice() {
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    let first = ONCE.set(5);
+    assert_eq!(first, Ok(()));
+    let second = ONCE.set(6);
+    assert_eq!(second, Err(OnceCellError::AlreadyInitialized));
+}
+
+#[test]
+fn lazy() {
+    // func2 sleeps for 1 second
+    static LAZY: Lazy<u32> = Lazy::new(func2);
+    let rt = Runtime::new().unwrap();
+
+    rt.block_on(async {
+        let start_time1 = Instant::now();
+        let _result1 = rt.spawn(async { LAZY.get().await }).await;
+        let execution_time1 = Instant::now().duration_since(start_time1).as_secs();
+
+        let start_time2 = Instant::now();
+        let _result2 = rt.spawn(async { LAZY.get().await }).await;
+        let execution_time2 = Instant::now().duration_since(start_time2).as_secs();
+
+        assert!(execution_time1 >= 1);
+        assert!(execution_time2 < 1);
+    });
+}

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -2,7 +2,7 @@
 #![cfg(feature = "full")]
 
 use tokio::runtime::Runtime;
-use tokio::sync::{Lazy, OnceCell, OnceCellError};
+use tokio::sync::{AlreadyInitializedError, Lazy, NotInitializedError, OnceCell};
 use tokio::time::sleep;
 
 use std::future::Future;
@@ -63,7 +63,7 @@ fn set_and_get() {
 fn get_uninit() {
     static ONCE: OnceCell<u32> = OnceCell::new();
     let uninit = ONCE.get();
-    assert_eq!(uninit, Err(OnceCellError::NotInitialized));
+    assert_eq!(uninit, Err(NotInitializedError));
 }
 
 #[test]
@@ -73,7 +73,7 @@ fn set_twice() {
     let first = ONCE.set(5);
     assert_eq!(first, Ok(()));
     let second = ONCE.set(6);
-    assert_eq!(second, Err(OnceCellError::AlreadyInitialized));
+    assert_eq!(second, Err(AlreadyInitializedError));
 }
 
 #[test]

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -13,7 +13,7 @@ async fn func1() -> u32 {
 }
 
 async fn func2() -> u32 {
-    sleep(Duration::from_secs(1)).await;
+    sleep(Duration::from_millis(10)).await;
     10
 }
 
@@ -106,10 +106,9 @@ fn set_twice() {
 
 #[test]
 fn lazy() {
-    // func2 sleeps for 1 second
+    // func2 sleeps for 10ms
     static LAZY: Lazy<u32> = Lazy::new(func_lazy);
     let rt = Runtime::new().unwrap();
-    pause();
 
     rt.block_on(async {
         let start_time1 = Instant::now();


### PR DESCRIPTION
This PR adds versions of `std::lazy::OnceCell` and `std::lazy::Lazy` that allow one to initialize these objects with async functions. 

Fixes https://github.com/tokio-rs/tokio/issues/3482
