### PR TITLE
Call tcp.set_nonblocking(true) in AsyncFd example.

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -81,6 +81,7 @@ use std::{task::Context, task::Poll};
 ///
 /// impl AsyncTcpStream {
 ///     pub fn new(tcp: TcpStream) -> io::Result<Self> {
+///         tcp.set_nonblocking(true)?;
 ///         Ok(Self {
 ///             inner: AsyncFd::new(tcp)?,
 ///         })


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Though the description for AsyncFd says, 

> the file descriptor must have the nonblocking mode set to true.

However, it does not set to true in the AsyncFd example. So if developers just copied the example, it would not work expectedly.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Call `tcp.set_nonblocking(true)?;` in AsyncTcpStream::new(). 
