### PR TITLE
Add fetch_add for AtomicU64

### DIFF
--- a/tokio/src/loom/std/atomic_u64.rs
+++ b/tokio/src/loom/std/atomic_u64.rs
@@ -34,6 +34,13 @@ cfg_not_has_atomic_u64! {
             *self.inner.lock() = val;
         }
 
+        pub(crate) fn fetch_add(&self, val: u64, _: Ordering) -> u64 {
+            let mut lock = self.inner.lock();
+            let prev = *lock;
+            *lock = prev + val;
+            prev
+        }
+
         pub(crate) fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
             let mut lock = self.inner.lock();
             let prev = *lock;


### PR DESCRIPTION
## Motivation
building with `tokio-unstable` fails for arm32v7

## Solution
Implement `fetch_add` for the custom AtomicU64 type fixes https://github.com/tokio-rs/tokio/issues/4452