### PR TITLE
chore: prepare Tokio v1.4.0

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,35 @@
+# 1.4.0 (March 20, 2021)
+
+### Added
+
+macros: introduce biased argument for `select!` ([#3603])
+runtime: add `Handle::block_on` ([#3569])
+
+### Fixed
+
+runtime: avoid unnecessary polling of `block_on` future ([#3582])
+runtime: fix memory leak/growth when creating many runtimes ([#3564])
+runtime: mark `EnterGuard` with `must_use` ([#3609])
+
+### Documented
+
+chore: mention fix for building docs in contributing guide ([#3618])
+doc: add link to `PollSender` ([#3613])
+doc: alias sleep to delay ([#3604])
+sync: improve `Mutex` FIFO explanation ([#3615])
+timer: fix double newline in module docs ([#3617])
+
+[#3564]: https://github.com/tokio-rs/tokio/pull/3564
+[#3613]: https://github.com/tokio-rs/tokio/pull/3613
+[#3618]: https://github.com/tokio-rs/tokio/pull/3618
+[#3617]: https://github.com/tokio-rs/tokio/pull/3617
+[#3582]: https://github.com/tokio-rs/tokio/pull/3582
+[#3615]: https://github.com/tokio-rs/tokio/pull/3615
+[#3603]: https://github.com/tokio-rs/tokio/pull/3603
+[#3609]: https://github.com/tokio-rs/tokio/pull/3609
+[#3604]: https://github.com/tokio-rs/tokio/pull/3604
+[#3569]: https://github.com/tokio-rs/tokio/pull/3569
+
 # 1.3.0 (March 9, 2021)
 
 ### Added

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -2,22 +2,22 @@
 
 ### Added
 
-macros: introduce biased argument for `select!` ([#3603])
-runtime: add `Handle::block_on` ([#3569])
+- macros: introduce biased argument for `select!` ([#3603])
+- runtime: add `Handle::block_on` ([#3569])
 
 ### Fixed
 
-runtime: avoid unnecessary polling of `block_on` future ([#3582])
-runtime: fix memory leak/growth when creating many runtimes ([#3564])
-runtime: mark `EnterGuard` with `must_use` ([#3609])
+- runtime: avoid unnecessary polling of `block_on` future ([#3582])
+- runtime: fix memory leak/growth when creating many runtimes ([#3564])
+- runtime: mark `EnterGuard` with `must_use` ([#3609])
 
 ### Documented
 
-chore: mention fix for building docs in contributing guide ([#3618])
-doc: add link to `PollSender` ([#3613])
-doc: alias sleep to delay ([#3604])
-sync: improve `Mutex` FIFO explanation ([#3615])
-timer: fix double newline in module docs ([#3617])
+- chore: mention fix for building docs in contributing guide ([#3618])
+- doc: add link to `PollSender` ([#3613])
+- doc: alias sleep to delay ([#3604])
+- sync: improve `Mutex` FIFO explanation ([#3615])
+- timer: fix double newline in module docs ([#3617])
 
 [#3564]: https://github.com/tokio-rs/tokio/pull/3564
 [#3613]: https://github.com/tokio-rs/tokio/pull/3613

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,12 +7,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.3.0"
+version = "1.4.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/1.3.0/tokio/"
+documentation = "https://docs.rs/tokio/1.4.0/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """


### PR DESCRIPTION
### Added

- macros: introduce biased argument for `select!` ([#3603])
- runtime: add `Handle::block_on` ([#3569])

### Fixed

- runtime: avoid unnecessary polling of `block_on` future ([#3582])
- runtime: fix memory leak/growth when creating many runtimes ([#3564])
- runtime: mark `EnterGuard` with `must_use` ([#3609])

### Documented

- chore: mention fix for building docs in contributing guide ([#3618])
- doc: add link to `PollSender` ([#3613])
- doc: alias sleep to delay ([#3604])
- sync: improve `Mutex` FIFO explanation ([#3615])
- timer: fix double newline in module docs ([#3617])

[#3564]: https://github.com/tokio-rs/tokio/pull/3564
[#3613]: https://github.com/tokio-rs/tokio/pull/3613
[#3618]: https://github.com/tokio-rs/tokio/pull/3618
[#3617]: https://github.com/tokio-rs/tokio/pull/3617
[#3582]: https://github.com/tokio-rs/tokio/pull/3582
[#3615]: https://github.com/tokio-rs/tokio/pull/3615
[#3603]: https://github.com/tokio-rs/tokio/pull/3603
[#3609]: https://github.com/tokio-rs/tokio/pull/3609
[#3604]: https://github.com/tokio-rs/tokio/pull/3604
[#3569]: https://github.com/tokio-rs/tokio/pull/3569