### PR TITLE
time: fix time::advance() with sub-ms durations

### DIFF
--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -7,7 +7,7 @@
 //! configurable.
 
 cfg_not_test_util! {
-    use crate::time::{Duration, Instant};
+    use crate::time::{Instant};
 
     #[derive(Debug, Clone)]
     pub(crate) struct Clock {}
@@ -23,14 +23,6 @@ cfg_not_test_util! {
 
         pub(crate) fn now(&self) -> Instant {
             now()
-        }
-
-        pub(crate) fn is_paused(&self) -> bool {
-            false
-        }
-
-        pub(crate) fn advance(&self, _dur: Duration) {
-            unreachable!();
         }
     }
 }

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -121,20 +121,9 @@ cfg_test_util! {
     /// runtime.
     pub async fn advance(duration: Duration) {
         let clock = clock().expect("time cannot be frozen from outside the Tokio runtime");
-        let until = clock.now() + duration;
         clock.advance(duration);
 
-        // Fixes tokio-rs/tokio#3837
-        //
-        // "sleep_until" is needed to ensure registered timers are fired after the
-        // advance call, however, it will also round up time to the nearest ms. To
-        // avoid this loss of precision, we sleep until the previous millisecond.
-        // If the advance is less than 1ms, then we just need to yield.
-        if duration >= Duration::from_millis(1) {
-            crate::time::sleep_until(until - Duration::from_millis(1)).await;
-        } else {
-            crate::task::yield_now().await;
-        }
+        crate::task::yield_now().await;
     }
 
     /// Return the current instant, factoring in frozen time.

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -124,7 +124,17 @@ cfg_test_util! {
         let until = clock.now() + duration;
         clock.advance(duration);
 
-        crate::time::sleep_until(until).await;
+        // Fixes tokio-rs/tokio#3837
+        //
+        // "sleep_until" is needed to ensure registered timers are fired after the
+        // advance call, however, it will also round up time to the nearest ms. To
+        // avoid this loss of precision, we sleep until the previous millisecond.
+        // If the advance is less than 1ms, then we just need to yield.
+        if duration >= Duration::from_millis(1) {
+            crate::time::sleep_until(until - Duration::from_millis(1)).await;
+        } else {
+            crate::task::yield_now().await;
+        }
     }
 
     /// Return the current instant, factoring in frozen time.

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -476,10 +476,10 @@ impl<P: Park + 'static> TimerUnpark<P> {
 
 impl<P: Park + 'static> Unpark for TimerUnpark<P> {
     fn unpark(&self) {
-        self.inner.unpark();
-
         #[cfg(feature = "test-util")]
         self.did_wake.store(true, Ordering::SeqCst);
+
+        self.inner.unpark();
     }
 }
 

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -274,7 +274,7 @@ where
     }
 
     cfg_not_test_util! {
-        fn park_timeout(&mut self, limit: Duration) -> Result<(), P::Error> {
+        fn park_timeout(&mut self, duration: Duration) -> Result<(), P::Error> {
             self.park.park_timeout(duration)
         }
     }

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -215,6 +215,40 @@ async fn interval() {
     assert_pending!(poll_next(&mut i));
 }
 
+#[tokio::test]
+async fn test_time_advance_sub_ms() {
+    time::pause();
+    let now = Instant::now();
+
+    let dur = Duration::from_micros(51_592);
+    time::advance(dur).await;
+
+    assert_eq!(now.elapsed(), dur);
+
+    let now = Instant::now();
+    let dur = Duration::from_micros(1);
+    time::advance(dur).await;
+
+    assert_eq!(now.elapsed(), dur);
+}
+
+#[tokio::test]
+async fn test_time_advance_3ms_and_change() {
+    time::pause();
+    let now = Instant::now();
+
+    let dur = Duration::from_micros(3_141_592);
+    time::advance(dur).await;
+
+    assert_eq!(now.elapsed(), dur);
+
+    let now = Instant::now();
+    let dur = Duration::from_micros(3_123_456);
+    time::advance(dur).await;
+
+    assert_eq!(now.elapsed(), dur);
+}
+
 fn poll_next(interval: &mut task::Spawn<time::Interval>) -> Poll<Instant> {
     interval.enter(|cx, mut interval| interval.poll_tick(cx))
 }


### PR DESCRIPTION
Update the advance logic to factor in the timer's ms rounding.

Fixes #3837