### PR TITLE
Prepare Tokio v1.5.0

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,51 @@
+# 1.5.0 (April 12, 2021)
+
+### Added
+
+- io: add `AsyncSeekExt::stream_position` ([#3650])
+- io: add `AsyncWriteExt::write_vectored` ([#3678])
+- io: add a `copy_bidirectional` utility ([#3572])
+- net: implement `IntoRawFd` for `TcpSocket` ([#3684])
+- sync: add `OnceCell` ([#3591])
+- sync: add `OwnedRwLockReadGuard` and `OwnedRwLockWriteGuard` ([#3340])
+- sync: add `Semaphore::is_closed` ([#3673])
+- sync: add `mpsc::Sender::capacity` ([#3690])
+- sync: allow configuring `RwLock` max reads ([#3644])
+- task: add `sync_scope` for `LocalKey` ([#3612])
+
+### Fixed
+
+- chore: try to avoid `noalias` attributes on intrusive linked list ([#3654])
+- rt: fix panic in `JoinHandle::abort()` when called from other threads ([#3672])
+- sync: don't panic in `oneshot::try_recv` ([#3674])
+- sync: fix notifications getting dropped on receiver drop ([#3652])
+
+### Documented
+
+- io: clarify requirements of `AsyncFd` ([#3635])
+- runtime: fix unclear docs for `{Handle,Runtime}::block_on` ([#3628])
+- sync: document that `Semaphore` is fair ([#3693])
+- sync: improve doc on blocking mutex ([#3645])
+
+[#3340]: https://github.com/tokio-rs/tokio/pull/3340
+[#3572]: https://github.com/tokio-rs/tokio/pull/3572
+[#3591]: https://github.com/tokio-rs/tokio/pull/3591
+[#3612]: https://github.com/tokio-rs/tokio/pull/3612
+[#3628]: https://github.com/tokio-rs/tokio/pull/3628
+[#3635]: https://github.com/tokio-rs/tokio/pull/3635
+[#3644]: https://github.com/tokio-rs/tokio/pull/3644
+[#3645]: https://github.com/tokio-rs/tokio/pull/3645
+[#3650]: https://github.com/tokio-rs/tokio/pull/3650
+[#3652]: https://github.com/tokio-rs/tokio/pull/3652
+[#3654]: https://github.com/tokio-rs/tokio/pull/3654
+[#3672]: https://github.com/tokio-rs/tokio/pull/3672
+[#3673]: https://github.com/tokio-rs/tokio/pull/3673
+[#3674]: https://github.com/tokio-rs/tokio/pull/3674
+[#3678]: https://github.com/tokio-rs/tokio/pull/3678
+[#3684]: https://github.com/tokio-rs/tokio/pull/3684
+[#3690]: https://github.com/tokio-rs/tokio/pull/3690
+[#3693]: https://github.com/tokio-rs/tokio/pull/3693
+
 # 1.4.0 (March 20, 2021)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,12 +7,12 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.4.0"
+version = "1.5.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
-documentation = "https://docs.rs/tokio/1.4.0/tokio/"
+documentation = "https://docs.rs/tokio/1.5.0/tokio/"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
 description = """

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -216,13 +216,13 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     /// use tokio::sync::RwLock;
     ///
-    /// let lock = RwLock::new_with_max_reads(5, 1024);
+    /// let lock = RwLock::with_max_readers(5, 1024);
     /// ```
     ///
     /// # Panics
     ///
     /// Panics if `max_reads` is more than `u32::MAX >> 3`.
-    pub fn new_with_max_reads(value: T, max_reads: u32) -> RwLock<T>
+    pub fn with_max_readers(value: T, max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {
@@ -268,11 +268,11 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     /// use tokio::sync::RwLock;
     ///
-    /// static LOCK: RwLock<i32> = RwLock::const_new_with_max_reads(5, 1024);
+    /// static LOCK: RwLock<i32> = RwLock::const_with_max_readers(5, 1024);
     /// ```
     #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
     #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
-    pub const fn const_new_with_max_reads(value: T, mut max_reads: u32) -> RwLock<T>
+    pub const fn const_with_max_readers(value: T, mut max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -54,7 +54,7 @@ fn read_exclusive_pending() {
 // should be made available when one of the shared acesses is dropped
 #[test]
 fn exhaust_reading() {
-    let rwlock = RwLock::new_with_max_reads(100, 1024);
+    let rwlock = RwLock::with_max_readers(100, 1024);
     let mut reads = Vec::new();
     loop {
         let mut t = spawn(rwlock.read());


### PR DESCRIPTION
# 1.5.0 (April 12, 2021)

### Added

- io: add `AsyncSeekExt::stream_position` (#3650)
- io: add `AsyncWriteExt::write_vectored` (#3678)
- io: add a `copy_bidirectional` utility (#3572)
- net: implement `IntoRawFd` for `TcpSocket` (#3684)
- sync: add `OnceCell` (#3591)
- sync: add `OwnedRwLockReadGuard` and `OwnedRwLockWriteGuard` (#3340)
- sync: add `Semaphore::is_closed` (#3673)
- sync: add `mpsc::Sender::capacity` (#3690)
- sync: allow configuring `RwLock` max reads (#3644)
- task: add `sync_scope` for `LocalKey` (#3612)

### Fixed

- chore: try to avoid `noalias` attributes on intrusive linked list (#3654)
- rt: fix panic in `JoinHandle::abort()` when called from other threads (#3672)
- sync: don't panic in `oneshot::try_recv` (#3674)
- sync: fix notifications getting dropped on receiver drop (#3652)

### Documented

- io: clarify requirements of `AsyncFd` (#3635)
- runtime: fix unclear docs for `{Handle,Runtime}::block_on` (#3628)
- sync: document that `Semaphore` is fair (#3693)
- sync: improve doc on blocking mutex (#3645)
