### PR TITLE
Documentation: document panic in oneshot::Receiver::try_recv

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -609,6 +609,10 @@ impl<T> Receiver<T> {
     /// - `Err(TryRecvError::Closed)` if the sender has dropped without sending
     ///   a value.
     ///
+    /// # Panics
+    ///
+    /// This function panics if called after a pending value has been received.
+    ///
     /// # Examples
     ///
     /// `try_recv` before a value is sent, then after.


### PR DESCRIPTION
When initially consulting the docs I assumed the channel would report as closed after the value was sent and received partially due to not noticing any mention of panics. I had a look through the module and Receiver docs for oneshot and didn't find mention of the panic so updated the receiver docs accordingly.