### PR TITLE
Fix mio version in cross compilation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: update
-          args: -p mio --precise 0.7.6
+          args: -p libc --precise 0.2.86
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: update
-          args: -p mio --precise 0.7.8
+          args: -p mio --precise 0.7.7
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: update
-          args: -p mio --precise 0.7.7
+          args: -p mio --precise 0.7.6
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,10 @@ jobs:
           override: true
       - uses: actions-rs/cargo@v1
         with:
+          command: update
+          args: -p mio --precise 0.7.8
+      - uses: actions-rs/cargo@v1
+        with:
           use-cross: true
           command: check
           args: --workspace --target ${{ matrix.target }}


### PR DESCRIPTION
This PR fixes the version of mio in use to 0.7.8 for the cross-compilation CI run. This is a temporary fix, and the intention is to remove it once [#1467](https://github.com/tokio-rs/mio/issues/1467) is resolved in some manner.