### PR TITLE
Add From<Receiver<T>> impl for receiver streams

### DIFF
--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -71,3 +71,9 @@ impl<T> fmt::Debug for BroadcastStream<T> {
         f.debug_struct("BroadcastStream").finish()
     }
 }
+
+impl<T: 'static + Clone + Send> From<Receiver<T>> for BroadcastStream<T> {
+    fn from(recv: Receiver<T>) -> Self {
+        Self::new(recv)
+    }
+}

--- a/tokio-stream/src/wrappers/mpsc_bounded.rs
+++ b/tokio-stream/src/wrappers/mpsc_bounded.rs
@@ -57,3 +57,9 @@ impl<T> AsMut<Receiver<T>> for ReceiverStream<T> {
         &mut self.inner
     }
 }
+
+impl<T> From<Receiver<T>> for ReceiverStream<T> {
+    fn from(recv: Receiver<T>) -> Self {
+        Self::new(recv)
+    }
+}

--- a/tokio-stream/src/wrappers/mpsc_unbounded.rs
+++ b/tokio-stream/src/wrappers/mpsc_unbounded.rs
@@ -51,3 +51,9 @@ impl<T> AsMut<UnboundedReceiver<T>> for UnboundedReceiverStream<T> {
         &mut self.inner
     }
 }
+
+impl<T> From<UnboundedReceiver<T>> for UnboundedReceiverStream<T> {
+    fn from(recv: UnboundedReceiver<T>) -> Self {
+        Self::new(recv)
+    }
+}

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -59,7 +59,7 @@ async fn make_future<T: Clone + Send + Sync>(
     (result, rx)
 }
 
-impl<T: 'static + Clone + Unpin + Send + Sync> WatchStream<T> {
+impl<T: 'static + Clone + Send + Sync> WatchStream<T> {
     /// Create a new `WatchStream`.
     pub fn new(rx: Receiver<T>) -> Self {
         Self {
@@ -95,7 +95,7 @@ impl<T> fmt::Debug for WatchStream<T> {
     }
 }
 
-impl<T: 'static + Clone + Unpin + Send + Sync> From<Receiver<T>> for WatchStream<T> {
+impl<T: 'static + Clone + Send + Sync> From<Receiver<T>> for WatchStream<T> {
     fn from(recv: Receiver<T>) -> Self {
         Self::new(recv)
     }

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -94,3 +94,9 @@ impl<T> fmt::Debug for WatchStream<T> {
         f.debug_struct("WatchStream").finish()
     }
 }
+
+impl<T: 'static + Clone + Unpin + Send + Sync> From<Receiver<T>> for WatchStream<T> {
+    fn from(recv: Receiver<T>) -> Self {
+        Self::new(recv)
+    }
+}


### PR DESCRIPTION
## Motivation

Receiver streams can be better created via `From` trait.

## Solution

Add `From<Receiver<T>>` implementation for streams that take a `Receiver`.

Note: Should other streams implement the `From` trait as well?

Resolves #4015 

