### PR TITLE
util: impl AsRawFd/AsRawHandle for Compat<T>

### DIFF
--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -215,3 +215,17 @@ where
         tokio::io::AsyncWrite::poll_shutdown(self.project().inner, cx)
     }
 }
+
+#[cfg(unix)]
+impl<T: std::os::unix::io::AsRawFd> std::os::unix::io::AsRawFd for Compat<T> {
+    fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(windows)]
+impl<T: std::os::windows::io::AsRawHandle> std::os::windows::io::AsRawHandle for Compat<T> {
+    fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
+        self.inner.as_raw_handle()
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
When appropriate, implement `AsRawFd` and `AsRawHandle` for `tokio_util::compat::Compat<T>`, so this wrapper type can be used in contexts requiring them.

I ran into this while trying to wrap tokio's `Stdin`/`Stdout` for usage with the futures crate, while still being able to check if they're a tty with crossterm.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A blanket impl passing AsRawFd/AsRawHandle through to the inner read/write type


