### PR TITLE
tokio-macros: compat with clippy::unwrap_used

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -206,7 +206,12 @@ fn parse_knobs(
                     let msg = "Must have specified ident";
                     return Err(syn::Error::new_spanned(namevalue, msg));
                 }
-                match ident.unwrap().to_string().to_lowercase().as_str() {
+                match ident
+                    .expect("Must have specified ident")
+                    .to_string()
+                    .to_lowercase()
+                    .as_str()
+                {
                     "worker_threads" => {
                         config.set_worker_threads(
                             namevalue.lit.clone(),
@@ -244,7 +249,10 @@ fn parse_knobs(
                     let msg = "Must have specified ident";
                     return Err(syn::Error::new_spanned(path, msg));
                 }
-                let name = ident.unwrap().to_string().to_lowercase();
+                let name = ident
+                    .expect("Must have specified ident")
+                    .to_string()
+                    .to_lowercase();
                 let msg = match name.as_str() {
                     "threaded_scheduler" | "multi_thread" => {
                         format!(
@@ -326,11 +334,11 @@ fn parse_knobs(
             #rt
                 .enable_all()
                 .build()
-                .unwrap()
+                .expect("Failed building the Runtime")
                 .block_on(async #body)
         }
     })
-    .unwrap();
+    .expect("Parsing failure");
     input.block.brace_token = brace_token;
 
     let result = quote! {

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -201,12 +201,14 @@ fn parse_knobs(
     for arg in args {
         match arg {
             syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
-                let ident = if let Some(ident) = namevalue.path.get_ident() {
-                    ident.to_string().to_lowercase()
-                } else {
-                    let msg = "Must have specified ident";
-                    return Err(syn::Error::new_spanned(namevalue, msg));
-                };
+                let ident = namevalue
+                    .path
+                    .get_ident()
+                    .ok_or_else(|| {
+                        syn::Error::new_spanned(&namevalue, "Must have specified ident")
+                    })?
+                    .to_string()
+                    .to_lowercase();
                 match ident.as_str() {
                     "worker_threads" => {
                         config.set_worker_threads(
@@ -240,13 +242,9 @@ fn parse_knobs(
                 }
             }
             syn::NestedMeta::Meta(syn::Meta::Path(path)) => {
-                let ident = path.get_ident();
-                if ident.is_none() {
-                    let msg = "Must have specified ident";
-                    return Err(syn::Error::new_spanned(path, msg));
-                }
-                let name = ident
-                    .expect("Must have specified ident")
+                let name = path
+                    .get_ident()
+                    .ok_or_else(|| syn::Error::new_spanned(&path, "Must have specified ident"))?
                     .to_string()
                     .to_lowercase();
                 let msg = match name.as_str() {

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -201,17 +201,13 @@ fn parse_knobs(
     for arg in args {
         match arg {
             syn::NestedMeta::Meta(syn::Meta::NameValue(namevalue)) => {
-                let ident = namevalue.path.get_ident();
-                if ident.is_none() {
+                let ident = if let Some(ident) = namevalue.path.get_ident() {
+                    ident.to_string().to_lowercase()
+                } else {
                     let msg = "Must have specified ident";
                     return Err(syn::Error::new_spanned(namevalue, msg));
-                }
-                match ident
-                    .expect("Must have specified ident")
-                    .to_string()
-                    .to_lowercase()
-                    .as_str()
-                {
+                };
+                match ident.as_str() {
                     "worker_threads" => {
                         config.set_worker_threads(
                             namevalue.lit.clone(),


### PR DESCRIPTION
Up until now there were a few places on the code where
both the macros tokio::test and tokio::main were unwrapping.

This patch changes .unwrap() for .expect(), to be compatible with
clippy::unwrap_used

Ref: #3887

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
