### PR TITLE
adjusted feature name in tests

### DIFF
--- a/tokio-stream/tests/stream_timeout.rs
+++ b/tokio-stream/tests/stream_timeout.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "io-util")]
+#![cfg(all(feature = "time", feature = "sync", feature = "io-util"))]
 
 use tokio::time::{self, sleep, Duration};
 use tokio_stream::{self, StreamExt};

--- a/tokio-stream/tests/stream_timeout.rs
+++ b/tokio-stream/tests/stream_timeout.rs
@@ -4,7 +4,7 @@ use tokio::time::{self, sleep, Duration};
 use tokio_stream::{self, StreamExt};
 use tokio_test::*;
 
-use futures::StreamExt as _;
+use futures::stream;
 
 async fn maybe_sleep(idx: i32) -> i32 {
     if idx % 2 == 0 {

--- a/tokio-stream/tests/stream_timeout.rs
+++ b/tokio-stream/tests/stream_timeout.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "full")]
+#![cfg(feature = "io-util")]
 
 use tokio::time::{self, sleep, Duration};
 use tokio_stream::{self, StreamExt};

--- a/tokio-stream/tests/time_throttle.rs
+++ b/tokio-stream/tests/time_throttle.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(feature = "time")]
 
 use tokio::time;
 use tokio_stream::StreamExt;

--- a/tokio-stream/tests/time_throttle.rs
+++ b/tokio-stream/tests/time_throttle.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "time")]
+#![cfg(all(feature = "time", feature = "sync", feature = "io-util"))]
 
 use tokio::time;
 use tokio_stream::StreamExt;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation


Closes: #4341 



## Solution

Before was using full that is not a feature in tokio-stream/cargo, in time_thorttle i could use time as feature, in stream_time out i could not. I chose io-util because I think makes sense but i would like some help to make this one correct too

