### PR TITLE
mpsc: ensure try_reserve error is consistent with try_send

### DIFF
--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -410,13 +410,15 @@ fn dropping_rx_closes_channel_for_try() {
 
     drop(rx);
 
-    {
-        let err = assert_err!(tx.try_send(msg.clone()));
-        match err {
-            TrySendError::Closed(..) => {}
-            _ => panic!(),
-        }
-    }
+    assert!(matches!(
+        tx.try_send(msg.clone()),
+        Err(TrySendError::Closed(_))
+    ));
+    assert!(matches!(tx.try_reserve(), Err(TrySendError::Closed(_))));
+    assert!(matches!(
+        tx.try_reserve_owned(),
+        Err(TrySendError::Closed(_))
+    ));
 
     assert_eq!(1, Arc::strong_count(&msg));
 }


### PR DESCRIPTION
Fixes #4118.

## Motivation

`try_reserve()` and `try_reserve_owned()` of `tokio::sync::mpsc::Sender` are inconsistent with `try_send()` in the error they return, signalling `Full` instead of `Closed` for a closed channel. If other code relies on this error as documented, it might forever retry sending to a closed channel.

## Solution

I copied the handling of the `TryAcquireError` from `try_send()` to `try_reserve()` and `try_reserve_owned()`; as far as I can tell, this is probably what it should have been in the first place when `try_reserve()` was introduced by 672be92a03a489d028ed7ec2c6b1abdbf0874a1d, and then `try_reserve_owned()` just copied `try_reserve()` behaviour.
