### PR TITLE
feat: add wait alias to sleep

### DIFF
--- a/tokio/src/time/driver/sleep.rs
+++ b/tokio/src/time/driver/sleep.rs
@@ -57,7 +57,7 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 /// [`interval`]: crate::time::interval()
 // Alias for old name in 0.x
 #[cfg_attr(docsrs, doc(alias = "delay_for"))]
-#[doc(alias = "wait")]
+#[cfg_attr(docsrs, doc(alias = "wait"))]
 pub fn sleep(duration: Duration) -> Sleep {
     match Instant::now().checked_add(duration) {
         Some(deadline) => sleep_until(deadline),

--- a/tokio/src/time/driver/sleep.rs
+++ b/tokio/src/time/driver/sleep.rs
@@ -57,6 +57,7 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 /// [`interval`]: crate::time::interval()
 // Alias for old name in 0.x
 #[cfg_attr(docsrs, doc(alias = "delay_for"))]
+#[doc(alias = "wait")]
 pub fn sleep(duration: Duration) -> Sleep {
     match Instant::now().checked_add(duration) {
         Some(deadline) => sleep_until(deadline),


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I was searching for how to wait, and I couldn't find anything so I then looked for sleep after 5 minutes. Now, on the docs, if you search for `wait` the sleep method will come up.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I added a `#[doc(alias = "wait")]` to make it so when you search on the docs for wait, you will get shown the sleep method.
