### PR TITLE
CI: check docs of private items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
           override: true
 
       - name: "doc --lib --all-features"
-        run: cargo doc --lib --no-deps --all-features
+        run: cargo doc --lib --no-deps --all-features --document-private-items
         env:
           RUSTDOCFLAGS: --cfg docsrs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-04-21
+  nightly: nightly-2020-09-21
   minrust: 1.45.2
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2020-09-21
+  nightly: nightly-2021-04-21
   minrust: 1.45.2
 
 jobs:

--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -605,7 +605,7 @@ mod rand {
     /// Fast random number generate
     ///
     /// Implement xorshift64+: 2 32-bit xorshift sequences added together.
-    /// Shift triplet \[17,7,16\] was calculated as indicated in Marsaglia's
+    /// Shift triplet `[17,7,16]` was calculated as indicated in Marsaglia's
     /// Xorshift paper: https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
     /// This generator passes the SmallCrush suite, part of TestU01 framework:
     /// http://simul.iro.umontreal.ca/testu01/tu01.html

--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -605,7 +605,7 @@ mod rand {
     /// Fast random number generate
     ///
     /// Implement xorshift64+: 2 32-bit xorshift sequences added together.
-    /// Shift triplet [17,7,16] was calculated as indicated in Marsaglia's
+    /// Shift triplet \[17,7,16\] was calculated as indicated in Marsaglia's
     /// Xorshift paper: https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
     /// This generator passes the SmallCrush suite, part of TestU01 framework:
     /// http://simul.iro.umontreal.ca/testu01/tu01.html

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -14,8 +14,9 @@ cfg_io_driver! {
     /// that it will receive task notifications on readiness. This is the lowest
     /// level API for integrating with a reactor.
     ///
-    /// The association between an I/O resource is made by calling [`new`]. Once
-    /// the association is established, it remains established until the
+    /// The association between an I/O resource is made by calling
+    /// [`new_with_interest_and_handle`].
+    /// Once the association is established, it remains established until the
     /// registration instance is dropped.
     ///
     /// A registration instance represents two separate readiness streams. One
@@ -36,7 +37,7 @@ cfg_io_driver! {
     /// stream. The write readiness event stream is only for `Ready::writable()`
     /// events.
     ///
-    /// [`new`]: method@Self::new
+    /// [`new_with_interest_and_handle`]: method@Self::new_with_interest_and_handle
     /// [`poll_read_ready`]: method@Self::poll_read_ready`
     /// [`poll_write_ready`]: method@Self::poll_write_ready`
     #[derive(Debug)]

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -56,8 +56,7 @@ cfg_io_driver! {
     ///
     /// [`AsyncRead`]: crate::io::AsyncRead
     /// [`AsyncWrite`]: crate::io::AsyncWrite
-    /// [`Registration`]: struct@Registration
-    /// [`TcpListener`]: struct@crate::net::TcpListener
+    /// [`TcpListener`]: crate::net::TcpListener
     /// [`clear_read_ready`]: method@Self::clear_read_ready
     /// [`clear_write_ready`]: method@Self::clear_write_ready
     /// [`poll_read_ready`]: method@Self::poll_read_ready

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -54,8 +54,8 @@ cfg_io_driver! {
     /// These events are included as part of the read readiness event stream. The
     /// write readiness event stream is only for `Ready::writable()` events.
     ///
-    /// [`AsyncRead`]: trait@AsyncRead
-    /// [`AsyncWrite`]: trait@AsyncWrite
+    /// [`AsyncRead`]: crate::io::AsyncRead
+    /// [`AsyncWrite`]: crate::io::AsyncWrite
     /// [`Registration`]: struct@Registration
     /// [`TcpListener`]: struct@crate::net::TcpListener
     /// [`clear_read_ready`]: method@Self::clear_read_ready

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -40,13 +40,13 @@ cfg_io_driver! {
     /// [`poll_read_ready`] again will also indicate read readiness.
     ///
     /// When the operation is attempted and is unable to succeed due to the I/O
-    /// resource not being ready, the caller must call [`clear_read_ready`] or
-    /// [`clear_write_ready`]. This clears the readiness state until a new
+    /// resource not being ready, the caller must call `clear_read_ready` or
+    /// `clear_write_ready`. This clears the readiness state until a new
     /// readiness event is received.
     ///
     /// This allows the caller to implement additional functions. For example,
     /// [`TcpListener`] implements poll_accept by using [`poll_read_ready`] and
-    /// [`clear_read_ready`].
+    /// `clear_read_ready`.
     ///
     /// ## Platform-specific events
     ///
@@ -57,10 +57,8 @@ cfg_io_driver! {
     /// [`AsyncRead`]: crate::io::AsyncRead
     /// [`AsyncWrite`]: crate::io::AsyncWrite
     /// [`TcpListener`]: crate::net::TcpListener
-    /// [`clear_read_ready`]: method@Self::clear_read_ready
-    /// [`clear_write_ready`]: method@Self::clear_write_ready
-    /// [`poll_read_ready`]: method@Self::poll_read_ready
-    /// [`poll_write_ready`]: method@Self::poll_write_ready
+    /// [`poll_read_ready`]: Registration::poll_read_ready
+    /// [`poll_write_ready`]: Registration::poll_write_ready
     pub(crate) struct PollEvented<E: Source> {
         io: Option<E>,
         registration: Registration,

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -10,10 +10,10 @@ cfg_io_driver! {
     /// [`std::io::Write`] traits with the reactor that drives it.
     ///
     /// `PollEvented` uses [`Registration`] internally to take a type that
-    /// implements [`mio::Evented`] as well as [`std::io::Read`] and or
+    /// implements [`mio::event::Source`] as well as [`std::io::Read`] and or
     /// [`std::io::Write`] and associate it with a reactor that will drive it.
     ///
-    /// Once the [`mio::Evented`] type is wrapped by `PollEvented`, it can be
+    /// Once the [`mio::event::Source`] type is wrapped by `PollEvented`, it can be
     /// used from within the future's execution model. As such, the
     /// `PollEvented` type provides [`AsyncRead`] and [`AsyncWrite`]
     /// implementations using the underlying I/O resource as well as readiness
@@ -56,7 +56,6 @@ cfg_io_driver! {
     ///
     /// [`AsyncRead`]: trait@AsyncRead
     /// [`AsyncWrite`]: trait@AsyncWrite
-    /// [`mio::Evented`]: trait@mio::Evented
     /// [`Registration`]: struct@Registration
     /// [`TcpListener`]: struct@crate::net::TcpListener
     /// [`clear_read_ready`]: method@Self::clear_read_ready

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -54,8 +54,6 @@ cfg_io_driver! {
     /// These events are included as part of the read readiness event stream. The
     /// write readiness event stream is only for `Ready::writable()` events.
     ///
-    /// [`std::io::Read`]: trait@std::io::Read
-    /// [`std::io::Write`]: trait@std::io::Write
     /// [`AsyncRead`]: trait@AsyncRead
     /// [`AsyncWrite`]: trait@AsyncWrite
     /// [`mio::Evented`]: trait@mio::Evented

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -85,7 +85,7 @@ const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
 /// requires only the driver lock.
 pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
-    /// timer has been fired and is unregistered), [`u64::max_value()`].
+    /// timer has been fired and is unregistered), [`u64::max_value`].
     ///
     /// [`u64::max_value`]: prim@u64::max_value
     state: AtomicU64,

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -85,7 +85,7 @@ const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
 /// requires only the driver lock.
 pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
-    /// timer has been fired and is unregistered), `u64::max_value`.
+    /// timer has been fired and is unregistered), `u64::max_value()`.
     state: AtomicU64,
     /// If the timer is fired (an Acquire order read on state shows
     /// `u64::max_value()`), holds the result that should be returned from

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -87,7 +87,7 @@ pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
     /// timer has been fired and is unregistered), [`u64::max_value()`].
     ///
-    /// [`u64::max_value()`]: prim@u64::max_value
+    /// [`u64::max_value`]: prim@u64::max_value
     state: AtomicU64,
     /// If the timer is fired (an Acquire order read on state shows
     /// `u64::max_value()`), holds the result that should be returned from

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -85,9 +85,7 @@ const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
 /// requires only the driver lock.
 pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
-    /// timer has been fired and is unregistered), [`u64::max_value`].
-    ///
-    /// [`u64::max_value`]: prim@u64::max_value
+    /// timer has been fired and is unregistered), `u64::max_value`.
     state: AtomicU64,
     /// If the timer is fired (an Acquire order read on state shows
     /// `u64::max_value()`), holds the result that should be returned from

--- a/tokio/src/time/driver/entry.rs
+++ b/tokio/src/time/driver/entry.rs
@@ -86,6 +86,8 @@ const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
 pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
     /// timer has been fired and is unregistered), [`u64::max_value()`].
+    ///
+    /// [`u64::max_value()`]: prim@u64::max_value
     state: AtomicU64,
     /// If the timer is fired (an Acquire order read on state shows
     /// `u64::max_value()`), holds the result that should be returned from

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 /// Fast random number generate
 ///
 /// Implement xorshift64+: 2 32-bit xorshift sequences added together.
-/// Shift triplet \[17,7,16\] was calculated as indicated in Marsaglia's
+/// Shift triplet `[17,7,16]` was calculated as indicated in Marsaglia's
 /// Xorshift paper: https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
 /// This generator passes the SmallCrush suite, part of TestU01 framework:
 /// http://simul.iro.umontreal.ca/testu01/tu01.html

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -3,7 +3,7 @@ use std::cell::Cell;
 /// Fast random number generate
 ///
 /// Implement xorshift64+: 2 32-bit xorshift sequences added together.
-/// Shift triplet [17,7,16] was calculated as indicated in Marsaglia's
+/// Shift triplet \[17,7,16\] was calculated as indicated in Marsaglia's
 /// Xorshift paper: https://www.jstatsoft.org/article/view/v008i14/xorshift.pdf
 /// This generator passes the SmallCrush suite, part of TestU01 framework:
 /// http://simul.iro.umontreal.ca/testu01/tu01.html


### PR DESCRIPTION
## Motivation

Documentation of private items is not tested in CI.

## Solution

Adding the `--document-private-items` should check all documentation.
