### PR TITLE
Add blocking_recv method to oneshot::Receiver

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1040,6 +1040,7 @@ impl<T> Receiver<T> {
     ///     sync_code.join().unwrap();
     /// }
     /// ```
+    #[cfg(feature = "sync")]
     pub fn blocking_recv(self) -> Option<T> {
         crate::future::block_on(self).ok()
     }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1014,6 +1014,35 @@ impl<T> Receiver<T> {
         self.inner = None;
         result
     }
+
+    /// Blocking receive to call outside of asynchronous contexts.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution
+    /// context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::thread;
+    /// use tokio::sync::oneshot;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = oneshot::channel::<u8>();
+    ///
+    ///     let sync_code = thread::spawn(move || {
+    ///         assert_eq!(Some(10), rx.blocking_recv());
+    ///     });
+    ///
+    ///     let _ = tx.send(10);
+    ///     sync_code.join().unwrap();
+    /// }
+    /// ```
+    pub fn blocking_recv(self) -> Option<T> {
+        crate::future::block_on(self).ok()
+    }
 }
 
 impl<T> Drop for Receiver<T> {

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1033,7 +1033,7 @@ impl<T> Receiver<T> {
     ///     let (tx, rx) = oneshot::channel::<u8>();
     ///
     ///     let sync_code = thread::spawn(move || {
-    ///         assert_eq!(Some(10), rx.blocking_recv());
+    ///         assert_eq!(Ok(10), rx.blocking_recv());
     ///     });
     ///
     ///     let _ = tx.send(10);
@@ -1041,8 +1041,8 @@ impl<T> Receiver<T> {
     /// }
     /// ```
     #[cfg(feature = "sync")]
-    pub fn blocking_recv(self) -> Option<T> {
-        crate::future::block_on(self).ok()
+    pub fn blocking_recv(self) -> Result<T, RecvError> {
+        crate::future::block_on(self)
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
See #4319
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
The solution is same as in `mpsc` channels, except that method receiver is `self` instead of `&mut self`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
