### PR TITLE
Usage typo

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -14,7 +14,7 @@
 /// branch, which evaluates if none of the other branches match their patterns:
 ///
 /// ```text
-/// else <expression>
+/// else => <expression>
 /// ```
 ///
 /// The macro aggregates all `<async expression>` expressions and runs them


### PR DESCRIPTION
Not sure if `<expression>` should be `<handler>` for consistency, or not since it doesn't get anything bound.
But the arrow was definitely missing.
