### PR TITLE
process: avoid redundant effort to reap orphan processes

### DIFF
--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -3,7 +3,6 @@
 //! Process driver
 
 use crate::park::Park;
-use crate::process::unix::orphan::ReapOrphanQueue;
 use crate::process::unix::GlobalOrphanQueue;
 use crate::signal::unix::driver::{Driver as SignalDriver, Handle as SignalHandle};
 
@@ -40,13 +39,13 @@ impl Park for Driver {
 
     fn park(&mut self) -> Result<(), Self::Error> {
         self.park.park()?;
-        GlobalOrphanQueue.reap_orphans(&self.signal_handle);
+        GlobalOrphanQueue::reap_orphans(&self.signal_handle);
         Ok(())
     }
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         self.park.park_timeout(duration)?;
-        GlobalOrphanQueue.reap_orphans(&self.signal_handle);
+        GlobalOrphanQueue::reap_orphans(&self.signal_handle);
         Ok(())
     }
 

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -23,7 +23,10 @@ impl Driver {
     pub(crate) fn new(park: SignalDriver) -> io::Result<Self> {
         let signal_handle = park.handle();
 
-        Ok(Self { park, signal_handle, })
+        Ok(Self {
+            park,
+            signal_handle,
+        })
     }
 }
 

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -6,8 +6,6 @@ use crate::park::Park;
 use crate::process::unix::orphan::ReapOrphanQueue;
 use crate::process::unix::GlobalOrphanQueue;
 use crate::signal::unix::driver::{Driver as SignalDriver, Handle as SignalHandle};
-use crate::signal::unix::{signal_with_handle, SignalKind};
-use crate::sync::watch;
 
 use std::io;
 use std::time::Duration;
@@ -17,37 +15,6 @@ use std::time::Duration;
 pub(crate) struct Driver {
     park: SignalDriver,
     signal_handle: SignalHandle,
-    inner: CoreDriver<watch::Receiver<()>, GlobalOrphanQueue>,
-}
-
-#[derive(Debug)]
-struct CoreDriver<S, Q> {
-    sigchild: S,
-    orphan_queue: Q,
-}
-
-trait HasChanged {
-    fn has_changed(&mut self) -> bool;
-}
-
-impl<T> HasChanged for watch::Receiver<T> {
-    fn has_changed(&mut self) -> bool {
-        self.try_has_changed().and_then(Result::ok).is_some()
-    }
-}
-
-// ===== impl CoreDriver =====
-
-impl<S, Q> CoreDriver<S, Q>
-where
-    S: HasChanged,
-    Q: ReapOrphanQueue,
-{
-    fn process(&mut self, handle: &SignalHandle) {
-        if self.sigchild.has_changed() {
-            self.orphan_queue.reap_orphans(handle);
-        }
-    }
 }
 
 // ===== impl Driver =====
@@ -56,17 +23,8 @@ impl Driver {
     /// Creates a new signal `Driver` instance that delegates wakeups to `park`.
     pub(crate) fn new(park: SignalDriver) -> io::Result<Self> {
         let signal_handle = park.handle();
-        let sigchild = signal_with_handle(SignalKind::child(), &signal_handle)?;
-        let inner = CoreDriver {
-            sigchild,
-            orphan_queue: GlobalOrphanQueue,
-        };
 
-        Ok(Self {
-            park,
-            signal_handle,
-            inner,
-        })
+        Ok(Self { park, signal_handle, })
     }
 }
 
@@ -82,57 +40,17 @@ impl Park for Driver {
 
     fn park(&mut self) -> Result<(), Self::Error> {
         self.park.park()?;
-        self.inner.process(&self.signal_handle);
+        GlobalOrphanQueue.reap_orphans(&self.signal_handle);
         Ok(())
     }
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         self.park.park_timeout(duration)?;
-        self.inner.process(&self.signal_handle);
+        GlobalOrphanQueue.reap_orphans(&self.signal_handle);
         Ok(())
     }
 
     fn shutdown(&mut self) {
         self.park.shutdown()
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use crate::process::unix::orphan::test::MockQueue;
-
-    struct MockStream {
-        total_try_recv: usize,
-        values: Vec<Option<()>>,
-    }
-
-    impl MockStream {
-        fn new(values: Vec<Option<()>>) -> Self {
-            Self {
-                total_try_recv: 0,
-                values,
-            }
-        }
-    }
-
-    impl HasChanged for MockStream {
-        fn has_changed(&mut self) -> bool {
-            self.total_try_recv += 1;
-            self.values.remove(0).is_some()
-        }
-    }
-
-    #[test]
-    fn no_reap_if_no_signal() {
-        let mut driver = CoreDriver {
-            sigchild: MockStream::new(vec![None]),
-            orphan_queue: MockQueue::<()>::new(),
-        };
-
-        driver.process(&SignalHandle::default());
-
-        assert_eq!(1, driver.sigchild.total_try_recv);
-        assert_eq!(0, driver.orphan_queue.total_reaps.get());
     }
 }

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -20,13 +20,13 @@ pub(crate) struct Driver {
 
 impl Driver {
     /// Creates a new signal `Driver` instance that delegates wakeups to `park`.
-    pub(crate) fn new(park: SignalDriver) -> io::Result<Self> {
+    pub(crate) fn new(park: SignalDriver) -> Self {
         let signal_handle = park.handle();
 
-        Ok(Self {
+        Self {
             park,
             signal_handle,
-        })
+        }
     }
 }
 

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -24,7 +24,7 @@
 pub(crate) mod driver;
 
 pub(crate) mod orphan;
-use orphan::{OrphanQueue, OrphanQueueImpl, ReapOrphanQueue, Wait};
+use orphan::{OrphanQueue, OrphanQueueImpl, Wait};
 
 mod reap;
 use reap::Reaper;
@@ -74,8 +74,8 @@ impl fmt::Debug for GlobalOrphanQueue {
     }
 }
 
-impl ReapOrphanQueue for GlobalOrphanQueue {
-    fn reap_orphans(&self, handle: &SignalHandle) {
+impl GlobalOrphanQueue {
+    fn reap_orphans(handle: &SignalHandle) {
         ORPHAN_QUEUE.reap_orphans(handle)
     }
 }

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -32,6 +32,7 @@ use reap::Reaper;
 use crate::io::PollEvented;
 use crate::process::kill::Kill;
 use crate::process::SpawnedChild;
+use crate::signal::unix::driver::Handle as SignalHandle;
 use crate::signal::unix::{signal, Signal, SignalKind};
 
 use mio::event::Source;
@@ -74,8 +75,8 @@ impl fmt::Debug for GlobalOrphanQueue {
 }
 
 impl ReapOrphanQueue for GlobalOrphanQueue {
-    fn reap_orphans(&self) {
-        ORPHAN_QUEUE.reap_orphans()
+    fn reap_orphans(&self, handle: &SignalHandle) {
+        ORPHAN_QUEUE.reap_orphans(handle)
     }
 }
 

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -89,7 +89,6 @@ impl<T> OrphanQueueImpl<T> {
                         // register/initialize here, so we can try again later
                         if let Ok(sigchild) = signal_with_handle(SignalKind::child(), &handle) {
                             *sigchild_guard = Some(sigchild);
-                            drop(sigchild_guard);
                             drain_orphan_queue(queue);
                         }
                     }
@@ -103,8 +102,6 @@ fn drain_orphan_queue<T>(mut queue: MutexGuard<'_, Vec<T>>)
 where
     T: Wait,
 {
-    // let mut queue = self.queue.lock().unwrap();
-    // let queue = &mut *queue;
     for i in (0..queue.len()).rev() {
         match queue[i].try_wait() {
             Ok(None) => {}

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -3,7 +3,7 @@ use crate::signal::unix::{signal_with_handle, SignalKind};
 use crate::sync::watch;
 use std::io;
 use std::process::ExitStatus;
-use std::sync::{Mutex, MutexGuard};
+use crate::loom::sync::{Mutex, MutexGuard};
 
 /// An interface for waiting on a process to exit.
 pub(crate) trait Wait {

--- a/tokio/src/process/unix/reap.rs
+++ b/tokio/src/process/unix/reap.rs
@@ -224,7 +224,6 @@ mod test {
         assert!(grim.poll_unpin(&mut context).is_pending());
         assert_eq!(1, grim.signal.total_polls);
         assert_eq!(1, grim.total_waits);
-        assert_eq!(0, grim.orphan_queue.total_reaps.get());
         assert!(grim.orphan_queue.all_enqueued.borrow().is_empty());
 
         // Not yet exited, couldn't register interest the first time
@@ -232,7 +231,6 @@ mod test {
         assert!(grim.poll_unpin(&mut context).is_pending());
         assert_eq!(3, grim.signal.total_polls);
         assert_eq!(3, grim.total_waits);
-        assert_eq!(0, grim.orphan_queue.total_reaps.get());
         assert!(grim.orphan_queue.all_enqueued.borrow().is_empty());
 
         // Exited
@@ -245,7 +243,6 @@ mod test {
         }
         assert_eq!(4, grim.signal.total_polls);
         assert_eq!(4, grim.total_waits);
-        assert_eq!(0, grim.orphan_queue.total_reaps.get());
         assert!(grim.orphan_queue.all_enqueued.borrow().is_empty());
     }
 
@@ -260,7 +257,6 @@ mod test {
 
         grim.kill().unwrap();
         assert_eq!(1, grim.total_kills);
-        assert_eq!(0, grim.orphan_queue.total_reaps.get());
         assert!(grim.orphan_queue.all_enqueued.borrow().is_empty());
     }
 
@@ -276,7 +272,6 @@ mod test {
 
             drop(grim);
 
-            assert_eq!(0, queue.total_reaps.get());
             assert!(queue.all_enqueued.borrow().is_empty());
         }
 
@@ -294,7 +289,6 @@ mod test {
             let grim = Reaper::new(&mut mock, &queue, MockStream::new(vec![]));
             drop(grim);
 
-            assert_eq!(0, queue.total_reaps.get());
             assert_eq!(1, queue.all_enqueued.borrow().len());
         }
 

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -23,7 +23,7 @@ cfg_io_driver! {
             let io_handle = io_driver.handle();
 
             let (signal_driver, signal_handle) = create_signal_driver(io_driver)?;
-            let process_driver = create_process_driver(signal_driver)?;
+            let process_driver = create_process_driver(signal_driver);
 
             (Either::A(process_driver), Some(io_handle), signal_handle)
         } else {
@@ -80,7 +80,7 @@ cfg_not_signal_internal! {
 cfg_process_driver! {
     type ProcessDriver = crate::process::unix::driver::Driver;
 
-    fn create_process_driver(signal_driver: SignalDriver) -> io::Result<ProcessDriver> {
+    fn create_process_driver(signal_driver: SignalDriver) -> ProcessDriver {
         crate::process::unix::driver::Driver::new(signal_driver)
     }
 }
@@ -89,8 +89,8 @@ cfg_not_process_driver! {
     cfg_io_driver! {
         type ProcessDriver = SignalDriver;
 
-        fn create_process_driver(signal_driver: SignalDriver) -> io::Result<ProcessDriver> {
-            Ok(signal_driver)
+        fn create_process_driver(signal_driver: SignalDriver) -> ProcessDriver {
+            signal_driver
         }
     }
 }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -222,7 +222,7 @@ fn action(globals: Pin<&'static Globals>, signal: c_int) {
 ///
 /// This will register the signal handler if it hasn't already been registered,
 /// returning any error along the way if that fails.
-fn signal_enable(signal: SignalKind, handle: Handle) -> io::Result<()> {
+fn signal_enable(signal: SignalKind, handle: &Handle) -> io::Result<()> {
     let signal = signal.0;
     if signal < 0 || signal_hook_registry::FORBIDDEN.contains(&signal) {
         return Err(Error::new(
@@ -352,7 +352,7 @@ pub struct Signal {
 /// * If the signal is one of
 ///   [`signal_hook::FORBIDDEN`](fn@signal_hook_registry::register#panics)
 pub fn signal(kind: SignalKind) -> io::Result<Signal> {
-    let rx = signal_with_handle(kind, Handle::current())?;
+    let rx = signal_with_handle(kind, &Handle::current())?;
 
     Ok(Signal {
         inner: RxFuture::new(rx),
@@ -361,7 +361,7 @@ pub fn signal(kind: SignalKind) -> io::Result<Signal> {
 
 pub(crate) fn signal_with_handle(
     kind: SignalKind,
-    handle: Handle,
+    handle: &Handle,
 ) -> io::Result<watch::Receiver<()>> {
     // Turn the signal delivery on once we are ready for it
     signal_enable(kind, handle)?;
@@ -457,14 +457,14 @@ mod tests {
 
     #[test]
     fn signal_enable_error_on_invalid_input() {
-        signal_enable(SignalKind::from_raw(-1), Handle::default()).unwrap_err();
+        signal_enable(SignalKind::from_raw(-1), &Handle::default()).unwrap_err();
     }
 
     #[test]
     fn signal_enable_error_on_forbidden_input() {
         signal_enable(
             SignalKind::from_raw(signal_hook_registry::FORBIDDEN[0]),
-            Handle::default(),
+            &Handle::default(),
         )
         .unwrap_err();
     }


### PR DESCRIPTION
* Child processes are akin to global variables within the parent
  process. Reaping orphaned child processes can be done by any thread
  (so long as someone does it), but repeated efforts from multiple
  threads to reap the same process do not add any additional benefit
* Previously, each Runtime would register its own SIGCHLD listener and
  check it for updates during every tick. If a signal was received, then
  it will attempt to reap the orphan queue.
* Signals are also "global resources" meaning that when one signal comes
  in, all listeners within that process are woken up. This means that if
  an application has multiple runtimes, each of them will attempt to
  drain the entire orphan queue any time a SIGCHLD is received (the
  first one to try will reap whichever orphans have exited, and the
  other will perform redundant effort).
* Now we register a single SIGCHLD listener for the entire global queue
  itself, which allows us to "dedup" signal notifications even if
  multiple runtimes tick at the same time and attempt to drive the
  orphan queue (one will grab a lock and win the race, and everyone else
  will move on).
* Moreover, the single, global SIGCHLD listener will be registered
  lazily (instead of eagerly on the runtime initialization). This means
  that applications which do not use child processes will not "pollute"
  the signal handler space, even if the feature is enabled at compile
  time

Refs #3520 