### PR TITLE
rt: optimize spawn functions

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 bencher = "0.1.5"
+quanta = "0.9"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
@@ -49,4 +50,9 @@ harness = false
 [[bench]]
 name = "fs"
 path = "fs.rs"
+harness = false
+
+[[bench]]
+name = "spawn_size"
+path = "spawn_size.rs"
 harness = false

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 bencher = "0.1.5"
-quanta = "0.9"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }

--- a/benches/spawn_size.rs
+++ b/benches/spawn_size.rs
@@ -1,0 +1,144 @@
+//! Benchmark spawning tasks of different sizes.
+//! This measures the time to start the task and wait the result.
+
+use std::future::Future;
+
+use bencher::black_box;
+use tokio::runtime::Runtime;
+
+const NITER: usize = 50000;
+
+struct SizedFuture<const SIZE: usize> {
+    _data: [u8; SIZE],
+}
+
+impl<const SIZE: usize> SizedFuture<SIZE> {
+    fn new() -> Self {
+        Self {
+            _data: unsafe { std::mem::MaybeUninit::uninit().assume_init() },
+        }
+    }
+}
+
+impl<const SIZE: usize> Future for SizedFuture<SIZE> {
+    type Output = u32;
+
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        std::task::Poll::Ready(0)
+    }
+}
+
+async fn bench_spawn<const SIZE: usize, const BATCH: usize>() -> u128 {
+    let begin = std::time::Instant::now();
+    for _ in 0..NITER {
+        if BATCH == 1 {
+            tokio::task::spawn(SizedFuture::<SIZE>::new())
+                .await
+                .unwrap();
+        } else {
+            let mut vec = Vec::with_capacity(BATCH);
+            for _ in 0..BATCH {
+                vec.push(tokio::task::spawn(SizedFuture::<SIZE>::new()));
+            }
+
+            for handle in vec {
+                black_box(handle.await.unwrap());
+            }
+        }
+    }
+    let dur = begin.elapsed();
+
+    dur.as_nanos() / (NITER as u128)
+}
+
+fn bench_block_on<const SIZE: usize>(rt: &Runtime) -> u128 {
+    let begin = std::time::Instant::now();
+    for _ in 0..NITER {
+        let ans = rt.block_on(SizedFuture::<SIZE>::new());
+        black_box(ans);
+    }
+    let dur = begin.elapsed();
+
+    dur.as_nanos() / (NITER as u128)
+}
+
+fn bench<const SIZE: usize>() {
+    let mut data = vec![];
+    {
+        let curr = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        data.push(curr.block_on(bench_spawn::<SIZE, 1>()));
+        data.push(curr.block_on(bench_spawn::<SIZE, 10>()));
+        data.push(curr.block_on(bench_spawn::<SIZE, 50>()));
+        data.push(bench_block_on::<SIZE>(&curr));
+    }
+
+    {
+        let multi = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+        data.push(multi.block_on(bench_spawn::<SIZE, 1>()));
+        data.push(multi.block_on(bench_spawn::<SIZE, 10>()));
+        data.push(multi.block_on(bench_spawn::<SIZE, 50>()));
+        data.push(bench_block_on::<SIZE>(&multi));
+    }
+
+    print!("|{:>7} |", SIZE);
+    for v in data {
+        print!("{:>6} ns |", v);
+    }
+    println!();
+}
+
+fn print_sep() {
+    println!(
+        "+{0:-^8}+{0:-^10}+{0:-^10}+{0:-^10}+{0:-^10}+{0:-^10}+{0:-^10}+{0:-^10}+{0:-^10}+",
+        ""
+    )
+}
+
+fn main() {
+    if let Some(filter) = std::env::args().skip(1).find(|arg| *arg != "--bench") {
+        if !"spawn_size".contains(&filter) {
+            return;
+        }
+    }
+
+    println!();
+    println!("Benchmark performance of spawn/block_on tasks of different sizes.");
+    println!();
+    println!("+{0:-<8}+{0:-^43}+{0:-^43}+", "");
+    println!(
+        "|{:>8}|{:^43}|{:^43}|",
+        "", "current_thread", "multi_thread"
+    );
+    print_sep();
+    println!(
+        "|{:^8}|{:^10}|{:^10}|{:^10}|{:^10}|{:^10}|{:^10}|{:^10}|{:^10}|",
+        "size",
+        "spawn 1",
+        "spawn 10",
+        "spawn 50",
+        "block_on",
+        "spawn 1",
+        "spawn 10",
+        "spawn 50",
+        "block_on"
+    );
+    print_sep();
+
+    bench::<16>();
+    bench::<32>();
+    bench::<64>();
+    bench::<128>();
+    bench::<256>();
+    bench::<512>();
+    bench::<1024>();
+    bench::<2048>();
+    bench::<4096>();
+    bench::<8192>();
+
+    print_sep();
+}

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -154,6 +154,7 @@ impl Handle {
     /// # }
     /// ```
     #[track_caller]
+    #[inline]
     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -393,6 +393,7 @@ cfg_rt! {
         /// # }
         /// ```
         #[track_caller]
+        #[inline]
         pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -223,6 +223,9 @@ cfg_rt! {
 
     mod spawner;
     use self::spawner::Spawner;
+
+    mod scheduler;
+    pub(crate) use self::scheduler::Scheduler;
 }
 
 cfg_rt_multi_thread! {

--- a/tokio/src/runtime/scheduler.rs
+++ b/tokio/src/runtime/scheduler.rs
@@ -18,9 +18,9 @@ impl SchedulerHandle for ThreadPoolHandle {}
 /// Scheduler handle wrapper which may contains a basic scheduler handle or
 /// thread pool scheduler handle.
 ///
-/// This ensures that task cell layout is same no matter which scheduler the
-/// runtime uses. So we can create a `UninitTask` and send future to task cell
-/// immediately during spawning tasks.
+/// This ensures that the task cell layout is the same, no matter which scheduler
+/// the runtime uses. This way, we can create a `UninitTask` and send the future to
+/// the task cell immediately when spawning tasks.
 #[repr(C)]
 pub(crate) union Scheduler<S = ()> {
     basic: ManuallyDrop<BasicSchedulerHandle>,
@@ -30,7 +30,7 @@ pub(crate) union Scheduler<S = ()> {
 }
 
 impl<F: Future> super::task::UninitTask<F, Scheduler<()>> {
-    /// Transumte type after the scheduler type is determined.
+    /// Transmute type after the scheduler type is determined.
     pub(crate) fn transmute<S: SchedulerHandle>(self) -> super::task::UninitTask<F, Scheduler<S>> {
         unsafe { std::mem::transmute(self) }
     }

--- a/tokio/src/runtime/scheduler.rs
+++ b/tokio/src/runtime/scheduler.rs
@@ -1,0 +1,75 @@
+use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
+
+use crate::future::Future;
+use crate::loom::sync::Arc;
+
+/// Marker trait for runtime scheduler handle.
+pub(crate) trait SchedulerHandle {}
+
+type BasicSchedulerHandle = Arc<super::basic_scheduler::Shared>;
+impl SchedulerHandle for BasicSchedulerHandle {}
+
+#[cfg(feature = "rt-multi-thread")]
+type ThreadPoolHandle = Arc<super::thread_pool::Shared>;
+#[cfg(feature = "rt-multi-thread")]
+impl SchedulerHandle for ThreadPoolHandle {}
+
+/// Scheduler handle wrapper which may contains a basic scheduler handle or
+/// thread pool scheduler handle.
+///
+/// This ensures that task cell layout is same no matter which scheduler the
+/// runtime uses. So we can create a `UninitTask` and send future to task cell
+/// immediately during spawning tasks.
+#[repr(C)]
+pub(crate) union Scheduler<S = ()> {
+    basic: ManuallyDrop<BasicSchedulerHandle>,
+    #[cfg(feature = "rt-multi-thread")]
+    multi: ManuallyDrop<ThreadPoolHandle>,
+    _marker: PhantomData<S>,
+}
+
+impl<F: Future> super::task::UninitTask<F, Scheduler<()>> {
+    /// Transumte type after the scheduler type is determined.
+    pub(crate) fn transmute<S: SchedulerHandle>(self) -> super::task::UninitTask<F, Scheduler<S>> {
+        unsafe { std::mem::transmute(self) }
+    }
+}
+
+impl Scheduler<BasicSchedulerHandle> {
+    pub(crate) fn new(basic: BasicSchedulerHandle) -> Self {
+        Self {
+            basic: ManuallyDrop::new(basic),
+        }
+    }
+}
+
+impl AsRef<BasicSchedulerHandle> for Scheduler<BasicSchedulerHandle> {
+    fn as_ref(&self) -> &BasicSchedulerHandle {
+        unsafe { &*self.basic }
+    }
+}
+
+#[cfg(feature = "rt-multi-thread")]
+impl Scheduler<ThreadPoolHandle> {
+    pub(crate) fn new(multi: ThreadPoolHandle) -> Self {
+        Self {
+            multi: ManuallyDrop::new(multi),
+        }
+    }
+}
+
+#[cfg(feature = "rt-multi-thread")]
+impl AsRef<ThreadPoolHandle> for Scheduler<ThreadPoolHandle> {
+    fn as_ref(&self) -> &ThreadPoolHandle {
+        unsafe { &*self.multi }
+    }
+}
+
+impl<S> Drop for Scheduler<S> {
+    fn drop(&mut self) {
+        unsafe {
+            std::ptr::drop_in_place(self as *mut _ as *mut S);
+        }
+    }
+}

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -1,5 +1,5 @@
 use crate::future::Future;
-use crate::runtime::basic_scheduler;
+use crate::runtime::{basic_scheduler, task::UninitTask, Scheduler};
 use crate::task::JoinHandle;
 
 cfg_rt_multi_thread! {
@@ -23,15 +23,15 @@ impl Spawner {
         }
     }
 
-    pub(crate) fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+    pub(crate) fn spawn<F>(&self, task: UninitTask<F, Scheduler>) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
         match self {
-            Spawner::Basic(spawner) => spawner.spawn(future),
+            Spawner::Basic(spawner) => spawner.spawn(task),
             #[cfg(feature = "rt-multi-thread")]
-            Spawner::ThreadPool(spawner) => spawner.spawn(future),
+            Spawner::ThreadPool(spawner) => spawner.spawn(task),
         }
     }
 }

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -37,13 +37,13 @@ pub(super) struct Cell<T: Future, S> {
     pub(super) trailer: Trailer,
 }
 
-/// Uninitialized task cell. Only the holds a valid future.
+/// Uninitialized task cell. Only holds a valid future.
 ///
-/// `UninitCell<T, S>` should have same layout as `Cell<T, S>`, so it can
-/// be initialized and transmute into a `Cell<T, S>` lately.
+/// `UninitCell<T, S>` should have the same layout as `Cell<T, S>`, so it can
+/// be initialized and transmute into a `Cell<T, S>` later.
 ///
-/// If `S1` and `S2` have same layout, the layout of `UninitCell<T, S1>`
-/// and `UninitCell<T, S2>` should be same. This allows trick used in
+/// If `S1` and `S2` have the same layout, the layout of `UninitCell<T, S1>`
+/// and `UninitCell<T, S2>` should be the same. This allows the trick used in
 /// [`crate::runtime::Scheduler`].
 #[repr(C)]
 pub(super) struct UninitCell<T: Future, S> {
@@ -65,8 +65,8 @@ pub(super) struct CoreStage<T: Future> {
 ///
 /// Holds the future or output, depending on the stage of execution.
 ///
-/// `#[repr(C)]` guarantee `Core<T, S1>` has same layout as `Core<T, S2>`
-/// if `S1` and `S2` have same layout.
+/// `#[repr(C)]` guarantees `Core<T, S1>` has the same layout as `Core<T, S2>`
+/// if `S1` and `S2` have the same layout.
 #[repr(C)]
 pub(super) struct Core<T: Future, S> {
     /// Scheduler used to drive this future.

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -185,10 +185,10 @@ unsafe impl<S> Sync for Task<S> {}
 
 /// A uninitialized task, which only contains a valid future.
 ///
-/// UninitTask can be constructed without getting the scheduler handle,
-/// and bind to a scheduler lately. This makes it possible to quickly
-/// sending the future to the task cell. Compiler can optimize out
-/// data copy during spawn tasks easily.
+/// An `UninitTask` can be constructed without getting the scheduler handle,
+/// and bind to a scheduler later. This makes it possible to quickly
+/// send the future to the task cell. The compiler can optimize out
+/// the data copy while spawn tasks easily.
 pub(crate) struct UninitTask<F: Future, S> {
     inner: Box<UninitCell<F, S>>,
 }
@@ -286,7 +286,7 @@ impl<F: Future, S: Schedule> UninitTask<F, S> {
         (task, notified, join)
     }
 
-    /// Initlializes a new task with an associated join handle. This method is used
+    /// Initializes a new task with an associated join handle. This method is used
     /// only when the task is not going to be stored in an `OwnedTasks` list.
     ///
     /// Currently only blocking tasks use this method.

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -1,5 +1,5 @@
 use crate::future::Future;
-use crate::runtime::task::{Cell, Harness, Header, Schedule, State};
+use crate::runtime::task::{Harness, Header, Schedule};
 
 use std::ptr::NonNull;
 use std::task::{Poll, Waker};
@@ -48,17 +48,6 @@ pub(super) fn vtable<T: Future, S: Schedule>() -> &'static Vtable {
 }
 
 impl RawTask {
-    pub(super) fn new<T, S>(task: T, scheduler: S) -> RawTask
-    where
-        T: Future,
-        S: Schedule,
-    {
-        let ptr = Box::into_raw(Cell::<_, S>::new(task, scheduler, State::new()));
-        let ptr = unsafe { NonNull::new_unchecked(ptr as *mut Header) };
-
-        RawTask { ptr }
-    }
-
     pub(super) unsafe fn from_raw(ptr: NonNull<Header>) -> RawTask {
         RawTask { ptr }
     }

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -11,9 +11,11 @@ mod unowned_wrapper {
         T::Output: Send + 'static,
     {
         use tracing::Instrument;
+
         let span = tracing::trace_span!("test_span");
         let task = task.instrument(span);
-        let (task, handle) = crate::runtime::task::unowned(task, NoopSchedule);
+        let task = crate::runtime::task::UninitTask::new(task);
+        let (task, handle) = task.init_unowned(NoopSchedule);
         (task.into_notified(), handle)
     }
 
@@ -23,7 +25,8 @@ mod unowned_wrapper {
         T: std::future::Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, handle) = crate::runtime::task::unowned(task, NoopSchedule);
+        let task = crate::runtime::task::UninitTask::new(task);
+        let (task, handle) = task.init_unowned(NoopSchedule);
         (task.into_notified(), handle)
     }
 }

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -76,6 +76,7 @@ impl<'a> Builder<'a> {
     /// See [`task::spawn`](crate::task::spawn) for
     /// more details.
     #[track_caller]
+    #[inline]
     pub fn spawn<Fut>(self, future: Fut) -> JoinHandle<Fut::Output>
     where
         Fut: Future + Send + 'static,
@@ -89,6 +90,7 @@ impl<'a> Builder<'a> {
     /// See [`task::spawn_local`](crate::task::spawn_local)
     /// for more details.
     #[track_caller]
+    #[inline]
     pub fn spawn_local<Fut>(self, future: Fut) -> JoinHandle<Fut::Output>
     where
         Fut: Future + 'static,

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -71,6 +71,7 @@ impl<T: 'static> JoinSet<T> {
     /// # Panics
     ///
     /// This method panics if called outside of a Tokio runtime.
+    #[inline]
     pub fn spawn<F>(&mut self, task: F)
     where
         F: Future<Output = T>,
@@ -81,6 +82,7 @@ impl<T: 'static> JoinSet<T> {
     }
 
     /// Spawn the provided task on the provided runtime and store it in this `JoinSet`.
+    #[inline]
     pub fn spawn_on<F>(&mut self, task: F, handle: &Handle)
     where
         F: Future<Output = T>,
@@ -97,6 +99,7 @@ impl<T: 'static> JoinSet<T> {
     /// This method panics if it is called outside of a `LocalSet`.
     ///
     /// [`LocalSet`]: crate::task::LocalSet
+    #[inline]
     pub fn spawn_local<F>(&mut self, task: F)
     where
         F: Future<Output = T>,
@@ -108,6 +111,7 @@ impl<T: 'static> JoinSet<T> {
     /// Spawn the provided task on the provided [`LocalSet`] and store it in this `JoinSet`.
     ///
     /// [`LocalSet`]: crate::task::LocalSet
+    #[inline]
     pub fn spawn_local_on<F>(&mut self, task: F, local_set: &LocalSet)
     where
         F: Future<Output = T>,


### PR DESCRIPTION
## Motivation

Tokio doesn't peform well when spawing large futures. There are many function calls on spawn code path. Futures are passed as parameter values between these functions. Compilers can't optimize out data copies very well. For larger futures (several or tens of KBs), the impact on performance cannot be ignored. Similarly, for devices with limited stack space, the waste of stack space also needs consideration.

Under rust 1.58, using the default configuration of release mode, spawning a 3MB future without `await` on `JoinHandle` will cause stackoverflow. The stack size is 8MB. This might means that there are three copies on the stack before the future is placed in task cell on the heap.

In addition, there is extra overhead when `await` async tasks. In the implementation of `take_output`, even if the output type is unit type `()`, the entire `CoreStage` is copied. It's weird that llvm doesn't optimize this code.

```rust
pub(super) fn take_output(&self) -> super::Result<T::Output> {
    use std::mem;

    self.stage.with_mut(|ptr| {
        // Safety:: the caller ensures mutual exclusion to the field.
        match mem::replace(unsafe { &mut *ptr }, Stage::Consumed) {
            Stage::Finished(output) => output,
            _ => panic!("JoinHandle polled after completion"),
        }
    })
}
```

It would be good for performance and stack space, if we could eliminate or reduce data copying when spawning futures.

## Solution

Add a benchmark to test the performance when spawning futures of different sizes. The spawned futures only contain an uninitialized memory space, they will do nothing and become ready immediately.

Add a new type `UninitTask`. `UninitTask` creates an uninitialized task cell(or partially initialized to be precise) on the heap, which onlys contains a valid future. `UninitTask` can bind to a scheduler to complete initialization (update task header, vtable, trailer, etc) and convert into a `RawTask` lately.
    
In this way the spawn function can move futures to the heap immediately. Since the code path is shorter, it's easier for compiler to optimize out some data copy with inline hint.

When spawning a future on runtime, we don't know the actual scheduler type(basic or thread pool) before checking the runtime handle. The solution is to make the task cell independent of the scheduler used by runtime. This is achieved by wrapping handle of basic scheduler and thread pool scheduler in a union.

Function `take_output` is rewritten.

## Benchmark

Rust: 1.58.1-x86_64-unknown-linux-gnu
CPU: Intel(R) Core(TM) i7-8700K CPU @ 3.70GHz

Before optimization:
```
+--------+-------------------------------------------+-------------------------------------------+
|        |              current_thread               |               multi_thread                |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
|  size  | spawn 1  | spawn 10 | spawn 50 | block_on | spawn 1  | spawn 10 | spawn 50 | block_on |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
|     16 |   218 ns |  1451 ns |  6509 ns |   104 ns |  5731 ns |  7951 ns | 17890 ns |    72 ns |
|     32 |   225 ns |  1557 ns |  7191 ns |   103 ns |  5673 ns |  8719 ns | 17121 ns |    71 ns |
|     64 |   221 ns |  1603 ns |  7817 ns |   107 ns |  5603 ns |  8199 ns | 17898 ns |    81 ns |
|    128 |   225 ns |  1551 ns |  7938 ns |   104 ns |  5687 ns |  8232 ns | 19541 ns |    74 ns |
|    256 |   231 ns |  1602 ns |  8523 ns |   106 ns |  5758 ns |  8898 ns | 20555 ns |    74 ns |
|    512 |   234 ns |  1666 ns |  9353 ns |   112 ns |  5724 ns |  8664 ns | 19269 ns |    75 ns |
|   1024 |   289 ns |  2183 ns | 11227 ns |   123 ns |  5821 ns |  8722 ns | 21506 ns |    79 ns |
|   2048 |   313 ns |  2726 ns | 12730 ns |   134 ns |  5810 ns |  9623 ns | 25184 ns |    91 ns |
|   4096 |   386 ns |  3674 ns | 34464 ns |   171 ns |  6240 ns |  9325 ns | 48225 ns |   103 ns |
|   8192 |   593 ns |  5796 ns |105036 ns |   275 ns |  6303 ns |  9997 ns |127638 ns |   135 ns |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
```

After:

```
+--------+-------------------------------------------+-------------------------------------------+
|        |              current_thread               |               multi_thread                |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
|  size  | spawn 1  | spawn 10 | spawn 50 | block_on | spawn 1  | spawn 10 | spawn 50 | block_on |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
|     16 |   216 ns |  1407 ns |  6348 ns |   101 ns |  5741 ns |  7453 ns | 17668 ns |    73 ns |
|     32 |   216 ns |  1487 ns |  6808 ns |   103 ns |  5543 ns |  8428 ns | 20845 ns |    72 ns |
|     64 |   218 ns |  1537 ns |  7552 ns |   103 ns |  5813 ns |  8405 ns | 17758 ns |    71 ns |
|    128 |   212 ns |  1516 ns |  7569 ns |   104 ns |  5669 ns |  7596 ns | 17560 ns |    74 ns |
|    256 |   219 ns |  1447 ns |  7572 ns |   107 ns |  5678 ns |  8174 ns | 20528 ns |    76 ns |
|    512 |   218 ns |  1494 ns |  7633 ns |   114 ns |  5757 ns |  8087 ns | 20844 ns |    79 ns |
|   1024 |   244 ns |  1712 ns |  8234 ns |   121 ns |  5612 ns |  8874 ns | 20940 ns |    83 ns |
|   2048 |   258 ns |  1850 ns |  8001 ns |   132 ns |  5703 ns |  8919 ns | 21308 ns |    91 ns |
|   4096 |   247 ns |  1753 ns | 20062 ns |   167 ns |  5760 ns |  9056 ns | 32155 ns |   105 ns |
|   8192 |   255 ns |  1739 ns | 39311 ns |   268 ns |  5652 ns |  8721 ns | 51768 ns |   152 ns |
+--------+----------+----------+----------+----------+----------+----------+----------+----------+
```

When spawning 50 futures of 512 bytes size (pretty common usage I guess) on current thread, the performance improvement has been relatively obvious (9353ns vs 7633ns). For very large futures, the performance improvement brought by optimization is very significant.

