### PR TITLE
timer: Fix double newline in module docs

### DIFF
--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -24,10 +24,8 @@
 //! Wait 100ms and print "100 ms have elapsed"
 //!
 //! ```
-//! use tokio::time::sleep;
-//!
 //! use std::time::Duration;
-//!
+//! use tokio::time::sleep;
 //!
 //! #[tokio::main]
 //! async fn main() {


### PR DESCRIPTION
Tiny thing I noticed.

Before:

![image](https://user-images.githubusercontent.com/718941/111304618-3afe8400-8656-11eb-87c1-2b4cbf96d34c.png)

After:

![image](https://user-images.githubusercontent.com/718941/111304640-418cfb80-8656-11eb-82c9-b42066005f94.png)
