### PR TITLE
runtime: add tracing span for block_on futures

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -296,7 +296,11 @@ impl Handle {
     /// [`tokio::fs`]: crate::fs
     /// [`tokio::net`]: crate::net
     /// [`tokio::time`]: crate::time
+    #[cfg_attr(tokio_track_caller, track_caller)]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let future = crate::util::trace::task(future, "block_on", None);
+
         // Enter the **runtime** context. This configures spawning, the current I/O driver, ...
         let _rt_enter = self.enter();
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -450,7 +450,11 @@ cfg_rt! {
         /// ```
         ///
         /// [handle]: fn@Handle::block_on
+        #[cfg_attr(tokio_track_caller, track_caller)]
         pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            let future = crate::util::trace::task(future, "block_on", None);
+
             let _enter = self.enter();
 
             match &self.kind {


### PR DESCRIPTION
This adds a tracing span to the future in `block_on`, when the unstable tracing support is enabled. While not technically a spawn, we still call it a "task spawn" with the kind set to `block_on`.

Unfortunately, it cannot collect the `#[tokio::main]` task, since even though it is instrumented, the task is entered before we can call `console_subscriber::init()`. But all manual usage of `block_on` is collected.

Closes https://github.com/tokio-rs/console/issues/106