### PR TITLE
Give Notified a safe API

### DIFF
--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -317,9 +317,7 @@ impl<P: Park> Drop for BasicScheduler<P> {
             // By closing the OwnedTasks, no new tasks can be spawned on it.
             context.shared.owned.close();
             // Drain the OwnedTasks collection.
-            while let Some(task) = context.shared.owned.pop_back() {
-                task.shutdown();
-            }
+            context.shared.owned.drain_tasks();
 
             // Drain local queue
             // We already shut down every task, so we just need to drop the task.

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -7,6 +7,7 @@
 //! the scheduler with the collection.
 
 use crate::future::Future;
+use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::Mutex;
 use crate::runtime::task::{JoinHandle, LocalNotified, Notified, Schedule, Task};
 use crate::util::linked_list::{Link, LinkedList};
@@ -56,16 +57,14 @@ pub(crate) struct OwnedTasks<S: 'static> {
     inner: Mutex<OwnedTasksInner<S>>,
     id: u64,
 }
+pub(crate) struct LocalOwnedTasks<S: 'static> {
+    inner: UnsafeCell<OwnedTasksInner<S>>,
+    id: u64,
+    _not_send_or_sync: PhantomData<*const ()>,
+}
 struct OwnedTasksInner<S: 'static> {
     list: LinkedList<Task<S>, <Task<S> as Link>::Target>,
     closed: bool,
-}
-
-pub(crate) struct LocalOwnedTasks<S: 'static> {
-    list: LinkedList<Task<S>, <Task<S> as Link>::Target>,
-    closed: bool,
-    id: u64,
-    _not_send_or_sync: PhantomData<*const ()>,
 }
 
 impl<S: 'static> OwnedTasks<S> {
@@ -115,18 +114,28 @@ impl<S: 'static> OwnedTasks<S> {
     /// a LocalNotified, giving the thread permission to poll this task.
     #[inline]
     pub(crate) fn assert_owner(&self, task: Notified<S>) -> LocalNotified<S> {
-        assert_eq!(task.0.header().get_owner_id(), self.id);
+        assert_eq!(task.header().get_owner_id(), self.id);
 
         // safety: All tasks bound to this OwnedTasks are Send, so it is safe
         // to poll it on this thread no matter what thread we are on.
         LocalNotified {
-            task: task.0,
+            task,
             _not_send: PhantomData,
         }
     }
 
-    pub(crate) fn pop_back(&self) -> Option<Task<S>> {
-        self.inner.lock().list.pop_back()
+    pub(crate) fn drain_tasks(&self)
+    where
+        S: Schedule,
+    {
+        loop {
+            let task = match self.inner.lock().list.pop_back() {
+                Some(task) => task,
+                None => return,
+            };
+
+            task.shutdown();
+        }
     }
 
     pub(crate) fn remove(&self, task: &Task<S>) -> Option<Task<S>> {
@@ -161,15 +170,17 @@ impl<S: 'static> OwnedTasks<S> {
 impl<S: 'static> LocalOwnedTasks<S> {
     pub(crate) fn new() -> Self {
         Self {
-            list: LinkedList::new(),
-            closed: false,
+            inner: UnsafeCell::new(OwnedTasksInner {
+                list: LinkedList::new(),
+                closed: false,
+            }),
             id: get_next_id(),
             _not_send_or_sync: PhantomData,
         }
     }
 
     pub(crate) fn bind<T>(
-        &mut self,
+        &self,
         task: T,
         scheduler: S,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
@@ -186,21 +197,28 @@ impl<S: 'static> LocalOwnedTasks<S> {
             task.header().set_owner_id(self.id);
         }
 
-        if self.closed {
+        if self.is_closed() {
             drop(notified);
             task.shutdown();
             (join, None)
         } else {
-            self.list.push_front(task);
+            self.with_inner(|inner| {
+                inner.list.push_front(task);
+            });
             (join, Some(notified))
         }
     }
 
-    pub(crate) fn pop_back(&mut self) -> Option<Task<S>> {
-        self.list.pop_back()
+    pub(crate) fn drain_tasks(&self)
+    where
+        S: Schedule,
+    {
+        while let Some(task) = self.with_inner(|inner| inner.list.pop_back()) {
+            task.shutdown();
+        }
     }
 
-    pub(crate) fn remove(&mut self, task: &Task<S>) -> Option<Task<S>> {
+    pub(crate) fn remove(&self, task: &Task<S>) -> Option<Task<S>> {
         let task_id = task.header().get_owner_id();
         if task_id == 0 {
             // The task is unowned.
@@ -209,34 +227,50 @@ impl<S: 'static> LocalOwnedTasks<S> {
 
         assert_eq!(task_id, self.id);
 
-        // safety: We just checked that the provided task is not in some other
-        // linked list.
-        unsafe { self.list.remove(task.header().into()) }
+        self.with_inner(|inner|
+            // safety: We just checked that the provided task is not in some
+            // other linked list.
+            unsafe { inner.list.remove(task.header().into()) })
     }
 
     /// Assert that the given task is owned by this LocalOwnedTasks and convert
     /// it to a LocalNotified, giving the thread permission to poll this task.
     #[inline]
     pub(crate) fn assert_owner(&self, task: Notified<S>) -> LocalNotified<S> {
-        assert_eq!(task.0.header().get_owner_id(), self.id);
+        assert_eq!(task.header().get_owner_id(), self.id);
 
         // safety: The task was bound to this LocalOwnedTasks, and the
         // LocalOwnedTasks is not Send or Sync, so we are on the right thread
         // for polling this task.
         LocalNotified {
-            task: task.0,
+            task,
             _not_send: PhantomData,
         }
     }
 
+    #[inline]
+    fn with_inner<F, T>(&self, f: F) -> T
+    where
+        F: FnOnce(&mut OwnedTasksInner<S>) -> T,
+    {
+        // safety: This type is not Sync, so concurrent calls of this method
+        // can't happen.  Furthermore, all uses of this method in this file make
+        // sure that they don't call `with_inner` recursively.
+        self.inner.with_mut(|ptr| unsafe { f(&mut *ptr) })
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.with_inner(|inner| inner.closed)
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
-        self.list.is_empty()
+        self.with_inner(|inner| inner.list.is_empty())
     }
 
     /// Close the LocalOwnedTasks. This prevents adding new tasks to the
     /// collection.
-    pub(crate) fn close(&mut self) {
-        self.closed = true;
+    pub(crate) fn close(&self) {
+        self.with_inner(|inner| inner.closed = true);
     }
 }
 

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -64,6 +64,11 @@ impl RawTask {
         unsafe { self.ptr.as_ref() }
     }
 
+    /// Returns the raw pointer to the headers.
+    pub(super) fn as_raw(&self) -> NonNull<Header> {
+        self.ptr
+    }
+
     /// Safety: mutual exclusion is required to call this function.
     pub(super) fn poll(self) {
         let vtable = self.header().vtable;

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -603,9 +603,7 @@ impl Core {
         debug_assert!(worker.shared.owned.is_closed());
 
         // Signal to all tasks to shut down.
-        while let Some(header) = worker.shared.owned.pop_back() {
-            header.shutdown();
-        }
+        worker.shared.owned.drain_tasks();
     }
 
     /// Shutdown the core

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -2,8 +2,9 @@
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, Task};
 use crate::sync::AtomicWaker;
+use crate::util::VecDequeCell;
 
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
@@ -223,19 +224,14 @@ cfg_rt! {
 
 /// State available from the thread-local
 struct Context {
-    /// Owned task set and local run queue
-    tasks: RefCell<Tasks>,
-
-    /// State shared between threads.
-    shared: Arc<Shared>,
-}
-
-struct Tasks {
     /// Collection of all active tasks spawned onto this executor.
     owned: LocalOwnedTasks<Arc<Shared>>,
 
     /// Local run queue sender and receiver.
-    queue: VecDeque<task::Notified<Arc<Shared>>>,
+    queue: VecDequeCell<task::Notified<Arc<Shared>>>,
+
+    /// State shared between threads.
+    shared: Arc<Shared>,
 }
 
 /// LocalSet state shared between threads.
@@ -308,7 +304,7 @@ cfg_rt! {
             let cx = maybe_cx
                 .expect("`spawn_local` called from outside of a `task::LocalSet`");
 
-            let (handle, notified) = cx.tasks.borrow_mut().owned.bind(future, cx.shared.clone());
+            let (handle, notified) = cx.owned.bind(future, cx.shared.clone());
 
             if let Some(notified) = notified {
                 cx.shared.schedule(notified);
@@ -334,10 +330,8 @@ impl LocalSet {
         LocalSet {
             tick: Cell::new(0),
             context: Context {
-                tasks: RefCell::new(Tasks {
-                    owned: LocalOwnedTasks::new(),
-                    queue: VecDeque::with_capacity(INITIAL_CAPACITY),
-                }),
+                owned: LocalOwnedTasks::new(),
+                queue: VecDequeCell::with_capacity(INITIAL_CAPACITY),
                 shared: Arc::new(Shared {
                     queue: Mutex::new(Some(VecDeque::with_capacity(INITIAL_CAPACITY))),
                     waker: AtomicWaker::new(),
@@ -391,12 +385,7 @@ impl LocalSet {
     {
         let future = crate::util::trace::task(future, "local", None);
 
-        let (handle, notified) = self
-            .context
-            .tasks
-            .borrow_mut()
-            .owned
-            .bind(future, self.context.shared.clone());
+        let (handle, notified) = self.context.owned.bind(future, self.context.shared.clone());
 
         if let Some(notified) = notified {
             self.context.shared.schedule(notified);
@@ -551,24 +540,19 @@ impl LocalSet {
                 .lock()
                 .as_mut()
                 .and_then(|queue| queue.pop_front())
-                .or_else(|| self.context.tasks.borrow_mut().queue.pop_front())
+                .or_else(|| self.context.queue.pop_front())
         } else {
-            self.context
-                .tasks
-                .borrow_mut()
-                .queue
-                .pop_front()
-                .or_else(|| {
-                    self.context
-                        .shared
-                        .queue
-                        .lock()
-                        .as_mut()
-                        .and_then(|queue| queue.pop_front())
-                })
+            self.context.queue.pop_front().or_else(|| {
+                self.context
+                    .shared
+                    .queue
+                    .lock()
+                    .as_mut()
+                    .and_then(|queue| queue.pop_front())
+            })
         };
 
-        task.map(|task| self.context.tasks.borrow_mut().owned.assert_owner(task))
+        task.map(|task| self.context.owned.assert_owner(task))
     }
 
     fn with<T>(&self, f: impl FnOnce() -> T) -> T {
@@ -594,7 +578,7 @@ impl Future for LocalSet {
             // there are still tasks remaining in the run queue.
             cx.waker().wake_by_ref();
             Poll::Pending
-        } else if self.context.tasks.borrow().owned.is_empty() {
+        } else if self.context.owned.is_empty() {
             // If the scheduler has no remaining futures, we're done!
             Poll::Ready(())
         } else {
@@ -619,23 +603,14 @@ impl Drop for LocalSet {
             // spawn_local in the destructor of a future on this LocalSet will
             // immediately cancel the task, and prevents the task from being
             // added to `owned`.
-            self.context.tasks.borrow_mut().owned.close();
+            self.context.owned.close();
 
-            // Loop required here to ensure borrow is dropped between iterations
-            #[allow(clippy::while_let_loop)]
-            loop {
-                let task = match self.context.tasks.borrow_mut().owned.pop_back() {
-                    Some(task) => task,
-                    None => break,
-                };
-
-                // Safety: same as `run_unchecked`.
-                task.shutdown();
-            }
+            // Shut down all tasks in the LocalOwnedTasks.
+            self.context.owned.drain_tasks();
 
             // We already called shutdown on all tasks above, so there is no
             // need to call shutdown.
-            for task in self.context.tasks.borrow_mut().queue.drain(..) {
+            for task in self.context.queue.take() {
                 drop(task);
             }
 
@@ -646,7 +621,7 @@ impl Drop for LocalSet {
                 drop(task);
             }
 
-            assert!(self.context.tasks.borrow().owned.is_empty());
+            assert!(self.context.owned.is_empty());
         });
     }
 }
@@ -689,7 +664,7 @@ impl Shared {
     fn schedule(&self, task: task::Notified<Arc<Self>>) {
         CURRENT.with(|maybe_cx| match maybe_cx {
             Some(cx) if cx.shared.ptr_eq(self) => {
-                cx.tasks.borrow_mut().queue.push_back(task);
+                cx.queue.push_back(task);
             }
             _ => {
                 // First check whether the queue is still there (if not, the
@@ -716,7 +691,7 @@ impl task::Schedule for Arc<Shared> {
         CURRENT.with(|maybe_cx| {
             let cx = maybe_cx.expect("scheduler context missing");
             assert!(cx.shared.ptr_eq(self));
-            cx.tasks.borrow_mut().owned.remove(&task)
+            cx.owned.remove(&task)
         })
     }
 

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -24,6 +24,9 @@ cfg_rt! {
 
     mod sync_wrapper;
     pub(crate) use sync_wrapper::SyncWrapper;
+
+    mod vec_deque_cell;
+    pub(crate) use vec_deque_cell::VecDequeCell;
 }
 
 cfg_rt_multi_thread! {

--- a/tokio/src/util/vec_deque_cell.rs
+++ b/tokio/src/util/vec_deque_cell.rs
@@ -1,0 +1,48 @@
+use crate::loom::cell::UnsafeCell;
+
+use std::collections::VecDeque;
+use std::marker::PhantomData;
+
+/// This type is like VecDeque, except that it is not Sync and can be modified
+/// through immutable references.
+pub(crate) struct VecDequeCell<T> {
+    inner: UnsafeCell<VecDeque<T>>,
+    _not_sync: PhantomData<*const ()>,
+}
+
+// This is Send for the same reasons that RefCell<VecDeque<T>> is Send.
+unsafe impl<T: Send> Send for VecDequeCell<T> {}
+
+impl<T> VecDequeCell<T> {
+    pub(crate) fn with_capacity(cap: usize) -> Self {
+        Self {
+            inner: UnsafeCell::new(VecDeque::with_capacity(cap)),
+            _not_sync: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn with_inner<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut VecDeque<T>) -> R,
+    {
+        // safety: This type is not Sync, so concurrent calls of this method
+        // can't happen.  Furthermore, all uses of this method in this file make
+        // sure that they don't call `with_inner` recursively.
+        self.inner.with_mut(|ptr| unsafe { f(&mut *ptr) })
+    }
+
+    pub(crate) fn pop_front(&self) -> Option<T> {
+        self.with_inner(VecDeque::pop_front)
+    }
+
+    pub(crate) fn push_back(&self, item: T) {
+        self.with_inner(|inner| inner.push_back(item));
+    }
+
+    /// Replace the inner VecDeque with an empty VecDeque and return the current
+    /// contents.
+    pub(crate) fn take(&self) -> VecDeque<T> {
+        self.with_inner(|inner| std::mem::take(inner))
+    }
+}


### PR DESCRIPTION
This PR works toward giving the task module a safe API. Currently, the Notified object is hard to reason about. It doesn't hold a ref-count if the task is idle and not yet completed, as the runtime already holds a ref-count via the `OwnedTasks` structure, however this means that the task module does not have a safe API as removing the task from the `OwnedTasks` structure without shutting it down could lead to a `Notified` existing for a deallocated task.

In this PR, The ref-count for Notified is changed. Previously a Notified had a ref-count only sometimes. Now it never has a ref-count, holding the task alive via the `NOTIFIED` bit. Properly keeping track of this throughout polls and shutdown is done by introducing a state machine for touching the future.

Replacing the `pop_back` call on OwnedTasks with a `drain_tasks` call also simplifies the safety guarantees of the task module as we don't have to return a value that could be dropped or moved to other threads before shutdown is called. This change required removal of the RefCell guard around the LocalSet context, so it is replaced with a different cell type.

I inverted the `RUNNING` bit to `IDLE` because I thought I could make a lot of the state transitions become `fetch_or` or `fetch_and` instead of a CAS loop, but in the end only `transition_to_running` could be turned into a `fetch_or`. I'm open to other suggestions, but note that having every `Notified` hold a ref-count would turn `wake_by_ref` into a CAS loop.

The `OwnedTasks::remove` method is still not totally safe, but I can look at that in a future PR.