### PR TITLE
Remove panic from oneshot receiver

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -672,7 +672,7 @@ impl<T> Receiver<T> {
                 return Err(TryRecvError::Empty);
             }
         } else {
-            panic!("called after complete");
+            Err(TryRecvError::Closed)
         };
 
         self.inner = None;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -202,7 +202,6 @@ fn try_recv_after_completion() {
     rx.close();
 }
 
-
 #[test]
 fn drops_tasks() {
     let (mut tx, mut rx) = oneshot::channel::<i32>();

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -2,6 +2,7 @@
 #![cfg(feature = "full")]
 
 use tokio::sync::oneshot;
+use tokio::sync::oneshot::error::TryRecvError;
 use tokio_test::*;
 
 use std::future::Future;
@@ -189,6 +190,18 @@ fn close_after_recv() {
     assert_eq!(17, rx.try_recv().unwrap());
     rx.close();
 }
+
+#[test]
+fn try_recv_after_completion() {
+    let (tx, mut rx) = oneshot::channel::<i32>();
+
+    tx.send(17).unwrap();
+
+    assert_eq!(17, rx.try_recv().unwrap());
+    assert_eq!(Err(TryRecvError::Closed), rx.try_recv());
+    rx.close();
+}
+
 
 #[test]
 fn drops_tasks() {


### PR DESCRIPTION
Get oneshot channel to return closed if value already read. This is an alternative to #3671 opening it now to make sure that CI is all good

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
