### PR TITLE
sync: add same_channel method to mpsc Senders

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -16,6 +16,7 @@ use std::task::{Context, Poll};
 /// Send values to the associated `Receiver`.
 ///
 /// Instances are created by the [`channel`](channel) function.
+#[derive(PartialEq, Eq)]
 pub struct Sender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -38,6 +39,7 @@ pub struct Permit<'a, T> {
 /// This receiver can be turned into a `Stream` using [`ReceiverStream`].
 ///
 /// [`ReceiverStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.ReceiverStream.html
+#[derive(PartialEq, Eq)]
 pub struct Receiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -700,6 +700,15 @@ impl<T> Sender<T> {
     }
 
     /// Returns `true` if senders belong to the same channel.
+    ///
+    /// ```
+    /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(1);
+    /// let  tx2 = tx.clone();
+    /// assert!(tx.same_channel(&tx2));
+    ///
+    /// let (tx3, rx3) = tokio::sync::mpsc::channel::<()>(1);
+    /// assert!(!tx3.same_channel(&tx2));
+    /// ```
     pub fn same_channel(&self, other: &Self) -> bool {
         self.chan.same_channel(&other.chan)
     }

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -16,7 +16,6 @@ use std::task::{Context, Poll};
 /// Send values to the associated `Receiver`.
 ///
 /// Instances are created by the [`channel`](channel) function.
-#[derive(PartialEq, Eq)]
 pub struct Sender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -39,7 +38,6 @@ pub struct Permit<'a, T> {
 /// This receiver can be turned into a `Stream` using [`ReceiverStream`].
 ///
 /// [`ReceiverStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.ReceiverStream.html
-#[derive(PartialEq, Eq)]
 pub struct Receiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,
@@ -699,6 +697,11 @@ impl<T> Sender<T> {
         }
 
         Ok(Permit { chan: &self.chan })
+    }
+
+    /// Returns `true` if senders belong to the same channel.
+    pub fn same_channel(&self, other: &Self) -> bool {
+        self.chan.same_channel(&other.chan)
     }
 }
 

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -701,6 +701,8 @@ impl<T> Sender<T> {
 
     /// Returns `true` if senders belong to the same channel.
     ///
+    /// # Examples
+    ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::channel::<()>(1);
     /// let  tx2 = tx.clone();

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -22,14 +22,6 @@ impl<T, S: fmt::Debug> fmt::Debug for Tx<T, S> {
     }
 }
 
-impl<T, S> PartialEq for Tx<T, S> {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
-    }
-}
-
-impl<T, S> Eq for Tx<T, S> {}
-
 /// Channel receiver
 pub(crate) struct Rx<T, S: Semaphore> {
     inner: Arc<Chan<T, S>>,
@@ -40,14 +32,6 @@ impl<T, S: Semaphore + fmt::Debug> fmt::Debug for Rx<T, S> {
         fmt.debug_struct("Rx").field("inner", &self.inner).finish()
     }
 }
-
-impl<T, S: Semaphore> PartialEq for Rx<T, S> {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.inner, &other.inner)
-    }
-}
-
-impl<T, S: Semaphore> Eq for Rx<T, S> {}
 
 pub(crate) trait Semaphore {
     fn is_idle(&self) -> bool;
@@ -154,6 +138,11 @@ impl<T, S> Tx<T, S> {
     /// Wake the receive half
     pub(crate) fn wake_rx(&self) {
         self.inner.rx_waker.wake();
+    }
+
+    /// Returns `true` if senders belong to the same channel.
+    pub(crate) fn same_channel(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
     }
 }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -22,6 +22,14 @@ impl<T, S: fmt::Debug> fmt::Debug for Tx<T, S> {
     }
 }
 
+impl<T, S> PartialEq for Tx<T, S> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl<T, S> Eq for Tx<T, S> {}
+
 /// Channel receiver
 pub(crate) struct Rx<T, S: Semaphore> {
     inner: Arc<Chan<T, S>>,
@@ -32,6 +40,14 @@ impl<T, S: Semaphore + fmt::Debug> fmt::Debug for Rx<T, S> {
         fmt.debug_struct("Rx").field("inner", &self.inner).finish()
     }
 }
+
+impl<T, S: Semaphore> PartialEq for Rx<T, S> {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.inner, &other.inner)
+    }
+}
+
+impl<T, S: Semaphore> Eq for Rx<T, S> {}
 
 pub(crate) trait Semaphore {
     fn is_idle(&self) -> bool;

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -293,6 +293,15 @@ impl<T> UnboundedSender<T> {
     }
 
     /// Returns `true` if senders belong to the same channel.
+    ///
+    /// ```
+    /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+    /// let  tx2 = tx.clone();
+    /// assert!(tx.same_channel(&tx2));
+    ///
+    /// let (tx3, rx3) = tokio::sync::mpsc::unbounded_channel::<()>();
+    /// assert!(!tx3.same_channel(&tx2));
+    /// ```
     pub fn same_channel(&self, other: &Self) -> bool {
         self.chan.same_channel(&other.chan)
     }

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -9,6 +9,7 @@ use std::task::{Context, Poll};
 ///
 /// Instances are created by the
 /// [`unbounded_channel`](unbounded_channel) function.
+#[derive(PartialEq, Eq)]
 pub struct UnboundedSender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -37,6 +38,7 @@ impl<T> fmt::Debug for UnboundedSender<T> {
 /// This receiver can be turned into a `Stream` using [`UnboundedReceiverStream`].
 ///
 /// [`UnboundedReceiverStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.UnboundedReceiverStream.html
+#[derive(PartialEq, Eq)]
 pub struct UnboundedReceiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -294,6 +294,8 @@ impl<T> UnboundedSender<T> {
 
     /// Returns `true` if senders belong to the same channel.
     ///
+    /// # Examples
+    ///
     /// ```
     /// let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<()>();
     /// let  tx2 = tx.clone();

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -9,7 +9,6 @@ use std::task::{Context, Poll};
 ///
 /// Instances are created by the
 /// [`unbounded_channel`](unbounded_channel) function.
-#[derive(PartialEq, Eq)]
 pub struct UnboundedSender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -38,7 +37,6 @@ impl<T> fmt::Debug for UnboundedSender<T> {
 /// This receiver can be turned into a `Stream` using [`UnboundedReceiverStream`].
 ///
 /// [`UnboundedReceiverStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.UnboundedReceiverStream.html
-#[derive(PartialEq, Eq)]
 pub struct UnboundedReceiver<T> {
     /// The channel receiver
     chan: chan::Rx<T, Semaphore>,
@@ -292,5 +290,10 @@ impl<T> UnboundedSender<T> {
     /// ```
     pub fn is_closed(&self) -> bool {
         self.chan.is_closed()
+    }
+
+    /// Returns `true` if senders belong to the same channel.
+    pub fn same_channel(&self, other: &Self) -> bool {
+        self.chan.same_channel(&other.chan)
     }
 }


### PR DESCRIPTION
## Motivation
Sometimes we need to check if two senders belongs to the same channel.

## Solution

Just use Arc::ptr_eq to impl PartialEq and Eq.