### PR TITLE
tokio-stream: exposed Elapsed

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -50,7 +50,7 @@ use take_while::TakeWhile;
 
 cfg_time! {
     mod timeout;
-    use timeout::Timeout;
+    use timeout::{Elapsed, Timeout};
     use tokio::time::Duration;
     mod throttle;
     use throttle::{throttle, Throttle};


### PR DESCRIPTION
Without this, the error from `Timeout` is not accessible.

## Motivation

Using `StreamExt::timeout()`, I found I was unable to convert the error because it was inaccessible.

## Solution

Export `Elapsed` with `Timeout`.