### PR TITLE
Fix doc: Let comment match example

### DIFF
--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -34,7 +34,7 @@
 //! }
 //! ```
 //!
-//! Require that an operation takes no more than 300ms.
+//! Require that an operation takes no more than 1s.
 //!
 //! ```
 //! use tokio::time::{timeout, Duration};


### PR DESCRIPTION
The example uses `Duration::from_secs(1)` and the explanation says something about 300ms, which does not match.
Use "1s" instead in the explanation.

--- 

As said in the Contributors guide: 

> Even tiny pull requests (e.g., one character pull request fixing a typo in API documentation) are greatly appreciated

:laughing: