### PR TITLE
task: fix missing doc(cfg(...)) attributes for `JoinSet`

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -48,6 +48,7 @@ use crate::util::IdleNotifiedSet;
 /// ```
 ///
 /// [unstable]: crate#unstable-features
+#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 pub struct JoinSet<T> {
     inner: IdleNotifiedSet<JoinHandle<T>>,
 }


### PR DESCRIPTION
## Motivation

The `JoinSet` type is currently missing the `tokio_unstable` and
`feature = "rt"` `doc(cfg(...))` attributes, making it erroneously
appear to be available without the required feature and without unstable
features enabled. This is incorrect.

I believe this is because `doc(cfg(...))` on a re-export doesn't
actually add the required cfgs to the type itself, and the
`cfg_unstable!` is currently only guarding a re-export and module.

## Solution

This PR fixes the missing attributes.

Before:

![image](https://user-images.githubusercontent.com/2796466/155403491-10be1a17-8709-4323-8ea3-cbc1046f6000.png)

After:

![image](https://user-images.githubusercontent.com/2796466/155403583-2c47262a-c1dc-47dc-99e2-c82cd39e3663.png)
