### PR TITLE
io: wake pending writers on DuplexStream close

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -16,6 +16,14 @@ use std::{
 /// that can be used as in-memory IO types. Writing to one of the pairs will
 /// allow that data to be read from the other, and vice versa.
 ///
+/// # Closing a `DuplexStream`
+///
+/// If one end of the `DuplexStream` channel is dropped, any pending reads on
+/// the other side will continue to read data until the buffer is drained, then
+/// they will signal EOF by returning 0 bytes. Any writes to the other side,
+/// including pending ones (that are waiting for free space in the buffer) will
+/// return `Err(BrokenPipe)` immediately.
+///
 /// # Example
 ///
 /// ```
@@ -134,7 +142,8 @@ impl AsyncWrite for DuplexStream {
 impl Drop for DuplexStream {
     fn drop(&mut self) {
         // notify the other side of the closure
-        self.write.lock().close();
+        self.write.lock().close_write();
+        self.read.lock().close_read();
     }
 }
 
@@ -151,9 +160,18 @@ impl Pipe {
         }
     }
 
-    fn close(&mut self) {
+    fn close_write(&mut self) {
         self.is_closed = true;
+        // needs to notify any readers that no more data will come
         if let Some(waker) = self.read_waker.take() {
+            waker.wake();
+        }
+    }
+
+    fn close_read(&mut self) {
+        self.is_closed = true;
+        // needs to notify any writers that they have to abort
+        if let Some(waker) = self.write_waker.take() {
             waker.wake();
         }
     }
@@ -217,7 +235,7 @@ impl AsyncWrite for Pipe {
         mut self: Pin<&mut Self>,
         _: &mut task::Context<'_>,
     ) -> Poll<std::io::Result<()>> {
-        self.close();
+        self.close_write();
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
Performing a write on a closed DuplexStream (i.e. other end is dropped) results in an Err(BrokenPipe). However, if there is a writer waiting to be awoken from a buffer-full condition, it would previously be ignored, and thus stuck in suspended state, as no further reads could ever be made.

We encountered this when trying to write data from a tokio task via the duplex stream to a hyper Body::wrap_stream (via `ReaderStream`) for a server application. If the client aborted the download prematurely, the socket would be closed and the error propagated up to the duplex, but if there was a pending write (very likely, as we read from a fast source over potentially slow network) it would get stuck and never woken up, thus the tokio task would run indefinitely and cleanup routines wouldn't.

This PR fixes the issue by waking pending writers on a DuplexStream on Drop of the other side. This works for our use case, and also satisfies the reproducer, included as a test case (`disconnect_reader`). I've also updated the documentation with a paragraph about the behaviour of the DuplexStream when one side is closed.

Note that this requires modifications to an existing test case, so I'm not sure if this would qualify as a "breaking change" - AFAICT that test case was most likely slightly broken beforehand too, as it somewhat relied on timing between drop and awake.