### PR TITLE
chore: prepare tokio-test v0.4.2

### DIFF
--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.4.2 (March 20, 2021)
+
+### Fixed
+
+test: Make `Mock` both `Send` and `Sync` ([#3594])
+
+[#3594]: https://github.com/tokio-rs/tokio/pull/3594
+
 # 0.4.1 (March 10, 2021)
 
 - Fix `io::Mock` to be `Send` and `Sync` ([#3594])

--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-test: Make `Mock` both `Send` and `Sync` ([#3594])
+- test: Make `Mock` both `Send` and `Sync` ([#3594])
 
 [#3594]: https://github.com/tokio-rs/tokio/pull/3594
 

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-test"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-test-0.4.x" git tag.
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-test/0.4.1/tokio_test"
+documentation = "https://docs.rs/tokio-test/0.4.2/tokio_test"
 description = """
 Testing utilities for Tokio- and futures-based code
 """


### PR DESCRIPTION
### Fixed

- test: Make `Mock` both `Send` and `Sync` ([#3594])

[#3594]: https://github.com/tokio-rs/tokio/pull/3594