### PR TITLE
io: document cancellation safety of AsyncBufReadExt

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -56,7 +56,7 @@ enum State {
 impl ReadDir {
     /// Returns the next entry in the directory stream.
     ///
-    /// # Cancellation safety
+    /// # Cancel safety
     ///
     /// This method is cancellation safe.
     pub async fn next_entry(&mut self) -> io::Result<Option<DirEntry>> {

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -55,6 +55,10 @@ enum State {
 
 impl ReadDir {
     /// Returns the next entry in the directory stream.
+    ///
+    /// # Cancellation safety
+    ///
+    /// This method is cancellation safe.
     pub async fn next_entry(&mut self) -> io::Result<Option<DirEntry>> {
         use crate::future::poll_fn;
         poll_fn(|cx| self.poll_next_entry(cx)).await

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -47,6 +47,10 @@ where
 {
     /// Returns the next line in the stream.
     ///
+    /// # Cancellation safety
+    ///
+    /// This method is cancellation safe.
+    ///
     /// # Examples
     ///
     /// ```
@@ -102,11 +106,9 @@ where
     ///
     /// When the method returns `Poll::Pending`, the `Waker` in the provided
     /// `Context` is scheduled to receive a wakeup when more bytes become
-    /// available on the underlying IO resource.
-    ///
-    /// Note that on multiple calls to `poll_next_line`, only the `Waker` from
-    /// the `Context` passed to the most recent call is scheduled to receive a
-    /// wakeup.
+    /// available on the underlying IO resource.  Note that on multiple calls to
+    /// `poll_next_line`, only the `Waker` from the `Context` passed to the most
+    /// recent call is scheduled to receive a wakeup.
     pub fn poll_next_line(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -47,7 +47,7 @@ where
 {
     /// Returns the next line in the stream.
     ///
-    /// # Cancellation safety
+    /// # Cancel safety
     ///
     /// This method is cancellation safe.
     ///


### PR DESCRIPTION
This PR documents cancellation safety of the methods on `AsyncBufReadExt` and related methods on various structs.