### PR TITLE
doc: rename notify to notify_one

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -349,7 +349,7 @@ impl Notify {
     /// Notifies all waiting tasks
     ///
     /// If a task is currently waiting, that task is notified. Unlike with
-    /// `notify()`, no permit is stored to be used by the next call to
+    /// `notify_one()`, no permit is stored to be used by the next call to
     /// [`notified().await`]. The purpose of this method is to notify all
     /// already registered waiters. Registering for notification is done by
     /// acquiring an instance of the `Notified` future via calling `notified()`.

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -350,7 +350,7 @@ impl Notify {
     ///
     /// If a task is currently waiting, that task is notified. Unlike with
     /// `notify_one()`, no permit is stored to be used by the next call to
-    /// [`notified().await`]. The purpose of this method is to notify all
+    /// `notified().await`. The purpose of this method is to notify all
     /// already registered waiters. Registering for notification is done by
     /// acquiring an instance of the `Notified` future via calling `notified()`.
     ///


### PR DESCRIPTION
there is no more method `notify`, it has been renamed to `notify_one`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
