### PR TITLE
net: add TcpSocket::take_error

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -378,7 +378,7 @@ impl TcpSocket {
     ///
     /// [`set_linger`]: TcpSocket::set_linger
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        self.inner.get_linger()
+        self.inner.linger()
     }
 
     /// Gets the local address of this socket.

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -409,6 +409,11 @@ impl TcpSocket {
             .map(|addr| addr.as_socket().unwrap())
     }
 
+    /// Returns the value of the `SO_ERROR` option.
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        self.inner.take_error()
+    }
+
     /// Binds the socket to the given address.
     ///
     /// This calls the `bind(2)` operating-system function. Behavior is


### PR DESCRIPTION
Solves https://github.com/tokio-rs/tokio/discussions/3170

cc #3082

The first commit is from #4361.

Refs:
- [socket2::Socket::take_error](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.take_error)
