### PR TITLE
task: add `AbortHandle` type for cancelling tasks in a `JoinSet`

### DIFF
--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -1,0 +1,69 @@
+use crate::runtime::task::RawTask;
+use std::fmt;
+use std::panic::{RefUnwindSafe, UnwindSafe};
+
+/// An owned permission to abort a spawned task, without awaiting its completion.
+///
+/// Unlike a [`JoinHandle`], an `AbortHandle` does *not* represent the
+/// permission to await the task's completion, only to terminate it.
+///
+/// The task may be aborted by calling the [`AbortHandle::abort`] method.
+/// Dropping an `AbortHandle` releases the permission to terminate the task
+/// --- it does *not* abort the task.
+///
+/// **Note**: This is an [unstable API][unstable]. The public API of this type
+/// may break in 1.x releases. See [the documentation on unstable
+/// features][unstable] for details.
+///
+/// [unstable]: crate#unstable-features
+/// [`JoinHandle`]: crate::task::JoinHandle
+#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+pub struct AbortHandle {
+    raw: Option<RawTask>,
+}
+
+impl AbortHandle {
+    pub(super) fn new(raw: Option<RawTask>) -> Self {
+        Self { raw }
+    }
+
+    /// Abort the task associated with the handle.
+    ///
+    /// Awaiting a cancelled task might complete as usual if the task was
+    /// already completed at the time it was cancelled, but most likely it
+    /// will fail with a [cancelled] `JoinError`.
+    ///
+    /// If the task was already cancelled, such as by [`JoinHandle::abort`],
+    /// this method will do nothing.
+    ///
+    /// [cancelled]: method@super::error::JoinError::is_cancelled
+    // the `AbortHandle` type is only publicly exposed when `tokio_unstable` is
+    // enabled, but it is still defined for testing purposes.
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    pub fn abort(self) {
+        if let Some(raw) = self.raw {
+            raw.remote_abort();
+        }
+    }
+}
+
+unsafe impl Send for AbortHandle {}
+unsafe impl Sync for AbortHandle {}
+
+impl UnwindSafe for AbortHandle {}
+impl RefUnwindSafe for AbortHandle {}
+
+impl fmt::Debug for AbortHandle {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("AbortHandle").finish()
+    }
+}
+
+impl Drop for AbortHandle {
+    fn drop(&mut self) {
+        if let Some(raw) = self.raw.take() {
+            raw.drop_abort_handle();
+        }
+    }
+}

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -291,7 +291,7 @@ where
 // === impl AbortHandle ===
 
 impl AbortHandle {
-    pub(crate) fn abort(&self) {
+    pub(crate) fn abort(self) {
         if let Some(raw) = self.raw {
             raw.remote_abort();
         }

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -161,9 +161,7 @@ cfg_rt! {
     /// features][unstable] for details.
     ///
     /// [unstable]: crate#unstable-features
-    // this type is only publicly exposed when `tokio_unstable` is enabled, but
-    // it is still defined for testing purposes.
-    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    #[cfg(any(tokio_unstable, test))]
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub struct AbortHandle {
         raw: Option<RawTask>,

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -164,6 +164,7 @@ cfg_rt! {
     // this type is only publicly exposed when `tokio_unstable` is enabled, but
     // it is still defined for testing purposes.
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub struct AbortHandle {
         raw: Option<RawTask>,
     }

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -146,27 +146,6 @@ cfg_rt! {
         raw: Option<RawTask>,
         _p: PhantomData<T>,
     }
-
-    /// An owned permission to abort a spawned task, without awaiting its completion.
-    ///
-    /// Unlike a [`JoinHandle`], an `AbortHandle` does *not* represent the
-    /// permission to await the task's completion, only to terminate it.
-    ///
-    /// The task may be aborted by calling the [`AbortHandle::abort`] method.
-    /// Dropping an `AbortHandle` releases the permission to terminate the task
-    /// --- it does *not* abort the task.
-    ///
-    /// **Note**: This is an [unstable API][unstable]. The public API of this type
-    /// may break in 1.x releases. See [the documentation on unstable
-    /// features][unstable] for details.
-    ///
-    /// [unstable]: crate#unstable-features
-    #[cfg(any(tokio_unstable, test))]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
-    pub struct AbortHandle {
-        raw: Option<RawTask>,
-    }
-
 }
 
 unsafe impl<T: Send> Send for JoinHandle<T> {}
@@ -233,12 +212,13 @@ impl<T> JoinHandle<T> {
     }
 
     /// Returns a new `AbortHandle` that can be used to remotely abort this task.
-    pub(crate) fn abort_handle(&self) -> AbortHandle {
+    #[cfg(any(tokio_unstable, test))]
+    pub(crate) fn abort_handle(&self) -> super::AbortHandle {
         let raw = self.raw.map(|raw| {
             raw.ref_inc();
             raw
         });
-        AbortHandle { raw }
+        super::AbortHandle::new(raw)
     }
 }
 
@@ -301,46 +281,5 @@ where
 {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("JoinHandle").finish()
-    }
-}
-
-impl AbortHandle {
-    /// Abort the task associated with the handle.
-    ///
-    /// Awaiting a cancelled task might complete as usual if the task was
-    /// already completed at the time it was cancelled, but most likely it
-    /// will fail with a [cancelled] `JoinError`.
-    ///
-    /// If the task was already cancelled, such as by [`JoinHandle::abort`],
-    /// this method will do nothing.
-    ///
-    /// [cancelled]: method@super::error::JoinError::is_cancelled
-    // the `AbortHandle` type is only publicly exposed when `tokio_unstable` is
-    // enabled, but it is still defined for testing purposes.
-    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
-    pub fn abort(self) {
-        if let Some(raw) = self.raw {
-            raw.remote_abort();
-        }
-    }
-}
-
-unsafe impl Send for AbortHandle {}
-unsafe impl Sync for AbortHandle {}
-
-impl UnwindSafe for AbortHandle {}
-impl RefUnwindSafe for AbortHandle {}
-
-impl fmt::Debug for AbortHandle {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("AbortHandle").finish()
-    }
-}
-
-impl Drop for AbortHandle {
-    fn drop(&mut self) {
-        if let Some(raw) = self.raw.take() {
-            raw.drop_abort_handle();
-        }
     }
 }

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -147,10 +147,27 @@ cfg_rt! {
         _p: PhantomData<T>,
     }
 
-    /// An owned permission to abort a spawned task, _without_ awaiting its completion.
-    pub(crate) struct AbortHandle {
+    /// An owned permission to abort a spawned task, without awaiting its completion.
+    ///
+    /// Unlike a [`JoinHandle`], an `AbortHandle` does *not* represent the
+    /// permission to await the task's completion, only to terminate it.
+    ///
+    /// The task may be aborted by calling the [`AbortHandle::abort`] method.
+    /// Dropping an `AbortHandle` releases the permission to terminate the task
+    /// --- it does *not* abort the task.
+    ///
+    /// **Note**: This is an [unstable API][unstable]. The public API of this type
+    /// may break in 1.x releases. See [the documentation on unstable
+    /// features][unstable] for details.
+    ///
+    /// [unstable]: crate#unstable-features
+    // this type is only publicly exposed when `tokio_unstable` is enabled, but
+    // it is still defined for testing purposes.
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    pub struct AbortHandle {
         raw: Option<RawTask>,
     }
+
 }
 
 unsafe impl<T: Send> Send for JoinHandle<T> {}
@@ -288,15 +305,32 @@ where
     }
 }
 
-// === impl AbortHandle ===
-
 impl AbortHandle {
-    pub(crate) fn abort(self) {
+    /// Abort the task associated with the handle.
+    ///
+    /// Awaiting a cancelled task might complete as usual if the task was
+    /// already completed at the time it was cancelled, but most likely it
+    /// will fail with a [cancelled] `JoinError`.
+    ///
+    /// If the task was already cancelled, such as by [`JoinHandle::abort`],
+    /// this method will do nothing.
+    ///
+    /// [cancelled]: method@super::error::JoinError::is_cancelled
+    // the `AbortHandle` type is only publicly exposed when `tokio_unstable` is
+    // enabled, but it is still defined for testing purposes.
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    pub fn abort(self) {
         if let Some(raw) = self.raw {
             raw.remote_abort();
         }
     }
 }
+
+unsafe impl Send for AbortHandle {}
+unsafe impl Sync for AbortHandle {}
+
+impl UnwindSafe for AbortHandle {}
+impl RefUnwindSafe for AbortHandle {}
 
 impl fmt::Debug for AbortHandle {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -156,6 +156,8 @@ cfg_rt_multi_thread! {
 }
 
 mod join;
+#[allow(unused_imports)] // this will be used later
+pub(crate) use self::join::AbortHandle;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::join::JoinHandle;
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -156,8 +156,14 @@ cfg_rt_multi_thread! {
 }
 
 mod join;
-#[allow(unused_imports)] // this will be used later
+
+cfg_unstable! {
+    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+    pub use self::join::AbortHandle;
+}
+#[cfg(all(not(tokio_unstable), test))]
 pub(crate) use self::join::AbortHandle;
+
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::join::JoinHandle;
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -155,15 +155,13 @@ cfg_rt_multi_thread! {
     pub(super) use self::inject::Inject;
 }
 
+#[cfg(all(feature = "rt", any(tokio_unstable, test)))]
+mod abort;
 mod join;
 
-cfg_unstable! {
-    #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-    pub use self::join::AbortHandle;
-}
-#[cfg(all(not(tokio_unstable), test))]
-#[allow(unused_imports)]
-pub(crate) use self::join::AbortHandle;
+#[cfg(all(feature = "rt", any(tokio_unstable, test)))]
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+pub use self::abort::AbortHandle;
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 pub use self::join::JoinHandle;

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -162,6 +162,7 @@ cfg_unstable! {
     pub use self::join::AbortHandle;
 }
 #[cfg(all(not(tokio_unstable), test))]
+#[allow(unused_imports)]
 pub(crate) use self::join::AbortHandle;
 
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -78,7 +78,6 @@ fn create_drop2() {
     handle.assert_dropped();
 }
 
-
 #[test]
 fn drop_abort_handle1() {
     let (ad, handle) = AssertDrop::new();

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -78,6 +78,45 @@ fn create_drop2() {
     handle.assert_dropped();
 }
 
+
+#[test]
+fn drop_abort_handle1() {
+    let (ad, handle) = AssertDrop::new();
+    let (notified, join) = unowned(
+        async {
+            drop(ad);
+            unreachable!()
+        },
+        NoopSchedule,
+    );
+    let abort = join.abort_handle();
+    drop(join);
+    handle.assert_not_dropped();
+    drop(notified);
+    handle.assert_not_dropped();
+    drop(abort);
+    handle.assert_dropped();
+}
+
+#[test]
+fn drop_abort_handle2() {
+    let (ad, handle) = AssertDrop::new();
+    let (notified, join) = unowned(
+        async {
+            drop(ad);
+            unreachable!()
+        },
+        NoopSchedule,
+    );
+    let abort = join.abort_handle();
+    drop(notified);
+    handle.assert_not_dropped();
+    drop(abort);
+    handle.assert_not_dropped();
+    drop(join);
+    handle.assert_dropped();
+}
+
 // Shutting down through Notified works
 #[test]
 fn create_shutdown1() {

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::runtime::Handle;
-use crate::task::{JoinError, JoinHandle, LocalSet};
+use crate::task::{JoinError, JoinHandle, LocalSet, AbortHandle};
 use crate::util::IdleNotifiedSet;
 
 /// A collection of tasks spawned on a Tokio runtime.
@@ -73,61 +73,76 @@ impl<T> JoinSet<T> {
 }
 
 impl<T: 'static> JoinSet<T> {
-    /// Spawn the provided task on the `JoinSet`.
+    /// Spawn the provided task on the `JoinSet`, returning an [`AbortHandle`]
+    /// that can be used to remotely cancel the task.
     ///
     /// # Panics
     ///
     /// This method panics if called outside of a Tokio runtime.
-    pub fn spawn<F>(&mut self, task: F)
+    ///
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    pub fn spawn<F>(&mut self, task: F) -> AbortHandle
     where
         F: Future<Output = T>,
         F: Send + 'static,
         T: Send,
     {
-        self.insert(crate::spawn(task));
+        self.insert(crate::spawn(task))
     }
 
-    /// Spawn the provided task on the provided runtime and store it in this `JoinSet`.
-    pub fn spawn_on<F>(&mut self, task: F, handle: &Handle)
+    /// Spawn the provided task on the provided runtime and store it in this
+    /// `JoinSet` returning an [`AbortHandle`] that can be used to remotely
+    /// cancel the task.
+    ///
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    pub fn spawn_on<F>(&mut self, task: F, handle: &Handle) -> AbortHandle
     where
         F: Future<Output = T>,
         F: Send + 'static,
         T: Send,
     {
-        self.insert(handle.spawn(task));
+        self.insert(handle.spawn(task))
     }
 
-    /// Spawn the provided task on the current [`LocalSet`] and store it in this `JoinSet`.
+    /// Spawn the provided task on the current [`LocalSet`] and store it in this
+    /// `JoinSet`, returning an [`AbortHandle`]  that can be used to remotely
+    /// cancel the task.
     ///
     /// # Panics
     ///
     /// This method panics if it is called outside of a `LocalSet`.
     ///
     /// [`LocalSet`]: crate::task::LocalSet
-    pub fn spawn_local<F>(&mut self, task: F)
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    pub fn spawn_local<F>(&mut self, task: F) -> AbortHandle
     where
         F: Future<Output = T>,
         F: 'static,
     {
-        self.insert(crate::task::spawn_local(task));
+        self.insert(crate::task::spawn_local(task))
     }
 
-    /// Spawn the provided task on the provided [`LocalSet`] and store it in this `JoinSet`.
+    /// Spawn the provided task on the provided [`LocalSet`] and store it in
+    /// this `JoinSet`, returning an [`AbortHandle`] that can be used to
+    /// remotely cancel the task.
     ///
     /// [`LocalSet`]: crate::task::LocalSet
-    pub fn spawn_local_on<F>(&mut self, task: F, local_set: &LocalSet)
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    pub fn spawn_local_on<F>(&mut self, task: F, local_set: &LocalSet) -> AbortHandle
     where
         F: Future<Output = T>,
         F: 'static,
     {
-        self.insert(local_set.spawn_local(task));
+        self.insert(local_set.spawn_local(task))
     }
 
-    fn insert(&mut self, jh: JoinHandle<T>) {
+    fn insert(&mut self, jh: JoinHandle<T>) -> AbortHandle {
+        let abort = jh.abort_handle();
         let mut entry = self.inner.insert_idle(jh);
 
         // Set the waker that is notified when the task completes.
         entry.with_value_and_context(|jh, ctx| jh.set_join_waker(ctx.waker()));
+        abort
     }
 
     /// Waits until one of the tasks in the set completes and returns its output.

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -4,7 +4,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use crate::runtime::Handle;
-use crate::task::{JoinError, JoinHandle, LocalSet, AbortHandle};
+use crate::task::{AbortHandle, JoinError, JoinHandle, LocalSet};
 use crate::util::IdleNotifiedSet;
 
 /// A collection of tasks spawned on a Tokio runtime.

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -303,6 +303,7 @@ cfg_rt! {
     cfg_unstable! {
         mod join_set;
         pub use join_set::JoinSet;
+        pub use crate::runtime::task::AbortHandle;
     }
 
     cfg_trace! {


### PR DESCRIPTION

## Motivation

Before we stabilize the `JoinSet` API, we intend to add a method for
individual tasks in the `JoinSet` to be aborted. Because the
`JoinHandle`s for the tasks spawned on a `JoinSet` are owned by the
`JoinSet`, the user can no longer use them to abort tasks on the
`JoinSet`. Therefore, we need another way to cause a remote abort of a
task on a `JoinSet` without holding its `JoinHandle`.

## Solution

This branch adds a new `AbortHandle` type in `tokio::task`, which
represents the owned permission to remotely cancel a task, but _not_ to
await its output. The `AbortHandle` type holds an additional reference
to the task cell.

A crate-private method is added to `JoinHandle` that returns an
`AbortHandle` for the same task, incrementing its ref count.
`AbortHandle` provides a single method, `AbortHandle::abort(self)`, that
remotely cancels the task. Dropping an `AbortHandle` decrements the
task's ref count but does not cancel it. The `AbortHandle` type is
currently marked as unstable.

The spawning methods on `JoinSet` are modified to return an
`AbortHandle` that can be used to cancel the spawned task.

## Future Work

- Currently, the `AbortHandle` type is _only_ available in the public
API through a `JoinSet`. We could also make the
`JoinHandle::abort_handle` method public, to allow users to use the
`AbortHandle` type in other contexts. I didn't do that in this PR,
because I wanted to make the API addition as minimal as possible, but we
could make this method public later.

- Currently, `AbortHandle` is not `Clone`. We could easily make it
`Clone` by incrementing the task's ref count. Since this adds more trait
impls to the API, we may want to be cautious about this, but I see no
obvious reason we would need to remove a `Clone` implementation if one
was added...

- There's been some discussion of adding a `JoinMap` type that allows
aborting tasks by key, and manages a hash map of keys to `AbortHandle`s,
and removes the tasks from the map when they complete. This would make
aborting by key much easier, since the user wouldn't have to worry about
keeping the state of the map of abort handles and the tasks actually
active on the `JoinSet` in sync. After thinking about it a bit, I
thought this is probably best as a `tokio-util` API --- it can currently
be implemented in `tokio-util` with the APIs added in `tokio` in this
PR.

- I noticed while working on this that `JoinSet::join_one` and
`JoinSet::poll_join_one` return a cancelled `JoinError` when a task is
cancelled. I'm not sure if I love this behavior --- it seems like it
would be nicer to just skip cancelled tasks and continue polling. But,
there are currently tests that expect a cancelled `JoinError` to be
returned for each cancelled task, so I didn't want to change it in
_this_ PR. I think this is worth revisiting before stabilizing the API,
though?

