### PR TITLE
tokio-util: expose key used in DelayQueue's Expired

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -176,7 +176,7 @@ pub struct Expired<T> {
 ///
 /// [`DelayQueue`]: struct@DelayQueue
 /// [`DelayQueue::insert`]: method@DelayQueue::insert
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 pub struct Key {
     index: usize,
 }
@@ -920,5 +920,10 @@ impl<T> Expired<T> {
     /// Returns the deadline that the expiration was set to.
     pub fn deadline(&self) -> Instant {
         self.deadline
+    }
+
+    /// Returns the key that the expiration is indexed by.
+    pub fn key(&self) -> Key {
+        self.key
     }
 }


### PR DESCRIPTION
## Motivation

It's useful to be able to extract the `Key` assigned to a given entry in a `DelayQueue` when being handed back an expired item, so that callers can interact with the delay queue in a correct fashion.

## Solution

We've exposed the `Key` used in `Expired<T>` such that it can be not only accessed from `Expired<T>`, but is now also `Copy`, `Eq`, and `Hash`, so it can be easily used in hash maps and sets, as well as trivially copied, since it's just a `usize` under the hood.

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>
