### PR TITLE
RwLock guard lock ref recovery methods, owned guards

### DIFF
--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -113,6 +113,33 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
             _p: PhantomData,
         })
     }
+
+    /// Returns a reference to the original `Arc<RwLock>`.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{OwnedRwLockReadGuard, RwLock};
+    ///
+    /// async fn unlock_and_relock(guard: OwnedRwLockReadGuard<u32>) -> OwnedRwLockReadGuard<u32> {
+    ///     println!("1. contains: {:?}", *guard);
+    ///     let mutex: Arc<RwLock<u32>> = OwnedRwLockReadGuard::rwlock(&guard).clone();
+    ///     drop(guard);
+    ///     let guard = mutex.read_owned().await;
+    ///     println!("2. contains: {:?}", *guard);
+    ///     guard
+    /// }
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #     let rwlock = Arc::new(RwLock::new(0u32));
+    /// #     let guard = rwlock.read_owned().await;
+    /// #     unlock_and_relock(guard).await;
+    /// # }
+    /// ```
+    #[inline]
+    pub fn rwlock(this: &Self) -> &Arc<RwLock<T>> {
+        &this.lock
+    }
 }
 
 impl<T: ?Sized, U: ?Sized> ops::Deref for OwnedRwLockReadGuard<T, U> {

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -192,6 +192,33 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             _p: PhantomData,
         }
     }
+
+    /// Returns a reference to the original `Arc<RwLock>`.
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{OwnedRwLockWriteGuard, RwLock};
+    ///
+    /// async fn unlock_and_relock(guard: OwnedRwLockWriteGuard<u32>) -> OwnedRwLockWriteGuard<u32> {
+    ///     println!("1. contains: {:?}", *guard);
+    ///     let mutex: Arc<RwLock<u32>> = OwnedRwLockWriteGuard::rwlock(&guard).clone();
+    ///     drop(guard);
+    ///     let guard = mutex.write_owned().await;
+    ///     println!("2. contains: {:?}", *guard);
+    ///     guard
+    /// }
+    /// #
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// #     let rwlock = Arc::new(RwLock::new(0u32));
+    /// #     let guard = rwlock.write_owned().await;
+    /// #     unlock_and_relock(guard).await;
+    /// # }
+    /// ```
+    #[inline]
+    pub fn rwlock(this: &Self) -> &Arc<RwLock<T>> {
+        &this.lock
+    }
 }
 
 impl<T: ?Sized> ops::Deref for OwnedRwLockWriteGuard<T> {


### PR DESCRIPTION
Split off from #3928 which is (now) the same thing just for `Mutex`.

### Open questions:

 * Are these the best names?  `parking_lot` uses `fn mutex()` for its mutex type but does not provide these facilities for its rwlocks.  `smol` uses `source()` which is more general, leading to less variation between `Mutex` and `RwLock`.

 * Currently these methods are only provided here for the owned forms of the guards, which is suboptimal as noted in https://github.com/tokio-rs/tokio/pull/3928#issuecomment-874540719 .  However, providing them for the non-owned forms is not entirely straighrforward: https://github.com/tokio-rs/tokio/pull/3928#issuecomment-874706729