### PR TITLE
process: implement `raw_handle` getter on Child (#3987)

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -199,6 +199,8 @@ use std::io;
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 #[cfg(windows)]
+use std::os::windows::io::{AsRawHandle, RawHandle};
+#[cfg(windows)]
 use std::os::windows::process::CommandExt;
 use std::path::Path;
 use std::pin::Pin;
@@ -948,6 +950,16 @@ impl Child {
     pub fn id(&self) -> Option<u32> {
         match &self.child {
             FusedChild::Child(child) => Some(child.inner.id()),
+            FusedChild::Done(_) => None,
+        }
+    }
+
+    /// Extracts the raw handle of the process associated with this child while
+    /// it is still running. Returns `None` if the child has exited.
+    #[cfg(windows)]
+    pub fn raw_handle(&self) -> Option<RawHandle> {
+        match &self.child {
+            FusedChild::Child(c) => Some(c.inner.as_raw_handle()),
             FusedChild::Done(_) => None,
         }
     }

--- a/tokio/src/process/windows.rs
+++ b/tokio/src/process/windows.rs
@@ -24,7 +24,7 @@ use mio::windows::NamedPipe;
 use std::fmt;
 use std::future::Future;
 use std::io;
-use std::os::windows::prelude::{AsRawHandle, FromRawHandle, IntoRawHandle};
+use std::os::windows::prelude::{AsRawHandle, FromRawHandle, IntoRawHandle, RawHandle};
 use std::pin::Pin;
 use std::process::Stdio;
 use std::process::{Child as StdChild, Command as StdCommand, ExitStatus};
@@ -141,6 +141,12 @@ impl Future for Child {
                 tx: ptr,
             });
         }
+    }
+}
+
+impl AsRawHandle for Child {
+    fn as_raw_handle(&self) -> RawHandle {
+        self.child.as_raw_handle()
     }
 }
 

--- a/tokio/tests/process_raw_handle.rs
+++ b/tokio/tests/process_raw_handle.rs
@@ -1,0 +1,23 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(windows)]
+
+use tokio::process::Command;
+use winapi::um::processthreadsapi::GetProcessId;
+
+#[tokio::test]
+async fn obtain_raw_handle() {
+    let mut cmd = Command::new("cmd");
+    cmd.kill_on_drop(true);
+    cmd.arg("/c");
+    cmd.arg("pause");
+
+    let child = cmd.spawn().unwrap();
+
+    let orig_id = child.id().expect("missing id");
+    assert!(orig_id > 0);
+
+    let handle = child.raw_handle().expect("process stopped");
+    let handled_id = unsafe { GetProcessId(handle as _) };
+    assert_eq!(handled_id, orig_id);
+}


### PR DESCRIPTION
Implementation of #3987. /ping @ipetkov 

Notes from discussion in issue:

- The process id returned by `Child.id()` is not the Windows handle.
- It _is_ possible to obtain a Handle from a PID, but it is without many access privileges that the handle obtained by spawning the child process has.
- Windows process handles do not suffer from the PID problem where a stale PID can be recycled:

> When a new process is created by the `CreateProcess` function, handles of the new process and its primary thread are returned. These handles are created with full access rights, and — subject to security access checking — can be used in any of the functions that accept thread or process handles. These handles can be inherited by child processes, depending on the inheritance flag specified when they are created. **The handles are valid until closed, even after the process or thread they represent has been terminated.**
> — https://docs.microsoft.com/en-us/windows/win32/procthread/process-handles-and-identifiers
> (emphasis mine)

Thus, it should be possible to implement the [`AsRawHandle`](https://doc.rust-lang.org/std/os/windows/io/trait.AsRawHandle.html) trait from std, with the signature:

```rust
fn as_raw_handle(&self) -> RawHandle
```

---

Implementation notes:

- I implemented `AsRawHandle` on both `imp::Child` ~~and the "public" `Child`~~: the latter delegates to the former.
- Despite the discussion above, there is no way to obtain the raw handle after the child has exited, due to the `FusedChild` design: once the process has exited, all that remains is `FusedChild::Done(ExitStatus)` — while the underlying std `Child` instance could very well be queried for the raw handle safely, it's gone.
- I am unsure what to do:
  * `Child.as_raw_handle()` panics if `FusedChild` is `Done`, or
  * Write a `fn as_raw_handle(&self) -> Option<RawHandle>` instead, or
  * Change how `FusedChild` works.