### PR TITLE
chore: enable syntax highlighting for toml in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A basic TCP echo server with Tokio.
 
 Make sure you activated the full features of the tokio crate on Cargo.toml:
 
-```text
+```toml
 [dependencies]
 tokio = { version = "1.5.0", features = ["full"] }
 ```


### PR DESCRIPTION

It is currently being treated as text.

Before:

https://github.com/tokio-rs/tokio#example

<img width="556" alt="before" src="https://user-images.githubusercontent.com/43724913/117574145-b0e31100-b116-11eb-95d6-0329d0562129.png">

After:

https://github.com/taiki-e/tokio/tree/readme#example

<img width="556" alt="after" src="https://user-images.githubusercontent.com/43724913/117574150-b4769800-b116-11eb-9b4c-0889d02a53e0.png">
