### PR TITLE
Make tokio-macros attributes more IDE friendly

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -409,9 +409,9 @@ pub(crate) fn test(args: TokenStream, item: TokenStream, rt_multi_thread: bool) 
         Ok(it) => it,
         Err(e) => return token_stream_with_error(item, e),
     };
-    let config = if input.attrs.iter().any(|attr| attr.path.is_ident("test")) {
+    let config = if let Some(attr) = input.attrs.iter().find(|attr| attr.path.is_ident("test")) {
         let msg = "second test attribute is supplied";
-        Err(syn::Error::new_spanned(&input.sig.ident, msg))
+        Err(syn::Error::new_spanned(&attr, msg))
     } else {
         AttributeArgs::parse_terminated
             .parse(args)


### PR DESCRIPTION
## Motivation

Fixes #4154

## Solution

As outlined in the aforementioned issue, in case the attribute fails its expansion for whatever reason, it now emits the input item alongside the `compile_error!` macro invocation to keep the item alive for IDE analysis.