### PR TITLE
rt: refactor current-thread scheduler (take 2)

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -283,7 +283,7 @@ cfg_rt! {
     #[derive(Debug)]
     enum Kind {
         /// Execute all tasks on the current-thread.
-        CurrentThread(BasicScheduler<driver::Driver>),
+        CurrentThread(BasicScheduler),
 
         /// Execute tasks across multiple threads.
         #[cfg(feature = "rt-multi-thread")]

--- a/tokio/src/runtime/tests/loom_basic_scheduler.rs
+++ b/tokio/src/runtime/tests/loom_basic_scheduler.rs
@@ -34,20 +34,22 @@ fn assert_at_most_num_polls(rt: Arc<Runtime>, at_most_polls: usize) {
 #[test]
 fn block_on_num_polls() {
     loom::model(|| {
-        // we expect at most 3 number of polls because there are
-        // three points at which we poll the future. At any of these
-        // points it can be ready:
+        // we expect at most 4 number of polls because there are three points at
+        // which we poll the future and an opportunity for a false-positive.. At
+        // any of these points it can be ready:
         //
-        // - when we fail to steal the parker and we block on a
-        //   notification that it is available.
+        // - when we fail to steal the parker and we block on a notification
+        //   that it is available.
         //
         // - when we steal the parker and we schedule the future
         //
-        // - when the future is woken up and we have ran the max
-        //   number of tasks for the current tick or there are no
-        //   more tasks to run.
+        // - when the future is woken up and we have ran the max number of tasks
+        //   for the current tick or there are no more tasks to run.
         //
-        let at_most = 3;
+        // - a thread is notified that the parker is available but a third
+        //   thread acquires it before the notified thread can.
+        //
+        let at_most = 4;
 
         let rt1 = Arc::new(Builder::new_current_thread().build().unwrap());
         let rt2 = rt1.clone();

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -1,8 +1,5 @@
 //! Threadpool
 
-mod atomic_cell;
-use atomic_cell::AtomicCell;
-
 mod idle;
 use self::idle::Idle;
 

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -66,8 +66,9 @@ use crate::runtime::enter::EnterContext;
 use crate::runtime::park::{Parker, Unparker};
 use crate::runtime::stats::{RuntimeStats, WorkerStatsBatcher};
 use crate::runtime::task::{Inject, JoinHandle, OwnedTasks};
-use crate::runtime::thread_pool::{AtomicCell, Idle};
+use crate::runtime::thread_pool::Idle;
 use crate::runtime::{queue, task, Callback};
+use crate::util::atomic_cell::AtomicCell;
 use crate::util::FastRand;
 
 use std::cell::RefCell;

--- a/tokio/src/util/atomic_cell.rs
+++ b/tokio/src/util/atomic_cell.rs
@@ -3,7 +3,7 @@ use crate::loom::sync::atomic::AtomicPtr;
 use std::ptr;
 use std::sync::atomic::Ordering::AcqRel;
 
-pub(super) struct AtomicCell<T> {
+pub(crate) struct AtomicCell<T> {
     data: AtomicPtr<T>,
 }
 
@@ -11,22 +11,22 @@ unsafe impl<T: Send> Send for AtomicCell<T> {}
 unsafe impl<T: Send> Sync for AtomicCell<T> {}
 
 impl<T> AtomicCell<T> {
-    pub(super) fn new(data: Option<Box<T>>) -> AtomicCell<T> {
+    pub(crate) fn new(data: Option<Box<T>>) -> AtomicCell<T> {
         AtomicCell {
             data: AtomicPtr::new(to_raw(data)),
         }
     }
 
-    pub(super) fn swap(&self, val: Option<Box<T>>) -> Option<Box<T>> {
+    pub(crate) fn swap(&self, val: Option<Box<T>>) -> Option<Box<T>> {
         let old = self.data.swap(to_raw(val), AcqRel);
         from_raw(old)
     }
 
-    pub(super) fn set(&self, val: Box<T>) {
+    pub(crate) fn set(&self, val: Box<T>) {
         let _ = self.swap(Some(val));
     }
 
-    pub(super) fn take(&self) -> Option<Box<T>> {
+    pub(crate) fn take(&self) -> Option<Box<T>> {
         self.swap(None)
     }
 }

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -3,6 +3,9 @@ cfg_io_driver! {
     pub(crate) mod slab;
 }
 
+#[cfg(feature = "rt")]
+pub(crate) mod atomic_cell;
+
 #[cfg(any(
     // io driver uses `WakeList` directly
     feature = "net",


### PR DESCRIPTION
Re-applies #4377 and fixes the bug resulting in Hyper's double panic.

Revert: #4394

Original PR:

This PR does some refactoring to the current-thread scheduler bringing it closer to the structure of the multi-threaded scheduler. More specifically, the core scheduler data is stored in a Core struct and that struct is passed around as a "token" indicating permission to do work. The Core structure is also stored in the thread-local context.

This refactor is intended to support #4373, making it easier to track counters in more locations in the current-thread scheduler.

I tried to keep commits small, but the "set Core in thread-local context" is both the biggest commit and the key one.