### PR TITLE
Require Park::Error: Debug for better panic messages.

### DIFF
--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -41,6 +41,7 @@ cfg_rt! {
 #[cfg(any(feature = "rt", feature = "sync"))]
 pub(crate) mod thread;
 
+use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -50,7 +51,7 @@ pub(crate) trait Park {
     type Unpark: Unpark;
 
     /// Error returned by `park`
-    type Error;
+    type Error: Debug;
 
     /// Gets a new `Unpark` handle associated with this `Park` instance.
     fn unpark(&self) -> Self::Unpark;

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -221,7 +221,7 @@ impl<P: Park> Inner<P> {
                         Some(task) => crate::coop::budget(|| task.run()),
                         None => {
                             // Park until the thread is signaled
-                            scheduler.park.park().ok().expect("failed to park");
+                            scheduler.park.park().expect("failed to park");
 
                             // Try polling the `block_on` future next
                             continue 'outer;
@@ -234,7 +234,6 @@ impl<P: Park> Inner<P> {
                 scheduler
                     .park
                     .park_timeout(Duration::from_millis(0))
-                    .ok()
                     .expect("failed to park");
             }
         })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

We are seeing a few "failed to park" panics in the wild. The panic messages are very unhelpful as they don't contain information about the underlying error.

## Solution

Add a `fmt::Debug` constraint to `Park::Error`. This trait is internal and all implementors already satisfy it. Then we can use `expect()` on the result of `park()` directly.