### PR TITLE
io: make duplex stream cooperative (#4470)

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -177,10 +177,8 @@ impl Pipe {
             waker.wake();
         }
     }
-}
 
-impl AsyncRead for Pipe {
-    fn poll_read(
+    fn poll_read_internal(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
@@ -205,10 +203,8 @@ impl AsyncRead for Pipe {
             Poll::Pending
         }
     }
-}
 
-impl AsyncWrite for Pipe {
-    fn poll_write(
+    fn poll_write_internal(
         mut self: Pin<&mut Self>,
         cx: &mut task::Context<'_>,
         buf: &[u8],
@@ -229,6 +225,61 @@ impl AsyncWrite for Pipe {
             waker.wake();
         }
         Poll::Ready(Ok(len))
+    }
+}
+
+impl AsyncRead for Pipe {
+    cfg_coop! {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            let coop = ready!(crate::coop::poll_proceed(cx));
+
+            let ret = self.poll_read_internal(cx, buf);
+            if ret.is_ready() {
+                coop.made_progress();
+            }
+            ret
+        }
+    }
+
+    cfg_not_coop! {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            self.poll_read_internal(cx, buf)
+        }
+    }
+}
+
+impl AsyncWrite for Pipe {
+    cfg_coop! {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            let coop = ready!(crate::coop::poll_proceed(cx));
+            let ret = self.poll_write_internal(cx, buf);
+            if ret.is_ready() {
+                coop.made_progress();
+            }
+            ret
+        }
+    }
+
+    cfg_not_coop! {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut task::Context<'_>,
+            buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            self.poll_write_internal(cx, buf)
+        }
     }
 
     fn poll_flush(self: Pin<&mut Self>, _: &mut task::Context<'_>) -> Poll<std::io::Result<()>> {

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -245,7 +245,7 @@ impl AsyncRead for Pipe {
 
     cfg_not_coop! {
         fn poll_read(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut task::Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
@@ -273,7 +273,7 @@ impl AsyncWrite for Pipe {
 
     cfg_not_coop! {
         fn poll_write(
-            mut self: Pin<&mut Self>,
+            self: Pin<&mut Self>,
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -111,9 +111,9 @@ async fn duplex_is_cooperative() {
         _ = async {
             loop {
                 let buf = [3u8; 4096];
-                let _ = tx.write_all(&buf).await;
+                tx.write_all(&buf).await.unwrap();
                 let mut buf = [0u8; 4096];
-                let _ = rx.read(&mut buf).await;
+                rx.read(&mut buf).await.unwrap();
             }
         } => {},
         _ = tokio::task::yield_now() => {}

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -100,3 +100,22 @@ async fn max_write_size() {
     // drop b only after task t1 finishes writing
     drop(b);
 }
+
+#[tokio::test]
+async fn duplex_is_cooperative() {
+    let (mut tx, mut rx) = tokio::io::duplex(1024 * 8);
+
+    tokio::select! {
+        biased;
+
+        _ = async {
+            loop {
+                let buf = [3u8; 4096];
+                let _ = tx.write_all(&buf).await;
+                let mut buf = [0u8; 4096];
+                let _ = rx.read(&mut buf).await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}


### PR DESCRIPTION
Add coop checks on pipe poll_read and poll_write.

Fixes: #4470
Refs: #4291, #4300

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This attempts to fix https://github.com/tokio-rs/tokio/issues/4470 DuplexStream does not participate in coop.

## Solution

Similar to what's done in https://github.com/tokio-rs/tokio/issues/4291. The change calls coop `poll_proceed` to decrement budge on poll_read and poll_write, then it calls `made_progress` to resume budget if made progress. 

## Testing

Without the changes, the added `duplex_is_cooperative` test would hang. 
Ran cargo build, check and test with all-features. Ran cargo fmt. 
