### PR TITLE
chore: explicitly relaxed clippy lint for runtime entry macro

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -325,12 +325,13 @@ fn parse_knobs(
     let brace_token = input.block.brace_token;
     input.block = syn::parse2(quote_spanned! {last_stmt_end_span=>
         {
+            let body_closure = || async #body;
             #[allow(clippy::expect_used)]
             #rt
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")
-                .block_on(async #body)
+                .block_on(body_closure())
         }
     })
     .expect("Parsing failure");

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -325,6 +325,7 @@ fn parse_knobs(
     let brace_token = input.block.brace_token;
     input.block = syn::parse2(quote_spanned! {last_stmt_end_span=>
         {
+            #[allow(clippy::expect_used)]
             #rt
                 .enable_all()
                 .build()

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -325,13 +325,13 @@ fn parse_knobs(
     let brace_token = input.block.brace_token;
     input.block = syn::parse2(quote_spanned! {last_stmt_end_span=>
         {
-            let body_closure = || async #body;
+            let body = async #body;
             #[allow(clippy::expect_used)]
             #rt
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")
-                .block_on(body_closure())
+                .block_on(body)
         }
     })
     .expect("Parsing failure");


### PR DESCRIPTION
This change explicitly allows `clippy::expect` for the `.expect()` used in the entry macro

## Motivation

Our projects have a strict clippy setting and currently, the `tokio::main` macro breaks our pipelines.

## Solution

`#[allow(clippy::expect_used)]` for the runtime build command :)
