### PR TITLE
replace deprecated `spin_loop_hint` with `hint::spin_loop`

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -25,6 +25,10 @@ pub(crate) mod future {
     pub(crate) use crate::sync::AtomicWaker;
 }
 
+pub(crate) mod hint {
+    pub(crate) use std::hint::spin_loop;
+}
+
 pub(crate) mod rand {
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hash, Hasher};
@@ -75,9 +79,6 @@ pub(crate) mod sync {
         pub(crate) use crate::loom::std::atomic_usize::AtomicUsize;
 
         pub(crate) use std::sync::atomic::{fence, AtomicBool, Ordering};
-        // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
-        #[allow(deprecated)]
-        pub(crate) use std::sync::atomic::spin_loop_hint;
     }
 }
 
@@ -96,9 +97,7 @@ pub(crate) mod sys {
 pub(crate) mod thread {
     #[inline]
     pub(crate) fn yield_now() {
-        // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
-        #[allow(deprecated)]
-        std::sync::atomic::spin_loop_hint();
+        std::hint::spin_loop();
     }
 
     #[allow(unused_imports)]

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -1,7 +1,8 @@
 #![cfg_attr(any(loom, not(feature = "sync")), allow(dead_code, unreachable_pub))]
 
 use crate::loom::cell::UnsafeCell;
-use crate::loom::sync::atomic::{self, AtomicUsize};
+use crate::loom::hint;
+use crate::loom::sync::atomic::AtomicUsize;
 
 use std::fmt;
 use std::panic::{resume_unwind, AssertUnwindSafe, RefUnwindSafe, UnwindSafe};
@@ -281,9 +282,7 @@ impl AtomicWaker {
                 waker.wake();
 
                 // This is equivalent to a spin lock, so use a spin hint.
-                // TODO: once we bump MSRV to 1.49+, use `hint::spin_loop` instead.
-                #[allow(deprecated)]
-                atomic::spin_loop_hint();
+                hint::spin_loop();
             }
             state => {
                 // In this case, a concurrent thread is holding the


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Since our MSRV has been increased to 1.49 in #4457, it's ok to replace deprecated `spin_loop_hint` with `hint::spin_loop`.

close #3498.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
