### PR TITLE
sync: Implement `From<T>` for `OnceCell<T>`

### DIFF
--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -77,6 +77,18 @@ impl<T> Drop for OnceCell<T> {
     }
 }
 
+impl<T> From<T> for OnceCell<T> {
+    fn from(value: T) -> Self {
+        let semaphore = Semaphore::new(0);
+        semaphore.close();
+        OnceCell {
+            value_set: AtomicBool::new(true),
+            value: UnsafeCell::new(MaybeUninit::new(value)),
+            semaphore,
+        }
+    }
+}
+
 impl<T> OnceCell<T> {
     /// Creates a new uninitialized OnceCell instance.
     pub fn new() -> Self {
@@ -93,13 +105,7 @@ impl<T> OnceCell<T> {
     /// [`OnceCell::new`]: crate::sync::OnceCell::new
     pub fn new_with(value: Option<T>) -> Self {
         if let Some(v) = value {
-            let semaphore = Semaphore::new(0);
-            semaphore.close();
-            OnceCell {
-                value_set: AtomicBool::new(true),
-                value: UnsafeCell::new(MaybeUninit::new(v)),
-                semaphore,
-            }
+            OnceCell::from(v)
         } else {
             OnceCell::new()
         }

--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -266,3 +266,9 @@ fn drop_into_inner_new_with() {
     let count = NUM_DROPS.load(Ordering::Acquire);
     assert!(count == 1);
 }
+
+#[test]
+fn from() {
+    let cell = OnceCell::from(2);
+    assert_eq!(*cell.get().unwrap(), 2);
+}


### PR DESCRIPTION
# Motivation
[`std::lazy::OnceCell`](https://doc.rust-lang.org/std/lazy/struct.OnceCell.html) [implements `From<T>` for `OnceCell<T>`](https://doc.rust-lang.org/std/lazy/struct.OnceCell.html#impl-From%3CT%3E), but [`tokio::sync::OnceCell`](https://docs.rs/tokio/1.7.1/tokio/sync/struct.OnceCell.html) does not. Generally, tokio tries to match std's API as closely as possible, so this could be considered an API hole.

# Solution
This PR adds that implementation. While this is a niche case, it also allows `tokio::OnceCell` to be constructed from a `T`. As it is right now, one can construct an uninitialized `OnceCell` with `new` and `const_new`, or one that may or may not be initialized using `new_with`, but it is not possible to construct one directly from a `T` (although this could be done with `new_with(Some(T))`).