### PR TITLE
util: bump tokio dependency to 1.6 to satisfy minimal versions

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.6.0", path = "../tokio", features = ["sync"] }
 
 bytes = "1.0.0"
 futures-core = "0.3.0"


### PR DESCRIPTION
This failed in h2 CI:

https://github.com/hyperium/h2/runs/5153518790?check_suite_focus=true

It looks like minimal versions support does not the right thing in the face of path dependencies.