### PR TITLE
doc: Sync interval.rs and time/mod.rs docs

### DIFF
--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -56,10 +56,10 @@
 //!
 //! A simple example using [`interval`] to execute a task every two seconds.
 //!
-//! The difference between [`interval`] and [`sleep`] is that an
-//! [`interval`] measures the time since the last tick, which means that
-//! `.tick().await` may wait for a shorter time than the duration specified
-//! for the interval if some time has passed between calls to `.tick().await`.
+//! The difference between [`interval`] and [`sleep`] is that an [`interval`]
+//! measures the time since the last tick, which means that `.tick().await`
+//! may wait for a shorter time than the duration specified for the interval
+//! if some time has passed between calls to `.tick().await`.
 //!
 //! If the tick in the example below was replaced with [`sleep`], the task
 //! would only be executed once every three seconds, and not every two
@@ -75,11 +75,9 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let interval = time::interval(time::Duration::from_secs(2));
-//!     tokio::pin!(interval);
-//!
+//!     let mut interval = time::interval(time::Duration::from_secs(2));
 //!     for _i in 0..5 {
-//!         interval.as_mut().tick().await;
+//!         interval.tick().await;
 //!         task_that_takes_a_second().await;
 //!     }
 //! }


### PR DESCRIPTION
## Motivation

It's confusing to see two slightly different documentations for the same function.

## Solution

I copied the text from interval.rs into the module documentation.
