### PR TITLE
Fix case where cancelled future would be leaked and add a regression …

### DIFF
--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -420,7 +420,7 @@ fn poll_future<T: Future>(
     cx: Context<'_>,
 ) -> PollFuture<T::Output> {
     if snapshot.is_cancelled() {
-        PollFuture::Complete(Err(JoinError::cancelled()), snapshot.is_join_interested())
+        PollFuture::Complete(Err(cancel_task(core)), snapshot.is_join_interested())
     } else {
         let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
             struct Guard<'a, T: Future> {


### PR DESCRIPTION
…test.

Fixes #3964 

~~I have no idea if this is the correct fix as I don't really understand the design behind this code. EIther way, the comment here "The future has already been dropped" seems to be inaccurate.~~

edit:
Updated based on feedback from @Darksonn - pretty sure this is the correct fix now.