### PR TITLE
Doc block_in_place can replace thread::spawn

### DIFF
--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -1,8 +1,10 @@
 use crate::task::JoinHandle;
 
 cfg_rt_multi_thread! {
-    /// Runs the provided blocking function on the current thread without
-    /// blocking the executor.
+    /// Runs the provided blocking function on the current thread (synchronous
+    /// context) without blocking the executor. This function could be a
+    /// replacement for [`thread::spawn`] in cases where a `join` is needed
+    /// but will block the executor whereas this does not.
     ///
     /// In general, issuing a blocking call or performing a lot of compute in a
     /// future without yielding is not okay, as it may prevent the executor from
@@ -72,7 +74,7 @@ cfg_rt! {
     ///
     /// This function is intended for non-async operations that eventually finish on
     /// their own. If you want to spawn an ordinary thread, you should use
-    /// [`thread::spawn`] instead.
+    /// [`block_in_place`] or [`thread::spawn`] instead.
     ///
     /// Closures spawned using `spawn_blocking` cannot be cancelled. When you shut
     /// down the executor, it will wait indefinitely for all blocking operations to


### PR DESCRIPTION
In cases where `thread::spawn(...).join()` within synchronous context
it will block the executor but block_in_place does not.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The relationship between `block_in_place` and `thread::spawn` is not clear.
Other than that, the examples provided also does not show clearly that
`block_in_place` can run within sync code.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Mention that sometimes `block_in_place` could be a replacement for `thread::spawn`
when `join` is required.