### PR TITLE
Prepare tokio-util 0.6.6

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,18 @@
+# 0.6.6 (April 12, 2021)
+
+### Added
+
+- util: makes `Framed` and `FramedStream` resumable after eof ([#3272])
+- util: add `PollSemaphore::{add_permits, available_permits}` ([#3683])
+
+### Fixed
+
+- chore: avoid allocation if `PollSemaphore` is unused ([#3634])
+
+[#3272]: https://github.com/tokio-rs/tokio/pull/3272
+[#3634]: https://github.com/tokio-rs/tokio/pull/3634
+[#3683]: https://github.com/tokio-rs/tokio/pull/3683
+
 # 0.6.5 (March 20, 2021)
 
 ### Fixed

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.6.x" git tag.
-version = "0.6.5"
+version = "0.6.6"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.6.5/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.6.6/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """


### PR DESCRIPTION
# 0.6.6 (April 12, 2021)

### Added

- util: makes `Framed` and `FramedStream` resumable after eof (#3272)
- util: add `PollSemaphore::{add_permits, available_permits}` (#3683)

### Fixed

- chore: avoid allocation if `PollSemaphore` is unused (#3634)
 