### PR TITLE
Fix flaky test

### DIFF
--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -398,6 +398,7 @@ fn local_tasks_wake_join_all() {
     });
 }
 
+#[test]
 fn local_tasks_are_polled_after_tick() {
     // This test depends on timing, so we run it up to five times.
     for _ in 0..4 {
@@ -413,7 +414,7 @@ fn local_tasks_are_polled_after_tick() {
     local_tasks_are_polled_after_tick_inner();
 }
 
-#[tokio::test]
+#[tokio::main(flavor = "current_thread")]
 async fn local_tasks_are_polled_after_tick_inner() {
     // Reproduces issues #1899 and #1900
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -420,7 +420,10 @@ async fn local_tasks_are_polled_after_tick_inner() {
 
     static RX1: AtomicUsize = AtomicUsize::new(0);
     static RX2: AtomicUsize = AtomicUsize::new(0);
-    static EXPECTED: usize = 500;
+    const EXPECTED: usize = 500;
+
+    RX1.store(0, SeqCst);
+    RX2.store(0, SeqCst);
 
     let (tx, mut rx) = mpsc::unbounded_channel();
 


### PR DESCRIPTION
This test has failed a few times because only some of the tasks had completed. This is simply due to bad timing.