### PR TITLE
net: add tos and set_tos methods to TCP and UDP sockets

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -378,7 +378,7 @@ impl TcpSocket {
     ///
     /// [`set_linger`]: TcpSocket::set_linger
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        self.inner.get_linger()
+        self.inner.linger()
     }
 
     /// Gets the local address of this socket.

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -381,6 +381,67 @@ impl TcpSocket {
         self.inner.linger()
     }
 
+    /// Gets the value of the `IP_TOS` option for this socket.
+    ///
+    /// For more information about this option, see [`set_tos`].
+    ///
+    /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
+    /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
+    ///
+    /// [`set_tos`]: Self::set_tos
+    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    #[cfg(not(any(
+        target_os = "fuchsia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "fuchsia",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "illumos",
+            ))
+        )))
+    )]
+    pub fn tos(&self) -> io::Result<u32> {
+        self.inner.tos()
+    }
+
+    /// Sets the value for the `IP_TOS` option on this socket.
+    ///
+    /// This value sets the time-to-live field that is used in every packet sent
+    /// from this socket.
+    ///
+    /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
+    /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
+    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    #[cfg(not(any(
+        target_os = "fuchsia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "fuchsia",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "illumos",
+            ))
+        )))
+    )]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        self.inner.set_tos(tos)
+    }
+
     /// Gets the local address of this socket.
     ///
     /// Will fail on windows if called before `bind`.

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -398,15 +398,12 @@ impl TcpSocket {
     )))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(
-            unix,
-            not(any(
-                target_os = "fuchsia",
-                target_os = "redox",
-                target_os = "solaris",
-                target_os = "illumos",
-            ))
-        )))
+        doc(cfg(not(any(
+            target_os = "fuchsia",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "illumos",
+        ))))
     )]
     pub fn tos(&self) -> io::Result<u32> {
         self.inner.tos()
@@ -428,15 +425,12 @@ impl TcpSocket {
     )))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(
-            unix,
-            not(any(
-                target_os = "fuchsia",
-                target_os = "redox",
-                target_os = "solaris",
-                target_os = "illumos",
-            ))
-        )))
+        doc(cfg(not(any(
+            target_os = "fuchsia",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "illumos",
+        ))))
     )]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
         self.inner.set_tos(tos)

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1090,7 +1090,7 @@ impl TcpStream {
     /// # }
     /// ```
     pub fn linger(&self) -> io::Result<Option<Duration>> {
-        let socket = self.to_socket();
+        let socket = self.as_socket();
         socket.linger()
     }
 
@@ -1116,11 +1116,11 @@ impl TcpStream {
     /// # }
     /// ```
     pub fn set_linger(&self, dur: Option<Duration>) -> io::Result<()> {
-        let socket = self.to_socket();
+        let socket = self.as_socket();
         socket.set_linger(dur)
     }
 
-    fn to_socket(&self) -> socket2::SockRef<'_> {
+    fn as_socket(&self) -> socket2::SockRef<'_> {
         socket2::SockRef::from(self)
     }
 

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1480,6 +1480,71 @@ impl UdpSocket {
         self.io.set_ttl(ttl)
     }
 
+    /// Gets the value of the `IP_TOS` option for this socket.
+    ///
+    /// For more information about this option, see [`set_tos`].
+    ///
+    /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
+    /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
+    ///
+    /// [`set_tos`]: Self::set_tos
+    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    #[cfg(not(any(
+        target_os = "fuchsia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "fuchsia",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "illumos",
+            ))
+        )))
+    )]
+    pub fn tos(&self) -> io::Result<u32> {
+        self.to_socket().tos()
+    }
+
+    /// Sets the value for the `IP_TOS` option on this socket.
+    ///
+    /// This value sets the time-to-live field that is used in every packet sent
+    /// from this socket.
+    ///
+    /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
+    /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
+    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    #[cfg(not(any(
+        target_os = "fuchsia",
+        target_os = "redox",
+        target_os = "solaris",
+        target_os = "illumos",
+    )))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(all(
+            unix,
+            not(any(
+                target_os = "fuchsia",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "illumos",
+            ))
+        )))
+    )]
+    pub fn set_tos(&self, tos: u32) -> io::Result<()> {
+        self.to_socket().set_tos(tos)
+    }
+
+    fn to_socket(&self) -> socket2::SockRef<'_> {
+        socket2::SockRef::from(self)
+    }
+
     /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.
     ///
     /// This function specifies a new multicast group for this socket to join.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1528,7 +1528,7 @@ impl UdpSocket {
         ))))
     )]
     pub fn tos(&self) -> io::Result<u32> {
-        self.to_socket().tos()
+        self.as_socket().tos()
     }
 
     /// Sets the value for the `IP_TOS` option on this socket.
@@ -1555,10 +1555,10 @@ impl UdpSocket {
         ))))
     )]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
-        self.to_socket().set_tos(tos)
+        self.as_socket().set_tos(tos)
     }
 
-    fn to_socket(&self) -> socket2::SockRef<'_> {
+    fn as_socket(&self) -> socket2::SockRef<'_> {
         socket2::SockRef::from(self)
     }
 

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1520,15 +1520,12 @@ impl UdpSocket {
     )))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(
-            unix,
-            not(any(
-                target_os = "fuchsia",
-                target_os = "redox",
-                target_os = "solaris",
-                target_os = "illumos",
-            ))
-        )))
+        doc(cfg(not(any(
+            target_os = "fuchsia",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "illumos",
+        ))))
     )]
     pub fn tos(&self) -> io::Result<u32> {
         self.to_socket().tos()
@@ -1550,15 +1547,12 @@ impl UdpSocket {
     )))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(all(
-            unix,
-            not(any(
-                target_os = "fuchsia",
-                target_os = "redox",
-                target_os = "solaris",
-                target_os = "illumos",
-            ))
-        )))
+        doc(cfg(not(any(
+            target_os = "fuchsia",
+            target_os = "redox",
+            target_os = "solaris",
+            target_os = "illumos",
+        ))))
     )]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
         self.to_socket().set_tos(tos)

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -253,6 +253,78 @@ impl UdpSocket {
         }
     }
 
+    /// Sets the size of the UDP send buffer on this socket.
+    ///
+    /// On most operating systems, this sets the `SO_SNDBUF` socket option.
+    pub fn set_send_buffer_size(&self, size: u32) -> io::Result<()> {
+        self.as_socket().set_send_buffer_size(size as usize)
+    }
+
+    /// Returns the size of the UDP send buffer for this socket.
+    ///
+    /// On most operating systems, this is the value of the `SO_SNDBUF` socket
+    /// option.
+    ///
+    /// Note that if [`set_send_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_send_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   send buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket send buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_send_buffer_size`]: Self::set_send_buffer_size
+    pub fn send_buffer_size(&self) -> io::Result<u32> {
+        self.as_socket().send_buffer_size().map(|n| n as u32)
+    }
+
+    /// Sets the size of the UDP receive buffer on this socket.
+    ///
+    /// On most operating systems, this sets the `SO_RCVBUF` socket option.
+    pub fn set_recv_buffer_size(&self, size: u32) -> io::Result<()> {
+        self.as_socket().set_recv_buffer_size(size as usize)
+    }
+
+    /// Returns the size of the UDP receive buffer for this socket.
+    ///
+    /// On most operating systems, this is the value of the `SO_RCVBUF` socket
+    /// option.
+    ///
+    /// Note that if [`set_recv_buffer_size`] has been called on this socket
+    /// previously, the value returned by this function may not be the same as
+    /// the argument provided to `set_send_buffer_size`. This is for the
+    /// following reasons:
+    ///
+    /// * Most operating systems have minimum and maximum allowed sizes for the
+    ///   receive buffer, and will clamp the provided value if it is below the
+    ///   minimum or above the maximum. The minimum and maximum buffer sizes are
+    ///   OS-dependent.
+    /// * Linux will double the buffer size to account for internal bookkeeping
+    ///   data, and returns the doubled value from `getsockopt(2)`. As per `man
+    ///   7 socket`:
+    ///   > Sets or gets the maximum socket send buffer in bytes. The
+    ///   > kernel doubles this value (to allow space for bookkeeping
+    ///   > overhead) when it is set using `setsockopt(2)`, and this doubled
+    ///   > value is returned by `getsockopt(2)`.
+    ///
+    /// [`set_recv_buffer_size`]: Self::set_recv_buffer_size
+    pub fn recv_buffer_size(&self) -> io::Result<u32> {
+        self.as_socket().recv_buffer_size().map(|n| n as u32)
+    }
+
+    fn as_socket(&self) -> socket2::SockRef<'_> {
+        socket2::SockRef::from(self)
+    }
+
     /// Returns the local address that this socket is bound to.
     ///
     /// # Example
@@ -1556,10 +1628,6 @@ impl UdpSocket {
     )]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
         self.as_socket().set_tos(tos)
-    }
-
-    fn as_socket(&self) -> socket2::SockRef<'_> {
-        socket2::SockRef::from(self)
     }
 
     /// Executes an operation of the `IP_ADD_MEMBERSHIP` type.


### PR DESCRIPTION
Closes #3545

cc #3082

The first commit is from #4361.

Refs:
- [socket2::Socket::tos](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.tos)
- [socket2::Socket::set_tos](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.set_tos)