### PR TITLE
chore: prepare tokio-util v0.6.8

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,22 @@
+# 0.6.8 (September 3, 2021)
+
+### Added
+
+- sync: add drop guard for `CancellationToken` ([#3839])
+- compact: added `AsyncSeek` compat ([#4078])
+- time: expose `Key` used in `DelayQueue`'s `Expired` ([#4081])
+- io: add `with_capacity` to `ReaderStream` ([#4086])
+
+### Fixed
+
+- codec: remove unnecessary `doc(cfg(...))` ([#3989])
+
+[#3839]: https://github.com/tokio-rs/tokio/pull/3839
+[#4078]: https://github.com/tokio-rs/tokio/pull/4078
+[#4081]: https://github.com/tokio-rs/tokio/pull/4081
+[#4086]: https://github.com/tokio-rs/tokio/pull/4086
+[#3989]: https://github.com/tokio-rs/tokio/pull/3989
+
 # 0.6.7 (May 14, 2021)
 
 ### Added

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-util"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.6.x" git tag.
-version = "0.6.7"
+version = "0.6.8"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-util/0.6.7/tokio_util"
+documentation = "https://docs.rs/tokio-util/0.6.8/tokio_util"
 description = """
 Additional utilities for working with Tokio.
 """


### PR DESCRIPTION
# 0.6.8 (September 3, 2021)

### Added

- sync: add drop guard for `CancellationToken` (#3839)
- compact: added `AsyncSeek` compat (#4078)
- time: expose `Key` used in `DelayQueue`'s `Expired` (#4081)
- io: add `with_capacity` to `ReaderStream` (#4086)

### Fixed

- codec: remove unnecessary `doc(cfg(...))` (#3989)

Signed-off-by: Toby Lawrence <toby@nuclearfurnace.com>