### PR TITLE
benches: fix build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
         run: cargo hack test --each-feature
         working-directory: tests-build
 
+      # Build benchmarks. Run of benchmarks is done by bench.yml workflow.
+      - name: build benches
+        run: cargo build --benches
+        working-directory: benches
+
   valgrind:
     name: valgrind
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,8 @@ jobs:
       - name: build benches
         run: cargo build --benches
         working-directory: benches
+        # bench.yml workflow runs benchmarks only on linux.
+        if: startsWith(matrix.os, 'ubuntu')
 
   valgrind:
     name: valgrind

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,6 +10,7 @@ bencher = "0.1.5"
 
 [dev-dependencies]
 tokio-util = { version = "0.6.6", path = "../tokio-util", features = ["full"] }
+tokio-stream = { path = "../tokio-stream" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.42"

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use tokio_stream::StreamExt;
 
 use tokio::fs::File;

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -1,5 +1,3 @@
-#![cfg(unix)]
-
 use tokio_stream::StreamExt;
 
 use tokio::fs::File;

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use tokio::stream::StreamExt;
+use tokio_stream::StreamExt;
 
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;


### PR DESCRIPTION
```console
$ cargo build --benches --manifest-path benches/Cargo.toml
   Compiling benches v0.0.0 (...)
error[E0432]: unresolved import `tokio::stream::StreamExt`
 --> benches/fs.rs:3:5
  |
3 | use tokio::stream::StreamExt;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^ no `StreamExt` in `stream`

error[E0599]: no method named `next` found for struct `FramedRead<tokio::fs::File, BytesCodec>` in the current scope
  --> benches/fs.rs:35:43
   |
35 |                 let _bytes = input_stream.next().await.unwrap();
   |                                           ^^^^ method not found in `FramedRead<tokio::fs::File, BytesCodec>`

error: aborting due to 2 previous errors
```