### PR TITLE
Draft: Add ability to disable paused clock auto-advance

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -48,7 +48,7 @@ pub struct Builder {
     enable_time: bool,
 
     /// Whether or not the clock should start paused.
-    start_paused: bool,
+    start_paused: driver::PauseMode,
 
     /// The number of worker threads, used by Runtime.
     ///
@@ -125,7 +125,7 @@ impl Builder {
             enable_time: false,
 
             // The clock starts not-paused
-            start_paused: false,
+            start_paused: driver::PauseMode::Unpaused,
 
             // Default to lazy auto-detection (one thread per CPU core)
             worker_threads: None,
@@ -652,7 +652,21 @@ cfg_test_util! {
         ///     .unwrap();
         /// ```
         pub fn start_paused(&mut self, start_paused: bool) -> &mut Self {
-            self.start_paused = start_paused;
+            if start_paused {
+                self.start_paused = driver::PauseMode::Paused;
+            } else {
+                self.start_paused = driver::PauseMode::Unpaused;
+            }
+            self
+        }
+
+        /// Controls if the runtime's clock starts paused without auto-advance or advancing.
+        pub fn start_paused_no_advance(&mut self, start_paused_no_advance: bool) -> &mut Self {
+            if start_paused_no_advance {
+                self.start_paused = driver::PauseMode::PausedNoAdvance;
+            } else {
+                self.start_paused = driver::PauseMode::Unpaused;
+            }
             self
         }
     }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -103,8 +103,16 @@ cfg_time! {
     pub(crate) type Clock = crate::time::Clock;
     pub(crate) type TimeHandle = Option<crate::time::driver::Handle>;
 
-    fn create_clock(enable_pausing: bool, start_paused: bool) -> Clock {
-        crate::time::Clock::new(enable_pausing, start_paused)
+    #[allow(unused_variables)]
+    fn create_clock(enable_pausing: bool, start_paused: PauseMode) -> Clock {
+        let clock = crate::time::Clock::new(enable_pausing);
+        #[cfg(feature = "test-util")]
+            match start_paused {
+                PauseMode::Paused => clock.pause(),
+                PauseMode::PausedNoAdvance => clock.pause_no_advance(),
+                _ => ()
+            }
+        clock
     }
 
     fn create_time_driver(
@@ -158,11 +166,20 @@ pub(crate) struct Resources {
     pub(crate) clock: Clock,
 }
 
+#[derive(Copy, Clone)]
+pub(crate) enum PauseMode {
+    Unpaused,
+    #[cfg(feature = "test-util")]
+    Paused,
+    #[cfg(feature = "test-util")]
+    PausedNoAdvance,
+}
+
 pub(crate) struct Cfg {
     pub(crate) enable_io: bool,
     pub(crate) enable_time: bool,
     pub(crate) enable_pause_time: bool,
-    pub(crate) start_paused: bool,
+    pub(crate) start_paused: PauseMode,
 }
 
 impl Driver {

--- a/tokio/src/time/driver/mod.rs
+++ b/tokio/src/time/driver/mod.rs
@@ -250,7 +250,10 @@ where
         fn park_timeout(&mut self, duration: Duration) -> Result<(), P::Error> {
             let clock = &self.time_source.clock;
 
-            if clock.is_paused() {
+            if clock.is_paused_no_advance() {
+                // As autoadvance is disabled the next timer won't ever be reached
+                self.park.park_timeout(Duration::from_secs(3600))?;
+            } else if clock.is_paused() {
                 self.park.park_timeout(Duration::from_secs(0))?;
 
                 // If the time driver was woken, then the park completed

--- a/tokio/src/time/driver/tests/mod.rs
+++ b/tokio/src/time/driver/tests/mod.rs
@@ -46,7 +46,7 @@ fn model(f: impl Fn() + Send + Sync + 'static) {
 #[test]
 fn single_timer() {
     model(|| {
-        let clock = crate::time::clock::Clock::new(true, false);
+        let clock = crate::time::clock::Clock::new(true);
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
@@ -77,7 +77,7 @@ fn single_timer() {
 #[test]
 fn drop_timer() {
     model(|| {
-        let clock = crate::time::clock::Clock::new(true, false);
+        let clock = crate::time::clock::Clock::new(true);
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
@@ -108,7 +108,7 @@ fn drop_timer() {
 #[test]
 fn change_waker() {
     model(|| {
-        let clock = crate::time::clock::Clock::new(true, false);
+        let clock = crate::time::clock::Clock::new(true);
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
@@ -143,7 +143,7 @@ fn reset_future() {
     model(|| {
         let finished_early = Arc::new(AtomicBool::new(false));
 
-        let clock = crate::time::clock::Clock::new(true, false);
+        let clock = crate::time::clock::Clock::new(true);
         let time_source = super::ClockTime::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
@@ -199,7 +199,7 @@ fn normal_or_miri<T>(normal: T, miri: T) -> T {
 #[test]
 #[cfg(not(loom))]
 fn poll_process_levels() {
-    let clock = crate::time::clock::Clock::new(true, false);
+    let clock = crate::time::clock::Clock::new(true);
     clock.pause();
 
     let time_source = super::ClockTime::new(clock.clone());
@@ -240,7 +240,7 @@ fn poll_process_levels() {
 fn poll_process_levels_targeted() {
     let mut context = Context::from_waker(noop_waker_ref());
 
-    let clock = crate::time::clock::Clock::new(true, false);
+    let clock = crate::time::clock::Clock::new(true);
     clock.pause();
 
     let time_source = super::ClockTime::new(clock.clone());

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -86,7 +86,7 @@
 mod clock;
 pub(crate) use self::clock::Clock;
 #[cfg(feature = "test-util")]
-pub use clock::{advance, pause, resume};
+pub use clock::{advance, pause, pause_no_advance, resume};
 
 pub(crate) mod driver;
 


### PR DESCRIPTION
## Motivation

In some cases one might want to stop the clock from auto-advancing to
allow I/O happen before timers expire.

## Solution

 Add an no advance mode to pausing
which can be enabled/disabled to support this mode 

fixes #4522