### PR TITLE
chore: make the introduction in examples/Cargo.toml more clear

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -5,10 +5,10 @@ publish = false
 edition = "2018"
 
 # If you copy one of the examples into a new project, you should be using
-# [dependencies] instead.
+# [dependencies] instead, and delete the **path**.
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio",features = ["full", "tracing"] }
-tokio-util = { version = "0.7.0", path = "../tokio-util",features = ["full"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing"] }
+tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 tracing = "0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

When I copy some examples to my own project, found the introduce in examples/Cargo.toml are not clear enough.

## Solution

1. Make the introduction more clear in examples/Cargo.toml.
2. Fix a style problem for examples/Cargo.toml
