### PR TITLE
sync: change rwlock::MAX_READS to Semaphore::MAX_PERMITS

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -11,7 +11,7 @@ pub(crate) use write_guard::RwLockWriteGuard;
 pub(crate) use write_guard_mapped::RwLockMappedWriteGuard;
 
 #[cfg(not(loom))]
-const MAX_READS: usize = 32;
+const MAX_READS: usize = Semaphore::MAX_PERMITS;
 
 #[cfg(loom)]
 const MAX_READS: usize = 10;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The default permit count of `MAX_READS` which is 32 is too low for my use case. I need it to be 128 or higher. I'm making a Scratch virtual machine (Scratch PL) and for big Scratch projects they can have more than 32 concurrently executing sprites. I have them all indexed on a `RwLock<HashMap<SpriteID, Sprite>>`. When 32+ sprites are executing concurrently, other sprites can block for a long time, even if none of them want write access.

Here is an example to illustrate the problem. [Playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=5408e77aa54b93b613f2f2e14cfa7ed0)

```rust
use std::sync::Arc;
use tokio::spawn;
use tokio::sync::RwLock;
use tokio::time::{sleep, Duration};

#[tokio::main]
async fn main() {
    let lock = Arc::new(RwLock::new(0));
    dbg!(&lock);
    for _ in 0..60 {
        spawn({
            let lock = lock.clone();
            async move {
                let _guard = lock.read().await;
                dbg!(&lock);
                sleep(Duration::from_secs(60 * 60 * 24)).await;
            }
        });
    }

    sleep(Duration::from_millis(100)).await;
    dbg!(&lock);
    lock.read().await; // Blocks for a long time here
}
```

I am using `async-std`'s [`RwLock`](https://docs.rs/async-lock/2.3.0/async_lock/struct.RwLock.html) right now because this implementation does not have the same problem. It looks like they are using a bit flag to indicate reading/writing status so it does not have a concurrent read limit.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR adds `RwLock::with_permits()` to allow one to specify how many permits to initialize `RwLock` with. If I put 64 as the permit parameter, it allows me to acquire a read lock on up to 64 tasks concurrently. 