### PR TITLE
Add Semaphore::is_closed method

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -280,6 +280,11 @@ impl Semaphore {
     pub fn close(&self) {
         self.ll_sem.close();
     }
+
+    /// Returns true if the semaphore is closed
+    pub fn is_closed(&self) {
+        self.ll_sem.is_closed()
+    }
 }
 
 impl<'a> SemaphorePermit<'a> {

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -282,7 +282,7 @@ impl Semaphore {
     }
 
     /// Returns true if the semaphore is closed
-    pub fn is_closed(&self) {
+    pub fn is_closed(&self) -> bool {
         self.ll_sem.is_closed()
     }
 }


### PR DESCRIPTION
## Motivation

Right now the only way to check if a semaphore is closed is to do the following:

```rust
let is_closed = matches!(
    semaphore.try_acquire_many(0),
    Err(TryAcquireError::Closed)
);
```

It would be nice if I could just call `semaphore.is_closed()` instead.

## Solution

Add a `is_closed` method to the public `Semaphore` API which calls the `is_closed` method of the underlying low level semaphore.