### PR TITLE
Document cancellation safety

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -105,8 +105,10 @@ cfg_io_util! {
         /// async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize>;
         /// ```
         ///
-        /// This function does not provide any guarantees about whether it
-        /// completes immediately or asynchronously
+        /// This method does not provide any guarantees about whether it
+        /// completes immediately or asynchronously, however the method is
+        /// cancellation safe, so it can safely be used as the event in a
+        /// [`select!`](crate::select) statement without loss of data.
         ///
         /// # Return
         ///
@@ -177,8 +179,10 @@ cfg_io_util! {
         /// Usually, only a single `read` syscall is issued, even if there is
         /// more space in the supplied buffer.
         ///
-        /// This function does not provide any guarantees about whether it
-        /// completes immediately or asynchronously
+        /// This method does not provide any guarantees about whether it
+        /// completes immediately or asynchronously, however the method is
+        /// cancellation safe, so it can safely be used as the event in a
+        /// [`select!`](crate::select) statement without loss of data.
         ///
         /// # Return
         ///
@@ -245,6 +249,9 @@ cfg_io_util! {
         ///
         /// This function reads as many bytes as necessary to completely fill
         /// the specified buffer `buf`.
+        ///
+        /// This method is not cancellation safe, and any partially read data is
+        /// lost on cancellation.
         ///
         /// # Errors
         ///

--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -106,9 +106,7 @@ cfg_io_util! {
         /// ```
         ///
         /// This method does not provide any guarantees about whether it
-        /// completes immediately or asynchronously, however the method is
-        /// cancellation safe, so it can safely be used as the event in a
-        /// [`select!`](crate::select) statement without loss of data.
+        /// completes immediately or asynchronously.
         ///
         /// # Return
         ///
@@ -139,6 +137,12 @@ cfg_io_util! {
         /// If this function encounters any form of I/O or other error, an error
         /// variant will be returned. If an error is returned then it must be
         /// guaranteed that no bytes were read.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is cancel safe. If you use it as the event in a
+        /// [`tokio::select!`](crate::select) statement and some other branch
+        /// completes first, then it is guaranteed that no data was read.
         ///
         /// # Examples
         ///
@@ -180,9 +184,7 @@ cfg_io_util! {
         /// more space in the supplied buffer.
         ///
         /// This method does not provide any guarantees about whether it
-        /// completes immediately or asynchronously, however the method is
-        /// cancellation safe, so it can safely be used as the event in a
-        /// [`select!`](crate::select) statement without loss of data.
+        /// completes immediately or asynchronously.
         ///
         /// # Return
         ///
@@ -200,6 +202,12 @@ cfg_io_util! {
         /// If this function encounters any form of I/O or other error, an error
         /// variant will be returned. If an error is returned then it must be
         /// guaranteed that no bytes were read.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is cancel safe. If you use it as the event in a
+        /// [`tokio::select!`](crate::select) statement and some other branch
+        /// completes first, then it is guaranteed that no data was read.
         ///
         /// # Examples
         ///
@@ -250,9 +258,6 @@ cfg_io_util! {
         /// This function reads as many bytes as necessary to completely fill
         /// the specified buffer `buf`.
         ///
-        /// This method is not cancellation safe, and any partially read data is
-        /// lost on cancellation.
-        ///
         /// # Errors
         ///
         /// If the operation encounters an "end of file" before completely
@@ -267,6 +272,13 @@ cfg_io_util! {
         /// If this operation returns an error, it is unspecified how many bytes
         /// it has read, but it will never read more than would be necessary to
         /// completely fill the buffer.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is not cancellation safe. If the method is used as the
+        /// event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then some data may already have been
+        /// read into `buf`.
         ///
         /// # Examples
         ///

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -80,11 +80,6 @@ cfg_io_util! {
         /// error. A call to `write` represents *at most one* attempt to write to
         /// any wrapped object.
         ///
-        /// This method is cancellation safe in the sense that if it is used as
-        /// the event in a [`tokio::select!`](crate::select) statement and some
-        /// other branch completes first, then it is guaranteed that no data was
-        /// written to this `AsyncWrite`.
-        ///
         /// # Return
         ///
         /// If the return value is `Ok(n)` then it must be guaranteed that `n <=
@@ -101,6 +96,13 @@ cfg_io_util! {
         ///
         /// It is **not** considered an error if the entire buffer could not be
         /// written to this writer.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no data was
+        /// written to this `AsyncWrite`.
         ///
         /// # Examples
         ///
@@ -133,6 +135,8 @@ cfg_io_util! {
         /// ```
         ///
         /// See [`AsyncWrite::poll_write_vectored`] for more details.
+        ///
+        /// # Cancel safety
         ///
         /// This method is cancellation safe in the sense that if it is used as
         /// the event in a [`tokio::select!`](crate::select) statement and some
@@ -188,11 +192,6 @@ cfg_io_util! {
         /// A call to `write_buf` represents *at most one* attempt to write to any
         /// wrapped object.
         ///
-        /// This method is cancellation safe in the sense that if it is used as
-        /// the event in a [`tokio::select!`](crate::select) statement and some
-        /// other branch completes first, then it is guaranteed that no data was
-        /// written to this `AsyncWrite`.
-        ///
         /// # Return
         ///
         /// If the return value is `Ok(n)` then it must be guaranteed that `n <=
@@ -209,6 +208,13 @@ cfg_io_util! {
         ///
         /// It is **not** considered an error if the entire buffer could not be
         /// written to this writer.
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no data was
+        /// written to this `AsyncWrite`.
         ///
         /// # Examples
         ///
@@ -258,6 +264,7 @@ cfg_io_util! {
         ///     while buf.has_remaining() {
         ///         self.write_buf(&mut buf).await?;
         ///     }
+        ///     Ok(())
         /// }
         /// ```
         ///
@@ -269,6 +276,15 @@ cfg_io_util! {
         /// The buffer is advanced after each chunk is successfully written. After failure,
         /// `src.chunk()` will return the chunk that failed to write.
         ///
+        /// # Cancel safety
+        ///
+        /// If `write_all_buf` is used as the event in a
+        /// [`tokio::select!`](crate::select) statement and some other branch
+        /// completes first, then the data in the provided buffer may have been
+        /// partially written. However, it is guaranteed that the provided
+        /// buffer has been [advanced] by the amount of bytes that have been
+        /// partially written.
+        ///
         /// # Examples
         ///
         /// [`File`] implements [`AsyncWrite`] and [`Cursor`]`<&[u8]>` implements [`Buf`]:
@@ -276,6 +292,7 @@ cfg_io_util! {
         /// [`File`]: crate::fs::File
         /// [`Buf`]: bytes::Buf
         /// [`Cursor`]: std::io::Cursor
+        /// [advanced]: bytes::Buf::advance
         ///
         /// ```no_run
         /// use tokio::io::{self, AsyncWriteExt};
@@ -314,6 +331,8 @@ cfg_io_util! {
         /// to be written. This method will not return until the entire buffer
         /// has been successfully written or such an error occurs. The first
         /// error generated from this method will be returned.
+        ///
+        /// # Cancel safety
         ///
         /// This method is not cancellation safe. If it is used as the event
         /// in a [`tokio::select!`](crate::select) statement and some other

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -80,6 +80,11 @@ cfg_io_util! {
         /// error. A call to `write` represents *at most one* attempt to write to
         /// any wrapped object.
         ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no data was
+        /// written to this `AsyncWrite`.
+        ///
         /// # Return
         ///
         /// If the return value is `Ok(n)` then it must be guaranteed that `n <=
@@ -129,6 +134,11 @@ cfg_io_util! {
         ///
         /// See [`AsyncWrite::poll_write_vectored`] for more details.
         ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no data was
+        /// written to this `AsyncWrite`.
+        ///
         /// # Examples
         ///
         /// ```no_run
@@ -177,6 +187,11 @@ cfg_io_util! {
         /// resume from the point that the first call to `write_buf` completed.
         /// A call to `write_buf` represents *at most one* attempt to write to any
         /// wrapped object.
+        ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no data was
+        /// written to this `AsyncWrite`.
         ///
         /// # Return
         ///
@@ -299,6 +314,12 @@ cfg_io_util! {
         /// to be written. This method will not return until the entire buffer
         /// has been successfully written or such an error occurs. The first
         /// error generated from this method will be returned.
+        ///
+        /// This method is not cancellation safe. If it is used as the event
+        /// in a [`tokio::select!`](crate::select) statement and some other
+        /// branch completes first, then the provided buffer may have been
+        /// partially written, but future calls to `write_all` will start over
+        /// from the beginning of the buffer.
         ///
         /// # Errors
         ///

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -89,7 +89,9 @@
 ///
 /// When using `select!` in a loop to receive messages from multiple sources,
 /// you should make sure that the receive call is cancellation safe to avoid
-/// losing messages. The lists in this section are not exhaustive.
+/// losing messages. This section goes through various common methods and
+/// describes whether they are cancel safe.  The lists in this section are not
+/// exhaustive.
 ///
 /// The following methods are cancellation safe:
 ///
@@ -130,8 +132,8 @@
 ///
 /// Be aware that cancelling something that is not cancellation safe is not
 /// necessarily wrong. For example, if you are cancelling a task because the
-/// application is shutting down, then you might not care that partially read
-/// data is lost.
+/// application is shutting down, then you probably don't care that partially
+/// read data is lost.
 ///
 /// # Examples
 ///

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -23,10 +23,10 @@
 /// returns the result of evaluating the completed branch's `<handler>`
 /// expression.
 ///
-/// Additionally, each branch may include an optional `if` precondition. This
-/// precondition is evaluated **before** the `<async expression>`. If the
-/// precondition returns `false`, the branch is entirely disabled. This
-/// capability is useful when using `select!` within a loop.
+/// Additionally, each branch may include an optional `if` precondition. If the
+/// precondition returns `false`, then the branch is disabled. The provided
+/// `<async expression>` is still evaluated but the resulting future is never
+/// polled. This capability is useful when using `select!` within a loop.
 ///
 /// The complete lifecycle of a `select!` expression is as follows:
 ///
@@ -42,12 +42,10 @@
 ///    to the provided `<pattern>`, if the pattern matches, evaluate `<handler>`
 ///    and return. If the pattern **does not** match, disable the current branch
 ///    and for the remainder of the current call to `select!`. Continue from step 3.
-/// 5. If **all** branches are disabled, evaluate the `else` expression. If none
-///    is provided, panic.
+/// 5. If **all** branches are disabled, evaluate the `else` expression. If no
+///    else branch is provided, panic.
 ///
-/// # Notes
-///
-/// ### Runtime characteristics
+/// # Runtime characteristics
 ///
 /// By running all async expressions on the current task, the expressions are
 /// able to run **concurrently** but not in **parallel**. This means all
@@ -58,76 +56,7 @@
 ///
 /// [`tokio::spawn`]: crate::spawn
 ///
-/// ### Avoid racy `if` preconditions
-///
-/// Given that `if` preconditions are used to disable `select!` branches, some
-/// caution must be used to avoid missing values.
-///
-/// For example, here is **incorrect** usage of `sleep` with `if`. The objective
-/// is to repeatedly run an asynchronous task for up to 50 milliseconds.
-/// However, there is a potential for the `sleep` completion to be missed.
-///
-/// ```no_run
-/// use tokio::time::{self, Duration};
-///
-/// async fn some_async_work() {
-///     // do work
-/// }
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let sleep = time::sleep(Duration::from_millis(50));
-///     tokio::pin!(sleep);
-///
-///     while !sleep.is_elapsed() {
-///         tokio::select! {
-///             _ = &mut sleep, if !sleep.is_elapsed() => {
-///                 println!("operation timed out");
-///             }
-///             _ = some_async_work() => {
-///                 println!("operation completed");
-///             }
-///         }
-///     }
-/// }
-/// ```
-///
-/// In the above example, `sleep.is_elapsed()` may return `true` even if
-/// `sleep.poll()` never returned `Ready`. This opens up a potential race
-/// condition where `sleep` expires between the `while !sleep.is_elapsed()`
-/// check and the call to `select!` resulting in the `some_async_work()` call to
-/// run uninterrupted despite the sleep having elapsed.
-///
-/// One way to write the above example without the race would be:
-///
-/// ```
-/// use tokio::time::{self, Duration};
-///
-/// async fn some_async_work() {
-/// # time::sleep(Duration::from_millis(10)).await;
-///     // do work
-/// }
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let sleep = time::sleep(Duration::from_millis(50));
-///     tokio::pin!(sleep);
-///
-///     loop {
-///         tokio::select! {
-///             _ = &mut sleep => {
-///                 println!("operation timed out");
-///                 break;
-///             }
-///             _ = some_async_work() => {
-///                 println!("operation completed");
-///             }
-///         }
-///     }
-/// }
-/// ```
-///
-/// ### Fairness
+/// # Fairness
 ///
 /// By default, `select!` randomly picks a branch to check first. This provides
 /// some level of fairness when calling `select!` in a loop with branches that
@@ -151,10 +80,58 @@
 ///
 /// # Panics
 ///
-/// `select!` panics if all branches are disabled **and** there is no provided
-/// `else` branch. A branch is disabled when the provided `if` precondition
-/// returns `false` **or** when the pattern does not match the result of `<async
-/// expression>`.
+/// The `select!` macro panics if all branches are disabled **and** there is no
+/// provided `else` branch. A branch is disabled when the provided `if`
+/// precondition returns `false` **or** when the pattern does not match the
+/// result of `<async expression>`.
+///
+/// # Cancellation safety
+///
+/// When using `select!` in a loop to receive messages from multiple sources,
+/// you should make sure that the receive call is cancellation safe to avoid
+/// losing messages. The lists in this section are not exhaustive.
+///
+/// The following methods are cancellation safe:
+///
+///  * [`tokio::sync::mpsc::Receiver::recv`](crate::sync::mpsc::Receiver::recv)
+///  * [`tokio::sync::mpsc::UnboundedReceiver::recv`](crate::sync::mpsc::UnboundedReceiver::recv)
+///  * [`tokio::sync::broadcast::Receiver::recv`](crate::sync::broadcast::Receiver::recv)
+///  * [`tokio::sync::watch::Receiver::changed`](crate::sync::watch::Receiver::changed)
+///  * [`tokio::net::TcpListener::accept`](crate::net::TcpListener::accept)
+///  * [`tokio::net::UnixListener::accept`](crate::net::UnixListener::accept)
+///  * [`tokio::io::AsyncReadExt::read`](crate::io::AsyncReadExt::read) on any `AsyncRead`
+///  * [`tokio::io::AsyncReadExt::read_buf`](crate::io::AsyncReadExt::read_buf) on any `AsyncRead`
+///  * [`tokio::io::AsyncWriteExt::write`](crate::io::AsyncWriteExt::write) on any `AsyncWrite`
+///  * [`tokio::io::AsyncWriteExt::write_buf`](crate::io::AsyncWriteExt::write_buf) on any `AsyncWrite`
+///  * [`tokio_stream::StreamExt::next`](https://docs.rs/tokio-stream/0.1/tokio_stream/trait.StreamExt.html#method.next) on any `Stream`
+///  * [`futures::stream::StreamExt::next`](https://docs.rs/futures/0.3/futures/stream/trait.StreamExt.html#method.next) on any `Stream`
+///
+/// The following methods are not cancellation safe and can lead to loss of data:
+///
+///  * [`tokio::io::AsyncReadExt::read_exact`](crate::io::AsyncReadExt::read_exact)
+///  * [`tokio::io::AsyncReadExt::read_to_end`](crate::io::AsyncReadExt::read_to_end)
+///  * [`tokio::io::AsyncReadExt::read_to_string`](crate::io::AsyncReadExt::read_to_string)
+///  * [`tokio::io::AsyncWriteExt::write_all`](crate::io::AsyncWriteExt::write_all)
+///
+/// The following methods are not cancellation safe because they use a queue for
+/// fairness and cancellation makes you lose your place in the queue:
+///
+///  * [`tokio::sync::Mutex::lock`](crate::sync::Mutex::lock)
+///  * [`tokio::sync::RwLock::read`](crate::sync::RwLock::read)
+///  * [`tokio::sync::RwLock::write`](crate::sync::RwLock::write)
+///  * [`tokio::sync::Semaphore::acquire`](crate::sync::Semaphore::acquire)
+///  * [`tokio::sync::Notify::notified`](crate::sync::Notify::notified)
+///
+/// To determine whether your own methods are cancellation safe, look for the
+/// location of uses of `.await`. This is because when an asynchronous method is
+/// cancelled, that always happens at an `.await`. If your function behaves
+/// correctly even if it is restarted while waiting at an `.await`, then it is
+/// cancellation safe.
+///
+/// Be aware that cancelling something that is not cancellation safe is not
+/// necessarily wrong. For example, if you are cancelling a task because the
+/// application is shutting down, then you might not care that partially read
+/// data is lost.
 ///
 /// # Examples
 ///
@@ -335,6 +312,77 @@
 ///                 break;
 ///             }
 ///         };
+///     }
+/// }
+/// ```
+///
+/// ## Avoid racy `if` preconditions
+///
+/// Given that `if` preconditions are used to disable `select!` branches, some
+/// caution must be used to avoid missing values.
+///
+/// For example, here is **incorrect** usage of `sleep` with `if`. The objective
+/// is to repeatedly run an asynchronous task for up to 50 milliseconds.
+/// However, there is a potential for the `sleep` completion to be missed.
+///
+/// ```no_run,should_panic
+/// use tokio::time::{self, Duration};
+///
+/// async fn some_async_work() {
+///     // do work
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let sleep = time::sleep(Duration::from_millis(50));
+///     tokio::pin!(sleep);
+///
+///     while !sleep.is_elapsed() {
+///         tokio::select! {
+///             _ = &mut sleep, if !sleep.is_elapsed() => {
+///                 println!("operation timed out");
+///             }
+///             _ = some_async_work() => {
+///                 println!("operation completed");
+///             }
+///         }
+///     }
+///
+///     panic!("This example shows how not to do it!");
+/// }
+/// ```
+///
+/// In the above example, `sleep.is_elapsed()` may return `true` even if
+/// `sleep.poll()` never returned `Ready`. This opens up a potential race
+/// condition where `sleep` expires between the `while !sleep.is_elapsed()`
+/// check and the call to `select!` resulting in the `some_async_work()` call to
+/// run uninterrupted despite the sleep having elapsed.
+///
+/// One way to write the above example without the race would be:
+///
+/// ```
+/// use tokio::time::{self, Duration};
+///
+/// async fn some_async_work() {
+/// # time::sleep(Duration::from_millis(10)).await;
+///     // do work
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let sleep = time::sleep(Duration::from_millis(50));
+///     tokio::pin!(sleep);
+///
+///     loop {
+///         tokio::select! {
+///             _ = &mut sleep => {
+///                 println!("operation timed out");
+///                 break;
+///             }
+///             _ = some_async_work() => {
+///                 println!("operation completed");
+///             }
+///         }
 ///     }
 /// }
 /// ```

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -125,9 +125,12 @@ impl TcpListener {
     /// established, the corresponding [`TcpStream`] and the remote peer's
     /// address will be returned.
     ///
-    /// This method is cancellation safe in the sense that new connections
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If the method is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that no new connections were
+    /// accepted by this method.
     ///
     /// [`TcpStream`]: struct@crate::net::TcpStream
     ///

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -125,6 +125,10 @@ impl TcpListener {
     /// established, the corresponding [`TcpStream`] and the remote peer's
     /// address will be returned.
     ///
+    /// This method is cancellation safe in the sense that new connections
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// [`TcpStream`]: struct@crate::net::TcpStream
     ///
     /// # Examples

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -356,9 +356,12 @@ impl TcpStream {
     /// can be used to concurrently read / write to the same socket on a single
     /// task without splitting the socket.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read or write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -424,9 +427,12 @@ impl TcpStream {
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually
     /// paired with `try_read()`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -733,9 +739,12 @@ impl TcpStream {
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is usually
     /// paired with `try_write()`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -356,6 +356,10 @@ impl TcpStream {
     /// can be used to concurrently read / write to the same socket on a single
     /// task without splitting the socket.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// Concurrently read and write to the stream on the same task without
@@ -419,6 +423,10 @@ impl TcpStream {
     ///
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually
     /// paired with `try_read()`.
+    ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     ///
     /// # Examples
     ///
@@ -724,6 +732,10 @@ impl TcpStream {
     ///
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is usually
     /// paired with `try_write()`.
+    ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     ///
     /// # Examples
     ///
@@ -1151,6 +1163,12 @@ impl TcpStream {
     pub fn into_split(self) -> (OwnedReadHalf, OwnedWriteHalf) {
         split_owned(self)
     }
+
+    // == Poll IO functions that takes `&self` ==
+    //
+    // To read or write without mutable access to the `UnixStream`, combine the
+    // `poll_read_ready` or `poll_write_ready` methods with the `try_read` or
+    // `try_write` methods.
 
     pub(crate) fn poll_read_priv(
         &self,

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -327,6 +327,10 @@ impl UdpSocket {
     /// false-positive and attempting an operation will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// Concurrently receive from and send to the socket on the same task
@@ -390,6 +394,10 @@ impl UdpSocket {
     /// false-positive and attempting a `try_send()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -434,6 +442,11 @@ impl UdpSocket {
     ///
     /// The [`connect`] method will connect this socket to a remote address.
     /// This method will fail if the socket is not connected.
+    ///
+    /// This method is cancellation safe in the sense that if it is used as
+    /// the event in a [`tokio::select!`](crate::select) statement and some
+    /// other branch completes first, then it is guaranteed that the provided
+    /// message was not sent.
     ///
     /// [`connect`]: method@Self::connect
     ///
@@ -559,6 +572,10 @@ impl UdpSocket {
     /// false-positive and attempting a `try_recv()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -612,6 +629,9 @@ impl UdpSocket {
     ///
     /// The [`connect`] method will connect this socket to a remote address.
     /// This method will fail if the socket is not connected.
+    ///
+    /// This method is cancellation safe, so it is not possible to lose messages
+    /// when using it as the event in a [`select!`](crate::select) statement.
     ///
     /// [`connect`]: method@Self::connect
     ///
@@ -880,6 +900,11 @@ impl UdpSocket {
     /// This will return an error when the IP version of the local socket does
     /// not match that returned from [`ToSocketAddrs`].
     ///
+    /// This method is cancellation safe in the sense that if it is used as
+    /// the event in a [`tokio::select!`](crate::select) statement and some
+    /// other branch completes first, then it is guaranteed that the provided
+    /// message was not sent.
+    ///
     /// [`ToSocketAddrs`]: crate::net::ToSocketAddrs
     ///
     /// # Example
@@ -1004,6 +1029,9 @@ impl UdpSocket {
     /// The function must be called with valid byte array `buf` of sufficient
     /// size to hold the message bytes. If a message is too long to fit in the
     /// supplied buffer, excess bytes may be discarded.
+    ///
+    /// This method is cancellation safe, so it is not possible to lose messages
+    /// when using it as the event in a [`select!`](crate::select) statement.
     ///
     /// # Example
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -327,9 +327,12 @@ impl UdpSocket {
     /// false-positive and attempting an operation will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read or write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -394,9 +397,12 @@ impl UdpSocket {
     /// false-positive and attempting a `try_send()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -443,17 +449,18 @@ impl UdpSocket {
     /// The [`connect`] method will connect this socket to a remote address.
     /// This method will fail if the socket is not connected.
     ///
-    /// This method is cancellation safe in the sense that if it is used as
-    /// the event in a [`tokio::select!`](crate::select) statement and some
-    /// other branch completes first, then it is guaranteed that the provided
-    /// message was not sent.
-    ///
     /// [`connect`]: method@Self::connect
     ///
     /// # Return
     ///
     /// On success, the number of bytes sent is returned, otherwise, the
     /// encountered error is returned.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `send` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that the message was not sent.
     ///
     /// # Examples
     ///
@@ -572,9 +579,12 @@ impl UdpSocket {
     /// false-positive and attempting a `try_recv()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -630,8 +640,12 @@ impl UdpSocket {
     /// The [`connect`] method will connect this socket to a remote address.
     /// This method will fail if the socket is not connected.
     ///
-    /// This method is cancellation safe, so it is not possible to lose messages
-    /// when using it as the event in a [`select!`](crate::select) statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv_from` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// socket.
     ///
     /// [`connect`]: method@Self::connect
     ///
@@ -900,12 +914,13 @@ impl UdpSocket {
     /// This will return an error when the IP version of the local socket does
     /// not match that returned from [`ToSocketAddrs`].
     ///
-    /// This method is cancellation safe in the sense that if it is used as
-    /// the event in a [`tokio::select!`](crate::select) statement and some
-    /// other branch completes first, then it is guaranteed that the provided
-    /// message was not sent.
-    ///
     /// [`ToSocketAddrs`]: crate::net::ToSocketAddrs
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `send_to` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that the message was not sent.
     ///
     /// # Example
     ///
@@ -1030,8 +1045,12 @@ impl UdpSocket {
     /// size to hold the message bytes. If a message is too long to fit in the
     /// supplied buffer, excess bytes may be discarded.
     ///
-    /// This method is cancellation safe, so it is not possible to lose messages
-    /// when using it as the event in a [`select!`](crate::select) statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv_from` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// socket.
     ///
     /// # Example
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -106,9 +106,12 @@ impl UnixDatagram {
     /// false-positive and attempting an operation will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read or write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -175,9 +178,12 @@ impl UnixDatagram {
     /// false-positive and attempting a `try_send()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -229,9 +235,12 @@ impl UnixDatagram {
     /// false-positive and attempting a `try_recv()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -502,10 +511,11 @@ impl UnixDatagram {
 
     /// Sends data on the socket to the socket's peer.
     ///
-    /// This method is cancellation safe in the sense that if it is used as
-    /// the event in a [`tokio::select!`](crate::select) statement and some
-    /// other branch completes first, then it is guaranteed that the provided
-    /// message was not sent.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `send` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that the message was not sent.
     ///
     /// # Examples
     /// ```
@@ -630,8 +640,12 @@ impl UnixDatagram {
 
     /// Receives data from the socket.
     ///
-    /// This method is cancellation safe, so it is not possible to lose messages
-    /// when using it as the event in a [`select!`](crate::select) statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// socket.
     ///
     /// # Examples
     /// ```
@@ -840,10 +854,11 @@ impl UnixDatagram {
 
     /// Sends data on the socket to the specified address.
     ///
-    /// This method is cancellation safe in the sense that if it is used as
-    /// the event in a [`tokio::select!`](crate::select) statement and some
-    /// other branch completes first, then it is guaranteed that the provided
-    /// message was not sent.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `send_to` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that the message was not sent.
     ///
     /// # Examples
     /// ```
@@ -888,10 +903,12 @@ impl UnixDatagram {
 
     /// Receives data from the socket.
     ///
-    /// This method is cancellation safe in the sense that if it is used as
-    /// the event in a [`tokio::select!`](crate::select) statement and some
-    /// other branch completes first, then it is guaranteed that no messages
-    /// have been received.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv_from` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// socket.
     ///
     /// # Examples
     /// ```

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -106,6 +106,10 @@ impl UnixDatagram {
     /// false-positive and attempting an operation will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// Concurrently receive from and send to the socket on the same task
@@ -171,6 +175,10 @@ impl UnixDatagram {
     /// false-positive and attempting a `try_send()` will return with
     /// `io::ErrorKind::WouldBlock`.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -220,6 +228,10 @@ impl UnixDatagram {
     /// The function may complete without the socket being readable. This is a
     /// false-positive and attempting a `try_recv()` will return with
     /// `io::ErrorKind::WouldBlock`.
+    ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     ///
     /// # Examples
     ///
@@ -490,6 +502,11 @@ impl UnixDatagram {
 
     /// Sends data on the socket to the socket's peer.
     ///
+    /// This method is cancellation safe in the sense that if it is used as
+    /// the event in a [`tokio::select!`](crate::select) statement and some
+    /// other branch completes first, then it is guaranteed that the provided
+    /// message was not sent.
+    ///
     /// # Examples
     /// ```
     /// # use std::error::Error;
@@ -612,6 +629,9 @@ impl UnixDatagram {
     }
 
     /// Receives data from the socket.
+    ///
+    /// This method is cancellation safe, so it is not possible to lose messages
+    /// when using it as the event in a [`select!`](crate::select) statement.
     ///
     /// # Examples
     /// ```
@@ -820,6 +840,11 @@ impl UnixDatagram {
 
     /// Sends data on the socket to the specified address.
     ///
+    /// This method is cancellation safe in the sense that if it is used as
+    /// the event in a [`tokio::select!`](crate::select) statement and some
+    /// other branch completes first, then it is guaranteed that the provided
+    /// message was not sent.
+    ///
     /// # Examples
     /// ```
     /// # use std::error::Error;
@@ -862,6 +887,11 @@ impl UnixDatagram {
     }
 
     /// Receives data from the socket.
+    ///
+    /// This method is cancellation safe in the sense that if it is used as
+    /// the event in a [`tokio::select!`](crate::select) statement and some
+    /// other branch completes first, then it is guaranteed that no messages
+    /// have been received.
     ///
     /// # Examples
     /// ```

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -129,9 +129,12 @@ impl UnixListener {
 
     /// Accepts a new incoming connection to this listener.
     ///
-    /// This method is cancellation safe in the sense that new connections
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If the method is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that no new connections were
+    /// accepted by this method.
     pub async fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         let (mio, addr) = self
             .io

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -128,6 +128,10 @@ impl UnixListener {
     }
 
     /// Accepts a new incoming connection to this listener.
+    ///
+    /// This method is cancellation safe in the sense that new connections
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     pub async fn accept(&self) -> io::Result<(UnixStream, SocketAddr)> {
         let (mio, addr) = self
             .io

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -60,9 +60,12 @@ impl UnixStream {
     /// can be used to concurrently read / write to the same socket on a single
     /// task without splitting the socket.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read or write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -130,9 +133,12 @@ impl UnixStream {
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually
     /// paired with `try_read()`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to read that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///
@@ -443,9 +449,12 @@ impl UnixStream {
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is usually
     /// paired with `try_write()`.
     ///
-    /// This method is cancellation safe in the sense that readiness events
-    /// cannot be lost when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once a readiness event occurs, the method
+    /// will continue to return immediately until the readiness event is
+    /// consumed by an attempt to write that fails with `WouldBlock` or
+    /// `Poll::Pending`.
     ///
     /// # Examples
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -60,6 +60,10 @@ impl UnixStream {
     /// can be used to concurrently read / write to the same socket on a single
     /// task without splitting the socket.
     ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// # Examples
     ///
     /// Concurrently read and write to the stream on the same task without
@@ -125,6 +129,10 @@ impl UnixStream {
     ///
     /// This function is equivalent to `ready(Interest::READABLE)` and is usually
     /// paired with `try_read()`.
+    ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     ///
     /// # Examples
     ///
@@ -434,6 +442,10 @@ impl UnixStream {
     ///
     /// This function is equivalent to `ready(Interest::WRITABLE)` and is usually
     /// paired with `try_write()`.
+    ///
+    /// This method is cancellation safe in the sense that readiness events
+    /// cannot be lost when using it as the event in a [`select!`](crate::select)
+    /// statement.
     ///
     /// # Examples
     ///
@@ -826,14 +838,9 @@ impl AsyncWrite for UnixStream {
 impl UnixStream {
     // == Poll IO functions that takes `&self` ==
     //
-    // They are not public because (taken from the doc of `PollEvented`):
-    //
-    // While `PollEvented` is `Sync` (if the underlying I/O type is `Sync`), the
-    // caller must ensure that there are at most two tasks that use a
-    // `PollEvented` instance concurrently. One for reading and one for writing.
-    // While violating this requirement is "safe" from a Rust memory model point
-    // of view, it will result in unexpected behavior in the form of lost
-    // notifications and tasks hanging.
+    // To read or write without mutable access to the `UnixStream`, combine the
+    // `poll_read_ready` or `poll_write_ready` methods with the `try_read` or
+    // `try_write` methods.
 
     pub(crate) fn poll_read_priv(
         &self,

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -163,6 +163,10 @@ impl NamedPipeServer {
     ///
     /// This corresponds to the [`ConnectNamedPipe`] system call.
     ///
+    /// This method is cancellation safe in the sense that if it is used as the
+    /// event in a [`select!`](crate::select) statement and some other branch
+    /// completes first, then no connection events have been lost.
+    ///
     /// [`ConnectNamedPipe`]: https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe
     ///
     /// ```no_run

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -163,11 +163,15 @@ impl NamedPipeServer {
     ///
     /// This corresponds to the [`ConnectNamedPipe`] system call.
     ///
+    /// # Cancel safety
+    ///
     /// This method is cancellation safe in the sense that if it is used as the
     /// event in a [`select!`](crate::select) statement and some other branch
     /// completes first, then no connection events have been lost.
     ///
     /// [`ConnectNamedPipe`]: https://docs.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-connectnamedpipe
+    ///
+    /// # Example
     ///
     /// ```no_run
     /// use tokio::net::windows::named_pipe::ServerOptions;

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -824,6 +824,10 @@ impl<T: Clone> Receiver<T> {
     /// the channel. A subsequent call to [`recv`] will return this value
     /// **unless** it has been since overwritten.
     ///
+    /// This method is cancellation safe, so it is not possible to lose a
+    /// message when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// [`Receiver`]: crate::sync::broadcast::Receiver
     /// [`recv`]: crate::sync::broadcast::Receiver::recv
     ///

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -824,9 +824,12 @@ impl<T: Clone> Receiver<T> {
     /// the channel. A subsequent call to [`recv`] will return this value
     /// **unless** it has been since overwritten.
     ///
-    /// This method is cancellation safe, so it is not possible to lose a
-    /// message when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// channel.
     ///
     /// [`Receiver`]: crate::sync::broadcast::Receiver
     /// [`recv`]: crate::sync::broadcast::Receiver::recv

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -132,13 +132,14 @@ impl<T> Receiver<T> {
     /// further values can ever be received from this `Receiver`. The channel is
     /// closed when all senders have been dropped, or when [`close`] is called.
     ///
+    /// This method is cancellation safe, so it is not possible to lose messages
+    /// when using it as the event in a [`select!`](crate::select) statement.
+    ///
     /// If there are no messages in the channel's buffer, but the channel has
     /// not yet been closed, this method will sleep until a message is sent or
-    /// the channel is closed.
-    ///
-    /// Note that if [`close`] is called, but there are still outstanding
-    /// [`Permits`] from before it was closed, the channel is not considered
-    /// closed by `recv` until the permits are released.
+    /// the channel is closed.  Note that if [`close`] is called, but there are
+    /// still outstanding [`Permits`] from before it was closed, the channel is
+    /// not considered closed by `recv` until the permits are released.
     ///
     /// [`close`]: Self::close
     /// [`Permits`]: struct@crate::sync::mpsc::Permit

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -132,14 +132,18 @@ impl<T> Receiver<T> {
     /// further values can ever be received from this `Receiver`. The channel is
     /// closed when all senders have been dropped, or when [`close`] is called.
     ///
-    /// This method is cancellation safe, so it is not possible to lose messages
-    /// when using it as the event in a [`select!`](crate::select) statement.
-    ///
     /// If there are no messages in the channel's buffer, but the channel has
     /// not yet been closed, this method will sleep until a message is sent or
     /// the channel is closed.  Note that if [`close`] is called, but there are
     /// still outstanding [`Permits`] from before it was closed, the channel is
     /// not considered closed by `recv` until the permits are released.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// channel.
     ///
     /// [`close`]: Self::close
     /// [`Permits`]: struct@crate::sync::mpsc::Permit
@@ -336,6 +340,16 @@ impl<T> Sender<T> {
     /// [`close`]: Receiver::close
     /// [`Receiver`]: Receiver
     ///
+    /// # Cancel safety
+    ///
+    /// If `send` is used as the event in a [`tokio::select!`](crate::select)
+    /// statement and some other branch completes first, then it is guaranteed
+    /// that the message was not sent.
+    ///
+    /// This channel uses a queue to ensure that calls to `send` and `reserve`
+    /// complete in the order they were requested.  Cancelling a call to
+    /// `send` makes you lose your place in the queue.
+    ///
     /// # Examples
     ///
     /// In the following example, each call to `send` will block until the
@@ -376,6 +390,11 @@ impl<T> Sender<T> {
     ///
     /// This allows the producers to get notified when interest in the produced
     /// values is canceled and immediately stop doing work.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once the channel is closed, it stays closed
+    /// forever and all future calls to `closed` will return immediately.
     ///
     /// # Examples
     ///
@@ -618,6 +637,12 @@ impl<T> Sender<T> {
     /// [`Permit`]: Permit
     /// [`send`]: Permit::send
     ///
+    /// # Cancel safety
+    ///
+    /// This channel uses a queue to ensure that calls to `send` and `reserve`
+    /// complete in the order they were requested.  Cancelling a call to
+    /// `reserve` makes you lose your place in the queue.
+    ///
     /// # Examples
     ///
     /// ```
@@ -666,6 +691,12 @@ impl<T> Sender<T> {
     ///
     /// Dropping the [`OwnedPermit`] without sending a message releases the
     /// capacity back to the channel.
+    ///
+    /// # Cancel safety
+    ///
+    /// This channel uses a queue to ensure that calls to `send` and `reserve`
+    /// complete in the order they were requested.  Cancelling a call to
+    /// `reserve_owned` makes you lose your place in the queue.
     ///
     /// # Examples
     /// Sending a message using an [`OwnedPermit`]:

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -82,6 +82,9 @@ impl<T> UnboundedReceiver<T> {
     /// `None` is returned when all `Sender` halves have dropped, indicating
     /// that no further values can be sent on the channel.
     ///
+    /// This method is cancellation safe, so it is not possible to lose messages
+    /// when using it as the event in a [`select!`](crate::select) statement.
+    ///
     /// # Examples
     ///
     /// ```

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -82,8 +82,12 @@ impl<T> UnboundedReceiver<T> {
     /// `None` is returned when all `Sender` halves have dropped, indicating
     /// that no further values can be sent on the channel.
     ///
-    /// This method is cancellation safe, so it is not possible to lose messages
-    /// when using it as the event in a [`select!`](crate::select) statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If `recv` is used as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, it is guaranteed that no messages were received on this
+    /// channel.
     ///
     /// # Examples
     ///
@@ -244,6 +248,11 @@ impl<T> UnboundedSender<T> {
     /// This allows the producers to get notified when interest in the produced
     /// values is canceled and immediately stop doing work.
     ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once the channel is closed, it stays closed
+    /// forever and all future calls to `closed` will return immediately.
+    ///
     /// # Examples
     ///
     /// ```
@@ -273,6 +282,7 @@ impl<T> UnboundedSender<T> {
     pub async fn closed(&self) {
         self.chan.closed().await
     }
+
     /// Checks if the channel has been closed. This happens when the
     /// [`UnboundedReceiver`] is dropped, or when the
     /// [`UnboundedReceiver::close`] method is called.

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -277,9 +277,11 @@ impl<T: ?Sized> Mutex<T> {
     /// been acquired.  When the lock has been acquired, function returns a
     /// [`MutexGuard`].
     ///
+    /// # Cancel safety
+    ///
     /// This method uses a queue to fairly distribute locks in the order they
-    /// were requested. This means that the method is not cancellation safe, as
-    /// cancelling a call to `lock` makes you lose your place in the queue.
+    /// were requested. Cancelling a call to `lock` makes you lose your place in
+    /// the queue.
     ///
     /// # Examples
     ///
@@ -309,9 +311,11 @@ impl<T: ?Sized> Mutex<T> {
     /// method, and the guard will live for the `'static` lifetime, as it keeps
     /// the `Mutex` alive by holding an `Arc`.
     ///
+    /// # Cancel safety
+    ///
     /// This method uses a queue to fairly distribute locks in the order they
-    /// were requested. This means that the method is not cancellation safe, as
-    /// cancelling a call to `lock_owned` makes you lose your place in the queue.
+    /// were requested. Cancelling a call to `lock_owned` makes you lose your
+    /// place in the queue.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -273,9 +273,13 @@ impl<T: ?Sized> Mutex<T> {
         }
     }
 
-    /// Locks this mutex, causing the current task
-    /// to yield until the lock has been acquired.
-    /// When the lock has been acquired, function returns a [`MutexGuard`].
+    /// Locks this mutex, causing the current task to yield until the lock has
+    /// been acquired.  When the lock has been acquired, function returns a
+    /// [`MutexGuard`].
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. This means that the method is not cancellation safe, as
+    /// cancelling a call to `lock` makes you lose your place in the queue.
     ///
     /// # Examples
     ///
@@ -304,6 +308,10 @@ impl<T: ?Sized> Mutex<T> {
     /// it. Therefore, the `Mutex` must be wrapped in an `Arc` to call this
     /// method, and the guard will live for the `'static` lifetime, as it keeps
     /// the `Mutex` alive by holding an `Arc`.
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. This means that the method is not cancellation safe, as
+    /// cancelling a call to `lock_owned` makes you lose your place in the queue.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -246,6 +246,12 @@ impl Notify {
     ///
     /// [`notify_one()`]: Notify::notify_one
     ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute notifications in the order
+    /// they were requested. Cancelling a call to `notified` makes you lose your
+    /// place in the queue.
+    ///
     /// # Examples
     ///
     /// ```

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -299,6 +299,12 @@ impl<T: ?Sized> RwLock<T> {
     /// Returns an RAII guard which will drop this read access of the `RwLock`
     /// when dropped.
     ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. Cancelling a call to `read` makes you lose your place in
+    /// the queue.
+    ///
     /// # Examples
     ///
     /// ```
@@ -356,6 +362,12 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// Returns an RAII guard which will drop this read access of the `RwLock`
     /// when dropped.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. Cancelling a call to `read_owned` makes you lose your
+    /// place in the queue.
     ///
     /// # Examples
     ///
@@ -501,6 +513,12 @@ impl<T: ?Sized> RwLock<T> {
     /// Returns an RAII guard which will drop the write access of this `RwLock`
     /// when dropped.
     ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. Cancelling a call to `write` makes you lose your place
+    /// in the queue.
+    ///
     /// # Examples
     ///
     /// ```
@@ -542,6 +560,12 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// Returns an RAII guard which will drop the write access of this `RwLock`
     /// when dropped.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute locks in the order they
+    /// were requested. Cancelling a call to `write_owned` makes you lose your
+    /// place in the queue.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -162,9 +162,11 @@ impl Semaphore {
     /// Otherwise, this returns a [`SemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// # Cancel safety
+    ///
     /// This method uses a queue to fairly distribute permits in the order they
-    /// were requested. This means that the method is not cancellation safe, as
-    /// cancelling a call to `acquire` makes you lose your place in the queue.
+    /// were requested. Cancelling a call to `acquire` makes you lose your place
+    /// in the queue.
     ///
     /// # Examples
     ///
@@ -201,6 +203,12 @@ impl Semaphore {
     /// If the semaphore has been closed, this returns an [`AcquireError`].
     /// Otherwise, this returns a [`SemaphorePermit`] representing the
     /// acquired permits.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute permits in the order they
+    /// were requested. Cancelling a call to `acquire_many` makes you lose your
+    /// place in the queue.
     ///
     /// # Examples
     ///
@@ -306,6 +314,12 @@ impl Semaphore {
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute permits in the order they
+    /// were requested. Cancelling a call to `acquire_owned` makes you lose your
+    /// place in the queue.
+    ///
     /// # Examples
     ///
     /// ```
@@ -349,6 +363,12 @@ impl Semaphore {
     /// If the semaphore has been closed, this returns an [`AcquireError`].
     /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method uses a queue to fairly distribute permits in the order they
+    /// were requested. Cancelling a call to `acquire_many_owned` makes you lose
+    /// your place in the queue.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -162,6 +162,10 @@ impl Semaphore {
     /// Otherwise, this returns a [`SemaphorePermit`] representing the
     /// acquired permit.
     ///
+    /// This method uses a queue to fairly distribute permits in the order they
+    /// were requested. This means that the method is not cancellation safe, as
+    /// cancelling a call to `acquire` makes you lose your place in the queue.
+    ///
     /// # Examples
     ///
     /// ```

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -261,9 +261,12 @@ impl<T> Receiver<T> {
     ///
     /// This method returns an error if and only if the [`Sender`] is dropped.
     ///
-    /// This method is cancellation safe, so it is not possible to miss a change
-    /// notification when using it as the event in a [`select!`](crate::select)
-    /// statement.
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. If you use it as the event in a
+    /// [`tokio::select!`](crate::select) statement and some other branch
+    /// completes first, then it is guaranteed that no values have been marked
+    /// seen by this call to `changed`.
     ///
     /// [`Sender`]: struct@Sender
     ///
@@ -421,6 +424,11 @@ impl<T> Sender<T> {
     ///
     /// This allows the producer to get notified when interest in the produced
     /// values is canceled and immediately stop doing work.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. Once the channel is closed, it stays closed
+    /// forever and all future calls to `closed` will return immediately.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -261,6 +261,10 @@ impl<T> Receiver<T> {
     ///
     /// This method returns an error if and only if the [`Sender`] is dropped.
     ///
+    /// This method is cancellation safe, so it is not possible to miss a change
+    /// notification when using it as the event in a [`select!`](crate::select)
+    /// statement.
+    ///
     /// [`Sender`]: struct@Sender
     ///
     /// # Examples


### PR DESCRIPTION
This PR documents cancellation safety. It also moves the "Avoid racy `if` preconditions" section in the `select!` documentation since otherwise the first code block on the page shows how _not_ to use it, which seems counterintuitive.