### PR TITLE
docs: add returning on the first error example for try_join!

### DIFF
--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -59,6 +59,44 @@
 ///     }
 /// }
 /// ```
+///
+/// Returning on the first error.
+///
+/// ```
+/// use tokio::task::JoinHandle;
+///
+/// async fn do_stuff_async() -> Result<(), &'static str> {
+///     // async work
+/// # Err("failed")
+/// }
+///
+/// async fn more_async_work() -> Result<(), &'static str> {
+///     // more here
+/// # Ok(())
+/// }
+///
+/// async fn flatten<T>(handle: JoinHandle<Result<T, &'static str>>) -> Result<T, &'static str> {
+///     match handle.await {
+///         Ok(Ok(result)) => Ok(result),
+///         Ok(Err(err)) => Err(err),
+///         Err(err) => Err("handling failed"),
+///     }
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let handle1 = tokio::spawn(do_stuff_async());
+///     let handle2 = tokio::spawn(more_async_work());
+///     match tokio::try_join!(flatten(handle1), flatten(handle2)) {
+///         Ok(val) => {
+///             // do something with the values
+///         }
+///         Err(val) => {
+///             assert_eq!(val, "failed");
+///         }
+///     }
+/// }
+/// ```
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! try_join {

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -92,7 +92,7 @@
 ///             // do something with the values
 ///         }
 ///         Err(val) => {
-///             assert_eq!(val, "failed1");
+///             assert_eq!(val, "failed");
 ///         }
 ///     }
 /// }

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -91,8 +91,9 @@
 ///         Ok(val) => {
 ///             // do something with the values
 ///         }
-///         Err(val) => {
-///             assert_eq!(val, "failed");
+///         Err(err) => {
+///             println!("Failed with {}.", err);
+///             # assert_eq!(err, "failed");
 ///         }
 ///     }
 /// }

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -60,7 +60,7 @@
 /// }
 /// ```
 ///
-/// Returning on the first error.
+/// Using `try_join!` with spawned tasks.
 ///
 /// ```
 /// use tokio::task::JoinHandle;
@@ -92,7 +92,7 @@
 ///             // do something with the values
 ///         }
 ///         Err(val) => {
-///             assert_eq!(val, "failed");
+///             assert_eq!(val, "failed1");
 ///         }
 ///     }
 /// }


### PR DESCRIPTION
Signed-off-by: hi-rustin <rustin.liu@gmail.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

close https://github.com/tokio-rs/tokio/issues/4127
## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
 add returning on the first error example for try_join!