### PR TITLE
chore: test hyper on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - valgrind
       - loom-compile
       - check-readme
+      - test-hyper
     steps:
       - run: exit 0
 
@@ -355,3 +356,31 @@ jobs:
       - name: Verify that Tokio version is up to date in README
         working-directory: tokio
         run: grep -q "$(sed '/^version = /!d' Cargo.toml | head -n1)" README.md
+
+  test-hyper:
+    name: Test hyper
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.nightly }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: Test hyper
+        run: |
+          set -x
+          git clone https://github.com/hyperium/hyper.git
+          cd hyper
+          # checkout the latest release because HEAD maybe contains breakage.
+          tag=$(curl -fsSL https://api.github.com/repos/hyperium/hyper/releases/latest | jq -r '.tag_name')
+          git checkout "${tag}"
+          echo '[workspace]' >>Cargo.toml
+          echo '[patch.crates-io]' >>Cargo.toml
+          echo 'tokio = { path = "../tokio" }' >>Cargo.toml
+          echo 'tokio-util = { path = "../tokio-util" }' >>Cargo.toml
+          echo 'tokio-stream = { path = "../tokio-stream" }' >>Cargo.toml
+          echo 'tokio-test = { path = "../tokio-test" }' >>Cargo.toml
+          git diff
+          cargo test --features full
+          cargo bench --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,7 +359,13 @@ jobs:
 
   test-hyper:
     name: Test hyper
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -383,4 +389,3 @@ jobs:
           echo 'tokio-test = { path = "../tokio-test" }' >>Cargo.toml
           git diff
           cargo test --features full
-          cargo bench --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,7 +383,7 @@ jobs:
           git clone https://github.com/hyperium/hyper.git
           cd hyper
           # checkout the latest release because HEAD maybe contains breakage.
-          tag=$(curl -fsSL https://api.github.com/repos/hyperium/hyper/releases/latest | jq -r '.tag_name')
+          tag=$(git describe --abbrev=0 --tags)
           git checkout "${tag}"
           echo '[workspace]' >>Cargo.toml
           echo '[patch.crates-io]' >>Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,8 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.nightly }}
-          override: true
+      - name: Install Rust
+        run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - name: Test hyper
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ env:
   nightly: nightly-2021-11-23
   minrust: 1.46
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   # Depends on all action sthat are required for a "successful" CI run.
   tests-pass:


### PR DESCRIPTION
Split from #4390.

~~As said in #4392, this fails until https://github.com/tokio-rs/tokio/commit/cc8ad367a0e5d8536f8be58fe560bfdea1a976a5 (#4377) is reverted (or until the regression introduced by that commit is fixed).~~
UPD: https://github.com/tokio-rs/tokio/commit/cc8ad367a0e5d8536f8be58fe560bfdea1a976a5 has been reverted in #4394 
