### PR TITLE
doc: Clarify EOF condition for AsyncReadExt::read_buf

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -182,11 +182,9 @@ cfg_io_util! {
         ///
         /// # Return
         ///
-        /// If the return value of this method is `Ok(n)`, then it must be
-        /// guaranteed that `0 <= n <= buf.len()`. A nonzero `n` value indicates
-        /// that the buffer `buf` has been filled in with `n` bytes of data from
-        /// this source. If `n` is `0`, then it can indicate one of two
-        /// scenarios:
+        /// A nonzero `n` value indicates that the buffer `buf` has been filled
+        /// in with `n` bytes of data from this source. If `n` is `0`, then it
+        /// can indicate one of two scenarios:
         ///
         /// 1. This reader has reached its "end of file" and will likely no longer
         ///    be able to produce bytes. Note that this does not mean that the

--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -108,6 +108,8 @@ cfg_io_util! {
         /// This function does not provide any guarantees about whether it
         /// completes immediately or asynchronously
         ///
+        /// # Return
+        ///
         /// If the return value of this method is `Ok(n)`, then it must be
         /// guaranteed that `0 <= n <= buf.len()`. A nonzero `n` value indicates
         /// that the buffer `buf` has been filled in with `n` bytes of data from
@@ -180,10 +182,16 @@ cfg_io_util! {
         ///
         /// # Return
         ///
-        /// On a successful read, the number of read bytes is returned. If the
-        /// remaining capacity of the supplied buffer is greater than 0 and
-        /// the function returns `Ok(0)` then the source has reached an
-        /// "end-of-file" event.
+        /// If the return value of this method is `Ok(n)`, then it must be
+        /// guaranteed that `0 <= n <= buf.len()`. A nonzero `n` value indicates
+        /// that the buffer `buf` has been filled in with `n` bytes of data from
+        /// this source. If `n` is `0`, then it can indicate one of two
+        /// scenarios:
+        ///
+        /// 1. This reader has reached its "end of file" and will likely no longer
+        ///    be able to produce bytes. Note that this does not mean that the
+        ///    reader will *always* no longer be able to produce bytes.
+        /// 2. The buffer specified had a remaining capacity of zero.
         ///
         /// # Errors
         ///

--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -181,8 +181,9 @@ cfg_io_util! {
         /// # Return
         ///
         /// On a successful read, the number of read bytes is returned. If the
-        /// supplied buffer is not empty and the function returns `Ok(0)` then
-        /// the source has reached an "end-of-file" event.
+        /// remaining capacity of the supplied buffer is greater than 0 and
+        /// the function returns `Ok(0)` then the source has reached an
+        /// "end-of-file" event.
         ///
         /// # Errors
         ///


### PR DESCRIPTION
## Motivation
The current documentation for `read_buf` says:
> If the supplied buffer is not empty and the function returns `Ok(0)` then the source has reached an “end-of-file” event.

This confused me since I took "empty" to mean that the buffer had no readable data in it (like a vec with len() == 0).
I think part of the confusion is due to buffers like `bytes::BytesMut` using "empty" to refer to buffers that have
no readable data (i.e. a newly created buffer that hasn't been written to yet).

After reading the source code and chatting with @Darksonn it's clear that `Ok(0)` is returned when there's no more
room in the buffer to write additional bytes. This is "empty" in the sense that an empty in the sense that an empty struct is,
but not in the sense that an empty vec is (which IMO is a closer mental model to a buffer).

## Solution
I propose we change the above sentence to read:
> If the remaining capacity of the supplied buffer is greater than 0 and the function returns `Ok(0)` then the source has reached an "end-of-file" event.

The use of "remaining capacity" here is consistent with the phrasing `bytes::BytesMut` uses.