### PR TITLE
net: hide net::unix::datagram module from docs

### DIFF
--- a/tokio/src/net/unix/mod.rs
+++ b/tokio/src/net/unix/mod.rs
@@ -1,5 +1,9 @@
 //! Unix domain socket utility types
 
+// This module does not currently provide any public API, but it was
+// unintentionally defined as a public module. Hide it from the documentation
+// instead of changing it to a private module to avoid breakage.
+#[doc(hidden)]
 pub mod datagram;
 
 pub(crate) mod listener;


### PR DESCRIPTION
This module does not currently provide any public API, but it was unintentionally defined as a public module. Hide it from the documentation instead of changing it to a private module to avoid breakage. (I think it is unlikely that it will actually break, but it is technically possible.)

Fixes #3772