### PR TITLE
Allow consumers to implement POSIX AIO sources.

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -136,7 +136,6 @@ async-stream = "0.3"
 socket2 = "0.4"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-futures-test = "0.3.7"
 mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "2f56696", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -28,7 +28,6 @@ default = []
 
 # enable everything
 full = [
-  "aio",
   "fs",
   "io-util",
   "io-std",
@@ -41,10 +40,6 @@ full = [
   "signal",
   "sync",
   "time",
-]
-
-aio = [
-  "mio/os-poll"
 ]
 
 fs = []

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -137,7 +137,7 @@ socket2 = "0.4"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 futures-test = "0.3.7"
-mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "a740a87"  }
+mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "2f56696", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -28,6 +28,7 @@ default = []
 
 # enable everything
 full = [
+  "aio",
   "fs",
   "io-util",
   "io-std",
@@ -40,6 +41,10 @@ full = [
   "signal",
   "sync",
   "time",
+]
+
+aio = [
+  "mio/os-poll"
 ]
 
 fs = []
@@ -129,6 +134,10 @@ rand = "0.8.0"
 tempfile = "3.1.0"
 async-stream = "0.3"
 socket2 = "0.4"
+
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
+futures-test = "0.3.7"
+mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "a740a87"  }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }

--- a/tokio/src/io/bsd/poll_aio.rs
+++ b/tokio/src/io/bsd/poll_aio.rs
@@ -66,7 +66,7 @@ impl<T: AioSource> Source for MioSource<T> {
 ///
 /// ## Clearing readiness
 ///
-/// If [`Aio::poll`] returns ready, but the consumer determines that the
+/// If [`Aio::poll_ready`] returns ready, but the consumer determines that the
 /// Source is not completely ready and must return to the Pending state,
 /// [`Aio::clear_ready`] may be used.  This can be useful with
 /// [`lio_listio`], which may generate a kevent when only a portion of the
@@ -188,7 +188,7 @@ impl<E: AioSource + fmt::Debug> fmt::Debug for Aio<E> {
     }
 }
 
-/// Opaque data returned by [`Aio::poll`].
+/// Opaque data returned by [`Aio::poll_ready`].
 ///
 /// It can be fed back to [`Aio::clear_ready`].
 #[derive(Debug)]

--- a/tokio/src/io/bsd/poll_aio.rs
+++ b/tokio/src/io/bsd/poll_aio.rs
@@ -162,7 +162,7 @@ impl<E: AioSource> Aio<E> {
     /// is scheduled to receive a wakeup when the underlying operation
     /// completes. Note that on multiple calls to poll, only the Waker from the
     /// Context passed to the most recent call is scheduled to receive a wakeup.
-    pub fn poll<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<AioEvent>> {
+    pub fn poll_ready<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<AioEvent>> {
         let ev = ready!(self.registration.poll_read_ready(cx))?;
         Poll::Ready(Ok(AioEvent(ev)))
     }

--- a/tokio/src/io/bsd/poll_aio.rs
+++ b/tokio/src/io/bsd/poll_aio.rs
@@ -85,7 +85,7 @@ impl<T: AioSource> Source for MioSource<T> {
 //
 // Note that Aio doesn't implement Drop.  There's no need.  Unlike other
 // kqueue sources, simply dropping the object effectively deregisters it.
-pub struct Aio<E: AioSource> {
+pub struct Aio<E> {
     io: MioSource<E>,
     registration: Registration,
 }
@@ -114,7 +114,7 @@ impl<E: AioSource> Aio<E> {
         self.registration.clear_readiness(ev.0)
     }
 
-    /// Destroy the [`Aio`] and return its inner Source
+    /// Destroy the [`Aio`] and return its inner source.
     pub fn into_inner(self) -> E {
         self.io.0
     }
@@ -123,7 +123,7 @@ impl<E: AioSource> Aio<E> {
     ///
     /// It will be associated with the default reactor.  The runtime is usually
     /// set implicitly when this function is called from a future driven by a
-    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// Tokio runtime, otherwise runtime can be set explicitly with
     /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
     pub fn new_for_aio(io: E) -> io::Result<Self> {
         Self::new_with_interest(io, Interest::AIO)
@@ -133,7 +133,7 @@ impl<E: AioSource> Aio<E> {
     ///
     /// It will be associated with the default reactor.  The runtime is usually
     /// set implicitly when this function is called from a future driven by a
-    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// Tokio runtime, otherwise runtime can be set explicitly with
     /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
     ///
     /// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
@@ -158,10 +158,10 @@ impl<E: AioSource> Aio<E> {
     ///  * `Poll::Ready(Err(_))` if the reactor has been shutdown.  This does
     ///     _not_ indicate that the underlying operation encountered an error.
     ///
-    /// When the method returns Poll::Pending, the Waker in the provided Context
+    /// When the method returns `Poll::Pending`, the `Waker` in the provided `Context`
     /// is scheduled to receive a wakeup when the underlying operation
-    /// completes. Note that on multiple calls to poll, only the Waker from the
-    /// Context passed to the most recent call is scheduled to receive a wakeup.
+    /// completes. Note that on multiple calls to `poll_ready`, only the `Waker` from the
+    /// `Context` passed to the most recent call is scheduled to receive a wakeup.
     pub fn poll_ready<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<AioEvent>> {
         let ev = ready!(self.registration.poll_read_ready(cx))?;
         Poll::Ready(Ok(AioEvent(ev)))

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -14,6 +14,16 @@ use std::ops;
 pub struct Interest(mio::Interest);
 
 impl Interest {
+    cfg_aio! {
+        /// Interest for POSIX AIO
+        pub const AIO: Interest = Interest(mio::Interest::AIO);
+    }
+
+    cfg_aio! {
+        /// Interest for POSIX AIO lio_listio events
+        pub const LIO: Interest = Interest(mio::Interest::LIO);
+    }
+
     /// Interest in all readable events.
     ///
     /// Readable interest includes read-closed events.

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -14,6 +14,8 @@ use std::ops;
 pub struct Interest(mio::Interest);
 
 impl Interest {
+    // The non-FreeBSD definitions in this block are active only when
+    // building documentation.
     cfg_aio! {
         /// Interest for POSIX AIO
         #[cfg(target_os = "freebsd")]

--- a/tokio/src/io/driver/interest.rs
+++ b/tokio/src/io/driver/interest.rs
@@ -16,12 +16,20 @@ pub struct Interest(mio::Interest);
 impl Interest {
     cfg_aio! {
         /// Interest for POSIX AIO
+        #[cfg(target_os = "freebsd")]
         pub const AIO: Interest = Interest(mio::Interest::AIO);
-    }
 
-    cfg_aio! {
+        /// Interest for POSIX AIO
+        #[cfg(not(target_os = "freebsd"))]
+        pub const AIO: Interest = Interest(mio::Interest::READABLE);
+
         /// Interest for POSIX AIO lio_listio events
+        #[cfg(target_os = "freebsd")]
         pub const LIO: Interest = Interest(mio::Interest::LIO);
+
+        /// Interest for POSIX AIO lio_listio events
+        #[cfg(not(target_os = "freebsd"))]
+        pub const LIO: Interest = Interest(mio::Interest::READABLE);
     }
 
     /// Interest in all readable events.

--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -51,6 +51,7 @@ pub(crate) struct Handle {
     inner: Weak<Inner>,
 }
 
+#[derive(Debug)]
 pub(crate) struct ReadyEvent {
     tick: u8,
     pub(crate) ready: Ready,

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -38,6 +38,17 @@ impl Ready {
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {
         let mut ready = Ready::EMPTY;
 
+        #[cfg(all(target_os = "freebsd", feature = "aio"))]
+        {
+            if event.is_aio() {
+                ready |= Ready::READABLE;
+            }
+
+            if event.is_lio() {
+                ready |= Ready::READABLE;
+            }
+        }
+
         if event.is_readable() {
             ready |= Ready::READABLE;
         }

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -38,7 +38,7 @@ impl Ready {
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {
         let mut ready = Ready::EMPTY;
 
-        #[cfg(all(target_os = "freebsd", feature = "aio"))]
+        #[cfg(all(target_os = "freebsd", feature = "net"))]
         {
             if event.is_aio() {
                 ready |= Ready::READABLE;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -213,7 +213,7 @@ cfg_io_driver_impl! {
 
     cfg_aio! {
         mod poll_aio;
-        pub use poll_aio::{PollAio, PollAioEvent};
+        pub use poll_aio::{AioSource, PollAio, PollAioEvent};
     }
 
     mod poll_evented;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -218,7 +218,10 @@ cfg_io_driver_impl! {
 }
 
 cfg_aio! {
-    pub mod poll_aio;
+    /// BSD-specific I/O types
+    pub mod bsd {
+        pub mod poll_aio;
+    }
 }
 
 cfg_net_unix! {

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -220,7 +220,9 @@ cfg_io_driver_impl! {
 cfg_aio! {
     /// BSD-specific I/O types
     pub mod bsd {
-        pub mod poll_aio;
+        mod poll_aio;
+
+        pub use poll_aio::{Aio, AioEvent, AioSource};
     }
 }
 

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -211,15 +211,14 @@ cfg_io_driver_impl! {
         pub use driver::{Interest, Ready};
     }
 
-    cfg_aio! {
-        mod poll_aio;
-        pub use poll_aio::{AioSource, PollAio, PollAioEvent};
-    }
-
     mod poll_evented;
 
     #[cfg(not(loom))]
     pub(crate) use poll_evented::PollEvented;
+}
+
+cfg_aio! {
+    pub mod poll_aio;
 }
 
 cfg_net_unix! {

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -211,6 +211,11 @@ cfg_io_driver_impl! {
         pub use driver::{Interest, Ready};
     }
 
+    cfg_aio! {
+        mod poll_aio;
+        pub use poll_aio::{PollAio, PollAioEvent};
+    }
+
     mod poll_evented;
 
     #[cfg(not(loom))]

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -1,0 +1,121 @@
+use crate::io::driver::{Handle, Interest, ReadyEvent, Registration};
+use mio::event::Source;
+use std::fmt;
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::task::{Context, Poll};
+
+/// Associates a POSIX AIO control block with the reactor that drives it.
+///
+/// `PollAio`'s wrapped type must implement [`mio::event::Source`] to be driven
+/// by the reactor.
+///
+/// The wrapped source may be accessed through the `PollAio` via the `Deref` and
+/// `DerefMut` traits.
+///
+/// ## Clearing readiness
+///
+/// If [`PollAio::poll`] returns ready, but the consumer determines that the
+/// Source is not completely ready and must return to the Pending state,
+/// [`PollAio::clear_ready`] may be used.  This can be useful with
+/// [`lio_listio`], which may generate a kevent when only a portion of the
+/// operations have completed.
+///
+/// ## Platforms
+///
+/// Only FreeBSD implements POSIX AIO with kqueue notification, so
+/// `PollAio` is only available for that operating system.
+///
+/// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
+// Note: Unlike every other kqueue event source, POSIX AIO registers events not
+// via kevent(2) but when the aiocb is submitted to the kernel via aio_read,
+// aio_write, etc.  It needs the kqueue's file descriptor to do that.  So
+// AsyncFd can't be used for POSIX AIO.
+//
+// Note that PollAio doesn't implement Drop.  There's no need.  Unlike other
+// kqueue sources, there is nothing to deregister.
+pub struct PollAio<E: Source> {
+    io: E,
+    registration: Registration,
+}
+
+// ===== impl PollAio =====
+
+impl<E: Source> PollAio<E> {
+    /// Indicates to Tokio that the source is no longer ready.  The internal
+    /// readiness flag will be cleared, and tokio will wait for the next
+    /// edge-triggered readiness notification from the OS.
+    ///
+    /// It is critical that this function not be called unless your code
+    /// _actually observes_ that the source is _not_ ready.  The OS must
+    /// deliver a subsequent notification, or this source will block
+    /// forever.
+    pub fn clear_ready(&self, ev: PollAioEvent) {
+        self.registration.clear_readiness(ev.0)
+    }
+
+    /// Destroy the [`PollAio`] and return its inner Source
+    pub fn into_inner(self) -> E {
+        self.io
+    }
+
+    /// Creates a new `PollAio` suitable for use with POSIX AIO functions.
+    ///
+    /// It will be associated with the default reactor.  The runtime is usually
+    /// set implicitly when this function is called from a future driven by a
+    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
+    pub fn new_for_aio(io: E) -> io::Result<Self> {
+        Self::new_with_interest(io, Interest::AIO)
+    }
+
+    /// Creates a new `PollAio` suitable for use with [`lio_listio`].
+    ///
+    /// It will be associated with the default reactor.  The runtime is usually
+    /// set implicitly when this function is called from a future driven by a
+    /// tokio runtime, otherwise runtime can be set explicitly with
+    /// [`Runtime::enter`](crate::runtime::Runtime::enter) function.
+    ///
+    /// [`lio_listio`]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/lio_listio.html
+    pub fn new_for_lio(io: E) -> io::Result<Self> {
+        Self::new_with_interest(io, Interest::LIO)
+    }
+
+    fn new_with_interest(mut io: E, interest: Interest) -> io::Result<Self> {
+        let handle = Handle::current();
+        let registration = Registration::new_with_interest_and_handle(&mut io, interest, handle)?;
+        Ok(Self { io, registration })
+    }
+
+    /// Polls for readiness.  Either AIO or LIO counts.
+    pub fn poll<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<PollAioEvent>> {
+        let ev = ready!(self.registration.poll_read_ready(cx))?;
+        Poll::Ready(Ok(PollAioEvent(ev)))
+    }
+}
+
+impl<E: Source> Deref for PollAio<E> {
+    type Target = E;
+
+    fn deref(&self) -> &E {
+        &self.io
+    }
+}
+
+impl<E: Source> DerefMut for PollAio<E> {
+    fn deref_mut(&mut self) -> &mut E {
+        &mut self.io
+    }
+}
+
+impl<E: Source + fmt::Debug> fmt::Debug for PollAio<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PollAio").field("io", &self.io).finish()
+    }
+}
+
+/// Opaque data returned by [`PollAio::poll`].
+///
+/// It can be fed back to [`PollAio::clear_ready`].
+#[derive(Debug)]
+pub struct PollAioEvent(ReadyEvent);

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -147,6 +147,14 @@ impl<E: AioSource> PollAio<E> {
     }
 
     /// Polls for readiness.  Either AIO or LIO counts.
+    ///
+    /// This method returns:
+    ///  * `Poll::Pending` if the underlying operation is not complete, whether
+    ///     or not it completed successfully.  This will be true if the OS is
+    ///     still processing it, or if it has not yet been submitted to the OS.
+    ///  * `Poll::Ready(Ok(_))` if the underlying operation is complete.
+    ///  * `Poll::Ready(Err(_))` if the reactor has been shutdown.  This does
+    ///     _not_ indicate that the underlying operation encountered an error.
     pub fn poll<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<PollAioEvent>> {
         let ev = ready!(self.registration.poll_read_ready(cx))?;
         Poll::Ready(Ok(PollAioEvent(ev)))

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -155,6 +155,11 @@ impl<E: AioSource> PollAio<E> {
     ///  * `Poll::Ready(Ok(_))` if the underlying operation is complete.
     ///  * `Poll::Ready(Err(_))` if the reactor has been shutdown.  This does
     ///     _not_ indicate that the underlying operation encountered an error.
+    ///
+    /// When the method returns Poll::Pending, the Waker in the provided Context
+    /// is scheduled to receive a wakeup when the underlying operation
+    /// completes. Note that on multiple calls to poll, only the Waker from the
+    /// Context passed to the most recent call is scheduled to receive a wakeup.
     pub fn poll<'a>(&'a self, cx: &mut Context<'_>) -> Poll<io::Result<PollAioEvent>> {
         let ev = ready!(self.registration.poll_read_ready(cx))?;
         Poll::Ready(Ok(PollAioEvent(ev)))

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -30,8 +30,8 @@ impl<T: AioSource> Source for MioSource<T> {
         &mut self,
         registry: &Registry,
         token: Token,
-        interests: mio::Interest) -> io::Result<()>
-    {
+        interests: mio::Interest,
+    ) -> io::Result<()> {
         assert!(interests.is_aio() || interests.is_lio());
         self.0.register(registry.as_raw_fd(), usize::from(token));
         Ok(())

--- a/tokio/src/io/poll_aio.rs
+++ b/tokio/src/io/poll_aio.rs
@@ -1,3 +1,5 @@
+//! Use POSIX AIO futures with Tokio
+
 use crate::io::driver::{Handle, Interest, ReadyEvent, Registration};
 use mio::event::Source;
 use mio::Registry;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -316,6 +316,7 @@
 //! - `sync`: Enables all `tokio::sync` types.
 //! - `signal`: Enables all `tokio::signal` types.
 //! - `fs`: Enables `tokio::fs` types.
+//! - `aio`: Enables `tokio::io::PollAio`, for working with POSIX AIO.
 //! - `test-util`: Enables testing based infrastructure for the Tokio runtime.
 //!
 //! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -307,8 +307,9 @@
 //! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.
 //! - `io-util`: Enables the IO based `Ext` traits.
 //! - `io-std`: Enable `Stdout`, `Stdin` and `Stderr` types.
-//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and `UdpSocket`,
-//!          as well as (on Unix-like systems) `AsyncFd`
+//! - `net`: Enables `tokio::net` types such as `TcpStream`, `UnixStream` and
+//!          `UdpSocket`, as well as (on Unix-like systems) `AsyncFd` and (on
+//!          FreeBSD) `PollAio`.
 //! - `time`: Enables `tokio::time` types and allows the schedulers to enable
 //!           the built in timer.
 //! - `process`: Enables `tokio::process` types.
@@ -316,7 +317,6 @@
 //! - `sync`: Enables all `tokio::sync` types.
 //! - `signal`: Enables all `tokio::signal` types.
 //! - `fs`: Enables `tokio::fs` types.
-//! - `aio`: Enables `tokio::io::PollAio`, for working with POSIX AIO.
 //! - `test-util`: Enables testing based infrastructure for the Tokio runtime.
 //!
 //! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -48,7 +48,7 @@ macro_rules! cfg_atomic_waker_impl {
 macro_rules! cfg_aio {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_os = "freebsd", feature = "net"))]
+            #[cfg(all(any(docsrs, target_os = "freebsd"), feature = "net"))]
             #[cfg_attr(docsrs,
                 doc(cfg(all(target_os = "freebsd", feature = "net")))
             )]

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -45,6 +45,18 @@ macro_rules! cfg_atomic_waker_impl {
     }
 }
 
+macro_rules! cfg_aio {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(target_os = "freebsd", feature = "aio"))]
+            #[cfg_attr(docsrs,
+                doc(cfg(all(target_os = "freebsd", feature = "aio")))
+            )]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_fs {
     ($($item:item)*) => {
         $(
@@ -65,6 +77,7 @@ macro_rules! cfg_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -83,6 +96,7 @@ macro_rules! cfg_io_driver_impl {
     ( $( $item:item )* ) => {
         $(
             #[cfg(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -96,6 +110,7 @@ macro_rules! cfg_not_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(not(any(
+                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -48,9 +48,9 @@ macro_rules! cfg_atomic_waker_impl {
 macro_rules! cfg_aio {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_os = "freebsd", feature = "aio"))]
+            #[cfg(all(target_os = "freebsd", feature = "net"))]
             #[cfg_attr(docsrs,
-                doc(cfg(all(target_os = "freebsd", feature = "aio")))
+                doc(cfg(all(target_os = "freebsd", feature = "net")))
             )]
             $item
         )*
@@ -77,7 +77,6 @@ macro_rules! cfg_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(any(
-                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -96,7 +95,6 @@ macro_rules! cfg_io_driver_impl {
     ( $( $item:item )* ) => {
         $(
             #[cfg(any(
-                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),
@@ -110,7 +108,6 @@ macro_rules! cfg_not_io_driver {
     ($($item:item)*) => {
         $(
             #[cfg(not(any(
-                all(target_os = "freebsd", feature = "aio"),
                 feature = "net",
                 feature = "process",
                 all(unix, feature = "signal"),

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -2,14 +2,15 @@
 #![cfg(all(target_os = "freebsd", feature = "aio"))]
 
 use futures_test::task::noop_context;
-use mio_aio::{AioCb, AioFsyncMode};
+use mio_aio::{AioCb, AioFsyncMode, LioCb};
 use std::{
-    os::unix::io::AsRawFd,
+    io::{Read, Seek, SeekFrom},
+    os::unix::io::{AsRawFd, RawFd},
     task::Poll,
     time::{Duration, Instant},
 };
 use tempfile::tempdir;
-use tokio::io::PollAio;
+use tokio::io::{AioSource, PollAio};
 use tokio_test::{assert_pending, assert_ready_ok};
 
 fn rt() -> tokio::runtime::Runtime {
@@ -19,38 +20,123 @@ fn rt() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
-/// aio_fsync is the simplest AIO operation.  This test ensures that Tokio can
-/// register an aiocb, and set its readiness.
-#[test]
-fn fsync() {
-    let dir = tempdir().unwrap();
-    let path = dir.path().join("testfile");
-    let f = std::fs::File::create(&path).unwrap();
-    let fd = f.as_raw_fd();
-    let aiocb = AioCb::from_fd(fd, 0);
-    let rt = rt();
-    let mut poll_aio = {
-        let _enter = rt.enter();
-        PollAio::new_for_aio(aiocb).unwrap()
-    };
-    let mut ctx = noop_context();
-    // Should be not ready after initialization
-    assert_pending!(poll_aio.poll(&mut ctx));
-
-    // Send the operation to the kernel
-    (*poll_aio).fsync(AioFsyncMode::O_SYNC).unwrap();
-
-    // Wait for completeness
-    let start = Instant::now();
-    while Instant::now() - start < Duration::new(5, 0) {
-        if let Poll::Ready(_ev) = poll_aio.poll(&mut ctx) {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(10));
+struct WrappedAioCb<'a>(AioCb<'a>);
+impl<'a> AioSource for WrappedAioCb<'a> {
+    fn register(&mut self, kq: RawFd, token: usize) {
+        self.0.register_raw(kq, token)
     }
-    assert_ready_ok!(poll_aio.poll(&mut ctx));
+    fn deregister(&mut self) {
+        self.0.deregister_raw()
+    }
+}
 
-    // Free its in-kernel state, so Nix doesn't panic.
-    let mut aiocb = poll_aio.into_inner();
-    aiocb.aio_return().unwrap();
+struct WrappedLioCb<'a>(LioCb<'a>);
+impl<'a> AioSource for WrappedLioCb<'a> {
+    fn register(&mut self, kq: RawFd, token: usize) {
+        self.0.register_raw(kq, token)
+    }
+    fn deregister(&mut self) {
+        self.0.deregister_raw()
+    }
+}
+
+mod aio {
+    use super::*;
+
+    /// aio_fsync is the simplest AIO operation.  This test ensures that Tokio
+    /// can register an aiocb, and set its readiness.
+    #[test]
+    fn fsync() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("testfile");
+        let f = std::fs::File::create(&path).unwrap();
+        let fd = f.as_raw_fd();
+        let aiocb = AioCb::from_fd(fd, 0);
+        let source = WrappedAioCb(aiocb);
+        let rt = rt();
+        let mut poll_aio = {
+            let _enter = rt.enter();
+            PollAio::new_for_aio(source).unwrap()
+        };
+        let mut ctx = noop_context();
+        // Should be not ready after initialization
+        assert_pending!(poll_aio.poll(&mut ctx));
+
+        // Send the operation to the kernel
+        (*poll_aio).0.fsync(AioFsyncMode::O_SYNC).unwrap();
+
+        // Wait for completeness
+        let start = Instant::now();
+        while Instant::now() - start < Duration::new(5, 0) {
+            if let Poll::Ready(_ev) = poll_aio.poll(&mut ctx) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_ready_ok!(poll_aio.poll(&mut ctx));
+
+        // Free its in-kernel state, so Nix doesn't panic.
+        let mut aiocb = poll_aio.into_inner().0;
+        aiocb.aio_return().unwrap();
+    }
+}
+
+mod lio {
+    use super::*;
+
+    /// An lio_listio operation with one write element
+    #[test]
+    fn onewrite() {
+        let wbuf = b"abcdef";
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("testfile");
+        let mut f = std::fs::OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+        let mut rbuf = Vec::new();
+
+        let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
+        builder = builder.emplace_slice(f.as_raw_fd(), 0, &wbuf[..], 0,
+                            mio_aio::LioOpcode::LIO_WRITE);
+        let liocb = builder.finish();
+        let source = WrappedLioCb(liocb);
+        let rt = rt();
+        let mut poll_aio = {
+            let _enter = rt.enter();
+            PollAio::new_for_lio(source).unwrap()
+        };
+        let mut ctx = noop_context();
+        // Should be not ready after initialization
+        assert_pending!(poll_aio.poll(&mut ctx));
+
+        // Send the operation to the kernel
+        (*poll_aio).0.submit().unwrap();
+
+        // Wait for completeness
+        let start = Instant::now();
+        while Instant::now() - start < Duration::new(5, 0) {
+            if let Poll::Ready(_ev) = poll_aio.poll(&mut ctx) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_ready_ok!(poll_aio.poll(&mut ctx));
+        let liocb = poll_aio.into_inner().0;
+
+        // Check results
+        liocb.into_results(|mut iter| {
+            let lr = iter.next().unwrap();
+            assert_eq!(lr.result.unwrap(), wbuf.len() as isize);
+            assert!(iter.next().is_none());
+        });
+
+        // Verify that it actually wrote to the file
+        f.seek(SeekFrom::Start(0)).unwrap();
+        let len = f.read_to_end(&mut rbuf).unwrap();
+        assert_eq!(len, wbuf.len());
+        assert_eq!(&wbuf[..], &rbuf[..]);
+    }
 }

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -1,0 +1,56 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(target_os = "freebsd", feature = "aio"))]
+
+use futures_test::task::noop_context;
+use mio_aio::{AioCb, AioFsyncMode};
+use std::{
+    os::unix::io::AsRawFd,
+    task::Poll,
+    time::{Duration, Instant},
+};
+use tempfile::tempdir;
+use tokio::io::PollAio;
+use tokio_test::{assert_pending, assert_ready_ok};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_io()
+        .build()
+        .unwrap()
+}
+
+/// aio_fsync is the simplest AIO operation.  This test ensures that Tokio can
+/// register an aiocb, and set its readiness.
+#[test]
+fn fsync() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("testfile");
+    let f = std::fs::File::create(&path).unwrap();
+    let fd = f.as_raw_fd();
+    let aiocb = AioCb::from_fd(fd, 0);
+    let rt = rt();
+    let mut poll_aio = {
+        let _enter = rt.enter();
+        PollAio::new_for_aio(aiocb).unwrap()
+    };
+    let mut ctx = noop_context();
+    // Should be not ready after initialization
+    assert_pending!(poll_aio.poll(&mut ctx));
+
+    // Send the operation to the kernel
+    (*poll_aio).fsync(AioFsyncMode::O_SYNC).unwrap();
+
+    // Wait for completeness
+    let start = Instant::now();
+    while Instant::now() - start < Duration::new(5, 0) {
+        if let Poll::Ready(_ev) = poll_aio.poll(&mut ctx) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert_ready_ok!(poll_aio.poll(&mut ctx));
+
+    // Free its in-kernel state, so Nix doesn't panic.
+    let mut aiocb = poll_aio.into_inner();
+    aiocb.aio_return().unwrap();
+}

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -10,7 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 use tempfile::tempfile;
-use tokio::io::bsd::poll_aio::{AioSource, Aio};
+use tokio::io::bsd::poll_aio::{Aio, AioSource};
 use tokio_test::assert_pending;
 
 mod aio {

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -99,8 +99,13 @@ mod lio {
         let mut rbuf = Vec::new();
 
         let mut builder = mio_aio::LioCbBuilder::with_capacity(1);
-        builder = builder.emplace_slice(f.as_raw_fd(), 0, &wbuf[..], 0,
-                            mio_aio::LioOpcode::LIO_WRITE);
+        builder = builder.emplace_slice(
+            f.as_raw_fd(),
+            0,
+            &wbuf[..],
+            0,
+            mio_aio::LioOpcode::LIO_WRITE,
+        );
         let liocb = builder.finish();
         let source = WrappedLioCb(liocb);
         let rt = rt();

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -34,7 +34,7 @@ mod aio {
         type Output = std::io::Result<()>;
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let poll_result = self.0.poll(cx);
+            let poll_result = self.0.poll_ready(cx);
             match poll_result {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
@@ -81,7 +81,7 @@ mod aio {
         type Output = std::io::Result<()>;
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let poll_result = self.0.poll(cx);
+            let poll_result = self.0.poll_ready(cx);
             match poll_result {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
@@ -135,7 +135,7 @@ mod aio {
         type Output = std::io::Result<()>;
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let poll_result = self.0.poll(cx);
+            let poll_result = self.0.poll_ready(cx);
             match poll_result {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
@@ -200,7 +200,7 @@ mod aio {
         let aiocb1 = AioCb::from_fd(fd, 0);
         poll_aio.reset(aiocb1);
         let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
-        assert_pending!(poll_aio.poll(&mut ctx));
+        assert_pending!(poll_aio.poll_ready(&mut ctx));
         poll_aio.fsync();
         let fut1 = ReusableFsyncFut(&mut poll_aio);
         fut1.await.unwrap();
@@ -227,7 +227,7 @@ mod lio {
         type Output = std::io::Result<Vec<isize>>;
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let poll_result = self.0.as_mut().unwrap().poll(cx);
+            let poll_result = self.0.as_mut().unwrap().poll_ready(cx);
             match poll_result {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
@@ -284,7 +284,7 @@ mod lio {
         type Output = std::io::Result<Vec<isize>>;
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            let poll_result = self.0.poll(cx);
+            let poll_result = self.0.poll_ready(cx);
             match poll_result {
                 Poll::Pending => Poll::Pending,
                 Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
@@ -365,7 +365,7 @@ mod lio {
         let liocb1 = builder1.finish();
         poll_aio.reset(liocb1);
         let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
-        assert_pending!(poll_aio.poll(&mut ctx));
+        assert_pending!(poll_aio.poll_ready(&mut ctx));
         poll_aio.submit();
         let fut1 = ReusableLioFut(&mut poll_aio);
         let v = fut1.await.unwrap();

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(target_os = "freebsd", feature = "aio"))]
+#![cfg(all(target_os = "freebsd", feature = "net"))]
 
 use mio_aio::{AioCb, AioFsyncMode, LioCb};
 use std::{

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -10,7 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 use tempfile::tempfile;
-use tokio::io::bsd::poll_aio::{Aio, AioSource};
+use tokio::io::bsd::{Aio, AioSource};
 use tokio_test::assert_pending;
 
 mod aio {

--- a/tokio/tests/io_poll_aio.rs
+++ b/tokio/tests/io_poll_aio.rs
@@ -10,7 +10,7 @@ use std::{
     task::{Context, Poll},
 };
 use tempfile::tempfile;
-use tokio::io::{AioSource, PollAio};
+use tokio::io::poll_aio::{AioSource, PollAio};
 use tokio_test::assert_pending;
 
 mod aio {


### PR DESCRIPTION
Unlike every other kqueue event source, POSIX AIO registers events not
via kevent(2) but by a different mechanism that needs the kqueue's file
descriptor. This commit adds a new PollAio type, designed to be used
by an external crate that implements a POSIX AIO Future for use with
Tokio's reactor.

Fixes: #3197

# Motivation

With Tokio 0.1 and 0.2, PollEvented was sufficiently powerful to allow external crates to implement a POSIX AIO event source. Beginning with Tokio 0.3, PollEvented became private, and it also lost some needed functionality. Thus, there was no possible way for a consumer to use POSIX AIO with Tokio.

# Solution

The first proposed solution was to reexpose `PollEvented.`  That idea was rejected because Tokio's maintainers thought that `PollEvented` peered too intimately into Tokio's internals, and they wanted a more stable external API that wasn't tied to mio's implementation.

The second solution was made in PR #3841.  It created a new type, `PollAio` that worked much like `PollEvented` but crippled so that it would only be useful with POSIX AIO.  However, its public API did include the `mio::event::Source` trait, so Tokio's maintainers rejected it because it still exposed mio data types.  This PR preserves that solution as a discrete commit.

This PR introduces a third solution.  It builds on the previous one, but instead of using `mio::event::Source` in the public API, it creates a new trait: `AioSource`.  The new trait is very similar to `mio::event::Source`, but stripped down.

The new solution's advantages are that:
* It's smaller than `mio::event::Source`
* It's controlled by Tokio, not by mio, which may ease Tokio's next mio upgrade.

The new solution's disadvantages are that:
* Seen in the perspective of the overall stack, `AioSource` is an unhelpful anti-abstraction.  `mio_aio::AioCb` already implements `mio::event::Source`.  But now tokio_file must implement `AioSource` on top of that, only for Tokio to internally reimplement `mio::event::Source` again.  At least the runtime impact is likely to be tiny.
* It requires more code upstream (https://github.com/asomers/mio-aio/commit/2f566960c81c7df3033ff67ec6160ed51d800b8c)
* It requires more code downstream (https://github.com/asomers/tokio-file/commit/8aa8c1d92051b4dcc1af08f90d233e24a673940b)
* `AioSource` deabstracts `mio_aio::AioCb` and `mio_aio::LioCb`.  Previously in solution 2 those could be passed to Tokio in exactly the same way.  Now, Tokio's consumers must separately implement `AioSource` for both.  See the tests in this PR.
* By using `RawFd` and `usize` in the public API instead of `Registry` and `Token` it conceals information, reducing the ability to detect bugs at compile time, though not technically `unsafe`.
