### PR TITLE
io: improve safety comment on FillBuf

### DIFF
--- a/tokio/src/io/util/fill_buf.rs
+++ b/tokio/src/io/util/fill_buf.rs
@@ -42,9 +42,9 @@ impl<'a, R: AsyncBufRead + ?Sized + Unpin> Future for FillBuf<'a, R> {
                 // checker, this can be simplified.
                 //
                 // The safety of this transmute relies on the fact that the
-                // value of `reader` is `None` when we return in this branch,
-                // since otherwise the caller could poll us again after
-                // completion and access the mutable reference while the
+                // value of `reader` is `None` when we return in this branch.
+                // Otherwise the caller could poll us again after
+                // completion, and access the mutable reference while the
                 // returned immutable reference still exists.
                 let slice = std::mem::transmute::<&[u8], &'a [u8]>(slice);
                 Poll::Ready(Ok(slice))

--- a/tokio/src/io/util/fill_buf.rs
+++ b/tokio/src/io/util/fill_buf.rs
@@ -40,6 +40,12 @@ impl<'a, R: AsyncBufRead + ?Sized + Unpin> Future for FillBuf<'a, R> {
                 // Safety: This is necessary only due to a limitation in the
                 // borrow checker. Once Rust starts using the polonius borrow
                 // checker, this can be simplified.
+                //
+                // The safety of this transmute relies on the fact that the
+                // value of `reader` is `None` when we return in this branch,
+                // since otherwise the caller could poll us again after
+                // completion and access the mutable reference while the
+                // returned immutable reference still exists.
                 let slice = std::mem::transmute::<&[u8], &'a [u8]>(slice);
                 Poll::Ready(Ok(slice))
             },


### PR DESCRIPTION
This improves the safety comment on `FillBuf`.