### PR TITLE
io: update copy buffer size

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -23,7 +23,7 @@ impl CopyBuffer {
             pos: 0,
             cap: 0,
             amt: 0,
-            buf: vec![0; 8*1024].into_boxed_slice(),
+            buf: vec![0; 8192].into_boxed_slice(),
         }
     }
 

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -23,7 +23,7 @@ impl CopyBuffer {
             pos: 0,
             cap: 0,
             amt: 0,
-            buf: vec![0; 8192].into_boxed_slice(),
+            buf: vec![0; super::DEFAULT_BUF_SIZE].into_boxed_slice(),
         }
     }
 

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -23,7 +23,7 @@ impl CopyBuffer {
             pos: 0,
             cap: 0,
             amt: 0,
-            buf: vec![0; 2048].into_boxed_slice(),
+            buf: vec![0; 8*1024].into_boxed_slice(),
         }
     }
 


### PR DESCRIPTION
This updates the buffer sized used by `tokio::io::copy` to match the size in std.