### PR TITLE
Replace time crate with httpdate

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 httparse = "1.0"
-time = "0.1"
+httpdate = "1.0"
 once_cell = "1.5.2"
 rand = "0.8.3"
 


### PR DESCRIPTION
httpdate is used by hyper/warp/headers,
& this addresses the time crate used here being 0.1 while latest time crate is 0.3