### PR TITLE
chore: prepare tokio-macros 1.6.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.6.0 (November 16th, 2021)
+
+- macros: fix mut patterns in `select!` macro ([#4211])
+
+[#4211]: https://github.com/tokio-rs/tokio/pull/4211
+
 # 1.5.1 (October 29th, 2021)
 
 - macros: fix type resolution error in `#[tokio::main]` ([#4176])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,13 +6,13 @@ name = "tokio-macros"
 #   - Cargo.toml
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.0.x" git tag.
-version = "1.5.1"
+version = "1.6.0"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"
 homepage = "https://tokio.rs"
-documentation = "https://docs.rs/tokio-macros/1.5.1/tokio_macros"
+documentation = "https://docs.rs/tokio-macros/1.6.0/tokio_macros"
 description = """
 Tokio's proc macros.
 """

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,7 +87,7 @@ test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]
-tokio-macros = { path = "../tokio-macros", optional = true }
+tokio-macros = { version = "1.6.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.0"
 


### PR DESCRIPTION
# 1.6.0 (November 16th, 2021)

- macros: fix mut patterns in `select!` macro ([#4211])

[#4211]: https://github.com/tokio-rs/tokio/pull/4211