### PR TITLE
Fix copy buffered write

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -58,8 +58,8 @@ impl CopyBuffer {
 
                 match reader.as_mut().poll_read(cx, &mut buf) {
                     Poll::Ready(Ok(_)) => (),
-                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err.into())),
-                    Poll::Pending =>  {
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                    Poll::Pending => {
                         // Try flushing when the reader has no progress to avoid deadlock
                         // when the reader depends on buffered writer.
                         if let FlushState::Need = self.flush_state {

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -2,9 +2,9 @@
 #![cfg(feature = "full")]
 
 use bytes::BytesMut;
-use tokio::io::{self, AsyncRead, ReadBuf, AsyncWrite, AsyncReadExt, AsyncWriteExt};
-use tokio_test::assert_ok;
 use futures::ready;
+use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+use tokio_test::assert_ok;
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -41,7 +41,7 @@ async fn copy() {
 async fn proxy() {
     struct BufferedWd {
         buf: BytesMut,
-        writer: io::DuplexStream
+        writer: io::DuplexStream,
     }
 
     impl AsyncWrite for BufferedWd {
@@ -74,7 +74,7 @@ async fn proxy() {
     let mut rd = rd.take(1024);
     let mut wd = BufferedWd {
         buf: BytesMut::new(),
-        writer: wd
+        writer: wd,
     };
 
     // write start bytes

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -1,8 +1,10 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::io::{self, AsyncRead, ReadBuf};
+use bytes::BytesMut;
+use tokio::io::{self, AsyncRead, ReadBuf, AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;
+use futures::ready;
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -33,4 +35,80 @@ async fn copy() {
     let n = assert_ok!(io::copy(&mut rd, &mut wr).await);
     assert_eq!(n, 11);
     assert_eq!(wr, b"hello world");
+}
+
+#[tokio::test]
+async fn proxy() {
+    struct LimitRd {
+        count: usize,
+        reader: io::DuplexStream
+    }
+
+    struct BufferedWd {
+        buf: BytesMut,
+        writer: io::DuplexStream
+    }
+
+    impl AsyncRead for LimitRd {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let this = self.get_mut();
+
+            if this.count < 1024 {
+                let read_before = buf.filled().len();
+                ready!(Pin::new(&mut this.reader).poll_read(cx, buf))?;
+                let read_after = buf.filled().len();
+                this.count += read_after - read_before;
+            }
+
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl AsyncWrite for BufferedWd {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            self.get_mut().buf.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            let this = self.get_mut();
+
+            while !this.buf.is_empty() {
+                let n = ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buf))?;
+                let _ = this.buf.split_to(n);
+            }
+
+            Pin::new(&mut this.writer).poll_flush(cx)
+        }
+
+        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.writer).poll_shutdown(cx)
+        }
+    }
+
+    let (rd, wd) = io::duplex(1024);
+    let mut rd = LimitRd {
+        count: 0,
+        reader: rd
+    };
+    let mut wd = BufferedWd {
+        buf: BytesMut::new(),
+        writer: wd
+    };
+
+    // write start bytes
+    assert_ok!(wd.write_all(&[0x42; 512]).await);
+    assert_ok!(wd.flush().await);
+
+    let n = assert_ok!(io::copy(&mut rd, &mut wd).await);
+
+    assert_eq!(n, 1024);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The current copy works poorly in some cases.
when reader output depends on writer and writer is buffered, a deadlock may occur.

see https://github.com/tokio-rs/tls/issues/66

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

we can call flush when the reader is not progressing to prevent such deadlocks.