### PR TITLE
stream: remove duplicate `doc(test(..))` & `cfg_attr` declarations

### DIFF
--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -9,11 +9,6 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
-#![doc(test(
-    no_crate_inject,
-    attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
-))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, deny(broken_intra_doc_links))]
 #![doc(test(


### PR DESCRIPTION
I noticed more duplicate declarations