### PR TITLE
Prepare tokio-macros 1.4.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 - macros: fix invalid error messages in functions wrapped with `#[main]` or `#[test]` ([#4067])
 
+[#4027]: https://github.com/tokio-rs/tokio/pull/4027
+[#4030]: https://github.com/tokio-rs/tokio/pull/4030
+[#4067]: https://github.com/tokio-rs/tokio/pull/4067
+
 # 1.3.0 (July 7, 2021)
 
 - macros: don't trigger `clippy::unwrap_used` ([#3926])

--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.4.0 (September 29th, 2021)
+### Changed
+
+- macros: run current_thread inside LocalSet ([#4027])
+- macros: explicitly relaxed clippy lint for `.expect()` in runtime entry macro ([#4030])
+
+### Fixed
+
+- macros: fix invalid error messages in functions wrapped with `#[main]` or `#[test]` ([#4067])
+
 # 1.3.0 (July 7, 2021)
 
 - macros: don't trigger `clippy::unwrap_used` ([#3926])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.0.x" git tag.
-version = "1.3.0"
+version = "1.4.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/1.3.0/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/1.4.0/tokio_macros"
 description = """
 Tokio's proc macros.
 """


### PR DESCRIPTION
# 1.4.0 (September 29th, 2021)
### Changed

- macros: run current_thread inside LocalSet ([#4027])
- macros: explicitly relaxed clippy lint for `.expect()` in runtime entry macro ([#4030])

### Fixed

- macros: fix invalid error messages in functions wrapped with `#[main]` or `#[test]` ([#4067])

[#4027]: https://github.com/tokio-rs/tokio/pull/4027
[#4030]: https://github.com/tokio-rs/tokio/pull/4030
[#4067]: https://github.com/tokio-rs/tokio/pull/4067