### PR TITLE
tokio-test: extract assert_elapsed macro

### DIFF
--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -4,28 +4,13 @@
 use rand::SeedableRng;
 use rand::{rngs::StdRng, Rng};
 use tokio::time::{self, Duration, Instant, Sleep};
-use tokio_test::{assert_err, assert_pending, assert_ready_eq, task};
+use tokio_test::{assert_err, assert_pending, assert_ready_eq, assert_elapsed, task};
 
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
-
-macro_rules! assert_elapsed {
-    ($now:expr, $ms:expr) => {{
-        let elapsed = $now.elapsed();
-        let lower = ms($ms);
-
-        // Handles ms rounding
-        assert!(
-            elapsed >= lower && elapsed <= lower + ms(1),
-            "actual = {:?}, expected = {:?}",
-            elapsed,
-            lower
-        );
-    }};
-}
 
 #[tokio::test]
 async fn pause_time_in_main() {
@@ -91,7 +76,7 @@ async fn advance_after_poll() {
 
     let before = Instant::now();
     time::advance(ms(100)).await;
-    assert_elapsed!(before, 100);
+    assert_elapsed!(before, ms(100));
 
     assert_pending!(sleep.poll());
 }
@@ -107,7 +92,7 @@ async fn sleep_no_poll() {
 
     let before = Instant::now();
     time::advance(ms(100)).await;
-    assert_elapsed!(before, 100);
+    assert_elapsed!(before, ms(100));
 
     assert_pending!(sleep.poll());
 }
@@ -147,7 +132,7 @@ impl Future for Tester {
                 }
             },
             State::AfterAdvance => {
-                assert_elapsed!(self.before.unwrap(), 100);
+                assert_elapsed!(self.before.unwrap(), ms(100));
 
                 assert_pending!(self.sleep.as_mut().poll(cx));
 
@@ -207,24 +192,24 @@ async fn interval() {
 
     let before = Instant::now();
     time::advance(ms(100)).await;
-    assert_elapsed!(before, 100);
+    assert_elapsed!(before, ms(100));
     assert_pending!(poll_next(&mut i));
 
     let before = Instant::now();
     time::advance(ms(200)).await;
-    assert_elapsed!(before, 200);
+    assert_elapsed!(before, ms(200));
     assert_ready_eq!(poll_next(&mut i), start + ms(300));
     assert_pending!(poll_next(&mut i));
 
     let before = Instant::now();
     time::advance(ms(400)).await;
-    assert_elapsed!(before, 400);
+    assert_elapsed!(before, ms(400));
     assert_ready_eq!(poll_next(&mut i), start + ms(600));
     assert_pending!(poll_next(&mut i));
 
     let before = Instant::now();
     time::advance(ms(500)).await;
-    assert_elapsed!(before, 500);
+    assert_elapsed!(before, ms(500));
     assert_ready_eq!(poll_next(&mut i), start + ms(900));
     assert_ready_eq!(poll_next(&mut i), start + ms(1200));
     assert_pending!(poll_next(&mut i));

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -4,7 +4,7 @@
 use rand::SeedableRng;
 use rand::{rngs::StdRng, Rng};
 use tokio::time::{self, Duration, Instant, Sleep};
-use tokio_test::{assert_err, assert_pending, assert_ready_eq, assert_elapsed, task};
+use tokio_test::{assert_elapsed, assert_err, assert_pending, assert_ready_eq, task};
 
 use std::{
     future::Future,

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -7,8 +7,7 @@ use std::task::Context;
 use futures::task::noop_waker_ref;
 
 use tokio::time::{self, Duration, Instant};
-use tokio_test::{assert_pending, assert_ready, assert_elapsed, task};
-
+use tokio_test::{assert_elapsed, assert_pending, assert_ready, task};
 
 #[tokio::test]
 async fn immediate_sleep() {

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -7,22 +7,8 @@ use std::task::Context;
 use futures::task::noop_waker_ref;
 
 use tokio::time::{self, Duration, Instant};
-use tokio_test::{assert_pending, assert_ready, task};
+use tokio_test::{assert_pending, assert_ready, assert_elapsed, task};
 
-macro_rules! assert_elapsed {
-    ($now:expr, $ms:expr) => {{
-        let elapsed = $now.elapsed();
-        let lower = ms($ms);
-
-        // Handles ms rounding
-        assert!(
-            elapsed >= lower && elapsed <= lower + ms(1),
-            "actual = {:?}, expected = {:?}",
-            elapsed,
-            lower
-        );
-    }};
-}
 
 #[tokio::test]
 async fn immediate_sleep() {
@@ -32,7 +18,7 @@ async fn immediate_sleep() {
 
     // Ready!
     time::sleep_until(now).await;
-    assert_elapsed!(now, 0);
+    assert_elapsed!(now, 1);
 }
 
 #[tokio::test]
@@ -60,10 +46,11 @@ async fn delayed_sleep_level_0() {
 
     for &i in &[1, 10, 60] {
         let now = Instant::now();
+        let dur = ms(i);
 
-        time::sleep_until(now + ms(i)).await;
+        time::sleep_until(now + dur).await;
 
-        assert_elapsed!(now, i);
+        assert_elapsed!(now, dur);
     }
 }
 
@@ -77,7 +64,7 @@ async fn sub_ms_delayed_sleep() {
 
         time::sleep_until(deadline).await;
 
-        assert_elapsed!(now, 1);
+        assert_elapsed!(now, ms(1));
     }
 }
 
@@ -90,7 +77,7 @@ async fn delayed_sleep_wrapping_level_0() {
     let now = Instant::now();
     time::sleep_until(now + ms(60)).await;
 
-    assert_elapsed!(now, 60);
+    assert_elapsed!(now, ms(60));
 }
 
 #[tokio::test]
@@ -107,7 +94,7 @@ async fn reset_future_sleep_before_fire() {
     sleep.as_mut().reset(Instant::now() + ms(200));
     sleep.await;
 
-    assert_elapsed!(now, 200);
+    assert_elapsed!(now, ms(200));
 }
 
 #[tokio::test]
@@ -124,7 +111,7 @@ async fn reset_past_sleep_before_turn() {
     sleep.as_mut().reset(now + ms(80));
     sleep.await;
 
-    assert_elapsed!(now, 80);
+    assert_elapsed!(now, ms(80));
 }
 
 #[tokio::test]
@@ -143,7 +130,7 @@ async fn reset_past_sleep_before_fire() {
     sleep.as_mut().reset(now + ms(80));
     sleep.await;
 
-    assert_elapsed!(now, 80);
+    assert_elapsed!(now, ms(80));
 }
 
 #[tokio::test]
@@ -154,11 +141,11 @@ async fn reset_future_sleep_after_fire() {
     let mut sleep = Box::pin(time::sleep_until(now + ms(100)));
 
     sleep.as_mut().await;
-    assert_elapsed!(now, 100);
+    assert_elapsed!(now, ms(100));
 
     sleep.as_mut().reset(now + ms(110));
     sleep.await;
-    assert_elapsed!(now, 110);
+    assert_elapsed!(now, ms(110));
 }
 
 #[tokio::test]

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -18,7 +18,7 @@ async fn immediate_sleep() {
 
     // Ready!
     time::sleep_until(now).await;
-    assert_elapsed!(now, 1);
+    assert_elapsed!(now, ms(1));
 }
 
 #[tokio::test]


### PR DESCRIPTION
The `assert_elapsed` macro is generally useful for Tokio users. This
commit extracts `assert_elapsed` into `tokio-test`.

It adapts the macro for general use by using `std::time::Duration`
instead of an integral millis value for time comparison.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`assert_elapsed` is a generally very handy macro when interacting with tokio & time, especially because the 1ms tolerance is required.

## Solution

Extract the macro into tokio-test in the two locations it was defined, refactor to use the slightly modified macro.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
