### PR TITLE
chore: make it easier to pin Rust versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ jobs:
     machine:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
+    environment:
+      # Change to pin rust versino
+      RUST_STABLE: stable
     steps:
       - checkout
       - run:
@@ -11,7 +14,7 @@ jobs:
           command: |
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup.sh
             chmod +x rustup.sh
-            ./rustup.sh -y
+            ./rustup.sh -y --default-toolchain $RUST_STABLE
             source "$HOME"/.cargo/env
       # Only run Tokio tests
       - run: cargo test --all-features -p tokio

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,8 @@
 freebsd_instance:
   image: freebsd-12-2-release-amd64
 env:
+  RUST_STABLE: stable
+  RUST_NIGHTLY: nightly-2022-01-12
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the
@@ -12,7 +14,7 @@ task:
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain stable
+    - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
     - . $HOME/.cargo/env
     - |
       echo "~~~~ rustc --version ~~~~"
@@ -29,7 +31,7 @@ task:
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain nightly-2022-01-12
+    - sh rustup.sh -y --profile minimal --default-toolchain $RUST_NIGHTLY
     - . $HOME/.cargo/env
     - |
       echo "~~~~ rustc --version ~~~~"
@@ -43,7 +45,7 @@ task:
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
-    - sh rustup.sh -y --profile minimal --default-toolchain stable
+    - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
     - . $HOME/.cargo/env
     - rustup target add i686-unknown-freebsd
     - |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,8 +373,6 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: build --cfg loom
         run: cargo test --no-run --lib --features full
-      - name: loom ${{ matrix.scope }}
-        run: cargo test --lib --release --features full -- --nocapture $SCOPE
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2021-04-25
   rust_clippy: 1.52.0
-  rust_min: 1.45.2
+  rust_min: 1.46.0
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,11 @@ name: CI
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  nightly: nightly-2022-01-12
-  minrust: 1.46
+  # Change to specific Rust release to pin
+  rust_stable: stable
+  rust_nightly: nightly-2021-04-25
+  rust_clippy: 1.52.0
+  rust_min: 1.45.2
 
 defaults:
   run:
@@ -51,6 +54,11 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - name: Install Rust
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
@@ -96,8 +104,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - uses: Swatinem/rust-cache@v1
       - name: Enable parking_lot send_guard feature
         # Inserts the line "plsend = ["parking_lot/send_guard"]" right after [features]
@@ -110,8 +121,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - uses: Swatinem/rust-cache@v1
 
       - name: Install Valgrind
@@ -148,10 +162,12 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - uses: Swatinem/rust-cache@v1
-
       # Run `tokio` with "unstable" cfg flag.
       - name: test tokio full --cfg unstable
         run: cargo test --all-features
@@ -164,29 +180,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.nightly }}
+          toolchain: ${{ env.rust_nightly }}
+          components: miri
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: Install Miri
+      - name: miri
         run: |
           set -e
-          rustup component add miri
-          cargo miri setup
-          rm -rf tokio/tests
-
-      - name: miri
-        run: cargo miri test --features rt,rt-multi-thread,sync task
+          rm -rf tests
+          cargo miri test --features rt,rt-multi-thread,sync task
         working-directory: tokio
+
   san:
     name: san
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.nightly }}
+          toolchain: ${{ env.rust_nightly }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: asan
@@ -209,9 +225,10 @@ jobs:
           - arm-linux-androideabi
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: ${{ env.rust_stable }}
           target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v1
@@ -226,17 +243,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.nightly }}
+          toolchain: ${{ env.rust_nightly }}
+          target: ${{ matrix.target }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
         run: cargo install cargo-hack
-
       - name: check --each-feature
         run: cargo hack check --all --each-feature -Z avoid-dev-deps
-
       # Try with unstable feature flags
       - name: check --each-feature --unstable
         run: cargo hack check --all --each-feature -Z avoid-dev-deps
@@ -248,9 +265,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_min }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.minrust }}
+          toolchain: ${{ env.rust_min }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: "test --workspace --all-features"
@@ -261,9 +279,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.nightly }}
+          toolchain: ${{ env.rust_nightly }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
@@ -292,10 +311,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_stable }}
+          override: true
+          components: rustfmt
       - uses: Swatinem/rust-cache@v1
-
       # Check fmt
       - name: "rustfmt --check"
         # Workaround for rust-lang/cargo#7732
@@ -310,12 +332,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update 1.57 && rustup default 1.57
+      - name: Install Rust ${{ env.rust_clippy }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_clippy }}
+          override: true
+          components: clippy
       - uses: Swatinem/rust-cache@v1
-      - name: Install clippy
-        run: rustup component add clippy
-
       # Run clippy
       - name: "clippy --all"
         run: cargo clippy --all --tests --all-features
@@ -325,9 +348,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.nightly }}
+          toolchain: ${{ env.rust_nightly }}
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: "doc --lib --all-features"
@@ -341,11 +365,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_stable }}
+          override: true
       - uses: Swatinem/rust-cache@v1
       - name: build --cfg loom
         run: cargo test --no-run --lib --features full
+      - name: loom ${{ matrix.scope }}
+        run: cargo test --lib --release --features full -- --nocapture $SCOPE
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
@@ -373,8 +402,11 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_stable }}
+          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Test hyper
         run: |
@@ -398,8 +430,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_stable }}
+          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2021-04-25
+  rust_nightly: nightly-2022-01-12
   rust_clippy: 1.52.0
   rust_min: 1.46.0
 

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -10,6 +10,8 @@ name: Loom
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
+  # Change to specific Rust release to pin
+  rust_stable: stable
 
 jobs:
   loom:
@@ -28,8 +30,11 @@ jobs:
           - time::driver
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - uses: Swatinem/rust-cache@v1
       - name: loom ${{ matrix.scope }}
         run: cargo test --lib --release --features full -- --nocapture $SCOPE

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - master
 
+env:
+  RUSTFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+  # Change to specific Rust release to pin
+  rust_stable: stable
+
 jobs:
   stess-test:
     name: Stress Test
@@ -15,8 +21,11 @@ jobs:
           - simple_echo_tcp
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ env.rust_stable }}
+            override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install Valgrind
         run: |


### PR DESCRIPTION
When backporting patches to LTS branches, we often run into CI failures due to changes in rust. Newer rust versions add more lints, which break CI. We really don't want to also have to backport patches that fix CI, so instead, LTS branches should pin the stable rust version in CI (e.g. #4434).

This PR restructures the CI config files to make it a bit easier to set a specific rust version in CI.