### PR TITLE
sync: add `watch::Sender::send_modify` method

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -444,7 +444,15 @@ impl<T> Sender<T> {
     /// having to allocate a new instance. Additionally, this
     /// method permits sending values even when there are no receivers.
     ///
+    /// # Panics
+    ///
+    /// This function panics if calling `func` results in a panic.
+    /// No receivers are notified if panic occurred.
+    /// If the panic is caught, this might leave the watched value
+    /// in an inconsistent state.
+    ///
     /// # Examples
+    ///
     /// ```
     /// use tokio::sync::watch;
     ///

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -447,9 +447,8 @@ impl<T> Sender<T> {
     /// # Panics
     ///
     /// This function panics if calling `func` results in a panic.
-    /// No receivers are notified if panic occurred.
-    /// If the panic is caught, this might leave the watched value
-    /// in an inconsistent state.
+    /// No receivers are notified if panic occurred, but if the closure has modified
+    /// the value, that change is still visible to future calls to `borrow`.
     ///
     /// # Examples
     ///

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -468,6 +468,8 @@ impl<T> Sender<T> {
             }));
             // If the func panicked return the panic to the caller.
             if let Err(error) = result {
+                // Drop the lock to avoid poisoning it.
+                drop(lock);
                 panic::resume_unwind(error);
             }
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -434,7 +434,7 @@ impl<T> Sender<T> {
             return Err(error::SendError(value));
         }
 
-        self.send_replace(value);
+        self.send_modify(|old| *old = value);
         Ok(())
     }
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -439,7 +439,7 @@ impl<T> Sender<T> {
 
     /// Modifies watched value, notifying all receivers.
     ///
-    /// This can useful for modyfing the watched value, without
+    /// This can useful for modifying the watched value, without
     /// having to allocate a new instance. Additionally, this
     /// method permits sending values even when there are no receivers.
     ///

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -434,7 +434,7 @@ impl<T> Sender<T> {
             return Err(error::SendError(value));
         }
 
-        self.send_modify(|old| *old = value);
+        self.send_replace(value);
         Ok(())
     }
 

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -223,6 +223,7 @@ fn send_modify_panic() {
     assert!(result.is_err());
 
     assert_pending!(task.poll());
+    assert_eq!(*rx.borrow(), "panicked");
 
     tx.send_modify(|old| *old = "three");
     assert_ready_ok!(task.poll());

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -201,3 +201,30 @@ fn reopened_after_subscribe() {
     drop(rx);
     assert!(tx.is_closed());
 }
+
+#[test]
+fn send_modify_panic() {
+    let (tx, mut rx) = watch::channel("one");
+
+    tx.send_modify(|old| *old = "two");
+    assert_eq!(*rx.borrow_and_update(), "two");
+
+    let mut rx2 = rx.clone();
+    assert_eq!(*rx2.borrow_and_update(), "two");
+
+    let mut task = spawn(rx2.changed());
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        tx.send_modify(|old| {
+            *old = "panicked";
+            panic!();
+        })
+    }));
+    assert!(result.is_err());
+
+    assert_pending!(task.poll());
+
+    tx.send_modify(|old| *old = "three");
+    assert_ready_ok!(task.poll());
+    assert_eq!(*rx.borrow_and_update(), "three");
+}


### PR DESCRIPTION
`send_modify` allows to modify inner value without having to allocate new value which can be expensive if the inner value is for example struct that holds a lot of data.