### PR TITLE
Expand `Debug for Mutex<T>` implementation to unsized `T`

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -496,14 +496,14 @@ where
     }
 }
 
-impl<T> std::fmt::Debug for Mutex<T>
+impl<T: ?Sized> std::fmt::Debug for Mutex<T>
 where
     T: std::fmt::Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut d = f.debug_struct("Mutex");
         match self.try_lock() {
-            Ok(inner) => d.field("data", &*inner),
+            Ok(inner) => d.field("data", &&*inner),
             Err(_) => d.field("data", &format_args!("<locked>")),
         };
         d.finish()


### PR DESCRIPTION
This follows precedent of e.g. [the standard library](https://doc.rust-lang.org/1.55.0/src/std/sync/mutex.rs.html#431-454). Adds a level of indirection in order to still be able to coerce the argument to a `&dyn Debug`.

I tried to do an exhaustive search, AFAICT this seems to be the only type in this repo with an `?Sized` type argument that has a too restrictive (<code>\<T: <s>?Sized</s>\></code>) impl for Debug.