### PR TITLE
io: Add convenience method `AsyncSeekExt::rewind`.

### DIFF
--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -67,6 +67,16 @@ cfg_io_util! {
             seek(self, pos)
         }
 
+        /// Creates a future which will rewind to the beginning of the stream.
+        ///
+        /// This is convenience method, equivalent to to `self.seek(SeekFrom::Start(0))`.
+        fn rewind(&mut self) -> Seek<'_, Self>
+        where
+            Self: Unpin,
+        {
+            self.seek(SeekFrom::Start(0))
+        }
+
         /// Creates a future which will return the current seek position from the
         /// start of the stream.
         ///

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -1,11 +1,11 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use tokio::fs::File;
-use tokio_test::task;
 use std::io::prelude::*;
 use tempfile::NamedTempFile;
+use tokio::fs::File;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio_test::task;
 
 const HELLO: &[u8] = b"hello world...";
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -2,11 +2,10 @@
 #![cfg(feature = "full")]
 
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio_test::task;
-
 use std::io::prelude::*;
 use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
 
 const HELLO: &[u8] = b"hello world...";
 
@@ -48,6 +47,19 @@ async fn basic_write_and_shutdown() {
 
     let file = std::fs::read(tempfile.path()).unwrap();
     assert_eq!(file, HELLO);
+}
+
+#[tokio::test]
+async fn rewind_seek_position() {
+    let tempfile = tempfile();
+
+    let mut file = File::create(tempfile.path()).await.unwrap();
+
+    file.seek(SeekFrom::Current(10)).await.unwrap();
+
+    file.rewind().await.unwrap();
+
+    assert_eq!(file.stream_position().await.unwrap(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Since version 1.55 has the Rust std library implemented a convenience function called [rewind](https://doc.rust-lang.org/std/io/trait.Seek.html#method.rewind) that is part of the io::Seek trait. I have found this to be a very helpful function in making my code more readable/simpler.

## Solution

Implement the rewind function as part of the AsyncSeekExt trait.

#### [Disclaimer]
The test might not be in the proper place apologies for that. I didn't know of a better place to put it.