### PR TITLE
chore: specify tokio-macros version

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,7 +87,7 @@ test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]
-tokio-macros = { path = "../tokio-macros", optional = true }
+tokio-macros = { version = "1.5.1", optional = true }
 
 pin-project-lite = "0.2.0"
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,7 +87,7 @@ test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]
-tokio-macros = { version = "1.5.1", optional = true }
+tokio-macros = { version = "1.6.0", optional = true }
 
 pin-project-lite = "0.2.0"
 


### PR DESCRIPTION
The version was not specified, preventing publishing a crate.