### PR TITLE
examples: update `tracing-subscriber` to 0.3

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -2,8 +2,6 @@
 
 [advisories]
 ignore = [
-    # https://github.com/tokio-rs/tokio/issues/4177
-    "RUSTSEC-2020-0159",
     # We depend on nix 0.22 only via mio-aio, a dev-dependency.
     # https://github.com/tokio-rs/tokio/pull/4255#issuecomment-974786349
     "RUSTSEC-2021-0119",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,7 @@ tokio-util = { version = "0.7.0", path = "../tokio-util",features = ["full"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 tracing = "0.1"
-tracing-subscriber = { version = "0.2.7", default-features = false, features = ["fmt", "ansi", "env-filter", "chrono", "tracing-log"] }
+tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt", "ansi", "env-filter", "tracing-log"] }
 bytes = "1.0.0"
 futures = { version = "0.3.0", features = ["thread-pool"]}
 http = "0.2"


### PR DESCRIPTION
## Motivation

The Tokio examples currently depend on an outdated `tracing-subscriber`
version, 0.2.7. This depends on the `chrono` crate, which is not
necessary.

## Solution

I've updated the examples to the latest version. This also lets us stop
ignoring RUSTSEC-2020-0159 in `cargo audit`, so I removed the
configuration that was added in #4186.

Fixes #4177