### PR TITLE
tracing: add resource instrumentation macros

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -1,3 +1,4 @@
+use crate::util;
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{quote, quote_spanned, ToTokens};
@@ -56,7 +57,7 @@ impl Configuration {
             return Err(syn::Error::new(span, "`flavor` set multiple times."));
         }
 
-        let runtime_str = parse_string(runtime, span, "flavor")?;
+        let runtime_str = util::parse_string(runtime, span, "flavor")?;
         let runtime =
             RuntimeFlavor::from_str(&runtime_str).map_err(|err| syn::Error::new(span, err))?;
         self.flavor = Some(runtime);
@@ -75,7 +76,7 @@ impl Configuration {
             ));
         }
 
-        let worker_threads = parse_int(worker_threads, span, "worker_threads")?;
+        let worker_threads = util::parse_int(worker_threads, span, "worker_threads")?;
         if worker_threads == 0 {
             return Err(syn::Error::new(span, "`worker_threads` may not be 0."));
         }
@@ -88,7 +89,7 @@ impl Configuration {
             return Err(syn::Error::new(span, "`start_paused` set multiple times."));
         }
 
-        let start_paused = parse_bool(start_paused, span, "start_paused")?;
+        let start_paused = util::parse_bool(start_paused, span, "start_paused")?;
         self.start_paused = Some((start_paused, span));
         Ok(())
     }
@@ -144,43 +145,6 @@ impl Configuration {
             worker_threads,
             start_paused,
         })
-    }
-}
-
-fn parse_int(int: syn::Lit, span: Span, field: &str) -> Result<usize, syn::Error> {
-    match int {
-        syn::Lit::Int(lit) => match lit.base10_parse::<usize>() {
-            Ok(value) => Ok(value),
-            Err(e) => Err(syn::Error::new(
-                span,
-                format!("Failed to parse value of `{}` as integer: {}", field, e),
-            )),
-        },
-        _ => Err(syn::Error::new(
-            span,
-            format!("Failed to parse value of `{}` as integer.", field),
-        )),
-    }
-}
-
-fn parse_string(int: syn::Lit, span: Span, field: &str) -> Result<String, syn::Error> {
-    match int {
-        syn::Lit::Str(s) => Ok(s.value()),
-        syn::Lit::Verbatim(s) => Ok(s.to_string()),
-        _ => Err(syn::Error::new(
-            span,
-            format!("Failed to parse value of `{}` as string.", field),
-        )),
-    }
-}
-
-fn parse_bool(bool: syn::Lit, span: Span, field: &str) -> Result<bool, syn::Error> {
-    match bool {
-        syn::Lit::Bool(b) => Ok(b.value),
-        _ => Err(syn::Error::new(
-            span,
-            format!("Failed to parse value of `{}` as bool.", field),
-        )),
     }
 }
 

--- a/tokio-macros/src/instrument.rs
+++ b/tokio-macros/src/instrument.rs
@@ -1,0 +1,292 @@
+use crate::util;
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use quote::{quote, quote_spanned};
+use syn::spanned::Spanned;
+use syn::{
+    parse::Parser, parse_macro_input, DeriveInput, Ident, ItemFn, ReturnType, Signature, Type,
+};
+
+#[derive(Default)]
+struct ResourceMeta {
+    concrete_type: Option<String>,
+    resource_kind: Option<String>,
+}
+
+const RESOURCE_SPAN_NAME: &str = "resource";
+const OP_SPAN_NAME: &str = "resource_op";
+const RESULT_TYPE_FIELD_NAME: &str = "result_type";
+const OP_FIELD_NAME: &str = "op";
+
+const RESULT_TYPE_READY: &str = "READY";
+const RESULT_TYPE_PENDING: &str = "PENDING";
+const RESULT_TYPE_ERROR: &str = "ERROR";
+
+pub(crate) fn add_resource_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+
+    // add the span field
+    match &mut ast.data {
+        syn::Data::Struct(ref mut struct_data) => match &mut struct_data.fields {
+            syn::Fields::Named(fields) => {
+                fields.named.push(
+                    syn::Field::parse_named
+                        .parse2(quote! { span: tracing::Span })
+                        .unwrap(),
+                );
+            }
+            _ => {
+                let message = "Only structs with named fields are supported";
+                return syn::Error::new(Span::call_site(), message)
+                    .to_compile_error()
+                    .into();
+            }
+        },
+        _ => {
+            let message = "Only structs are supported";
+            return syn::Error::new(Span::call_site(), message)
+                .to_compile_error()
+                .into();
+        }
+    }
+
+    // add getter impl
+    let args = parse_macro_input!(args as syn::AttributeArgs);
+
+    let name = &ast.ident;
+    let resource_meta = match parse_resource_impld_args(args) {
+        Ok(meta) => meta,
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let concrete_type = match resource_meta.concrete_type {
+        Some(t) => t,
+        None => name.to_string(),
+    };
+
+    let resource_kind = match resource_meta.resource_kind {
+        Some(kind) => kind,
+        None => {
+            let message = "Unspecified resource_kind";
+            return syn::Error::new(Span::call_site(), message)
+                .to_compile_error()
+                .into();
+        }
+    };
+
+    let gen = quote! {
+        #ast
+        impl #name {
+            fn create_span() -> tracing::Span {
+                tracing::trace_span!(#RESOURCE_SPAN_NAME, concrete_type = #concrete_type, kind = #resource_kind)
+            }
+        }
+    };
+
+    gen.into()
+}
+
+fn parse_resource_impld_args(args: syn::AttributeArgs) -> Result<ResourceMeta, syn::Error> {
+    let mut resource_meta = ResourceMeta::default();
+    for arg in args {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
+                let ident = namevalue.path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(namevalue, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "concrete_type" => {
+                        let concrete_type = util::parse_string(
+                            namevalue.lit.clone(),
+                            syn::spanned::Spanned::span(&namevalue.lit),
+                            "concrete_type",
+                        )?;
+
+                        resource_meta.concrete_type = Some(concrete_type);
+                    }
+                    "resource_kind" => {
+                        let resource_kind = util::parse_string(
+                            namevalue.lit.clone(),
+                            syn::spanned::Spanned::span(&namevalue.lit),
+                            "resource_kind",
+                        )?;
+
+                        resource_meta.resource_kind = Some(resource_kind);
+                    }
+                    name => {
+                        let msg = format!(
+                            "Unknown attribute {} is specified; expected one of: `concrete_type`, `resource_kind`",
+                            name,
+                        );
+                        return Err(syn::Error::new_spanned(namevalue, msg));
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "Unsupported attribute inside the macro",
+                ));
+            }
+        }
+    }
+
+    Ok(resource_meta)
+}
+
+pub(crate) fn instrument_resource_op(args: TokenStream, input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as ItemFn);
+
+    let ItemFn {
+        attrs,
+        vis,
+        block,
+        sig,
+        ..
+    } = input;
+
+    if sig.receiver().is_none() {
+        let message = "Instrumented op needs to be a method on a Resource";
+        return syn::Error::new_spanned(sig.fn_token, message)
+            .to_compile_error()
+            .into();
+    }
+
+    if sig.asyncness.is_some() {
+        let message = "Cannot instrument async resource ops";
+        return syn::Error::new_spanned(sig.fn_token, message)
+            .to_compile_error()
+            .into();
+    }
+
+    let Signature {
+        output,
+        inputs,
+        unsafety,
+        asyncness,
+        constness,
+        abi,
+        ident,
+        generics:
+            syn::Generics {
+                params: gen_params,
+                where_clause,
+                ..
+            },
+        ..
+    } = sig;
+
+    let returns_poll = match output.clone() {
+        ReturnType::Default => false,
+        ReturnType::Type(_, ty) => match ty.as_ref() {
+            Type::Path(ty) => match ty.path.segments.last() {
+                Some(ps) => ps.ident == "Poll",
+                None => false,
+            },
+            _ => false,
+        },
+    };
+
+    if !returns_poll {
+        let message = "Instrumented op should return Poll<Result<_, _>>";
+        return syn::Error::new_spanned(sig.fn_token, message)
+            .to_compile_error()
+            .into();
+    }
+
+    let op_name = ident.to_string();
+
+    let op_span = quote!(tracing::trace_span!(
+        #OP_SPAN_NAME,
+        #OP_FIELD_NAME = #op_name,
+        #RESULT_TYPE_FIELD_NAME = tracing::field::Empty,
+    ));
+
+    let args = parse_macro_input!(args as syn::AttributeArgs);
+
+    let resource_span_guard = match parse_resource_span_location(args) {
+        Ok(Some(loc)) => quote!(
+            let __resource_span = self.#loc.span.clone();
+            let __resource_span_guard = __resource_span.enter();
+        ),
+        Ok(None) => quote!(
+            let __resource_span = self.span.clone();
+            let __resource_span_guard = __resource_span.enter();
+        ),
+        Err(e) => return e.to_compile_error().into(),
+    };
+
+    let instrumented_block = quote_spanned!(block.span()=>
+        #resource_span_guard
+        let __op_span = #op_span;
+        let __op_span_guard = __op_span.enter();
+        match (move || #block)() {
+            std::task::Poll::Ready(Ok(v)) => {
+                __op_span.record(#RESULT_TYPE_FIELD_NAME, &#RESULT_TYPE_READY);
+                drop(__op_span_guard);
+                std::task::Poll::Ready(Ok(v))
+            },
+            std::task::Poll::Ready(Err(e)) => {
+                __op_span.record(#RESULT_TYPE_FIELD_NAME, &#RESULT_TYPE_ERROR);
+                drop(__op_span_guard);
+                std::task::Poll::Ready(Err(e))
+            },
+            std::task::Poll::Pending => {
+                __op_span.record(#RESULT_TYPE_FIELD_NAME, &#RESULT_TYPE_PENDING);
+                drop(__op_span_guard);
+                std::task::Poll::Pending
+            }
+        }
+    );
+
+    quote!(
+        #(#attrs) *
+        #vis #constness #unsafety #asyncness #abi fn #ident<#gen_params>(#inputs) #output
+        #where_clause
+        {
+            #instrumented_block
+        }
+    )
+    .into()
+}
+
+fn parse_resource_span_location(args: syn::AttributeArgs) -> Result<Option<Ident>, syn::Error> {
+    if let Some(arg) = args.first() {
+        match arg {
+            syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
+                let ident = namevalue.path.get_ident();
+                if ident.is_none() {
+                    let msg = "Must have specified ident";
+                    return Err(syn::Error::new_spanned(namevalue, msg));
+                }
+                match ident.unwrap().to_string().to_lowercase().as_str() {
+                    "resource_span_location" => {
+                        let resource_span_location = util::parse_string(
+                            namevalue.lit.clone(),
+                            syn::spanned::Spanned::span(&namevalue.lit),
+                            "resource_span_location",
+                        )?;
+
+                        return Ok(Some(Ident::new(&resource_span_location, Span::call_site())));
+                    }
+                    name => {
+                        let msg = format!(
+                            "Unknown attribute {} is specified; expected: `resource_span_location`",
+                            name,
+                        );
+                        return Err(syn::Error::new_spanned(namevalue, msg));
+                    }
+                }
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "Unsupported attribute inside the macro",
+                ));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -19,7 +19,9 @@
 extern crate proc_macro;
 
 mod entry;
+mod instrument;
 mod select;
+mod util;
 
 use proc_macro::TokenStream;
 
@@ -328,4 +330,16 @@ pub fn test_fail(_args: TokenStream, _item: TokenStream) -> TokenStream {
 #[doc(hidden)]
 pub fn select_priv_declare_output_enum(input: TokenStream) -> TokenStream {
     select::declare_output_enum(input)
+}
+
+#[proc_macro_attribute]
+#[doc(hidden)]
+pub fn instrument_resource(args: TokenStream, item: TokenStream) -> TokenStream {
+    instrument::add_resource_impl(args, item)
+}
+
+#[proc_macro_attribute]
+#[doc(hidden)]
+pub fn instrument_resource_op(args: TokenStream, item: TokenStream) -> TokenStream {
+    instrument::instrument_resource_op(args, item)
 }

--- a/tokio-macros/src/util.rs
+++ b/tokio-macros/src/util.rs
@@ -1,0 +1,38 @@
+use proc_macro2::Span;
+
+pub(crate) fn parse_int(int: syn::Lit, span: Span, field: &str) -> Result<usize, syn::Error> {
+    match int {
+        syn::Lit::Int(lit) => match lit.base10_parse::<usize>() {
+            Ok(value) => Ok(value),
+            Err(e) => Err(syn::Error::new(
+                span,
+                format!("Failed to parse value of `{}` as integer: {}", field, e),
+            )),
+        },
+        _ => Err(syn::Error::new(
+            span,
+            format!("Failed to parse value of `{}` as integer.", field),
+        )),
+    }
+}
+
+pub(crate) fn parse_string(int: syn::Lit, span: Span, field: &str) -> Result<String, syn::Error> {
+    match int {
+        syn::Lit::Str(s) => Ok(s.value()),
+        syn::Lit::Verbatim(s) => Ok(s.to_string()),
+        _ => Err(syn::Error::new(
+            span,
+            format!("Failed to parse value of `{}` as string.", field),
+        )),
+    }
+}
+
+pub(crate) fn parse_bool(bool: syn::Lit, span: Span, field: &str) -> Result<bool, syn::Error> {
+    match bool {
+        syn::Lit::Bool(b) => Ok(b.value),
+        _ => Err(syn::Error::new(
+            span,
+            format!("Failed to parse value of `{}` as bool.", field),
+        )),
+    }
+}

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -464,13 +464,13 @@ pub(crate) use self::doc::winapi;
 #[cfg(all(not(docsrs), windows, feature = "net"))]
 #[allow(unused)]
 pub(crate) use ::winapi;
-
 cfg_macros! {
     /// Implementation detail of the `select!` macro. This macro is **not**
     /// intended to be used as part of the public API and is permitted to
     /// change.
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
+
 
     cfg_rt! {
         #[cfg(feature = "rt-multi-thread")]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -464,13 +464,13 @@ pub(crate) use self::doc::winapi;
 #[cfg(all(not(docsrs), windows, feature = "net"))]
 #[allow(unused)]
 pub(crate) use ::winapi;
+
 cfg_macros! {
     /// Implementation detail of the `select!` macro. This macro is **not**
     /// intended to be used as part of the public API and is permitted to
     /// change.
     #[doc(hidden)]
     pub use tokio_macros::select_priv_declare_output_enum;
-
 
     cfg_rt! {
         #[cfg(feature = "rt-multi-thread")]


### PR DESCRIPTION
This PR adds two macros that will be used to instrument poll operations of resources. In essence this is heavily inspired by what `tracing_attributes::instrument` does, albeit a bit more specialized.

- `instrument_resource` - adds a span to a resource struct. This span should be entered whenever a resource op is called
- `instrument_resource_op` - used in a resource op method (e.g. `poll_elapsed`) wraps the invocation in a span that is a child
of the main resource span added by `instrument_resource`. The macro records a field with the op invocation result type (READY, ERROR, PENDING)


Some open questions: 
While this works fine for types like Sleep and Stream that expose these poll_* operations, I think it will be a bit more tricky to incorporate the approach into other types such as `Notify` that do not have these explicit `poll` methods. Also not all poll methods return a Result type, so this will likely not work.


Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>
