### PR TITLE
Remove mutex in JoinError

### DIFF
--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -21,6 +21,9 @@ cfg_rt! {
     mod wake;
     pub(crate) use wake::WakerRef;
     pub(crate) use wake::{waker_ref, Wake};
+
+    mod sync_wrapper;
+    pub(crate) use sync_wrapper::SyncWrapper;
 }
 
 cfg_rt_multi_thread! {

--- a/tokio/src/util/sync_wrapper.rs
+++ b/tokio/src/util/sync_wrapper.rs
@@ -17,9 +17,7 @@ unsafe impl<T> Sync for SyncWrapper<T> {}
 
 impl<T> SyncWrapper<T> {
     pub(crate) fn new(value: T) -> Self {
-        Self {
-            value,
-        }
+        Self { value }
     }
 
     pub(crate) fn into_inner(self) -> T {

--- a/tokio/src/util/sync_wrapper.rs
+++ b/tokio/src/util/sync_wrapper.rs
@@ -1,0 +1,28 @@
+//! This module contains a type that can make `Send + !Sync` types `Sync` by
+//! disallowing all immutable access to the value.
+//!
+//! A similar primitive is provided in the `sync_wrapper` crate.
+
+pub(crate) struct SyncWrapper<T> {
+    value: T,
+}
+
+// safety: The SyncWrapper being send allows you to send the inner value across
+// thread boundaries.
+unsafe impl<T: Send> Send for SyncWrapper<T> {}
+
+// safety: An immutable reference to a SyncWrapper is useless, so moving such an
+// immutable reference across threads is safe.
+unsafe impl<T> Sync for SyncWrapper<T> {}
+
+impl<T> SyncWrapper<T> {
+    pub(crate) fn new(value: T) -> Self {
+        Self {
+            value,
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> T {
+        self.value
+    }
+}

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -452,6 +452,7 @@ assert_value!(tokio::task::LocalSet: !Send & !Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<YY>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<YN>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<NN>: !Send & !Sync & Unpin);
+assert_value!(tokio::task::JoinError: Send & Sync & Unpin);
 
 assert_value!(tokio::runtime::Builder: Send & Sync & Unpin);
 assert_value!(tokio::runtime::EnterGuard<'_>: Send & Sync & Unpin);


### PR DESCRIPTION
This PR removes a mutex from the `JoinError` type. The mutex was originally added in #1888 to make the `JoinError` type `Sync`, but we can achieve the same with the technique outlined in [`sync_wrapper`](https://crates.io/crates/sync_wrapper).