### PR TITLE
cargo: path dependencies for all tokio things

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead.
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["full", "tracing"] }
-tokio-util = { version = "0.6.3", features = ["full"] }
-tokio-stream = { version = "0.1" }
+tokio = { version = "1.0.0", path = "../tokio",features = ["full", "tracing"] }
+tokio-util = { version = "0.6.3", path = "../tokio-util",features = ["full"] }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -31,7 +31,7 @@ signal = ["tokio/signal"]
 futures-core = { version = "0.3.0" }
 pin-project-lite = "0.2.0"
 tokio = { version = "1.2.0", path = "../tokio", features = ["sync"] }
-tokio-util = { version = "0.6.3", optional = true }
+tokio-util = { version = "0.6.3", path = "../tokio-util", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["full", "test-util"] }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -35,7 +35,7 @@ rt = ["tokio/rt"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.0.0", features = ["sync"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["sync"] }
 
 bytes = "1.0.0"
 futures-core = "0.3.0"
@@ -47,9 +47,9 @@ pin-project-lite = "0.2.0"
 slab = { version = "0.4.1", optional = true } # Backs `DelayQueue`
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["full"] }
-tokio-test = { version = "0.4.0" }
-tokio-stream = { version = "0.1" }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 async-stream = "0.3.0"
 futures = "0.3.0"


### PR DESCRIPTION
This adds path fragments to all workspace tokio dependencies.

## Motivation

If this is not in place, test builds won't pick up now changes from other components. E.g. it's not possible to add an example of something recently added to tokio in `examples` (root cause of build failure in #3760). 

Passes locally so here's to hoping it works in CI. [A `resolver` bump](https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) was not needed AFAIU, so there's no MSRV implications.
