### PR TITLE
make `tokio::io::empty` cooperative

### DIFF
--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -76,16 +76,16 @@ impl fmt::Debug for Empty {
 }
 
 cfg_coop! {
-    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<()> {
         let coop = ready!(crate::coop::poll_proceed(cx));
         coop.made_progress();
-        Poll::Ready(Ok(()))
+        Poll::Ready(())
     }
 }
 
 cfg_not_coop! {
-    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<io::Result<()>> {
-        Poll::Ready(Ok(()))
+    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<()> {
+        Poll::Ready(())
     }
 }
 

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -50,16 +50,20 @@ impl AsyncRead for Empty {
     #[inline]
     fn poll_read(
         self: Pin<&mut Self>,
-        _: &mut Context<'_>,
+        cx: &mut Context<'_>,
         _: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
+        let coop = ready!(crate::coop::poll_proceed(cx));
+        coop.made_progress();
         Poll::Ready(Ok(()))
     }
 }
 
 impl AsyncBufRead for Empty {
     #[inline]
-    fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let coop = ready!(crate::coop::poll_proceed(cx));
+        coop.made_progress();
         Poll::Ready(Ok(&[]))
     }
 

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -53,7 +53,7 @@ impl AsyncRead for Empty {
         cx: &mut Context<'_>,
         _: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        let _ = ready!(poll_proceed_and_make_progress(cx));
+        ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 }
@@ -61,7 +61,7 @@ impl AsyncRead for Empty {
 impl AsyncBufRead for Empty {
     #[inline]
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        let _ = ready!(poll_proceed_and_make_progress(cx));
+        ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(&[]))
     }
 

--- a/tokio/tests/io_util_empty.rs
+++ b/tokio/tests/io_util_empty.rs
@@ -1,0 +1,31 @@
+use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+
+#[tokio::test]
+async fn empty_read_is_cooperative() {
+    tokio::select! {
+        biased;
+
+        _ = async {
+            loop {
+                let mut buf = [0u8; 4096];
+                let _ = tokio::io::empty().read(&mut buf).await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}
+
+#[tokio::test]
+async fn empty_buf_reads_are_cooperative() {
+    tokio::select! {
+        biased;
+
+        _ = async {
+            loop {
+                let mut buf = String::new();
+                let _ = tokio::io::empty().read_line(&mut buf).await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}

--- a/tokio/tests/io_util_empty.rs
+++ b/tokio/tests/io_util_empty.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "full")]
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
 #[tokio::test]


### PR DESCRIPTION
Fixes: #4291

## Motivation

Reads and buffered reads from a `tokio::io::empty` were always marked
as ready. That makes sense, given that there is nothing to wait for.
However, doing repeated reads on the `empty` could stall the event
loop and prevent other tasks from making progress.

## Solution

This change makes reads on empty objects cooperative. One of every two
reads will return `Poll::Pending`, which will give the executor a
chance to keep making progress elsewhere.

## Testing

I've added four integration tests. The tests wouldn't fail if the fix hadn't been implemented,
they would just hang forever (just like the original issue). 

This is my first contribution to the project, so maybe there are higher-level ways of achieving
this behaviour and testing this functionality. Let me know if that's the case!