### PR TITLE
rt: add Handle::block_on

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -315,7 +315,7 @@ impl Handle {
 
     pub(crate) fn is_shutdown(&self) -> bool {
         if let Some(inner) = self.inner.upgrade() {
-            inner.is_shutdown.load(Ordering::SeqCst)
+            inner.is_shutdown()
         } else {
             // if the inner type has been dropped then its `Drop` impl will have been called which
             // sets `Inner.is_shutdown` to `true`. So therefore it must have been shutdown.
@@ -365,6 +365,10 @@ impl Inner {
     /// Deregisters an I/O resource from the reactor.
     pub(super) fn deregister_source(&self, source: &mut impl mio::event::Source) -> io::Result<()> {
         self.registry.deregister(source)
+    }
+
+    pub(super) fn is_shutdown(&self) -> bool {
+        self.is_shutdown.load(Ordering::SeqCst)
     }
 }
 

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -235,7 +235,10 @@ cfg_io_readiness! {
 
             crate::future::poll_fn(|cx| {
                 if self.handle.inner().is_none() {
-                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "reactor gone")));
+                    return Poll::Ready(Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR
+                    )));
                 }
 
                 Pin::new(&mut fut).poll(cx).map(Ok)

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -241,7 +241,8 @@ cfg_io_readiness! {
             pin!(fut);
 
             crate::future::poll_fn(|cx| {
-                if self.handle.inner().is_none() || self.handle.is_shutdown() {
+                let inner = self.handle.inner();
+                if inner.is_none() || inner.filter(|i| i.is_shutdown()).is_some() {
                     return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "reactor gone")));
                 }
 

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -56,7 +56,7 @@ unsafe impl Sync for Registration {}
 
 impl Registration {
     /// Registers the I/O resource with the default reactor, for a specific
-    /// `Interest`. `new_with_interest` should be ucrate::util::error::RUNTIME_SHUTTING_DOWN_ERRORsed over `new` when you need
+    /// `Interest`. `new_with_interest` should be used over `new` when you need
     /// control over the readiness state, such as when a file descriptor only
     /// allows reads. This does not add `hup` or `error` so if you are
     /// interested in those states, you will need to add them to the readiness

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -71,13 +71,6 @@ impl Registration {
         interest: Interest,
         handle: Handle,
     ) -> io::Result<Registration> {
-        if handle.is_shutdown() {
-            return Err(io::Error::new(
-                io::ErrorKind::Other,
-                crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR,
-            ));
-        }
-
         let shared = if let Some(inner) = handle.inner() {
             inner.add_source(io, interest)?
         } else {
@@ -241,8 +234,7 @@ cfg_io_readiness! {
             pin!(fut);
 
             crate::future::poll_fn(|cx| {
-                let inner = self.handle.inner();
-                if inner.is_none() || inner.filter(|i| i.is_shutdown()).is_some() {
+                if self.handle.inner().is_none() {
                     return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "reactor gone")));
                 }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -212,7 +212,17 @@ impl Handle {
         let mut _blocking_enter = crate::runtime::enter(true);
 
         // Block on the future
-        _blocking_enter.block_on(future).expect("failed to park thread")
+        _blocking_enter
+            .block_on(future)
+            .expect("failed to park thread")
+    }
+
+    pub(crate) fn shutdown(mut self) {
+        self.spawner.shutdown();
+
+        if let Some(io_handle) = self.io_handle {
+            io_handle.shutdown();
+        }
     }
 }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -247,6 +247,8 @@ impl Handle {
     /// Or using `Handle::current`:
     ///
     /// ```no_run
+    /// use tokio::runtime::Handle;
+    ///
     /// #[tokio::main]
     /// async fn main () {
     ///     // Get a handle to the current runtime and execute the future, blocking

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -217,20 +217,8 @@ impl Handle {
             .expect("failed to park thread")
     }
 
-    cfg_io_driver! {
-        pub(crate) fn shutdown(mut self) {
-            self.spawner.shutdown();
-
-            if let Some(io_handle) = self.io_handle {
-                io_handle.shutdown();
-            }
-        }
-    }
-
-    cfg_not_io_driver! {
-        pub(crate) fn shutdown(mut self) {
-            self.spawner.shutdown();
-        }
+    pub(crate) fn shutdown(mut self) {
+        self.spawner.shutdown();
     }
 }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -218,38 +218,8 @@ impl Handle {
     /// If the `Handle`'s associated `Runtime` has been shut down (through
     /// [`Runtime::shutdown_background`], [`Runtime::shutdown_timeout`], or by
     /// dropping it) and `Handle::block_on` is used it might return an error or
-    /// panic. The exact behavior depends on the types of futures used.
-    ///
-    /// ## Runtime independent futures
-    ///
-    /// Runtime independent futures will run as normal. They are not affected by
-    /// shutdown. This includes, but is not limited to, channels, signals, and
-    /// basic futures that don't actually `await` anything.
-    ///
-    /// ## [`spawn_blocking`] futures
-    ///
-    /// Futures created with [`spawn_blocking`] will run if they were started
-    /// before the runtime was shut down. If they were created after the runtime
-    /// was shut down they will get cancelled and the [`JoinHandle`] will return
-    /// a [`JoinError`].
-    ///
-    /// ## File system futures
-    ///
-    /// File system futures created by something in [`tokio::fs`] behave
-    /// similarly to [`spawn_blocking`] futures. They will run if started before
-    /// shutdown but fail with an error if started after shutdown.
-    ///
-    /// ## I/O future
-    ///
-    /// I/O futures created by something in [`tokio::net`] will return an error
-    /// regardless if the runtime was shut down before or after the future was
-    /// created.
-    ///
-    /// ## Timer futures
-    ///
-    /// Timer futures created by something in [`tokio::time`] will panic if the
-    /// runtime has been shut down. This is because the function signatures don't
-    /// allow returning errors.
+    /// panic. Specifically IO resources will return an error and timers will
+    /// panic. Runtime independent futures will run as normal.
     ///
     /// # Panics
     ///

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -209,9 +209,12 @@ impl Handle {
     /// complete, and yielding its resolved result. Any tasks or timers which
     /// the future spawns internally will be executed on the runtime.
     ///
-    /// The behavior for multi threaded vs current thread schedulers is the same
-    /// as [`Runtime::block_on`]. See the docs of [`Runtime::block_on`] for more
-    /// details.
+    /// When this is used on a `current_thread` runtime, only the
+    /// [`Runtime::block_on`] method can drive the IO and timer drivers, but the
+    /// `Handle::block_on` method cannot drive them. This means that, when using
+    /// this method on a current_thread runtime, anything that relies on IO or
+    /// timers will not work unless there is another thread currently calling
+    /// [`Runtime::block_on`] on the same runtime.
     ///
     /// # If the runtime has been shut down
     ///

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -271,10 +271,10 @@ impl Handle {
         let _rt_enter = self.enter();
 
         // Enter a **blocking** context. This prevents blocking from a runtime.
-        let mut _blocking_enter = crate::runtime::enter(true);
+        let mut blocking_enter = crate::runtime::enter(true);
 
         // Block on the future
-        _blocking_enter
+        blocking_enter
             .block_on(future)
             .expect("failed to park thread")
     }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -232,7 +232,7 @@ impl Handle {
     ///
     /// # Examples
     ///
-    /// ```no_run
+    /// ```
     /// use tokio::runtime::Runtime;
     ///
     /// // Create the runtime
@@ -249,7 +249,7 @@ impl Handle {
     ///
     /// Or using `Handle::current`:
     ///
-    /// ```no_run
+    /// ```
     /// use tokio::runtime::Handle;
     ///
     /// #[tokio::main]

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -254,10 +254,12 @@ impl Handle {
     ///
     /// #[tokio::main]
     /// async fn main () {
-    ///     // Get a handle to the current runtime and execute the future, blocking
-    ///     // the current thread until completion
-    ///     Handle::current().block_on(async {
-    ///         println!("hello");
+    ///     let handle = Handle::current();
+    ///     std::thread::spawn(move || {
+    ///         // Using Handle::block_on to run async code in the new thread.
+    ///         handle.block_on(async {
+    ///             println!("hello");
+    ///         });
     ///     });
     /// }
     /// ```

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -277,20 +277,14 @@ impl Handle {
     /// Or using `Handle::current`:
     ///
     /// ```no_run
-    /// use tokio::runtime::Runtime;
-    ///
-    /// // Create the runtime
-    /// let rt  = Runtime::new().unwrap();
-    ///
-    /// // Enter the runtime context. This is necessary for `Handle::curent` to
-    /// // work
-    /// let _enter = rt.enter();
-    ///
-    /// // Get a handle to the current runtime and execute the future, blocking
-    /// // the current thread until completion
-    /// Handle::current().block_on(async {
-    ///     println!("hello");
-    /// });
+    /// #[tokio::main]
+    /// async fn main () {
+    ///     // Get a handle to the current runtime and execute the future, blocking
+    ///     // the current thread until completion
+    ///     Handle::current().block_on(async {
+    ///         println!("hello");
+    ///     });
+    /// }
     /// ```
     ///
     /// [`JoinError`]: struct@crate::task::JoinError

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -213,9 +213,9 @@ impl Handle {
     /// as [`Runtime::block_on`]. See the docs of [`Runtime::block_on`] for more
     /// details.
     ///
-    /// # If the runtime has been shutdown
+    /// # If the runtime has been shut down
     ///
-    /// If the `Handle`'s associated `Runtime` has been shutdown, through
+    /// If the `Handle`'s associated `Runtime` has been shut down, through
     /// [`Runtime::shutdown_background`] or [`Runtime::shutdown_timeout`], and
     /// `Handle::block_on` is used it might return an error or panic. The exact
     /// behavior depends on the types of futures used.
@@ -229,8 +229,8 @@ impl Handle {
     /// ## [`spawn_blocking`] futures
     ///
     /// Futures created with [`spawn_blocking`] will run if they were started
-    /// before the runtime was shutdown. If they were created after the runtime
-    /// was shutdown they will get cancelled and the [`JoinHandle`] will return
+    /// before the runtime was shut down. If they were created after the runtime
+    /// was shut down they will get cancelled and the [`JoinHandle`] will return
     /// a [`JoinError`].
     ///
     /// ## File system futures
@@ -242,20 +242,20 @@ impl Handle {
     /// ## I/O future
     ///
     /// I/O futures created by something in [`tokio::net`] will return an error
-    /// regardless if the runtime was shutdown before or after the future was
+    /// regardless if the runtime was shut down before or after the future was
     /// created.
     ///
     /// ## Timer futures
     ///
     /// Timer futures created by something in [`tokio::time`] will panic if the
-    /// runtime has been shutdown. This is because the function signatures don't
+    /// runtime has been shut down. This is because the function signatures don't
     /// allow returning errors.
     ///
     /// # Panics
     ///
     /// This function panics if the provided future panics, if called within an
     /// asynchronous execution context, or if a timer future is executed on a
-    /// runtime that has been shutdown.
+    /// runtime that has been shut down.
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -217,11 +217,19 @@ impl Handle {
             .expect("failed to park thread")
     }
 
-    pub(crate) fn shutdown(mut self) {
-        self.spawner.shutdown();
+    cfg_io_driver! {
+        pub(crate) fn shutdown(mut self) {
+            self.spawner.shutdown();
 
-        if let Some(io_handle) = self.io_handle {
-            io_handle.shutdown();
+            if let Some(io_handle) = self.io_handle {
+                io_handle.shutdown();
+            }
+        }
+    }
+
+    cfg_not_io_driver! {
+        pub(crate) fn shutdown(mut self) {
+            self.spawner.shutdown();
         }
     }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -202,6 +202,18 @@ impl Handle {
         let _ = self.blocking_spawner.spawn(task, &self);
         handle
     }
+
+    /// TODO: write docs if this is a good direction
+    pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        // Enter the **runtime** context. This configures spawning, the current I/O driver, ...
+        let _rt_enter = self.enter();
+
+        // Enter a **blocking** context. This prevents blocking from a runtime.
+        let mut _blocking_enter = crate::runtime::enter(true);
+
+        // Block on the future
+        _blocking_enter.block_on(future).expect("failed to park thread")
+    }
 }
 
 /// Error returned by `try_current` when no Runtime has been started

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -215,10 +215,10 @@ impl Handle {
     ///
     /// # If the runtime has been shut down
     ///
-    /// If the `Handle`'s associated `Runtime` has been shut down, through
-    /// [`Runtime::shutdown_background`] or [`Runtime::shutdown_timeout`], and
-    /// `Handle::block_on` is used it might return an error or panic. The exact
-    /// behavior depends on the types of futures used.
+    /// If the `Handle`'s associated `Runtime` has been shut down (through
+    /// [`Runtime::shutdown_background`], [`Runtime::shutdown_timeout`], or by
+    /// dropping it) and `Handle::block_on` is used it might return an error or
+    /// panic. The exact behavior depends on the types of futures used.
     ///
     /// ## Runtime independent futures
     ///

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -526,7 +526,7 @@ cfg_rt! {
         /// ```
         pub fn shutdown_timeout(mut self, duration: Duration) {
             // Wakeup and shutdown all the worker threads
-            self.handle.spawner.shutdown();
+            self.handle.shutdown();
             self.blocking_pool.shutdown(Some(duration));
         }
 

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -543,6 +543,10 @@ impl TimerEntry {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), super::Error>> {
+        if self.driver.is_shutdown() {
+            panic!(crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
+        }
+
         if let Some(deadline) = self.initial_deadline {
             self.as_mut().reset(deadline);
         }

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -1,4 +1,4 @@
-use crate::loom::sync::{Arc, Mutex};
+use crate::loom::sync::Arc;
 use crate::time::driver::ClockTime;
 use std::fmt;
 
@@ -6,13 +6,13 @@ use std::fmt;
 #[derive(Clone)]
 pub(crate) struct Handle {
     time_source: ClockTime,
-    inner: Arc<Mutex<super::Inner>>,
+    inner: Arc<super::Inner>,
 }
 
 impl Handle {
     /// Creates a new timer `Handle` from a shared `Inner` timer state.
-    pub(super) fn new(inner: Arc<Mutex<super::Inner>>) -> Self {
-        let time_source = inner.lock().time_source.clone();
+    pub(super) fn new(inner: Arc<super::Inner>) -> Self {
+        let time_source = inner.state.lock().time_source.clone();
         Handle { time_source, inner }
     }
 
@@ -21,9 +21,14 @@ impl Handle {
         &self.time_source
     }
 
-    /// Locks the driver's inner structure
-    pub(super) fn lock(&self) -> crate::loom::sync::MutexGuard<'_, super::Inner> {
-        self.inner.lock()
+    /// Access the driver's inner structure
+    pub(super) fn get(&self) -> &super::Inner {
+        &*self.inner
+    }
+
+    // Check whether the driver has been shutdown
+    pub(super) fn is_shutdown(&self) -> bool {
+        self.inner.is_shutdown()
     }
 }
 

--- a/tokio/src/time/driver/tests/mod.rs
+++ b/tokio/src/time/driver/tests/mod.rs
@@ -3,7 +3,7 @@ use std::{task::Context, time::Duration};
 #[cfg(not(loom))]
 use futures::task::noop_waker_ref;
 
-use crate::loom::sync::{Arc, Mutex};
+use crate::loom::sync::Arc;
 use crate::loom::thread;
 use crate::{
     loom::sync::atomic::{AtomicBool, Ordering},
@@ -45,7 +45,7 @@ fn single_timer() {
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
-        let handle = Handle::new(Arc::new(Mutex::new(inner)));
+        let handle = Handle::new(Arc::new(inner));
 
         let handle_ = handle.clone();
         let jh = thread::spawn(move || {
@@ -76,7 +76,7 @@ fn drop_timer() {
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
-        let handle = Handle::new(Arc::new(Mutex::new(inner)));
+        let handle = Handle::new(Arc::new(inner));
 
         let handle_ = handle.clone();
         let jh = thread::spawn(move || {
@@ -107,7 +107,7 @@ fn change_waker() {
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
-        let handle = Handle::new(Arc::new(Mutex::new(inner)));
+        let handle = Handle::new(Arc::new(inner));
 
         let handle_ = handle.clone();
         let jh = thread::spawn(move || {
@@ -142,7 +142,7 @@ fn reset_future() {
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
-        let handle = Handle::new(Arc::new(Mutex::new(inner)));
+        let handle = Handle::new(Arc::new(inner));
 
         let handle_ = handle.clone();
         let finished_early_ = finished_early.clone();
@@ -191,7 +191,7 @@ fn poll_process_levels() {
     let time_source = super::ClockTime::new(clock.clone());
 
     let inner = super::Inner::new(time_source, MockUnpark::mock());
-    let handle = Handle::new(Arc::new(Mutex::new(inner)));
+    let handle = Handle::new(Arc::new(inner));
 
     let mut entries = vec![];
 
@@ -232,7 +232,7 @@ fn poll_process_levels_targeted() {
     let time_source = super::ClockTime::new(clock.clone());
 
     let inner = super::Inner::new(time_source, MockUnpark::mock());
-    let handle = Handle::new(Arc::new(Mutex::new(inner)));
+    let handle = Handle::new(Arc::new(inner));
 
     let e1 = TimerEntry::new(&handle, clock.now() + Duration::from_millis(193));
     pin!(e1);

--- a/tokio/src/util/error.rs
+++ b/tokio/src/util/error.rs
@@ -1,3 +1,7 @@
 /// Error string explaining that the Tokio context hasn't been instantiated.
 pub(crate) const CONTEXT_MISSING_ERROR: &str =
     "there is no reactor running, must be called from the context of a Tokio 1.x runtime";
+
+/// Error string explaining that the Tokio context is shutting down and cannot drive timers.
+pub(crate) const RUNTIME_SHUTTING_DOWN_ERROR: &str =
+    "A Tokio 1.x context was found, but it is being shutdown.";

--- a/tokio/src/util/error.rs
+++ b/tokio/src/util/error.rs
@@ -2,6 +2,8 @@
 pub(crate) const CONTEXT_MISSING_ERROR: &str =
     "there is no reactor running, must be called from the context of a Tokio 1.x runtime";
 
+// some combinations of features might not use this
+#[allow(dead_code)]
 /// Error string explaining that the Tokio context is shutting down and cannot drive timers.
 pub(crate) const RUNTIME_SHUTTING_DOWN_ERROR: &str =
     "A Tokio 1.x context was found, but it is being shutdown.";

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,6 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
+// All io tests that deal with shutdown is currently ignored because there are known bugs in with
+// shutting down the io driver while concurrently registering new resources. See
+// https://github.com/tokio-rs/tokio/pull/3569#pullrequestreview-612703467 fo more details.
+//
+// When this has been fixed we want to re-enable these tests.
+
 use std::time::Duration;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
@@ -208,6 +214,8 @@ rt_test! {
             .unwrap();
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[test]
     fn tcp_listener_connect_after_shutdown() {
         let rt = rt();
@@ -226,6 +234,8 @@ rt_test! {
         );
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[test]
     fn tcp_listener_connect_before_shutdown() {
         let rt = rt();
@@ -254,6 +264,8 @@ rt_test! {
             .unwrap();
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[test]
     fn udp_stream_bind_after_shutdown() {
         let rt = rt();
@@ -272,6 +284,8 @@ rt_test! {
         );
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[test]
     fn udp_stream_bind_before_shutdown() {
         let rt = rt();
@@ -290,6 +304,8 @@ rt_test! {
         );
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_bind_after_shutdown() {
@@ -310,9 +326,11 @@ rt_test! {
         );
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[cfg(unix)]
     #[test]
-    fn unix_listener_bind_accept_after_shutdown_1() {
+    fn unix_listener_shutdown_after_bind() {
         let rt = rt();
         let _enter = rt.enter();
 
@@ -330,9 +348,11 @@ rt_test! {
         assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
     }
 
+    // All io tests are ignored for now. See above why that is.
+    #[ignore]
     #[cfg(unix)]
     #[test]
-    fn unix_listener_bind_accept_after_shutdown_2() {
+    fn unix_listener_shutdown_after_accept() {
         let rt = rt();
         let _enter = rt.enter();
 

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -372,6 +372,7 @@ rt_test! {
 }
 
 multi_threaded_rt_test! {
+    #[cfg(unix)]
     #[test]
     fn unix_listener_bind() {
         let rt = rt();

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,0 +1,491 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use std::time::Duration;
+use tempfile::tempdir;
+use tokio::runtime::{Handle, Runtime};
+use tokio::sync::mpsc;
+use tokio::task::spawn_blocking;
+use tokio::{fs, net, time};
+
+macro_rules! multi_threaded_rt_test {
+    ($($t:tt)*) => {
+        mod threaded_scheduler_4_threads_only {
+            use super::*;
+
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(4)
+                    .enable_all()
+                    .build()
+                    .unwrap()
+            }
+        }
+
+        mod threaded_scheduler_1_thread_only {
+            use super::*;
+
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .enable_all()
+                    .build()
+                    .unwrap()
+            }
+        }
+    }
+}
+
+macro_rules! rt_test {
+    ($($t:tt)*) => {
+        mod current_thread_scheduler {
+            use super::*;
+
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+            }
+        }
+
+        mod threaded_scheduler_4_threads {
+            use super::*;
+
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(4)
+                    .enable_all()
+                    .build()
+                    .unwrap()
+            }
+        }
+
+        mod threaded_scheduler_1_thread {
+            use super::*;
+
+            $($t)*
+
+            fn rt() -> Runtime {
+                tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(1)
+                    .enable_all()
+                    .build()
+                    .unwrap()
+            }
+        }
+    }
+}
+
+// ==== runtime independent futures ======
+
+#[test]
+fn basic() {
+    test_with_runtimes(|| {
+        let one = Handle::current().block_on(async { 1 });
+        assert_eq!(1, one);
+    });
+}
+
+#[test]
+fn bounded_mpsc_channel() {
+    test_with_runtimes(|| {
+        let (tx, mut rx) = mpsc::channel(1024);
+
+        Handle::current().block_on(tx.send(42)).unwrap();
+
+        let value = Handle::current().block_on(rx.recv()).unwrap();
+        assert_eq!(value, 42);
+    });
+}
+
+#[test]
+fn unbounded_mpsc_channel() {
+    test_with_runtimes(|| {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+
+        let _ = tx.send(42);
+
+        let value = Handle::current().block_on(rx.recv()).unwrap();
+        assert_eq!(value, 42);
+    })
+}
+
+rt_test! {
+    // ==== spawn blocking futures ======
+
+    #[test]
+    fn basic_fs() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let contents = Handle::current()
+            .block_on(fs::read_to_string("Cargo.toml"))
+            .unwrap();
+        assert!(contents.contains("Cargo.toml"));
+    }
+
+    #[test]
+    fn fs_shutdown_before_started() {
+        let rt = rt();
+        let _enter = rt.enter();
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err: std::io::Error = Handle::current()
+            .block_on(fs::read_to_string("Cargo.toml"))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+
+        let inner_err = err.get_ref().expect("no inner error");
+        assert_eq!(inner_err.to_string(), "background task failed");
+    }
+
+    #[test]
+    fn basic_spawn_blocking() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let answer = Handle::current()
+            .block_on(spawn_blocking(|| {
+                std::thread::sleep(Duration::from_millis(100));
+                42
+            }))
+            .unwrap();
+
+        assert_eq!(answer, 42);
+    }
+
+    #[test]
+    fn spawn_blocking_after_shutdown_fails() {
+        let rt = rt();
+        let _enter = rt.enter();
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let join_err = Handle::current()
+            .block_on(spawn_blocking(|| {
+                std::thread::sleep(Duration::from_millis(100));
+                42
+            }))
+            .unwrap_err();
+
+        assert!(join_err.is_cancelled());
+    }
+
+    #[test]
+    fn spawn_blocking_started_before_shutdown_continues() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let handle = spawn_blocking(|| {
+            std::thread::sleep(Duration::from_secs(1));
+            42
+        });
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let answer = Handle::current().block_on(handle).unwrap();
+
+        assert_eq!(answer, 42);
+    }
+
+    // ==== net ======
+
+    #[test]
+    fn tcp_listener_bind() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        Handle::current()
+            .block_on(net::TcpListener::bind("127.0.0.1:0"))
+            .unwrap();
+    }
+
+    #[test]
+    fn tcp_listener_connect_after_shutdown() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err = Handle::current()
+            .block_on(net::TcpListener::bind("127.0.0.1:0"))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
+    }
+
+    #[test]
+    fn tcp_listener_connect_before_shutdown() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let bind_future = net::TcpListener::bind("127.0.0.1:0");
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err = Handle::current().block_on(bind_future).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
+    }
+
+    #[test]
+    fn udp_socket_bind() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        Handle::current()
+            .block_on(net::UdpSocket::bind("127.0.0.1:0"))
+            .unwrap();
+    }
+
+    #[test]
+    fn udp_stream_bind_after_shutdown() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err = Handle::current()
+            .block_on(net::UdpSocket::bind("127.0.0.1:0"))
+            .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
+    }
+
+    #[test]
+    fn udp_stream_bind_before_shutdown() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let bind_future = net::UdpSocket::bind("127.0.0.1:0");
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err = Handle::current().block_on(bind_future).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_listener_bind_after_shutdown() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("socket");
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        let err = net::UnixListener::bind(path).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_listener_bind_accept_after_shutdown_1() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("socket");
+
+        let listener = net::UnixListener::bind(path).unwrap();
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        // this should not timeout but fail immediately since the runtime has been shutdown
+        let err = Handle::current().block_on(listener.accept()).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_listener_bind_accept_after_shutdown_2() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("socket");
+
+        let listener = net::UnixListener::bind(path).unwrap();
+
+        let accept_future = listener.accept();
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        // this should not timeout but fail immediately since the runtime has been shutdown
+        let err = Handle::current().block_on(accept_future).unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::Other);
+        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+    }
+
+    // ==== nesting ======
+
+    #[test]
+    #[should_panic(
+        expected = "Cannot start a runtime from within a runtime. This happens because a function (like `block_on`) attempted to block the current thread while the thread is being used to drive asynchronous tasks."
+    )]
+    fn nesting() {
+        fn some_non_async_function() -> i32 {
+            Handle::current().block_on(time::sleep(Duration::from_millis(10)));
+            1
+        }
+
+        let rt = rt();
+
+        rt.block_on(async { some_non_async_function() });
+    }
+}
+
+multi_threaded_rt_test! {
+    #[test]
+    fn unix_listener_bind() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("socket");
+
+        let listener = net::UnixListener::bind(path).unwrap();
+
+        // this should timeout and not fail immediately since the runtime has not been shutdown
+        let _: tokio::time::error::Elapsed = Handle::current()
+            .block_on(tokio::time::timeout(
+                Duration::from_millis(10),
+                listener.accept(),
+            ))
+            .unwrap_err();
+    }
+
+    // ==== timers ======
+
+    // `Handle::block_on` doesn't work with timer futures on a current thread runtime as there is no
+    // one to drive the timers so they will just hang forever. Therefore they are not tested.
+
+    #[test]
+    fn sleep() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        Handle::current().block_on(time::sleep(Duration::from_millis(100)));
+    }
+
+    #[test]
+    #[should_panic(expected = "A Tokio 1.x context was found, but it is being shutdown.")]
+    fn sleep_before_shutdown_panics() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        let f = time::sleep(Duration::from_millis(100));
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        Handle::current().block_on(f);
+    }
+
+    #[test]
+    #[should_panic(expected = "A Tokio 1.x context was found, but it is being shutdown.")]
+    fn sleep_after_shutdown_panics() {
+        let rt = rt();
+        let _enter = rt.enter();
+
+        rt.shutdown_timeout(Duration::from_secs(1000));
+
+        Handle::current().block_on(time::sleep(Duration::from_millis(100)));
+    }
+}
+
+// ==== utils ======
+
+/// Create a new multi threaded runtime
+fn new_multi_thread(n: usize) -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(n)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Create a new single threaded runtime
+fn new_current_thread() -> Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Utility to test things on both kinds of runtimes both before and after shutting it down.
+fn test_with_runtimes<F>(f: F)
+where
+    F: Fn(),
+{
+    {
+        println!("current thread runtime");
+
+        let rt = new_current_thread();
+        let _enter = rt.enter();
+        f();
+
+        println!("current thread runtime after shutdown");
+        rt.shutdown_timeout(Duration::from_secs(1000));
+        f();
+    }
+
+    {
+        println!("multi thread (1 thread) runtime");
+
+        let rt = new_multi_thread(1);
+        let _enter = rt.enter();
+        f();
+
+        println!("multi thread runtime after shutdown");
+        rt.shutdown_timeout(Duration::from_secs(1000));
+        f();
+    }
+
+    {
+        println!("multi thread (4 threads) runtime");
+
+        let rt = new_multi_thread(4);
+        let _enter = rt.enter();
+        f();
+
+        println!("multi thread runtime after shutdown");
+        rt.shutdown_timeout(Duration::from_secs(1000));
+        f();
+    }
+}

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -2,7 +2,6 @@
 #![cfg(feature = "full")]
 
 use std::time::Duration;
-use tempfile::tempdir;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
 use tokio::task::spawn_blocking;
@@ -297,7 +296,7 @@ rt_test! {
         let rt = rt();
         let _enter = rt.enter();
 
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("socket");
 
         rt.shutdown_timeout(Duration::from_secs(1000));
@@ -317,7 +316,7 @@ rt_test! {
         let rt = rt();
         let _enter = rt.enter();
 
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("socket");
 
         let listener = net::UnixListener::bind(path).unwrap();
@@ -337,7 +336,7 @@ rt_test! {
         let rt = rt();
         let _enter = rt.enter();
 
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("socket");
 
         let listener = net::UnixListener::bind(path).unwrap();
@@ -378,7 +377,7 @@ multi_threaded_rt_test! {
         let rt = rt();
         let _enter = rt.enter();
 
-        let dir = tempdir().unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("socket");
 
         let listener = net::UnixListener::bind(path).unwrap();


### PR DESCRIPTION
This is a continuation of https://github.com/tokio-rs/tokio/pull/3549 but with tests for the behavior described [here](https://github.com/tokio-rs/tokio/pull/3549#issuecomment-785382050) and part of the implementation.

Still missing network operations failing if runtime associated with the handle has been shutdown. Changes to make timers and filesystem operations fail are at least passing the tests.

This is my first contribution to Tokio but let me know if I'm on the right track here 😊

Refs: #3097
Fixes #2965, #3096
cc @stuhood, @Keruspe