### PR TITLE
tracing: change span naming to new console convention

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -192,20 +192,20 @@ impl Handle {
             let location = std::panic::Location::caller();
             #[cfg(tokio_track_caller)]
             let span = tracing::trace_span!(
-                target: "tokio::task",
-                "task",
+                target: "tokio::task::blocking",
+                "runtime.spawn",
                 kind = %"blocking",
-                function = %std::any::type_name::<F>(),
                 task.name = %name.unwrap_or_default(),
+                "fn" = %std::any::type_name::<F>(),
                 spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
             );
             #[cfg(not(tokio_track_caller))]
             let span = tracing::trace_span!(
-                target: "tokio::task",
-                "task",
+                target: "tokio::task::blocking",
+                "runtime.spawn",
                 kind = %"blocking",
                 task.name = %name.unwrap_or_default(),
-                function = %std::any::type_name::<F>(),
+                "fn" = %std::any::type_name::<F>(),
             );
             fut.instrument(span)
         };

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -11,15 +11,15 @@ cfg_trace! {
             #[cfg(tokio_track_caller)]
             let span = tracing::trace_span!(
                 target: "tokio::task",
-                "task",
+                "runtime.spawn",
                 %kind,
-                spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
                 task.name = %name.unwrap_or_default()
+                spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
             );
             #[cfg(not(tokio_track_caller))]
             let span = tracing::trace_span!(
                 target: "tokio::task",
-                "task",
+                "runtime.spawn",
                 %kind,
                 task.name = %name.unwrap_or_default()
             );

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -13,7 +13,7 @@ cfg_trace! {
                 target: "tokio::task",
                 "runtime.spawn",
                 %kind,
-                task.name = %name.unwrap_or_default()
+                task.name = %name.unwrap_or_default(),
                 spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
             );
             #[cfg(not(tokio_track_caller))]
@@ -21,7 +21,7 @@ cfg_trace! {
                 target: "tokio::task",
                 "runtime.spawn",
                 %kind,
-                task.name = %name.unwrap_or_default()
+                task.name = %name.unwrap_or_default(),
             );
             task.instrument(span)
         }


### PR DESCRIPTION
## Motivation

Currently, the per-task spans generated by Tokio's `tracing` feature
have the span name "task" and the target "tokio::task". This is because
the console subscriber identified tasks by looking specifically for the
"tokio::task" target.

In tokio-rs/console#41, it was proposed that the console change to a
more generic system for identifying the spans that correspond to tasks,
to allow recording tasks belonging to multiple runtime crates (e.g. an
application that uses Tokio for async tasks and Rayon for CPU-bound
tasks). PR tokio-rs/console#68 changed the console to track any spans
"runtime.spawn", regardless of target (so that the target can be used to
identify the runtime a task came from), with "tokio::task/task" tracked
for backwards-compatibility with the current release version of tokio.

## Solution

This branch changes Tokio's span naming to the new convention. I also
rearranged a couple fields so that the task's kind field always comes
before the name and spawn location, since it's likely to be the
shortest, and renamed the `function` field on blocking tasks to `fn`,
for brevity's sake.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>