### PR TITLE
macros: update `trybuild` output for Rust 1.59.0 

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -70,10 +70,10 @@ error: second test attribute is supplied
 37 | #[test]
    | ^^^^^^^
 
-warning: duplicated attribute
+error: duplicated attribute
   --> $DIR/macros_invalid_input.rs:37:1
    |
 37 | #[test]
    | ^^^^^^^
    |
-   = note: `#[warn(duplicate_macro_attributes)]` on by default
+   = note: `-D duplicate-macro-attributes` implied by `-D warnings`

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -69,3 +69,11 @@ error: second test attribute is supplied
    |
 37 | #[test]
    | ^^^^^^^
+
+warning: duplicated attribute
+  --> $DIR/macros_invalid_input.rs:37:1
+   |
+37 | #[test]
+   | ^^^^^^^
+   |
+   = note: `#[warn(duplicate_macro_attributes)]` on by default

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,25 +1,21 @@
 error[E0308]: mismatched types
- --> tests/fail/macros_type_mismatch.rs:5:5
+ --> $DIR/macros_type_mismatch.rs:5:5
   |
+4 | async fn missing_semicolon_or_return_type() {
+  |                                             - possibly return type missing here?
 5 |     Ok(())
-  |     ^^^^^^ expected `()`, found enum `Result`
+  |     ^^^^^^- help: consider using a semicolon here: `;`
+  |     |
+  |     expected `()`, found enum `Result`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
-help: consider using a semicolon here
-  |
-5 |     Ok(());
-  |           +
-help: try adding a return type
-  |
-4 | async fn missing_semicolon_or_return_type() -> Result<(), _> {
-  |                                             ++++++++++++++++
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:10:5
+  --> $DIR/macros_type_mismatch.rs:10:5
    |
 9  | async fn missing_return_type() {
-   |                                - help: try adding a return type: `-> Result<(), _>`
+   |                                - possibly return type missing here?
 10 |     return Ok(());
    |     ^^^^^^^^^^^^^^ expected `()`, found enum `Result`
    |
@@ -27,7 +23,7 @@ error[E0308]: mismatched types
                    found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:23:5
+  --> $DIR/macros_type_mismatch.rs:23:5
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
    |                               -------------- expected `Result<(), ()>` because of return type


### PR DESCRIPTION
## Motivation

Rust error messages seem to have changed a bit in 1.59.0

## Solution

Update the `trybuild` stderr output.

This should unbreak the tests on the latest Rust (and fix CI).