### PR TITLE
Fix missing backtick in select doc

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -154,7 +154,7 @@
 /// `select!` panics if all branches are disabled **and** there is no provided
 /// `else` branch. A branch is disabled when the provided `if` precondition
 /// returns `false` **or** when the pattern does not match the result of `<async
-/// expression>.
+/// expression>`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
