### PR TITLE
tracing: emit waker op as str instead as Debug

### DIFF
--- a/tokio/src/runtime/task/waker.rs
+++ b/tokio/src/runtime/task/waker.rs
@@ -50,7 +50,7 @@ cfg_trace! {
             if let Some(id) = $harness.id() {
                 tracing::trace!(
                     target: "tokio::task::waker",
-                    op = %$op,
+                    op = $op,
                     task.id = id.into_u64(),
                 );
             }


### PR DESCRIPTION
It was an mistake to emit the `op` as a `dyn Debug`, it should be emitted as a string directly.