### PR TITLE
sync: resize bounded channels

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -420,7 +420,8 @@ impl Semaphore {
         let underflow = match self.permits.fetch_update(Relaxed, Relaxed, |v| {
             Some(v.saturating_sub(reduction << Self::PERMIT_SHIFT))
         }) {
-            Ok(prev) | Err(prev) => reduction.saturating_sub(prev >> Self::PERMIT_SHIFT),
+            Ok(prev) => reduction.saturating_sub(prev >> Self::PERMIT_SHIFT),
+            Err(prev) => unreachable!()
         };
 
         self.underflow.store(underflow, Release);

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -34,6 +34,8 @@ pub(crate) struct Semaphore {
     waiters: Mutex<Waitlist>,
     /// The current number of available permits in the semaphore.
     permits: AtomicUsize,
+    /// The current underflow preventing the acquisition of new permits.
+    underflow: AtomicUsize,
 }
 
 struct Waitlist {
@@ -134,6 +136,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: false,
             }),
+            underflow: AtomicUsize::new(0),
         }
     }
 
@@ -155,6 +158,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: false,
             }),
+            underflow: AtomicUsize::new(0),
         }
     }
 
@@ -171,8 +175,17 @@ impl Semaphore {
             return;
         }
 
+        // Try to empty the underflow with the number of permits requested and
+        // return the number of permits remaining after the operation.
+        let remaining = match self
+            .underflow
+            .fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(added)))
+        {
+            Ok(prev) | Err(prev) => added.saturating_sub(prev),
+        };
+
         // Assign permits to the wait queue
-        self.add_permits_locked(added, self.waiters.lock());
+        self.add_permits_locked(remaining, self.waiters.lock());
     }
 
     /// Closes the semaphore. This prevents the semaphore from issuing new
@@ -207,6 +220,11 @@ impl Semaphore {
             "a semaphore may not have more than MAX_PERMITS permits ({})",
             Self::MAX_PERMITS
         );
+
+        if self.underflow.load(Acquire) > 0 {
+            return Err(TryAcquireError::NoPermits);
+        }
+
         let num_permits = (num_permits as usize) << Self::PERMIT_SHIFT;
         let mut curr = self.permits.load(Acquire);
         loop {
@@ -392,6 +410,20 @@ impl Semaphore {
         }
 
         Pending
+    }
+
+    /// Shrinks the number of available permits by the indicated reduction.
+    ///
+    /// This differs from `acquire` in that it does not block waiting for permits
+    /// to become available.
+    pub(crate) fn reduce_permits(&self, reduction: usize) {
+        let underflow = match self.permits.fetch_update(Relaxed, Relaxed, |v| {
+            Some(v.saturating_sub(reduction << Self::PERMIT_SHIFT))
+        }) {
+            Ok(prev) | Err(prev) => reduction.saturating_sub(prev >> Self::PERMIT_SHIFT),
+        };
+
+        self.underflow.store(underflow, Release);
     }
 }
 

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -422,7 +422,7 @@ impl Semaphore {
             Some(v.saturating_sub(reduction << Self::PERMIT_SHIFT))
         }) {
             Ok(prev) => reduction.saturating_sub(prev >> Self::PERMIT_SHIFT),
-            Err(_) => unreachable!()
+            Err(_) => unreachable!(),
         };
 
         self.underflow.store(underflow, Release);

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -181,7 +181,8 @@ impl Semaphore {
             .underflow
             .fetch_update(Relaxed, Relaxed, |v| Some(v.saturating_sub(added)))
         {
-            Ok(prev) | Err(prev) => added.saturating_sub(prev),
+            Ok(prev) => added.saturating_sub(prev),
+            Err(_) => unreachable!(),
         };
 
         // Assign permits to the wait queue
@@ -421,7 +422,7 @@ impl Semaphore {
             Some(v.saturating_sub(reduction << Self::PERMIT_SHIFT))
         }) {
             Ok(prev) => reduction.saturating_sub(prev >> Self::PERMIT_SHIFT),
-            Err(prev) => unreachable!()
+            Err(_) => unreachable!()
         };
 
         self.underflow.store(underflow, Release);

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -190,9 +190,7 @@ impl<T> Receiver<T> {
         // If there is already an underflow, the permit released by recv is
         // cancelled and the underflow is reduced accordingly.
         if self.underflow > 0 {
-            self.chan
-                .semaphore()
-                .reduce_permits(1);
+            self.chan.semaphore().reduce_permits(1);
 
             self.underflow -= 1;
         }
@@ -334,7 +332,7 @@ impl<T> Receiver<T> {
     /// use tokio::sync::mpsc;
     ///
     /// fn main() {
-    ///     let (tx, rx) = mpsc::channel(1);
+    ///     let (tx, mut rx) = mpsc::channel(1);
     ///
     ///     tx.try_send(()).unwrap();
     ///     assert!(tx.try_send(()).is_err());
@@ -354,7 +352,7 @@ impl<T> Receiver<T> {
             Ordering::Less => {
                 let sub = cap - new_size;
 
-                // Reduce the number of available permits and increase the 
+                // Reduce the number of available permits and increase the
                 // underflow if there's an excess of acquired permits.
                 semaphore.reduce_permits(sub);
                 self.underflow += sub.saturating_sub(semaphore.available_permits());
@@ -364,7 +362,7 @@ impl<T> Receiver<T> {
                 let add = new_size - cap;
 
                 // Empty the underflow if any and add the remaining permits to
-                // the semaphore. 
+                // the semaphore.
                 semaphore.add_permits(add.saturating_sub(self.underflow));
                 self.underflow = self.underflow.saturating_sub(add);
             }

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -221,7 +221,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     }
 
     /// Receive the next value
-    pub(crate) fn recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+    pub(crate) fn recv(&mut self, cx: &mut Context<'_>, release: bool) -> Poll<Option<T>> {
         use super::block::Read::*;
 
         // Keep track of task budget
@@ -234,7 +234,9 @@ impl<T, S: Semaphore> Rx<T, S> {
                 () => {
                     match rx_fields.list.pop(&self.inner.tx) {
                         Some(Value(value)) => {
-                            self.inner.semaphore.add_permits(1);
+                            if release {
+                                self.inner.semaphore.add_permits(1);
+                            }
                             coop.made_progress();
                             return Ready(Some(value));
                         }

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -379,7 +379,7 @@ impl Semaphore for AtomicUsize {
 
     fn reduce_permits(&self, reduction: usize) {
         self.fetch_update(Acquire, Release, |v| Some(v.saturating_sub(reduction)))
-            .expect("TODO");
+            .expect("update failed");
     }
 
     fn is_idle(&self) -> bool {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -176,7 +176,7 @@ impl<T> UnboundedReceiver<T> {
     /// `poll_recv`, only the `Waker` from the `Context` passed to the most
     /// recent call is scheduled to receive a wakeup.
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        self.chan.recv(cx)
+        self.chan.recv(cx, true)
     }
 }
 

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -276,7 +276,7 @@ fn poll_acquire_permit_with_underflow() {
     let s = Semaphore::new(0);
 
     // Introduce an underflow of 1
-    s.reduce_permits(2);
+    s.reduce_permits(1);
 
     // Try to acquire a permit
     let mut acquire = task::spawn(s.acquire(1));

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -250,45 +250,9 @@ fn cancel_acquire_releases_permits() {
 }
 
 #[test]
-fn try_acquire_with_underflow() {
+fn reduce_permits() {
     let s = Semaphore::new(1);
 
     s.reduce_permits(1);
-
-    assert_err!(s.try_acquire(1));
-}
-
-#[test]
-fn release_with_underflow() {
-    let s = Semaphore::new(1);
-
-    s.reduce_permits(1);
-    assert_eq!(s.available_permits(), 0);
-
-    assert_err!(s.try_acquire(1));
-
-    s.release(1);
-    assert_ok!(s.try_acquire(1));
-}
-
-#[test]
-fn poll_acquire_permit_with_underflow() {
-    let s = Semaphore::new(0);
-
-    // Introduce an underflow of 1
-    s.reduce_permits(1);
-
-    // Try to acquire a permit
-    let mut acquire = task::spawn(s.acquire(1));
-    assert_pending!(acquire.poll());
-
-    assert_eq!(s.available_permits(), 0);
-
-    // Cancel the underflow
-    s.release(2);
-
-    assert!(acquire.is_woken());
-    assert_ready_ok!(acquire.poll());
-
-    assert_eq!(s.available_permits(), 0);
+    assert_eq!(0, s.available_permits());
 }

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -494,3 +494,31 @@ async fn permit_available_not_acquired_close() {
     drop(permit2);
     assert!(rx.recv().await.is_none());
 }
+
+#[tokio::test]
+async fn bounded_resize_shrink() {
+    let (tx, rx) = mpsc::channel::<()>(2);
+
+    assert_ok!(tx.try_send(()));
+
+    rx.resize(1);
+    assert_err!(tx.try_send(()));
+}
+
+#[tokio::test]
+async fn bounded_resize_grow() {
+    let (tx, rx) = mpsc::channel::<()>(1);
+
+    assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+
+    rx.resize(2);
+    assert_ok!(tx.try_send(()));
+}
+
+#[tokio::test]
+#[should_panic]
+async fn bounded_resize_zero() {
+    let (_, rx) = mpsc::channel::<()>(1);
+    rx.resize(0);
+}

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -497,28 +497,78 @@ async fn permit_available_not_acquired_close() {
 
 #[tokio::test]
 async fn bounded_resize_shrink() {
-    let (tx, rx) = mpsc::channel::<()>(2);
-
-    assert_ok!(tx.try_send(()));
+    let (tx, mut rx) = mpsc::channel::<()>(5);
 
     rx.resize(1);
+
+    assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+}
+
+#[tokio::test]
+async fn bounded_resize_shrink_underflow() {
+    let (tx, mut rx) = mpsc::channel::<()>(2);
+
+    assert_ok!(tx.try_send(()));
+    assert_ok!(tx.try_send(()));
+
+    // resize to a lower capacity
+    rx.resize(1);
+    assert_err!(tx.try_send(()));
+
+    // resize to a higher capacity
+    rx.resize(3);
+    assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+
+    // resize to a higher capacity
+    rx.resize(5);
+    assert_ok!(tx.try_send(()));
+    assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+
+    // resize to 1 again
+    rx.resize(1);
+
+    // receive all underflowing values
+    for _ in 0..=4 {
+        assert_err!(tx.try_send(()));
+        assert!(rx.recv().await.is_some());
+    }
+
+    assert_ok!(tx.try_send(()));
     assert_err!(tx.try_send(()));
 }
 
 #[tokio::test]
 async fn bounded_resize_grow() {
-    let (tx, rx) = mpsc::channel::<()>(1);
+    let (tx, mut rx) = mpsc::channel::<()>(1);
 
     assert_ok!(tx.try_send(()));
     assert_err!(tx.try_send(()));
 
     rx.resize(2);
     assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+
+    rx.resize(4);
+    assert_ok!(tx.try_send(()));
+    assert_ok!(tx.try_send(()));
+    assert_err!(tx.try_send(()));
+}
+
+#[tokio::test]
+async fn bounded_resize_equal() {
+    let (tx, mut rx) = mpsc::channel::<()>(1);
+
+    // resizing to the same size has no effect
+    rx.resize(1);
+    assert_ok!(tx.try_send(()));
 }
 
 #[tokio::test]
 #[should_panic]
 async fn bounded_resize_zero() {
-    let (_, rx) = mpsc::channel::<()>(1);
+    let (_, mut rx) = mpsc::channel::<()>(1);
     rx.resize(0);
 }


### PR DESCRIPTION
Proposed solution to close #3730

## Motivation

Bounded channels can only have a fixed capacity. When a receiver wants to process more messages at a time than the originally intended capacity, it cannot resize the channel to do so.

## Solution

Implement a method that allows the user to resize the channel from the receiver handle