### PR TITLE
deprecate reexports from std

### DIFF
--- a/tokio/src/macros/support.rs
+++ b/tokio/src/macros/support.rs
@@ -4,6 +4,10 @@ cfg_macros! {
     pub use crate::util::thread_rng_n;
 }
 
+// Re-export not needed since it's pulling from std
+#[deprecated(note = "Prefer importing std::future::Future directly")]
 pub use std::future::Future;
+#[deprecated(note = "Prefer importing std::pin::Pin directly")]
 pub use std::pin::Pin;
+#[deprecated(note = "Prefer importing std::task::Poll directly")]
 pub use std::task::Poll;

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -109,6 +109,7 @@ pub use timeout::{timeout, timeout_at, Timeout};
 #[cfg(not(loom))]
 mod tests;
 
-// Re-export for convenience
+// Re-export not needed since it's pulling from std
+#[deprecated(note = "Prefer importing std::time::Duration directly")]
 #[doc(no_inline)]
 pub use std::time::Duration;


### PR DESCRIPTION
Looking a bit into the history, they appear motivated in an earlier
less stable version of tokio when the types may have been changing
or weren't in std yet.

## Motivation

Reexports for the sake of it are not helpful (confusing actually)
from std. For new developers, it's not obvious that
tokio::time::Duration is the same as std::time::Duration. This indirection
may be useful for re-exporting a particular version of a dependent crate,
but for `std` it appears to be mainly confusing.

## Solution

Deprecate the re-exports of std. Upon the next major release, remove them.