### PR TITLE
chore: fix new clippy complaint

### DIFF
--- a/tokio-stream/src/stream_ext/collect.rs
+++ b/tokio-stream/src/stream_ext/collect.rs
@@ -113,7 +113,7 @@ impl<T: AsRef<str>> sealed::FromStreamPriv<T> for String {
     }
 
     fn finalize(_: sealed::Internal, collection: &mut String) -> String {
-        mem::replace(collection, String::new())
+        mem::take(collection)
     }
 }
 
@@ -132,7 +132,7 @@ impl<T> sealed::FromStreamPriv<T> for Vec<T> {
     }
 
     fn finalize(_: sealed::Internal, collection: &mut Vec<T>) -> Vec<T> {
-        mem::replace(collection, vec![])
+        mem::take(collection)
     }
 }
 


### PR DESCRIPTION
```text
warning: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> tokio-stream/src/stream_ext/collect.rs:116:9
    |
116 |         mem::replace(collection, String::new())
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(collection)`
    |
    = note: `#[warn(clippy::mem_replace_with_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default

warning: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> tokio-stream/src/stream_ext/collect.rs:135:9
    |
135 |         mem::replace(collection, vec![])
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(collection)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default
```