### PR TITLE
time: allow users to specify `Interval` behavior when delayed

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -363,11 +363,10 @@ impl Default for MissedTickBehavior {
 /// duration between each instant. Unlike calling [`sleep`] in a loop, this lets
 /// you count the time spent between the calls to [`sleep`] as well.
 ///
-/// An `Interval` can be turned into a [`Stream`] with [`IntervalStream`].
+/// An `Interval` can be turned into a `Stream` with [`IntervalStream`].
 ///
 /// [`IntervalStream`]: https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.IntervalStream.html
 /// [`sleep`]: crate::time::sleep
-/// [`Stream`]: std::stream::Stream
 #[derive(Debug)]
 pub struct Interval {
     /// Future that completes the next time the `Interval` yields a value.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -123,11 +123,14 @@ pub fn interval_at(start: Instant, period: Duration) -> Interval {
 ///
 /// # async fn task_that_takes_one_to_three_seconds() {}
 ///
-/// let mut interval = time::interval(time::Duration::from_secs(2));
-/// for _ in 0..5 {
-///     interval.tick().await;
-///     // if this takes more than 2 seconds, a tick will be delayed
-///     task_that_takes_one_to_three_seconds().await;
+/// #[tokio::main]
+/// async fn main() {
+///     let mut interval = time::interval(time::Duration::from_secs(2));
+///     for _ in 0..5 {
+///         interval.tick().await;
+///         // if this takes more than 2 seconds, a tick will be delayed
+///         task_that_takes_one_to_three_seconds().await;
+///     }
 /// }
 /// ```
 ///

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -118,8 +118,10 @@ pub fn interval_at(start: Instant, period: Duration) -> Interval {
 /// Sometimes, an [`Interval`]'s tick is missed. For example, consider the
 /// following:
 ///
-/// ```ignore
+/// ```
 /// use tokio::time;
+///
+/// # async fn task_that_takes_one_to_three_seconds() {}
 ///
 /// let mut interval = time::interval(time::Duration::from_secs(2));
 /// for _ in 0..5 {

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -301,7 +301,7 @@ pub enum MissedTickBehavior {
 }
 
 impl MissedTickBehavior {
-    /// Determine when the next tick should happen.
+    /// If a tick is missed, this method is called to determine when the next tick should happen.
     fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
         match self {
             Self::Burst => timeout + period,

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -138,7 +138,7 @@ pub fn interval_at(start: Instant, period: Duration) -> Interval {
 /// behavior they want [`Interval`] to exhibit. Each variant represents a
 /// different strategy.
 ///
-/// Note that because the executor cannot guarantee exect precision with timers,
+/// Note that because the executor cannot guarantee exact precision with timers,
 /// these strategies will only apply when the error in time is greater than 5
 /// milliseconds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -254,16 +254,16 @@ pub enum MissedTickBehavior {
     /// versions of Tokio.
     Burst,
 
-    /// Delay missed ticks to happen at multiples of [`period`] from when
+    /// Delay missed ticks to happen at multiples of `period` from when
     /// [`Interval`] regained control.
     ///
     /// When this strategy is used, after regaining control, [`Interval`] ticks
     /// immediately, then schedules all future ticks to happen at a regular
-    /// [`period`] from the point when [`Interval`] regained control.
+    /// `period` from the point when [`Interval`] regained control.
     /// [`tick`] yields immediately with an [`Instant`] that represents the time
     /// that the tick should have happened. All subsequent calls to
     /// [`tick`] yield an [`Instant`] that is a multiple of
-    /// [`period`] away from the point that [`Interval`] regained control.
+    /// `period` away from the point that [`Interval`] regained control.
     ///
     /// This would look something like this:
     /// ```text
@@ -280,20 +280,19 @@ pub enum MissedTickBehavior {
     /// ```
     ///
     /// Note that as a result, the ticks are no longer guaranteed to happen at
-    /// a multiple of [`period`] from `delay`.
+    /// a multiple of `period` from `delay`.
     ///
-    /// [`period`]: Interval::period
     /// [`tick`]: Interval::tick
     Delay,
 
-    /// Skip the missed ticks and tick on the next multiple of [`period`].
+    /// Skip the missed ticks and tick on the next multiple of `period`.
     ///
     /// When this strategy is used, after regaining control, [`Interval`] ticks
     /// immediately, then schedules the next tick on the closest multiple of
-    /// [`period`] from `delay`. Thus, the yielded value from
+    /// `period` from `delay`. Thus, the yielded value from
     /// [`tick`](Interval::tick) is an [`Instant`] that is some multiple of
-    /// [`period`] from `start`. However, that yielded [`Instant`] is not
-    /// guarenteed to be exactly one multiple of [`period`] from the tick that
+    /// `period` from `start`. However, that yielded [`Instant`] is not
+    /// guarenteed to be exactly one multiple of `period` from the tick that
     /// got blocked.
     ///
     /// This would look something like this:
@@ -308,8 +307,6 @@ pub enum MissedTickBehavior {
     //                                                                              Ready(s + 6p)
     // * Where `s` is the start time and `p` is the period
     /// ```
-    ///
-    /// [`period`]: Interval::period
     Skip,
 }
 

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -1,17 +1,20 @@
 use crate::future::poll_fn;
 use crate::time::{sleep_until, Duration, Instant, Sleep};
 
-use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::{convert::TryInto, future::Future};
 
-/// Creates new `Interval` that yields with interval of `duration`. The first
-/// tick completes immediately.
+/// Creates new [`Interval`] that yields with interval of `period`. The first
+/// tick completes immediately. The [`MissedTickBehavior`] is the
+/// [default one](MissedTickBehavior::default), which is
+/// [`Burst`](MissedTickBehavior::Burst).
 ///
-/// An interval will tick indefinitely. At any time, the `Interval` value can be
-/// dropped. This cancels the interval.
+/// An interval will tick indefinitely. At any time, the [`Interval`] value can
+/// be dropped. This cancels the interval.
 ///
-/// This function is equivalent to `interval_at(Instant::now(), period)`.
+/// This function is equivalent to
+/// [`interval_at(Instant::now(), period)`](interval_at).
 ///
 /// # Panics
 ///
@@ -26,9 +29,9 @@ use std::task::{Context, Poll};
 /// async fn main() {
 ///     let mut interval = time::interval(Duration::from_millis(10));
 ///
-///     interval.tick().await;
-///     interval.tick().await;
-///     interval.tick().await;
+///     interval.tick().await; // ticks immediately
+///     interval.tick().await; // ticks after 10ms
+///     interval.tick().await; // ticks after 10ms
 ///
 ///     // approximately 20ms have elapsed.
 /// }
@@ -37,9 +40,9 @@ use std::task::{Context, Poll};
 /// A simple example using `interval` to execute a task every two seconds.
 ///
 /// The difference between `interval` and [`sleep`] is that an `interval`
-/// measures the time since the last tick, which means that `.tick().await`
+/// measures the time since the last tick, which means that [`.tick().await`]
 /// may wait for a shorter time than the duration specified for the interval
-/// if some time has passed between calls to `.tick().await`.
+/// if some time has passed between calls to [`.tick().await`].
 ///
 /// If the tick in the example below was replaced with [`sleep`], the task
 /// would only be executed once every three seconds, and not every two
@@ -64,17 +67,23 @@ use std::task::{Context, Poll};
 /// ```
 ///
 /// [`sleep`]: crate::time::sleep()
+/// [`.tick().await`]: Interval::tick
 pub fn interval(period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 
     interval_at(Instant::now(), period)
 }
 
-/// Creates new `Interval` that yields with interval of `period` with the
-/// first tick completing at `start`.
+/// Creates new [`Interval`] that yields with interval of `period` with the
+/// first tick completing at `start`. The [`MissedTickBehavior`] is the
+/// [default one](MissedTickBehavior::default), which is
+/// [`Burst`](MissedTickBehavior::Burst).
 ///
-/// An interval will tick indefinitely. At any time, the `Interval` value can be
-/// dropped. This cancels the interval.
+/// An interval will tick indefinitely. At any time, the [`Interval`] value can
+/// be dropped. This cancels the interval.
+///
+/// This function is equivalent to
+/// [`interval_with_missed_tick_behavior_at(start, period, Default::default())`](interval_with_missed_tick_behavior_at)
 ///
 /// # Panics
 ///
@@ -90,9 +99,9 @@ pub fn interval(period: Duration) -> Interval {
 ///     let start = Instant::now() + Duration::from_millis(50);
 ///     let mut interval = interval_at(start, Duration::from_millis(10));
 ///
-///     interval.tick().await;
-///     interval.tick().await;
-///     interval.tick().await;
+///     interval.tick().await; // ticks after 50ms
+///     interval.tick().await; // ticks after 10ms
+///     interval.tick().await; // ticks after 10ms
 ///
 ///     // approximately 70ms have elapsed.
 /// }
@@ -100,22 +109,265 @@ pub fn interval(period: Duration) -> Interval {
 pub fn interval_at(start: Instant, period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 
+    interval_with_missed_tick_behavior_at(start, period, Default::default())
+}
+
+/// Creates new [`Interval`] with a specific [`MissedTickBehavior`] that yields
+/// with interval of `period`. The first tick completes immediately.
+///
+/// An interval will tick indefinitely. At any time, the [`Interval`] value can
+/// be dropped. This cancels the interval.
+///
+/// This function is equivalent to
+/// [`interval_with_missed_tick_behavior_at(Instant::now(), period, missed_tick_behavior)`](interval_with_missed_tick_behavior_at)
+///
+/// # Panics
+///
+/// This function panics if `period` is zero.
+///
+/// # Examples
+///
+/// ```
+/// use tokio::time::{
+///     interval_with_missed_tick_behavior,
+///     sleep,
+///     Duration,
+///     MissedTickBehavior,
+/// };
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let mut interval = interval_with_missed_tick_behavior(
+///         Duration::from_millis(10),
+///         MissedTickBehavior::Skip,
+///     );
+///
+///     interval.tick().await;                  // ticks immediately
+///     sleep(Duration::from_millis(25)).await; // simulating executor getting blocked
+///     interval.tick().await;                  // ticks immediately, yielding an `Instant` 10ms after the starting tick
+///     interval.tick().await;                  // ticks after 5ms, yielding an `Instant` 30ms after the starting tick
+///
+///     // approximately 30ms have elapsed.
+/// }
+/// ```
+pub fn interval_with_missed_tick_behavior(
+    period: Duration,
+    missed_tick_behavior: MissedTickBehavior,
+) -> Interval {
+    assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
+
+    interval_with_missed_tick_behavior_at(Instant::now(), period, missed_tick_behavior)
+}
+
+/// Creates new [`Interval`] with a specific [`MissedTickBehavior`] that yields
+/// with interval of `period`. The first tick completes at `start`.
+///
+/// An interval will tick indefinitely. At any time, the [`Interval`] value can
+/// be dropped. This cancels the interval.
+///
+/// # Panics
+///
+/// This function panics if `period` is zero.
+///
+/// # Examples
+///
+/// ```
+/// use tokio::time::{
+///     interval_with_missed_tick_behavior_at,
+///     sleep,
+///     Duration,
+///     Instant,
+///     MissedTickBehavior
+/// };
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let start = Instant::now() + Duration::from_millis(50);
+///     let mut interval = interval_with_missed_tick_behavior_at(
+///         start,
+///         Duration::from_millis(10),
+///         MissedTickBehavior::Skip,
+///     );
+///
+///     interval.tick().await;                  // ticks after 50ms
+///     sleep(Duration::from_millis(25)).await; // simulating executor getting blocked
+///     interval.tick().await;                  // ticks immediately, yielding an `Instant` 10ms after the starting tick
+///     interval.tick().await;                  // ticks after 5ms, yielding an `Instant` 30ms after the starting tick
+///
+///     // approximately 30ms have elapsed.
+/// }
+/// ```
+pub fn interval_with_missed_tick_behavior_at(
+    start: Instant,
+    period: Duration,
+    missed_tick_behavior: MissedTickBehavior,
+) -> Interval {
+    assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
+
     Interval {
         delay: Box::pin(sleep_until(start)),
         period,
+        missed_tick_behavior,
     }
 }
 
-/// Interval returned by [`interval`](interval) and [`interval_at`](interval_at).
+/// Defines the behavior of an [`Interval`] when it misses a tick.
+///
+/// Occasionally, the executor may be blocked, and as a result, [`Interval`]
+/// misses a tick. By default, when this happens, [`Interval`] fires ticks
+/// as quickly as it can until it is back to where it should be. However,
+/// this is not always the desired behavior when ticks are missed.
+/// `MissedTickBehavior` allows users to specify which behavior they want
+/// [`Interval`] to exhibit. Each variant represents a different strategy.
+///
+/// Because the executor cannot guarantee exect precision with
+/// timers, these strategies will only apply when the
+/// error in time is greater than 5 milliseconds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MissedTickBehavior {
+    /// Tick as fast as possible until caught up.
+    ///
+    /// When this strategy is used, after regaining control, [`Interval`] ticks
+    /// as fast as it can until it is caught up to where it should be had the
+    /// executor not been blocked. The [`Instant`]s yielded by
+    /// [`tick`](Interval::tick()) are the same as they would have been if the executor had not
+    /// been blocked.
+    ///
+    /// This would look something like this:
+    /// ```text
+    /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+    /// Actual ticks:   | work -----|          delay          | work | work | work -| work -----|
+    //  Poll behavior:  |   |       |                         |      |      |       |           |
+    //                  |   |       |                         |      |      |       |           |
+    //           Ready(s)   |       |             Ready(s + 2p)      |      |       |           |
+    //                Pending       |                    Ready(s + 3p)      |       |           |
+    //                   Ready(s + p)                           Ready(s + 4p)       |           |
+    //                                                                  Ready(s + 5p)           |
+    //                                                                              Ready(s + 6p)
+    // * Where `s` is the start time and `p` is the period
+    /// ```
+    ///
+    /// This is the default behavior when [`Interval`] is created with
+    /// [`interval`] and [`interval_at`].
+    ///
+    /// Note: this is the behavior that [`Interval`] exhibited in previous
+    /// versions of Tokio.
+    Burst,
+
+    /// Delay missed ticks to happen at multiples of [`period`] from when
+    /// [`Interval`] regained control.
+    ///
+    /// When this strategy is used, after regaining control, [`Interval`] ticks
+    /// immediately, then schedules all future ticks to happen at a regular
+    /// [`period`] from the point when [`Interval`] regained control.
+    /// [`tick`] yields immediately with an [`Instant`] that represents the time
+    /// that the tick should have happened. All subsequent calls to
+    /// [`tick`] yield an [`Instant`] that is a multiple of
+    /// [`period`] away from the point that [`Interval`] regained control.
+    ///
+    /// This would look something like this:
+    /// ```text
+    /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+    /// Actual ticks:   | work -----|          delay          | work -----| work -----| work -----|
+    //  Poll behavior:  |   |       |                         |   |       |           |           |
+    //                  |   |       |                         |   |       |           |           |
+    //           Ready(s)   |       |             Ready(s + 2p)   |       |           |           |
+    //                Pending       |                       Pending       |           |           |
+    //                   Ready(s + p)                     Ready(s + 2p + d)           |           |
+    //                                                                Ready(s + 3p + d)           |
+    //                                                                            Ready(s + 4p + d)
+    // * Where `s` is the start time, `p` is the period, and `d` is the delay
+    /// ```
+    ///
+    /// Note that as a result, the ticks are no longer guaranteed to happen at
+    /// a multiple of [`period`] from `delay`.
+    ///
+    /// [`period`]: Interval::period
+    /// [`tick`]: Interval::tick
+    Delay,
+
+    /// Skip the missed ticks and tick on the next multiple of [`period`].
+    ///
+    /// When this strategy is used, after regaining control, [`Interval`] ticks
+    /// immediately, then schedules the next tick on the closest multiple of
+    /// [`period`] from `delay`. Thus, the yielded value from
+    /// [`tick`](Interval::tick) is an [`Instant`] that is some multiple of
+    /// [`period`] from `start`. However, that yielded [`Instant`] is not
+    /// guarenteed to be exactly one multiple of [`period`] from the tick that
+    /// got blocked.
+    ///
+    /// This would look something like this:
+    /// ```text
+    /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+    /// Actual ticks:   | work -----|          delay          | work ---| work -----| work -----|
+    //  Poll behavior:  |   |       |                         |         |           |           |
+    //                  |   |       |                         |         |           |           |
+    //           Ready(s)   |       |             Ready(s + 2p)         |           |           |
+    //                Pending       |                       Ready(s + 4p)           |           |
+    //                   Ready(s + p)                                   Ready(s + 5p)           |
+    //                                                                              Ready(s + 6p)
+    // * Where `s` is the start time and `p` is the period
+    /// ```
+    ///
+    /// [`period`]: Interval::period
+    Skip,
+}
+
+impl MissedTickBehavior {
+    /// Determine when the next tick should happen.
+    fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
+        match self {
+            Self::Burst => timeout + period,
+            Self::Delay => now + period,
+            Self::Skip => {
+                now + period
+                    - Duration::from_nanos(
+                        ((now - timeout).as_nanos() % period.as_nanos())
+                            .try_into()
+                            // This operation is practically guaranteed not to
+                            // fail, as in order for it to fail, `period` would
+                            // have to be longer than `now - timeout`, and both
+                            // would have to be longer than 584 years.
+                            //
+                            // If it did fail, there's not a good way to pass
+                            // the error along to the user, so we just panic.
+                            .expect(
+                                "too much time has elapsed since the interval was supposed to tick",
+                            ),
+                    )
+            }
+        }
+    }
+}
+
+impl Default for MissedTickBehavior {
+    /// Returns [`MissedTickBehavior::Burst`].
+    ///
+    /// For most usecases, the [`Burst`] strategy is what is desired.
+    /// Additionally, to preserve backwards compatibility, the [`Burst`]
+    /// strategy must be the default. For these reasons,
+    /// [`MissedTickBehavior::Burst`] is the default for
+    /// [`MissedTickBehavior`]. See [`Burst`] for more details.
+    ///
+    /// [`Burst`]: MissedTickBehavior::Burst
+    fn default() -> Self {
+        Self::Burst
+    }
+}
+
+/// Interval returned by [`interval`], [`interval_at`],
+/// [`interval_with_missed_tick_behavior`], and
+/// [`interval_with_missed_tick_behavior_at`].
 ///
 /// This type allows you to wait on a sequence of instants with a certain
-/// duration between each instant. Unlike calling [`sleep`](crate::time::sleep)
-/// in a loop, this lets you count the time spent between the calls to `sleep`
-/// as well.
+/// duration between each instant. Unlike calling [`sleep`] in a loop, this lets
+/// you count the time spent between the calls to [`sleep`] as well.
 ///
-/// An `Interval` can be turned into a `Stream` with [`IntervalStream`].
+/// An `Interval` can be turned into a [`Stream`] with [`IntervalStream`].
 ///
-/// [`IntervalStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.IntervalStream.html
+/// [`IntervalStream`]: https://docs.rs/tokio-stream/latest/tokio_stream/wrappers/struct.IntervalStream.html
+/// [`sleep`]: crate::time::sleep
+/// [`Stream`]: std::stream::Stream
 #[derive(Debug)]
 pub struct Interval {
     /// Future that completes the next time the `Interval` yields a value.
@@ -123,6 +375,10 @@ pub struct Interval {
 
     /// The duration between values yielded by `Interval`.
     period: Duration,
+
+    /// The strategy `Interval` should use when the executor gets blocked and a
+    /// tick is missed.
+    missed_tick_behavior: MissedTickBehavior,
 }
 
 impl Interval {
@@ -159,22 +415,55 @@ impl Interval {
     ///
     /// When this method returns `Poll::Pending`, the current task is scheduled
     /// to receive a wakeup when the instant has elapsed. Note that on multiple
-    /// calls to `poll_tick`, only the `Waker` from the `Context` passed to the
-    /// most recent call is scheduled to receive a wakeup.
+    /// calls to `poll_tick`, only the [`Waker`](std::task::Waker) from the
+    /// [`Context`] passed to the most recent call is scheduled to receive a
+    /// wakeup.
     pub fn poll_tick(&mut self, cx: &mut Context<'_>) -> Poll<Instant> {
         // Wait for the delay to be done
         ready!(Pin::new(&mut self.delay).poll(cx));
 
-        // Get the `now` by looking at the `delay` deadline
-        let now = self.delay.deadline();
+        // Get the time at which the `delay` was supposed to complete
+        let timeout = self.delay.deadline();
 
-        // The next interval value is `duration` after the one that just
-        // yielded.
-        let next = now + self.period;
+        let now = Instant::now();
+
+        // If the executor was not blocked, and thus we are being called
+        // before the next tick is due, just schedule the next tick normally,
+        // one `period` after `scheduled_timeout`, when the last tick went
+        // off
+        //
+        // However, if a tick took excessively long and we are now behind,
+        // schedule the next tick according to how the user specified with
+        // `MissedTickBehavior`
+        let next = if now > timeout + Duration::from_millis(5) {
+            self.missed_tick_behavior
+                .next_timeout(timeout, now, self.period)
+        } else {
+            timeout + self.period
+        };
+
         self.delay.as_mut().reset(next);
 
         // Return the current instant
-        Poll::Ready(now)
+        Poll::Ready(timeout)
+    }
+
+    /// Returns the [`MissedTickBehavior`] strategy that is currently being
+    /// used.
+    pub fn missed_tick_behavior(&self) -> MissedTickBehavior {
+        self.missed_tick_behavior
+    }
+
+    /// Sets the [`MissedTickBehavior`] strategy that should be used.
+    pub fn set_missed_tick_behavior(&mut self, behavior: MissedTickBehavior) {
+        self.missed_tick_behavior = behavior;
+    }
+
+    /// Resets the [`MissedTickBehavior`] strategy that should be used to the
+    /// [default one](MissedTickBehavior::default), which is
+    /// [`Burst`](MissedTickBehavior::Burst).
+    pub fn reset_missed_tick_behavior(&mut self) {
+        self.missed_tick_behavior = Default::default();
     }
 
     /// Returns the period of the interval.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -159,14 +159,6 @@ pub enum MissedTickBehavior {
     /// ```text
     /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
     /// Actual ticks:   | work -----|          delay          | work | work | work -| work -----|
-    //  Poll behavior:  |   |       |                         |      |      |       |           |
-    //                  |   |       |                         |      |      |       |           |
-    //           Ready(s)   |       |             Ready(s + 2p)      |      |       |           |
-    //                Pending       |                    Ready(s + 3p)      |       |           |
-    //                   Ready(s + p)                           Ready(s + 4p)       |           |
-    //                                                                  Ready(s + 5p)           |
-    //                                                                              Ready(s + 6p)
-    // * Where `s` is the start time and `p` is the period
     /// ```
     ///
     /// This is the default behavior when [`Interval`] is created with
@@ -183,14 +175,6 @@ pub enum MissedTickBehavior {
     /// ```text
     /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
     /// Actual ticks:   | work -----|          delay          | work -----| work -----| work -----|
-    //  Poll behavior:  |   |       |                         |   |       |           |           |
-    //                  |   |       |                         |   |       |           |           |
-    //           Ready(s)   |       |             Ready(s + 2p)   |       |           |           |
-    //                Pending       |                       Pending       |           |           |
-    //                   Ready(s + p)                     Ready(s + 2p + d)           |           |
-    //                                                                Ready(s + 3p + d)           |
-    //                                                                            Ready(s + 4p + d)
-    // * Where `s` is the start time, `p` is the period, and `d` is the delay
     /// ```
     ///
     /// Note that as a result, the ticks are no longer guaranteed to happen at
@@ -208,12 +192,6 @@ pub enum MissedTickBehavior {
     /// ```text
     /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
     /// Actual ticks:   | work -----|          delay          | work ---| work -----| work -----|
-    //  Poll behavior:  |   |       |                         |         |           |           |
-    //                  |   |       |                         |         |           |           |
-    //           Ready(s)   |       |             Ready(s + 2p)         |           |           |
-    //                Pending       |                       Ready(s + 4p)           |           |
-    //                   Ready(s + p)                                   Ready(s + 5p)           |
-    //                                                                              Ready(s + 6p)
     // * Where `s` is the start time and `p` is the period
     /// ```
     ///

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -360,12 +360,6 @@ impl Interval {
         self.missed_tick_behavior = behavior;
     }
 
-    /// Resets the [`MissedTickBehavior`] strategy to the default, which is
-    /// [`Burst`](MissedTickBehavior::Burst).
-    pub fn reset_missed_tick_behavior(&mut self) {
-        self.missed_tick_behavior = Default::default();
-    }
-
     /// Returns the period of the interval.
     pub fn period(&self) -> Duration {
         self.period

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -166,9 +166,6 @@ pub enum MissedTickBehavior {
     ///
     /// This is the default behavior when [`Interval`] is created with
     /// [`interval`] and [`interval_at`].
-    ///
-    /// Note: this is the behavior that [`Interval`] exhibited in previous
-    /// versions of Tokio.
     Burst,
 
     /// Delay missed ticks to happen at multiples of `period` from when [`tick`]

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -192,7 +192,6 @@ pub enum MissedTickBehavior {
     /// ```text
     /// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
     /// Actual ticks:   | work -----|          delay          | work ---| work -----| work -----|
-    // * Where `s` is the start time and `p` is the period
     /// ```
     ///
     /// Note that the ticks aren't guarenteed to be one `period` away from the

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -82,9 +82,6 @@ pub fn interval(period: Duration) -> Interval {
 /// An interval will tick indefinitely. At any time, the [`Interval`] value can
 /// be dropped. This cancels the interval.
 ///
-/// This function is equivalent to
-/// [`interval_with_missed_tick_behavior_at(start, period, Default::default())`](interval_with_missed_tick_behavior_at)
-///
 /// # Panics
 ///
 /// This function panics if `period` is zero.
@@ -109,105 +106,10 @@ pub fn interval(period: Duration) -> Interval {
 pub fn interval_at(start: Instant, period: Duration) -> Interval {
     assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
 
-    interval_with_missed_tick_behavior_at(start, period, Default::default())
-}
-
-/// Creates new [`Interval`] with a specific [`MissedTickBehavior`] that yields
-/// with interval of `period`. The first tick completes immediately.
-///
-/// An interval will tick indefinitely. At any time, the [`Interval`] value can
-/// be dropped. This cancels the interval.
-///
-/// This function is equivalent to
-/// [`interval_with_missed_tick_behavior_at(Instant::now(), period, missed_tick_behavior)`](interval_with_missed_tick_behavior_at)
-///
-/// # Panics
-///
-/// This function panics if `period` is zero.
-///
-/// # Examples
-///
-/// ```
-/// use tokio::time::{
-///     interval_with_missed_tick_behavior,
-///     sleep,
-///     Duration,
-///     MissedTickBehavior,
-/// };
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let mut interval = interval_with_missed_tick_behavior(
-///         Duration::from_millis(10),
-///         MissedTickBehavior::Skip,
-///     );
-///
-///     interval.tick().await;                  // ticks immediately
-///     sleep(Duration::from_millis(25)).await; // simulating executor getting blocked
-///     interval.tick().await;                  // ticks immediately, yielding an `Instant` 10ms after the starting tick
-///     interval.tick().await;                  // ticks after 5ms, yielding an `Instant` 30ms after the starting tick
-///
-///     // approximately 30ms have elapsed.
-/// }
-/// ```
-pub fn interval_with_missed_tick_behavior(
-    period: Duration,
-    missed_tick_behavior: MissedTickBehavior,
-) -> Interval {
-    assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
-
-    interval_with_missed_tick_behavior_at(Instant::now(), period, missed_tick_behavior)
-}
-
-/// Creates new [`Interval`] with a specific [`MissedTickBehavior`] that yields
-/// with interval of `period`. The first tick completes at `start`.
-///
-/// An interval will tick indefinitely. At any time, the [`Interval`] value can
-/// be dropped. This cancels the interval.
-///
-/// # Panics
-///
-/// This function panics if `period` is zero.
-///
-/// # Examples
-///
-/// ```
-/// use tokio::time::{
-///     interval_with_missed_tick_behavior_at,
-///     sleep,
-///     Duration,
-///     Instant,
-///     MissedTickBehavior
-/// };
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let start = Instant::now() + Duration::from_millis(50);
-///     let mut interval = interval_with_missed_tick_behavior_at(
-///         start,
-///         Duration::from_millis(10),
-///         MissedTickBehavior::Skip,
-///     );
-///
-///     interval.tick().await;                  // ticks after 50ms
-///     sleep(Duration::from_millis(25)).await; // simulating executor getting blocked
-///     interval.tick().await;                  // ticks immediately, yielding an `Instant` 10ms after the starting tick
-///     interval.tick().await;                  // ticks after 5ms, yielding an `Instant` 30ms after the starting tick
-///
-///     // approximately 30ms have elapsed.
-/// }
-/// ```
-pub fn interval_with_missed_tick_behavior_at(
-    start: Instant,
-    period: Duration,
-    missed_tick_behavior: MissedTickBehavior,
-) -> Interval {
-    assert!(period > Duration::new(0, 0), "`period` must be non-zero.");
-
     Interval {
         delay: Box::pin(sleep_until(start)),
         period,
-        missed_tick_behavior,
+        missed_tick_behavior: Default::default(),
     }
 }
 
@@ -352,9 +254,7 @@ impl Default for MissedTickBehavior {
     }
 }
 
-/// Interval returned by [`interval`], [`interval_at`],
-/// [`interval_with_missed_tick_behavior`], and
-/// [`interval_with_missed_tick_behavior_at`].
+/// Interval returned by [`interval`], [`interval_at`]
 ///
 /// This type allows you to wait on a sequence of instants with a certain
 /// duration between each instant. Unlike calling [`sleep`] in a loop, this lets

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -3,21 +3,21 @@
 //! This module provides a number of types for executing code after a set period
 //! of time.
 //!
-//! * `Sleep` is a future that does no work and completes at a specific `Instant`
+//! * [`Sleep`] is a future that does no work and completes at a specific [`Instant`]
 //!   in time.
 //!
-//! * `Interval` is a stream yielding a value at a fixed period. It is
-//!   initialized with a `Duration` and repeatedly yields each time the duration
+//! * [`Interval`] is a stream yielding a value at a fixed period. It is
+//!   initialized with a [`Duration`] and repeatedly yields each time the duration
 //!   elapses.
 //!
-//! * `Timeout`: Wraps a future or stream, setting an upper bound to the amount
+//! * [`Timeout`]: Wraps a future or stream, setting an upper bound to the amount
 //!   of time it is allowed to execute. If the future or stream does not
 //!   complete in time, then it is canceled and an error is returned.
 //!
 //! These types are sufficient for handling a large number of scenarios
 //! involving time.
 //!
-//! These types must be used from within the context of the `Runtime`.
+//! These types must be used from within the context of the [`Runtime`](crate::runtime::Runtime).
 //!
 //! # Examples
 //!
@@ -52,11 +52,13 @@
 //! # }
 //! ```
 //!
-//! A simple example using [`interval`] to execute a task every two seconds.
+//! A simple example using [`interval`](self::interval::interval) to execute
+//! a task every two seconds.
 //!
-//! The difference between [`interval`] and [`sleep`] is that an [`interval`]
-//! measures the time since the last tick, which means that `.tick().await`
-//! may wait for a shorter time than the duration specified for the interval
+//! The difference between [`interval`](self::interval::interval) and
+//! [`sleep`] is that an [`interval`](self::interval::interval) measures
+//! the time since the last tick, which means that `.tick().await` may
+//! wait for a shorter time than the duration specified for the interval
 //! if some time has passed between calls to `.tick().await`.
 //!
 //! If the tick in the example below was replaced with [`sleep`], the task
@@ -80,9 +82,6 @@
 //!     }
 //! }
 //! ```
-//!
-//! [`sleep`]: crate::time::sleep()
-//! [`interval`]: crate::time::interval()
 
 mod clock;
 pub(crate) use self::clock::Clock;
@@ -100,7 +99,10 @@ mod instant;
 pub use self::instant::Instant;
 
 mod interval;
-pub use interval::{interval, interval_at, Interval};
+pub use interval::{
+    interval, interval_at, interval_with_missed_tick_behavior,
+    interval_with_missed_tick_behavior_at, Interval, MissedTickBehavior,
+};
 
 mod timeout;
 #[doc(inline)]

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -52,12 +52,10 @@
 //! # }
 //! ```
 //!
-//! A simple example using [`interval`](self::interval::interval) to execute
-//! a task every two seconds.
+//! A simple example using [`interval`] to execute a task every two seconds.
 //!
-//! The difference between [`interval`](self::interval::interval) and
-//! [`sleep`] is that an [`interval`](self::interval::interval) measures
-//! the time since the last tick, which means that `.tick().await` may
+//! The difference between [`interval`] and [`sleep`] is that an [`interval`]
+//! measures the time since the last tick, which means that `.tick().await` may
 //! wait for a shorter time than the duration specified for the interval
 //! if some time has passed between calls to `.tick().await`.
 //!
@@ -82,6 +80,8 @@
 //!     }
 //! }
 //! ```
+//!
+//! [`interval`]: crate::time::interval()
 
 mod clock;
 pub(crate) use self::clock::Clock;

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -99,10 +99,7 @@ mod instant;
 pub use self::instant::Instant;
 
 mod interval;
-pub use interval::{
-    interval, interval_at, interval_with_missed_tick_behavior,
-    interval_with_missed_tick_behavior_at, Interval, MissedTickBehavior,
-};
+pub use interval::{interval, interval_at, Interval, MissedTickBehavior};
 
 mod timeout;
 #[doc(inline)]

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -4,8 +4,23 @@
 use tokio::time::{self, Duration, Instant};
 use tokio_test::{assert_pending, assert_ready_eq, task};
 
-use std::future::Future;
 use std::task::Poll;
+
+// Takes the `Interval` task, `start` variable, and optional time deltas
+// For each time delta, it polls the `Interval` and asserts that the result is
+// equal to `start` + the specific time delta. Then it asserts that the
+// `Interval` is pending.
+macro_rules! check_interval_poll {
+    ($i:ident, $start:ident, $($delta:expr),*$(,)?) => {
+        $(
+            assert_ready_eq!(poll_next(&mut $i), $start + ms($delta));
+        )*
+        assert_pending!(poll_next(&mut $i));
+    };
+    ($i:ident, $start:ident) => {
+        check_interval_poll!($i, $start,);
+    };
+}
 
 #[tokio::test]
 #[should_panic]
@@ -13,44 +28,152 @@ async fn interval_zero_duration() {
     let _ = time::interval_at(Instant::now(), ms(0));
 }
 
-#[tokio::test]
-async fn usage() {
-    time::pause();
-
+// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+// Actual ticks:   | work -----|          delay          | work | work | work -| work -----|
+// Poll behavior:  |   |       |                         |      |      |       |           |
+//                 |   |       |                         |      |      |       |           |
+//          Ready(s)   |       |             Ready(s + 2p)      |      |       |           |
+//               Pending       |                    Ready(s + 3p)      |       |           |
+//                  Ready(s + p)                           Ready(s + 4p)       |           |
+//                                                                 Ready(s + 5p)           |
+//                                                                             Ready(s + 6p)
+#[tokio::test(start_paused = true)]
+async fn burst() {
     let start = Instant::now();
 
-    // TODO: Skip this
+    // This is necessary because the timer is only so granular, and in order for
+    // all our ticks to resolve, the time needs to be 1ms ahead of what we
+    // expect, so that the runtime will see that it is time to resolve the timer
     time::advance(ms(1)).await;
 
     let mut i = task::spawn(time::interval_at(start, ms(300)));
 
-    assert_ready_eq!(poll_next(&mut i), start);
-    assert_pending!(poll_next(&mut i));
+    check_interval_poll!(i, start, 0);
 
     time::advance(ms(100)).await;
-    assert_pending!(poll_next(&mut i));
+    check_interval_poll!(i, start);
 
     time::advance(ms(200)).await;
-    assert_ready_eq!(poll_next(&mut i), start + ms(300));
-    assert_pending!(poll_next(&mut i));
+    check_interval_poll!(i, start, 300);
 
-    time::advance(ms(400)).await;
-    assert_ready_eq!(poll_next(&mut i), start + ms(600));
-    assert_pending!(poll_next(&mut i));
+    time::advance(ms(650)).await;
+    check_interval_poll!(i, start, 600, 900);
 
-    time::advance(ms(500)).await;
-    assert_ready_eq!(poll_next(&mut i), start + ms(900));
-    assert_ready_eq!(poll_next(&mut i), start + ms(1200));
-    assert_pending!(poll_next(&mut i));
+    time::advance(ms(200)).await;
+    check_interval_poll!(i, start);
+
+    time::advance(ms(100)).await;
+    check_interval_poll!(i, start, 1200);
+
+    time::advance(ms(250)).await;
+    check_interval_poll!(i, start, 1500);
+
+    time::advance(ms(300)).await;
+    check_interval_poll!(i, start, 1800);
+}
+
+// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+// Actual ticks:   | work -----|          delay          | work -----| work -----| work -----|
+// Poll behavior:  |   |       |                         |   |       |           |           |
+//                 |   |       |                         |   |       |           |           |
+//          Ready(s)   |       |             Ready(s + 2p)   |       |           |           |
+//               Pending       |                       Pending       |           |           |
+//                  Ready(s + p)                     Ready(s + 2p + d)           |           |
+//                                                               Ready(s + 3p + d)           |
+//                                                                           Ready(s + 4p + d)
+#[tokio::test(start_paused = true)]
+async fn delay() {
+    let start = Instant::now();
+
+    // This is necessary because the timer is only so granular, and in order for
+    // all our ticks to resolve, the time needs to be 1ms ahead of what we
+    // expect, so that the runtime will see that it is time to resolve the timer
+    time::advance(ms(1)).await;
+
+    let mut i = task::spawn(time::interval_with_missed_tick_behavior_at(
+        start,
+        ms(300),
+        time::MissedTickBehavior::Delay,
+    ));
+
+    check_interval_poll!(i, start, 0);
+
+    time::advance(ms(100)).await;
+    check_interval_poll!(i, start);
+
+    time::advance(ms(200)).await;
+    check_interval_poll!(i, start, 300);
+
+    time::advance(ms(650)).await;
+    check_interval_poll!(i, start, 600);
+
+    time::advance(ms(100)).await;
+    check_interval_poll!(i, start);
+
+    // We have to add one here for the same reason as is above.
+    // Because `Interval` has reset its timer according to `Instant::now()`,
+    // we have to go forward 1 more millisecond than is expected so that the
+    // runtime realizes that it's time to resolve the timer.
+    time::advance(ms(201)).await;
+    // We add one because when using the `Delay` behavior, `Interval`
+    // adds the `period` from `Instant::now()`, which will always be off by one
+    // because we have to advance time by 1 (see above).
+    check_interval_poll!(i, start, 1251);
+
+    time::advance(ms(300)).await;
+    // Again, we add one.
+    check_interval_poll!(i, start, 1551);
+
+    time::advance(ms(300)).await;
+    check_interval_poll!(i, start, 1851);
+}
+
+// Expected ticks: |     1     |     2     |     3     |     4     |     5     |     6     |
+// Actual ticks:   | work -----|          delay          | work ---| work -----| work -----|
+// Poll behavior:  |   |       |                         |         |           |           |
+//                 |   |       |                         |         |           |           |
+//          Ready(s)   |       |             Ready(s + 2p)         |           |           |
+//               Pending       |                       Ready(s + 4p)           |           |
+//                  Ready(s + p)                                   Ready(s + 5p)           |
+//                                                                             Ready(s + 6p)
+#[tokio::test(start_paused = true)]
+async fn skip() {
+    let start = Instant::now();
+
+    // This is necessary because the timer is only so granular, and in order for
+    // all our ticks to resolve, the time needs to be 1ms ahead of what we
+    // expect, so that the runtime will see that it is time to resolve the timer
+    time::advance(ms(1)).await;
+
+    let mut i = task::spawn(time::interval_with_missed_tick_behavior_at(
+        start,
+        ms(300),
+        time::MissedTickBehavior::Skip,
+    ));
+
+    check_interval_poll!(i, start, 0);
+
+    time::advance(ms(100)).await;
+    check_interval_poll!(i, start);
+
+    time::advance(ms(200)).await;
+    check_interval_poll!(i, start, 300);
+
+    time::advance(ms(650)).await;
+    check_interval_poll!(i, start, 600);
+
+    time::advance(ms(250)).await;
+    check_interval_poll!(i, start, 1200);
+
+    time::advance(ms(300)).await;
+    check_interval_poll!(i, start, 1500);
+
+    time::advance(ms(300)).await;
+    check_interval_poll!(i, start, 1800);
 }
 
 fn poll_next(interval: &mut task::Spawn<time::Interval>) -> Poll<Instant> {
-    interval.enter(|cx, mut interval| {
-        tokio::pin! {
-            let fut = interval.tick();
-        }
-        fut.poll(cx)
-    })
+    interval.enter(|cx, mut interval| interval.poll_tick(cx))
 }
 
 fn ms(n: u64) -> Duration {

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::time::{self, Duration, Instant};
+use tokio::time::{self, Duration, Instant, MissedTickBehavior};
 use tokio_test::{assert_pending, assert_ready_eq, task};
 
 use std::task::Poll;
@@ -90,11 +90,8 @@ async fn delay() {
     // expect, so that the runtime will see that it is time to resolve the timer
     time::advance(ms(1)).await;
 
-    let mut i = task::spawn(time::interval_with_missed_tick_behavior_at(
-        start,
-        ms(300),
-        time::MissedTickBehavior::Delay,
-    ));
+    let mut i = task::spawn(time::interval_at(start, ms(300)));
+    i.set_missed_tick_behavior(MissedTickBehavior::Delay);
 
     check_interval_poll!(i, start, 0);
 
@@ -145,11 +142,8 @@ async fn skip() {
     // expect, so that the runtime will see that it is time to resolve the timer
     time::advance(ms(1)).await;
 
-    let mut i = task::spawn(time::interval_with_missed_tick_behavior_at(
-        start,
-        ms(300),
-        time::MissedTickBehavior::Skip,
-    ));
+    let mut i = task::spawn(time::interval_at(start, ms(300)));
+    i.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
     check_interval_poll!(i, start, 0);
 


### PR DESCRIPTION
## Motivation
Occasionally, `tokio::time::Interval` may be delayed from ticking, usually because `tick` isn't being called often enough (like if a task is `.await`ing something else). By default, `Interval` continues to schedule ticks normally, which causes a burst of ticks until it is "caught up" in time where it should be. This behavior is not always desired, however.

## Solution
This PR adds the `MissedTickBehavior` enum to the `time` module to allow users to specify what behavior they'd like `Interval` to exhibit when ticks are missed.

Closes #3574