### PR TITLE
tracing: use structured location fields for spawned tasks

### DIFF
--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -14,7 +14,9 @@ cfg_trace! {
                 "runtime.spawn",
                 %kind,
                 task.name = %name.unwrap_or_default(),
-                spawn.location = %format_args!("{}:{}:{}", location.file(), location.line(), location.column()),
+                loc.file = location.file(),
+                loc.line = location.line(),
+                loc.col = location.column(),
             );
             #[cfg(not(tokio_track_caller))]
             let span = tracing::trace_span!(


### PR DESCRIPTION
This change enables `tokio-console` to parse the location information
for a spawned task into a structured object rather than simply displaying
this info as a field on the task.

Signed-off-by: Zahari Dichev <zaharidichev@gmail.com>