### PR TITLE
net: add UdpSocket::peer_addr

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -378,7 +378,7 @@ impl TcpSocket {
     ///
     /// [`set_linger`]: TcpSocket::set_linger
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        self.inner.get_linger()
+        self.inner.linger()
     }
 
     /// Gets the local address of this socket.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -274,6 +274,29 @@ impl UdpSocket {
         self.io.local_addr()
     }
 
+    /// Returns the socket address of the remote peer this socket was connected
+    /// to.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+    /// let peer_addr = "127.0.0.1:11100".parse::<SocketAddr>().unwrap();
+    /// let sock = UdpSocket::bind(addr).await?;
+    /// sock.connect(peer_addr).await?;
+    /// assert_eq!(sock.peer_addr()?.ip(), peer_addr.ip());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.io.peer_addr()
+    }
+
     /// Connects the UDP socket setting the default destination for send() and
     /// limiting packets that are read via recv from the address specified in
     /// `addr`.

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -3,6 +3,7 @@
 
 use futures::future::poll_fn;
 use std::io;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::{io::ReadBuf, net::UdpSocket};
 use tokio_test::assert_ok;
@@ -483,4 +484,13 @@ async fn poll_ready() {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn peer_addr() {
+    let addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
+    let peer_addr = "127.0.0.1:11100".parse::<SocketAddr>().unwrap();
+    let sock = UdpSocket::bind(addr).await.unwrap();
+    sock.connect(peer_addr).await.unwrap();
+    assert_eq!(sock.peer_addr().unwrap().ip(), peer_addr.ip());
 }


### PR DESCRIPTION
Closes #3312
Solves https://github.com/tokio-rs/tokio/discussions/3309

The first commit is from #4361.

Refs:
- [`std::net::UdpSocket::peer_addr`](https://doc.rust-lang.org/nightly/std/net/struct.UdpSocket.html#method.peer_addr)
- [`mio::net::UdpSocket::peer_addr`](https://docs.rs/mio/latest/mio/net/struct.UdpSocket.html#method.peer_addr)