### PR TITLE
chore: Avoid allocation if PollSemaphore is unused

### DIFF
--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -59,10 +59,7 @@ impl PollSemaphore {
                 // avoid allocations completely if we can grab a permit immediately
                 match Arc::clone(&self.semaphore).try_acquire_owned() {
                     Ok(permit) => return Poll::Ready(Some(permit)),
-                    Err(TryAcquireError::Closed) => {
-                        self.permit_fut = None;
-                        return Poll::Ready(None);
-                    }
+                    Err(TryAcquireError::Closed) => return Poll::Ready(None),
                     Err(TryAcquireError::NoPermits) => {}
                 }
 
@@ -79,7 +76,10 @@ impl PollSemaphore {
 
         match result {
             Ok(permit) => Poll::Ready(Some(permit)),
-            Err(_closed) => Poll::Ready(None),
+            Err(_closed) => {
+                self.permit_fut = None;
+                Poll::Ready(None)
+            }
         }
     }
 }

--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -64,9 +64,7 @@ impl PollSemaphore {
                 }
 
                 let next_fut = Arc::clone(&self.semaphore).acquire_owned();
-                self.permit_fut = Some(ReusableBoxFuture::new(next_fut));
-
-                self.permit_fut.as_mut().unwrap()
+                self.permit_fut.get_or_insert(ReusableBoxFuture::new(next_fut));
             }
         };
 

--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -59,7 +59,10 @@ impl PollSemaphore {
                 // avoid allocations completely if we can grab a permit immediately
                 match Arc::clone(&self.semaphore).try_acquire_owned() {
                     Ok(permit) => return Poll::Ready(Some(permit)),
-                    Err(TryAcquireError::Closed) => return Poll::Ready(None),
+                    Err(TryAcquireError::Closed) => {
+                        self.permit_fut = None;
+                        return Poll::Ready(None);
+                    }
                     Err(TryAcquireError::NoPermits) => {}
                 }
 

--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -64,7 +64,8 @@ impl PollSemaphore {
                 }
 
                 let next_fut = Arc::clone(&self.semaphore).acquire_owned();
-                self.permit_fut.get_or_insert(ReusableBoxFuture::new(next_fut));
+                self.permit_fut
+                    .get_or_insert(ReusableBoxFuture::new(next_fut))
             }
         };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Cloning `PollSemaphore` allocates, even if it ends up unused (e. g. if `.try_acquire_owned` is used as a fast-path). This is due to the underlying `ReusableBoxFuture` which is always initialized and holding a future.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This turns the `ReusableBoxFuture` optional, and only initializes it on the first call to `.poll_acquire`, when it's actually needed.

The size of the semaphore doesn't change, rustc is able to exploit the niche in `NonNull` inside of `ReusableBoxFuture`, but this does introduce an additional branch, so not sure this optimization is worth it in the end.

If desired I can file a similar PR for `PollSender`.