### PR TITLE
util/tests/watch.rs: Add `#[cfg(sync)]`

### DIFF
--- a/tokio-stream/tests/watch.rs
+++ b/tokio-stream/tests/watch.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "sync")]
+
 use tokio::sync::watch;
 use tokio_stream::wrappers::WatchStream;
 use tokio_stream::StreamExt;


### PR DESCRIPTION
We can only run if we have the `sync` feature.

This fixes a basic `cargo t --no-run` for me.
