### PR TITLE
rt: make `JoinSet` unstable

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -373,6 +373,16 @@ macro_rules! cfg_trace {
     };
 }
 
+macro_rules! cfg_unstable {
+    ($($item:item)*) => {
+        $(
+            #[cfg(tokio_unstable)]
+            #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+            $item
+        )*
+    };
+}
+
 macro_rules! cfg_not_trace {
     ($($item:item)*) => {
         $(

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -135,6 +135,10 @@
 //! poll call will notice it when the poll finishes, and the task is cancelled
 //! at that point.
 
+// Some task infrastructure is here to support `JoinSet`, which is currently
+// unstable. This should be removed once `JoinSet` is stabilized.
+#![cfg_attr(not(tokio_unstable), allow(dead_code))]
+
 mod core;
 use self::core::Cell;
 use self::core::Header;

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -300,8 +300,10 @@ cfg_rt! {
     mod unconstrained;
     pub use unconstrained::{unconstrained, Unconstrained};
 
-    mod join_set;
-    pub use join_set::JoinSet;
+    cfg_unstable! {
+        mod join_set;
+        pub use join_set::JoinSet;
+    }
 
     cfg_trace! {
         mod builder;

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -44,8 +44,10 @@ pub(crate) mod linked_list;
 mod rand;
 
 cfg_rt! {
-    mod idle_notified_set;
-    pub(crate) use idle_notified_set::IdleNotifiedSet;
+    cfg_unstable! {
+        mod idle_notified_set;
+        pub(crate) use idle_notified_set::IdleNotifiedSet;
+    }
 
     mod wake;
     pub(crate) use wake::WakerRef;

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -434,13 +434,6 @@ async_assert_fn!(tokio::sync::watch::Receiver<YY>::changed(_): Send & Sync & !Un
 async_assert_fn!(tokio::sync::watch::Sender<NN>::closed(_): !Send & !Sync & !Unpin);
 async_assert_fn!(tokio::sync::watch::Sender<YN>::closed(_): !Send & !Sync & !Unpin);
 async_assert_fn!(tokio::sync::watch::Sender<YY>::closed(_): Send & Sync & !Unpin);
-
-async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::join_one(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::shutdown(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::task::JoinSet<Rc<u32>>::join_one(_): !Send & !Sync & !Unpin);
-async_assert_fn!(tokio::task::JoinSet<Rc<u32>>::shutdown(_): !Send & !Sync & !Unpin);
-async_assert_fn!(tokio::task::JoinSet<u32>::join_one(_): Send & Sync & !Unpin);
-async_assert_fn!(tokio::task::JoinSet<u32>::shutdown(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::task::LocalKey<Cell<u32>>::scope(_, Cell<u32>, BoxFuture<()>): !Send & !Sync & !Unpin);
 async_assert_fn!(tokio::task::LocalKey<Cell<u32>>::scope(_, Cell<u32>, BoxFutureSend<()>): Send & !Sync & !Unpin);
 async_assert_fn!(tokio::task::LocalKey<Cell<u32>>::scope(_, Cell<u32>, BoxFutureSync<()>): Send & !Sync & !Unpin);
@@ -458,10 +451,19 @@ assert_value!(tokio::task::JoinError: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<NN>: !Send & !Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<YN>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<YY>: Send & Sync & Unpin);
-assert_value!(tokio::task::JoinSet<YY>: Send & Sync & Unpin);
-assert_value!(tokio::task::JoinSet<YN>: Send & Sync & Unpin);
-assert_value!(tokio::task::JoinSet<NN>: !Send & !Sync & Unpin);
-assert_value!(tokio::task::LocalSet: !Send & !Sync & Unpin);
+#[cfg(tokio_unstable)]
+mod unstable {
+    async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::join_one(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::shutdown(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::task::JoinSet<Rc<u32>>::join_one(_): !Send & !Sync & !Unpin);
+    async_assert_fn!(tokio::task::JoinSet<Rc<u32>>::shutdown(_): !Send & !Sync & !Unpin);
+    async_assert_fn!(tokio::task::JoinSet<u32>::join_one(_): Send & Sync & !Unpin);
+    async_assert_fn!(tokio::task::JoinSet<u32>::shutdown(_): Send & Sync & !Unpin);
+    assert_value!(tokio::task::JoinSet<YY>: Send & Sync & Unpin);
+    assert_value!(tokio::task::JoinSet<YN>: Send & Sync & Unpin);
+    assert_value!(tokio::task::JoinSet<NN>: !Send & !Sync & Unpin);
+    assert_value!(tokio::task::LocalSet: !Send & !Sync & Unpin);
+}
 
 assert_value!(tokio::runtime::Builder: Send & Sync & Unpin);
 assert_value!(tokio::runtime::EnterGuard<'_>: Send & Sync & Unpin);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -453,6 +453,7 @@ assert_value!(tokio::task::JoinHandle<YN>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinHandle<YY>: Send & Sync & Unpin);
 #[cfg(tokio_unstable)]
 mod unstable {
+    use super::*;
     async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::join_one(_): Send & Sync & !Unpin);
     async_assert_fn!(tokio::task::JoinSet<Cell<u32>>::shutdown(_): Send & Sync & !Unpin);
     async_assert_fn!(tokio::task::JoinSet<Rc<u32>>::join_one(_): !Send & !Sync & !Unpin);

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(feature = "full")]
+#![cfg(all(feature = "full", tokio_unstable))]
 
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;


### PR DESCRIPTION
There are still some open questions related to the API. Until they are
resolved, the type should be marked as unstable so releases are not
blocked.

Specifically, how can tasks spawned onto the `JoinSet` be canceled?
My inclination would be to return an `AbortHandle` from `JoinSet::spawn`.