### PR TITLE
process: Updated example

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -994,7 +994,8 @@ impl Child {
     /// If the caller wishes to explicitly control when the child's stdin
     /// handle is closed, they may `.take()` it before calling `.wait()`:
     ///
-    /// ```no_run
+    /// ```
+    /// # #![cfg(unix)]
     /// use tokio::io::AsyncWriteExt;
     /// use tokio::process::Command;
     /// use std::process::Stdio;

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1002,8 +1002,8 @@ impl Child {
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut child = Command::new("cat")
-    ///         .spawn()
     ///         .stdin(Stdio::piped())
+    ///         .spawn()
     ///         .unwrap();
     ///
     ///     let mut stdin = child.stdin.take().unwrap();

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -997,10 +997,14 @@ impl Child {
     /// ```no_run
     /// use tokio::io::AsyncWriteExt;
     /// use tokio::process::Command;
+    /// use std::process::Stdio;
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let mut child = Command::new("cat").spawn().unwrap();
+    ///     let mut child = Command::new("cat")
+    ///         .spawn()
+    ///         .stdin(Stdio::piped())
+    ///         .unwrap();
     ///
     ///     let mut stdin = child.stdin.take().unwrap();
     ///     tokio::spawn(async move {

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -995,6 +995,7 @@ impl Child {
     /// handle is closed, they may `.take()` it before calling `.wait()`:
     ///
     /// ```
+    /// # #[cfg(not(unix))]fn main(){}
     /// # #![cfg(unix)]
     /// use tokio::io::AsyncWriteExt;
     /// use tokio::process::Command;

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -996,11 +996,11 @@ impl Child {
     ///
     /// ```
     /// # #[cfg(not(unix))]fn main(){}
-    /// # #![cfg(unix)]
     /// use tokio::io::AsyncWriteExt;
     /// use tokio::process::Command;
     /// use std::process::Stdio;
     ///
+    /// # #[cfg(unix)]
     /// #[tokio::main]
     /// async fn main() {
     ///     let mut child = Command::new("cat")

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -996,8 +996,11 @@ impl Child {
     ///
     /// ```
     /// # #[cfg(not(unix))]fn main(){}
+    /// # #[cfg(unix)]
     /// use tokio::io::AsyncWriteExt;
+    /// # #[cfg(unix)]
     /// use tokio::process::Command;
+    /// # #[cfg(unix)]
     /// use std::process::Stdio;
     ///
     /// # #[cfg(unix)]


### PR DESCRIPTION
If we don't supply `.stdin(Stdio::piped())`, the line `8` always panics on `unwrap() on None`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributor's guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
The example wasn't working when trying to copy-paste it over.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases, there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
I updated the example, adding `.stdin(Stdio::piped())` and import to fix the issue.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
