### PR TITLE
net: add connect_std -> TcpSocket doc alias

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -81,6 +81,7 @@ cfg_net! {
     /// [`AsRawFd`]: https://doc.rust-lang.org/std/os/unix/io/trait.AsRawFd.html
     /// [`AsRawSocket`]: https://doc.rust-lang.org/std/os/windows/io/trait.AsRawSocket.html
     /// [`socket2`]: https://docs.rs/socket2/
+    #[cfg_attr(docsrs, doc(alias = "connect_std"))]
     pub struct TcpSocket {
         inner: mio::net::TcpSocket,
     }


### PR DESCRIPTION
In old versions of Tokio there was a method called `connect_std`, which served some of the purposes that `TcpSocket` now serves.