### PR TITLE
io: Add write_all_buf to AsyncWriteExt

### DIFF
--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -197,10 +197,11 @@ cfg_io_util! {
         ///
         /// # Examples
         ///
-        /// [`File`] implements `Read` and [`Cursor<&[u8]>`] implements [`Buf`]:
+        /// [`File`] implements [`AsyncWrite`] and [`Cursor`]`<&[u8]>` implements [`Buf`]:
         ///
         /// [`File`]: crate::fs::File
         /// [`Buf`]: bytes::Buf
+        /// [`Cursor`]: std::io::Cursor
         ///
         /// ```no_run
         /// use tokio::io::{self, AsyncWriteExt};
@@ -255,10 +256,11 @@ cfg_io_util! {
         ///
         /// # Examples
         ///
-        /// [`File`] implements `Read` and [`Cursor<&[u8]>`] implements [`Buf`]:
+        /// [`File`] implements [`AsyncWrite`] and [`Cursor`]`<&[u8]>` implements [`Buf`]:
         ///
         /// [`File`]: crate::fs::File
         /// [`Buf`]: bytes::Buf
+        /// [`Cursor`]: std::io::Cursor
         ///
         /// ```no_run
         /// use tokio::io::{self, AsyncWriteExt};

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -276,6 +276,8 @@ cfg_io_util! {
         ///     Ok(())
         /// }
         /// ```
+        ///
+        /// [`write`]: AsyncWriteExt::write
         fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B> where Self: Sized + Unpin, B: Buf {
             write_all_buf(self, src)
         }

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -21,20 +21,20 @@ use bytes::Buf;
 cfg_io_util! {
     /// Defines numeric writer
     macro_rules! write_impl {
-        (
-            $(
-                $(#[$outer:meta])*
-                fn $name:ident(&mut self, n: $ty:ty) -> $($fut:ident)*;
-            )*
-        ) => {
-            $(
-                $(#[$outer])*
-                fn $name<'a>(&'a mut self, n: $ty) -> $($fut)*<&'a mut Self> where Self: Unpin {
-                    $($fut)*::new(self, n)
-                }
-            )*
+            (
+                $(
+                    $(#[$outer:meta])*
+                    fn $name:ident(&mut self, n: $ty:ty) -> $($fut:ident)*;
+                )*
+            ) => {
+                $(
+                    $(#[$outer])*
+                    fn $name<'a>(&'a mut self, n: $ty) -> $($fut)*<&'a mut Self> where Self: Unpin {
+                        $($fut)*::new(self, n)
+                    }
+                )*
+            }
         }
-    }
 
     /// Writes bytes to a sink.
     ///
@@ -160,7 +160,6 @@ cfg_io_util! {
             write_vectored(self, bufs)
         }
 
-
         /// Writes a buffer into this writer, advancing the buffer's internal
         /// cursor.
         ///
@@ -278,7 +277,11 @@ cfg_io_util! {
         /// ```
         ///
         /// [`write`]: AsyncWriteExt::write
-        fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B> where Self: Sized + Unpin, B: Buf {
+        fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B>
+        where
+            Self: Sized + Unpin,
+            B: Buf,
+        {
             write_all_buf(self, src)
         }
 

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -265,7 +265,6 @@ cfg_io_util! {
         /// use tokio::io::{self, AsyncWriteExt};
         /// use tokio::fs::File;
         ///
-        /// use bytes::Buf;
         /// use std::io::Cursor;
         ///
         /// #[tokio::main]
@@ -273,7 +272,7 @@ cfg_io_util! {
         ///     let mut file = File::create("foo.txt").await?;
         ///     let mut buffer = Cursor::new(b"data to write");
         ///
-        ///     file.write_all_buf(&mut buffer);
+        ///     file.write_all_buf(&mut buffer).await?;
         ///     Ok(())
         /// }
         /// ```

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -21,20 +21,20 @@ use bytes::Buf;
 cfg_io_util! {
     /// Defines numeric writer
     macro_rules! write_impl {
-            (
-                $(
-                    $(#[$outer:meta])*
-                    fn $name:ident(&mut self, n: $ty:ty) -> $($fut:ident)*;
-                )*
-            ) => {
-                $(
-                    $(#[$outer])*
-                    fn $name<'a>(&'a mut self, n: $ty) -> $($fut)*<&'a mut Self> where Self: Unpin {
-                        $($fut)*::new(self, n)
-                    }
-                )*
-            }
+        (
+            $(
+                $(#[$outer:meta])*
+                fn $name:ident(&mut self, n: $ty:ty) -> $($fut:ident)*;
+            )*
+        ) => {
+            $(
+                $(#[$outer])*
+                fn $name<'a>(&'a mut self, n: $ty) -> $($fut)*<&'a mut Self> where Self: Unpin {
+                    $($fut)*::new(self, n)
+                }
+            )*
         }
+    }
 
     /// Writes bytes to a sink.
     ///

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -1,6 +1,5 @@
 #![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 
-
 cfg_io_util! {
     mod async_buf_read_ext;
     pub use async_buf_read_ext::AsyncBufReadExt;

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -1,5 +1,6 @@
 #![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 
+
 cfg_io_util! {
     mod async_buf_read_ext;
     pub use async_buf_read_ext::AsyncBufReadExt;
@@ -77,6 +78,7 @@ cfg_io_util! {
     mod write_vectored;
     mod write_all;
     mod write_buf;
+    mod write_all_buf;
     mod write_int;
 
 

--- a/tokio/src/io/util/write_all_buf.rs
+++ b/tokio/src/io/util/write_all_buf.rs
@@ -1,0 +1,56 @@
+use crate::io::AsyncWrite;
+
+use bytes::Buf;
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io;
+use std::marker::PhantomPinned;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// A future to write some of the buffer to an `AsyncWrite`.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct WriteAllBuf<'a, W, B> {
+        writer: &'a mut W,
+        buf: &'a mut B,
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+/// Tries to write some bytes from the given `buf` to the writer in an
+/// asynchronous manner, returning a future.
+pub(crate) fn write_all_buf<'a, W, B>(writer: &'a mut W, buf: &'a mut B) -> WriteAllBuf<'a, W, B>
+where
+    W: AsyncWrite + Unpin,
+    B: Buf,
+{
+    WriteAllBuf {
+        writer,
+        buf,
+        _pin: PhantomPinned,
+    }
+}
+
+impl<W, B> Future for WriteAllBuf<'_, W, B>
+where
+    W: AsyncWrite + Unpin,
+    B: Buf,
+{
+    type Output = io::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let me = self.project();
+        while me.buf.has_remaining() {
+            let n = ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf.chunk())?);
+            me.buf.advance(n);
+            if n == 0 {
+                return Poll::Ready(Err(io::ErrorKind::WriteZero.into()));
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}

--- a/tokio/tests/io_write_all_buf.rs
+++ b/tokio/tests/io_write_all_buf.rs
@@ -1,0 +1,96 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio_test::{assert_err, assert_ok};
+
+use bytes::{Buf, Bytes, BytesMut};
+use std::cmp;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[tokio::test]
+async fn write_all_buf() {
+    struct Wr {
+        buf: BytesMut,
+        cnt: usize,
+    }
+
+    impl AsyncWrite for Wr {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let n = cmp::min(4, buf.len());
+            dbg!(buf);
+            let buf = &buf[0..n];
+
+            self.cnt += 1;
+            self.buf.extend(buf);
+            Ok(buf.len()).into()
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+    }
+
+    let mut wr = Wr {
+        buf: BytesMut::with_capacity(64),
+        cnt: 0,
+    };
+
+    let mut buf = Bytes::from_static(b"hello").chain(Bytes::from_static(b"world"));
+
+    assert_ok!(wr.write_all_buf(&mut buf).await);
+    assert_eq!(wr.buf, b"helloworld"[..]);
+    // expect 4 writes, [hell],[o],[worl],[d]
+    assert_eq!(wr.cnt, 4);
+    assert_eq!(buf.has_remaining(), false);
+}
+
+#[tokio::test]
+async fn write_buf_err() {
+    /// Error out after writing the first 4 bytes
+    struct Wr {
+        cnt: usize,
+    }
+
+    impl AsyncWrite for Wr {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.cnt += 1;
+            if self.cnt == 2 {
+                return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, "whoops")));
+            }
+            Poll::Ready(Ok(4))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+    }
+
+    let mut wr = Wr { cnt: 0 };
+
+    let mut buf = Bytes::from_static(b"hello").chain(Bytes::from_static(b"world"));
+
+    assert_err!(wr.write_all_buf(&mut buf).await);
+    assert_eq!(
+        buf.copy_to_bytes(buf.remaining()),
+        Bytes::from_static(b"oworld")
+    );
+}


### PR DESCRIPTION
This commit adds write_buf_all to AsyncWriteExt. This enables
users to write an entire `Buf` to a writer without needing to manually
loop through each chunk of the `Buf` manually.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

With `write_buf`, users still need to loop through the individual chunks of the buffer. This both more verbose and has a misuse potential where a user thinks that the entire buf will be written.


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add `write_all_buf` which provides a 1-call API to write an entire `impl Buf` to `AsyncWrite`
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
