### PR TITLE
Using tokio within shared libs: make `try_enter` a pub method

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -90,7 +90,7 @@ pub(crate) fn enter(new: Handle) -> EnterGuard {
 /// Sets this [`Handle`] as the current active [`Handle`].
 ///
 /// [`Handle`]: Handle
-pub(crate) fn try_enter(new: Handle) -> Option<EnterGuard> {
+pub fn try_enter(new: Handle) -> Option<EnterGuard> {
     CONTEXT
         .try_with(|ctx| {
             let old = ctx.borrow_mut().replace(new);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Allow shared libs to enter into the surrounding runtime without depending on threadlocal

Some related issues:
https://github.com/oxalica/async-ffi/issues/14
https://github.com/crypto-com/ibc-solo-machine/pull/37
https://github.com/crypto-com/ibc-solo-machine/pull/36
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Allow end user to call this as a callback publically

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
