### PR TITLE
Add acquire_many_owned and try_acquire_many_owned to tokio::sync::Semaphore

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -143,7 +143,7 @@ impl Semaphore {
         }
     }
 
-    /// Tries to acquire n permits from the semaphore.
+    /// Tries to acquire `n` permits from the semaphore.
     ///
     /// If the semaphore has been closed, this returns a [`TryAcquireError::Closed`]
     /// and a [`TryAcquireError::NoPermits`] if there are no permits left. Otherwise,
@@ -180,6 +180,24 @@ impl Semaphore {
         })
     }
 
+    /// Acquires `n` permits from the semaphore.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method.
+    /// If the semaphore has been closed, this returns an [`AcquireError`].
+    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// acquired permit.
+    ///
+    /// [`Arc`]: std::sync::Arc
+    /// [`AcquireError`]: crate::sync::AcquireError
+    /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
+    pub async fn acquire_many_owned(self: Arc<Self>, n: u32) -> Result<OwnedSemaphorePermit, AcquireError> {
+        self.ll_sem.acquire(n).await?;
+        Ok(OwnedSemaphorePermit {
+            sem: self,
+            permits: n,
+        })
+    }
+
     /// Tries to acquire a permit from the semaphore.
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method. If
@@ -197,6 +215,28 @@ impl Semaphore {
             Ok(_) => Ok(OwnedSemaphorePermit {
                 sem: self,
                 permits: 1,
+            }),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Tries to acquire `n` permits from the semaphore.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method. If
+    /// the semaphore has been closed, this returns a [`TryAcquireError::Closed`]
+    /// and a [`TryAcquireError::NoPermits`] if there are no permits left.
+    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// acquired permit.
+    ///
+    /// [`Arc`]: std::sync::Arc
+    /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
+    /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
+    /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
+    pub fn try_acquire_many_owned(self: Arc<Self>, n: u32) -> Result<OwnedSemaphorePermit, TryAcquireError> {
+        match self.ll_sem.try_acquire(n) {
+            Ok(_) => Ok(OwnedSemaphorePermit {
+                sem: self,
+                permits: n,
             }),
             Err(e) => Err(e),
         }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -190,7 +190,10 @@ impl Semaphore {
     /// [`Arc`]: std::sync::Arc
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
-    pub async fn acquire_many_owned(self: Arc<Self>, n: u32) -> Result<OwnedSemaphorePermit, AcquireError> {
+    pub async fn acquire_many_owned(
+        self: Arc<Self>,
+        n: u32,
+    ) -> Result<OwnedSemaphorePermit, AcquireError> {
         self.ll_sem.acquire(n).await?;
         Ok(OwnedSemaphorePermit {
             sem: self,
@@ -232,7 +235,10 @@ impl Semaphore {
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
     /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
     /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
-    pub fn try_acquire_many_owned(self: Arc<Self>, n: u32) -> Result<OwnedSemaphorePermit, TryAcquireError> {
+    pub fn try_acquire_many_owned(
+        self: Arc<Self>,
+        n: u32,
+    ) -> Result<OwnedSemaphorePermit, TryAcquireError> {
         match self.ll_sem.try_acquire(n) {
             Ok(_) => Ok(OwnedSemaphorePermit {
                 sem: self,

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -16,6 +16,22 @@ fn try_acquire() {
     assert!(p3.is_ok());
 }
 
+#[test]
+fn try_acquire_many() {
+    let sem = Arc::new(Semaphore::new(42));
+    {
+        let p1 = sem.clone().try_acquire_many_owned(42);
+        assert!(p1.is_ok());
+        let p2 = sem.clone().try_acquire_owned();
+        assert!(p2.is_err());
+    }
+    let p3 = sem.clone().try_acquire_many_owned(32);
+    assert!(p3.is_ok());
+    let p4 = sem.clone().try_acquire_many_owned(10);
+    assert!(p4.is_ok());
+    assert!(sem.try_acquire_owned().is_err());
+}
+
 #[tokio::test]
 async fn acquire() {
     let sem = Arc::new(Semaphore::new(1));
@@ -26,6 +42,21 @@ async fn acquire() {
     });
     drop(p1);
     j.await.unwrap();
+}
+
+#[tokio::test]
+async fn acquire_many() {
+    let semaphore = Arc::new(Semaphore::new(42));
+    let permit32 = semaphore.clone().try_acquire_many_owned(32).unwrap();
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let join_handle = tokio::spawn(async move {
+        let _permit10 = semaphore.clone().acquire_many_owned(10).await;
+        sender.send(());
+        let _permit32 = semaphore.acquire_many_owned(32).await;
+    });
+    receiver.await;
+    drop(permit32);
+    join_handle.await.unwrap();
 }
 
 #[tokio::test]

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -50,9 +50,9 @@ async fn acquire_many() {
     let permit32 = semaphore.clone().try_acquire_many_owned(32).unwrap();
     let (sender, receiver) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn(async move {
-        let _permit10 = semaphore.clone().acquire_many_owned(10).await;
-        sender.send(());
-        let _permit32 = semaphore.acquire_many_owned(32).await;
+        let _permit10 = semaphore.clone().acquire_many_owned(10).await.unwrap();
+        sender.send(()).unwrap();
+        let _permit32 = semaphore.acquire_many_owned(32).await.unwrap();
     });
     receiver.await.unwrap();
     drop(permit32);

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -54,7 +54,7 @@ async fn acquire_many() {
         sender.send(());
         let _permit32 = semaphore.acquire_many_owned(32).await;
     });
-    receiver.await;
+    receiver.await.unwrap();
     drop(permit32);
     join_handle.await.unwrap();
 }


### PR DESCRIPTION
## Motivation

There are `owned` methods for acquiring single permits, but for multiple ones they are missing.

## Solution

Therefore I added them :slightly_smiling_face: 

~~I didn't add tests because I couldn't find any for `acquire_many` and `try_acquire_many` in the first place, and because I couldn't successfully compile the tests locally at all.~~

Tests are now added.