### PR TITLE
feat: Export `sync::notify::Notified` publicly.

### DIFF
--- a/tokio/src/sync/futures.rs
+++ b/tokio/src/sync/futures.rs
@@ -1,3 +1,0 @@
-//! Sync future types.
-
-pub use super::notify::Notified;

--- a/tokio/src/sync/futures.rs
+++ b/tokio/src/sync/futures.rs
@@ -1,0 +1,3 @@
+//! Sync future types.
+
+pub use super::notify::Notified;

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -428,7 +428,10 @@
 //!   bounding of any kind.
 
 cfg_sync! {
-    pub mod futures;
+    /// Named future types.
+    pub mod futures {
+        pub use super::notify::Notified;
+    }
 
     mod barrier;
     pub use barrier::{Barrier, BarrierWaitResult};

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -428,6 +428,8 @@
 //!   bounding of any kind.
 
 cfg_sync! {
+    pub mod futures;
+
     mod barrier;
     pub use barrier::{Barrier, BarrierWaitResult};
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -140,7 +140,7 @@ struct Waiter {
     _p: PhantomPinned,
 }
 
-/// Future returned from `notified()`
+/// Future returned from [`Notify::notified()`]
 #[derive(Debug)]
 pub struct Notified<'a> {
     /// The `Notify` being received on.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This is my attempt to get #3372 in, so addressed the comment there and opened this PR.
Quoting that PR:
> I would like to avoid boxing the Notified future when storing it a struct in fede1024/rust-rdkafka#320 .

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `sync::futures` module which exposes `sync::notify::Notified`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
