### PR TITLE
tokio: add riscv32 to non atomic64 architectures

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -422,7 +422,8 @@ macro_rules! cfg_has_atomic_u64 {
             #[cfg(not(any(
                     target_arch = "arm",
                     target_arch = "mips",
-                    target_arch = "powerpc"
+                    target_arch = "powerpc",
+                    target_arch = "riscv32"
                     )))]
             $item
         )*
@@ -435,7 +436,8 @@ macro_rules! cfg_not_has_atomic_u64 {
             #[cfg(any(
                     target_arch = "arm",
                     target_arch = "mips",
-                    target_arch = "powerpc"
+                    target_arch = "powerpc",
+                    target_arch = "riscv32"
                     ))]
             $item
         )*


### PR DESCRIPTION
## Motivation

Attempting to build a tokio based project for the `riscv32` target architecture results in a compilation failure, due to lack of `AtomicU64`. The macro that checks this condition is based on a static list of architectures. The `riscv32` architecture is not included in this check, so it defaults to `std` support for `AtomicU64`, which is incorrect. `riscv32` does not have 64-bit atomics.

## Solution

This PR simply adds `riscv32` to the list of known architectures which do not have native `AtomicU64`. I've verified locally that projects build after this change.
