### PR TITLE
time: use bit manipulation instead of modulo

### DIFF
--- a/tokio/src/time/driver/wheel/level.rs
+++ b/tokio/src/time/driver/wheel/level.rs
@@ -143,6 +143,8 @@ impl Level {
         let level_range = level_range(self.level);
         let slot_range = slot_range(self.level);
 
+        // Compute the start date of the current level by masking the low bits
+        // of `now` (`level_range` is a power of 2).
         let level_start = now & !(level_range - 1);
         let mut deadline = level_start + slot as u64 * slot_range;
 

--- a/tokio/src/time/driver/wheel/level.rs
+++ b/tokio/src/time/driver/wheel/level.rs
@@ -143,8 +143,7 @@ impl Level {
         let level_range = level_range(self.level);
         let slot_range = slot_range(self.level);
 
-        // TODO: This can probably be simplified w/ power of 2 math
-        let level_start = now - (now % level_range);
+        let level_start = now & !(level_range - 1);
         let mut deadline = level_start + slot as u64 * slot_range;
 
         if deadline <= now {


### PR DESCRIPTION
time: resolve TODO

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Existing `TODO` comment in `src/time/driver/wheel/level.rs`.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`level_range()` always return a strictly positive power of 2. If `b` is a
strictly positive power of 2, `a - (a % b)` is equal to `a & !(b - 1)`.

