### PR TITLE
Fix doc failure in CI on master

### DIFF
--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -1,13 +1,4 @@
 //! Wrappers for Tokio types that implement `Stream`.
-//!
-#![cfg_attr(
-    unix,
-    doc = "You are viewing documentation built under unix. To view windows-specific wrappers, change to the `x86_64-pc-windows-msvc` platform."
-)]
-#![cfg_attr(
-    windows,
-    doc = "You are viewing documentation built under windows. To view unix-specific wrappers, change to the `x86_64-unknown-linux-gnu` platform."
-)]
 
 /// Error types for the wrappers.
 pub mod errors {

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -185,7 +185,7 @@ macro_rules! cfg_net_unix {
 macro_rules! cfg_net_windows {
     ($($item:item)*) => {
         $(
-            #[cfg(all(any(docsrs, windows), feature = "net"))]
+            #[cfg(all(any(all(doc, docsrs), windows), feature = "net"))]
             #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "net"))))]
             $item
         )*


### PR DESCRIPTION
I merged #3213 and CI on master broke. This PR fixes that by not generating the module when generating documentation if Tokio is not the crate being documented.