### PR TITLE
tokio: Add initial time driver metrics

### DIFF
--- a/tokio/src/runtime/metrics/mod.rs
+++ b/tokio/src/runtime/metrics/mod.rs
@@ -26,6 +26,11 @@ cfg_metrics! {
         mod io;
         pub(crate) use io::IoDriverMetrics;
     }
+
+    cfg_time! {
+        mod time;
+        pub(crate) use time::TimerDriverMetrics;
+    }
 }
 
 cfg_not_metrics! {

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -534,3 +534,27 @@ cfg_net! {
         }
     }
 }
+
+cfg_time! {
+    impl RuntimeMetrics {
+        /// Returns the number of timer entries currently tracked by the
+        /// runtime's timer driver.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Handle;
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///     let metrics = Handle::current().metrics();
+        ///
+        ///     let n = metrics.time_driver_entry_count();
+        ///     println!("{} timer entries currently tracked by the runtime's time driver.", n);
+        /// }
+        /// ```
+        pub fn time_driver_entry_count(&self) -> u64 {
+            self.handle.time_handle.as_ref().map(|h| h.metrics().entry_count.load(Relaxed)).unwrap_or(0)
+        }
+    }
+}

--- a/tokio/src/runtime/metrics/time.rs
+++ b/tokio/src/runtime/metrics/time.rs
@@ -1,0 +1,20 @@
+use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
+
+#[derive(Default)]
+pub(crate) struct TimerDriverMetrics {
+    pub(super) entry_count: AtomicU64,
+}
+
+impl TimerDriverMetrics {
+    pub(crate) fn incr_entry_count(&self) {
+        let prev = self.entry_count.load(Relaxed);
+        let new = prev.wrapping_add(1);
+        self.entry_count.store(new, Relaxed);
+    }
+
+    pub(crate) fn dec_entry_count(&self) {
+        let prev = self.entry_count.load(Relaxed);
+        let new = prev.wrapping_sub(1);
+        self.entry_count.store(new, Relaxed);
+    }
+}

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -191,6 +191,10 @@ cfg_metrics! {
     cfg_net! {
        pub(crate) use metrics::IoDriverMetrics;
     }
+
+    cfg_time! {
+        pub(crate) use metrics::TimerDriverMetrics;
+    }
 }
 
 cfg_not_metrics! {

--- a/tokio/src/time/driver/handle.rs
+++ b/tokio/src/time/driver/handle.rs
@@ -1,5 +1,5 @@
 use crate::loom::sync::Arc;
-use crate::time::driver::ClockTime;
+use crate::time::driver::{ClockTime, TimerDriverMetrics};
 use std::fmt;
 
 /// Handle to time driver instance.
@@ -29,6 +29,10 @@ impl Handle {
     /// Checks whether the driver has been shutdown.
     pub(super) fn is_shutdown(&self) -> bool {
         self.inner.is_shutdown()
+    }
+
+    pub(crate) fn metrics(&self) -> &TimerDriverMetrics {
+        &self.inner.metrics
     }
 }
 

--- a/tokio/src/time/driver/metrics.rs
+++ b/tokio/src/time/driver/metrics.rs
@@ -1,0 +1,15 @@
+cfg_not_rt_and_metrics! {
+    #[derive(Default)]
+    pub(crate) struct TimerDriverMetrics {}
+
+    impl TimerDriverMetrics {
+        pub(crate) fn incr_entry_count(&self) {}
+        pub(crate) fn dec_entry_count(&self) {}
+    }
+}
+
+cfg_rt! {
+    cfg_metrics! {
+        pub(crate) use crate::runtime::TimerDriverMetrics;
+    }
+}

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -403,6 +403,29 @@ fn io_driver_ready_count() {
     assert_eq!(metrics.io_driver_ready_count(), 2);
 }
 
+#[test]
+fn time_driver_entry_count() {
+    use tokio::time::sleep;
+    use tokio_test::task;
+
+    let rt = basic();
+    let metrics = rt.metrics();
+
+    let _guard = rt.handle().enter();
+
+    assert_eq!(metrics.time_driver_entry_count(), 0);
+
+    let mut fut = task::spawn(sleep(Duration::from_secs(1_000)));
+
+    assert!(fut.poll().is_pending());
+
+    assert_eq!(metrics.time_driver_entry_count(), 1);
+
+    drop(fut);
+
+    assert_eq!(metrics.time_driver_entry_count(), 0);
+}
+
 fn basic() -> Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()


### PR DESCRIPTION
This adds the initial time driver metrics.

Ref: https://github.com/tokio-rs/tokio/issues/4073