### PR TITLE
extend AsyncFdReadyGuard method rettypes lifetimes

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -525,7 +525,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     #[cfg_attr(docsrs, doc(alias = "with_io"))]
     pub fn try_io<R>(
         &mut self,
-        f: impl FnOnce(&AsyncFd<Inner>) -> io::Result<R>,
+        f: impl FnOnce(&'a AsyncFd<Inner>) -> io::Result<R>,
     ) -> Result<io::Result<R>, TryIoError> {
         let result = f(self.async_fd);
 
@@ -542,12 +542,12 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     }
 
     /// Returns a shared reference to the inner [`AsyncFd`].
-    pub fn get_ref(&self) -> &AsyncFd<Inner> {
+    pub fn get_ref(&self) -> &'a AsyncFd<Inner> {
         self.async_fd
     }
 
     /// Returns a shared reference to the backing object of the inner [`AsyncFd`].
-    pub fn get_inner(&self) -> &Inner {
+    pub fn get_inner(&self) -> &'a Inner {
         self.get_ref().get_ref()
     }
 }


### PR DESCRIPTION
## Motivation

The implicit elided lifetimes of the `AsyncFd` references in return types of methods on `AsyncFdReadyGuard` resolved to that of `&self`, which is needlessly small.

## Solution

Change the lifetimes of the references. Should not be a breaking change thanks to subtyping.

---

On a parallel note, I would also like to get an opinion on whether this pull request should be made to include a new `into_try_io()` method on `AsyncFdReadyMutGuard`:

```rust
pub fn into_try_io<R>(
    self,
    f: impl FnOnce(&'a mut Inner) -> io::Result<R>,
) -> Result<io::Result<R>, TryIoError> {
    let AsyncFdReadyMutGuard {
        async_fd,
        mut event,
    } = self;
    let result = f(async_fd.inner.as_mut().unwrap());

    match result {
        Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
            if let Some(event) = event.take() {
                async_fd.registration.clear_readiness(event);
            }
            Err(TryIoError(()))
        }
        result => return Ok(result),
    }
}
```

since the currently existing `try_io()` method is limiting when writing streaming streams, as the result of the closure cannot reference anything that outlives the guard handle. One example where this *perhaps* would have been useful is in the [implementation of the `capture-stream` feature][next_noblock] of the [pcap] crate.

[pcap]: https://github.com/ebfull/pcap
[next_noblock]: https://github.com/ebfull/pcap/blob/f755af559c2f4224ca4a79d14db88835e9d7abf3/src/lib.rs#L1082