### PR TITLE
codec: implement `Clone` for `LengthDelimitedCodec`

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -421,7 +421,7 @@ pub struct LengthDelimitedCodecError {
 /// See [module level] documentation for more detail.
 ///
 /// [module level]: index.html
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LengthDelimitedCodec {
     // Configuration values
     builder: Builder,


### PR DESCRIPTION
Hey there!

Unless I'm missing a reason why `LengthDelimitedCodec` can not implement `Clone`, this would come in handy.

This PR adds `Clone` to the derive macro, and all the internal fields already implement `Clone`.