### PR TITLE
Mutex guard lock ref recovery methods

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -622,6 +622,35 @@ impl<T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'_, T> {
 
 // === impl OwnedMutexGuard ===
 
+impl<T: ?Sized> OwnedMutexGuard<T> {
+    /// Returns a reference to the original `Arc<Mutex>`.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{Mutex, OwnedMutexGuard};
+    ///
+    /// async fn unlock_and_relock(guard: OwnedMutexGuard<u32>) -> OwnedMutexGuard<u32> {
+    ///     println!("1. contains: {:?}", *guard);
+    ///     let mutex: Arc<Mutex<u32>> = OwnedMutexGuard::mutex(&guard).clone();
+    ///     drop(guard);
+    ///     let guard = mutex.lock_owned().await;
+    ///     println!("2. contains: {:?}", *guard);
+    ///     guard
+    /// }
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #     let mutex = Arc::new(Mutex::new(0u32));
+    /// #     let guard = mutex.lock_owned().await;
+    /// #     unlock_and_relock(guard).await;
+    /// # }
+    /// ```
+    #[inline]
+    pub fn mutex(this: &Self) -> &Arc<Mutex<T>> {
+        &this.lock
+    }
+}
+
 impl<T: ?Sized> Drop for OwnedMutexGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(1)

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -561,6 +561,32 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             marker: marker::PhantomData,
         })
     }
+
+    /// Returns a reference to the original `Mutex`.
+    ///
+    /// ```
+    /// use tokio::sync::{Mutex, MutexGuard};
+    ///
+    /// async fn unlock_and_relock<'l>(guard: MutexGuard<'l, u32>) -> MutexGuard<'l, u32> {
+    ///     println!("1. contains: {:?}", *guard);
+    ///     let mutex = MutexGuard::mutex(&guard);
+    ///     drop(guard);
+    ///     let guard = mutex.lock().await;
+    ///     println!("2. contains: {:?}", *guard);
+    ///     guard
+    /// }
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #     let mutex = Mutex::new(0u32);
+    /// #     let guard = mutex.lock().await;
+    /// #     unlock_and_relock(guard).await;
+    /// # }
+    /// ```
+    #[inline]
+    pub fn mutex(this: &Self) -> &'a Mutex<T> {
+        this.lock
+    }
 }
 
 impl<T: ?Sized> Drop for MutexGuard<'_, T> {


### PR DESCRIPTION
## Motivation

There are various situations where it is useful to be able to recover `&Mutex` from a `MutexGuard`.  One of them is condition variables (see #3892 and my new [async-condvar-fair](https://crates.io/crates/async-condvar-fair) crate) but there are other possibilities.

## Solution

Broadly, for the applicable guard types, and where possible:
```
impl Guard<'l, T> {
    pub fn mutex(this: &Self) -> &'l Mutex<T> { self.lock }
}
```
(Mutatis mutandis for the various mutex types - varies eg for `Owned` and `RwLock`.)

In #3741 a method was proposed to *convert* the guard into the mutex reference.  Obtaining a borrow is strictly more general, and is what is implemented in `parking_lot` and `smol` for their mutex types.

## Open questions

 * Are these the best names?  `parking_lot` uses `fn mutex()` for its mutex type but does not provide these facilities for its rwlocks.  `smol` uses <strike>`lock()`</strike> `source()` which is more general, leading to less variation between `Mutex` and `RwLock`.

 * <strike>Was I right to use `#[tokio::main] async fn main(){...}` for my doctests?  The contribution guide suggests something involving `block_on` but the other tests in `mutex.rs` used `#[tokio::main]` so I chose that.</strike>

 * <strike>I wasn't sure whether to `#` out the `use`s at the top of the doctests.  I find them noisy here - in this particular case the intended types are extremely obvious.</strike>

 * <strike>I have skipped `RwLockReadGuard` and `RwLockWriteGuard`.  This is not because I think they wouldn't be useful, but those structs contain references to pieces of the rwlock, not the whole rwlock, and I wasn't sure how to recover a suitable reference (or whether that's even possible).</strike>  The (straightforward portions of) the corresponding feature for `RwLock` is now #3930.