### PR TITLE
add debug_assert in case pos > cap for copy_bidirectional

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -84,6 +84,14 @@ impl CopyBuffer {
                 }
             }
 
+            // If pos larger than cap, this loop will never stop.
+            // In particular, user's wrong poll_write implementation returning
+            // incorrect written length may lead to thread blocking.
+            debug_assert!(
+                self.pos <= self.cap,
+                "writer returned length larger than input slice"
+            );
+
             // If we've written all the data and we've seen EOF, flush out the
             // data and finish the transfer.
             if self.pos == self.cap && self.read_done {


### PR DESCRIPTION
## Motivation

Wrong poll_write implementation may lead to thread blocking.
e.g., poll_write returns written length larger than cap. When reader connection alive, thread will stuck in buf_copy.

## Solution

This is hard to debug, maybe add a `debug_assert!` will help.