### PR TITLE
chore: prepare tokio-util v0.6.5

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.6.5 (March 20, 2021)
+
+### Fixed
+
+chore: fix clippy warnings in newer versions ([#3588])
+util: annotate time module as requiring `time` feature ([#3606])
+
+[#3588]: https://github.com/tokio-rs/tokio/pull/3588
+[#3606]: https://github.com/tokio-rs/tokio/pull/3606
+
 # 0.6.4 (March 9, 2021)
 
 ### Added

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ### Fixed
 
-- chore: fix clippy warnings in newer versions ([#3588])
 - util: annotate time module as requiring `time` feature ([#3606])
 
-[#3588]: https://github.com/tokio-rs/tokio/pull/3588
 [#3606]: https://github.com/tokio-rs/tokio/pull/3606
 
 # 0.6.4 (March 9, 2021)

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Fixed
 
-chore: fix clippy warnings in newer versions ([#3588])
-util: annotate time module as requiring `time` feature ([#3606])
+- chore: fix clippy warnings in newer versions ([#3588])
+- util: annotate time module as requiring `time` feature ([#3606])
 
 [#3588]: https://github.com/tokio-rs/tokio/pull/3588
 [#3606]: https://github.com/tokio-rs/tokio/pull/3606

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.6.x" git tag.
-version = "0.6.4"
+version = "0.6.5"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.6.4/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.6.5/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """


### PR DESCRIPTION
### Fixed

- util: annotate time module as requiring `time` feature ([#3606])

[#3606]: https://github.com/tokio-rs/tokio/pull/3606