### PR TITLE
test: fix version requirement of tokio-stream

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["asynchronous", "testing"]
 
 [dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
-tokio-stream = { version = "0.1", path = "../tokio-stream" }
+tokio-stream = { version = "0.1.1", path = "../tokio-stream" }
 async-stream = "0.3"
 
 bytes = "1.0.0"


### PR DESCRIPTION
## Motivation

`cargo minimal-versions check` ([taiki-e/cargo-minimal-versions](https://github.com/taiki-e/cargo-minimal-versions)) should succeed on a project with tokio-test as a dependency.

Currently fails here:
```
...
    Checking tokio-stream v0.1.0
    Checking tokio-test v0.4.2
error[E0432]: unresolved import `tokio_stream::wrappers`
  --> /Users/rob/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-test-0.4.2/src/io.rs:24:19
   |
24 | use tokio_stream::wrappers::UnboundedReceiverStream;
   |                   ^^^^^^^^ could not find `wrappers` in `tokio_stream`

error[E0599]: no method named `poll_next` found for struct `Pin<_>` in the current scope
   --> /Users/rob/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-test-0.4.2/src/io.rs:206:32
    |
206 |         Pin::new(&mut self.rx).poll_next(cx)
    |                                ^^^^^^^^^ method not found in `Pin<_>`
    |
    = note: `Pin::new(&mut self.rx)` is a function, perhaps you wish to call it
...
```

## Solution

Use the correct minimal version of tokio-stream which appears to be `0.1.1` when the `wrappers` module was introduced.