### PR TITLE
chore: Fix some clippy lints

### DIFF
--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -128,7 +128,7 @@ where
             }
         }
 
-        Poll::Ready(Ok(Some(mem::replace(me.buf, String::new()))))
+        Poll::Ready(Ok(Some(mem::take(me.buf))))
     }
 }
 

--- a/tokio/src/io/util/read_line.rs
+++ b/tokio/src/io/util/read_line.rs
@@ -36,7 +36,7 @@ where
 {
     ReadLine {
         reader,
-        buf: mem::replace(string, String::new()).into_bytes(),
+        buf: mem::take(string).into_bytes(),
         output: string,
         read: 0,
         _pin: PhantomPinned,
@@ -99,7 +99,7 @@ pub(super) fn read_line_internal<R: AsyncBufRead + ?Sized>(
     read: &mut usize,
 ) -> Poll<io::Result<usize>> {
     let io_res = ready!(read_until_internal(reader, cx, b'\n', buf, read));
-    let utf8_res = String::from_utf8(mem::replace(buf, Vec::new()));
+    let utf8_res = String::from_utf8(mem::take(buf));
 
     // At this point both buf and output are empty. The allocation is in utf8_res.
 

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -37,7 +37,7 @@ pub(crate) fn read_to_string<'a, R>(
 where
     R: AsyncRead + ?Sized + Unpin,
 {
-    let buf = mem::replace(string, String::new()).into_bytes();
+    let buf = mem::take(string).into_bytes();
     ReadToString {
         reader,
         buf: VecWithInitialized::new(buf),

--- a/tokio/src/io/util/split.rs
+++ b/tokio/src/io/util/split.rs
@@ -106,7 +106,7 @@ where
             me.buf.pop();
         }
 
-        Poll::Ready(Ok(Some(mem::replace(me.buf, Vec::new()))))
+        Poll::Ready(Ok(Some(mem::take(me.buf))))
     }
 }
 

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -151,7 +151,7 @@ impl BlockingPool {
         self.spawner.inner.condvar.notify_all();
 
         let last_exited_thread = std::mem::take(&mut shared.last_exiting_thread);
-        let workers = std::mem::replace(&mut shared.worker_threads, HashMap::new());
+        let workers = std::mem::take(&mut shared.worker_threads);
 
         drop(shared);
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -205,7 +205,7 @@ impl<T> Receiver<T> {
         // not memory access.
         shared.ref_count_rx.fetch_add(1, Relaxed);
 
-        Self { version, shared }
+        Self { shared, version }
     }
 
     /// Returns a reference to the most recently sent value

--- a/tokio/src/util/slab.rs
+++ b/tokio/src/util/slab.rs
@@ -296,7 +296,7 @@ impl<T> Slab<T> {
 
             // Remove the slots vector from the page. This is done so that the
             // freeing process is done outside of the lock's critical section.
-            let vec = mem::replace(&mut slots.slots, vec![]);
+            let vec = mem::take(&mut slots.slots);
             slots.head = 0;
 
             // Drop the lock so we can drop the vector outside the lock below.


### PR DESCRIPTION
## Motivation
Make clippy a little bit happier.

## Solution
Apply some lints.

There are still few things that clippy complains about but some of them like:
https://github.com/tokio-rs/tokio/blob/2b9b55810847b4c7855e3de82f432ca997600f30/tokio/src/runtime/task/state.rs#L31-L38
were probably put there on purpose see https://github.com/tokio-rs/tokio/pull/3588#discussion_r588998717

And other warnings about wrong self conventions on internal functions and these warnings should be probably ignored but there are few of them so either at crate level or will require few single `#[allow]`
<details>

```
warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> tokio/src/io/driver/scheduled_io.rs:405:19
    |
405 |         fn as_raw(handle: &NonNull<Waiter>) -> NonNull<Waiter> {
    |                   ^^^^^^
    |
    = note: `#[warn(clippy::wrong_self_convention)]` on by default
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
    --> tokio/src/sync/broadcast.rs:1027:15
     |
1027 |     fn as_raw(handle: &NonNull<Waiter>) -> NonNull<Waiter> {
     |               ^^^^^^
     |
     = help: consider choosing a less ambiguous name
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> tokio/src/sync/notify.rs:720:15
    |
720 |     fn as_raw(handle: &NonNull<Waiter>) -> NonNull<Waiter> {
    |               ^^^^^^
    |
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> tokio/src/sync/batch_semaphore.rs:578:15
    |
578 |     fn as_raw(handle: &Self::Handle) -> NonNull<Waiter> {
    |               ^^^^^^
    |
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
   --> tokio/src/time/driver/entry.rs:464:15
    |
464 |     fn as_raw(handle: &Self::Handle) -> NonNull<Self::Target> {
    |               ^^^^^^
    |
    = help: consider choosing a less ambiguous name
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: methods called `as_*` usually take `self` by reference or `self` by mutable reference
  --> tokio/src/util/linked_list.rs:53:23
   |
53 |     fn as_raw(handle: &Self::Handle) -> NonNull<Self::Target>;
   |                       ^^^^^^^^^^^^^
   |
   = help: consider choosing a less ambiguous name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```
</details>

However I'm not knowledgeable about tokio internals to  say anything about these clippy errors:
<details>

```
error: the inner value of this ManuallyDrop will not be dropped
  --> tokio/src/util/wake.rs:60:5
   |
60 |     drop(arc);
   |     ^^^^^^^^^
   |
   = note: `#[deny(clippy::undropped_manually_drops)]` on by default
   = help: to drop a `ManuallyDrop<T>`, use std::mem::ManuallyDrop::drop
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undropped_manually_drops

error: the inner value of this ManuallyDrop will not be dropped
  --> tokio/src/util/wake.rs:61:5
   |
61 |     drop(arc_clone);
   |     ^^^^^^^^^^^^^^^
   |
   = help: to drop a `ManuallyDrop<T>`, use std::mem::ManuallyDrop::drop
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#undropped_manually_drops
   ```
</details>