### PR TITLE
Add #[cfg(...)] for select!

### DIFF
--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -547,3 +547,24 @@ pub async fn default_numeric_fallback() {
         else => (),
     }
 }
+
+#[tokio::test]
+async fn select_cfg_true() {
+    let foo = tokio::select! {
+        #[cfg(all())]
+        _ = async {} => true,
+    };
+
+    assert!(foo);
+}
+
+#[tokio::test]
+async fn select_cfg_false() {
+    let foo = tokio::select! {
+        #[cfg(any())]
+        _ = nani() => nani(),
+        _ = one() => true,
+    };
+
+    assert!(foo);
+}

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -562,7 +562,7 @@ async fn select_cfg_true() {
 async fn select_cfg_false() {
     let foo = tokio::select! {
         #[cfg(any())]
-        _ = nani() => nani(),
+        _ = this_function_does_not_exist() => this_function_does_not_exist(),
         _ = one() => true,
     };
 


### PR DESCRIPTION
Fix #3974

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Allow conditional compilation in `select!`

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Parse in `#[cfg($meta:meta)]` in the macro, not sure if we need to do the same for `cfg_attr`.

Currently it fails with recursion limit, not sure if to fix that.

```
error: recursion limit reached while expanding `$crate::select!`
   --> tokio/tests/macros_select.rs:487:15
    |
487 |       let foo = tokio::select! {
    |  _______________^
488 | |         foo = one() => foo,
489 | |         #[cfg(any())]
490 | |         _ = nani() => foo,
491 | |     };
    | |_____^
    |
    = help: consider adding a `#![recursion_limit="256"]` attribute to your crate (`macros_select`)
    = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```