### PR TITLE
fix: update num_cpus to 1.13.1 to fix cgroup parse problem

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -95,7 +95,7 @@ bytes = { version = "1.0.0", optional = true }
 once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.7.6", optional = true }
-num_cpus = { version = "1.8.0", optional = true }
+num_cpus = { version = "1.13.1", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
 
 # Currently unstable. The API exposed by these features may be broken at any time.


### PR DESCRIPTION
num_cpus prior to 1.13.1 has some bugs parsing cgroup config, this PR updates num_cpus to 1.13.1 to fix it.
For more information, refer to https://github.com/seanmonstar/num_cpus/pull/113.