### PR TITLE
docs: add link to PollSender

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -16,6 +16,11 @@ use std::task::{Context, Poll};
 /// Send values to the associated `Receiver`.
 ///
 /// Instances are created by the [`channel`](channel) function.
+///
+/// To use the `Sender` in a poll function, you can use the [`PollSender`]
+/// utility.
+///
+/// [`PollSender`]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSender.html
 pub struct Sender<T> {
     chan: chan::Tx<T, Semaphore>,
 }
@@ -309,10 +314,6 @@ impl<T> fmt::Debug for Receiver<T> {
 
 impl<T> Unpin for Receiver<T> {}
 
-/// To use the `Sender` in a poll function, you can use the [`PollSender`]
-/// utility.
-///
-/// [`PollSender`]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSender.html
 impl<T> Sender<T> {
     pub(crate) fn new(chan: chan::Tx<T, Semaphore>) -> Sender<T> {
         Sender { chan }

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -309,13 +309,16 @@ impl<T> fmt::Debug for Receiver<T> {
 
 impl<T> Unpin for Receiver<T> {}
 
+/// To use the `Sender` in a poll function, you can use the [`PollSender`]
+/// utility.
+///
+/// [`PollSender`]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSender.html
 impl<T> Sender<T> {
     pub(crate) fn new(chan: chan::Tx<T, Semaphore>) -> Sender<T> {
         Sender { chan }
     }
 
-    /// Sends a value, waiting until there is capacity. In case you need a
-    /// polling interface, use [`PollSender`].
+    /// Sends a value, waiting until there is capacity.
     ///
     /// A successful send occurs when it is determined that the other end of the
     /// channel has not hung up already. An unsuccessful send would be one where
@@ -333,7 +336,6 @@ impl<T> Sender<T> {
     ///
     /// [`close`]: Receiver::close
     /// [`Receiver`]: Receiver
-    /// [`PollSender`]: https://docs.rs/tokio-util/0.6.4/tokio_util/sync/struct.PollSender.html
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -314,7 +314,8 @@ impl<T> Sender<T> {
         Sender { chan }
     }
 
-    /// Sends a value, waiting until there is capacity.
+    /// Sends a value, waiting until there is capacity. In case you need a
+    /// polling interface, use [`PollSender`].
     ///
     /// A successful send occurs when it is determined that the other end of the
     /// channel has not hung up already. An unsuccessful send would be one where
@@ -332,6 +333,7 @@ impl<T> Sender<T> {
     ///
     /// [`close`]: Receiver::close
     /// [`Receiver`]: Receiver
+    /// [`PollSender`]: https://docs.rs/tokio-util/0.6.4/tokio_util/sync/struct.PollSender.html
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation
There was no link to `PollSender` in mpsc::Sender::send docs

## Solution

Add link

Fix: #3611