### PR TITLE
io: fix clippy lint in `write_all`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
-        run: rustup update 1.56 && rustup default 1.56
+        run: rustup update 1.57 && rustup default 1.57
       - uses: Swatinem/rust-cache@v1
       - name: Install clippy
         run: rustup component add clippy

--- a/tokio/src/io/util/write_all.rs
+++ b/tokio/src/io/util/write_all.rs
@@ -42,7 +42,7 @@ where
         while !me.buf.is_empty() {
             let n = ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf))?;
             {
-                let (_, rest) = mem::replace(&mut *me.buf, &[]).split_at(n);
+                let (_, rest) = mem::take(&mut *me.buf).split_at(n);
                 *me.buf = rest;
             }
             if n == 0 {


### PR DESCRIPTION
This fixes a clippy lint (from a newer version of clippy than we currently use in CI).