### PR TITLE
sync: preserve permit state in notify_waiters

### DIFF
--- a/tokio/src/sync/tests/loom_notify.rs
+++ b/tokio/src/sync/tests/loom_notify.rs
@@ -65,7 +65,6 @@ fn notify_waiters_and_one() {
             });
         });
 
-
         th1.join().unwrap();
         th2.join().unwrap();
         th3.join().unwrap();

--- a/tokio/src/sync/tests/loom_notify.rs
+++ b/tokio/src/sync/tests/loom_notify.rs
@@ -33,12 +33,42 @@ fn notify_waiters() {
             tx.notify_waiters();
         });
 
-        th.join().unwrap();
-
         block_on(async {
             notified1.await;
             notified2.await;
         });
+
+        th.join().unwrap();
+    });
+}
+
+#[test]
+fn notify_waiters_and_one() {
+    loom::model(|| {
+        let notify = Arc::new(Notify::new());
+        let tx1 = notify.clone();
+        let tx2 = notify.clone();
+
+        let th1 = thread::spawn(move || {
+            tx1.notify_waiters();
+        });
+
+        let th2 = thread::spawn(move || {
+            tx2.notify_one();
+        });
+
+        let th3 = thread::spawn(move || {
+            let notified = notify.notified();
+
+            block_on(async {
+                notified.await;
+            });
+        });
+
+
+        th1.join().unwrap();
+        th2.join().unwrap();
+        th3.join().unwrap();
     });
 }
 


### PR DESCRIPTION
## Motivation

When there are no current waiters (state is EMPTY or NOTIFIED), `Notify::notify_waiters` just bumps the current generation counter and returns. But it does so non-atomically. Since the lock is held we know that the generation counter is untouched, and we cannot have entered state WAITING; we might however be overwriting NOTIFIED by EMPTY or EMPTY by NOTIFIED if we race with another thread.

The former case is bad: if notify_waiters() races with notify_one(), we might overwrite NOTIFIED by EMPTY and drop a permit.

The latter case is more or less fine, because if we race with a waiter that uses up a permit we can claim to have notified it and have its permit remain. But with enough effort one can show an API contract violation.

## Solution

Use an atomic increment.