### PR TITLE
chore: fix unused field warnings

### DIFF
--- a/tokio/src/runtime/blocking/shutdown.rs
+++ b/tokio/src/runtime/blocking/shutdown.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub(super) struct Sender {
-    tx: Arc<oneshot::Sender<()>>,
+    _tx: Arc<oneshot::Sender<()>>,
 }
 
 #[derive(Debug)]
@@ -20,7 +20,7 @@ pub(super) struct Receiver {
 
 pub(super) fn channel() -> (Sender, Receiver) {
     let (tx, rx) = oneshot::channel();
-    let tx = Sender { tx: Arc::new(tx) };
+    let tx = Sender { _tx: Arc::new(tx) };
     let rx = Receiver { rx };
 
     (tx, rx)

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -4,6 +4,7 @@ use crate::runtime::{blocking, context, driver, Spawner};
 use crate::util::error::CONTEXT_MISSING_ERROR;
 
 use std::future::Future;
+use std::marker::PhantomData;
 use std::{error, fmt};
 
 /// Handle to the runtime.
@@ -41,8 +42,8 @@ pub struct Handle {
 #[derive(Debug)]
 #[must_use = "Creating and dropping a guard does nothing"]
 pub struct EnterGuard<'a> {
-    handle: &'a Handle,
-    guard: context::EnterGuard,
+    _guard: context::EnterGuard,
+    _handle_lifetime: PhantomData<&'a Handle>,
 }
 
 impl Handle {
@@ -55,8 +56,8 @@ impl Handle {
     /// [`tokio::spawn`]: fn@crate::spawn
     pub fn enter(&self) -> EnterGuard<'_> {
         EnterGuard {
-            handle: self,
-            guard: context::enter(self.clone()),
+            _guard: context::enter(self.clone()),
+            _handle_lifetime: PhantomData,
         }
     }
 


### PR DESCRIPTION
Rust nightly has some new warnings. This PR fixes them.