### PR TITLE
tracing: add tokio::task::Builder

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -145,7 +145,7 @@ impl Handle {
         F::Output: Send + 'static,
     {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let future = crate::util::trace::task(future, "task");
+        let future = crate::util::trace::task(future, "task", None);
         self.spawner.spawn(future)
     }
 

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -178,7 +178,6 @@ impl Handle {
     }
 
     #[cfg_attr(tokio_track_caller, track_caller)]
-
     pub(crate) fn spawn_blocking_inner<F, R>(&self, func: F, name: Option<&str>) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
@@ -210,6 +209,10 @@ impl Handle {
             );
             fut.instrument(span)
         };
+
+        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        drop(name);
+
         let (task, handle) = task::joinable(fut);
         let _ = self.blocking_spawner.spawn(task, &self);
         handle

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -211,7 +211,7 @@ impl Handle {
         };
 
         #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        drop(name);
+        let _ = name;
 
         let (task, handle) = task::joinable(fut);
         let _ = self.blocking_spawner.spawn(task, &self);

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -51,15 +51,15 @@ pub struct Builder<'a> {
     name: Option<&'a str>,
 }
 
-impl Builder<'_> {
+impl<'a> Builder<'a> {
     /// Creates a new task builder.
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Assigns a name to the task which will be spawned.
-    pub fn name<'b>(&self, name: &'b str) -> Builder<'b> {
-        Builder { name: Some(name) }
+    pub fn name(&self, name: &'a str) -> Self {
+        Self { name: Some(name) }
     }
 
     /// Spawns a task on the executor.

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -35,10 +35,10 @@ use std::future::Future;
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
 ///     loop {
-///         let (socket, socket) = listener.accept().await?;
+///         let (socket, _) = listener.accept().await?;
 ///
 ///         tokio::task::Builder::new()
-///             .name(&format!("connection from {:?}", socket.ip()))
+///             .name("tcp connection handler")
 ///             .spawn(async move {
 ///                 // Process each socket concurrently.
 ///                 process(socket).await

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -1,0 +1,95 @@
+#![allow(unreachable_pub)]
+use crate::task::JoinHandle;
+use std::future::Future;
+
+/// Factory which is used to configure the properties of a new task.
+///
+/// Methods can be chained in order to configure it.
+///
+/// Currently, there is only one configuration option:
+///
+/// - [`name`], which specifies an associated name for
+///   the task
+///
+/// There are three types of task that can be spawned from a Builder:
+/// - [`spawn_local`] for executing futures on the current thread
+/// - [`spawn`] for executing [`Send`] futures on the runtime
+/// - [`spawn_blocking`] for executing blocking code in the
+///   blocking thread pool.
+#[derive(Default, Debug)]
+pub struct Builder<'a> {
+    name: Option<&'a str>,
+}
+
+impl Builder<'_> {
+    /// Creates a new task builder
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Assigns a name to the task which will be spawned
+    pub fn name<'b>(&self, name: &'b str) -> Builder<'b> {
+        Builder { name: Some(name) }
+    }
+
+    /// Spawns a task on the executor.
+    ///
+    /// See
+    /// [`task::spawn`][crate::task::spawn] for more details
+    #[cfg_attr(tokio_track_caller, track_caller)]
+    pub fn spawn<T>(self, future: T) -> JoinHandle<T::Output>
+    where
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        super::spawn::spawn_inner(future, self.name)
+    }
+
+    /// Spawns a task on the current thread.
+    ///
+    /// See [`task::spawn_local`][crate::task::spawn_local]
+    /// for more details
+    #[cfg_attr(tokio_track_caller, track_caller)]
+    pub fn spawn_local<F>(self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+    {
+        super::local::spawn_local_inner(future, self.name)
+    }
+
+    /// Spawns blocking code on the blocking threadpool.
+    ///
+    /// See [`task::spawn_blocking`][crate::task::spawn_blocking]
+    /// for more details
+    #[cfg_attr(tokio_track_caller, track_caller)]
+    pub fn spawn_blocking<Function, Output>(self, function: Function) -> JoinHandle<Output>
+    where
+        Function: FnOnce() -> Output + Send + 'static,
+        Output: Send + 'static,
+    {
+        #[cfg(tokio_track_caller)]
+        let location = std::panic::Location::caller();
+        #[cfg(tokio_track_caller)]
+        let span = tracing::trace_span!(
+            target: "tokio::task",
+            "task",
+            kind = "blocking",
+            spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
+            task.name = %self.name.unwrap_or_default()
+        );
+
+        #[cfg(not(tokio_track_caller))]
+        let span = tracing::trace_span!(
+            target: "tokio::task",
+            "task",
+            kind = "blocking",
+            task.name = %self.name.unwrap_or_default()
+        );
+
+        crate::runtime::spawn_blocking(move || {
+            let _span = span.entered();
+            function()
+        })
+    }
+}

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -299,4 +299,9 @@ cfg_rt! {
 
     mod unconstrained;
     pub use unconstrained::{unconstrained, Unconstrained};
+
+    cfg_trace! {
+        mod builder;
+        pub use builder::Builder;
+    }
 }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -4,7 +4,7 @@ cfg_trace! {
 
         #[inline]
         #[cfg_attr(tokio_track_caller, track_caller)]
-        pub(crate) fn task<F>(task: F, kind: &'static str) -> Instrumented<F> {
+        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>) -> Instrumented<F> {
             use tracing::instrument::Instrument;
             #[cfg(tokio_track_caller)]
             let location = std::panic::Location::caller();
@@ -14,12 +14,14 @@ cfg_trace! {
                 "task",
                 %kind,
                 spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
+                task.name = %name.unwrap_or_default()
             );
             #[cfg(not(tokio_track_caller))]
             let span = tracing::trace_span!(
                 target: "tokio::task",
                 "task",
                 %kind,
+                task.name = %name.unwrap_or_default()
             );
             task.instrument(span)
         }
@@ -29,7 +31,7 @@ cfg_trace! {
 cfg_not_trace! {
     cfg_rt! {
         #[inline]
-        pub(crate) fn task<F>(task: F, _: &'static str) -> F {
+        pub(crate) fn task<F>(task: F, _: &'static str, _name: Option<&str>) -> F {
             // nop
             task
         }

--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,0 +1,67 @@
+#[cfg(all(tokio_unstable, feature = "tracing"))]
+mod tests {
+    use std::rc::Rc;
+    use tokio::{
+        task::{Builder, LocalSet},
+        test,
+    };
+
+    #[test]
+    async fn spawn_with_name() {
+        let result = Builder::new()
+            .name("name")
+            .spawn(async { "task executed" })
+            .await;
+
+        assert_eq!(result.unwrap(), "task executed");
+    }
+
+    #[test]
+    async fn spawn_blocking_with_name() {
+        let result = Builder::new()
+            .name("name")
+            .spawn_blocking(|| "task executed")
+            .await;
+
+        assert_eq!(result.unwrap(), "task executed");
+    }
+
+    #[test]
+    async fn spawn_local_with_name() {
+        let unsend_data = Rc::new("task executed");
+        let result = LocalSet::new()
+            .run_until(async move {
+                Builder::new()
+                    .name("name")
+                    .spawn_local(async move { unsend_data })
+                    .await
+            })
+            .await;
+
+        assert_eq!(*result.unwrap(), "task executed");
+    }
+
+    #[test]
+    async fn spawn_without_name() {
+        let result = Builder::new().spawn(async { "task executed" }).await;
+
+        assert_eq!(result.unwrap(), "task executed");
+    }
+
+    #[test]
+    async fn spawn_blocking_without_name() {
+        let result = Builder::new().spawn_blocking(|| "task executed").await;
+
+        assert_eq!(result.unwrap(), "task executed");
+    }
+
+    #[test]
+    async fn spawn_local_without_name() {
+        let unsend_data = Rc::new("task executed");
+        let result = LocalSet::new()
+            .run_until(async move { Builder::new().spawn_local(async move { unsend_data }).await })
+            .await;
+
+        assert_eq!(*result.unwrap(), "task executed");
+    }
+}


### PR DESCRIPTION

## Motivation
Task name annotations are helpful in order to better understand what is happening in an async application

## Solution

This PR adds a cfg_trace-gated unstable builder tokio::task::Builder, which allows authors to annotate a task at runtime with an appropriate name. It includes `task.name` instrumentation for Builder::spawn, Builder::spawn_local, and Builder::spawn_blocking