### PR TITLE
Doc aliases for pre-1.0 function names

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -519,6 +519,8 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     /// create this `AsyncFdReadyGuard`.
     ///
     /// [`WouldBlock`]: std::io::ErrorKind::WouldBlock
+    // Alias for old name in 0.x
+    #[cfg_attr(docsrs, doc(alias = "with_io"))]
     pub fn try_io<R>(
         &mut self,
         f: impl FnOnce(&AsyncFd<Inner>) -> io::Result<R>,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -233,6 +233,12 @@ impl Builder {
     /// # Panic
     ///
     /// This will panic if `val` is not larger than `0`.
+    ///
+    /// # Upgrading from 0.x
+    ///
+    /// In old versions `max_threads` limited both blocking and worker threads, but the
+    /// current `max_blocking_threads` does not include async worker threads in the count.
+    #[cfg_attr(docsrs, doc(alias = "max_threads"))]
     pub fn max_blocking_threads(&mut self, val: usize) -> &mut Self {
         assert!(val > 0, "Max blocking threads cannot be set to 0");
         self.max_blocking_threads = val;

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -312,6 +312,8 @@ impl Notify {
     ///     notify.notify_one();
     /// }
     /// ```
+    // Alias for old name in 0.x
+    #[cfg_attr(docsrs, doc(alias = "notify"))]
     pub fn notify_one(&self) {
         // Load the current state
         let mut curr = self.state.load(SeqCst);

--- a/tokio/src/time/driver/sleep.rs
+++ b/tokio/src/time/driver/sleep.rs
@@ -16,6 +16,8 @@ use std::task::{self, Poll};
 ///
 /// Canceling a sleep instance is done by dropping the returned future. No additional
 /// cleanup work is required.
+// Alias for old name in 0.x
+#[cfg_attr(docsrs, doc(alias = "delay_until"))]
 pub fn sleep_until(deadline: Instant) -> Sleep {
     Sleep::new_timeout(deadline)
 }
@@ -53,6 +55,8 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 /// ```
 ///
 /// [`interval`]: crate::time::interval()
+// Alias for old name in 0.x
+#[cfg_attr(docsrs, doc(alias = "delay_for"))]
 pub fn sleep(duration: Duration) -> Sleep {
     sleep_until(Instant::now() + duration)
 }


### PR DESCRIPTION
To aid migration from 0.x:

<img width="346" alt="Screen Shot 2021-02-14 at 14 35 27" src="https://user-images.githubusercontent.com/72159/107879653-08842e80-6ed2-11eb-81a5-e388bfc9b182.png">
