### PR TITLE
mpsc: use spin_loop_hint instead of yield_now

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -93,4 +93,17 @@ pub(crate) mod sys {
     }
 }
 
-pub(crate) use std::thread;
+pub(crate) mod thread {
+    #[inline]
+    pub(crate) fn yield_now() {
+        // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
+        #[allow(deprecated)]
+        std::sync::atomic::spin_loop_hint();
+    }
+
+    #[allow(unused_imports)]
+    pub(crate) use std::thread::{
+        current, panicking, park, park_timeout, sleep, spawn, Builder, JoinHandle, LocalKey,
+        Result, Thread, ThreadId,
+    };
+}

--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -343,13 +343,7 @@ impl<T> Block<T> {
                 Err(curr) => curr,
             };
 
-            #[cfg(all(test, loom))]
             crate::loom::thread::yield_now();
-
-            // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
-            #[cfg(not(all(test, loom)))]
-            #[allow(deprecated)]
-            std::sync::atomic::spin_loop_hint();
         }
     }
 }


### PR DESCRIPTION
The mpsc channel has a bunch of calls to `yield_now` that should be `spin_loop_hint`. However they should remain as calls to `yield_now` when testing with loom. This PR expands the `crate::loom` mock to handle this.

Related: #4037