### PR TITLE
chore: update labeler.yml to drop filepath prefixes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,8 @@
 
 R-loom:
-- ./tokio/src/sync/*
-- ./tokio/src/sync/**/*
-- ./tokio-util/src/sync/*
-- ./tokio-util/src/sync/**/*
-- ./tokio/src/runtime/*
-- ./tokio/src/runtime/**/*
-
+- tokio/src/sync/*
+- tokio/src/sync/**/*
+- tokio-util/src/sync/*
+- tokio-util/src/sync/**/*
+- tokio/src/runtime/*
+- tokio/src/runtime/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,3 +11,4 @@ jobs:
     - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true


### PR DESCRIPTION
Using the `./` prefix apparently foobars the config and makes it not match anything.

Closes #4164.