### PR TITLE
ci: make loom tests optional

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,9 @@
+
+R-loom:
+- ./tokio/src/sync/*
+- ./tokio/src/sync/**/*
+- ./tokio-util/src/sync/*
+- ./tokio-util/src/sync/**/*
+- ./tokio/src/runtime/*
+- ./tokio/src/runtime/**/*
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       - clippy
       - docs
       - valgrind
+      - loom-compile
       - check-readme
     steps:
       - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
       - fmt
       - clippy
       - docs
-      - loom
       - valgrind
       - check-readme
     steps:
@@ -299,31 +298,6 @@ jobs:
         env:
           RUSTFLAGS: --cfg docsrs
           RUSTDOCFLAGS: --cfg docsrs -Dwarnings
-
-  loom:
-    name: loom
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        scope:
-          - --skip loom_pool
-          - loom_pool::group_a
-          - loom_pool::group_b
-          - loom_pool::group_c
-          - loom_pool::group_d
-          - time::driver
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
-      - uses: Swatinem/rust-cache@v1
-      - name: loom ${{ matrix.scope }}
-        run: cargo test --lib --release --features full -- --nocapture $SCOPE
-        working-directory: tokio
-        env:
-          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
-          LOOM_MAX_PREEMPTIONS: 2
-          SCOPE: ${{ matrix.scope }}
 
   check-readme:
     name: Check README

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,20 @@ jobs:
           RUSTFLAGS: --cfg docsrs
           RUSTDOCFLAGS: --cfg docsrs -Dwarnings
 
+  loom-compile:
+    name: Loom tests compiles
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - uses: Swatinem/rust-cache@v1
+      - name: build --cfg loom
+        run: cargo build --tests --features full
+        working-directory: tokio
+        env:
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
+
   check-readme:
     name: Check README
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - name: build --cfg loom
-        run: cargo test --no-run --lib --release --features full
+        run: cargo test --no-run --lib --features full
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs -Dwarnings
 
   loom-compile:
-    name: Loom tests compiles
+    name: build loom tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -308,7 +308,7 @@ jobs:
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - name: build --cfg loom
-        run: cargo build --tests --features full
+        run: cargo test --no-run --lib --release --features full
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+- pull_request_target
+
+# See .github/labeler.yml file
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v3
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -1,11 +1,11 @@
 on:
-  label:
   push:
     branches: ["master", "tokio-*.x"]
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
     branches: ["master", "tokio-*.x"]
 
-name: Loom CI
+name: Loom
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -1,0 +1,41 @@
+on:
+  label:
+  push:
+    branches: ["master", "tokio-*.x"]
+  pull_request:
+    branches: ["master", "tokio-*.x"]
+
+name: Loom CI
+
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  nightly: nightly-2021-07-09
+
+jobs:
+  loom:
+    name: loom
+    # base_ref is null when it's not a pull request
+    if: contains(github.event.issue.labels.*.name, 'R-loom') || (github.base_ref == null)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        scope:
+          - --skip loom_pool
+          - loom_pool::group_a
+          - loom_pool::group_b
+          - loom_pool::group_c
+          - loom_pool::group_d
+          - time::driver
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - uses: Swatinem/rust-cache@v1
+      - name: loom ${{ matrix.scope }}
+        run: cargo test --lib --release --features full -- --nocapture $SCOPE
+        working-directory: tokio
+        env:
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
+          LOOM_MAX_PREEMPTIONS: 2
+          SCOPE: ${{ matrix.scope }}

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -16,7 +16,7 @@ jobs:
   loom:
     name: loom
     # base_ref is null when it's not a pull request
-    if: contains(github.event.issue.labels.*.name, 'R-loom') || (github.base_ref == null)
+    if: contains(github.event.pull_request.labels.*.name, 'R-loom') || (github.base_ref == null)
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
This PR makes the loom tests optional for merging PRs. They can be enabled on specific PRs by adding the `R-loom` label. Loom tests still run on the master branch.