### PR TITLE
runtime: mark JoinHandle as UnwindSafe (#4414)

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -3,6 +3,7 @@ use crate::runtime::task::RawTask;
 use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -149,6 +150,9 @@ cfg_rt! {
 
 unsafe impl<T: Send> Send for JoinHandle<T> {}
 unsafe impl<T: Send> Sync for JoinHandle<T> {}
+
+impl<T: Send> UnwindSafe for JoinHandle<T> {}
+impl<T: Send> RefUnwindSafe for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     pub(super) fn new(raw: RawTask) -> JoinHandle<T> {

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -151,8 +151,8 @@ cfg_rt! {
 unsafe impl<T: Send> Send for JoinHandle<T> {}
 unsafe impl<T: Send> Sync for JoinHandle<T> {}
 
-impl<T: Send> UnwindSafe for JoinHandle<T> {}
-impl<T: Send> RefUnwindSafe for JoinHandle<T> {}
+impl<T> UnwindSafe for JoinHandle<T> {}
+impl<T> RefUnwindSafe for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     pub(super) fn new(raw: RawTask) -> JoinHandle<T> {

--- a/tokio/tests/unwindsafe.rs
+++ b/tokio/tests/unwindsafe.rs
@@ -2,21 +2,10 @@
 #![cfg(feature = "full")]
 
 use std::panic::{RefUnwindSafe, UnwindSafe};
-use tokio::task::spawn_blocking;
 
-#[tokio::test]
-async fn futures_are_unwind_safe() {
-    unwind_safe_future(|| async {
-        let _ = spawn_blocking(|| {}).await;
-    })
-    .await
-}
-
-async fn unwind_safe_future<F, Fut>(_: F)
-where
-    F: FnOnce() -> Fut,
-    Fut: std::future::Future<Output = ()> + std::panic::UnwindSafe,
-{
+#[test]
+fn join_handle_is_unwind_safe() {
+    is_unwind_safe::<tokio::task::JoinHandle<()>>();
 }
 
 #[test]

--- a/tokio/tests/unwindsafe.rs
+++ b/tokio/tests/unwindsafe.rs
@@ -2,6 +2,22 @@
 #![cfg(feature = "full")]
 
 use std::panic::{RefUnwindSafe, UnwindSafe};
+use tokio::task::spawn_blocking;
+
+#[tokio::test]
+async fn futures_are_unwind_safe() {
+    unwind_safe_future(|| async {
+        let _ = spawn_blocking(|| {}).await;
+    })
+    .await
+}
+
+async fn unwind_safe_future<F, Fut>(_: F)
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = ()> + std::panic::UnwindSafe,
+{
+}
 
 #[test]
 fn net_types_are_unwind_safe() {


### PR DESCRIPTION
Marking JoinHandle as UnwindSafe allows for more ergonomic panic handling resolving this example: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=77e8b4432bd28f50080cbae9eb26b8ae

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
