### PR TITLE
ci: upgrade to new nightly

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -29,7 +29,7 @@ task:
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain nightly-2021-11-23
+    - sh rustup.sh -y --profile minimal --default-toolchain nightly-2022-01-12
     - . $HOME/.cargo/env
     - |
       echo "~~~~ rustc --version ~~~~"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2021-11-23
+  nightly: nightly-2022-01-12
   minrust: 1.46
 
 defaults:


### PR DESCRIPTION
I'd like to use a newer Miri that includes https://github.com/rust-lang/miri/pull/1952.