### PR TITLE
stream: avoid yielding in AllFuture and AnyFuture

### DIFF
--- a/tokio-stream/src/stream_ext/any.rs
+++ b/tokio-stream/src/stream_ext/any.rs
@@ -38,18 +38,17 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let me = self.project();
-        let next = futures_core::ready!(Pin::new(me.stream).poll_next(cx));
+        let mut stream = Pin::new(me.stream);
 
-        match next {
-            Some(v) => {
-                if (me.f)(v) {
-                    Poll::Ready(true)
-                } else {
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
+        loop {
+            match futures_core::ready!(stream.as_mut().poll_next(cx)) {
+                Some(v) => {
+                    if (me.f)(v) {
+                        break Poll::Ready(true);
+                    }
                 }
+                None => break Poll::Ready(false),
             }
-            None => Poll::Ready(false),
         }
     }
 }

--- a/tokio-stream/src/stream_ext/any.rs
+++ b/tokio-stream/src/stream_ext/any.rs
@@ -40,15 +40,19 @@ where
         let me = self.project();
         let mut stream = Pin::new(me.stream);
 
-        loop {
+        // Take a maximum of 32 items from the stream before yielding.
+        for _ in 0..32 {
             match futures_core::ready!(stream.as_mut().poll_next(cx)) {
                 Some(v) => {
                     if (me.f)(v) {
-                        break Poll::Ready(true);
+                        return Poll::Ready(true);
                     }
                 }
-                None => break Poll::Ready(false),
+                None => return Poll::Ready(false),
             }
         }
+
+        cx.waker().wake_by_ref();
+        Poll::Pending
     }
 }


### PR DESCRIPTION
## Motivation

Yielding can be expensive as the task is pushed to the back of the run queue.

## Solution

Use a loop to continue to process items from the stream as much as possible, instead of yielding every time an item is produced by the stream.