### PR TITLE
ci: ignore private crates in minimal-versions check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,7 @@ jobs:
           cargo hack --remove-dev-deps --workspace
           # Update Cargo.lock to minimal version dependencies.
           cargo update -Z minimal-versions
-          cargo check --all-features
+          cargo hack check --all-features --ignore-private
 
   fmt:
     name: fmt


### PR DESCRIPTION
~~Fixes CI fail on master: https://github.com/tokio-rs/tokio/runs/2710069192?check_suite_focus=true~~ EDIT: see https://github.com/tokio-rs/tokio/pull/3827#issuecomment-851445668

minimal-versions check is a check that is only worthwhile for public crates.