### PR TITLE
stream: implement Error and Display for BroadcastStreamRecvError

### DIFF
--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -9,13 +9,6 @@
     doc = "You are viewing documentation built under windows. To view unix-specific wrappers, change to the `x86_64-unknown-linux-gnu` platform."
 )]
 
-/// Error types for the wrappers.
-pub mod errors {
-    cfg_sync! {
-        pub use crate::wrappers::broadcast::BroadcastStreamRecvError;
-    }
-}
-
 mod mpsc_bounded;
 pub use mpsc_bounded::ReceiverStream;
 

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -9,6 +9,13 @@
     doc = "You are viewing documentation built under windows. To view unix-specific wrappers, change to the `x86_64-unknown-linux-gnu` platform."
 )]
 
+/// Error types for the wrappers.
+pub mod errors {
+    cfg_sync! {
+        pub use crate::wrappers::broadcast::BroadcastStreamRecvError;
+    }
+}
+
 mod mpsc_bounded;
 pub use mpsc_bounded::ReceiverStream;
 

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -17,6 +17,26 @@ pub struct BroadcastStream<T> {
     inner: ReusableBoxFuture<(Result<T, RecvError>, Receiver<T>)>,
 }
 
+/// An error returned from the inner stream of a [`BroadcastStream`].
+#[derive(Debug, PartialEq)]
+pub enum BroadcastStreamRecvError {
+    /// The receiver lagged too far behind. Attempting to receive again will
+    /// return the oldest message still retained by the channel.
+    ///
+    /// Includes the number of skipped messages.
+    Lagged(u64),
+}
+
+impl fmt::Display for BroadcastStreamRecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BroadcastStreamRecvError::Lagged(amt) => write!(f, "channel lagged by {}", amt),
+        }
+    }
+}
+
+impl std::error::Error for BroadcastStreamRecvError {}
+
 async fn make_future<T: Clone>(mut rx: Receiver<T>) -> (Result<T, RecvError>, Receiver<T>) {
     let result = rx.recv().await;
     (result, rx)
@@ -32,14 +52,16 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
 }
 
 impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
-    type Item = Result<T, RecvError>;
+    type Item = Result<T, BroadcastStreamRecvError>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let (result, rx) = ready!(self.inner.poll(cx));
         self.inner.set(make_future(rx));
         match result {
             Ok(item) => Poll::Ready(Some(Ok(item))),
             Err(RecvError::Closed) => Poll::Ready(None),
-            Err(err) => Poll::Ready(Some(Err(err))),
+            Err(RecvError::Lagged(n)) => {
+                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n))))
+            }
         }
     }
 }

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -17,16 +17,6 @@ pub struct BroadcastStream<T> {
     inner: ReusableBoxFuture<(Result<T, RecvError>, Receiver<T>)>,
 }
 
-/// An error returned from the inner stream of a [`BroadcastStream`].
-#[derive(Debug, PartialEq)]
-pub enum BroadcastStreamRecvError {
-    /// The receiver lagged too far behind. Attempting to receive again will
-    /// return the oldest message still retained by the channel.
-    ///
-    /// Includes the number of skipped messages.
-    Lagged(u64),
-}
-
 async fn make_future<T: Clone>(mut rx: Receiver<T>) -> (Result<T, RecvError>, Receiver<T>) {
     let result = rx.recv().await;
     (result, rx)
@@ -42,16 +32,14 @@ impl<T: 'static + Clone + Send> BroadcastStream<T> {
 }
 
 impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
-    type Item = Result<T, BroadcastStreamRecvError>;
+    type Item = Result<T, RecvError>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let (result, rx) = ready!(self.inner.poll(cx));
         self.inner.set(make_future(rx));
         match result {
             Ok(item) => Poll::Ready(Some(Ok(item))),
             Err(RecvError::Closed) => Poll::Ready(None),
-            Err(RecvError::Lagged(n)) => {
-                Poll::Ready(Some(Err(BroadcastStreamRecvError::Lagged(n))))
-            }
+            Err(err) => Poll::Ready(Some(Err(err))),
         }
     }
 }


### PR DESCRIPTION
Reuse the tokio::sync::broadcast::error::RecvError instead.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
I want to use the broadcast stream wrapper in the situtaion where some codes requiring the custom Error implementing std::error:Error trair, such as [wrap_stream()](https://docs.rs/hyper/0.14.7/hyper/body/struct.Body.html#method.wrap_stream) function in hyper crate.

## Solution
We can add impl std::error::Error, and core::fmt::Display for `BroadcastStreamRecvError`, but since the custom error doesn't provide any additional info, so it's better removing it and reusing the existing error from broadcast channel.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
