### PR TITLE
Edit API Docs to reference using port 0 on UDPSocket

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -129,7 +129,7 @@ impl UdpSocket {
     /// the `addr` provided.
     ///
     /// **Note**: To dynamically allocate a local port, pass an address with the port as "0". (Ex: "0.0.0.0:0"). 
-    //  This will let the underlying system choose a port for you.
+    /// This will let the underlying system choose a port for you.
     ///
     /// # Example
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -128,6 +128,9 @@ impl UdpSocket {
     /// This function will create a new UDP socket and attempt to bind it to
     /// the `addr` provided.
     ///
+    /// **Note**: To dynamically allocate a local port, pass an address with the port as "0" or omitted. (Ex: "0.0.0.0:0" or "0.0.0.0"). 
+    //  This will let the underlying system choose a port for you
+    ///
     /// # Example
     ///
     /// ```no_run

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -128,8 +128,8 @@ impl UdpSocket {
     /// This function will create a new UDP socket and attempt to bind it to
     /// the `addr` provided.
     ///
-    /// **Note**: To dynamically allocate a local port, pass an address with the port as "0" or omitted. (Ex: "0.0.0.0:0" or "0.0.0.0"). 
-    //  This will let the underlying system choose a port for you
+    /// **Note**: To dynamically allocate a local port, pass an address with the port as "0". (Ex: "0.0.0.0:0"). 
+    //  This will let the underlying system choose a port for you.
     ///
     /// # Example
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -128,8 +128,9 @@ impl UdpSocket {
     /// This function will create a new UDP socket and attempt to bind it to
     /// the `addr` provided.
     ///
-    /// **Note**: To dynamically allocate a local port, pass an address with the port as "0". (Ex: "0.0.0.0:0"). 
-    /// This will let the underlying system choose a port for you.
+    /// Binding with a port number of 0 will request that the OS assigns a port
+    /// to this listener. The port allocated can be queried via the `local_addr`
+    /// method.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Motivation
I came across needing to generate a UDP Socket and allow the port to be dynamically allocated. The docs didn't have anything referencing how to do that. Thanks to the discord community I was able to get this answered

## Solution
Add a note in the API Docs explaining that if Port 0 is given, then on bind() of the UDP socket, a port will be assigned.
