### PR TITLE
Bug fix subsequent calls to lines codec decode does not return the desired results

### DIFF
--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -133,7 +133,7 @@ impl Decoder for LinesCodec {
                     buf.advance(read_to);
                     self.next_index = 0;
                     if buf.is_empty() {
-                        return Err(LinesCodecError::MaxLineLengthExceeded);
+                        return Ok(None);
                     }
                 }
                 (false, Some(offset)) => {

--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -133,7 +133,7 @@ impl Decoder for LinesCodec {
                     buf.advance(read_to);
                     self.next_index = 0;
                     if buf.is_empty() {
-                        return Ok(None);
+                        return Err(LinesCodecError::MaxLineLengthExceeded);
                     }
                 }
                 (false, Some(offset)) => {

--- a/tokio-util/tests/codecs.rs
+++ b/tokio-util/tests/codecs.rs
@@ -201,26 +201,7 @@ fn lines_decoder_discard_repeat() {
     buf.put_slice(b"aa");
     assert!(codec.decode(buf).is_err());
     buf.put_slice(b"a");
-    assert_eq!(None, codec.decode(buf).unwrap());
-}
-
-// Regression test for [subsequent calls to LinesCodec decode does not return the desired results bug](https://github.com/tokio-rs/tokio/issues/3555)
-#[test]
-fn lines_decoder_max_length_underrun_twice() {
-    const MAX_LENGTH: usize = 11;
-
-    let mut codec = LinesCodec::new_with_max_length(MAX_LENGTH);
-    let buf = &mut BytesMut::new();
-
-    buf.reserve(200);
-    buf.put_slice(b"line ");
-    assert_eq!(None, codec.decode(buf).unwrap());
-    buf.put_slice(b"too very l");
     assert!(codec.decode(buf).is_err());
-    buf.put_slice(b"aaaaaaaaaaaaaaaaaaaaaaa");
-    assert_eq!(None, codec.decode(buf).unwrap());
-    buf.put_slice(b"ong\nshort\n");
-    assert_eq!("short", codec.decode(buf).unwrap().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

Fix bug on LinesCodec as described [here](https://github.com/tokio-rs/tokio/issues/3555)

## Solution

return Ok(None) instead of Err(LinesCodecError::MaxLineLengthExceeded)
