### PR TITLE
chore: prepare tokio-macros 1.5.1

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.6.0 (October 29th, 2021)
+# 1.5.1 (October 29th, 2021)
 
 - macros: fix type resolution error in `#[tokio::main]` ([#4176])
 

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.0.x" git tag.
-version = "1.6.0"
+version = "1.5.1"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/1.6.0/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/1.5.1/tokio_macros"
 description = """
 Tokio's proc macros.
 """


### PR DESCRIPTION
# 1.5.1 (October 29th, 2021)

- macros: fix type resolution error in `#[tokio::main]` ([#4176])

[#4176]: https://github.com/tokio-rs/tokio/pull/4176