### PR TITLE
process: Add `as_std()` method to `Command`

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -264,6 +264,12 @@ impl Command {
         Self::from(StdCommand::new(program))
     }
 
+    /// Cheaply convert to a `&std::process::Command` for places where the type from the standard
+    /// library is expected.
+    pub fn as_std(&self) -> &StdCommand {
+        &self.std
+    }
+
     /// Adds an argument to pass to the program.
     ///
     /// Only one argument can be passed per use. So instead of:

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -26,7 +26,10 @@ pub struct Handle {
 
     /// Handles to the signal drivers
     #[cfg_attr(
-        not(any(feature = "signal", all(unix, feature = "process"))),
+        not(any(
+            all(unix, feature = "signal"),
+            all(unix, feature = "process"),
+        )),
         allow(dead_code)
     )]
     pub(super) signal_handle: driver::SignalHandle,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -26,10 +26,7 @@ pub struct Handle {
 
     /// Handles to the signal drivers
     #[cfg_attr(
-        not(any(
-            all(unix, feature = "signal"),
-            all(unix, feature = "process"),
-        )),
+        not(any(all(unix, feature = "signal"), all(unix, feature = "process"))),
         allow(dead_code)
     )]
     pub(super) signal_handle: driver::SignalHandle,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -26,7 +26,11 @@ pub struct Handle {
 
     /// Handles to the signal drivers
     #[cfg_attr(
-        not(any(all(unix, feature = "signal"), all(unix, feature = "process"))),
+        any(
+            loom,
+            not(all(unix, feature = "signal")),
+            not(all(unix, feature = "process")),
+        ),
         allow(dead_code)
     )]
     pub(super) signal_handle: driver::SignalHandle,


### PR DESCRIPTION
* This allows callers to cheaply convert to a &std::process::Command and
  use any (immutable) methods added on the stdlib type in case they are
  missing from our own wrapper (e.g. because MSRV is lagging)

Refs #4285
