### PR TITLE
net: allow customized I/O operations for TcpStream (#3873)

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -977,8 +977,11 @@ impl TcpStream {
     /// The closure should attempt to read from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for reading.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the tcp stream becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
@@ -1055,8 +1058,11 @@ impl TcpStream {
     /// The closure should attempt to write from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for writing.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the tcp stream becomes ready for writing, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -966,7 +966,7 @@ impl TcpStream {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the tcp stream is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the tcp
@@ -980,7 +980,7 @@ impl TcpStream {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the tcp stream becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instant after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
@@ -1047,7 +1047,7 @@ impl TcpStream {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the tcp stream is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the tcp
@@ -1061,7 +1061,7 @@ impl TcpStream {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the tcp stream becomes ready for writing, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instant after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
@@ -1083,9 +1083,9 @@ impl TcpStream {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the tcp stream is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the tcp stream is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -966,57 +966,6 @@ impl TcpStream {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the tcp stream is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the tcp
-    /// stream becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the tcp stream is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the tcp stream becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instant after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `TcpStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the tcp stream is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
     /// Try to write from the socket using a user-provided IO operation.
     ///
     /// If the socket is ready for writing, the provided closure is called. The
@@ -1045,57 +994,6 @@ impl TcpStream {
     /// [`ready()`]: TcpStream::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the tcp stream is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the tcp
-    /// stream becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the tcp stream is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the tcp stream becomes ready for writing, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instant after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `TcpStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the tcp stream is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
     }
 
     /// Receives data on the socket from the remote address to which it is

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -936,16 +936,16 @@ impl TcpStream {
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(bufs))
     }
 
-    /// Try to read from the socket using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the socket is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the socket by manually calling the
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the socket is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
@@ -958,42 +958,17 @@ impl TcpStream {
     /// methods defined on the Tokio `TcpStream` type, as this will mess with
     /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: TcpStream::readable()
-    /// [`ready()`]: TcpStream::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Try to write from the socket using a user-provided IO operation.
-    ///
-    /// If the socket is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the socket is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `TcpStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: TcpStream::writable()
     /// [`ready()`]: TcpStream::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
+    pub fn try_io<R>(
+        &self,
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 
     /// Receives data on the socket from the remote address to which it is

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1002,12 +1002,32 @@ impl TcpStream {
         self.io.registration().poll_read_io(cx, f)
     }
 
-    /// Try to call a write I/O function, clearing write readiness if `f` returns
-    /// `WouldBlock`
+    /// Try to write from the socket using a user-provided IO operation.
     ///
-    /// # Return value
+    /// If the socket is ready for writing, the provided closure is called. The
+    /// closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the write readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_write_io`.
     ///
-    /// This functions returns exactly the same as `f`
+    /// If the socket is not ready for writing, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `TcpStream` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`writable()`]: TcpStream::writable()
+    /// [`ready()`]: TcpStream::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -962,7 +962,7 @@ impl TcpStream {
     ///
     /// [`readable()`]: TcpStream::readable()
     /// [`ready()`]: TcpStream::ready()
-    pub fn try_read_io<R>(&self, f: impl FnMut() -> io::Result<R>) -> io::Result<R> {
+    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
@@ -1008,7 +1008,7 @@ impl TcpStream {
     /// # Return value
     ///
     /// This functions returns exactly the same as `f`
-    pub fn try_write_io<R>(&self, f: impl FnMut() -> io::Result<R>) -> io::Result<R> {
+    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -966,22 +966,34 @@ impl TcpStream {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read readiness.
+    /// Polls for read from the socket using a user-provided IO operation.
     ///
     /// If the tcp stream is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the tcp
     /// stream becomes ready for reading, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the tcp stream is ready for reading, the provided closure is called.
+    /// The closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for reading.
+    ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
     /// passed to the most recent call is scheduled to receive a wakeup.
     /// (However, `poll_write_io` retains a second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the read
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `TcpStream` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///
@@ -1032,22 +1044,34 @@ impl TcpStream {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write readiness and then calls the `f` for writing operation.
+    /// Polls for write from the socket using a user-provided IO operation.
     ///
     /// If the tcp stream is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the tcp
     /// stream becomes ready for writing, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the tcp stream is ready for writing, the provided closure is called.
+    /// The closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for writing.
+    ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is
     /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
     /// second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the write
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `TcpStream` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1200,22 +1200,34 @@ impl UdpSocket {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read readiness.
+    /// Polls for read from the socket using a user-provided IO operation.
     ///
     /// If the udp socket is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the udp
     /// socket becomes ready for reading, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the udp socket is ready for reading, the provided closure is called.
+    /// The closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for reading.
+    ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
     /// passed to the most recent call is scheduled to receive a wakeup.
     /// (However, `poll_write_io` retains a second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the read
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///
@@ -1266,22 +1278,34 @@ impl UdpSocket {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write readiness and then calls the `f` for writing operation.
+    /// Polls for write from the socket using a user-provided IO operation.
     ///
     /// If the udp socket is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the udp
     /// socket becomes ready for writing, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the udp socket is ready for writing, the provided closure is called.
+    /// The closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for writing.
+    ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is
     /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
     /// second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the write
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1200,57 +1200,6 @@ impl UdpSocket {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the udp socket is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the udp
-    /// socket becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the udp socket is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the udp socket is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
     /// Try to write from the socket using a user-provided IO operation.
     ///
     /// If the socket is ready for writing, the provided closure is called. The
@@ -1279,57 +1228,6 @@ impl UdpSocket {
     /// [`ready()`]: UdpSocket::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the udp socket is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the udp
-    /// socket becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the udp socket is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the udp socket is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
     }
 
     /// Receives data from the socket, without removing it from the input queue.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1211,8 +1211,11 @@ impl UdpSocket {
     /// The closure should attempt to read from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for reading.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
@@ -1289,8 +1292,11 @@ impl UdpSocket {
     /// The closure should attempt to write from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for writing.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1170,16 +1170,16 @@ impl UdpSocket {
             .try_io(Interest::READABLE, || self.io.recv_from(buf))
     }
 
-    /// Try to read from the socket using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the socket is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the socket by manually calling the
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the socket is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
@@ -1192,42 +1192,17 @@ impl UdpSocket {
     /// methods defined on the Tokio `UdpSocket` type, as this will mess with
     /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: UdpSocket::readable()
-    /// [`ready()`]: UdpSocket::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Try to write from the socket using a user-provided IO operation.
-    ///
-    /// If the socket is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the socket is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: UdpSocket::writable()
     /// [`ready()`]: UdpSocket::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
+    pub fn try_io<R>(
+        &self,
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 
     /// Receives data from the socket, without removing it from the input queue.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1200,7 +1200,7 @@ impl UdpSocket {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the udp socket is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the udp
@@ -1214,7 +1214,7 @@ impl UdpSocket {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
@@ -1281,7 +1281,7 @@ impl UdpSocket {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the udp socket is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the udp
@@ -1295,7 +1295,7 @@ impl UdpSocket {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the udp socket becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
@@ -1317,9 +1317,9 @@ impl UdpSocket {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the udp socket is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the udp socket is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1170,6 +1170,138 @@ impl UdpSocket {
             .try_io(Interest::READABLE, || self.io.recv_from(buf))
     }
 
+    /// Try to read from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for reading, the provided closure is called. The
+    /// closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_read_io`.
+    ///
+    /// If the socket is not ready for reading, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: UdpSocket::readable()
+    /// [`ready()`]: UdpSocket::ready()
+    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::READABLE, f)
+    }
+
+    /// Polls for read readiness.
+    ///
+    /// If the udp socket is not currently ready for reading, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the udp
+    /// socket becomes ready for reading, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
+    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
+    /// passed to the most recent call is scheduled to receive a wakeup.
+    /// (However, `poll_write_io` retains a second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the read
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the udp socket is not ready for reading, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_read_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_read_io(cx, f)
+    }
+
+    /// Try to write from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for writing, the provided closure is called. The
+    /// closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the write readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_write_io`.
+    ///
+    /// If the socket is not ready for writing, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `UdpSocket` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`writable()`]: UdpSocket::writable()
+    /// [`ready()`]: UdpSocket::ready()
+    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::WRITABLE, f)
+    }
+
+    /// Polls for write readiness and then calls the `f` for writing operation.
+    ///
+    /// If the udp socket is not currently ready for writing, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the udp
+    /// socket becomes ready for writing, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_write_io` only
+    /// the `Waker` from the `Context` passed to the most recent call is
+    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
+    /// second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the write
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the udp socket is not ready for writing.
+    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
+    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_write_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_write_io(cx, f)
+    }
+
     /// Receives data from the socket, without removing it from the input queue.
     /// On success, returns the number of bytes read and the address from whence
     /// the data came.

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1173,7 +1173,7 @@ impl UnixDatagram {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the unix socket is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
@@ -1187,7 +1187,7 @@ impl UnixDatagram {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
@@ -1254,7 +1254,7 @@ impl UnixDatagram {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the unix socket is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
@@ -1268,7 +1268,7 @@ impl UnixDatagram {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
@@ -1290,9 +1290,9 @@ impl UnixDatagram {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the unix socket is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the unix socket is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1173,22 +1173,34 @@ impl UnixDatagram {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read readiness.
+    /// Polls for read from the socket using a user-provided IO operation.
     ///
     /// If the unix socket is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
     /// socket becomes ready for reading, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the unix socket is ready for reading, the provided closure is called.
+    /// The closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for reading.
+    ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
     /// passed to the most recent call is scheduled to receive a wakeup.
     /// (However, `poll_write_io` retains a second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the read
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///
@@ -1239,22 +1251,34 @@ impl UnixDatagram {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write readiness and then calls the `f` for writing operation.
+    /// Polls for write from the socket using a user-provided IO operation.
     ///
     /// If the unix socket is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
     /// socket becomes ready for writing, `Waker::wake` will be called on the
     /// waker.
     ///
+    /// If the unix socket is ready for writing, the provided closure is called.
+    /// The closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. Stores and wakes the clone of the
+    /// `Waker` just like it was not ready for writing.
+    ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is
     /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
     /// second, independent waker.)
     ///
-    /// This function is intended for cases where customized I/O operations
-    /// may change the readiness of the underlying socket.
-    /// If the `f` function returns an error `WouldBlock`, then the write
-    /// readiness will be cleared and returns `Poll::Pending`.
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1184,8 +1184,11 @@ impl UnixDatagram {
     /// The closure should attempt to read from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for reading.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
@@ -1262,8 +1265,11 @@ impl UnixDatagram {
     /// The closure should attempt to write from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for writing.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1173,57 +1173,6 @@ impl UnixDatagram {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the unix socket is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the unix
-    /// socket becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the unix socket is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the unix socket is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
     /// Try to write from the socket using a user-provided IO operation.
     ///
     /// If the socket is ready for writing, the provided closure is called. The
@@ -1252,57 +1201,6 @@ impl UnixDatagram {
     /// [`ready()`]: UnixDatagram::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the unix socket is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the unix
-    /// socket becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the unix socket is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the unix socket becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the unix socket is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
     }
 
     /// Returns the local address that this socket is bound to.

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1143,16 +1143,16 @@ impl UnixDatagram {
         Ok((n, SocketAddr(addr)))
     }
 
-    /// Try to read from the socket using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the socket is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the socket by manually calling the
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the socket is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
@@ -1165,42 +1165,17 @@ impl UnixDatagram {
     /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
     /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: UnixDatagram::readable()
-    /// [`ready()`]: UnixDatagram::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Try to write from the socket using a user-provided IO operation.
-    ///
-    /// If the socket is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the socket is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: UnixDatagram::writable()
     /// [`ready()`]: UnixDatagram::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
+    pub fn try_io<R>(
+        &self,
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 
     /// Returns the local address that this socket is bound to.

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1143,6 +1143,138 @@ impl UnixDatagram {
         Ok((n, SocketAddr(addr)))
     }
 
+    /// Try to read from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for reading, the provided closure is called. The
+    /// closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_read_io`.
+    ///
+    /// If the socket is not ready for reading, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: UnixDatagram::readable()
+    /// [`ready()`]: UnixDatagram::ready()
+    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::READABLE, f)
+    }
+
+    /// Polls for read readiness.
+    ///
+    /// If the unix socket is not currently ready for reading, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the unix
+    /// socket becomes ready for reading, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
+    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
+    /// passed to the most recent call is scheduled to receive a wakeup.
+    /// (However, `poll_write_io` retains a second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the read
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the unix socket is not ready for reading, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_read_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_read_io(cx, f)
+    }
+
+    /// Try to write from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for writing, the provided closure is called. The
+    /// closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the write readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_write_io`.
+    ///
+    /// If the socket is not ready for writing, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `UnixDatagram` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`writable()`]: UnixDatagram::writable()
+    /// [`ready()`]: UnixDatagram::ready()
+    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::WRITABLE, f)
+    }
+
+    /// Polls for write readiness and then calls the `f` for writing operation.
+    ///
+    /// If the unix socket is not currently ready for writing, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the unix
+    /// socket becomes ready for writing, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_write_io` only
+    /// the `Waker` from the `Context` passed to the most recent call is
+    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
+    /// second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the write
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the unix socket is not ready for writing.
+    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
+    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_write_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_write_io(cx, f)
+    }
+
     /// Returns the local address that this socket is bound to.
     ///
     /// # Examples

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -694,8 +694,11 @@ impl UnixStream {
     /// The closure should attempt to read from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for reading.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
@@ -772,8 +775,11 @@ impl UnixStream {
     /// The closure should attempt to write from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for writing.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -653,6 +653,138 @@ impl UnixStream {
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(buf))
     }
 
+    /// Try to read from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for reading, the provided closure is called. The
+    /// closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_read_io`.
+    ///
+    /// If the socket is not ready for reading, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `UnixStream` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: UnixStream::readable()
+    /// [`ready()`]: UnixStream::ready()
+    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::READABLE, f)
+    }
+
+    /// Polls for read readiness.
+    ///
+    /// If the unix stream is not currently ready for reading, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the unix
+    /// stream becomes ready for reading, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
+    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
+    /// passed to the most recent call is scheduled to receive a wakeup.
+    /// (However, `poll_write_io` retains a second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the read
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the unix stream is not ready for reading, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_read_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_read_io(cx, f)
+    }
+
+    /// Try to write from the socket using a user-provided IO operation.
+    ///
+    /// If the socket is ready for writing, the provided closure is called. The
+    /// closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the write readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_write_io`.
+    ///
+    /// If the socket is not ready for writing, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `UnixStream` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// Usually, [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`writable()`]: UnixStream::writable()
+    /// [`ready()`]: UnixStream::ready()
+    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::WRITABLE, f)
+    }
+
+    /// Polls for write readiness and then calls the `f` for writing operation.
+    ///
+    /// If the unix stream is not currently ready for writing, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the unix
+    /// stream becomes ready for writing, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// Note that on multiple calls to `poll_write_io` only
+    /// the `Waker` from the `Context` passed to the most recent call is
+    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
+    /// second, independent waker.)
+    ///
+    /// This function is intended for cases where customized I/O operations
+    /// may change the readiness of the underlying socket.
+    /// If the `f` function returns an error `WouldBlock`, then the write
+    /// readiness will be cleared and returns `Poll::Pending`.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the unix stream is not ready for writing.
+    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
+    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_write_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_write_io(cx, f)
+    }
+
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.
     ///
     /// This function is intended to be used to wrap a UnixStream from the

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -683,57 +683,6 @@ impl UnixStream {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the unix stream is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the unix
-    /// stream becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the unix stream is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `UnixStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the unix stream is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
     /// Try to write from the socket using a user-provided IO operation.
     ///
     /// If the socket is ready for writing, the provided closure is called. The
@@ -762,57 +711,6 @@ impl UnixStream {
     /// [`ready()`]: UnixStream::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the unix stream is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the unix
-    /// stream becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the unix stream is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UnixStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the unix stream is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
     }
 
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -683,7 +683,7 @@ impl UnixStream {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the unix stream is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
@@ -697,7 +697,7 @@ impl UnixStream {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
@@ -764,7 +764,7 @@ impl UnixStream {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the unix stream is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the unix
@@ -778,7 +778,7 @@ impl UnixStream {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the unix stream becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
@@ -800,9 +800,9 @@ impl UnixStream {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the unix stream is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the unix stream is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -653,16 +653,16 @@ impl UnixStream {
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(buf))
     }
 
-    /// Try to read from the socket using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the socket is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the socket by manually calling the
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the socket is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
@@ -675,42 +675,17 @@ impl UnixStream {
     /// methods defined on the Tokio `UnixStream` type, as this will mess with
     /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: UnixStream::readable()
-    /// [`ready()`]: UnixStream::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Try to write from the socket using a user-provided IO operation.
-    ///
-    /// If the socket is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the socket is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `UnixStream` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: UnixStream::writable()
     /// [`ready()`]: UnixStream::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
+    pub fn try_io<R>(
+        &self,
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -754,7 +754,7 @@ impl NamedPipeServer {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the named pipe is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the named
@@ -768,7 +768,7 @@ impl NamedPipeServer {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
@@ -835,7 +835,7 @@ impl NamedPipeServer {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the named pipe is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the named
@@ -849,7 +849,7 @@ impl NamedPipeServer {
     /// the read readiness flag is cleared. The `Waker` from the provided `Context`
     /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
     /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready right in the instance after the closure has returned
+    /// if the socket become ready in the instance after the closure has returned
     /// `WouldBlock`.
     ///
     /// Note that on multiple calls to `poll_write_io` only
@@ -871,9 +871,9 @@ impl NamedPipeServer {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the named pipe is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the named pipe is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///
@@ -1536,7 +1536,7 @@ impl NamedPipeClient {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Polls for read from the socket using a user-provided IO operation.
+    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
     ///
     /// If the named pipe is not currently ready for reading, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the named
@@ -1615,7 +1615,7 @@ impl NamedPipeClient {
         self.io.registration().try_io(Interest::WRITABLE, f)
     }
 
-    /// Polls for write from the socket using a user-provided IO operation.
+    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
     ///
     /// If the named pipe is not currently ready for writing, this method will
     /// store a clone of the `Waker` from the provided `Context`. When the named
@@ -1649,9 +1649,9 @@ impl NamedPipeClient {
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the named pipe is not ready for writing.
-    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
-    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    /// * `Poll::Pending` if the named pipe is not ready for writing, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
     ///
     /// # Errors
     ///

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -724,64 +724,39 @@ impl NamedPipeServer {
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(buf))
     }
 
-    /// Try to read from the named pipe using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the named pipe is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the named pipe by manually calling the
-    /// appropriate syscall. If the operation fails because the named pipe is not
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the named pipe is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the named pipe that failed due to the named pipe not being
+    /// an IO operation on the socket that failed due to the socket not being
     /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the named pipe to
+    /// incorrectly clear the readiness flag, which can cause the socket to
     /// behave incorrectly.
     ///
     /// The closure should not perform the read operation using any of the
     /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
-    /// the readiness flag and can cause the named pipe to behave incorrectly.
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: NamedPipeServer::readable()
-    /// [`ready()`]: NamedPipeServer::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Try to write from the named pipe using a user-provided IO operation.
-    ///
-    /// If the named pipe is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the named pipe by manually calling the
-    /// appropriate syscall. If the operation fails because the named pipe is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the named pipe is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the named pipe that failed due to the named pipe not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the named pipe to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
-    /// the readiness flag and can cause the named pipe to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: NamedPipeServer::writable()
     /// [`ready()`]: NamedPipeServer::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
+    pub fn try_io<R>(
+        &self,
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 }
 
@@ -1404,162 +1379,39 @@ impl NamedPipeClient {
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(buf))
     }
 
-    /// Try to read from the named pipe using a user-provided IO operation.
+    /// Try to perform IO operation from the socket using a user-provided IO operation.
     ///
-    /// If the named pipe is ready for reading, the provided closure is called. The
-    /// closure should attempt to read from the named pipe by manually calling the
-    /// appropriate syscall. If the operation fails because the named pipe is not
+    /// If the socket is ready, the provided closure is called. The
+    /// closure should attempt to perform IO operation from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_read_io`.
+    /// the readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_io`.
     ///
-    /// If the named pipe is not ready for reading, then the closure is not called
+    /// If the socket is not ready, then the closure is not called
     /// and a `WouldBlock` error is returned.
     ///
     /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the named pipe that failed due to the named pipe not being
+    /// an IO operation on the socket that failed due to the socket not being
     /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the named pipe to
+    /// incorrectly clear the readiness flag, which can cause the socket to
     /// behave incorrectly.
     ///
     /// The closure should not perform the read operation using any of the
     /// methods defined on the Tokio `NamedPipeClient` type, as this will mess with
-    /// the readiness flag and can cause the named pipe to behave incorrectly.
+    /// the readiness flag and can cause the socket to behave incorrectly.
     ///
-    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
     ///
     /// [`readable()`]: NamedPipeClient::readable()
-    /// [`ready()`]: NamedPipeClient::ready()
-    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::READABLE, f)
-    }
-
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the named pipe is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the named
-    /// pipe becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the named pipe is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
-    /// will be called on the waker.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `NamedPipeClient` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the named pipe is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
-    /// Try to write from the named pipe using a user-provided IO operation.
-    ///
-    /// If the named pipe is ready for writing, the provided closure is called. The
-    /// closure should attempt to write from the named pipe by manually calling the
-    /// appropriate syscall. If the operation fails because the named pipe is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the write readiness flag is cleared. The return value of the closure is
-    /// then returned by `try_write_io`.
-    ///
-    /// If the named pipe is not ready for writing, then the closure is not called
-    /// and a `WouldBlock` error is returned.
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the named pipe that failed due to the named pipe not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the named pipe to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `NamedPipeClient` type, as this will mess with
-    /// the readiness flag and can cause the named pipe to behave incorrectly.
-    ///
-    /// Usually, [`writable()`] or [`ready()`] is used with this function.
-    ///
     /// [`writable()`]: NamedPipeClient::writable()
     /// [`ready()`]: NamedPipeClient::ready()
-    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
-        self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the named pipe is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the named
-    /// pipe becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the named pipe is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
-    /// will be called on the waker.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `NamedPipeClient` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the named pipe is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
+    pub fn try_io<R>(
         &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
+        interest: Interest,
+        f: impl FnOnce() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io.registration().try_io(interest, f)
     }
 }
 

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -754,57 +754,6 @@ impl NamedPipeServer {
         self.io.registration().try_io(Interest::READABLE, f)
     }
 
-    /// Poll for read readiness, then reads from the socket using a user-provided IO operation.
-    ///
-    /// If the named pipe is not currently ready for reading, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the named
-    /// pipe becomes ready for reading, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the named pipe is ready for reading, the provided closure is called.
-    /// The closure should attempt to read from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
-    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
-    /// passed to the most recent call is scheduled to receive a wakeup.
-    /// (However, `poll_write_io` retains a second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the read operation using any of the
-    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the named pipe is not ready for reading, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_read_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_read_io(cx, f)
-    }
-
     /// Try to write from the named pipe using a user-provided IO operation.
     ///
     /// If the named pipe is ready for writing, the provided closure is called. The
@@ -833,57 +782,6 @@ impl NamedPipeServer {
     /// [`ready()`]: NamedPipeServer::ready()
     pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
         self.io.registration().try_io(Interest::WRITABLE, f)
-    }
-
-    /// Poll for write readiness, then writes to the socket using a user-provided IO operation.
-    ///
-    /// If the named pipe is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the named
-    /// pipe becomes ready for writing, `Waker::wake` will be called on the
-    /// waker.
-    ///
-    /// If the named pipe is ready for writing, the provided closure is called.
-    /// The closure should attempt to write from the socket by manually calling the
-    /// appropriate syscall. If the operation fails because the socket is not
-    /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
-    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
-    /// will be called on the waker. The provided closure may be called multiple times
-    /// if the socket become ready in the instance after the closure has returned
-    /// `WouldBlock`.
-    ///
-    /// Note that on multiple calls to `poll_write_io` only
-    /// the `Waker` from the `Context` passed to the most recent call is
-    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
-    /// second, independent waker.)
-    ///
-    /// The closure should only return a `WouldBlock` error if it has performed
-    /// an IO operation on the socket that failed due to the socket not being
-    /// ready. Returning a `WouldBlock` error in any other situation will
-    /// incorrectly clear the readiness flag, which can cause the socket to
-    /// behave incorrectly.
-    ///
-    /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
-    /// the readiness flag and can cause the socket to behave incorrectly.
-    ///
-    /// # Return value
-    ///
-    /// The function returns:
-    ///
-    /// * `Poll::Pending` if the named pipe is not ready for writing, or if `f` returns a `WouldBlock` error.
-    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
-    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
-    ///
-    /// # Errors
-    ///
-    /// This function may encounter any standard I/O error except `WouldBlock`.
-    pub fn poll_write_io<R>(
-        &self,
-        cx: &mut Context<'_>,
-        f: impl FnMut() -> io::Result<R>,
-    ) -> Poll<io::Result<R>> {
-        self.io.registration().poll_write_io(cx, f)
     }
 }
 

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -723,6 +723,168 @@ impl NamedPipeServer {
             .registration()
             .try_io(Interest::WRITABLE, || (&*self.io).write_vectored(buf))
     }
+
+    /// Try to read from the named pipe using a user-provided IO operation.
+    ///
+    /// If the named pipe is ready for reading, the provided closure is called. The
+    /// closure should attempt to read from the named pipe by manually calling the
+    /// appropriate syscall. If the operation fails because the named pipe is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_read_io`.
+    ///
+    /// If the named pipe is not ready for reading, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the named pipe that failed due to the named pipe not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the named pipe to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
+    /// the readiness flag and can cause the named pipe to behave incorrectly.
+    ///
+    /// Usually, [`readable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: NamedPipeServer::readable()
+    /// [`ready()`]: NamedPipeServer::ready()
+    pub fn try_read_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::READABLE, f)
+    }
+
+    /// Polls for read from the socket using a user-provided IO operation.
+    ///
+    /// If the named pipe is not currently ready for reading, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the named
+    /// pipe becomes ready for reading, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// If the named pipe is ready for reading, the provided closure is called.
+    /// The closure should attempt to read from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
+    ///
+    /// Note that on multiple calls to `poll_read_io`, `poll_read`,
+    /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
+    /// passed to the most recent call is scheduled to receive a wakeup.
+    /// (However, `poll_write_io` retains a second, independent waker.)
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the read operation using any of the
+    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the named pipe is not ready for reading, or if `f` returns a `WouldBlock` error.
+    /// * `Poll::Ready(Ok(r))` if `f` returns `Ok(r)`.
+    /// * `Poll::Ready(Err(e))` if `f` returns an error other than `WouldBlock`, or if polling for readiness encounters an IO error.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_read_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_read_io(cx, f)
+    }
+
+    /// Try to write from the named pipe using a user-provided IO operation.
+    ///
+    /// If the named pipe is ready for writing, the provided closure is called. The
+    /// closure should attempt to write from the named pipe by manually calling the
+    /// appropriate syscall. If the operation fails because the named pipe is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the write readiness flag is cleared. The return value of the closure is
+    /// then returned by `try_write_io`.
+    ///
+    /// If the named pipe is not ready for writing, then the closure is not called
+    /// and a `WouldBlock` error is returned.
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the named pipe that failed due to the named pipe not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the named pipe to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
+    /// the readiness flag and can cause the named pipe to behave incorrectly.
+    ///
+    /// Usually, [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`writable()`]: NamedPipeServer::writable()
+    /// [`ready()`]: NamedPipeServer::ready()
+    pub fn try_write_io<R>(&self, f: impl FnOnce() -> io::Result<R>) -> io::Result<R> {
+        self.io.registration().try_io(Interest::WRITABLE, f)
+    }
+
+    /// Polls for write from the socket using a user-provided IO operation.
+    ///
+    /// If the named pipe is not currently ready for writing, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the named
+    /// pipe becomes ready for writing, `Waker::wake` will be called on the
+    /// waker.
+    ///
+    /// If the named pipe is ready for writing, the provided closure is called.
+    /// The closure should attempt to write from the socket by manually calling the
+    /// appropriate syscall. If the operation fails because the socket is not
+    /// actually ready, then the closure should return a `WouldBlock` error and
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
+    /// will be called on the waker. The provided closure may be called multiple times
+    /// if the socket become ready right in the instance after the closure has returned
+    /// `WouldBlock`.
+    ///
+    /// Note that on multiple calls to `poll_write_io` only
+    /// the `Waker` from the `Context` passed to the most recent call is
+    /// scheduled to receive a wakeup. (However, `poll_read_io` retains a
+    /// second, independent waker.)
+    ///
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the write operation using any of the
+    /// methods defined on the Tokio `NamedPipeServer` type, as this will mess with
+    /// the readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// # Return value
+    ///
+    /// The function returns:
+    ///
+    /// * `Poll::Pending` if the named pipe is not ready for writing.
+    /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
+    /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
+    ///
+    /// # Errors
+    ///
+    /// This function may encounter any standard I/O error except `WouldBlock`.
+    pub fn poll_write_io<R>(
+        &self,
+        cx: &mut Context<'_>,
+        f: impl FnMut() -> io::Result<R>,
+    ) -> Poll<io::Result<R>> {
+        self.io.registration().poll_write_io(cx, f)
+    }
 }
 
 impl AsyncRead for NamedPipeServer {
@@ -1385,8 +1547,9 @@ impl NamedPipeClient {
     /// The closure should attempt to read from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for reading.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
+    /// will be called on the waker.
     ///
     /// Note that on multiple calls to `poll_read_io`, `poll_read`,
     /// `poll_read_ready` or `poll_peek`, only the `Waker` from the `Context`
@@ -1454,17 +1617,18 @@ impl NamedPipeClient {
 
     /// Polls for write from the socket using a user-provided IO operation.
     ///
-    /// If the tcp stream is not currently ready for writing, this method will
-    /// store a clone of the `Waker` from the provided `Context`. When the tcp
-    /// stream becomes ready for writing, `Waker::wake` will be called on the
+    /// If the named pipe is not currently ready for writing, this method will
+    /// store a clone of the `Waker` from the provided `Context`. When the named
+    /// pipe becomes ready for writing, `Waker::wake` will be called on the
     /// waker.
     ///
-    /// If the tcp stream is ready for writing, the provided closure is called.
+    /// If the named pipe is ready for writing, the provided closure is called.
     /// The closure should attempt to write from the socket by manually calling the
     /// appropriate syscall. If the operation fails because the socket is not
     /// actually ready, then the closure should return a `WouldBlock` error and
-    /// the read readiness flag is cleared. Stores and wakes the clone of the
-    /// `Waker` just like it was not ready for writing.
+    /// the read readiness flag is cleared. The `Waker` from the provided `Context`
+    /// will be stored. When the named pipe becomes ready for reading, `Waker::wake`
+    /// will be called on the waker.
     ///
     /// Note that on multiple calls to `poll_write_io` only
     /// the `Waker` from the `Context` passed to the most recent call is
@@ -1478,14 +1642,14 @@ impl NamedPipeClient {
     /// behave incorrectly.
     ///
     /// The closure should not perform the write operation using any of the
-    /// methods defined on the Tokio `TcpStream` type, as this will mess with
+    /// methods defined on the Tokio `NamedPipeClient` type, as this will mess with
     /// the readiness flag and can cause the socket to behave incorrectly.
     ///
     /// # Return value
     ///
     /// The function returns:
     ///
-    /// * `Poll::Pending` if the tcp stream is not ready for writing.
+    /// * `Poll::Pending` if the named pipe is not ready for writing.
     /// * `Poll::Ready(Ok(R))` if the `f` returns `Ok(R)`.
     /// * `Poll::Ready(Err(e))` if an error is encountered from `f` except `WouldBlock`.
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/tokio-rs/tokio/issues/3873

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Exposes two APIs from the underlying `registration`

- <del>`poll_read_io`</del>, `try_read_io`
- <del>`poll_write_io`</del>, `try_write_io`
