### PR TITLE
net: add `clear_ready()` to TcpStream, UdpSocket and Unix sockets

### DIFF
--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -205,6 +205,15 @@ impl Registration {
             res => res,
         }
     }
+
+    pub(crate) fn clear_interest(&self, interest: Interest) {
+        let ev = self.shared.ready_event(interest);
+
+        // No need to clear if it is already not ready
+        if !ev.ready.is_empty() {
+            self.shared.clear_readiness(ev);
+        }
+    }
 }
 
 impl Drop for Registration {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -415,6 +415,21 @@ impl TcpStream {
         Ok(event.ready)
     }
 
+    /// Indicates to tokio that the requested state is no longer ready. The
+    /// internal readiness flag will be cleared, and tokio will wait for the
+    /// next edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the requested state is _not_ ready. Do not call
+    /// it simply because, for example, a read succeeded; it should be called
+    /// when a read is observed to block.
+    ///
+    /// This function is only needed when working with async I/O operations outside
+    /// tokio since `try_write()` and `try_read()` take care of it internally.
+    pub fn clear_ready(&self, interest: Interest) {
+        self.io.registration().clear_interest(interest);
+    }
+
     /// Wait for the socket to become readable.
     ///
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -381,6 +381,21 @@ impl UdpSocket {
         Ok(event.ready)
     }
 
+    /// Indicates to tokio that the requested state is no longer ready. The
+    /// internal readiness flag will be cleared, and tokio will wait for the
+    /// next edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the requested state is _not_ ready. Do not call
+    /// it simply because, for example, a read succeeded; it should be called
+    /// when a read is observed to block.
+    ///
+    /// This function is only needed when working with async I/O operations outside
+    /// tokio since `try_send()` and `try_recv()` take care of it internally.
+    pub fn clear_ready(&self, interest: Interest) {
+        self.io.registration().clear_interest(interest);
+    }
+
     /// Wait for the socket to become writable.
     ///
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -162,6 +162,21 @@ impl UnixDatagram {
         Ok(event.ready)
     }
 
+    /// Indicates to tokio that the requested state is no longer ready. The
+    /// internal readiness flag will be cleared, and tokio will wait for the
+    /// next edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the requested state is _not_ ready. Do not call
+    /// it simply because, for example, a read succeeded; it should be called
+    /// when a read is observed to block.
+    ///
+    /// This function is only needed when working with async I/O operations outside
+    /// tokio since `try_send()` and `try_recv()` take care of it internally.
+    pub fn clear_ready(&self, interest: Interest) {
+        self.io.registration().clear_interest(interest);
+    }
+
     /// Wait for the socket to become writable.
     ///
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -121,6 +121,21 @@ impl UnixStream {
         Ok(event.ready)
     }
 
+    /// Indicates to tokio that the requested state is no longer ready. The
+    /// internal readiness flag will be cleared, and tokio will wait for the
+    /// next edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the requested state is _not_ ready. Do not call
+    /// it simply because, for example, a read succeeded; it should be called
+    /// when a read is observed to block.
+    ///
+    /// This function is only needed when working with async I/O operations outside
+    /// tokio since `try_write()` and `try_read()` take care of it internally.
+    pub fn clear_ready(&self, interest: Interest) {
+        self.io.registration().clear_interest(interest);
+    }
+
     /// Wait for the socket to become readable.
     ///
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually


### PR DESCRIPTION
This change introduces `clear_ready()` similar to that in AsyncFd. This
change allows I/O operations outside tokio to work with ready `ready()`.

## Motivation
#2968 (and a few followups) means to help support custom async I/O operations (#3000). However because only tokio first party I/O operations clear the ready states, as a result, readiness is not reset correctly when pairing `ready()` with I/O operations external to tokio.


## Solution
This change introduces `clear_ready()` similar to that in `AsyncFd` to help support external I/O operations.

