### PR TITLE
fs: document performance considerations

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -5,7 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -10,7 +10,7 @@
     unreachable_pub
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -4,7 +4,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -5,7 +5,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -13,9 +13,8 @@ use std::{io, path::Path};
 /// buffer based on the file size when available, so it is generally faster than
 /// reading into a vector created with `Vec::new()`.
 ///
-/// This operation is blocking. However, tokio runs it in a
-/// background thread pool dedicated to blocking operations, using
-/// [`spawn_blocking`].
+/// This operation is implemented by running the equivalent blocking operation
+/// on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`File::open`]: super::File::open
 /// [`read_to_end`]: crate::io::AsyncReadExt::read_to_end

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -15,11 +15,11 @@ use std::{io, path::Path};
 ///
 /// This operation is blocking. However, tokio runs it in a
 /// background thread pool dedicated to blocking operations, using
-/// [`block_in_place`].
+/// [`spawn_blocking`].
 ///
 /// [`File::open`]: super::File::open
 /// [`read_to_end`]: crate::io::AsyncReadExt::read_to_end
-/// [`block_in_place`]: crate::task::block_in_place
+/// [`spawn_blocking`]: crate::task::spawn_blocking
 ///
 /// # Errors
 ///

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -13,8 +13,13 @@ use std::{io, path::Path};
 /// buffer based on the file size when available, so it is generally faster than
 /// reading into a vector created with `Vec::new()`.
 ///
+/// This operation is blocking. However, tokio runs it in a
+/// background thread pool dedicated to blocking operations, using
+/// [`block_in_place`].
+///
 /// [`File::open`]: super::File::open
 /// [`read_to_end`]: crate::io::AsyncReadExt::read_to_end
+/// [`block_in_place`]: crate::task::block_in_place
 ///
 /// # Errors
 ///

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -14,9 +14,7 @@ use std::task::Poll;
 ///
 /// This is an async version of [`std::fs::read_dir`](std::fs::read_dir)
 ///
-/// This operation is blocking. However, tokio runs it in a
-/// background thread pool dedicated to blocking operations, using
-/// [`spawn_blocking`].
+/// This operation is implemented by running the equivalent blocking operation on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
 

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -13,6 +13,13 @@ use std::task::Poll;
 /// Returns a stream over the entries within a directory.
 ///
 /// This is an async version of [`std::fs::read_dir`](std::fs::read_dir)
+///
+/// This operation is blocking. However, tokio runs it in a
+/// background thread pool dedicated to blocking operations, using
+/// [`block_in_place`].
+///
+/// [`block_in_place`]: crate::task::block_in_place
+
 pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
     let path = path.as_ref().to_owned();
     let std = asyncify(|| std::fs::read_dir(path)).await?;

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -14,7 +14,8 @@ use std::task::Poll;
 ///
 /// This is an async version of [`std::fs::read_dir`](std::fs::read_dir)
 ///
-/// This operation is implemented by running the equivalent blocking operation on a separate thread pool using [`spawn_blocking`].
+/// This operation is implemented by running the equivalent blocking
+/// operation on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
 

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -16,9 +16,9 @@ use std::task::Poll;
 ///
 /// This operation is blocking. However, tokio runs it in a
 /// background thread pool dedicated to blocking operations, using
-/// [`block_in_place`].
+/// [`spawn_blocking`].
 ///
-/// [`block_in_place`]: crate::task::block_in_place
+/// [`spawn_blocking`]: crate::task::spawn_blocking
 
 pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
     let path = path.as_ref().to_owned();

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -18,7 +18,6 @@ use std::task::Poll;
 /// operation on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
-
 pub async fn read_dir(path: impl AsRef<Path>) -> io::Result<ReadDir> {
     let path = path.as_ref().to_owned();
     let std = asyncify(|| std::fs::read_dir(path)).await?;

--- a/tokio/src/fs/read_to_string.rs
+++ b/tokio/src/fs/read_to_string.rs
@@ -7,6 +7,11 @@ use std::{io, path::Path};
 ///
 /// This is the async equivalent of [`std::fs::read_to_string`][std].
 ///
+/// This operation is blocking. However, tokio runs it in a
+/// background thread pool dedicated to blocking operations, using
+/// [`block_in_place`].
+///
+/// [`block_in_place`]: crate::task::block_in_place
 /// [std]: fn@std::fs::read_to_string
 ///
 /// # Examples

--- a/tokio/src/fs/read_to_string.rs
+++ b/tokio/src/fs/read_to_string.rs
@@ -7,9 +7,8 @@ use std::{io, path::Path};
 ///
 /// This is the async equivalent of [`std::fs::read_to_string`][std].
 ///
-/// This operation is blocking. However, tokio runs it in a
-/// background thread pool dedicated to blocking operations, using
-/// [`spawn_blocking`].
+/// This operation is implemented by running the equivalent blocking operation
+/// on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
 /// [std]: fn@std::fs::read_to_string

--- a/tokio/src/fs/read_to_string.rs
+++ b/tokio/src/fs/read_to_string.rs
@@ -9,9 +9,9 @@ use std::{io, path::Path};
 ///
 /// This operation is blocking. However, tokio runs it in a
 /// background thread pool dedicated to blocking operations, using
-/// [`block_in_place`].
+/// [`spawn_blocking`].
 ///
-/// [`block_in_place`]: crate::task::block_in_place
+/// [`spawn_blocking`]: crate::task::spawn_blocking
 /// [std]: fn@std::fs::read_to_string
 ///
 /// # Examples

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -9,9 +9,9 @@ use std::{io, path::Path};
 ///
 /// This operation is blocking. However, tokio runs it in a
 /// background thread pool dedicated to blocking operations, using
-/// [`block_in_place`].
+/// [`spawn_blocking`].
 ///
-/// [`block_in_place`]: crate::task::block_in_place
+/// [`spawn_blocking`]: crate::task::spawn_blocking
 
 ///
 /// [std]: fn@std::fs::write

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -7,6 +7,13 @@ use std::{io, path::Path};
 ///
 /// This is the async equivalent of [`std::fs::write`][std].
 ///
+/// This operation is blocking. However, tokio runs it in a
+/// background thread pool dedicated to blocking operations, using
+/// [`block_in_place`].
+///
+/// [`block_in_place`]: crate::task::block_in_place
+
+///
 /// [std]: fn@std::fs::write
 ///
 /// # Examples

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -11,8 +11,6 @@ use std::{io, path::Path};
 /// on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
-
-///
 /// [std]: fn@std::fs::write
 ///
 /// # Examples

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -7,9 +7,8 @@ use std::{io, path::Path};
 ///
 /// This is the async equivalent of [`std::fs::write`][std].
 ///
-/// This operation is blocking. However, tokio runs it in a
-/// background thread pool dedicated to blocking operations, using
-/// [`spawn_blocking`].
+/// This operation is implemented by running the equivalent blocking operation
+/// on a separate thread pool using [`spawn_blocking`].
 ///
 /// [`spawn_blocking`]: crate::task::spawn_blocking
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -10,7 +10,7 @@
     unreachable_pub
 )]
 #![deny(unused_must_use)]
-#![cfg_attr(docsrs, deny(broken_intra_doc_links))]
+#![cfg_attr(docsrs, deny(rustdoc::broken_intra_doc_links))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))


### PR DESCRIPTION
Add a note on some functoins/methods that belong to `fs`
to let the user  note that they are blocking, and
handled by spawn_blocking.

Ref: #2700

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
