### PR TITLE
refactor: Add some helpers for BufMut/ReadBuf juggling

### DIFF
--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -60,7 +60,6 @@ mod util {
     use bytes::{Buf, BufMut};
     use futures_core::ready;
     use std::io::{self, IoSlice};
-    use std::mem::MaybeUninit;
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
@@ -113,9 +112,7 @@ mod util {
         }
 
         let n = {
-            let dst = buf.chunk_mut();
-            let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
-            let mut buf = ReadBuf::uninit(dst);
+            let mut buf = ReadBuf::from_buf(buf);
             let ptr = buf.filled().as_ptr();
             ready!(io.poll_read(cx, &mut buf)?);
 

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -55,6 +55,22 @@ impl<'a> ReadBuf<'a> {
         }
     }
 
+    cfg_io_util! {
+        #[doc(hidden)]
+        pub fn from_buf(buf: &'a mut impl bytes::BufMut) -> ReadBuf<'a> {
+            let buf = buf.chunk_mut();
+            ReadBuf {
+                // SAFETY: ReadBuf guarantees that no uninitialized bytes are written to `buf`
+                // (same guarantee as `UninitSlice`)
+                buf: unsafe {
+                    std::slice::from_raw_parts_mut(buf.as_mut_ptr() as *mut MaybeUninit<u8>, buf.len())
+                },
+                filled: 0,
+                initialized: 0,
+            }
+        }
+    }
+
     /// Returns the total capacity of the buffer.
     #[inline]
     pub fn capacity(&self) -> usize {

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -41,7 +41,6 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         use crate::io::ReadBuf;
-        use std::mem::MaybeUninit;
 
         let me = self.project();
 
@@ -50,9 +49,7 @@ where
         }
 
         let n = {
-            let dst = me.buf.chunk_mut();
-            let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
-            let mut buf = ReadBuf::uninit(dst);
+            let mut buf = ReadBuf::from_buf(me.buf);
             let ptr = buf.filled().as_ptr();
             ready!(Pin::new(me.reader).poll_read(cx, &mut buf)?);
 


### PR DESCRIPTION
## Motivation

There is some duplicated (unsafe) code when dealing with `BufMut` and `ReadBuf`

## Solution

We can de-duplicate these places by adding some helper functions to remove the duplication. These functions could be useful externally as well, but I kept them hidden for the moment.