### PR TITLE
DerefPinMut

### DIFF
--- a/tokio/src/io/deref_pin.rs
+++ b/tokio/src/io/deref_pin.rs
@@ -1,0 +1,29 @@
+use std::ops::{Deref, DerefMut};
+use std::pin::Pin;
+
+/// Similar to `DerefMut`, but dereferences `Pin` to `Pin`.
+pub trait DerefPinMut: Deref {
+    /// Deref.
+    fn deref_pin(self: Pin<&mut Self>) -> Pin<&mut Self::Target>;
+}
+
+impl<T: ?Sized + Unpin> DerefPinMut for &mut T {
+    fn deref_pin(self: Pin<&mut Self>) -> Pin<&mut T> {
+        Pin::new(&mut *self.get_mut())
+    }
+}
+
+impl<T: ?Sized + Unpin> DerefPinMut for Box<T> {
+    fn deref_pin(self: Pin<&mut Self>) -> Pin<&mut T> {
+        Pin::new(&mut *self.get_mut())
+    }
+}
+
+impl<P> DerefPinMut for Pin<P>
+where
+    P: DerefMut + Unpin,
+{
+    fn deref_pin(self: Pin<&mut Self>) -> Pin<&mut P::Target> {
+        self.get_mut().as_mut()
+    }
+}

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -184,6 +184,9 @@ cfg_io_blocking! {
     pub(crate) mod blocking;
 }
 
+mod deref_pin;
+pub use deref_pin::DerefPinMut;
+
 mod async_buf_read;
 pub use self::async_buf_read::AsyncBufRead;
 

--- a/tokio/tests/io_deref_pin_mut.rs
+++ b/tokio/tests/io_deref_pin_mut.rs
@@ -1,0 +1,31 @@
+use std::ops::Deref;
+use tokio::io::{AsyncRead, DerefPinMut};
+use tokio::macros::support::Pin;
+
+struct MyBox<A>(Box<A>);
+
+impl<A> Deref for MyBox<A> {
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}
+
+impl<A> DerefPinMut for MyBox<A>
+where
+    A: AsyncRead + Unpin,
+{
+    fn deref_pin(self: Pin<&mut Self>) -> Pin<&mut Self::Target> {
+        Pin::new(&mut self.get_mut().0)
+    }
+}
+
+fn _accepts_read<A: AsyncRead>(_: A) {}
+
+fn _accepts_box<A: AsyncRead + Unpin>(b: MyBox<A>) {
+    _accepts_read(b);
+}
+
+#[test]
+fn test_deref_pin_mut_can_be_implemented_for_custom_type_to_aquire_async_read() {}


### PR DESCRIPTION
Introduce `DerefPinMut` trait. It is similar to `DerefMut`, but
dereferences `Pin<&mut Self>` to `Pin<&mut Self::Target>`.

There are two reasons to do that:

* removal of copy-paste and macros in tokio implementation
  (this commit diffstat is 62 insertions(+), 126 deletions(-) excluding added test)
* ability to reuse this delegation implementation in user crates

The latter was my motivation for this commit. I have a couple
Box-like wrappers to traits, and implementing this delegation is
tedious and error-prone.

If tokio implement `AsyncWrite`, `AsyncRead` and friends for
`DerefPinMut`, then I could only implement `DerefPinMut` in my crate
and get all `Async` trait implementations for free.