### PR TITLE
assert platform-minimum requirements at build time

### DIFF
--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -19,4 +19,29 @@ fn main() {
             );
         }
     }
+
+    assert_platform_minimums();
+}
+
+/// Assert platform-minimum requirements for Tokio to work correctly. This might
+/// be feasible to do as a constant fn, once MSRC is bumped a bit more.
+fn assert_platform_minimums() {
+    use std::mem;
+    use std::sync::atomic::{AtomicIsize, AtomicUsize};
+
+    if mem::size_of::<usize>() < 4 {
+        panic!("Tokio only works correctly if usize is at least 4 bytes.");
+    }
+
+    if mem::size_of::<isize>() < 4 {
+        panic!("Tokio only works correctly if isize is at least 4 bytes.");
+    }
+
+    if mem::size_of::<AtomicUsize>() < 4 {
+        panic!("Tokio only works correctly if AtomicUsize is at least 4 bytes.");
+    }
+
+    if mem::size_of::<AtomicIsize>() < 4 {
+        panic!("Tokio only works correctly if AtomicIsize is at least 4 bytes.");
+    }
 }


### PR DESCRIPTION
Adds assertions in `build.rs` which ensures that the platform being built for supports the minimum required by Tokio.

## Motivation

Tokio currently makes a number of soft assumptions about the size of a `usize` (and `isize`), usually through the form of casting a `u32` like:

```rust
let value: u32 = todo!();
value as usize
```

Arguably the preferable way to do this would be to perform a checked conversion using `TryFrom`, but it would be a lot of work to trace all of them down *and* it might not always be immediately feasible when it comes to things like bit flags.

It is unlikely that someone will ever attempt to build Tokio for a platform where `usize` is not at least 4 bytes, but at least when they do, they should be firmly shown that it's a bad idea until assumptions around `usize` et. al. have been fixed.

## Solution

Add assertions to `build.rs`. I started tinkering with constant assertions, but Rust `1.45` is a bit too limiting to make them ergonomical. While it's possible that `build.rs` is run with a different `rustc` than the one used to compile the project, one would have to do something strange to have it do so.