### PR TITLE
Update the mio-aio dev-dependency

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -132,7 +132,7 @@ async-stream = "0.3"
 socket2 = "0.4"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { git = "https://github.com/asomers/mio-aio", rev = "2f56696", features = ["tokio"] }
+mio-aio = { version = "0.6.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }


### PR DESCRIPTION
## Motivation

Better to depend on released crates than git tags

## Solution

Update dependency to newly released mio-aio