### PR TITLE
time: panic in release when timer polled after completing

### DIFF
--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -180,7 +180,7 @@ impl StateCell {
                 break Err(cur_state);
             }
 
-            match self.state.compare_exchange(
+            match self.state.compare_exchange_weak(
                 cur_state,
                 STATE_PENDING_FIRE,
                 Ordering::AcqRel,


### PR DESCRIPTION
While this `debug_assert` could only be [triggered through UB][post]
panicking in release mode and including a more helpful error message is
nice.

Fixes https://github.com/tokio-rs/tokio/issues/3675

[post]: https://fasterthanli.me/articles/pin-and-suffering