### PR TITLE
util: fix import path of CancellationToken in example code

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -24,7 +24,7 @@ use guard::DropGuard;
 ///
 /// # Examples
 ///
-/// ```ignore
+/// ```no_run
 /// use tokio::select;
 /// use tokio_util::sync::CancellationToken;
 ///
@@ -172,7 +172,7 @@ impl CancellationToken {
     ///
     /// # Examples
     ///
-    /// ```ignore
+    /// ```no_run
     /// use tokio::select;
     /// use tokio_util::sync::CancellationToken;
     ///

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -26,7 +26,7 @@ use guard::DropGuard;
 ///
 /// ```ignore
 /// use tokio::select;
-/// use tokio::scope::CancellationToken;
+/// use tokio_util::sync::CancellationToken;
 ///
 /// #[tokio::main]
 /// async fn main() {
@@ -174,7 +174,7 @@ impl CancellationToken {
     ///
     /// ```ignore
     /// use tokio::select;
-    /// use tokio::scope::CancellationToken;
+    /// use tokio_util::sync::CancellationToken;
     ///
     /// #[tokio::main]
     /// async fn main() {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Examples in `cancellation_token.rs` doesn't work since import path of `CancellationToken` is not up to date. I'd like to fix this to make the examples work without each developer fixing import path.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Fix import path of CancellationToken👍
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
