### PR TITLE
sync: Add `try_recv` back

### DIFF
--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -111,7 +111,7 @@ impl<T> Block<T> {
 
     fn write_in_progress(&self, bits: usize, slot: usize) -> bool {
         // we first check if any of the slots ahead are ready
-        let mask = (READY_MASK << slot + 1) & READY_MASK;
+        let mask = (READY_MASK << (slot + 1)) & READY_MASK;
         let another_slot_ready = 0 != mask & bits;
         if another_slot_ready {
             return true;

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1,6 +1,6 @@
 use crate::sync::batch_semaphore::{self as semaphore, TryAcquireError};
 use crate::sync::mpsc::chan;
-use crate::sync::mpsc::error::{SendError, TrySendError};
+use crate::sync::mpsc::error::{SendError, TryRecvError, TrySendError};
 
 cfg_time! {
     use crate::sync::mpsc::error::SendTimeoutError;
@@ -219,6 +219,23 @@ impl<T> Receiver<T> {
     #[cfg(feature = "sync")]
     pub fn blocking_recv(&mut self) -> Option<T> {
         crate::future::block_on(self.recv())
+    }
+
+    /// Attempts to return a pending value on this receiver without blocking.
+    ///
+    /// This method will never block the caller in order to wait for data to
+    /// become available. Instead, this will always return immediately with
+    /// a possible option of pending data on the channel.
+    ///
+    /// This is useful for a flavor of "optimistic check" before deciding to
+    /// block on a receiver.
+    ///
+    /// Compared with recv, this function has two failure cases instead of
+    /// one (one for disconnection, one for an empty buffer).
+    #[cfg(unix)]
+    #[cfg(any(feature = "signal", feature = "process"))]
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        self.chan.try_recv()
     }
 
     /// Closes the receiving half of a channel without dropping it.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -232,8 +232,6 @@ impl<T> Receiver<T> {
     ///
     /// Compared with recv, this function has two failure cases instead of
     /// one (one for disconnection, one for an empty buffer).
-    #[cfg(unix)]
-    #[cfg(any(feature = "signal", feature = "process"))]
     pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
         self.chan.try_recv()
     }

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -65,6 +65,35 @@ impl fmt::Display for RecvError {
 
 impl Error for RecvError {}
 
+// ===== TryRecvError =====
+
+/// This enumeration is the list of the possible reasons that try_recv
+/// could not return data when called.
+#[derive(Debug, PartialEq)]
+pub enum TryRecvError {
+    /// This channel is currently empty, but the Sender(s) have not yet
+    /// disconnected, so data may yet become available.
+    Empty,
+    /// The channel's sending half has been closed, and there will
+    /// never be any more data received on it.
+    Closed,
+}
+
+impl fmt::Display for TryRecvError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                TryRecvError::Empty => "channel empty",
+                TryRecvError::Closed => "channel closed",
+            }
+        )
+    }
+}
+
+impl Error for TryRecvError {}
+
 cfg_time! {
     // ===== SendTimeoutError =====
 

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -1,7 +1,6 @@
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::sync::mpsc::chan;
-use crate::sync::mpsc::error::SendError;
-
+use crate::sync::mpsc::error::{SendError, TryRecvError};
 use std::fmt;
 use std::task::{Context, Poll};
 
@@ -150,6 +149,21 @@ impl<T> UnboundedReceiver<T> {
     #[cfg(feature = "sync")]
     pub fn blocking_recv(&mut self) -> Option<T> {
         crate::future::block_on(self.recv())
+    }
+
+    /// Attempts to return a pending value on this receiver without blocking.
+    ///
+    /// This method will never block the caller in order to wait for data to
+    /// become available. Instead, this will always return immediately with
+    /// a possible option of pending data on the channel.
+    ///
+    /// This is useful for a flavor of "optimistic check" before deciding to
+    /// block on a receiver.
+    ///
+    /// Compared with recv, this function has two failure cases instead of
+    /// one (one for disconnection, one for an empty buffer).
+    pub fn try_recv(&mut self) -> Result<T, TryRecvError> {
+        self.chan.try_recv()
     }
 
     /// Closes the receiving half of a channel, without dropping it.

--- a/tokio/src/sync/tests/loom_list.rs
+++ b/tokio/src/sync/tests/loom_list.rs
@@ -39,6 +39,9 @@ fn smoke() {
                 Some(Closed) => {
                     panic!();
                 }
+                Some(NotReady) => {
+                    thread::yield_now();
+                }
                 None => {
                     thread::yield_now();
                 }

--- a/tokio/src/sync/tests/loom_mpsc.rs
+++ b/tokio/src/sync/tests/loom_mpsc.rs
@@ -132,3 +132,59 @@ fn dropping_unbounded_tx() {
         assert!(v.is_none());
     });
 }
+
+#[test]
+fn try_recv() {
+    loom::model(|| {
+        use crate::sync::{mpsc, Semaphore};
+        use loom::sync::{Arc, Mutex};
+
+        const PERMITS: usize = 2;
+        const TASKS: usize = 2;
+        const CYCLES: usize = 1;
+
+        struct Context {
+            sem: Arc<Semaphore>,
+            tx: mpsc::Sender<()>,
+            rx: Mutex<mpsc::Receiver<()>>,
+        }
+
+        fn run(ctx: &Context) {
+            block_on(async {
+                let permit = ctx.sem.acquire().await;
+                assert_ok!(ctx.rx.lock().unwrap().try_recv());
+                crate::task::yield_now().await;
+                assert_ok!(ctx.tx.clone().try_send(()));
+                drop(permit);
+            });
+        }
+
+        let (tx, rx) = mpsc::channel(PERMITS);
+        let sem = Arc::new(Semaphore::new(PERMITS));
+        let ctx = Arc::new(Context {
+            sem,
+            tx,
+            rx: Mutex::new(rx),
+        });
+
+        for _ in 0..PERMITS {
+            assert_ok!(ctx.tx.clone().try_send(()));
+        }
+
+        let mut ths = Vec::new();
+
+        for _ in 0..TASKS {
+            let ctx = ctx.clone();
+
+            ths.push(thread::spawn(move || {
+                run(&ctx);
+            }));
+        }
+
+        run(&ctx);
+
+        for th in ths {
+            th.join().unwrap()
+        }
+    });
+}

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -5,7 +5,7 @@
 use std::thread;
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::TrySendError;
+use tokio::sync::mpsc::error::{TryRecvError, TrySendError};
 use tokio_test::task;
 use tokio_test::{
     assert_err, assert_ok, assert_pending, assert_ready, assert_ready_err, assert_ready_ok,
@@ -413,6 +413,44 @@ fn unconsumed_messages_are_dropped() {
     drop((tx, rx));
 
     assert_eq!(1, Arc::strong_count(&msg));
+}
+
+#[test]
+fn try_recv() {
+    let (tx, mut rx) = mpsc::channel(1);
+    match rx.try_recv() {
+        Err(TryRecvError::Empty) => {}
+        _ => panic!(),
+    }
+    tx.try_send(42).unwrap();
+    match rx.try_recv() {
+        Ok(42) => {}
+        _ => panic!(),
+    }
+    drop(tx);
+    match rx.try_recv() {
+        Err(TryRecvError::Closed) => {}
+        _ => panic!(),
+    }
+}
+
+#[test]
+fn try_recv_unbounded() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    match rx.try_recv() {
+        Err(TryRecvError::Empty) => {}
+        _ => panic!(),
+    }
+    tx.send(42).unwrap();
+    match rx.try_recv() {
+        Ok(42) => {}
+        _ => panic!(),
+    }
+    drop(tx);
+    match rx.try_recv() {
+        Err(TryRecvError::Closed) => {}
+        _ => panic!(),
+    }
 }
 
 #[test]


### PR DESCRIPTION
Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>

## Motivation
Some time ago, the `Receiver::try_recv` was removed, due to users experiencing
race conditions when consuming from the chan. This problem caused consumers
to receive a `TryRecvError::Empty` even though a write to the chan has been complete.

## Solution
The solution in this PR is to destinguish between a slot in the concurrent
block list not being ready and the list being empty.  When the chan is not
empty and a slot is still not ready to be consumed, we spin in `try_recv`.

Fix: #3350
