### PR TITLE
Update documentation on block_in_place

### DIFF
--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -6,18 +6,23 @@ cfg_rt_multi_thread! {
     ///
     /// In general, issuing a blocking call or performing a lot of compute in a
     /// future without yielding is not okay, as it may prevent the executor from
-    /// driving other futures forward.  This function runs the closure on the
-    /// current thread by having the thread temporarily cease from being a core
-    /// thread, and turns it into a blocking thread. See the [CPU-bound tasks
-    /// and blocking code][blocking] section for more information.
+    /// driving other tasks forward. By using this function, the executor
+    /// knows that the task it is currently executing is about to block the
+    /// thread, and the executor is able to hand off any other tasks it has to a
+    /// new worker thread. See the [CPU-bound tasks and blocking code][blocking]
+    /// section for more information.
     ///
-    /// Although this function avoids starving other independently spawned
-    /// tasks, any other code running concurrently in the same task will be
-    /// suspended during the call to `block_in_place`. This can happen e.g. when
-    /// using the [`join!`] macro. To avoid this issue, use [`spawn_blocking`]
-    /// instead.
+    /// Be aware that although this function avoids starving other independently
+    /// spawned tasks, any other code running concurrently in the same task will
+    /// be suspended during the call to `block_in_place`. This can happen e.g.
+    /// when using the [`join!`] macro. To avoid this issue, use
+    /// [`spawn_blocking`] instead of `block_in_place`.
     ///
-    /// Note that this function can only be used when using the `multi_thread` runtime.
+    /// Note that this function cannot be used within a [`current_thread`] runtime
+    /// because in this case there are no other worker threads to hand off tasks
+    /// to. On the other hand, calling the function outside a runtime is
+    /// allowed. In this case, `block_in_place` just calls the provided closure
+    /// normally.
     ///
     /// Code running behind `block_in_place` cannot be cancelled. When you shut
     /// down the executor, it will wait indefinitely for all blocking operations
@@ -43,6 +48,27 @@ cfg_rt_multi_thread! {
     /// });
     /// # }
     /// ```
+    ///
+    /// Code running inside `block_in_place` may use `block_on` to reenter the
+    /// async context.
+    ///
+    /// ```
+    /// use tokio::task::{self, Handle};
+    ///
+    /// # async fn docs() {
+    /// task::block_in_place(move || {
+    ///     Handle::current().block_on(async move {
+    ///         // do something async
+    ///     });
+    /// });
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called from a [`current_thread`] runtime.
+    ///
+    /// [`current_thread`]: fn@crate::runtime::Builder::new_current_thread
     pub fn block_in_place<F, R>(f: F) -> R
     where
         F: FnOnce() -> R,

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -53,7 +53,8 @@ cfg_rt_multi_thread! {
     /// async context.
     ///
     /// ```
-    /// use tokio::task::{self, Handle};
+    /// use tokio::task;
+    /// use tokio::runtime::Handle;
     ///
     /// # async fn docs() {
     /// task::block_in_place(move || {

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -5,12 +5,12 @@ cfg_rt_multi_thread! {
     /// blocking the executor.
     ///
     /// In general, issuing a blocking call or performing a lot of compute in a
-    /// future without yielding is not okay, as it may prevent the executor from
-    /// driving other tasks forward. By using this function, the executor
-    /// knows that the task it is currently executing is about to block the
-    /// thread, and the executor is able to hand off any other tasks it has to a
-    /// new worker thread. See the [CPU-bound tasks and blocking code][blocking]
-    /// section for more information.
+    /// future without yielding is problematic, as it may prevent the executor
+    /// from driving other tasks forward. Calling this function informs the
+    /// executor that the currently executing task is about to block the thread,
+    /// so the executor is able to hand off any other tasks it has to a new
+    /// worker thread before that happens. See the [CPU-bound tasks and blocking
+    /// code][blocking] section for more information.
     ///
     /// Be aware that although this function avoids starving other independently
     /// spawned tasks, any other code running concurrently in the same task will

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -122,6 +122,11 @@
 //! Instead, Tokio provides two APIs for running blocking operations in an
 //! asynchronous context: [`task::spawn_blocking`] and [`task::block_in_place`].
 //!
+//! Be aware that if you call a non-async method from async code, that non-async
+//! method is still inside the asynchronous context, so you should also avoid
+//! blocking operations there. This includes destructors of objects destroyed in
+//! async code.
+//!
 //! #### spawn_blocking
 //!
 //! The `task::spawn_blocking` function is similar to the `task::spawn` function


### PR DESCRIPTION
This PR updates the documentation on `block_in_place` to fix some things that were unclear. There is already a PR that tries to address this, but I have found that the documentation needed a larger change.

Closes: #3659, #3658