### PR TITLE
Add 1.14.x to LTS releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
  * `1.8.x` - LTS release until February 2022.
+ * `1.14.x` - LTS release until June 2022.
 
 Each LTS release will continue to receive backported fixes for at least half a
 year. If you wish to use a fixed minor release in your project, we recommend

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -181,6 +181,7 @@ released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
  * `1.8.x` - LTS release until February 2022.
+ * `1.14.x` - LTS release until June 2022.
 
 Each LTS release will continue to receive backported fixes for at least half a
 year. If you wish to use a fixed minor release in your project, we recommend


### PR DESCRIPTION
The MSRV was bumped to 1.46 in #4254 and 1.14.x will be the last release with a MSRV of 1.45. Hence, it seems reasonable to make 1.14.x an LTS release.