### PR TITLE
docs: anotate time module as requiring time ft

### DIFF
--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -47,3 +47,13 @@ macro_rules! cfg_rt {
         )*
     }
 }
+
+macro_rules! cfg_time {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "time")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+            $item
+        )*
+    }
+}

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -45,12 +45,13 @@ cfg_rt! {
     pub mod context;
 }
 
+cfg_time! {
+    pub mod time;
+}
+
 pub mod sync;
 
 pub mod either;
-
-#[cfg(feature = "time")]
-pub mod time;
 
 #[cfg(any(feature = "io", feature = "codec"))]
 mod util {


### PR DESCRIPTION
## Motivation
`tokio-util::time` requiring the `time` feature was not documented

## Solution
Add appropriate docs

Fix: #3596