### PR TITLE
sync: resize bounded channels

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -302,6 +302,11 @@ impl<T> Receiver<T> {
 
     /// Resizes the channel buffer to the provided size
     ///
+    /// If the buffer is reduced to a smaller number of elements than it already
+    /// contains, it is no longer possible to send elements. It will be possible
+    /// to send new elements when the excess messages are consumed and there is
+    /// capacity available with respect to the new size.
+    ///
     /// A return value of `Ok` means that the operation was successful and the
     /// channel was resized. An error means that the channel is closed and can
     /// no longer be resized.

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -51,19 +51,19 @@ impl<T> From<SendError<T>> for TrySendError<T> {
     }
 }
 
-// ===== RecvError =====
+// ===== ResizeError =====
 
-/// Error returned by `Receiver`.
+/// Error returned by `Receiver::resize`.
 #[derive(Debug)]
-pub struct RecvError(());
+pub struct ResizeError;
 
-impl fmt::Display for RecvError {
+impl fmt::Display for ResizeError {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "channel closed")
     }
 }
 
-impl Error for RecvError {}
+impl std::error::Error for ResizeError {}
 
 cfg_time! {
     // ===== SendTimeoutError =====

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -25,6 +25,8 @@ pub(crate) struct LinkedList<L, T> {
 
     /// Node type marker.
     _marker: PhantomData<*const L>,
+
+    len: usize,
 }
 
 unsafe impl<L: Link> Send for LinkedList<L, L::Target> where L::Target: Send {}
@@ -109,6 +111,7 @@ impl<L, T> LinkedList<L, T> {
             head: None,
             tail: None,
             _marker: PhantomData,
+            len: 0,
         }
     }
 }
@@ -148,6 +151,8 @@ impl<L: Link> LinkedList<L, L::Target> {
             } else {
                 self.head = None
             }
+
+            self.len -= 1;
 
             L::pointers(last).as_mut().set_prev(None);
             L::pointers(last).as_mut().set_next(None);
@@ -203,7 +208,13 @@ impl<L: Link> LinkedList<L, L::Target> {
         L::pointers(node).as_mut().set_next(None);
         L::pointers(node).as_mut().set_prev(None);
 
+        self.len -= 1;
+
         Some(L::from_raw(node))
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
     }
 }
 


### PR DESCRIPTION
Proposed solution to close https://github.com/tokio-rs/tokio/issues/3730

## Motivation

Bounded channels can only have a fixed capacity. When a receiver wants to process more messages at a time than the originally intended capacity, it cannot resize the channel to do so.

## Solution

Implement a method that allows the user to resize the channel from the receiver handle