### PR TITLE
chore: update version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.5.0", features = ["full"] }
+tokio = { version = "1.6.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.6.0", features = ["full"] }
+tokio = { version = "1.6.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
## Motivation

The first sample in the README mentions adding tokio to Cargo, but it uses version `1.5.0` while `1.6.0` is the current minor.

## Solution

This PR changes `1.5.0` to `1.6.0` to encourage new users to grab the latest stable.
