### PR TITLE
sync: add mpsc::{UnboundReceiver,Receiver}::sender()

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -299,6 +299,28 @@ impl<T> Receiver<T> {
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
     }
+
+    /// Creates a [`Sender`] that can be used to send messages to this receiver.
+    ///
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (_tx, mut rx) = mpsc::channel(100);
+    ///
+    ///     rx.sender().send("hello").await.unwrap();
+    ///     rx.sender().send("world").await.unwrap();
+    ///
+    ///     assert_eq!(Some("hello"), rx.recv().await);
+    ///     assert_eq!(Some("world"), rx.recv().await);
+    /// }
+    /// ```
+    pub fn sender(&self) -> Sender<T> {
+        Sender::new(self.chan.tx())
+    }
 }
 
 impl<T> fmt::Debug for Receiver<T> {

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -263,6 +263,13 @@ impl<T, S: Semaphore> Rx<T, S> {
             }
         })
     }
+
+    /// Creates a [`Tx`] that will send to this [`Rx`].
+    pub(crate) fn tx(&self) -> Tx<T, S> {
+        let chan = self.inner.clone();
+        chan.tx_count.fetch_add(1, Relaxed);
+        Tx::new(chan)
+    }
 }
 
 impl<T, S: Semaphore> Drop for Rx<T, S> {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -178,6 +178,28 @@ impl<T> UnboundedReceiver<T> {
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
     }
+
+    /// Creates a [`UnboundedSender`] that can be used to send messages to this receiver.
+    ///
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (_tx, mut rx) = mpsc::unbounded_channel();
+    ///
+    ///     rx.sender().send("hello").unwrap();
+    ///     rx.sender().send("world").unwrap();
+    ///
+    ///     assert_eq!(Some("hello"), rx.recv().await);
+    ///     assert_eq!(Some("world"), rx.recv().await);
+    /// }
+    /// ```
+    pub fn sender(&self) -> UnboundedSender<T> {
+        UnboundedSender::new(self.chan.tx())
+    }
 }
 
 impl<T> UnboundedSender<T> {


### PR DESCRIPTION
## Motivation

Sometimes you have a Receiver, and want to create a Sender that can send to it.

We use this pattern often, and have to store an adjacent Sender to that Receiver in order to accomplish this. But upon further investigation, the machinery to implement this exists in Tokio trivially. 

We write a lot of tasks that receive from a channel to process messages. Sometimes, these tasks want to spawn another task to perform some computation and then send the result back. By allowing the creation of a `Sender` from a `Receiver`, we can unlock the ability to do this without having to hold a `Sender` adjacent to the `Receiver`. This allows us to stop the task when no `Senders` exist anymore, which would be otherwise impossible if we need to store a sender adjacent to receiver, as they would only get dropped at the same time. 

## Solution

The solution to this is to implement `mpsc::{UnboundReceiver,Receiver}::sender()`, which will allow us to create a Sender that will send to the given Receiver from the Receiver itself. 