### PR TITLE
sync: make notify_waiters() atomic

### DIFF
--- a/tokio/src/loom/std/mutex.rs
+++ b/tokio/src/loom/std/mutex.rs
@@ -1,7 +1,7 @@
 use std::sync::{self, MutexGuard, TryLockError};
 
 /// Adapter for `std::Mutex` that removes the poisoning aspects
-// from its api
+/// from its api
 #[derive(Debug)]
 pub(crate) struct Mutex<T: ?Sized>(sync::Mutex<T>);
 

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -102,6 +102,24 @@ fn notified_multi_notify_drop_one() {
 }
 
 #[test]
+fn notify_many_waiters() {
+    let notify = Notify::new();
+    let mut notifieds = Vec::new();
+    for _ in 0..50 {
+        let mut notified = spawn(async { notify.notified().await });
+        assert_pending!(notified.poll());
+        notifieds.push(notified);
+    }
+
+    notify.notify_waiters();
+
+    for notified in notifieds.iter_mut() {
+        assert!(notified.is_woken());
+        assert_ready!(notified.poll());
+    }
+}
+
+#[test]
 fn notify_in_drop_after_wake() {
     use futures::task::ArcWake;
     use std::future::Future;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -102,24 +102,6 @@ fn notified_multi_notify_drop_one() {
 }
 
 #[test]
-fn notify_many_waiters() {
-    let notify = Notify::new();
-    let mut notifieds = Vec::new();
-    for _ in 0..50 {
-        let mut notified = spawn(async { notify.notified().await });
-        assert_pending!(notified.poll());
-        notifieds.push(notified);
-    }
-
-    notify.notify_waiters();
-
-    for notified in notifieds.iter_mut() {
-        assert!(notified.is_woken());
-        assert_ready!(notified.poll());
-    }
-}
-
-#[test]
 fn notify_in_drop_after_wake() {
     use futures::task::ArcWake;
     use std::future::Future;
@@ -168,4 +150,22 @@ fn notify_one_after_dropped_all() {
     let mut notified2 = spawn(async { notify.notified().await });
 
     assert_ready!(notified2.poll());
+}
+
+#[test]
+fn notify_many_waiters() {
+    let notify = Notify::new();
+    let mut notifieds = Vec::new();
+    for _ in 0..50 {
+        let mut notified = spawn(async { notify.notified().await });
+        assert_pending!(notified.poll());
+        notifieds.push(notified);
+    }
+
+    notify.notify_waiters();
+
+    for notified in notifieds.iter_mut() {
+        assert!(notified.is_woken());
+        assert_ready!(notified.poll());
+    }
 }


### PR DESCRIPTION
The relocking done in notify_waiters() when waking more than 32 waiters is buggy; here's a possible fix.

## Motivation

When there are many waiters, notify_waiters() gathers 32 at a time in an array and notifies them, releasing its lock before notifying, and retaking it afterwards. This is buggy in two ways:

- the state that's written back may be stale, because it can change while the lock is not held. We may overwrite NOTIFIED -> EMPTY, WAITING -> EMPTY, or change the number of waiter calls to an old value. (This could be fixed by writing/rereading the state in combination with each relocking)
- it makes notify_waiters() visibly non-atomic. We might wake up a waiter, which does some work and then registers a new waiter, and then wake up that waiter in the next loop iteration. This could cause livelocks or unexpected behavior.

## Solution

There's a couple of approaches that could taken to solve this.

This PR picks the simplest one: gather *all* the waiters in a `Vec<Waker>` and notify them, rather than 32 at a time. I don't know tokio's stance on dynamic memory allocation; I tried to compromise by hand-rolling a smallvec.

Instead of using a `Vec<Waker>` one could imagine using intrusive linked lists, putting the extracted wakers in a separate list from notify.waiters. Unfortunately this doesn't play well with Notified's Drop implementation which assumes that that's the only linked list they can live in. This can be hacked around (by storing a reference to a new stack-pinned list in each waker, or putting the extracted wakers in a circularly linked list which can be removed from without reference to the list head) but it's messy.

Another option is to first mark all waiters that are meant to be notified, and then process them in batches. This becomes complicated, because suddenly notify_one and the Drop implementation need to know about this marking scheme. I tested implementing this at https://github.com/simonlindholm/tokio/commit/d6b8e3c183ff1275870d8a8b08289d6ce169bfdf and it ended up with +100 lines, which is uncomfortably much for handling a hard-to-test edge case.