### PR TITLE
Add into_mutex_reference for MutexGuard

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -561,6 +561,12 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             marker: marker::PhantomData,
         })
     }
+
+    /// Releases the lock and returns a reference to the corresponding Mutex
+    pub fn into_mutex_reference(self) -> &'a Mutex<T> {
+        self.lock.s.release(1);
+        self.lock
+    }
 }
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {


### PR DESCRIPTION
## Motivation
In order to build a condition variable (#2739) in tokio there needs to be a way to release the lock and get a reference to the underlying Mutex.

One way to do this would be to pass both the MutexGuard and a reference to the Mutex to `Condvar::wait` but that would differ from the API in `std:sync`.

## Solution
This pull request adds a single function `MutexGuard::into_mutex_reference` (suggestions for a better name are welcome). The method consumes the `MutexGuard` object, releases the underlying lock and returns a reference to the `Mutex`. 