### PR TITLE
net: fix build error on master

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -378,7 +378,7 @@ impl TcpSocket {
     ///
     /// [`set_linger`]: TcpSocket::set_linger
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        self.inner.get_linger()
+        self.inner.linger()
     }
 
     /// Gets the local address of this socket.


### PR DESCRIPTION
This fixes CI failure on master: https://github.com/tokio-rs/tokio/actions/runs/1639606619

TcpSocket::linger has been added in https://github.com/tokio-rs/tokio/pull/4324 (2 weeks ago), but #4270 was last edited a month ago, so missed this change.

```
error[E0599]: no method named `get_linger` found for struct `Socket` in the current scope
   --> tokio/src/net/tcp/socket.rs:381:20
    |
381 |         self.inner.get_linger()
    |                    ^^^^^^^^^^ help: there is an associated function with a similar name: `set_linger`
```
