### PR TITLE
sync: add blocking_lock for mutex

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -310,7 +310,6 @@ impl<T: ?Sized> Mutex<T> {
     /// # Examples
     ///
     /// ```
-    /// use std::thread;
     /// use std::sync::Arc;
     /// use tokio::sync::Mutex;
     ///
@@ -319,12 +318,12 @@ impl<T: ?Sized> Mutex<T> {
     ///     let mutex =  Arc::new(Mutex::new(1));
     ///
     ///     let mutex1 = Arc::clone(&mutex);
-    ///     let sync_code = thread::spawn(move || {
+    ///     let sync_code = tokio::task::spawn_blocking(move || {
     ///         let mut n = mutex1.blocking_lock();
     ///         *n = 2;
     ///     });
     ///
-    ///     sync_code.join().unwrap();
+    ///     sync_code.await.unwrap();
     ///
     ///     let n = mutex.lock().await;
     ///     assert_eq!(*n, 2);

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -331,6 +331,7 @@ impl<T: ?Sized> Mutex<T> {
     /// }
     ///
     /// ```
+    #[cfg(feature = "sync")]
     pub fn blocking_lock(&self) -> MutexGuard<'_, T> {
         crate::future::block_on(self.lock())
     }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -301,6 +301,40 @@ impl<T: ?Sized> Mutex<T> {
         MutexGuard { lock: self }
     }
 
+    /// Blocking lock this mutex. When the lock has been acquired, function returns a
+    /// [`MutexGuard`].
+    ///
+    /// This method is intended for use cases where you
+    /// need to use this mutex in asynchronous code as well as in synchronous code.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::thread;
+    /// use std::sync::Arc;
+    /// use tokio::sync::Mutex;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mutex =  Arc::new(Mutex::new(1));
+    ///
+    ///     let mutex1 = Arc::clone(&mutex);
+    ///     let sync_code = thread::spawn(move || {
+    ///         let mut n = mutex1.blocking_lock();
+    ///         *n = 2;
+    ///     });
+    ///
+    ///     sync_code.join().unwrap();
+    ///
+    ///     let n = mutex.lock().await;
+    ///     assert_eq!(*n, 2);
+    /// }
+    ///
+    /// ```
+    pub fn blocking_lock(&self) -> MutexGuard<'_, T> {
+        crate::future::block_on(self.lock())
+    }
+
     /// Locks this mutex, causing the current task to yield until the lock has
     /// been acquired. When the lock has been acquired, this returns an
     /// [`OwnedMutexGuard`].


### PR DESCRIPTION
Signed-off-by: hi-rustin <rustin.liu@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

part of https://github.com/tokio-rs/tokio/issues/4109

## Solution

add blocking_lock for mutex