### PR TITLE
doc: Add examples to `Semaphore`

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -164,7 +164,7 @@ impl Semaphore {
     ///
     /// # Examples
     ///
-    ///```
+    /// ```
     /// use tokio::sync::Semaphore;
     ///
     /// #[tokio::main]
@@ -200,7 +200,7 @@ impl Semaphore {
     ///
     /// # Examples
     ///
-    ///```
+    /// ```
     /// use tokio::sync::Semaphore;
     ///
     /// #[tokio::main]
@@ -230,7 +230,7 @@ impl Semaphore {
     ///
     /// # Examples
     ///
-    ///```
+    /// ```
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
     /// #[tokio::main]
@@ -269,7 +269,7 @@ impl Semaphore {
     ///
     /// # Examples
     ///
-    ///```
+    /// ```
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
     /// #[tokio::main]
@@ -373,7 +373,6 @@ impl Semaphore {
     ///     }
     /// }
     /// ```
-    ///
     ///
     /// [`Arc`]: std::sync::Arc
     /// [`AcquireError`]: crate::sync::AcquireError

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -24,6 +24,51 @@ use std::sync::Arc;
 /// To use the `Semaphore` in a poll function, you can use the [`PollSemaphore`]
 /// utility.
 ///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+/// use tokio::sync::{Semaphore, TryAcquireError};
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let semaphore = Semaphore::new(3);
+///     {
+///         let a_permit = semaphore.acquire().await;
+///         let two_permits = semaphore.acquire_many(2).await;
+///         assert_eq!(a_permit.is_ok(), true);
+///         assert_eq!(two_permits.is_ok(), true);
+///         // all three permits acquired without waiting
+///         assert_eq!(semaphore.available_permits(), 0);
+///         // any more `acquire()` or `acquire_many()` calls will wait
+///         // `try_acquire` attempts to acquire, but fail immediately in this case
+///         let fourth_permit = semaphore.try_acquire();
+///         assert_eq!(fourth_permit.err(), Some(TryAcquireError::NoPermits));
+///         semaphore.close();
+///         // cannot obtain more permits after close
+///         assert_eq!(semaphore.acquire().await.is_err(), true);
+///     } // all permits are dropped at this point
+///     assert_eq!(semaphore.available_permits(), 3);
+///
+///     // wrap a semaphore in [`Arc`] to share a semaphore across tasks
+///     // use [`acquire_owned`] to move permits across tasks
+///     let semaphore = Arc::new(Semaphore::new(3));
+///     let mut join_handles = Vec::new();
+///     for _ in 1..=5 {
+///         let permit = semaphore.clone().acquire_owned().await.unwrap();
+///         join_handles.push(tokio::spawn(async move {
+///             // perform task...
+///             // explicitly own `permit` in the task
+///             drop(permit);
+///         }));
+///     }
+///     assert_eq!(join_handles.len(), 5);
+///     for j in join_handles {
+///         j.await.unwrap();
+///     }
+/// }
+/// ```
+///
 /// [`PollSemaphore`]: https://docs.rs/tokio-util/0.6/tokio_util/sync/struct.PollSemaphore.html
 #[derive(Debug)]
 pub struct Semaphore {
@@ -105,6 +150,25 @@ impl Semaphore {
     /// Otherwise, this returns a [`SemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// # Examples
+    ///
+    ///```
+    /// use tokio::sync::Semaphore;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Semaphore::new(2);
+    ///     let p1 = semaphore.acquire().await;
+    ///     let p2 = semaphore.acquire().await;
+    ///     assert_eq!(p1.is_ok(), true);
+    ///     assert_eq!(p2.is_ok(), true);
+    ///     assert_eq!(semaphore.available_permits(), 0);
+    ///     semaphore.close();
+    ///     let p3 = semaphore.acquire().await;
+    ///     assert_eq!(p3.is_err(), true);
+    /// }
+    /// ```
+    ///
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
     pub async fn acquire(&self) -> Result<SemaphorePermit<'_>, AcquireError> {
@@ -121,6 +185,25 @@ impl Semaphore {
     /// Otherwise, this returns a [`SemaphorePermit`] representing the
     /// acquired permits.
     ///
+    /// # Examples
+    ///
+    ///```
+    /// use tokio::sync::Semaphore;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Semaphore::new(5);
+    ///     let p1 = semaphore.acquire_many(3).await;
+    ///     assert_eq!(semaphore.available_permits(), 2);
+    ///     let p2 = semaphore.acquire_many(2).await;
+    ///     assert_eq!(p1.is_ok(), true);
+    ///     assert_eq!(p2.is_ok(), true);
+    ///     semaphore.close();
+    ///     let p3 = semaphore.acquire_many(99).await;
+    ///     assert_eq!(p3.is_err(), true);
+    /// }
+    /// ```
+    ///
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
     pub async fn acquire_many(&self, n: u32) -> Result<SemaphorePermit<'_>, AcquireError> {
@@ -136,6 +219,26 @@ impl Semaphore {
     /// If the semaphore has been closed, this returns a [`TryAcquireError::Closed`]
     /// and a [`TryAcquireError::NoPermits`] if there are no permits left. Otherwise,
     /// this returns a [`SemaphorePermit`] representing the acquired permits.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use tokio::sync::{Semaphore, TryAcquireError};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Semaphore::new(2);
+    ///     let p1 = semaphore.acquire().await;
+    ///     let p2 = semaphore.try_acquire();
+    ///     let p3 = semaphore.try_acquire();
+    ///     assert_eq!(p1.is_ok(), true);
+    ///     assert_eq!(p2.is_ok(), true);
+    ///     assert_eq!(p3.err(), Some(TryAcquireError::NoPermits));
+    ///     semaphore.close();
+    ///     let p4 = semaphore.try_acquire();
+    ///     assert_eq!(p4.err(), Some(TryAcquireError::Closed));
+    /// }
+    /// ```
     ///
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
     /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
@@ -155,6 +258,25 @@ impl Semaphore {
     /// If the semaphore has been closed, this returns a [`TryAcquireError::Closed`]
     /// and a [`TryAcquireError::NoPermits`] if there are no permits left. Otherwise,
     /// this returns a [`SemaphorePermit`] representing the acquired permits.
+    ///
+    /// # Examples
+    ///
+    ///```
+    /// use tokio::sync::{Semaphore, TryAcquireError};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Semaphore::new(4);
+    ///     let p1 = semaphore.try_acquire_many(3);
+    ///     assert_eq!(semaphore.available_permits(), 1);
+    ///     let p2 = semaphore.try_acquire_many(2);
+    ///     assert_eq!(p1.is_ok(), true);
+    ///     assert_eq!(p2.err(), Some(TryAcquireError::NoPermits));
+    ///     semaphore.close();
+    ///     let p3 = semaphore.try_acquire_many(99);
+    ///     assert_eq!(p3.err(), Some(TryAcquireError::Closed));
+    /// }
+    /// ```
     ///
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
     /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
@@ -176,6 +298,32 @@ impl Semaphore {
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::Semaphore;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(2));
+    ///     let sem_clone = semaphore.clone();
+    ///     let handle = tokio::spawn(async move {
+    ///         let permit = sem_clone.acquire_owned().await;
+    ///         assert_eq!(permit.is_ok(), true);
+    ///     });
+    ///     {
+    ///         let p1 = semaphore.clone().acquire_owned().await;
+    ///         assert_eq!(semaphore.available_permits(), 1);
+    ///         let p2 = semaphore.clone().acquire_owned().await;
+    ///         assert_eq!(semaphore.available_permits(), 0);
+    ///         assert_eq!(p1.is_ok(), true);
+    ///         assert_eq!(p2.is_ok(), true);
+    ///     } // release the permits so the task can acquire them
+    ///     handle.await.unwrap();
+    /// }
+    /// ```
+    ///
     /// [`Arc`]: std::sync::Arc
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
@@ -193,6 +341,33 @@ impl Semaphore {
     /// If the semaphore has been closed, this returns an [`AcquireError`].
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::Semaphore;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(5));
+    ///     let sem_clone = semaphore.clone();
+    ///     let handle = tokio::spawn(async move {
+    ///         let permit = sem_clone.acquire_many_owned(5).await;
+    ///         assert_eq!(permit.is_ok(), true);
+    ///     });
+    ///     {
+    ///         let p1 = semaphore.clone().acquire_many_owned(2).await;
+    ///         assert_eq!(semaphore.available_permits(), 3);
+    ///         let p2 = semaphore.clone().acquire_owned().await;
+    ///         assert_eq!(semaphore.available_permits(), 2);
+    ///         assert_eq!(p1.is_ok(), true);
+    ///         assert_eq!(p2.is_ok(), true);
+    ///     } // release the permits so the task can acquire them
+    ///     handle.await.unwrap();
+    /// }
+    /// ```
+    ///
     ///
     /// [`Arc`]: std::sync::Arc
     /// [`AcquireError`]: crate::sync::AcquireError
@@ -216,6 +391,34 @@ impl Semaphore {
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{Semaphore, TryAcquireError};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(2));
+    ///     let sem_clone = semaphore.clone();
+    ///     let handle = tokio::spawn(async move {
+    ///         let permit = sem_clone.try_acquire_owned();
+    ///         assert_eq!(permit.is_ok(), true);
+    ///     });
+    ///     {
+    ///         let p1 = semaphore.clone().try_acquire_owned();
+    ///         assert_eq!(semaphore.available_permits(), 1);
+    ///         let p2 = semaphore.clone().try_acquire_owned();
+    ///         assert_eq!(semaphore.available_permits(), 0);
+    ///         let p3 = semaphore.clone().try_acquire_owned();
+    ///         assert_eq!(p1.is_ok(), true);
+    ///         assert_eq!(p2.is_ok(), true);
+    ///         assert_eq!(p3.err(), Some(TryAcquireError::NoPermits));
+    ///     } // release the permits so the task can acquire them
+    ///     handle.await.unwrap();
+    /// }
+    /// ```
+    ///
     /// [`Arc`]: std::sync::Arc
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
     /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
@@ -237,6 +440,31 @@ impl Semaphore {
     /// and a [`TryAcquireError::NoPermits`] if there are no permits left.
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{Semaphore, TryAcquireError};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(5));
+    ///     let sem_clone = semaphore.clone();
+    ///     let handle = tokio::spawn(async move {
+    ///         let permit = sem_clone.try_acquire_many_owned(5);
+    ///         assert_eq!(permit.is_ok(), true);
+    ///     });
+    ///     {
+    ///         let p1 = semaphore.clone().try_acquire_many_owned(3);
+    ///         assert_eq!(semaphore.available_permits(), 2);
+    ///         let p2 = semaphore.clone().try_acquire_many_owned(99);
+    ///         assert_eq!(p1.is_ok(), true);
+    ///         assert_eq!(p2.err(), Some(TryAcquireError::NoPermits));
+    ///     } // release the permits so the task can acquire them
+    ///     handle.await.unwrap();
+    /// }
+    /// ```
     ///
     /// [`Arc`]: std::sync::Arc
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -26,6 +26,8 @@ use std::sync::Arc;
 ///
 /// # Examples
 ///
+/// Basic usage:
+///
 /// ```
 /// use tokio::sync::{Semaphore, TryAcquireError};
 ///
@@ -403,7 +405,6 @@ impl Semaphore {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     // use [`acquire_owned`] to move permits across tasks
     ///     let semaphore = Arc::new(Semaphore::new(5));
     ///     let mut join_handles = Vec::new();
     ///
@@ -452,7 +453,6 @@ impl Semaphore {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     // use [`acquire_owned`] to move permits across tasks
     ///     let semaphore = Arc::new(Semaphore::new(15));
     ///     let mut join_handles = Vec::new();
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -264,8 +264,8 @@ impl Semaphore {
     /// Tries to acquire `n` permits from the semaphore.
     ///
     /// If the semaphore has been closed, this returns a [`TryAcquireError::Closed`]
-    /// and a [`TryAcquireError::NoPermits`] if there are no permits left. Otherwise,
-    /// this returns a [`SemaphorePermit`] representing the acquired permits.
+    /// and a [`TryAcquireError::NoPermits`] if there are not enough permits left.
+    /// Otherwise, this returns a [`SemaphorePermit`] representing the acquired permits.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -65,8 +65,8 @@ use std::sync::Arc;
 ///         }));
 ///     }
 ///
-///     for j in join_handles {
-///         j.await.unwrap();
+///     for handle in join_handles {
+///         handle.await.unwrap();
 ///     }
 /// }
 /// ```
@@ -324,8 +324,8 @@ impl Semaphore {
     ///         }));
     ///     }
     ///
-    ///     for j in join_handles {
-    ///         j.await.unwrap();
+    ///     for handle in join_handles {
+    ///         handle.await.unwrap();
     ///     }
     /// }
     /// ```
@@ -359,7 +359,7 @@ impl Semaphore {
     ///     let semaphore = Arc::new(Semaphore::new(10));
     ///     let mut join_handles = Vec::new();
     ///
-    ///     for i in 1..=5 {
+    ///     for _ in 1..=5 {
     ///         let permit = semaphore.clone().acquire_many_owned(2).await.unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
@@ -368,8 +368,8 @@ impl Semaphore {
     ///         }));
     ///     }
     ///
-    ///     for j in join_handles {
-    ///         j.await.unwrap();
+    ///     for handle in join_handles {
+    ///         handle.await.unwrap();
     ///     }
     /// }
     /// ```
@@ -416,8 +416,8 @@ impl Semaphore {
     ///         }));
     ///     }
     ///
-    ///     for j in join_handles {
-    ///         j.await.unwrap();
+    ///     for handle in join_handles {
+    ///         handle.await.unwrap();
     ///     }
     /// }
     /// ```
@@ -455,7 +455,7 @@ impl Semaphore {
     ///     let semaphore = Arc::new(Semaphore::new(10));
     ///     let mut join_handles = Vec::new();
     ///
-    ///     for i in 1..=5 {
+    ///     for _ in 1..=5 {
     ///         let permit = semaphore.clone().try_acquire_many_owned(2).unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
@@ -464,8 +464,8 @@ impl Semaphore {
     ///         }));
     ///     }
     ///
-    ///     for j in join_handles {
-    ///         j.await.unwrap();
+    ///     for handle in join_handles {
+    ///         handle.await.unwrap();
     ///     }
     /// }
     /// ```

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -233,19 +233,18 @@ impl Semaphore {
     /// ```
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let semaphore = Semaphore::new(2);
+    /// # fn main() {
+    /// let semaphore = Semaphore::new(2);
     ///
-    ///     let permit_1 = semaphore.try_acquire().unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 1);
+    /// let permit_1 = semaphore.try_acquire().unwrap();
+    /// assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     let permit_2 = semaphore.try_acquire().unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 0);
+    /// let permit_2 = semaphore.try_acquire().unwrap();
+    /// assert_eq!(semaphore.available_permits(), 0);
     ///
-    ///     let permit_3 = semaphore.try_acquire();
-    ///     assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
-    /// }
+    /// let permit_3 = semaphore.try_acquire();
+    /// assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
+    /// # }
     /// ```
     ///
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
@@ -272,16 +271,15 @@ impl Semaphore {
     /// ```
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let semaphore = Semaphore::new(4);
+    /// # fn main() {
+    /// let semaphore = Semaphore::new(4);
     ///
-    ///     let permit_1 = semaphore.try_acquire_many(3).unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 1);
+    /// let permit_1 = semaphore.try_acquire_many(3).unwrap();
+    /// assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     let permit_2 = semaphore.try_acquire_many(2);
-    ///     assert_eq!(permit_2.err(), Some(TryAcquireError::NoPermits));
-    /// }
+    /// let permit_2 = semaphore.try_acquire_many(2);
+    /// assert_eq!(permit_2.err(), Some(TryAcquireError::NoPermits));
+    /// # }
     /// ```
     ///
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
@@ -402,19 +400,18 @@ impl Semaphore {
     /// use std::sync::Arc;
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(2));
+    /// # fn main() {
+    /// let semaphore = Arc::new(Semaphore::new(2));
     ///
-    ///     let permit_1 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 1);
+    /// let permit_1 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
+    /// assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     let permit_2 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 0);
+    /// let permit_2 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
+    /// assert_eq!(semaphore.available_permits(), 0);
     ///
-    ///     let permit_3 = semaphore.try_acquire_owned();
-    ///     assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
-    /// }
+    /// let permit_3 = semaphore.try_acquire_owned();
+    /// assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
+    /// # }
     /// ```
     ///
     /// [`Arc`]: std::sync::Arc
@@ -445,16 +442,15 @@ impl Semaphore {
     /// use std::sync::Arc;
     /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(4));
+    /// # fn main() {
+    /// let semaphore = Arc::new(Semaphore::new(4));
     ///
-    ///     let permit_1 = Arc::clone(&semaphore).try_acquire_many_owned(3).unwrap();
-    ///     assert_eq!(semaphore.available_permits(), 1);
+    /// let permit_1 = Arc::clone(&semaphore).try_acquire_many_owned(3).unwrap();
+    /// assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     let permit_2 = semaphore.try_acquire_many_owned(2);
-    ///     assert_eq!(permit_2.err(), Some(TryAcquireError::NoPermits));
-    /// }
+    /// let permit_2 = semaphore.try_acquire_many_owned(2);
+    /// assert_eq!(permit_2.err(), Some(TryAcquireError::NoPermits));
+    /// # }
     /// ```
     ///
     /// [`Arc`]: std::sync::Arc

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -158,14 +158,15 @@ impl Semaphore {
     /// #[tokio::main]
     /// async fn main() {
     ///     let semaphore = Semaphore::new(2);
-    ///     let p1 = semaphore.acquire().await;
-    ///     let p2 = semaphore.acquire().await;
-    ///     assert_eq!(p1.is_ok(), true);
-    ///     assert_eq!(p2.is_ok(), true);
+    ///
+    ///     let permit_1 = semaphore.acquire().await.unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 1);
+    ///
+    ///     let permit_2 = semaphore.acquire().await.unwrap();
     ///     assert_eq!(semaphore.available_permits(), 0);
-    ///     semaphore.close();
-    ///     let p3 = semaphore.acquire().await;
-    ///     assert_eq!(p3.is_err(), true);
+    ///
+    ///     drop(permit_1);
+    ///     assert_eq!(semaphore.available_permits(), 1);
     /// }
     /// ```
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -231,7 +231,7 @@ impl Semaphore {
     /// # Examples
     ///
     ///```
-    /// use tokio::sync::Semaphore;
+    /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -243,8 +243,8 @@ impl Semaphore {
     ///     let permit_2 = semaphore.try_acquire().unwrap();
     ///     assert_eq!(semaphore.available_permits(), 0);
     ///
-    ///     drop(permit_1);
-    ///     assert_eq!(semaphore.available_permits(), 1);
+    ///     let permit_3 = semaphore.try_acquire();
+    ///     assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
     /// }
     /// ```
     ///
@@ -356,11 +356,11 @@ impl Semaphore {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(15));
+    ///     let semaphore = Arc::new(Semaphore::new(10));
     ///     let mut join_handles = Vec::new();
     ///
     ///     for i in 1..=5 {
-    ///         let permit = semaphore.clone().acquire_many_owned(i).await.unwrap();
+    ///         let permit = semaphore.clone().acquire_many_owned(2).await.unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
     ///             // explicitly own `permit` in the task
@@ -453,11 +453,11 @@ impl Semaphore {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(15));
+    ///     let semaphore = Arc::new(Semaphore::new(10));
     ///     let mut join_handles = Vec::new();
     ///
     ///     for i in 1..=5 {
-    ///         let permit = semaphore.clone().try_acquire_many_owned(i).unwrap();
+    ///         let permit = semaphore.clone().try_acquire_many_owned(2).unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
     ///             // explicitly own `permit` in the task

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -56,7 +56,7 @@ use std::sync::Arc;
 ///     let semaphore = Arc::new(Semaphore::new(3));
 ///     let mut join_handles = Vec::new();
 ///
-///     for _ in 1..=5 {
+///     for _ in 0..5 {
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         join_handles.push(tokio::spawn(async move {
 ///             // perform task...
@@ -207,7 +207,7 @@ impl Semaphore {
     /// async fn main() {
     ///     let semaphore = Semaphore::new(5);
     ///
-    ///     let p1 = semaphore.acquire_many(3).await.unwrap();
+    ///     let permit = semaphore.acquire_many(3).await.unwrap();
     ///     assert_eq!(semaphore.available_permits(), 2);
     /// }
     /// ```
@@ -315,7 +315,7 @@ impl Semaphore {
     ///     let semaphore = Arc::new(Semaphore::new(3));
     ///     let mut join_handles = Vec::new();
     ///
-    ///     for _ in 1..=5 {
+    ///     for _ in 0..5 {
     ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
@@ -359,7 +359,7 @@ impl Semaphore {
     ///     let semaphore = Arc::new(Semaphore::new(10));
     ///     let mut join_handles = Vec::new();
     ///
-    ///     for _ in 1..=5 {
+    ///     for _ in 0..5 {
     ///         let permit = semaphore.clone().acquire_many_owned(2).await.unwrap();
     ///         join_handles.push(tokio::spawn(async move {
     ///             // perform task...
@@ -400,25 +400,20 @@ impl Semaphore {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tokio::sync::Semaphore;
+    /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(5));
-    ///     let mut join_handles = Vec::new();
+    ///     let semaphore = Arc::new(Semaphore::new(2));
     ///
-    ///     for _ in 1..=5 {
-    ///         let permit = semaphore.clone().try_acquire_owned().unwrap();
-    ///         join_handles.push(tokio::spawn(async move {
-    ///             // perform task...
-    ///             // explicitly own `permit` in the task
-    ///             drop(permit);
-    ///         }));
-    ///     }
+    ///     let permit_1 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     for handle in join_handles {
-    ///         handle.await.unwrap();
-    ///     }
+    ///     let permit_2 = Arc::clone(&semaphore).try_acquire_owned().unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 0);
+    ///
+    ///     let permit_3 = semaphore.try_acquire_owned();
+    ///     assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
     /// }
     /// ```
     ///
@@ -448,25 +443,17 @@ impl Semaphore {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tokio::sync::Semaphore;
+    /// use tokio::sync::{Semaphore, TryAcquireError};
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let semaphore = Arc::new(Semaphore::new(10));
-    ///     let mut join_handles = Vec::new();
+    ///     let semaphore = Arc::new(Semaphore::new(4));
     ///
-    ///     for _ in 1..=5 {
-    ///         let permit = semaphore.clone().try_acquire_many_owned(2).unwrap();
-    ///         join_handles.push(tokio::spawn(async move {
-    ///             // perform task...
-    ///             // explicitly own `permit` in the task
-    ///             drop(permit);
-    ///         }));
-    ///     }
+    ///     let permit_1 = Arc::clone(&semaphore).try_acquire_many_owned(3).unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 1);
     ///
-    ///     for handle in join_handles {
-    ///         handle.await.unwrap();
-    ///     }
+    ///     let permit_2 = semaphore.try_acquire_many_owned(2);
+    ///     assert_eq!(permit_2.err(), Some(TryAcquireError::NoPermits));
     /// }
     /// ```
     ///


### PR DESCRIPTION
## Motivation
Closes #3795 

Add examples to `Semaphore` and its methods. All doctests pass. Let me know if you find anything too verbose or confusing.