### PR TITLE
Add a configuration option to skip the `lifo_slot` optimization

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -263,7 +263,6 @@ impl Builder {
         self
     }
 
-
     /// Specifies the limit for additional threads spawned by the Runtime.
     ///
     /// These threads are used for blocking operations like tasks spawned
@@ -624,6 +623,7 @@ impl fmt::Debug for Builder {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Builder")
             .field("worker_threads", &self.worker_threads)
+            .field("lifo_slot_optimization", &self.lifo_slot_optimization)
             .field("max_blocking_threads", &self.max_blocking_threads)
             .field(
                 "thread_name",

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -43,8 +43,12 @@ pub(crate) struct Spawner {
 // ===== impl ThreadPool =====
 
 impl ThreadPool {
-    pub(crate) fn new(size: usize, parker: Parker) -> (ThreadPool, Launch) {
-        let (shared, launch) = worker::create(size, parker);
+    pub(crate) fn new(
+        size: usize,
+        lifo_slot_optimization: bool,
+        parker: Parker,
+    ) -> (ThreadPool, Launch) {
+        let (shared, launch) = worker::create(size, lifo_slot_optimization, parker);
         let spawner = Spawner { shared };
         let thread_pool = ThreadPool { spawner };
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -3,7 +3,7 @@
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::runtime::{self, Runtime, Builder};
+use tokio::runtime::{self, Builder, Runtime};
 use tokio::sync::oneshot;
 use tokio_test::{assert_err, assert_ok};
 
@@ -60,11 +60,13 @@ fn no_lifo_slot_complex() {
     // used for notifying the main thread
     const NUM: usize = 1_000;
 
-
     for _ in 0..5 {
         let (tx, rx) = mpsc::channel();
 
-        let rt = Builder::new_multi_thread().lifo_slot_optimization(false).build().unwrap();
+        let rt = Builder::new_multi_thread()
+            .lifo_slot_optimization(false)
+            .build()
+            .unwrap();
         let cnt = Arc::new(AtomicUsize::new(0));
 
         for _ in 0..NUM {


### PR DESCRIPTION
## Motivation

In our (my coworkers and I) RPC stack, our server overload detection relies on being able to detect when request processing throughput is stalled. Currently, we derive this metric interactively by injecting futures (via `spawn`() in our case) into the Runtime and measures how long they took to begin execution. (this is a vague overview and I can go into more detail if needed)

However, this flow relies on 'mostly-FIFO' ordering of request handling. 

While tokio does not explicitly provide a FIFO execution guarantee* for spawn()'d futures, the `lifo_slot` optimization path results in pathological behavior for this workload. 

*I stand to be corrected, but there are 2 parts of the runtime that are not strict-fifo, and they could be altered to be `fifo` to varying degrees (though, if this PR is accepted, I would be interested in exploring both more concretely):
1. when a `Local` queue is filled, work is pulled off the _front_ half of that queue and added to the global `Inject` queue. I can imagine a scheme where this is changed to the _back_ half or something, but upon reading the `queue` module, I think this would be complex to implement
2. tokio's runtime is work-stealing, which I think regardless of implementation can't be made loosely fifo. I was thinking rayon implemented this with `spawn_fifo`, but that appears to be per-thread fifo? I admittedly, don't know what I'm talking about here.

We also believe that the LIFO optimization creates surprising behavior in systems that have similar expectations of 'mostly-FIFO-ness'. Given that the LIFO optimization is an optimization and not key to the functioning of the runtime, we believe it to be reasonable to empower users who find this behavior pathological for their workflows to disable it at runtime.

## Solution

Change the runtime to allow `Core`'s to skip the `lifo_slot` optimization, and allow this to be configured in the runtime `Builder`