### PR TITLE
doc: Created a simple example for tokio::process::ChildStdin

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -97,6 +97,54 @@
 //! }
 //! ```
 //!
+//! Here is another example using `sort` writing into the child process
+//! standard input, capturing the output of the sorted text.
+//!
+//! ```no_run
+//! use tokio::io::AsyncWriteExt;
+//! use tokio::process::Command;
+//!
+//! use std::process::Stdio;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut cmd = Command::new("sort");
+//!
+//!     // Specifying that we want pipe both the output and the input.
+//!     // Similarily to capturing the output, by configuring the pipe
+//!     // to stdin it can now be used as an asynchronous writer.
+//!     cmd.stdout(Stdio::piped());
+//!     cmd.stdin(Stdio::piped());
+//!
+//!     let mut child = cmd.spawn().expect("failed to spawn command");
+//!
+//!     // These are the animals we want to sort
+//!     let animals: [&str; 5] = ["dog", "bird", "frog", "cat", "fish"];
+//!
+//!     let mut stdin = child
+//!         .stdin
+//!         .take()
+//!         .expect("child did not have a handle to stdin");
+//!
+//!     // Write our animals to the child process
+//!     stdin
+//!         .write(animals.join("\n").as_bytes())
+//!         .await
+//!         .expect("could not write to stdin");
+//!
+//!     // We drop the handle here which signals EOF to the child process.
+//!     // This tells the child process that it there is no more data on the pipe.
+//!     drop(stdin);
+//!
+//!     let op = child.wait_with_output().await?;
+//!
+//!     // Results should come back in sorted order
+//!     assert_eq!(op.stdout, "bird\ncat\ndog\nfish\nfrog\n".as_bytes());
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
 //! With some coordination, we can also pipe the output of one command into
 //! another.
 //!

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -127,6 +127,11 @@
 //!         .expect("child did not have a handle to stdin");
 //!
 //!     // Write our animals to the child process
+//!     // Note that the behavior of `sort` is to buffer _all input_ before writing any output.
+//!     // In the general sense, it is recommended to write to the child in a separate task as
+//!     // awaiting its exit (or output) to avoid deadlocks (for example, the child tries to write
+//!     // some output but gets stuck waiting on the parent to read from it, meanwhile the parent
+//!     // is stuck waiting to write its input completely before reading the output).
 //!     stdin
 //!         .write(animals.join("\n").as_bytes())
 //!         .await

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -119,7 +119,7 @@
 //!     let mut child = cmd.spawn().expect("failed to spawn command");
 //!
 //!     // These are the animals we want to sort
-//!     let animals: [&str; 5] = ["dog", "bird", "frog", "cat", "fish"];
+//!     let animals: &[&str] = &["dog", "bird", "frog", "cat", "fish"];
 //!
 //!     let mut stdin = child
 //!         .stdin


### PR DESCRIPTION
## Motivation

I struggled with figuring out how to effectively use `ChildStdin` in tokio::process . There are a lot of examples on how to capture `stdout` but only one combined example with stdin which focuses more on chaining. I've found this more well documented in other languages (Go, Python).

## Solution

I created a quick example which showcases how to write to `stdin` but also highlighting that the user needs to drop the handle for EOF to be signaled.

Closes: #4477