### PR TITLE
doc: fix invalid `#[doc(inline)]` warnings on latest nightly.

### DIFF
--- a/tokio-util/src/time/mod.rs
+++ b/tokio-util/src/time/mod.rs
@@ -12,7 +12,6 @@ use std::time::Duration;
 
 mod wheel;
 
-#[doc(inline)]
 pub mod delay_queue;
 
 pub use delay_queue::DelayQueue;

--- a/tokio-util/src/time/mod.rs
+++ b/tokio-util/src/time/mod.rs
@@ -14,6 +14,7 @@ mod wheel;
 
 pub mod delay_queue;
 
+#[doc(inline)]
 pub use delay_queue::DelayQueue;
 
 // ===== Internal utils =====

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -453,15 +453,20 @@ cfg_macros! {
         #[cfg(feature = "rt-multi-thread")]
         #[cfg(not(test))] // Work around for rust-lang/rust#62127
         #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[doc(inline)]
         pub use tokio_macros::main;
 
         #[cfg(feature = "rt-multi-thread")]
         #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[doc(inline)]
         pub use tokio_macros::test;
 
         cfg_not_rt_multi_thread! {
             #[cfg(not(test))] // Work around for rust-lang/rust#62127
+            #[doc(inline)]
             pub use tokio_macros::main_rt as main;
+
+            #[doc(inline)]
             pub use tokio_macros::test_rt as test;
         }
     }
@@ -469,7 +474,10 @@ cfg_macros! {
     // Always fail if rt is not enabled.
     cfg_not_rt! {
         #[cfg(not(test))]
+        #[doc(inline)]
         pub use tokio_macros::main_fail as main;
+
+        #[doc(inline)]
         pub use tokio_macros::test_fail as test;
     }
 }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -157,7 +157,6 @@ macro_rules! cfg_macros {
         $(
             #[cfg(feature = "macros")]
             #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
-            #[doc(inline)]
             $item
         )*
     }


### PR DESCRIPTION
## Motivation

This pull request proposed a solution to fix issue #3787.

## Solution

This pull request fixed issue #3787 by removing [doc(inline)] from
macro `cfg_macros` and added proper #[doc(inline)] attributes
to `pub use` items inside `cfg_macros` calls.

It's probably not `cfg_macros`s responsibility to inlining public
macros, though it's conveninent to do so. Notice that in lib.rs:

```rust
cfg_macros! {
    /// Implementation detail of the `select!` macro. This macro is **not**
    /// intended to be used as part of the public API and is permitted to
    /// change.
    #[doc(hidden)]
    pub use tokio_macros::select_priv_declare_output_enum;

    ...
}
```

`#[doc(hidden)]` and `#[doc(inline)]` are conflict with each other
in the sense of correctness.

## Drawbacks

- Adds a little bit of code verbosity, but should be acceptable because the number of public macros  are limited.
- Do need to remember to manually add `#[doc(inline)]` to any new public macros, if inlining doc is desired. 

Fixes: #3787