### PR TITLE
Fix warning from new Rust version

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -479,7 +479,7 @@ impl Command {
     /// Basic usage:
     ///
     /// ```no_run
-    /// use tokio::process::Command;;
+    /// use tokio::process::Command;
     /// use std::process::Stdio;
     ///
     /// let command = Command::new("ls")
@@ -503,7 +503,7 @@ impl Command {
     /// Basic usage:
     ///
     /// ```no_run
-    /// use tokio::process::Command;;
+    /// use tokio::process::Command;
     /// use std::process::{Stdio};
     ///
     /// let command = Command::new("ls")

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -544,7 +544,7 @@ impl TimerEntry {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), super::Error>> {
         if self.driver.is_shutdown() {
-            panic!(crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
+            panic!("{}", crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
         }
 
         if let Some(deadline) = self.initial_deadline {


### PR DESCRIPTION
Some new warnings were added by Rust 1.51, which broke ci.