### PR TITLE
sync: fix notification permit getting dropped on receiver drop

### DIFF
--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -134,3 +134,20 @@ fn notify_in_drop_after_wake() {
     // Now, notifying **should not** deadlock
     notify.notify_waiters();
 }
+
+#[test]
+fn notify_one_after_dropped_all() {
+    let notify = Notify::new();
+    let mut notified1 = spawn(async { notify.notified().await });
+
+    assert_pending!(notified1.poll());
+
+    notify.notify_waiters();
+    notify.notify_one();
+
+    drop(notified1);
+
+    let mut notified2 = spawn(async { notify.notified().await });
+
+    assert_ready!(notified2.poll());
+}


### PR DESCRIPTION
Noticed this small bug when reading through notify.rs.

## Motivation

The Drop implementation for sync::notify::Notified has a case where it sets the notification state to EMPTY, regardless of previous state. This is motivated by a comment claiming that this is correct in all cases except when the previous state is NOTIFIED, in which case the state will be changed back to NOTIFIED further down in notify_locked. But with the introduction of notify_waiters this is no longer always true, because that call is filtered by the notification type being NotificationType::OneWaiter. Indeed the following can happen:

```
n = Notify::new()
a = n.notified()
a.poll()            // adds a to waiters list, sets state to WAITING
n.notify_waiters()  // removes a from waiters list, sets state to EMPTY
n.notify_one()      // sets state to NOTIFIED
drop(a)             // sets state to EMPTY
n.notified().await  // waits forever
```

## Solution

Condition the write on state being WAITING. (I'm guessing the previous code is a remnant from when state wasn't already previously being read higher up in the function?)
