### PR TITLE
Link to futures::future::join_all/select_all from join and select docs

### DIFF
--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -14,6 +14,12 @@
 ///
 /// [`try_join!`]: macro@try_join
 ///
+///
+/// # Join on Vec or iterator
+///
+/// If you need to join an arbitrary number of futures at runtime, you
+/// should use [futures::future::join_all](https://docs.rs/futures/latest/futures/future/fn.join_all.html) instead.
+///
 /// # Notes
 ///
 /// The supplied futures are stored inline and does not require allocating a

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -45,6 +45,11 @@
 /// 5. If **all** branches are disabled, evaluate the `else` expression. If no
 ///    else branch is provided, panic.
 ///
+/// # Select on Vec or iterator
+///
+/// If you need to select an arbitrary number of futures at runtime, you
+/// should use [futures::future::select_all](https://docs.rs/futures/latest/futures/future/fn.select_all.html) instead.
+///
 /// # Runtime characteristics
 ///
 /// By running all async expressions on the current task, the expressions are


### PR DESCRIPTION
## Motivation
Multiple times when dealing with futures I have ended up confused because I am looking at the tokio docs and cant see a way to join a Vec of futures.
What I really want is the futures crate's join_all and select_all functions, but when I find join! and select! in tokio I naively expect to find this functionality in tokio too.

## Solution
Link to futures::future::join_all/select_all from join and select docs

Maybe this adds to much noise and isn't worth it, but I thought it would be worth proposing.