### PR TITLE
Prepare tokio-stream v0.1.4

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.1.4 (March 9, 2021)
+
+Added
+
+- signal: add `Signal` wrapper ([#3510])
+
+Fixed
+
+- stream: remove duplicate `doc_cfg` declaration ([#3561])
+- sync: yield initial value in `WatchStream` ([#3576])
+
+[#3510]: https://github.com/tokio-rs/tokio/pull/3510
+[#3561]: https://github.com/tokio-rs/tokio/pull/3561
+[#3576]: https://github.com/tokio-rs/tokio/pull/3576
+
 # 0.1.3 (February 5, 2021)
 
 Added

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-stream"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.3"
+version = "0.1.4"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-stream/0.1.3/tokio_stream"
+documentation = "https://docs.rs/tokio-stream/0.1.4/tokio_stream"
 description = """
 Utilities to work with `Stream` and `tokio`.
 """


### PR DESCRIPTION
### Added

- signal: add `Signal` wrapper (#3510)

### Fixed

- stream: remove duplicate `doc_cfg` declaration (#3561)
- sync: yield initial value in `WatchStream` (#3576)