### PR TITLE
task: elaborate on queue behavior of spawn_blocking

### DIFF
--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -89,13 +89,14 @@ cfg_rt! {
     ///
     /// Tokio will spawn more blocking threads when they are requested through this
     /// function until the upper limit configured on the [`Builder`] is reached.
-    /// This limit is very large by default, because `spawn_blocking` is often used
-    /// for various kinds of IO operations that cannot be performed asynchronously.
-    /// When you run CPU-bound code using `spawn_blocking`, you should keep this
-    /// large upper limit in mind. When running many CPU-bound computations, a
-    /// semaphore or some other synchronization primitive should be used to limit
-    /// the number of computation executed in parallel. Specialized CPU-bound
-    /// executors, such as [rayon], may also be a good fit.
+    /// After reaching the upper limit, the tasks are put in a queue.
+    /// The thread limit is very large by default, because `spawn_blocking` is often
+    /// used for various kinds of IO operations that cannot be performed
+    /// asynchronously.  When you run CPU-bound code using `spawn_blocking`, you
+    /// should keep this large upper limit in mind. When running many CPU-bound
+    /// computations, a semaphore or some other synchronization primitive should be
+    /// used to limit the number of computation executed in parallel. Specialized
+    /// CPU-bound executors, such as [rayon], may also be a good fit.
     ///
     /// This function is intended for non-async operations that eventually finish on
     /// their own. If you want to spawn an ordinary thread, you should use


### PR DESCRIPTION
The documentation of `spawn_blocking` does not say what happens when the upper thread limit is reached. This PR adds a line that says that tasks are put in a queue.