### PR TITLE
io: add AsyncSeekExt::stream_position

### DIFF
--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -66,6 +66,17 @@ cfg_io_util! {
         {
             seek(self, pos)
         }
+
+        /// Creates a future which will return the current seek position from the
+        /// start of the stream.
+        ///
+        /// This is equivalent to `self.seek(SeekFrom::Current(0))`.
+        fn stream_position(&mut self) -> Seek<'_, Self>
+        where
+            Self: Unpin,
+        {
+            self.seek(SeekFrom::Current(0))
+        }
     }
 }
 


### PR DESCRIPTION
An async equivalent to [`std::io::Seek::stream_position`](https://doc.rust-lang.org/nightly/std/io/trait.Seek.html#method.stream_position) that stabilized in Rust 1.51.
