### PR TITLE
io: always forward flush to stdout and stderr

### DIFF
--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -32,6 +32,7 @@ full = [
     "macros",
     "rt",
     "rt-multi-thread",
+    "rt-stdio",
 
     "tokio/full",
     "tokio-test"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -9,6 +9,10 @@ publish = false
 name = "test-cat"
 
 [[bin]]
+name = "test-stdio-flush"
+required-features = ["rt-stdio"]
+
+[[bin]]
 name = "test-mem"
 required-features = ["rt-net"]
 
@@ -21,6 +25,8 @@ required-features = ["rt-process-signal"]
 rt-net = ["tokio/rt", "tokio/rt-multi-thread", "tokio/net"]
 # For test-process-signal
 rt-process-signal = ["rt", "tokio/process", "tokio/signal"]
+# For test-stdio-flush
+rt-stdio = ["tokio/rt", "tokio/io-std", "tokio/io-util"]
 
 full = [
     "macros",

--- a/tests-integration/src/bin/test-stdio-flush.rs
+++ b/tests-integration/src/bin/test-stdio-flush.rs
@@ -1,0 +1,16 @@
+use tokio::io::{AsyncWriteExt, AsyncReadExt};
+
+fn main() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        tokio::io::stdout().write_all(b"Hello world!").await.unwrap();
+        tokio::io::stdout().flush().await.unwrap();
+
+        let mut buf = [0];
+        tokio::io::stdin().read_exact(&mut buf).await.unwrap();
+        assert_eq!(buf[0], 16);
+    });
+}

--- a/tests-integration/src/bin/test-stdio-flush.rs
+++ b/tests-integration/src/bin/test-stdio-flush.rs
@@ -1,4 +1,4 @@
-use tokio::io::{AsyncWriteExt, AsyncReadExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 fn main() {
     let rt = tokio::runtime::Builder::new_current_thread()
@@ -6,7 +6,10 @@ fn main() {
         .unwrap();
 
     rt.block_on(async {
-        tokio::io::stdout().write_all(b"Hello world!").await.unwrap();
+        tokio::io::stdout()
+            .write_all(b"Hello world!")
+            .await
+            .unwrap();
         tokio::io::stdout().flush().await.unwrap();
 
         let mut buf = [0];

--- a/tests-integration/tests/stdio_flush.rs
+++ b/tests-integration/tests/stdio_flush.rs
@@ -1,0 +1,41 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::process::Command;
+use tokio::time::{timeout, Duration};
+
+use std::process::Stdio;
+
+fn stdio_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_test-stdio-flush"));
+    cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+    cmd
+}
+
+async fn assert_flush_works_fn() {
+    let mut proc = stdio_cmd().spawn().expect("spawning test process");
+
+    let mut stdin = proc.stdin.take().unwrap();
+    let mut stdout = proc.stdout.take().unwrap();
+
+    let mut buf = [0; b"Hello world!".len()];
+    stdout.read_exact(&mut buf).await.unwrap();
+
+    assert_eq!(&buf, b"Hello world!");
+
+    stdin.write_all(&[16]).await.unwrap();
+    stdin.flush().await.unwrap();
+    drop(stdin);
+
+    let status = proc.wait().await.unwrap();
+    assert!(status.success());
+}
+
+
+#[tokio::test]
+async fn assert_flush_works() {
+    if timeout(Duration::from_secs(10), assert_flush_works_fn()).await.is_err() {
+        panic!("Test timed out.");
+    }
+}

--- a/tests-integration/tests/stdio_flush.rs
+++ b/tests-integration/tests/stdio_flush.rs
@@ -32,10 +32,12 @@ async fn assert_flush_works_fn() {
     assert!(status.success());
 }
 
-
 #[tokio::test]
 async fn assert_flush_works() {
-    if timeout(Duration::from_secs(10), assert_flush_works_fn()).await.is_err() {
+    if timeout(Duration::from_secs(10), assert_flush_works_fn())
+        .await
+        .is_err()
+    {
         panic!("Test timed out.");
     }
 }

--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -68,7 +68,7 @@ cfg_io_std! {
     pub fn stderr() -> Stderr {
         let std = io::stderr();
         Stderr {
-            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new(std)),
+            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new_always_flush(std)),
         }
     }
 }

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -67,7 +67,7 @@ cfg_io_std! {
     pub fn stdout() -> Stdout {
         let std = io::stdout();
         Stdout {
-            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new(std)),
+            std: SplitByUtf8BoundaryIfWindows::new(Blocking::new_always_flush(std)),
         }
     }
 }


### PR DESCRIPTION
Always call flush on the inner IO resource even if nothing has been written. This is necessary because someone could have written to stdout or stderr via some other object, and that data would go into the same shared buffer.

Closes: #4347