### PR TITLE
coop: allow disabling cooperative scheduling

### DIFF
--- a/tokio/src/runtime/blocking/shutdown.rs
+++ b/tokio/src/runtime/blocking/shutdown.rs
@@ -41,7 +41,7 @@ impl Receiver {
             return true;
         }
 
-        let mut e = match try_enter(false) {
+        let mut e = match try_enter(false, crate::coop::Budget::unconstrained()) {
             Some(enter) => enter,
             _ => {
                 if std::thread::panicking() {

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -1,3 +1,4 @@
+use crate::coop::Budget;
 use crate::runtime::{blocking, context, io, time, Spawner};
 use std::{error, fmt};
 
@@ -33,6 +34,9 @@ pub struct Handle {
 
     /// Blocking pool spawner
     pub(super) blocking_spawner: blocking::Spawner,
+
+    /// The coop_budget used by this handle when entering the runtime and blocking on tasks.
+    pub(super) coop_budget: Budget,
 }
 
 impl Handle {
@@ -273,7 +277,7 @@ cfg_rt_core! {
         ///
         pub fn block_on<F: Future>(&self, future: F) -> F::Output {
             self.enter(|| {
-                let mut enter = crate::runtime::enter(true);
+                let mut enter = crate::runtime::enter(true, self.coop_budget);
                 enter.block_on(future).expect("failed to park thread")
             })
         }


### PR DESCRIPTION
With deeply nested FuturesUnordered where most leaf futures are ready,
yields forced by the cooperative scheduling mechanism result in a lot of
useless polls when Tokio attempts to force a return to the runtime.

Indeed, it takes 32 useless polls to exit a single layer of
FuturesUnordered, so with e.g. 5 layers, it takes 32^5 polls (it doesn't
matter how many futures are in the FuturesUnordered instance since it'll
poll 32 times, even if it's the same future being polled 32 times). This
has to be done # total futures / 128 times, which can be a prohibitively
high amount of polling.

In our services, we've seen this result in ~50% of our CPU time being
spent in `wake_by_ref()` called by `poll_proceed`. Conversely, we've not
actually seen benefits from using cooperative scheduling, so turning it
off seems like a natural solution (in earlier conversations on other
issues related to cooperative scheduling, it was mentioned that the
Tokio team felt making it configurable could be good). 

This commit adds support for doing this in the runtime builder. It
targets the 2.x branch since that is the one we're currently using, but
I'm happy to port this to 1.x.
