### PR TITLE
macros: address remainging clippy::semicolon_if_nothing_returned warning

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -339,17 +339,17 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     let body = &input.block;
     let brace_token = input.block.brace_token;
     let (tail_return, tail_semicolon) = match body.stmts.last() {
-        Some(syn::Stmt::Semi(expr, _)) => match expr {
-            syn::Expr::Return(_) => (quote! { return }, quote! { ; }),
-            _ => match &input.sig.output {
+        Some(syn::Stmt::Semi(syn::Expr::Return(_), _)) => (quote! { return }, quote! { ; }),
+        Some(syn::Stmt::Semi(..)) | Some(syn::Stmt::Local(..)) | None => {
+            match &input.sig.output {
                 syn::ReturnType::Type(_, ty) if matches!(&**ty, syn::Type::Tuple(ty) if ty.elems.is_empty()) =>
                 {
                     (quote! {}, quote! { ; }) // unit
                 }
                 syn::ReturnType::Default => (quote! {}, quote! { ; }), // unit
                 syn::ReturnType::Type(..) => (quote! {}, quote! {}),   // ! or another
-            },
-        },
+            }
+        }
         _ => (quote! {}, quote! {}),
     };
     input.block = syn::parse2(quote_spanned! {last_stmt_end_span=>

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -46,3 +46,25 @@ pub async fn issue_4175_test() -> std::io::Result<()> {
     return Ok(());
     panic!();
 }
+
+// https://github.com/tokio-rs/tokio/issues/4175
+pub mod clippy_semicolon_if_nothing_returned {
+    #![deny(clippy::semicolon_if_nothing_returned)]
+
+    #[tokio::main]
+    pub async fn local() {
+        let _x = ();
+    }
+    #[tokio::main]
+    pub async fn item() {
+        fn _f() {}
+    }
+    #[tokio::main]
+    pub async fn semi() {
+        panic!();
+    }
+    #[tokio::main]
+    pub async fn empty() {
+        // To trigger clippy::semicolon_if_nothing_returned lint, the block needs to contain newline.
+    }
+}


### PR DESCRIPTION
Fixes #4245
