### PR TITLE
chore: prepare tokio-util 0.7.1 release

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 0.7.1 (February 21, 2022)
 
+### Added
+
+- codec: add `length_field_type` to `LengthDelimitedCodec` builder ([#4508])
+- io: add `StreamReader::into_inner_with_chunk()` ([#4559])
+
+### Changed
+
+- switch from log to tracing ([#4539])
+
 ### Fixed
 
 - sync: fix waker update condition in `CancellationToken` ([#4497])

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.1 (February 21, 2022)
+
+### Fixed
+
+- sync: fix waker update condition in `CancellationToken` ([#4497])
+- bumped tokio dependency to 1.6 to satisfy minimum requirements ([#4490])
+
 # 0.7.0 (February 9, 2022)
 
 ### Added

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -14,6 +14,12 @@
 - sync: fix waker update condition in `CancellationToken` ([#4497])
 - bumped tokio dependency to 1.6 to satisfy minimum requirements ([#4490])
 
+[#4490]: https://github.com/tokio-rs/tokio/pull/4490
+[#4497]: https://github.com/tokio-rs/tokio/pull/4497
+[#4508]: https://github.com/tokio-rs/tokio/pull/4508
+[#4539]: https://github.com/tokio-rs/tokio/pull/4539
+[#4559]: https://github.com/tokio-rs/tokio/pull/4559
+
 # 0.7.0 (February 9, 2022)
 
 ### Added

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.0"
+version = "0.7.1"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.6.0", features = ["sync"] }
+tokio = { version = "1.6.0", path = "../tokio", features = ["sync"] }
 
 bytes = "1.0.0"
 futures-core = "0.3.0"
@@ -46,9 +46,9 @@ slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.25", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["full"] }
-tokio-test = { version = "0.4.0" }
-tokio-stream = { version = "0.1" }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 async-stream = "0.3.0"
 futures = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.6.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.6.0", features = ["sync"] }
 
 bytes = "1.0.0"
 futures-core = "0.3.0"
@@ -46,9 +46,9 @@ slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.25", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
-tokio-test = { version = "0.4.0", path = "../tokio-test" }
-tokio-stream = { version = "0.1", path = "../tokio-stream" }
+tokio = { version = "1.0.0", features = ["full"] }
+tokio-test = { version = "0.4.0" }
+tokio-stream = { version = "0.1" }
 
 async-stream = "0.3.0"
 futures = "0.3.0"


### PR DESCRIPTION
The minimal versions fix from #4490 is required to bump h2, which is probably one of the more prominent tokio-util users.

We might want to wait to get #4520 and/or #4508 in, too?