### PR TITLE
rt: add Handle::block_on

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -201,6 +201,18 @@ impl Handle {
         let _ = self.blocking_spawner.spawn(task, &self);
         handle
     }
+
+    /// TODO: write docs if this is a good direction
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        // Enter the **runtime** context. This configures spawning, the current I/O driver, ...
+        let _rt_enter = self.enter();
+
+        // Enter a **blocking** context. This prevents blocking from a runtime.
+        let mut _blocking_enter = crate::runtime::enter(true);
+
+        // Block on the future
+        _blocking_enter.block_on(future).expect("failed to park thread")
+    }
 }
 
 /// Error returned by `try_current` when no Runtime has been started


### PR DESCRIPTION
Add `runtime::Handle::block_on`. The function enters the runtime context and blocks the current thread while the future executes. This strategy does not do anything special with the `current_thread` runtime. If there is no thread "driving" the runtime, then neither spawned tasks nor I/O resources will not make progress. To avoid this, it is recommended to use the multi-threaded scheduler (perhaps w/ core-threads set to 1).

This is a draft PR to demonstrate the direction. Before merging, the PR would need API documentation and tests.

Refs: #3097
Fixes #2965, #3096

cc @stuhood, @Keruspe