### PR TITLE
Don't inherit Send from parking_lot::*Guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     needs:
       - test
       - test-unstable
+      - test-parking_lot
       - miri
       - cross
       - features
@@ -76,6 +77,20 @@ jobs:
         working-directory: benches
         # bench.yml workflow runs benchmarks only on linux.
         if: startsWith(matrix.os, 'ubuntu')
+
+  test-parking_lot:
+    name: compile tests with parking lot send guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Rust
+        run: rustup update stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Enable parking_lot send_guard feature
+        # Inserts the line "plsend = ["parking_lot/send_guard"]" right after [features]
+        run: sed -i '/\[features\]/a plsend = ["parking_lot/send_guard"]' tokio/Cargo.toml
+      - name: Compile tests with all features enabled
+        run: cargo build --workspace --all-features --tests
 
   valgrind:
     name: valgrind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,13 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
 
   test-parking_lot:
+    # The parking_lot crate has a feature called send_guard which changes when
+    # some of its types are Send. Tokio has some measures in place to prevent
+    # this from affecting when Tokio types are Send, and this test exists to
+    # ensure that those measures are working.
+    #
+    # This relies on the potentially affected Tokio type being listed in
+    # `tokio/tokio/tests/async_send_sync.rs`.
     name: compile tests with parking lot send guards
     runs-on: ubuntu-latest
     steps:

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -8,6 +8,12 @@ use std::ops::{Deref, DerefMut};
 use std::sync::LockResult;
 use std::time::Duration;
 
+// All types in this file are marked with PhantomData to ensure that
+// parking_lot's send_guard feature does not leak through and affect when Tokio
+// types are Send.
+//
+// See <https://github.com/tokio-rs/tokio/pull/4359> for more info.
+
 // Types that do not need wrapping
 pub(crate) use parking_lot::WaitTimeoutResult;
 

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -3,6 +3,7 @@
 //!
 //! This can be extended to additional types/methods as required.
 
+use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::sync::LockResult;
@@ -162,4 +163,22 @@ impl Condvar {
 
     // Note: Additional methods `wait_timeout_ms`, `wait_timeout_until`,
     // `wait_until` can be provided here as needed.
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for MutexGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.1, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockReadGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.1, f)
+    }
+}
+
+impl<'a, T: ?Sized + fmt::Display> fmt::Display for RwLockWriteGuard<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.1, f)
+    }
 }

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -3,83 +3,125 @@
 //!
 //! This can be extended to additional types/methods as required.
 
+use std::marker::PhantomData;
+use std::ops::{Deref, DerefMut};
 use std::sync::LockResult;
 use std::time::Duration;
 
 // Types that do not need wrapping
-pub(crate) use parking_lot::{MutexGuard, RwLockReadGuard, RwLockWriteGuard, WaitTimeoutResult};
-
-/// Adapter for `parking_lot::Mutex` to the `std::sync::Mutex` interface.
-#[derive(Debug)]
-pub(crate) struct Mutex<T: ?Sized>(parking_lot::Mutex<T>);
+pub(crate) use parking_lot::WaitTimeoutResult;
 
 #[derive(Debug)]
-pub(crate) struct RwLock<T>(parking_lot::RwLock<T>);
+pub(crate) struct Mutex<T: ?Sized>(PhantomData<std::sync::Mutex<T>>, parking_lot::Mutex<T>);
 
-/// Adapter for `parking_lot::Condvar` to the `std::sync::Condvar` interface.
 #[derive(Debug)]
-pub(crate) struct Condvar(parking_lot::Condvar);
+pub(crate) struct RwLock<T>(PhantomData<std::sync::RwLock<T>>, parking_lot::RwLock<T>);
+
+#[derive(Debug)]
+pub(crate) struct Condvar(PhantomData<std::sync::Condvar>, parking_lot::Condvar);
+
+#[derive(Debug)]
+pub(crate) struct MutexGuard<'a, T: ?Sized>(PhantomData<std::sync::MutexGuard<'a, T>>, parking_lot::MutexGuard<'a, T>);
+
+#[derive(Debug)]
+pub(crate) struct RwLockReadGuard<'a, T: ?Sized>(PhantomData<std::sync::RwLockReadGuard<'a, T>>, parking_lot::RwLockReadGuard<'a, T>);
+
+#[derive(Debug)]
+pub(crate) struct RwLockWriteGuard<'a, T: ?Sized>(PhantomData<std::sync::RwLockWriteGuard<'a, T>>, parking_lot::RwLockWriteGuard<'a, T>);
 
 impl<T> Mutex<T> {
     #[inline]
     pub(crate) fn new(t: T) -> Mutex<T> {
-        Mutex(parking_lot::Mutex::new(t))
+        Mutex(PhantomData, parking_lot::Mutex::new(t))
     }
 
     #[inline]
     #[cfg(all(feature = "parking_lot", not(all(loom, test)),))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "parking_lot",))))]
     pub(crate) const fn const_new(t: T) -> Mutex<T> {
-        Mutex(parking_lot::const_mutex(t))
+        Mutex(PhantomData, parking_lot::const_mutex(t))
     }
 
     #[inline]
     pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
-        self.0.lock()
+        MutexGuard(PhantomData, self.1.lock())
     }
 
     #[inline]
     pub(crate) fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
-        self.0.try_lock()
+        self.1.try_lock().map(|guard| MutexGuard(PhantomData, guard))
     }
 
     #[inline]
     pub(crate) fn get_mut(&mut self) -> &mut T {
-        self.0.get_mut()
+        self.1.get_mut()
     }
 
     // Note: Additional methods `is_poisoned` and `into_inner`, can be
     // provided here as needed.
 }
 
+impl<'a, T: ?Sized> Deref for MutexGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.1.deref()
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for MutexGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.1.deref_mut()
+    }
+}
+
 impl<T> RwLock<T> {
     pub(crate) fn new(t: T) -> RwLock<T> {
-        RwLock(parking_lot::RwLock::new(t))
+        RwLock(PhantomData, parking_lot::RwLock::new(t))
     }
 
     pub(crate) fn read(&self) -> LockResult<RwLockReadGuard<'_, T>> {
-        Ok(self.0.read())
+        Ok(RwLockReadGuard(PhantomData, self.1.read()))
     }
 
     pub(crate) fn write(&self) -> LockResult<RwLockWriteGuard<'_, T>> {
-        Ok(self.0.write())
+        Ok(RwLockWriteGuard(PhantomData, self.1.write()))
+    }
+}
+
+impl<'a, T: ?Sized> Deref for RwLockReadGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.1.deref()
+    }
+}
+
+impl<'a, T: ?Sized> Deref for RwLockWriteGuard<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        self.1.deref()
+    }
+}
+
+impl<'a, T: ?Sized> DerefMut for RwLockWriteGuard<'a, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        self.1.deref_mut()
     }
 }
 
 impl Condvar {
     #[inline]
     pub(crate) fn new() -> Condvar {
-        Condvar(parking_lot::Condvar::new())
+        Condvar(PhantomData, parking_lot::Condvar::new())
     }
 
     #[inline]
     pub(crate) fn notify_one(&self) {
-        self.0.notify_one();
+        self.1.notify_one();
     }
 
     #[inline]
     pub(crate) fn notify_all(&self) {
-        self.0.notify_all();
+        self.1.notify_all();
     }
 
     #[inline]
@@ -87,7 +129,7 @@ impl Condvar {
         &self,
         mut guard: MutexGuard<'a, T>,
     ) -> LockResult<MutexGuard<'a, T>> {
-        self.0.wait(&mut guard);
+        self.1.wait(&mut guard.1);
         Ok(guard)
     }
 
@@ -97,7 +139,7 @@ impl Condvar {
         mut guard: MutexGuard<'a, T>,
         timeout: Duration,
     ) -> LockResult<(MutexGuard<'a, T>, WaitTimeoutResult)> {
-        let wtr = self.0.wait_for(&mut guard, timeout);
+        let wtr = self.1.wait_for(&mut guard.1, timeout);
         Ok((guard, wtr))
     }
 

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -21,13 +21,22 @@ pub(crate) struct RwLock<T>(PhantomData<std::sync::RwLock<T>>, parking_lot::RwLo
 pub(crate) struct Condvar(PhantomData<std::sync::Condvar>, parking_lot::Condvar);
 
 #[derive(Debug)]
-pub(crate) struct MutexGuard<'a, T: ?Sized>(PhantomData<std::sync::MutexGuard<'a, T>>, parking_lot::MutexGuard<'a, T>);
+pub(crate) struct MutexGuard<'a, T: ?Sized>(
+    PhantomData<std::sync::MutexGuard<'a, T>>,
+    parking_lot::MutexGuard<'a, T>,
+);
 
 #[derive(Debug)]
-pub(crate) struct RwLockReadGuard<'a, T: ?Sized>(PhantomData<std::sync::RwLockReadGuard<'a, T>>, parking_lot::RwLockReadGuard<'a, T>);
+pub(crate) struct RwLockReadGuard<'a, T: ?Sized>(
+    PhantomData<std::sync::RwLockReadGuard<'a, T>>,
+    parking_lot::RwLockReadGuard<'a, T>,
+);
 
 #[derive(Debug)]
-pub(crate) struct RwLockWriteGuard<'a, T: ?Sized>(PhantomData<std::sync::RwLockWriteGuard<'a, T>>, parking_lot::RwLockWriteGuard<'a, T>);
+pub(crate) struct RwLockWriteGuard<'a, T: ?Sized>(
+    PhantomData<std::sync::RwLockWriteGuard<'a, T>>,
+    parking_lot::RwLockWriteGuard<'a, T>,
+);
 
 impl<T> Mutex<T> {
     #[inline]
@@ -49,7 +58,9 @@ impl<T> Mutex<T> {
 
     #[inline]
     pub(crate) fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
-        self.1.try_lock().map(|guard| MutexGuard(PhantomData, guard))
+        self.1
+            .try_lock()
+            .map(|guard| MutexGuard(PhantomData, guard))
     }
 
     #[inline]


### PR DESCRIPTION
Currently our `tokio::sync::watch::Ref` type can become `Send` if Tokio is compiled with the `parking_lot` feature and `parking_lot` is compiled with its `send_guard` feature. This PR will prevent the `send_guard` feature from affecting whether Tokio types are `Send` or not.

Strictly speaking, this PR is a breaking change, however I believe we should make the change regardless. As it stands now, the `parking_lot` crate is in our public API, and if don't want to make this change, then we should also commit to never upgrading `parking_lot` beyond `0.11.x`, as such an upgrade would be also be a breaking change for the same reasons.

I don't think many people will be affected by this. Anyone who is affected is probably holding a `tokio::sync::watch::Ref` alive across an `.await`, which is always incorrect.

The first commit in this PR adds a test to CI that should catch this in the future. The commit is first so we can see the test fail without the change. The test relies on [`tokio/tokio/tests/async_send_sync.rs`][1].

[1]: https://github.com/tokio-rs/tokio/blob/master/tokio/tests/async_send_sync.rs