### PR TITLE
doc: fix doc-cfg on io::duplex, io::copy_bidirectional, and task::unconstrained

### DIFF
--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -77,43 +77,45 @@ where
     }
 }
 
-/// Copies data in both directions between `a` and `b`.
-///
-/// This function returns a future that will read from both streams,
-/// writing any data read to the opposing stream.
-/// This happens in both directions concurrently.
-///
-/// If an EOF is observed on one stream, [`shutdown()`] will be invoked on
-/// the other, and reading from that stream will stop. Copying of data in
-/// the other direction will continue.
-///
-/// The future will complete successfully once both directions of communication has been shut down.
-/// A direction is shut down when the reader reports EOF,
-/// at which point [`shutdown()`] is called on the corresponding writer. When finished,
-/// it will return a tuple of the number of bytes copied from a to b
-/// and the number of bytes copied from b to a, in that order.
-///
-/// [`shutdown()`]: crate::io::AsyncWriteExt::shutdown
-///
-/// # Errors
-///
-/// The future will immediately return an error if any IO operation on `a`
-/// or `b` returns an error. Some data read from either stream may be lost (not
-/// written to the other stream) in this case.
-///
-/// # Return value
-///
-/// Returns a tuple of bytes copied `a` to `b` and bytes copied `b` to `a`.
-pub async fn copy_bidirectional<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64), std::io::Error>
-where
-    A: AsyncRead + AsyncWrite + Unpin + ?Sized,
-    B: AsyncRead + AsyncWrite + Unpin + ?Sized,
-{
-    CopyBidirectional {
-        a,
-        b,
-        a_to_b: TransferState::Running(CopyBuffer::new()),
-        b_to_a: TransferState::Running(CopyBuffer::new()),
+cfg_io_util! {
+    /// Copies data in both directions between `a` and `b`.
+    ///
+    /// This function returns a future that will read from both streams,
+    /// writing any data read to the opposing stream.
+    /// This happens in both directions concurrently.
+    ///
+    /// If an EOF is observed on one stream, [`shutdown()`] will be invoked on
+    /// the other, and reading from that stream will stop. Copying of data in
+    /// the other direction will continue.
+    ///
+    /// The future will complete successfully once both directions of communication has been shut down.
+    /// A direction is shut down when the reader reports EOF,
+    /// at which point [`shutdown()`] is called on the corresponding writer. When finished,
+    /// it will return a tuple of the number of bytes copied from a to b
+    /// and the number of bytes copied from b to a, in that order.
+    ///
+    /// [`shutdown()`]: crate::io::AsyncWriteExt::shutdown
+    ///
+    /// # Errors
+    ///
+    /// The future will immediately return an error if any IO operation on `a`
+    /// or `b` returns an error. Some data read from either stream may be lost (not
+    /// written to the other stream) in this case.
+    ///
+    /// # Return value
+    ///
+    /// Returns a tuple of bytes copied `a` to `b` and bytes copied `b` to `a`.
+    pub async fn copy_bidirectional<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64), std::io::Error>
+    where
+        A: AsyncRead + AsyncWrite + Unpin + ?Sized,
+        B: AsyncRead + AsyncWrite + Unpin + ?Sized,
+    {
+        CopyBidirectional {
+            a,
+            b,
+            a_to_b: TransferState::Running(CopyBuffer::new()),
+            b_to_a: TransferState::Running(CopyBuffer::new()),
+        }
+        .await
     }
-    .await
 }

--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -77,45 +77,44 @@ where
     }
 }
 
-cfg_io_util! {
-    /// Copies data in both directions between `a` and `b`.
-    ///
-    /// This function returns a future that will read from both streams,
-    /// writing any data read to the opposing stream.
-    /// This happens in both directions concurrently.
-    ///
-    /// If an EOF is observed on one stream, [`shutdown()`] will be invoked on
-    /// the other, and reading from that stream will stop. Copying of data in
-    /// the other direction will continue.
-    ///
-    /// The future will complete successfully once both directions of communication has been shut down.
-    /// A direction is shut down when the reader reports EOF,
-    /// at which point [`shutdown()`] is called on the corresponding writer. When finished,
-    /// it will return a tuple of the number of bytes copied from a to b
-    /// and the number of bytes copied from b to a, in that order.
-    ///
-    /// [`shutdown()`]: crate::io::AsyncWriteExt::shutdown
-    ///
-    /// # Errors
-    ///
-    /// The future will immediately return an error if any IO operation on `a`
-    /// or `b` returns an error. Some data read from either stream may be lost (not
-    /// written to the other stream) in this case.
-    ///
-    /// # Return value
-    ///
-    /// Returns a tuple of bytes copied `a` to `b` and bytes copied `b` to `a`.
-    pub async fn copy_bidirectional<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64), std::io::Error>
-    where
-        A: AsyncRead + AsyncWrite + Unpin + ?Sized,
-        B: AsyncRead + AsyncWrite + Unpin + ?Sized,
-    {
-        CopyBidirectional {
-            a,
-            b,
-            a_to_b: TransferState::Running(CopyBuffer::new()),
-            b_to_a: TransferState::Running(CopyBuffer::new()),
-        }
-        .await
+/// Copies data in both directions between `a` and `b`.
+///
+/// This function returns a future that will read from both streams,
+/// writing any data read to the opposing stream.
+/// This happens in both directions concurrently.
+///
+/// If an EOF is observed on one stream, [`shutdown()`] will be invoked on
+/// the other, and reading from that stream will stop. Copying of data in
+/// the other direction will continue.
+///
+/// The future will complete successfully once both directions of communication has been shut down.
+/// A direction is shut down when the reader reports EOF,
+/// at which point [`shutdown()`] is called on the corresponding writer. When finished,
+/// it will return a tuple of the number of bytes copied from a to b
+/// and the number of bytes copied from b to a, in that order.
+///
+/// [`shutdown()`]: crate::io::AsyncWriteExt::shutdown
+///
+/// # Errors
+///
+/// The future will immediately return an error if any IO operation on `a`
+/// or `b` returns an error. Some data read from either stream may be lost (not
+/// written to the other stream) in this case.
+///
+/// # Return value
+///
+/// Returns a tuple of bytes copied `a` to `b` and bytes copied `b` to `a`.
+#[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+pub async fn copy_bidirectional<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64), std::io::Error>
+where
+    A: AsyncRead + AsyncWrite + Unpin + ?Sized,
+    B: AsyncRead + AsyncWrite + Unpin + ?Sized,
+{
+    CopyBidirectional {
+        a,
+        b,
+        a_to_b: TransferState::Running(CopyBuffer::new()),
+        b_to_a: TransferState::Running(CopyBuffer::new()),
     }
+    .await
 }

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -10,44 +10,46 @@ use std::{
     task::{self, Poll, Waker},
 };
 
-/// A bidirectional pipe to read and write bytes in memory.
-///
-/// A pair of `DuplexStream`s are created together, and they act as a "channel"
-/// that can be used as in-memory IO types. Writing to one of the pairs will
-/// allow that data to be read from the other, and vice versa.
-///
-/// # Closing a `DuplexStream`
-///
-/// If one end of the `DuplexStream` channel is dropped, any pending reads on
-/// the other side will continue to read data until the buffer is drained, then
-/// they will signal EOF by returning 0 bytes. Any writes to the other side,
-/// including pending ones (that are waiting for free space in the buffer) will
-/// return `Err(BrokenPipe)` immediately.
-///
-/// # Example
-///
-/// ```
-/// # async fn ex() -> std::io::Result<()> {
-/// # use tokio::io::{AsyncReadExt, AsyncWriteExt};
-/// let (mut client, mut server) = tokio::io::duplex(64);
-///
-/// client.write_all(b"ping").await?;
-///
-/// let mut buf = [0u8; 4];
-/// server.read_exact(&mut buf).await?;
-/// assert_eq!(&buf, b"ping");
-///
-/// server.write_all(b"pong").await?;
-///
-/// client.read_exact(&mut buf).await?;
-/// assert_eq!(&buf, b"pong");
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug)]
-pub struct DuplexStream {
-    read: Arc<Mutex<Pipe>>,
-    write: Arc<Mutex<Pipe>>,
+cfg_io_util! {
+    /// A bidirectional pipe to read and write bytes in memory.
+    ///
+    /// A pair of `DuplexStream`s are created together, and they act as a "channel"
+    /// that can be used as in-memory IO types. Writing to one of the pairs will
+    /// allow that data to be read from the other, and vice versa.
+    ///
+    /// # Closing a `DuplexStream`
+    ///
+    /// If one end of the `DuplexStream` channel is dropped, any pending reads on
+    /// the other side will continue to read data until the buffer is drained, then
+    /// they will signal EOF by returning 0 bytes. Any writes to the other side,
+    /// including pending ones (that are waiting for free space in the buffer) will
+    /// return `Err(BrokenPipe)` immediately.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # async fn ex() -> std::io::Result<()> {
+    /// # use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    /// let (mut client, mut server) = tokio::io::duplex(64);
+    ///
+    /// client.write_all(b"ping").await?;
+    ///
+    /// let mut buf = [0u8; 4];
+    /// server.read_exact(&mut buf).await?;
+    /// assert_eq!(&buf, b"ping");
+    ///
+    /// server.write_all(b"pong").await?;
+    ///
+    /// client.read_exact(&mut buf).await?;
+    /// assert_eq!(&buf, b"pong");
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[derive(Debug)]
+    pub struct DuplexStream {
+        read: Arc<Mutex<Pipe>>,
+        write: Arc<Mutex<Pipe>>,
+    }
 }
 
 /// A unidirectional IO over a piece of memory.
@@ -76,24 +78,26 @@ struct Pipe {
 
 // ===== impl DuplexStream =====
 
-/// Create a new pair of `DuplexStream`s that act like a pair of connected sockets.
-///
-/// The `max_buf_size` argument is the maximum amount of bytes that can be
-/// written to a side before the write returns `Poll::Pending`.
-pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
-    let one = Arc::new(Mutex::new(Pipe::new(max_buf_size)));
-    let two = Arc::new(Mutex::new(Pipe::new(max_buf_size)));
+cfg_io_util! {
+    /// Create a new pair of `DuplexStream`s that act like a pair of connected sockets.
+    ///
+    /// The `max_buf_size` argument is the maximum amount of bytes that can be
+    /// written to a side before the write returns `Poll::Pending`.
+    pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
+        let one = Arc::new(Mutex::new(Pipe::new(max_buf_size)));
+        let two = Arc::new(Mutex::new(Pipe::new(max_buf_size)));
 
-    (
-        DuplexStream {
-            read: one.clone(),
-            write: two.clone(),
-        },
-        DuplexStream {
-            read: two,
-            write: one,
-        },
-    )
+        (
+            DuplexStream {
+                read: one.clone(),
+                write: two.clone(),
+            },
+            DuplexStream {
+                read: two,
+                write: one,
+            },
+        )
+    }
 }
 
 impl AsyncRead for DuplexStream {

--- a/tokio/src/task/unconstrained.rs
+++ b/tokio/src/task/unconstrained.rs
@@ -5,6 +5,7 @@ use std::task::{Context, Poll};
 
 pin_project! {
     /// Future for the [`unconstrained`](unconstrained) method.
+    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
     #[must_use = "Unconstrained does nothing unless polled"]
     pub struct Unconstrained<F> {
         #[pin]
@@ -38,6 +39,7 @@ where
 /// otherwise.
 ///
 /// See also the usage example in the [task module](index.html#unconstrained).
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub fn unconstrained<F>(inner: F) -> Unconstrained<F> {
     Unconstrained { inner }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Both `duplex` and `copy_bidirectional` require io-util feature:

https://github.com/tokio-rs/tokio/blob/312321cbd37e544bf10d1e97e5a61b9fac01a49f/tokio/src/io/mod.rs#L242-L252

However, don't displayed on docs:

<img width="556" alt="don't displayed on docs" src="https://user-images.githubusercontent.com/43724913/117581108-214d5a80-b136-11eb-8fbb-ee4ddabcd2a9.png">

https://docs.rs/tokio/1.5.0/tokio/io/index.html#functions

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
