### PR TITLE
runtime: avoid unnecessary polling of block_on future

### DIFF
--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -1,4 +1,5 @@
 use crate::future::poll_fn;
+use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Mutex;
 use crate::park::{Park, Unpark};
 use crate::runtime::task::{self, JoinHandle, Schedule, Task};
@@ -10,7 +11,6 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
-use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering::{Acquire, Release};
 use std::sync::Arc;
 use std::task::Poll::{Pending, Ready};

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -11,7 +11,7 @@ use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
-use std::sync::atomic::Ordering::{Acquire, Release};
+use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use std::sync::Arc;
 use std::task::Poll::{Pending, Ready};
 use std::time::Duration;
@@ -343,7 +343,7 @@ impl Spawner {
 
     fn waker_ref(&self) -> WakerRef<'_> {
         // clear the woken bit
-        self.shared.woken.store(false, Release);
+        self.shared.woken.swap(false, AcqRel);
         waker_ref(&self.shared)
     }
 

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -90,6 +90,9 @@ struct Context {
 const INITIAL_CAPACITY: usize = 64;
 
 /// Max number of tasks to poll per tick.
+#[cfg(loom)]
+const MAX_TASKS_PER_TICK: usize = 4;
+#[cfg(not(loom))]
 const MAX_TASKS_PER_TICK: usize = 61;
 
 /// How often to check the remote queue first.

--- a/tokio/src/runtime/tests/loom_basic_scheduler.rs
+++ b/tokio/src/runtime/tests/loom_basic_scheduler.rs
@@ -1,0 +1,55 @@
+use crate::loom::sync::atomic::AtomicUsize;
+use crate::loom::sync::Arc;
+use crate::runtime;
+use crate::sync::oneshot::{self, Receiver};
+use crate::task;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::Ordering::{Acquire, Release};
+use std::task::{Context, Poll};
+
+#[test]
+fn block_on_num_polls() {
+    loom::model(|| {
+        let rt = runtime::Builder::new_current_thread().build().unwrap();
+
+        let (tx, rx) = oneshot::channel();
+        let num_polls = Arc::new(AtomicUsize::new(0));
+
+        rt.spawn(async move {
+            for _ in 0..70 {
+                task::yield_now().await;
+            }
+            tx.send(()).unwrap();
+        });
+
+        rt.block_on(async {
+            BlockedFuture {
+                rx,
+                num_polls: num_polls.clone(),
+            }
+            .await;
+        });
+
+        let result = num_polls.load(Acquire);
+        assert_eq!(2, result);
+    });
+}
+
+struct BlockedFuture {
+    rx: Receiver<()>,
+    num_polls: Arc<AtomicUsize>,
+}
+
+impl Future for BlockedFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.num_polls.fetch_add(1, Release);
+
+        match Pin::new(&mut self.rx).poll(cx) {
+            Poll::Pending => Poll::Pending,
+            _ => Poll::Ready(()),
+        }
+    }
+}

--- a/tokio/src/runtime/tests/loom_basic_scheduler.rs
+++ b/tokio/src/runtime/tests/loom_basic_scheduler.rs
@@ -9,7 +9,7 @@ use std::pin::Pin;
 use std::sync::atomic::Ordering::{Acquire, Release};
 use std::task::{Context, Poll};
 
-fn assert_num_polls(rt: Arc<Runtime>, at_most_polls: usize) {
+fn assert_at_most_num_polls(rt: Arc<Runtime>, at_most_polls: usize) {
     let (tx, rx) = oneshot::channel();
     let num_polls = Arc::new(AtomicUsize::new(0));
     rt.spawn(async move {
@@ -47,46 +47,19 @@ fn block_on_num_polls() {
         //   number of tasks for the current tick or there are no
         //   more tasks to run.
         //
-        let at_most_num_polls = 3;
+        let at_most = 3;
 
         let rt1 = Arc::new(Builder::new_current_thread().build().unwrap());
         let rt2 = rt1.clone();
         let rt3 = rt1.clone();
 
-        let th1 = thread::spawn(move || assert_num_polls(rt1, at_most_num_polls));
-        let th2 = thread::spawn(move || assert_num_polls(rt2, at_most_num_polls));
-        let th3 = thread::spawn(move || assert_num_polls(rt3, at_most_num_polls));
+        let th1 = thread::spawn(move || assert_at_most_num_polls(rt1, at_most));
+        let th2 = thread::spawn(move || assert_at_most_num_polls(rt2, at_most));
+        let th3 = thread::spawn(move || assert_at_most_num_polls(rt3, at_most));
 
         th1.join().unwrap();
         th2.join().unwrap();
         th3.join().unwrap();
-    });
-}
-
-#[test]
-fn completes_both() {
-    loom::model(|| {
-        let rt1 = Arc::new(Builder::new_current_thread().build().unwrap());
-        let rt2 = rt1.clone();
-
-        rt1.spawn(async {});
-        rt1.spawn(async {});
-        rt1.spawn(async {});
-
-        let th1 = thread::spawn(move || {
-            rt1.block_on(async {
-                PollNTimes { n: 3, polled: 0 }.await;
-            });
-        });
-
-        let th2 = thread::spawn(move || {
-            rt2.block_on(async {
-                PollNTimes { n: 3, polled: 0 }.await;
-            });
-        });
-
-        th1.join().unwrap();
-        th2.join().unwrap();
     });
 }
 
@@ -105,24 +78,5 @@ impl Future for BlockedFuture {
             Poll::Pending => Poll::Pending,
             _ => Poll::Ready(()),
         }
-    }
-}
-
-struct PollNTimes {
-    polled: usize,
-    n: usize,
-}
-
-impl Future for PollNTimes {
-    type Output = ();
-
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.polled += 1;
-        if self.polled == self.n {
-            return Poll::Ready(());
-        }
-
-        cx.waker().wake_by_ref();
-        Poll::Pending
     }
 }

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -1,4 +1,5 @@
 cfg_loom! {
+    mod loom_basic_scheduler;
     mod loom_blocking;
     mod loom_oneshot;
     mod loom_pool;

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -7,6 +7,8 @@ cfg_loom! {
 }
 
 cfg_not_loom! {
+    mod loom_basic_scheduler;
+
     mod queue;
 
     #[cfg(miri)]

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -7,8 +7,6 @@ cfg_loom! {
 }
 
 cfg_not_loom! {
-    mod loom_basic_scheduler;
-
     mod queue;
 
     #[cfg(miri)]


### PR DESCRIPTION
## Motivation

As explained in #3475,  futures passed to block_on get polled when subtasks become ready.

## Solution

Introduce a `was_woken` field in the waker to track when the future should be polled. 