### PR TITLE
io: add get_{ref,mut} methods to AsyncFdReadyGuard and AsyncFdReadyMutGuard.

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -480,16 +480,6 @@ impl<T: AsRawFd> Drop for AsyncFd<T> {
 }
 
 impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
-    /// Returns a shared reference to the inner [`AsyncFd`].
-    pub fn get_ref(&self) -> &AsyncFd<Inner> {
-        self.async_fd
-    }
-
-    /// Returns a shared reference to the backing object of the inner [`AsyncFd`].
-    pub fn get_inner(&self) -> &Inner {
-        self.get_ref().get_ref()
-    }
-
     /// Indicates to tokio that the file descriptor is no longer ready. The
     /// internal readiness flag will be cleared, and tokio will wait for the
     /// next edge-triggered readiness notification from the OS.
@@ -550,16 +540,9 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
             result => Ok(result),
         }
     }
-}
 
-impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     /// Returns a shared reference to the inner [`AsyncFd`].
     pub fn get_ref(&self) -> &AsyncFd<Inner> {
-        self.async_fd
-    }
-
-    /// Returns a mutable reference to the inner [`AsyncFd`].
-    pub fn get_mut(&mut self) -> &mut AsyncFd<Inner> {
         self.async_fd
     }
 
@@ -567,12 +550,9 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     pub fn get_inner(&self) -> &Inner {
         self.get_ref().get_ref()
     }
+}
 
-    /// Returns a mutable reference to the backing object of the inner [`AsyncFd`].
-    pub fn get_inner_mut(&mut self) -> &mut Inner {
-        self.get_mut().get_mut()
-    }
-
+impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     /// Indicates to tokio that the file descriptor is no longer ready. The
     /// internal readiness flag will be cleared, and tokio will wait for the
     /// next edge-triggered readiness notification from the OS.
@@ -630,6 +610,26 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
             Err(err) if err.kind() == io::ErrorKind::WouldBlock => Err(TryIoError(())),
             result => Ok(result),
         }
+    }
+
+    /// Returns a shared reference to the inner [`AsyncFd`].
+    pub fn get_ref(&self) -> &AsyncFd<Inner> {
+        self.async_fd
+    }
+
+    /// Returns a mutable reference to the inner [`AsyncFd`].
+    pub fn get_mut(&mut self) -> &mut AsyncFd<Inner> {
+        self.async_fd
+    }
+
+    /// Returns a shared reference to the backing object of the inner [`AsyncFd`].
+    pub fn get_inner(&self) -> &Inner {
+        self.get_ref().get_ref()
+    }
+
+    /// Returns a mutable reference to the backing object of the inner [`AsyncFd`].
+    pub fn get_inner_mut(&mut self) -> &mut Inner {
+        self.get_mut().get_mut()
     }
 }
 

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -482,7 +482,12 @@ impl<T: AsRawFd> Drop for AsyncFd<T> {
 impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     /// Returns a shared reference to the inner [`AsyncFd`].
     pub fn get_ref(&self) -> &AsyncFd<Inner> {
-        &self.async_fd
+        self.async_fd
+    }
+
+    /// Returns a shared reference to the backing object of the inner [`AsyncFd`].
+    pub fn get_inner(&self) -> &Inner {
+        self.get_ref().get_ref()
     }
 
     /// Indicates to tokio that the file descriptor is no longer ready. The
@@ -550,12 +555,22 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
 impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     /// Returns a shared reference to the inner [`AsyncFd`].
     pub fn get_ref(&self) -> &AsyncFd<Inner> {
-        &self.async_fd
+        self.async_fd
     }
 
     /// Returns a mutable reference to the inner [`AsyncFd`].
     pub fn get_mut(&mut self) -> &mut AsyncFd<Inner> {
-        &mut self.async_fd
+        self.async_fd
+    }
+
+    /// Returns a shared reference to the backing object of the inner [`AsyncFd`].
+    pub fn get_inner(&self) -> &Inner {
+        self.get_ref().get_ref()
+    }
+
+    /// Returns a mutable reference to the backing object of the inner [`AsyncFd`].
+    pub fn get_inner_mut(&mut self) -> &mut Inner {
+        self.get_mut().get_mut()
     }
 
     /// Indicates to tokio that the file descriptor is no longer ready. The

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -480,6 +480,11 @@ impl<T: AsRawFd> Drop for AsyncFd<T> {
 }
 
 impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
+    /// Returns a shared reference to the inner [`AsyncFd`].
+    pub fn get_ref(&self) -> &AsyncFd<Inner> {
+        &self.async_fd
+    }
+
     /// Indicates to tokio that the file descriptor is no longer ready. The
     /// internal readiness flag will be cleared, and tokio will wait for the
     /// next edge-triggered readiness notification from the OS.
@@ -543,6 +548,16 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
 }
 
 impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
+    /// Returns a shared reference to the inner [`AsyncFd`].
+    pub fn get_ref(&self) -> &AsyncFd<Inner> {
+        &self.async_fd
+    }
+
+    /// Returns a mutable reference to the inner [`AsyncFd`].
+    pub fn get_mut(&mut self) -> &mut AsyncFd<Inner> {
+        &mut self.async_fd
+    }
+
     /// Indicates to tokio that the file descriptor is no longer ready. The
     /// internal readiness flag will be cleared, and tokio will wait for the
     /// next edge-triggered readiness notification from the OS.


### PR DESCRIPTION
The only way to use `AsyncFdReadyMutGuard` currently is through `try_io`, since it is impossible to access the underlying object. In some situations, it is desirable to use `clear_ready` and `retain_ready` directly instead of `try_io`. Enable this by adding `get_ref` and `get_mut` methods.

## Motivation

When using `AsyncFd` with an I/O object that does not communicate readiness through `ErrorKind::WouldBlock`, code using `try_io` becomes hard to read. In the following example, the `next()` method returns `None` when no new data is ready.

```rust
let mut guard = ready!(self.inner.poll_read_ready_mut(cx))?;

match guard.try_io(|s| {
    s.get_mut()
        .next()
        .ok_or_else(|| ErrorKind::WouldBlock.into())
}) {
    Ok(event) => Poll::Ready(Some(event)),
    Err(_) => Poll::Pending,
}
```

As seen here, you have to explicitly convert `None` to a `WouldBlock` error in `try_io`, only to convert that error back into `Pending` afterwards. This is confusing to read.

## Solution

By adding `AsyncFdReadyMutGuard::get_mut`, this can be expressed in a more straight-forward way:

```rust
let mut guard = ready!(self.inner.poll_read_ready_mut(cx))?;

match guard.get_mut().get_mut().next() {
    Some(event) => {
        guard.retain_ready();
        Poll::Ready(Some(Ok(event)))
    }
    None => {
        guard.clear_ready();
        Poll::Pending
    }
}
```

The `get_ref` methods are added for consistency.

## Questions

Should we return a reference to `AsyncFd<T>` or `T`? `try_io` uses `AsyncFd<T>` in its argument, so the proposed solution is consistent. On the other hand, in probably all cases, this requires writing `guard.get_mut().get_mut()`.