### PR TITLE
Add OnceCell

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -462,7 +462,7 @@ cfg_sync! {
     pub(crate) use task::AtomicWaker;
 
     mod once_cell;
-    pub use self::once_cell::{OnceCell, NotInitializedError, AlreadyInitializedError};
+    pub use self::once_cell::{OnceCell, NotInitializedError, SetError};
 
     pub mod watch;
 }

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -461,6 +461,9 @@ cfg_sync! {
     mod task;
     pub(crate) use task::AtomicWaker;
 
+    mod once_cell;
+    pub use self::once_cell::{OnceCell, NotInitializedError, AlreadyInitializedError};
+
     pub mod watch;
 }
 

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -462,7 +462,7 @@ cfg_sync! {
     pub(crate) use task::AtomicWaker;
 
     mod once_cell;
-    pub use self::once_cell::{OnceCell, NotInitializedError, SetError};
+    pub use self::once_cell::{OnceCell, SetError};
 
     pub mod watch;
 }

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -28,9 +28,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let result1 = tokio::spawn(async {
-///         ONCE.get_or_init(some_computation).await
-///     }).await.unwrap();
+///     let result1 = ONCE.get_or_init(some_computation).await
 ///     assert_eq!(*result1, 2);
 /// }
 /// ```
@@ -260,7 +258,7 @@ impl<T> OnceCell<T> {
         }
     }
 
-    /// Moves the value out of the cell and drops the cell afterwards.
+    /// Moves the value out of the cell, destroying the cell in the process.
     ///
     /// Returns `None` if the cell is uninitialized.
     pub fn into_inner(mut self) -> Option<T> {
@@ -323,7 +321,7 @@ impl<T> fmt::Display for SetError<T> {
 impl<T: fmt::Debug> Error for SetError<T> {}
 
 impl<T> SetError<T> {
-    /// Whether `SetError` is `SetError::AlreadyInitializEderror`
+    /// Whether `SetError` is `SetError::AlreadyInitializedError`.
     pub fn is_already_init_err(&self) -> bool {
         match self {
             SetError::AlreadyInitializedError(_) => true,

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -144,14 +144,14 @@ impl<T> OnceCell<T> {
     /// Sets the value of the OnceCell to the argument value.
     ///
     /// If the value of the OnceCell was already set prior to this call
-    /// then [`AlreadyInitializedError`] is returned. If another thread
+    /// then [`SetError::AlreadyInitializedError`] is returned. If another thread
     /// is initializing the cell while this method is called,
-    /// ['InitializingError`] is returned. In order to wait
+    /// ['SetError::InitializingError`] is returned. In order to wait
     /// for an ongoing initialization to finish, call
     /// [`OnceCell::get_or_init`] instead.
     ///
-    /// [`AlreadyInitializedError`]: crate::sync::AlreadyInitializedError
-    /// [`InitializingError`]: crate::sync::InitializingError
+    /// [`SetError::AlreadyInitializedError`]: crate::sync::SetError::AlreadyInitializedError
+    /// [`SetError::InitializingError`]: crate::sync::SetError::InitializingError
     /// ['OnceCell::get_or_init`]: crate::sync::OnceCell::get_or_init
     pub fn set(&self, value: T) -> Result<(), SetError<T>> {
         if !self.initialized() {
@@ -273,25 +273,20 @@ unsafe impl<T: Sync + Send> Sync for OnceCell<T> {}
 // it's safe to send it to another thread
 unsafe impl<T: Send> Send for OnceCell<T> {}
 
-/// Errors that can be returned from [`OnceCell::set`] and
-/// [`OnceCell::set_mut`].
+/// Errors that can be returned from [`OnceCell::set`]
 ///
 /// [`OnceCell::set`]: crate::sync::OnceCell::set
-/// [`OnceCell::set_mut`]: crate::sync::OnceCell::set_mut
 #[derive(Debug, PartialEq)]
 pub enum SetError<T> {
-    /// Error resulting from [`OnceCell::set`] or [`OnceCell::set_mut`] calls if
-    /// the cell was previously initialized.
+    /// Error resulting from [`OnceCell::set`] calls if the cell was previously initialized.
     ///
     /// [`OnceCell::set`]: crate::sync::OnceCell::set
-    /// [`OnceCell::set_mut`]: crate::sync::OnceCell::set_mut
     AlreadyInitializedError(T),
 
-    /// Error resulting from [`OnceCell::set`] or [`OnceCell::set_mut`] calls when
-    /// the cell is currently being inintialized during the calls to those methods.
+    /// Error resulting from [`OnceCell::set`] calls when the cell is currently being
+    /// inintialized during the calls to that method.
     ///
     /// [`OnceCell::set`]: crate::sync::OnceCell::set
-    /// [`OnceCell::set_mut`]: crate::sync::OnceCell::set_mut
     InitializingError(T),
 }
 

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -167,7 +167,7 @@ impl<T> OnceCell<T> {
     /// If the value of the OnceCell was already set prior to this call
     /// then [`SetError::AlreadyInitializedError`] is returned. If another thread
     /// is initializing the cell while this method is called,
-    /// ['SetError::InitializingError`] is returned. In order to wait
+    /// [`SetError::InitializingError`] is returned. In order to wait
     /// for an ongoing initialization to finish, call
     /// [`OnceCell::get_or_init`] instead.
     ///

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -297,7 +297,7 @@ impl<T> OnceCell<T> {
                                 // SAFETY: once the value is initialized, no mutable references are given out, so
                                 // we can give out arbitrarily many immutable references
                                 unsafe { Ok(self.get_unchecked()) }
-                            },
+                            }
                             Err(e) => Err(e),
                         }
                     } else {

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -1,0 +1,313 @@
+use super::Semaphore;
+use crate::loom::cell::UnsafeCell;
+use std::error::Error;
+use std::fmt;
+use std::future::Future;
+use std::mem::MaybeUninit;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A thread-safe cell which can be written to only once.
+///
+/// Provides the functionality to either set the value, in case `OnceCell`
+/// is uninitialized, or get the already initialized value by using an async
+/// function via [`OnceCell::get_or_init_with`] or by using a Future via
+/// [`OnceCell::get_or_init`] directly via [`OnceCell::get_or_init`].
+///
+/// [`OnceCell::get_or_init_with`]: crate::sync::OnceCell::get_or_init_with
+/// [`OnceCell::get_or_init`]: crate::sync::OnceCell::get_or_init
+///
+/// # Examples
+/// ```
+/// use tokio::sync::OnceCell;
+///
+/// async fn some_computation() -> u32 {
+///     1 + 1
+/// }
+///
+/// static ONCE: OnceCell<u32> = OnceCell::new();
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let result1 = tokio::spawn(async {
+///         ONCE.get_or_init_with(some_computation).await
+///     }).await.unwrap();
+///     assert_eq!(*result1, 2);
+/// }
+/// ```
+pub struct OnceCell<T> {
+    value_set: AtomicBool,
+    value: UnsafeCell<MaybeUninit<T>>,
+    semaphore: Semaphore,
+}
+
+impl<T> Default for OnceCell<T> {
+    fn default() -> OnceCell<T> {
+        OnceCell::new()
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for OnceCell<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("OnceCell")
+            .field("value", &self.get())
+            .finish()
+    }
+}
+
+impl<T: Clone> Clone for OnceCell<T> {
+    fn clone(&self) -> OnceCell<T> {
+        let new_cell = OnceCell::new();
+        if let Ok(value) = self.get() {
+            match new_cell.set(value.clone()) {
+                Ok(()) => (),
+                Err(_) => unreachable!(),
+            }
+        }
+        new_cell
+    }
+}
+
+impl<T: PartialEq> PartialEq for OnceCell<T> {
+    fn eq(&self, other: &OnceCell<T>) -> bool {
+        self.get() == other.get()
+    }
+}
+
+impl<T: Eq> Eq for OnceCell<T> {}
+
+impl<T> OnceCell<T> {
+    /// Creates a new uninitialized OnceCell instance.
+    #[cfg(all(feature = "parking_lot", not(all(loom, test)),))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+    pub const fn new() -> Self {
+        OnceCell {
+            value_set: AtomicBool::new(false),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+            semaphore: Semaphore::const_new(1),
+        }
+    }
+
+    /// Whether the value of the OnceCell is set or not.
+    pub fn initialized(&self) -> bool {
+        self.value_set.load(Ordering::Acquire)
+    }
+
+    // SAFETY: safe to call only once self.initialized() is true
+    unsafe fn get_unchecked(&self) -> &T {
+        &*self.value.with(|ptr| (*ptr).as_ptr())
+    }
+
+    // SAFETY: safe to call only once a permit on the semaphore has been
+    // acquired
+    unsafe fn set_value(&self, value: T) {
+        self.value.with_mut(|ptr| (*ptr).as_mut_ptr().write(value));
+        self.value_set.store(true, Ordering::Release);
+        self.semaphore.close();
+    }
+
+    /// Tries to get a reference to the value of the OnceCell.
+    ///
+    /// Returns [`NotInitializedError`] if the value of the OnceCell
+    /// hasn't previously been initialized.
+    ///
+    /// [`NotInitializedError`]: crate::sync::NotInitializedError
+    pub fn get(&self) -> Result<&T, NotInitializedError> {
+        if self.initialized() {
+            Ok(unsafe { self.get_unchecked() })
+        } else {
+            Err(NotInitializedError)
+        }
+    }
+
+    /// Sets the value of the OnceCell to the argument value.
+    ///
+    /// If the value of the OnceCell was already set prior to this call
+    /// or some other set is currently initializing the cell, then
+    /// [`AlreadyInitializedError`] is returned. In order to wait
+    /// for an ongoing initialization to finish, call [`OnceCell::get_or_init`]
+    /// or [`OnceCell::get_or_init_with`] instead.
+    ///
+    /// [`AlreadyInitializedError`]: crate::sync::AlreadyInitializedError
+    /// ['OnceCell::get_or_init`]: crate::sync::OnceCell::get_or_init
+    /// ['OnceCell::get_or_init_with`]: crate::sync::OnceCell::get_or_init_with
+    pub fn set(&self, value: T) -> Result<(), AlreadyInitializedError> {
+        if !self.initialized() {
+            // After acquire().await we have either acquired a permit while self.value
+            // is still uninitialized, or another thread has intialized the value and
+            // closed the semaphore, in which case self.initialized is true and we
+            // don't set the value
+            match self.semaphore.try_acquire() {
+                Ok(_permit) => {
+                    if !self.initialized() {
+                        // SAFETY: There is only one permit on the semaphore, hence only one
+                        // mutable reference is created
+                        unsafe { self.set_value(value) };
+
+                        return Ok(());
+                    } else {
+                        unreachable!(
+                            "acquired the permit after OnceCell value was already initialized."
+                        );
+                    }
+                }
+                _ => {
+                    if !self.initialized() {
+                        panic!(
+                            "couldn't acquire a permit even though OnceCell value is uninitialized."
+                        );
+                    }
+                }
+            }
+        }
+
+        Err(AlreadyInitializedError)
+    }
+
+    /// Tries to initialize the value of the OnceCell using the async function `f`.
+    /// If the value of the OnceCell was already initialized prior to this call,
+    /// a reference to that initialized value is returned. If some other thread
+    /// initiated the initialization prior to this call and the initialization
+    /// hasn't completed, this call waits until the initialization is finished.
+    ///
+    /// This will deadlock if `f` tries to initialize the cell itself.
+    pub async fn get_or_init_with<F, Fut>(&self, f: F) -> &T
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = T>,
+    {
+        if self.initialized() {
+            // SAFETY: once the value is initialized, no mutable references are given out, so
+            // we can give out arbitrarily many immutable references
+            unsafe { self.get_unchecked() }
+        } else {
+            // After acquire().await we have either acquired a permit while self.value
+            // is still uninitialized, or current thread is awoken after another thread
+            // has intialized the value and closed the semaphore, in which case self.initialized
+            // is true and we don't set the value here
+            match self.semaphore.acquire().await {
+                Ok(_permit) => {
+                    if !self.initialized() {
+                        // If `f()` panics or `select!` is called, this `get_or_init_with` call
+                        // is aborted and the semaphore permit is dropped.
+                        let value = f().await;
+
+                        // SAFETY: There is only one permit on the semaphore, hence only one
+                        // mutable reference is created
+                        unsafe { self.set_value(value) };
+
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        unsafe { self.get_unchecked() }
+                    } else {
+                        unreachable!("acquired semaphore after value was already initialized.");
+                    }
+                }
+                Err(_) => {
+                    if self.initialized() {
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        unsafe { self.get_unchecked() }
+                    } else {
+                        unreachable!(
+                            "Semaphore closed, but the OnceCell has not been initialized."
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Tries to initialize the value of the `OnceCell` using the the Future `f`.
+    /// If the value of the `OnceCell` was already initialized prior to this call,
+    /// a reference to that initialized value is returned. If some other thread
+    /// initiated the initialization prior to this call and the initialization
+    /// hasn't completed, this call waits until the initialization is finished.
+    ///
+    /// This will deadlock if `f` internally tries to initialize the cell itself.
+    pub async fn get_or_init<F>(&self, f: F) -> &T
+    where
+        F: Future<Output = T>,
+    {
+        if self.initialized() {
+            // SAFETY: once the value is initialized, no mutable references are given out, so
+            // we can give out arbitrarily many immutable references
+            return unsafe { self.get_unchecked() };
+        } else {
+            // After acquire().await we have either acquired a permit while self.value
+            // is still uninitialized, or current thread is awoken after another thread
+            // has intialized the value and closed the semaphore, in which case self.initialized
+            // is true and we don't set the value here
+            match self.semaphore.acquire().await {
+                Ok(_permit) => {
+                    if !self.initialized() {
+                        // If `f` panics or `select!` is called, this `get_or_init` call
+                        // is aborted and the semaphore permit is dropped.
+                        let value = f.await;
+
+                        // SAFETY: There is only one permit on the semaphore, hence only one
+                        // mutable reference is created
+                        unsafe { self.set_value(value) };
+
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        return unsafe { self.get_unchecked() };
+                    } else {
+                        unreachable!("acquired semaphore after value was already initialized.");
+                    }
+                }
+                Err(_) => {
+                    if self.initialized() {
+                        // SAFETY: once the value is initialized, no mutable references are given out, so
+                        // we can give out arbitrarily many immutable references
+                        return unsafe { self.get_unchecked() };
+                    } else {
+                        unreachable!(
+                            "Semaphore closed, but the OnceCell has not been initialized."
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+// Since `get` gives us access to immutable references of the
+// OnceCell, OnceCell can only be Sync if T is Sync, otherwise
+// OnceCell would allow sharing references of !Sync values across
+// threads. We need T to be Send in order for OnceCell to by Sync
+// because we can use `set` on `&OnceCell<T>` to send
+// values (of type T) across threads.
+unsafe impl<T: Sync + Send> Sync for OnceCell<T> {}
+
+// Access to OnceCell's value is guarded by the semaphore permit
+// and atomic operations on `value_set`, so as long as T itself is Send
+// it's safe to send it to another thread
+unsafe impl<T: Send> Send for OnceCell<T> {}
+
+/// Error returned from the [`OnceCell::set`] method
+///
+/// [`OnceCell::set`]: crate::sync::OnceCell::set
+#[derive(Debug, PartialEq)]
+pub struct AlreadyInitializedError;
+
+impl fmt::Display for AlreadyInitializedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "AlreadyInitializedError")
+    }
+}
+
+impl Error for AlreadyInitializedError {}
+
+/// Error returned from the [`OnceCell::get`] method
+///
+/// [`OnceCell::get`]: crate::sync::OnceCell::get
+#[derive(Debug, PartialEq)]
+pub struct NotInitializedError;
+
+impl fmt::Display for NotInitializedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "NotInitializedError")
+    }
+}
+
+impl Error for NotInitializedError {}

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -263,10 +263,10 @@ impl<T> OnceCell<T> {
     /// Moves the value out of the cell and drops the cell afterwards.
     ///
     /// Returns `None` if the cell is uninitialized.
-    pub fn into_inner(self) -> Option<T> {
+    pub fn into_inner(mut self) -> Option<T> {
         if self.initialized() {
             // Set to uninitialized for the destructor of `OnceCell` to work properly
-            self.value_set.store(false, Ordering::Release);
+            *self.value_set.get_mut() = false;
             Some(unsafe { self.value.with(|ptr| ptr::read(ptr).assume_init()) })
         } else {
             None

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![allow(clippy::type_complexity)]
 
 use std::cell::Cell;
 use std::future::Future;
@@ -267,30 +268,24 @@ async_assert_fn!(tokio::sync::watch::Sender<u8>::closed(_): Send & Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Cell<u8>>::closed(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Rc<u8>>::closed(_): !Send & !Sync);
 
-type BoxedFutureSendSync = Box<dyn Future<Output = u8> + Send + Sync>;
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFutureSendSync>): Send & Sync);
-type BoxedFutureSend = Box<dyn Future<Output = u8> + Send>;
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFutureSend>): Send & !Sync);
-type BoxedFuture = Box<dyn Future<Output = u8>>;
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFuture>): !Send & !Sync);
-type BoxedCellFutureSendSync = Box<dyn Future<Output = Cell<u8>> + Send + Sync>;
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, fn() -> Pin<Box<dyn Future<Output = u8>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedCellFutureSendSync>): !Send & !Sync);
-type BoxedCellFutureSend = Box<dyn Future<Output = Cell<u8>> + Send>;
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedCellFutureSend>): !Send & !Sync);
-type BoxedCellFuture = Box<dyn Future<Output = Cell<u8>>>;
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedCellFuture>): !Send & !Sync);
-type BoxedRcFutureSendSync = Box<dyn Future<Output = Rc<u8>> + Send + Sync>;
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedRcFutureSendSync>): !Send & !Sync);
-type BoxedRcFutureSend = Box<dyn Future<Output = Rc<u8>> + Send>;
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedRcFutureSend>): !Send & !Sync);
-type BoxedRcFuture = Box<dyn Future<Output = Rc<u8>>>;
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, fn() -> Pin<BoxedRcFuture>): !Send & !Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
 assert_value!(tokio::sync::OnceCell<u8>: Send & Sync);
 assert_value!(tokio::sync::OnceCell<Cell<u8>>: Send & !Sync);
 assert_value!(tokio::sync::OnceCell<Rc<u8>>: !Send & !Sync);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -265,6 +265,46 @@ async_assert_fn!(tokio::sync::watch::Sender<u8>::closed(_): Send & Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Cell<u8>>::closed(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Rc<u8>>::closed(_): !Send & !Sync);
 
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = u8>>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
+    _, Pin<Box<dyn Future<Output = u8>>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): Send & Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): Send & !Sync);
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
+assert_value!(tokio::sync::OnceCell<u8>: Send & Sync);
+assert_value!(tokio::sync::OnceCell<Cell<u8>>: Send & !Sync);
+assert_value!(tokio::sync::OnceCell<Rc<u8>>: !Send & !Sync);
+
 async_assert_fn!(tokio::task::LocalKey<u32>::scope(_, u32, BoxFutureSync<()>): Send & Sync);
 async_assert_fn!(tokio::task::LocalKey<u32>::scope(_, u32, BoxFutureSend<()>): Send & !Sync);
 async_assert_fn!(tokio::task::LocalKey<u32>::scope(_, u32, BoxFuture<()>): !Send & !Sync);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -267,24 +267,30 @@ async_assert_fn!(tokio::sync::watch::Sender<u8>::closed(_): Send & Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Cell<u8>>::closed(_): !Send & !Sync);
 async_assert_fn!(tokio::sync::watch::Sender<Rc<u8>>::closed(_): !Send & !Sync);
 
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = u8>>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
+type BoxedFutureSendSync = Box<dyn Future<Output = u8> + Send + Sync>;
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFutureSendSync>): Send & Sync);
+type BoxedFutureSend = Box<dyn Future<Output = u8> + Send>;
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFutureSend>): Send & !Sync);
+type BoxedFuture = Box<dyn Future<Output = u8>>;
+async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(_, fn() -> Pin<BoxedFuture>): !Send & !Sync);
+type BoxedCellFutureSendSync = Box<dyn Future<Output = Cell<u8>> + Send + Sync>;
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedCellFutureSendSync>): !Send & !Sync);
+type BoxedCellFutureSend = Box<dyn Future<Output = Cell<u8>> + Send>;
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedCellFutureSend>): !Send & !Sync);
+type BoxedCellFuture = Box<dyn Future<Output = Cell<u8>>>;
+async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedCellFuture>): !Send & !Sync);
+type BoxedRcFutureSendSync = Box<dyn Future<Output = Rc<u8>> + Send + Sync>;
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedRcFutureSendSync>): !Send & !Sync);
+type BoxedRcFutureSend = Box<dyn Future<Output = Rc<u8>> + Send>;
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedRcFutureSend>): !Send & !Sync);
+type BoxedRcFuture = Box<dyn Future<Output = Rc<u8>>>;
+async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
+    _, fn() -> Pin<BoxedRcFuture>): !Send & !Sync);
 assert_value!(tokio::sync::OnceCell<u8>: Send & Sync);
 assert_value!(tokio::sync::OnceCell<Cell<u8>>: Send & !Sync);
 assert_value!(tokio::sync::OnceCell<Rc<u8>>: !Send & !Sync);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -2,8 +2,10 @@
 #![cfg(feature = "full")]
 
 use std::cell::Cell;
+use std::future::Future;
 use std::io::{Cursor, SeekFrom};
 use std::net::SocketAddr;
+use std::pin::Pin;
 use std::rc::Rc;
 use tokio::net::TcpStream;
 use tokio::time::{Duration, Instant};
@@ -270,37 +272,19 @@ async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
 async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
     _, fn() -> Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = u8>>>): Send & !Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = u8>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): Send & !Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init_with(
     _, fn() -> Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): Send & Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
-    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): Send & !Sync);
+    _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): !Send & !Sync);
 async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init_with(
     _, fn() -> Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
-    _, Pin<Box<dyn Future<Output = u8> + Send + Sync>>): Send & Sync);
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
-    _, Pin<Box<dyn Future<Output = u8> + Send>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<u8>::get_or_init(
-    _, Pin<Box<dyn Future<Output = u8>>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Cell<u8>> + Send + Sync>>): Send & Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Cell<u8>> + Send>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Cell<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Cell<u8>>>>): !Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Rc<u8>> + Send + Sync>>): Send & Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Rc<u8>> + Send>>): Send & !Sync);
-async_assert_fn!(tokio::sync::OnceCell<Rc<u8>>::get_or_init(
-    _, Pin<Box<dyn Future<Output = Rc<u8>>>>): !Send & !Sync);
 assert_value!(tokio::sync::OnceCell<u8>: Send & Sync);
 assert_value!(tokio::sync::OnceCell<Cell<u8>>: Send & !Sync);
 assert_value!(tokio::sync::OnceCell<Rc<u8>>: !Send & !Sync);

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
+use std::mem;
 use std::ops::Drop;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
@@ -181,7 +182,10 @@ fn drop_into_inner() {
 
     let once_cell = OnceCell::new();
     let _ = once_cell.set(fooer);
-    let _v = once_cell.into_inner();
+    let fooer = once_cell.into_inner();
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 0);
+    mem::drop(fooer);
+    let count = NUM_DROPS.load(Ordering::Acquire);
+    assert!(count == 1);
 }

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -235,11 +235,11 @@ fn drop_into_inner() {
     }
 
     let once_cell = OnceCell::new();
-    let _ = once_cell.set(fooer);
+    assert!(once_cell.set(fooer).is_ok());
     let fooer = once_cell.into_inner();
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 0);
-    mem::drop(fooer);
+    drop(fooer);
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 1);
 }

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -181,7 +181,7 @@ fn drop_into_inner() {
 
     let once_cell = OnceCell::new();
     let _ = once_cell.set(fooer);
-    let _ = once_cell.into_inner();
+    let v = once_cell.into_inner();
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 0);
 }

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -1,0 +1,94 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::runtime::Runtime;
+use tokio::sync::{AlreadyInitializedError, NotInitializedError, OnceCell};
+use tokio::time::{sleep, Duration};
+
+async fn func1() -> u32 {
+    5
+}
+
+async fn func2() -> u32 {
+    sleep(Duration::from_millis(10)).await;
+    10
+}
+
+async fn func_panic() -> u32 {
+    sleep(Duration::from_secs(1)).await;
+    panic!();
+}
+
+#[test]
+fn get_or_init_with() {
+    let rt = Runtime::new().unwrap();
+
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    rt.block_on(async {
+        let result1 = rt
+            .spawn(async { ONCE.get_or_init_with(func1).await })
+            .await
+            .unwrap();
+
+        let result2 = rt
+            .spawn(async { ONCE.get_or_init_with(func2).await })
+            .await
+            .unwrap();
+
+        assert_eq!(*result1, 5);
+        assert_eq!(*result2, 5);
+    });
+}
+
+#[test]
+fn get_or_init_panic() {
+    let rt = Runtime::new().unwrap();
+
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    rt.block_on(async {
+        let result1 = rt
+            .spawn(async { ONCE.get_or_init_with(func1).await })
+            .await
+            .unwrap();
+
+        let result2 = rt
+            .spawn(async { ONCE.get_or_init_with(func_panic).await })
+            .await
+            .unwrap();
+
+        assert_eq!(*result1, 5);
+        assert_eq!(*result2, 5);
+    });
+}
+
+#[test]
+fn set_and_get() {
+    let rt = Runtime::new().unwrap();
+
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    rt.block_on(async {
+        let _ = rt.spawn(async { ONCE.set(5) }).await;
+        let value = ONCE.get().unwrap();
+        assert_eq!(*value, 5);
+    });
+}
+
+#[test]
+fn get_uninit() {
+    static ONCE: OnceCell<u32> = OnceCell::new();
+    let uninit = ONCE.get();
+    assert_eq!(uninit, Err(NotInitializedError));
+}
+
+#[test]
+fn set_twice() {
+    static ONCE: OnceCell<u32> = OnceCell::new();
+
+    let first = ONCE.set(5);
+    assert_eq!(first, Ok(()));
+    let second = ONCE.set(6);
+    assert_eq!(second, Err(AlreadyInitializedError));
+}

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -181,7 +181,7 @@ fn drop_into_inner() {
 
     let once_cell = OnceCell::new();
     let _ = once_cell.set(fooer);
-    let v = once_cell.into_inner();
+    let _v = once_cell.into_inner();
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 0);
 }


### PR DESCRIPTION
Separating https://github.com/tokio-rs/tokio/pull/3513 into two PRs for clarity, as requested by @Darksonn. Since `Lazy` depends on `OnceCell`, a PR for `Lazy` will be opened once this PR lands.
