### PR TITLE
Fix fill_buf by not calling poll_fill_buf twice

### DIFF
--- a/tokio/tests/io_fill_buf.rs
+++ b/tokio/tests/io_fill_buf.rs
@@ -1,0 +1,32 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::{BufReader, AsyncBufReadExt};
+use tokio::fs::File;
+use tokio_test::assert_ok;
+use tempfile::NamedTempFile;
+
+#[tokio::test]
+async fn fill_buf_file() {
+    let file = NamedTempFile::new().unwrap();
+
+    assert_ok!(std::fs::write(file.path(), b"hello"));
+
+    let file = assert_ok!(File::open(file.path()).await);
+    let mut file = BufReader::new(file);
+
+    let mut contents = Vec::new();
+
+    loop {
+        let consumed = {
+            let buffer = assert_ok!(file.fill_buf().await);
+            if buffer.is_empty() { break; }
+            contents.extend_from_slice(buffer);
+            buffer.len()
+        };
+
+        file.consume(consumed);
+    }
+
+    assert_eq!(contents, b"hello");
+}

--- a/tokio/tests/io_fill_buf.rs
+++ b/tokio/tests/io_fill_buf.rs
@@ -1,10 +1,10 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::io::{BufReader, AsyncBufReadExt};
-use tokio::fs::File;
-use tokio_test::assert_ok;
 use tempfile::NamedTempFile;
+use tokio::fs::File;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio_test::assert_ok;
 
 #[tokio::test]
 async fn fill_buf_file() {
@@ -20,7 +20,9 @@ async fn fill_buf_file() {
     loop {
         let consumed = {
             let buffer = assert_ok!(file.fill_buf().await);
-            if buffer.is_empty() { break; }
+            if buffer.is_empty() {
+                break;
+            }
             contents.extend_from_slice(buffer);
             buffer.len()
         };


### PR DESCRIPTION
There are some IO resources which hit the panic when calling `poll_fill_buf` twice, e.g. a `BufReader<File>` will do this when you are at EOF.

A safe alternative is to check for empty slices and handle those in a special way, but I prefer this as it is a more robust solution.

Fixes: #4085