### PR TITLE
chore: prepare tokio-util 0.7.0

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- sync: add lifetime parameter to `ReusableBoxFuture` ([#3762])
 - sync: refactored `PollSender<T>` to fix a subtly broken `Sink<T>` implementation ([#4214])
 - util: remove error case from the infallible `DelayQueue::poll_elapsed` ([#4241])
 
@@ -22,6 +23,7 @@
 [#4385]: https://github.com/tokio-rs/tokio/pull/4385
 [#4427]: https://github.com/tokio-rs/tokio/pull/4427
 [#4465]: https://github.com/tokio-rs/tokio/pull/4465
+[#3762]: https://github.com/tokio-rs/tokio/pull/3762
 [#4214]: https://github.com/tokio-rs/tokio/pull/4214
 [#4241]: https://github.com/tokio-rs/tokio/pull/4241
 

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 - sync: add lifetime parameter to `ReusableBoxFuture` ([#3762])
 - sync: refactored `PollSender<T>` to fix a subtly broken `Sink<T>` implementation ([#4214])
-- util: remove error case from the infallible `DelayQueue::poll_elapsed` ([#4241])
+- time: remove error case from the infallible `DelayQueue::poll_elapsed` ([#4241])
 
 [#3370]: https://github.com/tokio-rs/tokio/pull/3370
 [#4170]: https://github.com/tokio-rs/tokio/pull/4170

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 0.7.0 (February 9, 2022)
+
+### Added
+
+- task: add `spawn_pinned` ([#3370])
+- time: add `shrink_to_fit` and `compact` methods to `DelayQueue` ([#4170])
+- codec: improve `Builder::max_frame_length` docs ([#4352])
+- codec: add mutable reference getters for codecs to pinned `Framed` ([#4372])
+- net: add generic trait to combine UnixListener and TcpListener ([#4385])
+- codec: implement `Framed::map_codec` ([#4427])
+- codec: implement Encoder<BytesMut> for BytesCodec ([#4465])
+
+### Changed
+
+- sync: refactored `PollSender<T>` to fix a subtly broken `Sink<T>` implementation ([#4214])
+- util: remove error case from the infallible DelayQueue::poll_elapsed ([#4241])
+
+[#3370]: https://github.com/tokio-rs/tokio/pull/3370
+[#4170]: https://github.com/tokio-rs/tokio/pull/4170
+[#4352]: https://github.com/tokio-rs/tokio/pull/4352
+[#4372]: https://github.com/tokio-rs/tokio/pull/4372
+[#4385]: https://github.com/tokio-rs/tokio/pull/4385
+[#4427]: https://github.com/tokio-rs/tokio/pull/4427
+[#4465]: https://github.com/tokio-rs/tokio/pull/4465
+[#4214]: https://github.com/tokio-rs/tokio/pull/4214
+[#4241]: https://github.com/tokio-rs/tokio/pull/4241
+
 # 0.6.9 (October 29, 2021)
 
 ### Added

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -6,14 +6,14 @@
 - time: add `shrink_to_fit` and `compact` methods to `DelayQueue` ([#4170])
 - codec: improve `Builder::max_frame_length` docs ([#4352])
 - codec: add mutable reference getters for codecs to pinned `Framed` ([#4372])
-- net: add generic trait to combine UnixListener and TcpListener ([#4385])
+- net: add generic trait to combine `UnixListener` and `TcpListener` ([#4385])
 - codec: implement `Framed::map_codec` ([#4427])
-- codec: implement Encoder<BytesMut> for BytesCodec ([#4465])
+- codec: implement `Encoder<BytesMut>` for `BytesCodec` ([#4465])
 
 ### Changed
 
 - sync: refactored `PollSender<T>` to fix a subtly broken `Sink<T>` implementation ([#4214])
-- util: remove error case from the infallible DelayQueue::poll_elapsed ([#4241])
+- util: remove error case from the infallible `DelayQueue::poll_elapsed` ([#4241])
 
 [#3370]: https://github.com/tokio-rs/tokio/pull/3370
 [#4170]: https://github.com/tokio-rs/tokio/pull/4170

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -15,7 +15,6 @@ description = """
 Additional utilities for working with Tokio.
 """
 categories = ["asynchronous"]
-publish = false
 
 [features]
 # No features on by default


### PR DESCRIPTION
# 0.7.0 (February 9, 2022)

### Added

- task: add `spawn_pinned` ([#3370])
- time: add `shrink_to_fit` and `compact` methods to `DelayQueue` ([#4170])
- codec: improve `Builder::max_frame_length` docs ([#4352])
- codec: add mutable reference getters for codecs to pinned `Framed` ([#4372])
- net: add generic trait to combine `UnixListener` and `TcpListener` ([#4385])
- codec: implement `Framed::map_codec` ([#4427])
- codec: implement `Encoder<BytesMut>` for `BytesCodec` ([#4465])

### Changed

- sync: add lifetime parameter to `ReusableBoxFuture` ([#3762])
- sync: refactored `PollSender<T>` to fix a subtly broken `Sink<T>` implementation ([#4214])
- time: remove error case from the infallible `DelayQueue::poll_elapsed` ([#4241])

[#3370]: https://github.com/tokio-rs/tokio/pull/3370
[#4170]: https://github.com/tokio-rs/tokio/pull/4170
[#4352]: https://github.com/tokio-rs/tokio/pull/4352
[#4372]: https://github.com/tokio-rs/tokio/pull/4372
[#4385]: https://github.com/tokio-rs/tokio/pull/4385
[#4427]: https://github.com/tokio-rs/tokio/pull/4427
[#4465]: https://github.com/tokio-rs/tokio/pull/4465
[#3762]: https://github.com/tokio-rs/tokio/pull/3762
[#4214]: https://github.com/tokio-rs/tokio/pull/4214
[#4241]: https://github.com/tokio-rs/tokio/pull/4241