### PR TITLE
Allow consumers to implement POSIX AIO sources.

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -28,6 +28,7 @@ default = []
 
 # enable everything
 full = [
+  "aio",
   "fs",
   "io-util",
   "io-std",
@@ -40,6 +41,10 @@ full = [
   "signal",
   "sync",
   "time",
+]
+
+aio = [
+  "mio/os-poll"
 ]
 
 fs = []
@@ -123,6 +128,10 @@ proptest = "1"
 rand = "0.8.0"
 tempfile = "3.1.0"
 async-stream = "0.3"
+
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
+futures-test = "0.3.7"
+mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "f0a68b53003436db30cd96480a9fcd9c410affb7"  }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -14,6 +14,16 @@ use std::ops;
 pub struct Interest(mio::Interest);
 
 impl Interest {
+    cfg_aio! {
+        /// Interest for POSIX AIO
+        pub const AIO: Interest = Interest(mio::Interest::AIO);
+    }
+
+    cfg_aio! {
+        /// Interest for POSIX AIO lio_listio events
+        pub const LIO: Interest = Interest(mio::Interest::LIO);
+    }
+
     /// Interest in all readable events.
     ///
     /// Readable interest includes read-closed events.

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -51,6 +51,7 @@ pub(crate) struct Handle {
     inner: Weak<Inner>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ReadyEvent {
     tick: u8,
     pub(crate) ready: Ready,

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -38,6 +38,17 @@ impl Ready {
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {
         let mut ready = Ready::EMPTY;
 
+        #[cfg(all(target_os = "freebsd", feature = "aio"))]
+        {
+            if event.is_aio() {
+                ready |= Ready::READABLE;
+            }
+
+            if event.is_lio() {
+                ready |= Ready::READABLE;
+            }
+        }
+
         if event.is_readable() {
             ready |= Ready::READABLE;
         }

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -211,6 +211,11 @@ cfg_io_driver_impl! {
         pub use driver::{Interest, Ready};
     }
 
+    cfg_aio! {
+        mod poll_aio;
+        pub use poll_aio::{PollAio, PollAioEvent};
+    }
+
     mod poll_evented;
 
     #[cfg(not(loom))]

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -1,0 +1,123 @@
+use crate::io::driver::{Handle, Interest, ReadyEvent, Registration};
+use mio::event::Source;
+use std::fmt;
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::task::{Context, Poll};
+
+/// Associates a POSIX AIO control block with the reactor that drives it.
+///
+/// `PollAio`'s wrapped type must implement [`mio::event::Source`] to be driven
+/// by the reactor.
+///
+/// The wrapped source may be accessed through the `PollAio` via the `Deref` and
+/// `DerefMut` traits.
+///
+/// ## Clearing readiness
+///
+/// If [`PollAio::poll`] returns ready, but the consumer determines that the
+/// Source is not completely ready and must return to the Pending state,
+/// [`PollAio::clear_ready`] may be used.  This can be useful with
+/// [`lio_listio`], which may generate a kevent when only a portion of the
+/// operations have completed.
+///
+/// ## Platforms
+///
+/// Only FreeBSD implements POSIX AIO with kqueue notification, so
+/// `PollAio` is only available for that operating system.
+///
+/// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
+// Note: Unlike every other kqueue event source, POSIX AIO registers events not
+// via kevent(2) but when the aiocb is submitted to the kernel via aio_read,
+// aio_write, etc.  It needs the kqueue's file descriptor to do that.  So
+// AsyncFd can't be used for POSIX AIO.
+//
+// Note that PollAio doesn't implement Drop.  There's no need.  Unlike other
+// kqueue sources, there is nothing to deregister.
+#[cfg_attr(docsrs, doc(cfg(all(target_os = "freebsd", feature = "aio"))))]
+pub struct PollAio<E: Source> {
+    io: E,
+    registration: Registration,
+}
+
+// ===== impl PollAio =====
+
+impl<E: Source> PollAio<E> {
+    /// Indicates to Tokio that the source is no longer ready.  The internal
+    /// readiness flag will be cleared, and tokio will wait for the next
+    /// edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the source is _not_ ready.  The OS must
+    /// deliver a subsequent notification, or this source will block
+    /// forever.
+    pub fn clear_ready(&self, ev: PollAioEvent) {
+        self.registration.clear_readiness(ev.0)
+    }
+
+    /// Destroy the [`PollAio`] and return its inner Source
+    pub fn into_inner(self) -> E {
+        self.io
+    }
+
+    /// Creates a new `PollAio` suitable for use with POSIX AIO functions.
+    ///
+    /// It will be associated with the default reactor.  The runtime is usually
+    /// set implicitly when this function is called from a future driven by a
+    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
+    pub fn new_for_aio(io: E) -> io::Result<Self> {
+        Self::new_with_interest(io, Interest::AIO)
+    }
+
+    /// Creates a new `PollAio` suitable for use with [`lio_listio`].
+    ///
+    /// It will be associated with the default reactor.  The runtime is usually
+    /// set implicitly when this function is called from a future driven by a
+    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
+    ///
+    /// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
+    pub fn new_for_lio(io: E) -> io::Result<Self> {
+        Self::new_with_interest(io, Interest::LIO)
+    }
+
+    fn new_with_interest(mut io: E, interest: Interest) -> io::Result<Self> {
+        let handle = Handle::current();
+        let registration = Registration::new_with_interest_and_handle(&mut io, interest, handle)?;
+        Ok(Self { io, registration })
+    }
+
+    /// Polls for readiness.  Either AIO or LIO counts.
+    pub fn poll<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<PollAioEvent>> {
+        let ev = ready!(self.registration.poll_read_ready(cx))?;
+        Poll::Ready(Ok(PollAioEvent(ev)))
+    }
+}
+
+impl<E: Source> Deref for PollAio<E> {
+    type Target = E;
+
+    fn deref(&self) -> &E {
+        &self.io
+    }
+}
+
+impl<E: Source> DerefMut for PollAio<E> {
+    fn deref_mut(&mut self) -> &mut E {
+        &mut self.io
+    }
+}
+
+impl<E: Source + fmt::Debug> fmt::Debug for PollAio<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollAio").field("io", &self.io).finish()
+    }
+}
+
+/// Opaque data returned by [`PollAio::poll`].
+///
+/// It can be fed back to [`PollAio::clear_ready`].
+#[cfg_attr(docsrs, doc(cfg(all(target_os = "freebsd", feature = "aio"))))]
+#[derive(Debug)]
+pub struct PollAioEvent(ReadyEvent);

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -45,6 +45,18 @@ macro_rules! cfg_atomic_waker_impl {
     }
 }
 
+macro_rules! cfg_aio {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(target_os = "freebsd", feature = "aio"))]
+            #[cfg_attr(docsrs,
+                doc(cfg(all(target_os = "freebsd", feature = "aio")))
+            )]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_fs {
     ($($item:item)*) => {
         $(
@@ -65,6 +77,7 @@ macro_rules! cfg_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -83,6 +96,7 @@ macro_rules! cfg_io_driver_impl {
     ( $( $item:item )* ) => {
         $(
             #[cfg(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -96,6 +110,7 @@ macro_rules! cfg_not_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(not(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -1,0 +1,56 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(target_os = "freebsd", feature = "aio"))]
+
+use futures_test::task::noop_context;
+use mio_aio::{AioCb, AioFsyncMode};
+use std::{
+    os::unix::io::AsRawFd,
+    task::Poll,
+    time::{Duration, Instant},
+};
+use tempfile::tempdir;
+use tokio::io::PollAio;
+use tokio_test::{assert_pending, assert_ready_ok};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_io()
+        .build()
+        .unwrap()
+}
+
+/// aio_fsync is the simplest AIO operation.  This test ensures that Tokio can
+/// register an aiocb, and set its readiness.
+#[test]
+fn fsync() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("testfile");
+    let f = std::fs::File::create(&path).unwrap();
+    let fd = f.as_raw_fd();
+    let aiocb = AioCb::from_fd(fd, 0);
+    let rt = rt();
+    let mut poll_aio = {
+        let _enter = rt.enter();
+        PollAio::new_for_aio(aiocb).unwrap()
+    };
+    let mut ctx = noop_context();
+    // Should be not ready after initialization
+    assert_pending!(poll_aio.poll(&mut ctx));
+
+    // Send the operation to the kernel
+    (*poll_aio).fsync(AioFsyncMode::O_SYNC).unwrap();
+
+    // Wait for completeness
+    let start = Instant::now();
+    while Instant::now() - start < Duration::new(5, 0) {
+        if let Poll::Ready(_ev) = poll_aio.poll(&mut ctx) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_ready_ok!(poll_aio.poll(&mut ctx));
+
+    // Free its in-kernel state, so Nix doesn't panic.
+    let mut aiocb = poll_aio.into_inner();
+    aiocb.aio_return().unwrap();
+}


### PR DESCRIPTION
Unlike every other kqueue event source, POSIX AIO registers events not
via kevent(2) but by a different mechanism that needs the kqueue's file
descriptor.  This commit adds a new `PollAio` type, designed to be used
by an external crate that implements a POSIX AIO Future for use with
Tokio's reactor.

Fixes: #3197

## Motivation

With Tokio 0.1 and 0.2, `PollEvented` was sufficiently powerful to allow external crates to implement a POSIX AIO event source.  Beginning with Tokio 0.3, `PollEvented` became private, and it also lost some needed functionality.  Thus, there was no possible way for a consumer to use POSIX AIO with Tokio.

## Solution

This PR restores that ability.  While leaving the actual implementation for an external crate, it adds just enough functionality for the external crate to hook in.  It deliberately does not expose all of `PollEvented`, so as not to encourage consumers to use that type over `AsyncFd`.  Instead, it creates a new, dedicated type.
