### PR TITLE
feat: implement `Framed::map_codec` 

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -204,6 +204,26 @@ impl<T, U> Framed<T, U> {
         &mut self.inner.codec
     }
 
+    /// Maps the codec `U` to `C`, preserving the read and write buffers
+    /// wrapped by `Framed`.
+    /// 
+    /// Note that care should be taken to not tamper with the underlying codec
+    /// as it may corrupt the stream of frames otherwise being worked with.
+    pub fn map_codec<C, F>(self, map: F) -> Framed<T, C>
+    where 
+        F: FnOnce(U) -> C
+    {
+        // This could be potentially simplified once rust-lang/rust#86555 hits stable
+        let parts = self.into_parts();
+        Framed::from_parts(FramedParts {
+            io: parts.io,
+            codec: map(parts.codec),
+            read_buf: parts.read_buf,
+            write_buf: parts.write_buf,
+            _priv: ()
+        })
+    }
+
     /// Returns a mutable reference to the underlying codec wrapped by
     /// `Framed`.
     ///

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -206,12 +206,12 @@ impl<T, U> Framed<T, U> {
 
     /// Maps the codec `U` to `C`, preserving the read and write buffers
     /// wrapped by `Framed`.
-    /// 
+    ///
     /// Note that care should be taken to not tamper with the underlying codec
     /// as it may corrupt the stream of frames otherwise being worked with.
     pub fn map_codec<C, F>(self, map: F) -> Framed<T, C>
-    where 
-        F: FnOnce(U) -> C
+    where
+        F: FnOnce(U) -> C,
     {
         // This could be potentially simplified once rust-lang/rust#86555 hits stable
         let parts = self.into_parts();
@@ -220,7 +220,7 @@ impl<T, U> Framed<T, U> {
             codec: map(parts.codec),
             read_buf: parts.read_buf,
             write_buf: parts.write_buf,
-            _priv: ()
+            _priv: (),
         })
     }
 

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -111,17 +111,21 @@ impl<T, D> FramedRead<T, D> {
     /// Maps the decoder `D` to `C`, preserving the read buffer
     /// wrapped by `Framed`.
     pub fn map_decoder<C, F>(self, map: F) -> FramedRead<T, C>
-    where 
-        F: FnOnce(D) -> C
+    where
+        F: FnOnce(D) -> C,
     {
         // This could be potentially simplified once rust-lang/rust#86555 hits stable
-        let FramedImpl { inner, state, codec } = self.inner;
+        let FramedImpl {
+            inner,
+            state,
+            codec,
+        } = self.inner;
         FramedRead {
             inner: FramedImpl {
                 inner,
                 state,
-                codec: map(codec)
-            }
+                codec: map(codec),
+            },
         }
     }
 

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -108,6 +108,23 @@ impl<T, D> FramedRead<T, D> {
         &mut self.inner.codec
     }
 
+    /// Maps the decoder `D` to `C`, preserving the read buffer
+    /// wrapped by `Framed`.
+    pub fn map_decoder<C, F>(self, map: F) -> FramedRead<T, C>
+    where 
+        F: FnOnce(D) -> C
+    {
+        // This could be potentially simplified once rust-lang/rust#86555 hits stable
+        let FramedImpl { inner, state, codec } = self.inner;
+        FramedRead {
+            inner: FramedImpl {
+                inner,
+                state,
+                codec: map(codec)
+            }
+        }
+    }
+
     /// Returns a mutable reference to the underlying decoder.
     pub fn decoder_pin_mut(self: Pin<&mut Self>) -> &mut D {
         self.project().inner.project().codec

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -91,17 +91,21 @@ impl<T, E> FramedWrite<T, E> {
     /// Maps the encoder `E` to `C`, preserving the write buffer
     /// wrapped by `Framed`.
     pub fn map_encoder<C, F>(self, map: F) -> FramedWrite<T, C>
-    where 
-        F: FnOnce(E) -> C
+    where
+        F: FnOnce(E) -> C,
     {
         // This could be potentially simplified once rust-lang/rust#86555 hits stable
-        let FramedImpl { inner, state, codec } = self.inner;
+        let FramedImpl {
+            inner,
+            state,
+            codec,
+        } = self.inner;
         FramedWrite {
             inner: FramedImpl {
                 inner,
                 state,
-                codec: map(codec)
-            }
+                codec: map(codec),
+            },
         }
     }
 

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -88,6 +88,23 @@ impl<T, E> FramedWrite<T, E> {
         &mut self.inner.codec
     }
 
+    /// Maps the encoder `E` to `C`, preserving the write buffer
+    /// wrapped by `Framed`.
+    pub fn map_encoder<C, F>(self, map: F) -> FramedWrite<T, C>
+    where 
+        F: FnOnce(E) -> C
+    {
+        // This could be potentially simplified once rust-lang/rust#86555 hits stable
+        let FramedImpl { inner, state, codec } = self.inner;
+        FramedWrite {
+            inner: FramedImpl {
+                inner,
+                state,
+                codec: map(codec)
+            }
+        }
+    }
+
     /// Returns a mutable reference to the underlying encoder.
     pub fn encoder_pin_mut(self: Pin<&mut Self>) -> &mut E {
         self.project().inner.project().codec

--- a/tokio-util/tests/framed.rs
+++ b/tokio-util/tests/framed.rs
@@ -12,7 +12,10 @@ use std::task::{Context, Poll};
 const INITIAL_CAPACITY: usize = 8 * 1024;
 
 /// Encode and decode u32 values.
-struct U32Codec;
+#[derive(Default)]
+struct U32Codec {
+    read_bytes: usize
+}
 
 impl Decoder for U32Codec {
     type Item = u32;
@@ -24,6 +27,7 @@ impl Decoder for U32Codec {
         }
 
         let n = buf.split_to(4).get_u32();
+        self.read_bytes += 4;
         Ok(Some(n))
     }
 }
@@ -35,6 +39,38 @@ impl Encoder<u32> for U32Codec {
         // Reserve space
         dst.reserve(4);
         dst.put_u32(item);
+        Ok(())
+    }
+}
+
+/// Encode and decode u64 values.
+#[derive(Default)]
+struct U64Codec {
+    read_bytes: usize
+}
+
+impl Decoder for U64Codec {
+    type Item = u64;
+    type Error = io::Error;
+
+    fn decode(&mut self, buf: &mut BytesMut) -> io::Result<Option<u64>> {
+        if buf.len() < 8 {
+            return Ok(None);
+        }
+
+        let n = buf.split_to(8).get_u64();
+        self.read_bytes += 8;
+        Ok(Some(n))
+    }
+}
+
+impl Encoder<u64> for U64Codec {
+    type Error = io::Error;
+
+    fn encode(&mut self, item: u64, dst: &mut BytesMut) -> io::Result<()> {
+        // Reserve space
+        dst.reserve(8);
+        dst.put_u64(item);
         Ok(())
     }
 }
@@ -63,18 +99,37 @@ impl tokio::io::AsyncRead for DontReadIntoThis {
 
 #[tokio::test]
 async fn can_read_from_existing_buf() {
-    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec);
+    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec::default());
     parts.read_buf = BytesMut::from(&[0, 0, 0, 42][..]);
 
     let mut framed = Framed::from_parts(parts);
     let num = assert_ok!(framed.next().await.unwrap());
 
     assert_eq!(num, 42);
+    assert_eq!(framed.codec().read_bytes, 4);
+}
+
+#[tokio::test]
+async fn can_read_from_existing_buf_after_codec_changed() {
+    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec::default());
+    parts.read_buf = BytesMut::from(&[0, 0, 0, 42, 0, 0, 0, 0, 0, 0, 0, 84][..]);
+
+    let mut framed = Framed::from_parts(parts);
+    let num = assert_ok!(framed.next().await.unwrap());
+
+    assert_eq!(num, 42);
+    assert_eq!(framed.codec().read_bytes, 4);
+
+    let mut framed = framed.map_codec(|codec| U64Codec { read_bytes: codec.read_bytes });
+    let num = assert_ok!(framed.next().await.unwrap());
+
+    assert_eq!(num, 84);
+    assert_eq!(framed.codec().read_bytes, 12);
 }
 
 #[test]
 fn external_buf_grows_to_init() {
-    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec);
+    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec::default());
     parts.read_buf = BytesMut::from(&[0, 0, 0, 42][..]);
 
     let framed = Framed::from_parts(parts);
@@ -85,7 +140,7 @@ fn external_buf_grows_to_init() {
 
 #[test]
 fn external_buf_does_not_shrink() {
-    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec);
+    let mut parts = FramedParts::new(DontReadIntoThis, U32Codec::default());
     parts.read_buf = BytesMut::from(&vec![0; INITIAL_CAPACITY * 2][..]);
 
     let framed = Framed::from_parts(parts);

--- a/tokio-util/tests/framed.rs
+++ b/tokio-util/tests/framed.rs
@@ -14,7 +14,7 @@ const INITIAL_CAPACITY: usize = 8 * 1024;
 /// Encode and decode u32 values.
 #[derive(Default)]
 struct U32Codec {
-    read_bytes: usize
+    read_bytes: usize,
 }
 
 impl Decoder for U32Codec {
@@ -46,7 +46,7 @@ impl Encoder<u32> for U32Codec {
 /// Encode and decode u64 values.
 #[derive(Default)]
 struct U64Codec {
-    read_bytes: usize
+    read_bytes: usize,
 }
 
 impl Decoder for U64Codec {
@@ -120,7 +120,9 @@ async fn can_read_from_existing_buf_after_codec_changed() {
     assert_eq!(num, 42);
     assert_eq!(framed.codec().read_bytes, 4);
 
-    let mut framed = framed.map_codec(|codec| U64Codec { read_bytes: codec.read_bytes });
+    let mut framed = framed.map_codec(|codec| U64Codec {
+        read_bytes: codec.read_bytes,
+    });
     let num = assert_ok!(framed.next().await.unwrap());
 
     assert_eq!(num, 84);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Currently, changing the codec of a `Framed` is verbose and unnecessarily complicated, as noted in #717.

## Solution

This PR implements a method that maps the inner codec to a new type, preserving the read/write buffers and IO state. The syntax was first suggested by Carl Lerche.
The usage is as follows:
```rust
let framed: Framed<Io, U32Codec> = Framed::new(io, U32Codec);
let _: u32 = framed.next().await.unwrap();

let framed: Framed<Io, U64Codec> = framed.map_codec(|_codec| U64Codec);
let _: u64 = framed.next().await.unwrap();
```
