### PR TITLE
Macros 1.4.1

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
- --> $DIR/macros_type_mismatch.rs:5:7
+ --> $DIR/macros_type_mismatch.rs:5:5
   |
 5 |     Ok(())
-  |       ^^^^ expected `()`, found enum `Result`
+  |     ^^^^^^ expected `()`, found enum `Result`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
@@ -16,12 +16,12 @@ help: try adding a return type
   |                                             ^^^^^^^^^^^^^^^^
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:10:18
+  --> $DIR/macros_type_mismatch.rs:10:5
    |
 9  | async fn missing_return_type() {
    |                                - help: try adding a return type: `-> Result<(), _>`
 10 |     return Ok(());
-   |                  ^ expected `()`, found enum `Result`
+   |     ^^^^^^^^^^^^^^ expected `()`, found enum `Result`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`

--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,7 +1,14 @@
+# 1.4.1 (September 30th, 2021)
+
+Reverted: run `current_thread` inside `LocalSet` ([#4027])
+
 # 1.4.0 (September 29th, 2021)
+
+(yanked)
+
 ### Changed
 
-- macros: run current_thread inside LocalSet ([#4027])
+- macros: run `current_thread` inside `LocalSet` ([#4027])
 - macros: explicitly relaxed clippy lint for `.expect()` in runtime entry macro ([#4030])
 
 ### Fixed

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.0.x" git tag.
-version = "1.4.0"
+version = "1.4.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/1.4.0/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/1.4.1/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -339,10 +339,11 @@ fn parse_knobs(
         {
             let body = async #body;
             #[allow(clippy::expect_used)]
-            #tail_return tokio::task::LocalSet::new().block_on(
-              &#rt.enable_all().build().expect("Failed building the Runtime"),
-              body,
-            )#tail_semicolon
+            #tail_return #rt
+                .enable_all()
+                .build()
+                .expect("Failed building the Runtime")
+                .block_on(body)#tail_semicolon
         }
     })
     .expect("Parsing failure");

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -27,9 +27,6 @@ use proc_macro::TokenStream;
 /// helps set up a `Runtime` without requiring the user to use
 /// [Runtime](../tokio/runtime/struct.Runtime.html) or
 /// [Builder](../tokio/runtime/struct.Builder.html) directly.
-/// The function executes in the context of a
-/// [LocalSet](../tokio/task/struct.LocalSet.html), allowing calls to
-/// [spawn_local](../tokio/task/fn.spawn_local.html) without further setup.
 ///
 /// Note: This macro is designed to be simplistic and targets applications that
 /// do not require a complex setup. If the provided functionality is not
@@ -87,14 +84,13 @@ use proc_macro::TokenStream;
 ///
 /// ```rust
 /// fn main() {
-///     let ls = tokio::task::LocalSet::new();
-///     let rt = tokio::runtime::Builder::new_multi_thread()
+///     tokio::runtime::Builder::new_multi_thread()
 ///         .enable_all()
 ///         .build()
-///         .unwrap();
-///     ls.block_on(&rt, async {
-///         println!("Hello world");
-///     })
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
 /// }
 /// ```
 ///
@@ -113,14 +109,13 @@ use proc_macro::TokenStream;
 ///
 /// ```rust
 /// fn main() {
-///     let ls = tokio::task::LocalSet::new();
-///     let rt = tokio::runtime::Builder::new_current_thread()
+///     tokio::runtime::Builder::new_current_thread()
 ///         .enable_all()
 ///         .build()
-///         .unwrap();
-///     ls.block_on(&rt, async {
-///         println!("Hello world");
-///     })
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
 /// }
 /// ```
 ///
@@ -137,15 +132,14 @@ use proc_macro::TokenStream;
 ///
 /// ```rust
 /// fn main() {
-///     let ls = tokio::task::LocalSet::new();
-///     let rt = tokio::runtime::Builder::new_multi_thread()
+///     tokio::runtime::Builder::new_multi_thread()
 ///         .worker_threads(2)
 ///         .enable_all()
 ///         .build()
-///         .unwrap();
-///     ls.block_on(&rt, async {
-///         println!("Hello world");
-///     })
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
 /// }
 /// ```
 ///
@@ -162,15 +156,14 @@ use proc_macro::TokenStream;
 ///
 /// ```rust
 /// fn main() {
-///     let ls = tokio::task::LocalSet::new();
-///     let rt = tokio::runtime::Builder::new_current_thread()
+///     tokio::runtime::Builder::new_current_thread()
 ///         .enable_all()
 ///         .start_paused(true)
 ///         .build()
-///         .unwrap();
-///     ls.block_on(&rt, async {
-///         println!("Hello world");
-///     })
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
 /// }
 /// ```
 ///
@@ -211,14 +204,13 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```rust
 /// fn main() {
-///     let ls = tokio::task::LocalSet::new();
-///     let rt = tokio::runtime::Builder::new_current_thread()
+///     tokio::runtime::Builder::new_current_thread()
 ///         .enable_all()
 ///         .build()
-///         .unwrap();
-///     ls.block_on(&rt, async {
-///         println!("Hello world");
-///     })
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
 /// }
 /// ```
 ///

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -14,10 +14,6 @@
 - runtime: callback when a worker parks and unparks ([#4070])
 - sync: implement `try_recv` for mpsc channels ([#4113])
 
-### Changed
-
-- macros: run runtime inside `LocalSet` when using macro ([#4027])
-
 ### Documented
 
 - docs: clarify CPU-bound tasks on Tokio ([#4105])

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -54,6 +54,7 @@ fn many_oneshot_futures() {
         drop(rt);
     }
 }
+
 #[test]
 fn many_multishot_futures() {
     const CHAIN: usize = 200;
@@ -471,6 +472,30 @@ fn wake_during_shutdown() {
     rt.spawn(f2);
 
     rt.block_on(async { tokio::time::sleep(tokio::time::Duration::from_millis(20)).await });
+}
+
+#[should_panic]
+#[tokio::test]
+async fn test_block_in_place1() {
+    tokio::task::block_in_place(|| {});
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_block_in_place2() {
+    tokio::task::block_in_place(|| {});
+}
+
+#[should_panic]
+#[tokio::main(flavor = "current_thread")]
+#[test]
+async fn test_block_in_place3() {
+    tokio::task::block_in_place(|| {});
+}
+
+#[tokio::main]
+#[test]
+async fn test_block_in_place4() {
+    tokio::task::block_in_place(|| {});
 }
 
 fn rt() -> Runtime {

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -17,16 +17,6 @@ use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::time::Duration;
 
 #[tokio::test(flavor = "current_thread")]
-async fn localset_implicit_current_thread() {
-    task::spawn_local(async {}).await.unwrap();
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn localset_implicit_multi_thread() {
-    task::spawn_local(async {}).await.unwrap();
-}
-
-#[tokio::test(flavor = "current_thread")]
 async fn local_basic_scheduler() {
     LocalSet::new()
         .run_until(async {


### PR DESCRIPTION
This PR prepares tokio-macros 1.4.1, reverting #4027. The previous version 1.4.0 was yanked due to breaking changes.

Closes: #4138
Closes: #4140