### PR TITLE
chore: prepare Tokio v1.16.1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.16.0", features = ["full"] }
+tokio = { version = "1.16.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.16.1 (January 28, 2022)
+
+This release fixes a bug in [#4428] with the change [#4437].
+
+[#4428]: https://github.com/tokio-rs/tokio/pull/4428
+[#4437]: https://github.com/tokio-rs/tokio/pull/4437
+
 # 1.16.0 (January 27, 2022)
 
 Fixes a soundness bug in `io::Take` ([#4428]). The unsoundness is exposed when

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.16.0"
+version = "1.16.1"
 edition = "2018"
 rust-version = "1.46"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.16.0", features = ["full"] }
+tokio = { version = "1.16.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.16.1 (January 28, 2022)

This release fixes a bug in [#4428] with the change [#4437].

[#4428]: https://github.com/tokio-rs/tokio/pull/4428
[#4437]: https://github.com/tokio-rs/tokio/pull/4437