### PR TITLE
The test-util feature depends on rt, sync, and time

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -82,7 +82,7 @@ signal = [
   "winapi/consoleapi",
 ]
 sync = []
-test-util = []
+test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]


### PR DESCRIPTION
Fixes #4035

## Motivation

The build will fail for a crate that uses tokio with the test-util feature but not the rt, sync, and time features.

## Solution

Add the features dependencies to Cargo.toml

## Tests

This bug was revealed by running `cargo hack check --feature-powerset --no-dev-deps`.  However, that command takes 205 minutes with this patch, and even longer without it, so it can't be added to CI.