### PR TITLE
chore: fix ci to track Rust 1.58

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/macros_type_mismatch.rs:5:5
+ --> tests/fail/macros_type_mismatch.rs:5:5
   |
 5 |     Ok(())
   |     ^^^^^^ expected `()`, found enum `Result`
@@ -16,7 +16,7 @@ help: try adding a return type
   |                                             ++++++++++++++++
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:10:5
+  --> tests/fail/macros_type_mismatch.rs:10:5
    |
 9  | async fn missing_return_type() {
    |                                - help: try adding a return type: `-> Result<(), _>`
@@ -27,7 +27,7 @@ error[E0308]: mismatched types
                    found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:23:5
+  --> tests/fail/macros_type_mismatch.rs:23:5
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
    |                               -------------- expected `Result<(), ()>` because of return type
@@ -37,9 +37,8 @@ error[E0308]: mismatched types
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try using a variant of the expected enum
+help: try adding an expression at the end of the block
    |
-23 |     Ok(Ok(());)
-   |
-23 |     Err(Ok(());)
+23 ~     Ok(());;
+24 +     Ok(())
    |


### PR DESCRIPTION
A change in rustc broke some tests checking our macro error output.