### PR TITLE
Update Nix to 0.22.0

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -109,7 +109,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.42" }
-nix = { version = "0.19.0" }
+nix = { version = "0.22.0" }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"


### PR DESCRIPTION
In this version, io::Error implements From<nix::Error>

## Motivation

To simplify existing test code.

## Solution

Update Nix and adapt the tests.