### PR TITLE
Fix docs.rs build with cfg(docsrs)

### DIFF
--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -20,7 +20,6 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Stream utilities for Tokio.
 //!


### PR DESCRIPTION
## Motivation

For crates which set `rustc-args = ["--cfg", "docsrs"] ` in `[package.metadata.docs.rs]`, tokio-stream fails to build on docs.rs with

```
[INFO] [stderr]    Compiling tokio-stream v0.1.3
[INFO] [stderr] error[E0636]: the feature `doc_cfg` has already been declared
[INFO] [stderr]   --> /opt/rustwide/cargo-home/registry/src/github.com-1ecc6299db9ec823/tokio-stream-0.1.3/src/lib.rs:24:29
[INFO] [stderr]    |
[INFO] [stderr] 24 | #![cfg_attr(docsrs, feature(doc_cfg))]
[INFO] [stderr]    |                             ^^^^^^^
```

## Solution

Remove duplicate `cfg_attr` line 

The first occurence is on https://github.com/tokio-rs/tokio/blob/master/tokio-stream/src/lib.rs#L17