### PR TITLE
replace use of `transmute` with pointer manipulations

### DIFF
--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -31,7 +31,7 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> ReadBuf<'a> {
         let initialized = buf.len();
-        let buf = unsafe { slice_to_uninit_mut(buf) } ;
+        let buf = unsafe { slice_to_uninit_mut(buf) };
         ReadBuf {
             buf,
             filled: 0,

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -116,7 +116,7 @@ impl<'a> ReadBuf<'a> {
     /// initialized.
     ///
     /// The elements between 0 and `self.filled().len()` are filled, and those between 0 and
-    /// `self.initialized().len()` are initialized (and so can be transmuted to a `&mut [u8]`).
+    /// `self.initialized().len()` are initialized (and so can be converted to a `&mut [u8]`).
     ///
     /// The caller of this method must ensure that these invariants are upheld. For example, if the
     /// caller initializes some of the uninitialized section of the buffer, it must call

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -277,8 +277,8 @@ impl fmt::Debug for ReadBuf<'_> {
     }
 }
 
-fn slice_to_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
-    unsafe {slice::from_raw_parts_mut::<MaybeUninit<u8>>(slice.as_mut_ptr().cast(), slice.len())}
+unsafe fn slice_to_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
+    slice::from_raw_parts_mut::<MaybeUninit<u8>>(slice.as_mut_ptr().cast(), slice.len())
 }
 
 // TODO: This could use `MaybeUninit::slice_assume_init` when it is stable.

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -64,7 +64,6 @@ impl<'a> ReadBuf<'a> {
         let slice = &self.buf[..self.filled];
         // safety: filled describes how far into the buffer that the
         // user has filled with bytes, so it's been initialized.
-        // TODO: This could use `MaybeUninit::slice_get_ref` when it is stable.
         unsafe { slice_assume_init(slice) }
     }
 
@@ -74,7 +73,6 @@ impl<'a> ReadBuf<'a> {
         let slice = &mut self.buf[..self.filled];
         // safety: filled describes how far into the buffer that the
         // user has filled with bytes, so it's been initialized.
-        // TODO: This could use `MaybeUninit::slice_get_mut` when it is stable.
         unsafe { slice_assume_init_mut(slice) }
     }
 
@@ -94,7 +92,6 @@ impl<'a> ReadBuf<'a> {
         let slice = &self.buf[..self.initialized];
         // safety: initialized describes how far into the buffer that the
         // user has at some point initialized with bytes.
-        // TODO: This could use `MaybeUninit::slice_get_ref` when it is stable.
         unsafe { slice_assume_init(slice) }
     }
 
@@ -106,7 +103,6 @@ impl<'a> ReadBuf<'a> {
         let slice = &mut self.buf[..self.initialized];
         // safety: initialized describes how far into the buffer that the
         // user has at some point initialized with bytes.
-        // TODO: This could use `MaybeUninit::slice_get_mut` when it is stable.
         unsafe { slice_assume_init_mut(slice) }
     }
 
@@ -285,10 +281,12 @@ fn slice_to_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
     unsafe {slice::from_raw_parts_mut::<MaybeUninit<u8>>(slice.as_mut_ptr().cast(), slice.len())}
 }
 
+// TODO: This could use `MaybeUninit::slice_assume_init` when it is stable.
 unsafe fn slice_assume_init(slice: &[MaybeUninit<u8>]) -> &[u8] {
     slice::from_raw_parts(slice.as_ptr().cast(), slice.len())
 }
 
+// TODO: This could use `MaybeUninit::slice_assume_init_mut` when it is stable.
 unsafe fn slice_assume_init_mut(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
     slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len())
 }

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -32,7 +32,7 @@ impl<'a> ReadBuf<'a> {
     #[inline]
     pub fn new(buf: &'a mut [u8]) -> ReadBuf<'a> {
         let initialized = buf.len();
-        let buf = slice_to_uninit_mut(buf);
+        let buf = unsafe { slice_to_uninit_mut(buf) } ;
         ReadBuf {
             buf,
             filled: 0,

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -278,15 +278,15 @@ impl fmt::Debug for ReadBuf<'_> {
 }
 
 unsafe fn slice_to_uninit_mut(slice: &mut [u8]) -> &mut [MaybeUninit<u8>] {
-    slice::from_raw_parts_mut::<MaybeUninit<u8>>(slice.as_mut_ptr().cast(), slice.len())
+    &mut *(slice as *mut [u8] as *mut [MaybeUninit<u8>])
 }
 
 // TODO: This could use `MaybeUninit::slice_assume_init` when it is stable.
 unsafe fn slice_assume_init(slice: &[MaybeUninit<u8>]) -> &[u8] {
-    slice::from_raw_parts(slice.as_ptr().cast(), slice.len())
+    &*(slice as *const [MaybeUninit<u8>] as *const [u8])
 }
 
 // TODO: This could use `MaybeUninit::slice_assume_init_mut` when it is stable.
 unsafe fn slice_assume_init_mut(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
-    slice::from_raw_parts_mut(slice.as_mut_ptr().cast(), slice.len())
+    &mut *(slice as *mut [MaybeUninit<u8>] as *mut [u8])
 }

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -1,6 +1,5 @@
 use std::fmt;
 use std::mem::MaybeUninit;
-use std::slice;
 
 /// A wrapper around a byte buffer that is incrementally filled and initialized.
 ///


### PR DESCRIPTION
## Motivation

The layout of wide pointers is unspecified, so `transmute`ing them is not valid.

## Solution

Use `slice::from_raw_parts(_mut)` instead 
