### PR TITLE
doc: alias sleep to delay

### DIFF
--- a/tokio/src/time/driver/sleep.rs
+++ b/tokio/src/time/driver/sleep.rs
@@ -152,6 +152,8 @@ pin_project! {
     ///
     /// [`select!`]: ../macro.select.html
     /// [`tokio::pin!`]: ../macro.pin.html
+    // Alias for old name in 0.2
+    #[cfg_attr(docsrs, doc(alias = "Delay"))]
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Sleep {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Rustdoc search doesn't do partial matches on aliases so currently searching "delay" doesn't show the `delay_for` or `delay_until` aliases (https://docs.rs/tokio/1.3.0/tokio/?search=delay). 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Alias the `Sleep` struct itself to "Delay" in order to increase visibility.
