### PR TITLE
stream: documentation note for throttle unpin

### DIFF
--- a/tokio-stream/src/stream_ext/throttle.rs
+++ b/tokio-stream/src/stream_ext/throttle.rs
@@ -23,7 +23,8 @@ where
 }
 
 pin_project! {
-    /// Stream for the [`throttle`](throttle) function.
+    /// Stream for the [`throttle`](throttle) function. This object is `!Unpin`. If you need it to
+    /// implement `Unpin` you can pin your throttle like this: `Box::pin(your_throttle)`.
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
     pub struct Throttle<T> {


### PR DESCRIPTION
Add a note in the documentation for Throttle that it can be made to
implement Unpin by pinning it.

## Motivation

I had trouble updating to tokio v1 because the `Throttle` struct is `!Unpin` and my code required it to be `Unpin`.
I asked for help on the PR that I think made the change, #3278. In [that discussion](https://github.com/tokio-rs/tokio/commit/d74d17307dd53215061c4a8a1f20a0e30461e296#r48012180) it was recommended that we document the fix.

## Solution

Added a sentence to help anyone else in the same boat!
