### PR TITLE
Fix the uds_datagram tests with the latest nightly stdlib

### DIFF
--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -88,8 +88,14 @@ async fn try_send_recv_never_block() -> io::Result<()> {
 
         match dgram1.try_send(payload) {
             Err(err) => match err.kind() {
-                io::ErrorKind::WouldBlock | io::ErrorKind::Other => break,
-                _ => unreachable!("unexpected error {:?}", err),
+                io::ErrorKind::WouldBlock => break,
+                _ => {
+                    let errno = err.raw_os_error().expect("Not an errno?");
+                    if errno == libc::ENOBUFS {
+                        break;
+                    }
+                    unreachable!("unexpected error {:?}", err);
+                }
             },
             Ok(len) => {
                 assert_eq!(len, payload.len());
@@ -292,8 +298,14 @@ async fn try_recv_buf_never_block() -> io::Result<()> {
 
         match dgram1.try_send(payload) {
             Err(err) => match err.kind() {
-                io::ErrorKind::WouldBlock | io::ErrorKind::Other => break,
-                _ => unreachable!("unexpected error {:?}", err),
+                io::ErrorKind::WouldBlock => break,
+                _ => {
+                    let errno = err.raw_os_error().expect("Not an errno?");
+                    if errno == libc::ENOBUFS {
+                        break;
+                    }
+                    unreachable!("unexpected error {:?}", err);
+                }
             },
             Ok(len) => {
                 assert_eq!(len, payload.len());

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -87,14 +87,11 @@ async fn try_send_recv_never_block() -> io::Result<()> {
         dgram1.writable().await.unwrap();
 
         match dgram1.try_send(payload) {
-            Err(err) => match err.kind() {
-                io::ErrorKind::WouldBlock => break,
+            Err(err) => match (err.kind(), err.raw_os_error()) {
+                (io::ErrorKind::WouldBlock, _) => break,
+                (_, Some(libc::ENOBUFS)) => break,
                 _ => {
-                    let errno = err.raw_os_error().expect("Not an errno?");
-                    if errno == libc::ENOBUFS {
-                        break;
-                    }
-                    unreachable!("unexpected error {:?}", err);
+                    panic!("unexpected error {:?}", err);
                 }
             },
             Ok(len) => {
@@ -297,14 +294,11 @@ async fn try_recv_buf_never_block() -> io::Result<()> {
         dgram1.writable().await.unwrap();
 
         match dgram1.try_send(payload) {
-            Err(err) => match err.kind() {
-                io::ErrorKind::WouldBlock => break,
+            Err(err) => match (err.kind(), err.raw_os_error()) {
+                (io::ErrorKind::WouldBlock, _) => break,
+                (_, Some(libc::ENOBUFS)) => break,
                 _ => {
-                    let errno = err.raw_os_error().expect("Not an errno?");
-                    if errno == libc::ENOBUFS {
-                        break;
-                    }
-                    unreachable!("unexpected error {:?}", err);
+                    panic!("unexpected error {:?}", err);
                 }
             },
             Ok(len) => {


### PR DESCRIPTION
io::ErrorKind just replaced most uses of "Other" with "Uncategorized"
and prohibits users from matching on "Uncategorized".  So match on the
errno instead.

https://github.com/rust-lang/rust/pull/85746

## Motivation

Fix tests on the latest nightly stdlib

## Solution

Don't match io::Error::Errorkind to Other or Uncategorized.