### PR TITLE
fix: allocate callback immediately on heap in debug mode

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -193,7 +193,11 @@ impl Handle {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        self.spawn_blocking_inner(func, None)
+        if cfg!(debug_assertions) && std::mem::size_of::<F>() > 2048 {
+            self.spawn_blocking_inner(Box::new(func), None)
+        } else {
+            self.spawn_blocking_inner(func, None)
+        }
     }
 
     #[cfg_attr(tokio_track_caller, track_caller)]


### PR DESCRIPTION
Addresses #4202. I have not been able to verify whether or not this fixes my issue with the stack overflow, due to it being a transitive dependency for me. However, the approach is very similar to the one taken in #4009, as suggested by @Darksonn in the issue. The only difference is that here the argument is a `FnOnce` instead of a `Future`. I'm not sure if that makes a difference with regard to stack usage.