### PR TITLE
chore: add Debug to NotDefinedHere

### DIFF
--- a/tokio/src/doc/mod.rs
+++ b/tokio/src/doc/mod.rs
@@ -17,6 +17,7 @@
 /// will ever accidentally use it.
 ///
 /// [`never` type]: https://doc.rust-lang.org/std/primitive.never.html
+#[derive(Debug)]
 pub enum NotDefinedHere {}
 
 pub mod os;


### PR DESCRIPTION
Fixes the following warning:
```
warning: type does not implement `Debug`; consider adding `#[derive(Debug)]` or a manual implementation
  --> tokio/src/doc/mod.rs:20:1
   |
20 | pub enum NotDefinedHere {}
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
note: the lint level is defined here
  --> tokio/src/lib.rs:7:5
   |
7  |     missing_debug_implementations,
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```