### PR TITLE
add receiver_count to sync::watch::Sender

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -417,6 +417,28 @@ impl<T> Sender<T> {
             Receiver::from_shared(version, shared)
         }
     }
+
+    /// Returns the number of receivers that currently exist
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::watch;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx1) = watch::channel("hello");
+    ///
+    ///     assert_eq!(1, tx.receiver_count());
+    ///
+    ///     let mut _rx2 = rx1.clone();
+    ///
+    ///     assert_eq!(2, tx.receiver_count());
+    /// }
+    /// ```
+    pub fn receiver_count(&self) -> usize {
+        self.shared.ref_count_rx.load(Relaxed)
+    }
 }
 
 impl<T> Drop for Sender<T> {


### PR DESCRIPTION
Add a method to `sync::watch::Sender` to be able to check how many receivers currently exist.

## Motivation

I wanted to be able to get a new `Receiver` from a `Sender` and stop sending if there aren't any receivers. To get a new `Receiver` however i need to store one (a `Sender` cannot create a `Receiver`). Which makes it impossible with the current methods to detect if the channel has no active receivers left.

### Example
```rust
struct Sender<T> {
    tx: watch::Sender<T>,
    rx: watch::Receiver<T>
}

impl<T> Sender<T> {
    pub fn subscribe(&self) -> watch::Receiver<T> {
       self.rx.clone()
   }
    /// Returns Err(()) if no receivers exist
    pub fn send(&mut self, msg: T) -> Result<(), ()> {
        if self.tx.receiver_count() <= 1 {
            Err(())
        } else {
            self.sender.send(msg).unwrap();
            Ok(())
        }
    }
}
```

## Solution

Adding `receiver_count` seams to be the smallest change that solves my problem.
However if your open to it and feel that `watch::Sender` could benefit from `subscribe` i can add that to this PR.