### PR TITLE
Update chat example to use `tokio::select!`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,7 +11,6 @@ tokio = { version = "1.0.0", features = ["full", "tracing"] }
 tokio-util = { version = "0.6.3", features = ["full"] }
 tokio-stream = { version = "0.1" }
 
-async-stream = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
 bytes = "1.0.0"


### PR DESCRIPTION
This change simplifies [examples/chat.rs](https://github.com/tokio-rs/tokio/blob/master/examples/chat.rs) by replacing the `Stream` impl with `tokio::select!`, removing the need for the `async-stream` dependency. It also lets us get rid of the `Message` enum since we have enough context in the `select!` block to handle everything.

Closes: #3586