### PR TITLE
File: Try doing a non-blocking read before punting to the threadpool

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -42,7 +42,7 @@ full = [
   "time",
 ]
 
-fs = []
+fs = ["libc"]
 io-util = ["memchr", "bytes"]
 # stdin, stdout, stderr
 io-std = []
@@ -103,11 +103,11 @@ parking_lot = { version = "0.11.0", optional = true }
 tracing = { version = "0.1.21", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.42", optional = true }
+libc = { version = "0.2.87", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-libc = { version = "0.2.42" }
+libc = { version = "0.2.87" }
 nix = { version = "0.19.0" }
 
 [target.'cfg(windows)'.dependencies.winapi]

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -22,6 +22,27 @@ async fn basic_read() {
 
     assert_eq!(n, HELLO.len());
     assert_eq!(&buf[..n], HELLO);
+
+    // Drop the data from the cache to stimulate uncached codepath on Linux (see preadv2 in
+    // file.rs)
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::io::AsRawFd;
+        nix::unistd::fsync(tempfile.as_raw_fd()).unwrap();
+        nix::fcntl::posix_fadvise(
+            tempfile.as_raw_fd(),
+            0,
+            0,
+            nix::fcntl::PosixFadviseAdvice::POSIX_FADV_DONTNEED,
+        )
+        .unwrap();
+    }
+
+    let mut file = File::open(tempfile.path()).await.unwrap();
+    let n = file.read(&mut buf).await.unwrap();
+
+    assert_eq!(n, HELLO.len());
+    assert_eq!(&buf[..n], HELLO);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

I saw [this](https://www.reddit.com/r/rust/comments/lg0a7b/benchmarking_tokio_tasks_and_goroutines/) on the rust subreddit and I wondered if `preadv2(..., RWF_NOWAIT)` would help.

## Solution

Try doing a non-blocking read before punting to the threadpool on Linux.

If the data is already available in cache this will avoid cross-thread interaction and remove a copy.  It should help with latency too as reads that can be satisfied now won't need to wait in queue until other fs operations are complete.

According to my basic testing it helps. The benchmark I ran was https://github.com/wmanley/tokio-fs-bench which is based on the gist from the reddit thread above. On my laptop with the frequency scaling disabled I get 32s with this change and 42s without.  For comparison the rust_block_in_place implementation runs in 11s.

So it's faster in this micro-benchmark, but it would be good to see if it actually helps with representative workloads.  Perhaps you can suggest something?

~~The implementation is a bit rough-and-ready.  It requires an [unreleased libc](https://github.com/rust-lang/libc/pull/2066) and currently it'll only work on glibc.~~ I wanted to raise it early to get feedback as to whether the work is worthwhile in the first place.

**TODO:**

- [x] Resolve linker failures when compiling against old glibc which predate `preadv2`
- [x] Copy definition of `RWF_NOWAIT` too
- [x] Add tests for `preadv2_safe`, particularly around uninitialised data handling.
- [x] Comment why we're using the syscall directly