### PR TITLE
Issue 3608. Annotate struct EnterGuard with attr must_use

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -39,6 +39,7 @@ pub struct Handle {
 ///
 /// [`Runtime::enter`]: fn@crate::runtime::Runtime::enter
 #[derive(Debug)]
+#[must_use = "Creating and dropping a guard does nothing"]
 pub struct EnterGuard<'a> {
     handle: &'a Handle,
     guard: context::EnterGuard,


### PR DESCRIPTION
EnterGuard must always be used.

  {
    let _guard = handle.enter(); // skipping _guard is wrong in all likelihood
  }

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Enterguard should be used. Without the let binding the its no-op. 

## Solution

Mark EnterGuard struct as must_use
