### PR TITLE
time: add getter for Interval's period

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -176,4 +176,9 @@ impl Interval {
         // Return the current instant
         Poll::Ready(now)
     }
+
+    /// Returns the period of the interval.
+    pub fn period(&self) -> Duration {
+        self.period
+    }
 }


### PR DESCRIPTION
This patch allows accessing the period of an `Interval`

Closes: #3701