### PR TITLE
Add example with background listener

### DIFF
--- a/tokio/src/signal/ctrl_c.rs
+++ b/tokio/src/signal/ctrl_c.rs
@@ -52,7 +52,7 @@ use std::io;
 ///
 /// ```rust,no_run
 /// tokio::spawn(async move {
-///     tokio::signal::ctrl_c().await;
+///     tokio::signal::ctrl_c().await.unwrap();
 ///     // Your handler here
 /// });
 /// ```


### PR DESCRIPTION
## Motivation

Easier to get started with a example for the common scenario of having the <kbd>Ctrl</kbd>+<kbd>C</kbd> handler listen in the background.

## Solution

An example code snippet that shows how its done.
