### PR TITLE
Allow to configure RwLock max reads

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -271,6 +271,7 @@ impl Semaphore {
                     Self::MAX_PERMITS
                 );
                 let prev = self.permits.fetch_add(rem << Self::PERMIT_SHIFT, Release);
+                let prev = prev >> Self::PERMIT_SHIFT;
                 assert!(
                     prev + permits <= Self::MAX_PERMITS,
                     "number of added permits ({}) would overflow MAX_PERMITS ({})",

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -268,15 +268,11 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
     #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
-    pub const fn const_new_with_max_reads(value: T, max_reads: u32) -> RwLock<T>
+    pub const fn const_new_with_max_reads(value: T, mut max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {
-        assert!(
-            max_reads <= MAX_READS,
-            "a RwLock may not be created with more than MAX_READS ({})",
-            MAX_READS
-        );
+        max_reads &= MAX_READS;
         RwLock {
             mr: max_reads,
             c: UnsafeCell::new(value),

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -218,13 +218,17 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// let lock = RwLock::new_with_max_reads(5, 1024);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_reads` is more than `u32::MAX >> 3`.
     pub fn new_with_max_reads(value: T, max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {
         assert!(
             max_reads <= MAX_READS,
-            "a RwLock may not be created with more than MAX_READS ({})",
+            "a RwLock may not be created with more than {} readers",
             MAX_READS
         );
         RwLock {

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -20,10 +20,10 @@ pub(crate) use write_guard::RwLockWriteGuard;
 pub(crate) use write_guard_mapped::RwLockMappedWriteGuard;
 
 #[cfg(not(loom))]
-const MAX_READS: usize = 32;
+const MAX_READS: u32 = std::u32::MAX >> 3;
 
 #[cfg(loom)]
-const MAX_READS: usize = 10;
+const MAX_READS: u32 = 10;
 
 /// An asynchronous reader-writer lock.
 ///
@@ -86,6 +86,9 @@ const MAX_READS: usize = 10;
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
 #[derive(Debug)]
 pub struct RwLock<T: ?Sized> {
+    // maximum number of concurrent readers
+    mr: u32,
+
     //semaphore to coordinate read and write access to T
     s: Semaphore,
 
@@ -199,8 +202,35 @@ impl<T: ?Sized> RwLock<T> {
         T: Sized,
     {
         RwLock {
+            mr: MAX_READS,
             c: UnsafeCell::new(value),
-            s: Semaphore::new(MAX_READS),
+            s: Semaphore::new(MAX_READS as usize),
+        }
+    }
+
+    /// Creates a new instance of an `RwLock<T>` which is unlocked
+    /// and allows a maximum of `max_reads` concurrent readers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::RwLock;
+    ///
+    /// let lock = RwLock::new_with_max_reads(5, 1024);
+    /// ```
+    pub fn new_with_max_reads(value: T, max_reads: u32) -> RwLock<T>
+    where
+        T: Sized,
+    {
+        assert!(
+            max_reads <= MAX_READS,
+            "a RwLock may not be created with more than MAX_READS ({})",
+            MAX_READS
+        );
+        RwLock {
+            mr: max_reads,
+            c: UnsafeCell::new(value),
+            s: Semaphore::new(max_reads as usize),
         }
     }
 
@@ -220,8 +250,37 @@ impl<T: ?Sized> RwLock<T> {
         T: Sized,
     {
         RwLock {
+            mr: MAX_READS,
             c: UnsafeCell::new(value),
-            s: Semaphore::const_new(MAX_READS),
+            s: Semaphore::const_new(MAX_READS as usize),
+        }
+    }
+
+    /// Creates a new instance of an `RwLock<T>` which is unlocked
+    /// and allows a maximum of `max_reads` concurrent readers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::RwLock;
+    ///
+    /// static LOCK: RwLock<i32> = RwLock::const_new_with_max_reads(5, 1024);
+    /// ```
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+    pub const fn const_new_with_max_reads(value: T, max_reads: u32) -> RwLock<T>
+    where
+        T: Sized,
+    {
+        assert!(
+            max_reads <= MAX_READS,
+            "a RwLock may not be created with more than MAX_READS ({})",
+            MAX_READS
+        );
+        RwLock {
+            mr: max_reads,
+            c: UnsafeCell::new(value),
+            s: Semaphore::const_new(max_reads as usize),
         }
     }
 
@@ -456,12 +515,13 @@ impl<T: ?Sized> RwLock<T> {
     ///}
     /// ```
     pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
-        self.s.acquire(MAX_READS as u32).await.unwrap_or_else(|_| {
+        self.s.acquire(self.mr).await.unwrap_or_else(|_| {
             // The semaphore was closed. but, we never explicitly close it, and we have a
             // handle to it through the Arc, which means that this can never happen.
             unreachable!()
         });
         RwLockWriteGuard {
+            permits_acquired: self.mr,
             s: &self.s,
             data: self.c.get(),
             marker: marker::PhantomData,
@@ -534,13 +594,14 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     pub fn try_write(&self) -> Result<RwLockWriteGuard<'_, T>, TryLockError> {
-        match self.s.try_acquire(MAX_READS as u32) {
+        match self.s.try_acquire(self.mr) {
             Ok(permit) => permit,
             Err(TryAcquireError::NoPermits) => return Err(TryLockError(())),
             Err(TryAcquireError::Closed) => unreachable!(),
         }
 
         Ok(RwLockWriteGuard {
+            permits_acquired: self.mr,
             s: &self.s,
             data: self.c.get(),
             marker: marker::PhantomData,

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -15,6 +15,7 @@ use std::ops;
 /// [`write`]: method@crate::sync::RwLock::write
 /// [`RwLock`]: struct@crate::sync::RwLock
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
+    pub(super) permits_acquired: u32,
     pub(super) s: &'a Semaphore,
     pub(super) data: *mut T,
     pub(super) marker: marker::PhantomData<&'a mut T>,
@@ -64,9 +65,11 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     {
         let data = f(&mut *this) as *mut U;
         let s = this.s;
+        let permits_acquired = this.permits_acquired;
         // NB: Forget to avoid drop impl from being called.
         mem::forget(this);
         RwLockMappedWriteGuard {
+            permits_acquired,
             s,
             data,
             marker: marker::PhantomData,
@@ -125,9 +128,11 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             None => return Err(this),
         };
         let s = this.s;
+        let permits_acquired = this.permits_acquired;
         // NB: Forget to avoid drop impl from being called.
         mem::forget(this);
         Ok(RwLockMappedWriteGuard {
+            permits_acquired,
             s,
             data,
             marker: marker::PhantomData,
@@ -185,7 +190,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         let RwLockWriteGuard { s, data, .. } = self;
 
         // Release all but one of the permits held by the write guard
-        s.release(super::MAX_READS - 1);
+        s.release((self.permits_acquired - 1) as usize);
         // NB: Forget to avoid drop impl from being called.
         mem::forget(self);
         RwLockReadGuard {
@@ -230,6 +235,6 @@ where
 
 impl<'a, T: ?Sized> Drop for RwLockWriteGuard<'a, T> {
     fn drop(&mut self) {
-        self.s.release(super::MAX_READS);
+        self.s.release(self.permits_acquired as usize);
     }
 }

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -54,7 +54,7 @@ fn read_exclusive_pending() {
 // should be made available when one of the shared acesses is dropped
 #[test]
 fn exhaust_reading() {
-    let rwlock = RwLock::new(100);
+    let rwlock = RwLock::new_with_max_reads(100, 1024);
     let mut reads = Vec::new();
     loop {
         let mut t = spawn(rwlock.read());


### PR DESCRIPTION
## Motivation

Currently `RwLock` `MAX_READS` is capped to 32 which is too low
for some usecases (see #3633).

## Solution

This PR adds a constructor that allows for specifying the max reads.
It also bumps the default number of max reads from 32 to `u32::MAX >> 3`

Fix: #3633