### PR TITLE
Do not panic on timeout(Duration::MAX)

### DIFF
--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -54,6 +54,14 @@ impl Instant {
         Instant { std }
     }
 
+    pub(crate) fn far_future() -> Instant {
+        // Roughly 30 years from now.
+        // API does not provide a way to obtain max `Instant`
+        // or convert specific date in the future to instant.
+        // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
+        Self::now() + Duration::from_secs(86400 * 365 * 30)
+    }
+
     /// Convert the value into a `std::time::Instant`.
     pub fn into_std(self) -> std::time::Instant {
         self.std

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -49,7 +49,11 @@ pub fn timeout<T>(duration: Duration, future: T) -> Timeout<T>
 where
     T: Future,
 {
-    let delay = Sleep::new_timeout(Instant::now() + duration);
+    let deadline = Instant::now().checked_add(duration);
+    let delay = match deadline {
+        Some(deadline) => Sleep::new_timeout(deadline),
+        None => Sleep::far_future(),
+    };
     Timeout::new_with_delay(future, delay)
 }
 


### PR DESCRIPTION
It is tempting to use very large `Duration` value to get a practically
infinite timeout.

Before this commit tokio panics on checked Instant + Duration
overflow.

This commit implements very simple fix: if Instant + Duration
overflows, we use duration = 30 years. Better fix should avoid
firing a timer on duration overflow. It requires deeper understanding
how timers work, but also it is not clear, for example, what
`Sleep::deadline` function should return.

Similar fix is done for `sleep`.