### PR TITLE
Fix link to std src in util

### DIFF
--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -77,7 +77,7 @@ cfg_io_util! {
 
 
     // used by `BufReader` and `BufWriter`
-    // https://github.com/rust-lang/rust/blob/master/src/libstd/sys_common/io.rs#L1
+    // https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/io.rs#L1
     const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 }
 


### PR DESCRIPTION
The big move or 'src' in rust-lang caused this link to be broken

