### PR TITLE
chore: lifted out return from match

### DIFF
--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -78,19 +78,19 @@ where
                     let (res, mut buf, inner) = ready!(Pin::new(rx).poll(cx))?;
                     self.inner = Some(inner);
 
-                    match res {
+                    return match res {
                         Ok(_) => {
                             buf.copy_to(dst);
                             self.state = Idle(Some(buf));
-                            return Ready(Ok(()));
+                            Ready(Ok(()))
                         }
                         Err(e) => {
                             assert!(buf.is_empty());
 
                             self.state = Idle(Some(buf));
-                            return Ready(Err(e));
+                            Ready(Err(e))
                         }
-                    }
+                    };
                 }
             }
         }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -466,15 +466,15 @@ fn notify_locked(waiters: &mut WaitList, state: &AtomicUsize, curr: usize) -> Op
             EMPTY | NOTIFIED => {
                 let res = state.compare_exchange(curr, set_state(curr, NOTIFIED), SeqCst, SeqCst);
 
-                match res {
-                    Ok(_) => return None,
+                return match res {
+                    Ok(_) => None,
                     Err(actual) => {
                         let actual_state = get_state(actual);
                         assert!(actual_state == EMPTY || actual_state == NOTIFIED);
                         state.store(set_state(actual, NOTIFIED), SeqCst);
-                        return None;
+                        None
                     }
-                }
+                };
             }
             WAITING => {
                 // At this point, it is guaranteed that the state will not


### PR DESCRIPTION
Lifted out return from match. Maybe it's more readable that way.