### PR TITLE
task block_in_place doc can run in sync code

### DIFF
--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -161,11 +161,11 @@
 //!
 //! When using the [multi-threaded runtime][rt-multi-thread], the [`task::block_in_place`]
 //! function is also available. Like `task::spawn_blocking`, this function
-//! allows running a blocking operation from an asynchronous context. Unlike
-//! `spawn_blocking`, however, `block_in_place` works by transitioning the
-//! _current_ worker thread to a blocking thread, moving other tasks running on
-//! that thread to another worker thread. This can improve performance by avoiding
-//! context switches.
+//! allows running a blocking operation from an asynchronous context (or a
+//! synchronous context within asynchronous context). Unlike `spawn_blocking`,
+//! however, `block_in_place` works by transitioning the _current_ worker thread
+//! to a blocking thread, moving other tasks running on that thread to another worker thread.
+//! This can improve performance by avoiding context switches.
 //!
 //! For example:
 //!

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -161,8 +161,8 @@
 //!
 //! When using the [multi-threaded runtime][rt-multi-thread], the [`task::block_in_place`]
 //! function is also available. Like `task::spawn_blocking`, this function
-//! allows running a blocking operation from an asynchronous context (or a
-//! synchronous context within asynchronous context). Unlike `spawn_blocking`,
+//! allows running a blocking operation from an asynchronous context (this
+//! includes synchronous functions called by an async function). Unlike `spawn_blocking`,
 //! however, `block_in_place` works by transitioning the _current_ worker thread
 //! to a blocking thread, moving other tasks running on that thread to another worker thread.
 //! This can improve performance by avoiding context switches.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

It isn't clear that `block_in_place` could be run within synchronous context
and can be a replacement for `thread::spawn` in some cases.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Mention that it can run in sync code.
