### PR TITLE
stats: make sure that 'full' enables 'stats'

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -37,6 +37,7 @@ full = [
   "rt",
   "rt-multi-thread",
   "signal",
+  "stats",
   "sync",
   "time",
 ]


### PR DESCRIPTION
Otherwise this is really misleading since full is not really full

## Motivation

It seems to me this is an oversight since 'full' should really turn on all features.

## Solution

Add 'stats' as part of the dependency list of 'full'