### PR TITLE
sync: sync watch local version with shared version

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -281,7 +281,7 @@ impl<T> Receiver<T> {
     /// # Examples
     ///
     /// ```
-    /// use tokio::sync::watch;
+    /// use tokio::{sync::watch, time::sleep};
     /// use std::time::Duration;
     ///
     /// #[tokio::main]


### PR DESCRIPTION
Implements the proposed solution to close https://github.com/tokio-rs/tokio/issues/3666

## Motivation

When a `watch` receiver is cloned, it does not use the latest version when calling `changed()`. It is therefore possible that if a receiver whose `changed` method has not been called is cloned, the call to `changed()` is not blocking.

See #3666 for more context

## Solution

Implement a method that allows the user to synchronize the local version counter with the shared one
