### PR TITLE
doc: note the EOF behaviour of `read_until`

### DIFF
--- a/tokio/src/io/util/async_buf_read_ext.rs
+++ b/tokio/src/io/util/async_buf_read_ext.rs
@@ -23,6 +23,8 @@ cfg_io_util! {
         ///
         /// If successful, this function will return the total number of bytes read.
         ///
+        /// If this function returns `Ok(0)`, the stream has reached EOF.
+        ///
         /// # Errors
         ///
         /// This function will ignore all instances of [`ErrorKind::Interrupted`] and


### PR DESCRIPTION
This is completely stolen from the `read_line` documentation.

My motivation here is that this tripped me up after a quick skim of the documentation: it's obvious in retrospect that `read_until` would have the same behaviour as `read_line`, but I ended up with a loop taking 100% CPU as a result of not handling the `Ok(0)` case correctly!