### PR TITLE
Prevent panicking in sleep() with large durations

### DIFF
--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -129,7 +129,7 @@ impl ClockTime {
             .unwrap_or_else(|| Duration::from_secs(0));
         let ms = dur.as_millis();
 
-        ms.try_into().expect("Duration too far into the future")
+        ms.try_into().unwrap_or(u64::MAX)
     }
 
     pub(self) fn tick_to_duration(&self, t: u64) -> Duration {

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -236,22 +236,6 @@ async fn long_sleeps() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Duration too far into the future")]
-async fn very_long_sleeps() {
-    tokio::time::pause();
-
-    // Some platforms (eg macos) can't represent times this far in the future
-    if let Some(deadline) = tokio::time::Instant::now().checked_add(Duration::from_secs(1u64 << 62))
-    {
-        tokio::time::sleep_until(deadline).await;
-    } else {
-        // make it pass anyway (we can't skip/ignore the test based on the
-        // result of checked_add)
-        panic!("Duration too far into the future (test ignored)")
-    }
-}
-
-#[tokio::test]
 async fn reset_after_firing() {
     let timer = tokio::time::sleep(std::time::Duration::from_millis(1));
     tokio::pin!(timer);


### PR DESCRIPTION
Closes #4494.

Replaced an `expect()` with a graceful failure of returning u64::MAX.
When looking at the usages of deadline/instant_to_tick, this new
behavior appears to be consistent with the expectations of the callers.

## Motivation

A user of my crate reported a panic in code that was calling `sleep()` with a large duration. The code behind `sleep()` does a checked_add()`, which to me implied that the code handled large durations. The documentation doesn't mention this panic as a possible outcome, despite a unit test being present to test for the failure.

## Solution

My initial report was that this was purely a bug, but after looking at the code the panic was intentionally added due to the resolution of Instant on some platforms. However, when looking at the code that causes the panic, it has nothing to do with platform-specific behaviors.

The code in `time/driver/entry.rs` seems to only care about the relative order of the returned u64, and a value of u64::MAX seems to me to produce consistent, predictable results. So, this PR's proposed fix is to remove the panic and gracefully fail with `u64::MAX`.

The only test broken by this change is the panic-testing unit test. After removing that one unit test, the entire test suite passes.