### PR TITLE
chore: prepare tokio-stream v0.1.5

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-stream: documentation note for throttle `Unpin` ([#3600])
+- stream: documentation note for throttle `Unpin` ([#3600])
 
 [#3600]: https://github.com/tokio-rs/tokio/pull/3600
 

--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.5 (March 20, 2021)
+
+### Fixed
+
+stream: documentation note for throttle `Unpin` ([#3600])
+
+[#3600]: https://github.com/tokio-rs/tokio/pull/3600
+
 # 0.1.4 (March 9, 2021)
 
 Added

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-stream"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.4"
+version = "0.1.5"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-stream/0.1.4/tokio_stream"
+documentation = "https://docs.rs/tokio-stream/0.1.5/tokio_stream"
 description = """
 Utilities to work with `Stream` and `tokio`.
 """


### PR DESCRIPTION
### Fixed

- stream: documentation note for throttle `Unpin` ([#3600])

[#3600]: https://github.com/tokio-rs/tokio/pull/3600
