### PR TITLE
Fix typo in Instant::saturating_duration_since docs

### DIFF
--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -98,7 +98,7 @@ impl Instant {
     }
 
     /// Returns the amount of time elapsed from another instant to this one, or
-    /// zero duration if that instant is earlier than this one.
+    /// zero duration if that instant is later than this one.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation

The `tokio::time::Instant::saturating_duration_since` docs contain a confusing typo: they say `zero duration if that instant is earlier than this one` instead of `later`.

The corresponding `std::time::Instant` docs say `later`: https://doc.rust-lang.org/std/time/struct.Instant.html#method.saturating_duration_since

In both cases, the doctests confirm that `later` is the correct behaviour.

## Solution

- Fix the typo