### PR TITLE
a sketch for how task naming might work for tracing

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -145,7 +145,7 @@ impl Handle {
         F::Output: Send + 'static,
     {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let future = crate::util::trace::task(future, "task");
+        let future = crate::util::trace::task(future, "task", None);
         self.spawner.spawn(future)
     }
 

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -297,7 +297,7 @@ cfg_rt! {
         F: Future + 'static,
         F::Output: 'static,
     {
-        let future = crate::util::trace::task(future, "local");
+        let future = crate::util::trace::task(future, "local", None);
         CURRENT.with(|maybe_cx| {
             let cx = maybe_cx
                 .expect("`spawn_local` called from outside of a `task::LocalSet`");
@@ -381,7 +381,7 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
-        let future = crate::util::trace::task(future, "local");
+        let future = crate::util::trace::task(future, "local", None);
         let (task, handle) = unsafe { task::joinable_local(future) };
         self.context.tasks.borrow_mut().queue.push_back(task);
         self.context.shared.waker.wake();

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -299,4 +299,8 @@ cfg_rt! {
 
     mod unconstrained;
     pub use unconstrained::{unconstrained, Unconstrained};
+
+    cfg_trace! {
+        pub use spawn::spawn_named;
+    }
 }

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -137,14 +137,14 @@ cfg_rt! {
 
     cfg_trace! {
         #[cfg_attr(tokio_track_caller, track_caller)]
-        pub fn spawn_named<T>(name: impl Into<std::borrow::Cow<'static, str>>, task: T) -> JoinHandle<T::Output>
+        pub fn spawn_named<T>(name: &str, task: T) -> JoinHandle<T::Output>
         where
             T: Future + Send + 'static,
             T::Output: Send + 'static,
         {
             let spawn_handle = runtime::context::spawn_handle()
                 .expect(CONTEXT_MISSING_ERROR);
-            let task = crate::util::trace::task(task, "task", Some(name.into()));
+            let task = crate::util::trace::task(task, "task", Some(name));
             spawn_handle.spawn(task)
         }
     }

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -131,7 +131,21 @@ cfg_rt! {
     {
         let spawn_handle = runtime::context::spawn_handle()
         .expect(CONTEXT_MISSING_ERROR);
-        let task = crate::util::trace::task(task, "task");
+        let task = crate::util::trace::task(task, "task", None);
         spawn_handle.spawn(task)
+    }
+
+    cfg_trace! {
+        #[cfg_attr(tokio_track_caller, track_caller)]
+        pub fn spawn_named<T>(name: impl Into<std::borrow::Cow<'static, str>>, task: T) -> JoinHandle<T::Output>
+        where
+            T: Future + Send + 'static,
+            T::Output: Send + 'static,
+        {
+            let spawn_handle = runtime::context::spawn_handle()
+                .expect(CONTEXT_MISSING_ERROR);
+            let task = crate::util::trace::task(task, "task", Some(name.into()));
+            spawn_handle.spawn(task)
+        }
     }
 }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -4,7 +4,7 @@ cfg_trace! {
 
         #[inline]
         #[cfg_attr(tokio_track_caller, track_caller)]
-        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<std::borrow::Cow<'static, str>>) -> Instrumented<F> {
+        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>) -> Instrumented<F> {
             use tracing::instrument::Instrument;
             #[cfg(tokio_track_caller)]
             let location = std::panic::Location::caller();
@@ -31,7 +31,7 @@ cfg_trace! {
 cfg_not_trace! {
     cfg_rt! {
         #[inline]
-        pub(crate) fn task<F>(task: F, _: &'static str, _name: Option<std::borrow::Cow<'static, str>>) -> F {
+        pub(crate) fn task<F>(task: F, _: &'static str, _name: Option<&str>) -> F {
             // nop
             task
         }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -4,7 +4,7 @@ cfg_trace! {
 
         #[inline]
         #[cfg_attr(tokio_track_caller, track_caller)]
-        pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
+        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<std::borrow::Cow<'static, str>>) -> Instrumented<F> {
             use tracing::instrument::Instrument;
             #[cfg(tokio_track_caller)]
             let location = std::panic::Location::caller();
@@ -14,12 +14,14 @@ cfg_trace! {
                 "task",
                 %kind,
                 spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
+                task.name = %name.unwrap_or_default()
             );
             #[cfg(not(tokio_track_caller))]
             let span = tracing::trace_span!(
                 target: "tokio::task",
                 "task",
                 %kind,
+                task.name = %name.unwrap_or_default()
             );
             task.instrument(span)
         }
@@ -29,7 +31,7 @@ cfg_trace! {
 cfg_not_trace! {
     cfg_rt! {
         #[inline]
-        pub(crate) fn task<F>(task: F, _: &'static str) -> F {
+        pub(crate) fn task<F>(task: F, _: &'static str, _name: Option<std::borrow::Cow<'static, str>>) -> F {
             // nop
             task
         }


### PR DESCRIPTION
## Motivation

Currently, there is no way to attach a name to a task span for [tokio-rs/console](https://github.com/tokio-rs/console), but it would be great if that could be a predictably-present field that describes the task to a human reader. This is a quick sketch of one way this might look.

## Solution

This PR adds a cfg_trace-gated unstable function tokio::task::spawn_named, which allows users to annotate a task at runtime with an appropriate name. Completing this PR would likely involve adding similar …_named spawn interfaces for spawn_blocking and spawn_local.

## Example Usage

Modified from the `console-subscriber` example app:

```rust
use std::time::Duration;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
    console_subscriber::init();

    let task1 = tokio::task::spawn_named("first", spawn_tasks(1, 10));
    let task2 = tokio::task::spawn_named("second", spawn_tasks(10, 100));
    let result = tokio::try_join! {
        task1,
        task2,
    };
    result?;

    Ok(())
}

#[tracing::instrument]
async fn spawn_tasks(min: u64, max: u64) {
    loop {
        for i in min..max {
            tokio::task::spawn_named(&format!("spawned {}", i), wait(i));
            tokio::time::sleep(Duration::from_secs(max) - Duration::from_secs(i)).await;
        }
    }
}

#[tracing::instrument]
async fn wait(seconds: u64) {
    tokio::time::sleep(Duration::from_secs(seconds)).await;
}
```
![image](https://user-images.githubusercontent.com/13301/122623803-65dfe600-d052-11eb-9cd6-04336c3410e0.png)
