### PR TITLE
ci: fix test not working on wasm

### DIFF
--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -213,6 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");
 


### PR DESCRIPTION
This fixes a test failure that broke master.