### PR TITLE
chore: update minimal mio requirement to 0.7.11

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -98,7 +98,7 @@ pin-project-lite = "0.2.0"
 bytes = { version = "1.0.0", optional = true }
 once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
-mio = { version = "0.7.6", optional = true }
+mio = { version = "0.7.11", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Update minimal mio requirement to 0.7.11 includes https://github.com/tokio-rs/mio/pull/1478 (needed for windows) and https://github.com/tokio-rs/mio/pull/1434 (needed for macos).

Caught in https://github.com/tokio-rs/tokio/pull/4490#issuecomment-1037008658 by using https://github.com/taiki-e/cargo-minimal-versions/pull/4.

```
info: running `cargo check --all-features` on tokio-stream (1/1)
   Compiling libc v0.2.69
   Compiling log v0.4.8
   Compiling autocfg v1.0.0
   Compiling memchr v2.2.0
    Checking cfg-if v0.1.2
    Checking arc-swap v0.4.0
    Checking pin-project-lite v0.2.5
    Checking once_cell v1.5.2
    Checking bytes v1.0.0
    Checking futures-core v0.3.0
    Checking futures-sink v0.3.0
   Compiling tokio v1.8.0
    Checking signal-hook-registry v1.1.1
    Checking mio v0.7.6
error[E0425]: cannot find value `TCP_KEEPINTVL` in crate `libc`
    --> /Users/taiki/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.7.6/src/sys/unix/tcp.rs:334:15
     |
334  |         libc::TCP_KEEPINTVL,
     |               ^^^^^^^^^^^^^ help: a constant with a similar name exists: `TCP_KEEPALIVE`
     |
    ::: /Users/taiki/.cargo/registry/src/github.com-1ecc6299db9ec823/libc-0.2.69/src/unix/bsd/apple/mod.rs:2259:1
     |
2259 | pub const TCP_KEEPALIVE: ::c_int = 0x10;
     | ---------------------------------------- similarly named constant `TCP_KEEPALIVE` defined here
```
