### PR TITLE
runtime: swallow panics in drop(join_handle)

### DIFF
--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -165,8 +165,6 @@ where
     }
 
     pub(super) fn drop_join_handle_slow(self) {
-        let mut maybe_panic = None;
-
         // Try to unset `JOIN_INTEREST`. This must be done as a first step in
         // case the task concurrently completed.
         if self.header().state.unset_join_interested().is_err() {
@@ -175,21 +173,13 @@ where
             // the scheduler or `JoinHandle`. i.e. if the output remains in the
             // task structure until the task is deallocated, it may be dropped
             // by a Waker on any arbitrary thread.
-            let panic = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 self.core().stage.drop_future_or_output();
             }));
-
-            if let Err(panic) = panic {
-                maybe_panic = Some(panic);
-            }
         }
 
         // Drop the `JoinHandle` reference, possibly deallocating the task
         self.drop_reference();
-
-        if let Some(panic) = maybe_panic {
-            panic::resume_unwind(panic);
-        }
     }
 
     /// Remotely aborts the task.

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -173,6 +173,10 @@ where
             // the scheduler or `JoinHandle`. i.e. if the output remains in the
             // task structure until the task is deallocated, it may be dropped
             // by a Waker on any arbitrary thread.
+            //
+            // Panics are delivered to the user via the `JoinHandle`. Given that
+            // they are dropping it, we assume they are not interested in it,
+            // and swallow it.
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 self.core().stage.drop_future_or_output();
             }));

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -175,8 +175,8 @@ where
             // by a Waker on any arbitrary thread.
             //
             // Panics are delivered to the user via the `JoinHandle`. Given that
-            // they are dropping it, we assume they are not interested in it,
-            // and swallow it.
+            // they are dropping the `JoinHandle`, we assume they are not
+            // interested in the panic and swallow it.
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 self.core().stage.drop_future_or_output();
             }));

--- a/tokio/tests/join_handle_panic.rs
+++ b/tokio/tests/join_handle_panic.rs
@@ -1,0 +1,20 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+struct PanicsOnDrop;
+
+impl Drop for PanicsOnDrop {
+    fn drop(&mut self) {
+        panic!("I told you so");
+    }
+}
+
+#[tokio::test]
+async fn test_panics_do_not_propagate_when_dropping_join_handle() {
+    let join_handle = tokio::spawn(async move { PanicsOnDrop });
+
+    // only drop the JoinHandle when the task has completed
+    // (which is difficult to synchronize precisely)
+    tokio::time::sleep(std::time::Duration::from_millis(3)).await;
+    drop(join_handle);
+}


### PR DESCRIPTION
Fixes #4412

## Motivation
From the issue description:

> In Tokio, panics are generally caught and not passed resumed when
dropping the JoinHandle, however when dropping the JoinHandle of a task
that has already completed, that panic can propagate to the user who
dropped the JoinHandle.

## Solution

Just swallow the panic? I've seen other places in tokio where that happens, but I'm open to hearing
if you had other ideas for this.

