### PR TITLE
Fix clippy warnings

### DIFF
--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -143,7 +143,7 @@ where
             ..
         } = *self;
 
-        let n = ready!(socket.borrow().poll_send_to(cx, &wr, *out_addr))?;
+        let n = ready!(socket.borrow().poll_send_to(cx, wr, *out_addr))?;
 
         let wrote_all = n == self.wr.len();
         self.wr.clear();

--- a/tokio-util/tests/sync_cancellation_token.rs
+++ b/tokio-util/tests/sync_cancellation_token.rs
@@ -11,7 +11,7 @@ use futures_test::task::new_count_waker;
 fn cancel_token() {
     let (waker, wake_counter) = new_count_waker();
     let token = CancellationToken::new();
-    assert_eq!(false, token.is_cancelled());
+    assert!(!token.is_cancelled());
 
     let wait_fut = token.cancelled();
     pin!(wait_fut);
@@ -27,7 +27,7 @@ fn cancel_token() {
 
     token.cancel();
     assert_eq!(wake_counter, 1);
-    assert_eq!(true, token.is_cancelled());
+    assert!(token.is_cancelled());
 
     assert_eq!(
         Poll::Ready(()),
@@ -64,8 +64,8 @@ fn cancel_child_token_through_parent() {
 
     token.cancel();
     assert_eq!(wake_counter, 2);
-    assert_eq!(true, token.is_cancelled());
-    assert_eq!(true, child_token.is_cancelled());
+    assert!(token.is_cancelled());
+    assert!(child_token.is_cancelled());
 
     assert_eq!(
         Poll::Ready(()),
@@ -101,8 +101,8 @@ fn cancel_child_token_without_parent() {
 
     child_token_1.cancel();
     assert_eq!(wake_counter, 1);
-    assert_eq!(false, token.is_cancelled());
-    assert_eq!(true, child_token_1.is_cancelled());
+    assert!(!token.is_cancelled());
+    assert!(child_token_1.is_cancelled());
 
     assert_eq!(
         Poll::Ready(()),
@@ -128,8 +128,8 @@ fn cancel_child_token_without_parent() {
 
     token.cancel();
     assert_eq!(wake_counter, 3);
-    assert_eq!(true, token.is_cancelled());
-    assert_eq!(true, child_token_2.is_cancelled());
+    assert!(token.is_cancelled());
+    assert!(child_token_2.is_cancelled());
 
     assert_eq!(
         Poll::Ready(()),

--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -63,7 +63,7 @@ impl<T> ReadHalf<T> {
     /// Checks if this `ReadHalf` and some `WriteHalf` were split from the same
     /// stream.
     pub fn is_pair_of(&self, other: &WriteHalf<T>) -> bool {
-        other.is_pair_of(&self)
+        other.is_pair_of(self)
     }
 
     /// Reunites with a previously split `WriteHalf`.

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -87,7 +87,7 @@ impl<T> OrphanQueueImpl<T> {
                         // means that the signal driver isn't running, in
                         // which case there isn't anything we can
                         // register/initialize here, so we can try again later
-                        if let Ok(sigchild) = signal_with_handle(SignalKind::child(), &handle) {
+                        if let Ok(sigchild) = signal_with_handle(SignalKind::child(), handle) {
                             *sigchild_guard = Some(sigchild);
                             drain_orphan_queue(queue);
                         }

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -186,7 +186,7 @@ impl<P: Park> BasicScheduler<P> {
 
         Some(InnerGuard {
             inner: Some(inner),
-            basic_scheduler: &self,
+            basic_scheduler: self,
         })
     }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -214,7 +214,7 @@ impl Handle {
         let _ = name;
 
         let (task, handle) = task::unowned(fut, NoopSchedule);
-        let _ = self.blocking_spawner.spawn(task, &self);
+        let _ = self.blocking_spawner.spawn(task, self);
         handle
     }
 

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -207,7 +207,7 @@ where
                 stage.store_output(output);
 
                 // Transition to `Complete`, notifying the `JoinHandle` if necessary.
-                transition_to_complete(self.header(), stage, &self.trailer());
+                transition_to_complete(self.header(), stage, self.trailer());
             } else {
                 drop(output);
             }

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -240,17 +240,17 @@ mod tests {
         let registry = Registry::new(vec![EventInfo::default(), EventInfo::default()]);
 
         registry.record_event(0);
-        assert_eq!(false, registry.broadcast());
+        assert!(!registry.broadcast());
 
         let first = registry.register_listener(0);
         let second = registry.register_listener(1);
 
         registry.record_event(0);
-        assert_eq!(true, registry.broadcast());
+        assert!(registry.broadcast());
 
         drop(first);
         registry.record_event(0);
-        assert_eq!(false, registry.broadcast());
+        assert!(!registry.broadcast());
 
         drop(second);
     }

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -478,7 +478,7 @@ impl<'a> Acquire<'a> {
             let this = self.get_unchecked_mut();
             (
                 Pin::new_unchecked(&mut this.node),
-                &this.semaphore,
+                this.semaphore,
                 this.num_permits,
                 &mut this.queued,
             )

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -528,7 +528,7 @@ impl Notified<'_> {
             is_unpin::<AtomicUsize>();
 
             let me = self.get_unchecked_mut();
-            (&me.notify, &mut me.state, &me.waiter)
+            (me.notify, &mut me.state, &me.waiter)
         }
     }
 }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -193,7 +193,7 @@ impl Semaphore {
     pub async fn acquire(&self) -> Result<SemaphorePermit<'_>, AcquireError> {
         self.ll_sem.acquire(1).await?;
         Ok(SemaphorePermit {
-            sem: &self,
+            sem: self,
             permits: 1,
         })
     }
@@ -229,7 +229,7 @@ impl Semaphore {
     pub async fn acquire_many(&self, n: u32) -> Result<SemaphorePermit<'_>, AcquireError> {
         self.ll_sem.acquire(n).await?;
         Ok(SemaphorePermit {
-            sem: &self,
+            sem: self,
             permits: n,
         })
     }

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -716,7 +716,7 @@ impl task::Schedule for Arc<Shared> {
         CURRENT.with(|maybe_cx| {
             let cx = maybe_cx.expect("scheduler context missing");
             assert!(cx.shared.ptr_eq(self));
-            cx.tasks.borrow_mut().owned.remove(&task)
+            cx.tasks.borrow_mut().owned.remove(task)
         })
     }
 

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -121,7 +121,7 @@ impl<T: 'static> LocalKey<T> {
         F: Future,
     {
         TaskLocalFuture {
-            local: &self,
+            local: self,
             slot: Some(value),
             future: f,
             _pinned: PhantomPinned,
@@ -150,7 +150,7 @@ impl<T: 'static> LocalKey<T> {
         F: FnOnce() -> R,
     {
         let scope = TaskLocalFuture {
-            local: &self,
+            local: self,
             slot: Some(value),
             future: (),
             _pinned: PhantomPinned,

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -50,10 +50,10 @@ fn is_send_and_sync() {
 fn split_stream_id() {
     let (r1, w1) = split(RW);
     let (r2, w2) = split(RW);
-    assert_eq!(r1.is_pair_of(&w1), true);
-    assert_eq!(r1.is_pair_of(&w2), false);
-    assert_eq!(r2.is_pair_of(&w2), true);
-    assert_eq!(r2.is_pair_of(&w1), false);
+    assert!(r1.is_pair_of(&w1));
+    assert!(!r1.is_pair_of(&w2));
+    assert!(r2.is_pair_of(&w2));
+    assert!(!r2.is_pair_of(&w1));
 }
 
 #[test]

--- a/tokio/tests/io_write_all_buf.rs
+++ b/tokio/tests/io_write_all_buf.rs
@@ -52,7 +52,7 @@ async fn write_all_buf() {
     assert_eq!(wr.buf, b"helloworld"[..]);
     // expect 4 writes, [hell],[o],[worl],[d]
     assert_eq!(wr.cnt, 4);
-    assert_eq!(buf.has_remaining(), false);
+    assert!(!buf.has_remaining());
 }
 
 #[tokio::test]

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -139,12 +139,12 @@ fn try_lock() {
     let m: Mutex<usize> = Mutex::new(0);
     {
         let g1 = m.try_lock();
-        assert_eq!(g1.is_ok(), true);
+        assert!(g1.is_ok());
         let g2 = m.try_lock();
-        assert_eq!(g2.is_ok(), false);
+        assert!(!g2.is_ok());
     }
     let g3 = m.try_lock();
-    assert_eq!(g3.is_ok(), true);
+    assert!(g3.is_ok());
 }
 
 #[tokio::test]

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -106,12 +106,12 @@ fn try_lock_owned() {
     let m: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     {
         let g1 = m.clone().try_lock_owned();
-        assert_eq!(g1.is_ok(), true);
+        assert!(g1.is_ok());
         let g2 = m.clone().try_lock_owned();
-        assert_eq!(g2.is_ok(), false);
+        assert!(!g2.is_ok());
     }
     let g3 = m.try_lock_owned();
-    assert_eq!(g3.is_ok(), true);
+    assert!(g3.is_ok());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation
To improve the code quality, the clippy warnings were fixed.

## Solution
Fix the clippy warnings. Also, prevent futures warnings to be merged by add the option `-D warnings` to the build job.

Fixes #3585.