### PR TITLE
io: make `EPOLLERR` awake `AsyncFd::readable`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,6 +23,7 @@ httparse = "1.0"
 httpdate = "1.0"
 once_cell = "1.5.2"
 rand = "0.8.3"
+nix = "0.23"
 
 [target.'cfg(windows)'.dev-dependencies.winapi]
 version = "0.3.8"
@@ -91,3 +92,11 @@ path = "named-pipe-ready.rs"
 [[example]]
 name = "named-pipe-multi-client"
 path = "named-pipe-multi-client.rs"
+
+[[example]]
+name = "fuse"
+path = "fuse.rs"
+
+[[example]]
+name = "fuse2"
+path = "fuse2.rs"

--- a/examples/fuse.rs
+++ b/examples/fuse.rs
@@ -1,0 +1,63 @@
+// This "test" is based on the code sample in #3442
+// It is meant to test that `readable()` will surface the
+// polling error to the caller.
+// This program has to be run as `root` to be able to use
+// fuse.
+// The expected output is a polling error along the lines of:
+// ```
+// thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "Polling error" }', examples/fuse.rs:44:14
+// ```
+// This is just to show what testing I'm doing, and I don't intend
+// to get it merged
+use tokio::io::{unix::AsyncFd, Interest};
+
+use nix::{
+    fcntl::{fcntl, open, FcntlArg, OFlag},
+    mount::{mount, umount, MsFlags},
+    sys::stat::Mode,
+    unistd::read,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let fuse = open("/dev/fuse", OFlag::O_RDWR, Mode::empty()).unwrap();
+    let fcntl_arg = FcntlArg::F_SETFL(OFlag::O_NONBLOCK | OFlag::O_LARGEFILE);
+    fcntl(fuse, fcntl_arg).unwrap();
+
+    let options = format!(
+        "fd={},user_id=0,group_id=0,allow_other,rootmode=40000",
+        fuse
+    );
+
+    mount(
+        Some("test"),
+        "/mnt",
+        Some("fuse"),
+        MsFlags::empty(),
+        Some(options.as_str()),
+    )
+    .unwrap();
+
+    let async_fd = AsyncFd::with_interest(fuse, Interest::READABLE).unwrap();
+
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        umount("/mnt").unwrap();
+    });
+
+    let mut buffer = [0; 8192];
+    loop {
+        let result = async_fd
+            .readable()
+            .await
+            .unwrap()
+            .try_io(|_| read(fuse, &mut buffer).map_err(Into::into));
+
+        match result {
+            Err(_) => continue,
+            Ok(result) => {
+                result.unwrap();
+            }
+        }
+    }
+}

--- a/examples/fuse2.rs
+++ b/examples/fuse2.rs
@@ -1,0 +1,62 @@
+// This "test" is based on the code sample in #3442
+// It is meant to test that `poll_read_ready()` will surface the
+// polling error to the caller.
+// This program has to be run as `root` to be able to use
+// fuse.
+// The expected output is a polling error along the lines of:
+// ```
+// thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Custom { kind: Other, error: "Polling error" }', examples/fuse.rs:44:14
+// ```
+// This is just to show what testing I'm doing, and I don't intend
+// to get it merged
+use tokio::io::{unix::AsyncFd, Interest};
+
+use nix::{
+    fcntl::{fcntl, open, FcntlArg, OFlag},
+    mount::{mount, umount, MsFlags},
+    sys::stat::Mode,
+    unistd::read,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let fuse = open("/dev/fuse", OFlag::O_RDWR, Mode::empty()).unwrap();
+    let fcntl_arg = FcntlArg::F_SETFL(OFlag::O_NONBLOCK | OFlag::O_LARGEFILE);
+    fcntl(fuse, fcntl_arg).unwrap();
+
+    let options = format!(
+        "fd={},user_id=0,group_id=0,allow_other,rootmode=40000",
+        fuse
+    );
+
+    mount(
+        Some("test"),
+        "/mnt",
+        Some("fuse"),
+        MsFlags::empty(),
+        Some(options.as_str()),
+    )
+    .unwrap();
+
+    let async_fd = AsyncFd::with_interest(fuse, Interest::READABLE).unwrap();
+
+    std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_secs(1));
+        umount("/mnt").unwrap();
+    });
+
+    let mut buffer = [0; 8192];
+    loop {
+        let result = futures::future::poll_fn(|cx| async_fd.poll_read_ready(cx))
+            .await
+            .unwrap()
+            .try_io(|_| read(fuse, &mut buffer).map_err(Into::into));
+
+        match result {
+            Err(_) => continue,
+            Ok(result) => {
+                result.unwrap();
+            }
+        }
+    }
+}

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -142,6 +142,9 @@ wasm-bindgen-test = "0.3.0"
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
 mio-aio = { version = "0.6.0", features = ["tokio"] }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+userfaultfd = "0.4"
+
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5", features = ["futures", "checkpoint"] }
 

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -7,6 +7,7 @@ const READABLE: usize = 0b0_01;
 const WRITABLE: usize = 0b0_10;
 const READ_CLOSED: usize = 0b0_0100;
 const WRITE_CLOSED: usize = 0b0_1000;
+const ERROR: usize = 0b1_0000;
 
 /// Describes the readiness state of an I/O resources.
 ///
@@ -30,6 +31,9 @@ impl Ready {
 
     /// Returns a `Ready` representing write closed readiness.
     pub const WRITE_CLOSED: Ready = Ready(WRITE_CLOSED);
+
+    /// Returns a `Ready` representing error readiness
+    pub const ERROR: Ready = Ready(ERROR);
 
     /// Returns a `Ready` representing readiness for all operations.
     pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED);
@@ -63,6 +67,10 @@ impl Ready {
 
         if event.is_write_closed() {
             ready |= Ready::WRITE_CLOSED;
+        }
+
+        if event.is_error() {
+            ready |= Ready::ERROR;
         }
 
         ready
@@ -142,6 +150,21 @@ impl Ready {
     /// ```
     pub fn is_write_closed(self) -> bool {
         self.contains(Ready::WRITE_CLOSED)
+    }
+
+    /// Returns `true` if the value includes write-closed `readiness`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_write_closed());
+    /// assert!(!Ready::WRITABLE.is_write_closed());
+    /// assert!(Ready::WRITE_CLOSED.is_write_closed());
+    /// ```
+    pub fn is_error(self) -> bool {
+        self.contains(Ready::ERROR)
     }
 
     /// Returns true if `self` is a superset of `other`.
@@ -245,6 +268,7 @@ impl fmt::Debug for Ready {
             .field("is_writable", &self.is_writable())
             .field("is_read_closed", &self.is_read_closed())
             .field("is_write_closed", &self.is_write_closed())
+            .field("is_error", &self.is_error())
             .finish()
     }
 }

--- a/tokio/src/io/driver/ready.rs
+++ b/tokio/src/io/driver/ready.rs
@@ -36,7 +36,7 @@ impl Ready {
     pub const ERROR: Ready = Ready(ERROR);
 
     /// Returns a `Ready` representing readiness for all operations.
-    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED);
+    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED | ERROR);
 
     // Must remain crate-private to avoid adding a public dependency on Mio.
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -155,7 +155,8 @@ impl Registration {
     ) -> Poll<io::Result<ReadyEvent>> {
         // Keep track of task budget
         let coop = ready!(crate::coop::poll_proceed(cx));
-        let ev = ready!(self.shared.poll_readiness(cx, direction));
+        // TODO: should this "coop.made_progress()" though?
+        let ev = ready!(self.shared.poll_readiness(cx, direction))?;
 
         if self.handle.inner().is_none() {
             return Poll::Ready(Err(gone()));

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -155,15 +155,16 @@ impl Registration {
     ) -> Poll<io::Result<ReadyEvent>> {
         // Keep track of task budget
         let coop = ready!(crate::coop::poll_proceed(cx));
-        // TODO: should this "coop.made_progress()" though?
-        let ev = ready!(self.shared.poll_readiness(cx, direction))?;
+        let ev = ready!(self.shared.poll_readiness(cx, direction));
 
         if self.handle.inner().is_none() {
             return Poll::Ready(Err(gone()));
         }
 
+        // Regardless of whether we got a polling error or an actual
+        // `ReadyEvent`, count it as work having been done
         coop.made_progress();
-        Poll::Ready(Ok(ev))
+        Poll::Ready(Ok(ev?))
     }
 
     fn poll_io<R>(

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -242,7 +242,7 @@ cfg_io_readiness! {
                     )));
                 }
 
-                Pin::new(&mut fut).poll(cx).map(Ok)
+                Pin::new(&mut fut).poll(cx)
             }).await
         }
 

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -604,25 +604,19 @@ mod tests {
         let scheduled_io: ScheduledIo = Default::default();
 
         // WHEN: marking an error and polling readiness
-        scheduled_io.set_readiness(
-            None,
-            Tick::Set(0),
-            |_| Ready::ERROR
-        ).unwrap();
+        scheduled_io
+            .set_readiness(None, Tick::Set(0), |_| Ready::ERROR)
+            .unwrap();
 
         let mut task = tokio_test::task::spawn(async {
-            let readiness = crate::future::poll_fn(|cx| {
-                scheduled_io.poll_readiness(cx, Direction::Read)
-            }).await;
+            let readiness =
+                crate::future::poll_fn(|cx| scheduled_io.poll_readiness(cx, Direction::Read)).await;
 
             readiness
         });
 
         // THEN
         let readiness = unwrap_ready(task.poll());
-        assert_eq!(
-            readiness.unwrap_err().kind(),
-            std::io::ErrorKind::Other
-        );
+        assert_eq!(readiness.unwrap_err().kind(), std::io::ErrorKind::Other);
     }
 }

--- a/tokio/src/io/driver/scheduled_io.rs
+++ b/tokio/src/io/driver/scheduled_io.rs
@@ -185,7 +185,6 @@ impl ScheduledIo {
             // function doesn't see them.
             let current_readiness = Ready::from_usize(current);
             let new = f(current_readiness);
-
             let packed = match tick {
                 Tick::Set(t) => TICK.pack(t as usize, new.as_usize()),
                 Tick::Clear(t) => {
@@ -585,4 +584,45 @@ cfg_io_readiness! {
 
     unsafe impl Send for Readiness<'_> {}
     unsafe impl Sync for Readiness<'_> {}
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    fn unwrap_ready<T>(p: Poll<T>) -> T {
+        match p {
+            Poll::Pending => panic!("Expected a Ready"),
+            Poll::Ready(t) => t,
+        }
+    }
+
+    #[test]
+    fn test_setting_error_awakes_poll_read_readiness() {
+        // GIVEN
+        let scheduled_io: ScheduledIo = Default::default();
+
+        // WHEN: marking an error and polling readiness
+        scheduled_io.set_readiness(
+            None,
+            Tick::Set(0),
+            |_| Ready::ERROR
+        ).unwrap();
+
+        let mut task = tokio_test::task::spawn(async {
+            let readiness = crate::future::poll_fn(|cx| {
+                scheduled_io.poll_readiness(cx, Direction::Read)
+            }).await;
+
+            readiness
+        });
+
+        // THEN
+        let readiness = unwrap_ready(task.poll());
+        assert_eq!(
+            readiness.unwrap_err().kind(),
+            std::io::ErrorKind::Other
+        );
+    }
 }

--- a/tokio/tests/io_poll_error.rs
+++ b/tokio/tests/io_poll_error.rs
@@ -1,4 +1,5 @@
-#[cfg(target_os = "linux")]
+#![cfg(target_os = "linux")]
+
 use tokio::io::{unix::AsyncFd, Interest};
 use userfaultfd::{Uffd, UffdBuilder};
 

--- a/tokio/tests/io_poll_error.rs
+++ b/tokio/tests/io_poll_error.rs
@@ -1,0 +1,47 @@
+#[cfg(target_os = "linux")]
+use tokio::io::{unix::AsyncFd, Interest};
+use userfaultfd::{Uffd, UffdBuilder};
+
+fn get_blocking_userfault_fd() -> Uffd {
+    UffdBuilder::new()
+        // yes-blocking
+        .non_blocking(false)
+        .create()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_poll_error_propagates_to_readable() {
+    // GIVEN: a blocking `userfault` fd. The only reason we use a `userfault` fd
+    // is that it is a reliable way of getting `EPOLLERR`.
+
+    // From userfault(2)
+    // > If the `O_NONBLOCK` flag is not enabled, then poll(2) (always)
+    // indicates the file as having a POLLERR condition, and select(2) indicates
+    // the file descriptor as both readable and writable.
+    let async_fd = AsyncFd::with_interest(get_blocking_userfault_fd(), Interest::READABLE).unwrap();
+
+    // WHEN
+    let result = async_fd.readable().await;
+
+    // THEN
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Other);
+}
+
+#[tokio::test]
+async fn test_poll_error_propagates_to_poll_read_ready() {
+    // GIVEN: a blocking `userfault` fd. The only reason we use a `userfault` fd
+    // is that it is a reliable way of getting `EPOLLERR`.
+
+    // From userfault(2)
+    // > If the `O_NONBLOCK` flag is not enabled, then poll(2) (always)
+    // indicates the file as having a POLLERR condition, and select(2) indicates
+    // the file descriptor as both readable and writable.
+    let async_fd = AsyncFd::with_interest(get_blocking_userfault_fd(), Interest::READABLE).unwrap();
+
+    // WHEN
+    let result = futures::future::poll_fn(|cx| async_fd.poll_read_ready(cx)).await;
+
+    // THEN
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::Other);
+}


### PR DESCRIPTION
Ref: https://github.com/tokio-rs/tokio/issues/4349

## Motivation
Currently, if a user is awaiting on a `AsyncFd` becoming readable and we
get a polling error (which may happen in some cases, see the referenced
issue), the awaiter will never be woken. Ideally, they would be notified
of this error in some way.

## Solution
The solution here involves communicating to the `Readiness` object that
there was an error, and when that happens, the `Readiness` future will
return a synthetic error that boils down to "there was a polling error".
If the user wants to find more information about the underlying error,
they would have to find some other way (not clear how yet? as pointed
out in the issue, for sockets one could use `SO_ERROR`).

## Open questions

1. How do we go about testing? My manual tests involved using the example piece of code in #4349 but that requires `sudo` which might not be great for automated testing. It's also kind of an involved setup. I will have to look into this.
2. `EPOLLERR` also triggers `is_write_closed` in the mio event. I don't know if we should notify writers of an error or just of "write closed". 
3. More things that I've written down here and there in the source code
