### PR TITLE
Improve docs for tokio_unstable.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,8 +26,8 @@ task:
 task:
   name: FreeBSD docs
   env:
-    RUSTFLAGS: --cfg docsrs
-    RUSTDOCFLAGS: --cfg docsrs -Dwarnings
+    RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
+    RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,7 +360,7 @@ jobs:
         run: cargo doc --lib --no-deps --all-features --document-private-items
         env:
           RUSTFLAGS: --cfg docsrs
-          RUSTDOCFLAGS: --cfg docsrs -Dwarnings
+          RUSTDOCFLAGS: --cfg docsrs --cfg unstable_tokio -Dwarnings
 
   loom-compile:
     name: build loom tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,8 +359,8 @@ jobs:
       - name: "doc --lib --all-features"
         run: cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTFLAGS: --cfg docsrs
-          RUSTDOCFLAGS: --cfg docsrs --cfg unstable_tokio -Dwarnings
+          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
+          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
 
   loom-compile:
     name: build loom tests

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -339,25 +339,25 @@
 //! _parking_lot_ release in use.
 //!
 //! ### Unstable features
-//! 
+//!
 //! Some feature flags are only available when specifying the `tokio_unstable` flag:
-//! 
+//!
 //! - `tracing`: Enables tracing events.
-//! 
+//!
 //! Likewise, some parts of the API are only available with the same flag:
-//! 
+//!
 //! - [`task::JoinSet`]
 //! - [`task::Builder`]
 //!  
 //! This flag enables **unstable** features. The public API of these features
 //! may break in 1.x releases.
-//! 
+//!
 //! To enable these features, the `--cfg tokio_unstable` must be passed to
 //! `rustc` when compiling. This is easiest done using the `RUSTFLAGS` env
 //! variable: `RUSTFLAGS="--cfg tokio_unstable"`.
-//! 
+//!
 //! You can also specify it in your project's `.cargo/config.toml` file:
-//! 
+//!
 //! ```toml
 //! [build]
 //! rustflags = ["--cfg", "tokio_unstable"]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -339,14 +339,32 @@
 //! _parking_lot_ release in use.
 //!
 //! ### Unstable features
-//!
-//! These feature flags enable **unstable** features. The public API may break in 1.x
-//! releases. To enable these features, the `--cfg tokio_unstable` must be passed to
-//! `rustc` when compiling. This is easiest done using the `RUSTFLAGS` env variable:
-//! `RUSTFLAGS="--cfg tokio_unstable"`.
-//!
+//! 
+//! Some feature flags are only available when specifying the `tokio_unstable` flag:
+//! 
 //! - `tracing`: Enables tracing events.
+//! 
+//! Likewise, some parts of the API are only available with the same flag:
+//! 
+//! - [`task::JoinSet`]
+//!  
+//! This flag enables **unstable** features. The public API of these features
+//! may break in 1.x releases.
+//! 
+//! To enable these features, the `--cfg tokio_unstable` must be passed to
+//! `rustc` when compiling. This is easiest done using the `RUSTFLAGS` env
+//! variable: `RUSTFLAGS="--cfg tokio_unstable"`.
+//! 
+//! You can also specify it in your project's `.cargo/config.toml` file:
+//! 
+//! ```toml
+//! [build]
+//! rustflags = ["--cfg", "tokio_unstable"]
+//! ```
+//! This serves to explicitly opt-in to features which may break semver conventions,
+//! since Cargo [does not yet directly support such opt-ins][unstable features].
 //!
+//! [unstable features]: https://internals.rust-lang.org/t/feature-request-unstable-opt-in-non-transitive-crate-features/16193#why-not-a-crate-feature-2
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 
 // Test that pointer width is compatible. This asserts that e.g. usize is at

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -347,6 +347,7 @@
 //! Likewise, some parts of the API are only available with the same flag:
 //! 
 //! - [`task::JoinSet`]
+//! - [`task::Builder`]
 //!  
 //! This flag enables **unstable** features. The public API of these features
 //! may break in 1.x releases.

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -350,20 +350,31 @@
 //! - [`task::Builder`]
 //!  
 //! This flag enables **unstable** features. The public API of these features
-//! may break in 1.x releases.
+//! may break in 1.x releases. To enable these features, the `--cfg
+//! tokio_unstable` argument must be passed to `rustc` when compiling. This
+//! serves to explicitly opt-in to features which may break semver conventions,
+//! since Cargo [does not yet directly support such opt-ins][unstable features].
 //!
-//! To enable these features, the `--cfg tokio_unstable` must be passed to
-//! `rustc` when compiling. This is easiest done using the `RUSTFLAGS` env
-//! variable: `RUSTFLAGS="--cfg tokio_unstable"`.
-//!
-//! You can also specify it in your project's `.cargo/config.toml` file:
+//! You can specify it in your project's `.cargo/config.toml` file:
 //!
 //! ```toml
 //! [build]
 //! rustflags = ["--cfg", "tokio_unstable"]
 //! ```
-//! This serves to explicitly opt-in to features which may break semver conventions,
-//! since Cargo [does not yet directly support such opt-ins][unstable features].
+//!
+//! Alternatively, you can specify it with an environment variable:
+//!
+//! ```sh
+//! ## Many *nix shells:
+//! export RUSTFLAGS="--cfg tokio_unstable"
+//! cargo build
+//! ```
+//!
+//! ```powershell
+//! ## Windows PowerShell:
+//! $Env:RUSTFLAGS="--cfg tokio_unstable"
+//! cargo build
+//! ```
 //!
 //! [unstable features]: https://internals.rust-lang.org/t/feature-request-unstable-opt-in-non-transitive-crate-features/16193#why-not-a-crate-feature-2
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section


### PR DESCRIPTION
## Motivation

Ran into some headaches getting `tokio_unstable` working, since I'd never had to deal with `--cfg` directly before. I was told "PRs welcome" in the [Tokio Discord][1], so here I am. :) 

[1]: https://discord.com/channels/500028886025895936/500336333500448798/945420414052614204

## Solution

Mostly I added an example `.cargo/config.toml` for others who run into this.

But the existing docs seemed really focused on "these feature flags are enabled by tokio_unstable", but now tioko_unstable also enables JoinSet, so I reworked it a bit to call that out explicitly.

I didn't want to blather on too much in rustdoc about "this is why we can't just use a crate feature", so I just linked to the writeup I posted about it on the Rust internals forum.  Is that weird? 😅 

