### PR TITLE
ci: split FreeBSD into two jobs

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,7 @@
 freebsd_instance:
   image: freebsd-12-2-release-amd64
+env:
+  RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the
 # same VM.  The binary will be built in 32-bit mode, but will execute on a
@@ -7,8 +9,6 @@ freebsd_instance:
 # the system's binaries, so the environment shouldn't matter.
 task:
   name: FreeBSD 64-bit
-  env:
-    RUSTFLAGS: -Dwarnings
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
@@ -40,8 +40,6 @@ task:
 
 task:
   name: FreeBSD 32-bit
-  env:
-    RUSTFLAGS: -Dwarnings
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
FreeBSD is currently our bottleneck for running CI. Split the FreeBSD CI job into two halves, hopefully reducing the total execution time.