### PR TITLE
Reenable test_socket_pair on FreeBSD

### DIFF
--- a/tokio/tests/uds_cred.rs
+++ b/tokio/tests/uds_cred.rs
@@ -9,10 +9,6 @@ use libc::geteuid;
 
 #[tokio::test]
 #[cfg_attr(
-    target_os = "freebsd",
-    ignore = "Requires FreeBSD 12.0 or later. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=176419"
-)]
-#[cfg_attr(
     target_os = "netbsd",
     ignore = "NetBSD does not support getpeereid() for sockets created by socketpair()"
 )]


### PR DESCRIPTION
It was disabled due to an OS bug that has been fixed on all currently
supported releases of FreeBSD

## Motivation

To increase test coverage

## Solution

To reenable a test that no longer needs to be disabled