### PR TITLE
docs: document that parking_lot is enabled by full

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -312,7 +312,7 @@
 //! Beware though that this will pull in many extra dependencies that you may not
 //! need.
 //!
-//! - `full`: Enables all Tokio public API features listed below except `test-util`.
+//! - `full`: Enables all features listed below except `test-util` and `tracing`.
 //! - `rt`: Enables `tokio::spawn`, the basic (current thread) scheduler,
 //!         and non-scheduler utilities.
 //! - `rt-multi-thread`: Enables the heavier, multi-threaded, work-stealing scheduler.


### PR DESCRIPTION
## Motivation

The current docs only specify that public API features are enabled using full, this is not correct.

## Solution

Update documentation to be in line with actual features.
