### PR TITLE
Add drop guard for cancellation token

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -279,6 +279,8 @@ impl CancellationToken {
     }
 
     /// Returns a `DropGuard` for this token.
+    /// This guard will cancel this token (and all its children)
+    /// on drop unless disarmed.
     pub fn drop_guard(self) -> DropGuard {
         DropGuard { inner: Some(self) }
     }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -1,5 +1,6 @@
 //! An asynchronously awaitable `CancellationToken`.
 //! The token allows to signal a cancellation request to one or more tasks.
+pub(crate) mod guard;
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Mutex;
@@ -10,6 +11,8 @@ use core::pin::Pin;
 use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 use core::task::{Context, Poll, Waker};
+
+use guard::DropGuard;
 
 /// A token which can be used to signal a cancellation request to one or more
 /// tasks.
@@ -273,6 +276,11 @@ impl CancellationToken {
             wait_node: ListNode::new(WaitQueueEntry::new()),
             is_registered: false,
         }
+    }
+
+    /// Returns a `DropGuard` for this token.
+    pub fn drop_guard(self) -> DropGuard {
+        DropGuard { inner: Some(self) }
     }
 
     unsafe fn register(

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -278,9 +278,10 @@ impl CancellationToken {
         }
     }
 
-    /// Returns a `DropGuard` for this token.
-    /// This guard will cancel this token (and all its children)
-    /// on drop unless disarmed.
+    /// Creates a `DropGuard` for this token.
+    ///
+    /// Returned guard will cancel this token (and all its children) on drop
+    /// unless disarmed.
     pub fn drop_guard(self) -> DropGuard {
         DropGuard { inner: Some(self) }
     }

--- a/tokio-util/src/sync/cancellation_token/guard.rs
+++ b/tokio-util/src/sync/cancellation_token/guard.rs
@@ -1,0 +1,27 @@
+use crate::sync::CancellationToken;
+
+/// A wrapper for cancellation token which automatically cancels
+/// it on drop. It is created using `drop_guard` method on the `CancellationToken`.
+#[derive(Debug)]
+pub struct DropGuard {
+    pub(super) inner: Option<CancellationToken>,
+}
+
+impl DropGuard {
+    /// Returns stored cancellation token and removes this drop guard instance
+    /// (i.e. it will no longer cancel token). Other guards for this token
+    /// are not affected.
+    pub fn disarm(mut self) -> CancellationToken {
+        self.inner
+            .take()
+            .expect("`inner` can be only None in a destructor")
+    }
+}
+
+impl Drop for DropGuard {
+    fn drop(&mut self) {
+        if let Some(inner) = &self.inner {
+            inner.cancel();
+        }
+    }
+}

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,7 +1,7 @@
 //! Synchronization primitives
 
 mod cancellation_token;
-pub use cancellation_token::{CancellationToken, WaitForCancellationFuture};
+pub use cancellation_token::{guard::DropGuard, CancellationToken, WaitForCancellationFuture};
 
 mod intrusive_double_linked_list;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Usually, cancellation is implemented as dropping a future. However, this does not work when a future internally spawns background tasks.

## Solution

A new method `drop_guard` is added. It returns a special guard which cancels the token unless disarmed.
Intended usage:
```rust
async fn my_simple_fut() {
    let token = CancellationToken::new();
    let _g = token.clone().drop_guard();
    tokio::task::spawn(async move {
         some_lib::do_work(..., token);
    });
    // some other work here.
}
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
