### PR TITLE
process: add arg0 method to Command

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -573,6 +573,20 @@ impl Command {
         self
     }
 
+    /// Set executable argument
+    ///
+    /// Set the first process argument, `argv[0]`, to something other than the
+    /// default executable path.
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    pub fn arg0<S>(&mut self, arg: S) -> &mut Command
+    where
+        S: AsRef<OsStr>,
+    {
+        self.std.arg0(arg);
+        self
+    }
+
     /// Schedules a closure to be run just before the `exec` function is
     /// invoked.
     ///

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -551,6 +551,7 @@ impl Command {
     ///
     /// [1]: https://msdn.microsoft.com/en-us/library/windows/desktop/ms684863(v=vs.85).aspx
     #[cfg(windows)]
+    #[cfg_attr(docsrs, doc(cfg(windows)))]
     pub fn creation_flags(&mut self, flags: u32) -> &mut Command {
         self.std.creation_flags(flags);
         self
@@ -560,6 +561,7 @@ impl Command {
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
     #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn uid(&mut self, id: u32) -> &mut Command {
         self.std.uid(id);
         self
@@ -568,6 +570,7 @@ impl Command {
     /// Similar to `uid` but sets the group ID of the child process. This has
     /// the same semantics as the `uid` field.
     #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn gid(&mut self, id: u32) -> &mut Command {
         self.std.gid(id);
         self
@@ -617,6 +620,7 @@ impl Command {
     /// working directory have successfully been changed, so output to these
     /// locations may not appear where intended.
     #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub unsafe fn pre_exec<F>(&mut self, f: F) -> &mut Command
     where
         F: FnMut() -> io::Result<()> + Send + Sync + 'static,

--- a/tokio/tests/process_arg0.rs
+++ b/tokio/tests/process_arg0.rs
@@ -1,0 +1,13 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", unix))]
+
+use tokio::process::Command;
+
+#[tokio::test]
+async fn arg0() {
+    let mut cmd = Command::new("sh");
+    cmd.arg0("test_string").arg("-c").arg("echo $0");
+
+    let output = cmd.output().await.unwrap();
+    assert_eq!(output.stdout, b"test_string\n");
+}


### PR DESCRIPTION
## Motivation
Currently, there is no way to set the `arg0` parameter in the `Command` struct.

## Solution
Therefore, the `arg0` method of the `Process` struct is exposed by `Command`. 