### PR TITLE
Add generic trait to combine UnixListener and TcpListener

### DIFF
--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -31,6 +31,7 @@ cfg_codec! {
 
 cfg_net! {
     pub mod udp;
+    pub mod net;
 }
 
 cfg_compat! {

--- a/tokio-util/src/net/mod.rs
+++ b/tokio-util/src/net/mod.rs
@@ -1,0 +1,4 @@
+//! TCP/UDP/Unix helpers for tokio.
+
+#[cfg(unix)]
+pub mod unix;

--- a/tokio-util/src/net/unix/mod.rs
+++ b/tokio-util/src/net/unix/mod.rs
@@ -1,0 +1,108 @@
+//! Unix domain socket helpers.
+
+use std::future::Future;
+use std::io::Result;
+use std::pin::Pin;
+
+/// Listening address.
+#[derive(Debug)]
+pub enum ListenAddr {
+    /// Socket address.
+    SocketAddr(std::net::SocketAddr),
+    /// Unix socket.
+    UnixSocket(tokio::net::unix::SocketAddr),
+}
+
+impl From<std::net::SocketAddr> for ListenAddr {
+    fn from(addr: std::net::SocketAddr) -> Self {
+        Self::SocketAddr(addr)
+    }
+}
+
+impl From<tokio::net::unix::SocketAddr> for ListenAddr {
+    fn from(addr: tokio::net::unix::SocketAddr) -> Self {
+        Self::UnixSocket(addr)
+    }
+}
+
+/// A trait for a listener: `TcpListener` and `UnixListener`.
+pub trait Listener: Send + Unpin {
+    /// Accepts a new incoming connection from this listener.
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<(Box<dyn AsyncReadWrite + Send + Unpin + 'static>, ListenAddr)>,
+                > + Send
+                + 'a,
+        >,
+    >;
+
+    /// Returns the local address that this listener is bound to.
+    fn local_addr(&self) -> Result<ListenAddr>;
+}
+
+impl Listener for tokio::net::TcpListener {
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<(Box<dyn AsyncReadWrite + Send + Unpin + 'static>, ListenAddr)>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        let accept = self.accept();
+        Box::pin(async move {
+            let (stream, addr) = accept.await?;
+            Ok((Box::new(stream) as Box<_>, addr.into()))
+        })
+    }
+
+    fn local_addr(&self) -> Result<ListenAddr> {
+        self.local_addr().map(Into::into)
+    }
+}
+
+impl Listener for tokio::net::UnixListener {
+    fn accept<'a>(
+        &'a self,
+    ) -> Pin<
+        Box<
+            dyn Future<
+                    Output = Result<(Box<dyn AsyncReadWrite + Send + Unpin + 'static>, ListenAddr)>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        let accept = self.accept();
+        Box::pin(async {
+            let (stream, addr) = accept.await?;
+            Ok((Box::new(stream) as Box<_>, addr.into()))
+        })
+    }
+
+    fn local_addr(&self) -> Result<ListenAddr> {
+        self.local_addr().map(Into::into)
+    }
+}
+
+/// A trait that combines `tokio::io::AsyncRead` and `tokio::io::AsyncWrite`.
+pub trait AsyncReadWrite: tokio::io::AsyncRead + tokio::io::AsyncWrite {
+    /// Sets the value of the `TCP_NODELAY` option on this socket if this is a TCP socket.
+    fn set_nodelay(&self, nodelay: bool) -> Result<()>;
+}
+
+impl AsyncReadWrite for tokio::net::TcpStream {
+    fn set_nodelay(&self, nodelay: bool) -> Result<()> {
+        self.set_nodelay(nodelay)
+    }
+}
+
+impl AsyncReadWrite for tokio::net::UnixStream {
+    fn set_nodelay(&self, _nodelay: bool) -> Result<()> {
+        Ok(())
+    }
+}

--- a/tokio-util/src/net/unix/mod.rs
+++ b/tokio-util/src/net/unix/mod.rs
@@ -55,7 +55,7 @@ impl Listener for tokio::net::TcpListener {
         >,
     > {
         let accept = self.accept();
-        Box::pin(async move {
+        Box::pin(async {
             let (stream, addr) = accept.await?;
             Ok((Box::new(stream) as Box<_>, addr.into()))
         })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I would like to have a generic type for creating a socket from TCP or from a Unix socket so I don't need to duplicate code.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Added a new type that combines the SocketAddr of TcpListener and the one of UnixListener. I called it ListenAddr.
2. Added a new trait Listener with an `accept()` method and a `local_addr()` method to reflect the methods from TcpListener and UnixListener.
3. Added a new trait AsyncReadWrite which combines AsyncRead and AsyncWrite. This is because I will need to box the stream.
4. Added a method `set_nodelay()` to reflect the method `set_nodelay()` of TcpStream which I needed.

### Problem encountered

There is a module "udp" at root of tokio-util. It should probably moved to the new module "net" I created. One alternative would be to rename the "unix" module I created to something else.