### PR TITLE
Add a has_changed function to `watch::Receiver`

### DIFF
--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -174,17 +174,24 @@ fn poll_close() {
 fn borrow_and_update() {
     let (tx, mut rx) = watch::channel("one");
 
+    assert!(!rx.has_changed().unwrap());
+
     tx.send("two").unwrap();
+    assert!(rx.has_changed().unwrap());
     assert_ready!(spawn(rx.changed()).poll()).unwrap();
     assert_pending!(spawn(rx.changed()).poll());
+    assert!(!rx.has_changed().unwrap());
 
     tx.send("three").unwrap();
+    assert!(rx.has_changed().unwrap());
     assert_eq!(*rx.borrow_and_update(), "three");
     assert_pending!(spawn(rx.changed()).poll());
+    assert!(!rx.has_changed().unwrap());
 
     drop(tx);
     assert_eq!(*rx.borrow_and_update(), "three");
     assert_ready!(spawn(rx.changed()).poll()).unwrap_err();
+    assert!(rx.has_changed().is_err());
 }
 
 #[test]


### PR DESCRIPTION
## Motivation
I'm using `sync::watch` to tell a bunch of workers to do some work, and once in a while they check to see what's the latest job, and if there's no new job they should keep doing what they're already doing, and currently the only way to do that is via `rex.changed().now_or_never().is_some()` which has some `Waker` overhead (see asm in https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=8fdf2f1bf2b6b16827b106dc13ef5895)

## Solution
Add a `has_changed` method to check if the value had changed.

## Alternatives
1. This method doesn't change the version that the receiver currently holds, this is the only function in the API that observes the version without changing it, should it maybe also change it? (that comes at the cost of being a `&mut self` function).
2. Implement  a `try_changed` function that doesn't block if the value hasn't changed.
