### PR TITLE
Test for shutdown of runtime in `Handle::spawn `

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -260,6 +260,12 @@ impl Spawner {
             })
             .unwrap()
     }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        let inner = self.inner.clone();
+        let shared = inner.shared.lock();
+        shared.shutdown
+    }
 }
 
 impl Inner {

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -144,6 +144,10 @@ impl Handle {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
+        if self.is_shutdown() {
+            return JoinHandle::new_dropped_runtime();
+        }
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(future, "task");
         self.spawner.spawn(future)
@@ -288,6 +292,10 @@ impl Handle {
 
     pub(crate) fn shutdown(mut self) {
         self.spawner.shutdown();
+    }
+
+    pub(crate) fn is_shutdown(&self) -> bool {
+        self.blocking_spawner.is_shutdown()
     }
 }
 

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -13,6 +13,7 @@ cfg_rt! {
 enum Repr {
     Cancelled,
     Panic(Mutex<Box<dyn Any + Send + 'static>>),
+    DroppedRuntime,
 }
 
 impl JoinError {
@@ -28,9 +29,21 @@ impl JoinError {
         }
     }
 
+    pub(crate) fn dropped_runtime() -> JoinError {
+        JoinError {
+            repr: Repr::DroppedRuntime,
+        }
+    }
+
     /// Returns true if the error was caused by the task being cancelled
     pub fn is_cancelled(&self) -> bool {
         matches!(&self.repr, Repr::Cancelled)
+    }
+
+    /// Returns true if the the runtime was dropped before the task
+    /// could execute.
+    pub fn is_dropped_runtime(&self) -> bool {
+        matches!(&self.repr, Repr::DroppedRuntime)
     }
 
     /// Returns true if the error was caused by the task panicking
@@ -117,6 +130,7 @@ impl fmt::Display for JoinError {
         match &self.repr {
             Repr::Cancelled => write!(fmt, "cancelled"),
             Repr::Panic(_) => write!(fmt, "panic"),
+            Repr::DroppedRuntime => write!(fmt, "dropped runtime"),
         }
     }
 }
@@ -126,6 +140,7 @@ impl fmt::Debug for JoinError {
         match &self.repr {
             Repr::Cancelled => write!(fmt, "JoinError::Cancelled"),
             Repr::Panic(_) => write!(fmt, "JoinError::Panic(...)"),
+            Repr::DroppedRuntime => write!(fmt, "JoinError::DroppedRuntime"),
         }
     }
 }
@@ -139,6 +154,7 @@ impl From<JoinError> for io::Error {
             match src.repr {
                 Repr::Cancelled => "task was cancelled",
                 Repr::Panic(_) => "task panicked",
+                Repr::DroppedRuntime => "runtime was dropped before task could be spawned",
             },
         )
     }

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -218,7 +218,7 @@ impl<T> Future for JoinHandle<T> {
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self.runtime_dropped {
-            return Poll::Ready(Err(JoinError::dropped_runtime()));
+            return Poll::Ready(Err(JoinError::cancelled()));
         }
 
         let mut ret = Poll::Pending;

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -406,7 +406,7 @@ rt_test! {
         drop(rt);
 
         let err = block_on(handle.spawn(foo())).unwrap_err();
-        assert!(err.is_dropped_runtime());
+        assert!(err.is_cancelled());
     }
 
 }


### PR DESCRIPTION
Tries to fix https://github.com/tokio-rs/tokio/issues/3548

We use the `shutdown` flag of the blocking spawner's `Shared` field to allow a `Handle` to infer that the runtime was shutdown. If the flag is set, `Handle::spawn` and `Handle::spawn_blocking` will return a newly introduced `JoinError::DroppedRuntime`.

A potential downside is that `JoinError` was previously solely related to errors caused by a task itself. I couldn't find a cleaner alternative than to introduce a new kind of `JoinError` since returning a `Result` from the spawn methods breaks all kinds of things in the API.

Also I'm not 100% sure that the shutdown of the blocking spawner is always caused by the runtime being dropped.
