### PR TITLE
stats: mark stats feature unstable in lib.rs

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -346,6 +346,7 @@
 //! `RUSTFLAGS="--cfg tokio_unstable"`.
 //!
 //! - `tracing`: Enables tracing events.
+//! - `stats`: Enables runtime stats collection. ([RFC](https://github.com/tokio-rs/tokio/pull/3845))
 //!
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 


### PR DESCRIPTION
The PR #4325 reminded me that stats is not currently mentioned in lib.rs.