### PR TITLE
Typo in socket.rs: operationg => operating

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -448,7 +448,7 @@ impl TcpSocket {
     /// `backlog` defines the maximum number of pending connections are queued
     /// by the operating system at any given time. Connection are removed from
     /// the queue with [`TcpListener::accept`]. When the queue is full, the
-    /// operationg-system will start rejecting connections.
+    /// operating-system will start rejecting connections.
     ///
     /// [`TcpListener::accept`]: TcpListener::accept
     ///


### PR DESCRIPTION
## Motivation

There's a typo in a rustdoc comment.

## Solution

Make the typo go away 😅 