### PR TITLE
feat: Add SignalKind Hash/Eq impls and c_int conversion

### DIFF
--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -89,9 +89,9 @@ impl SignalKind {
     /// ```rust,no_run
     /// # use tokio::signal::unix::SignalKind;
     /// let kind = SignalKind::interrupt();
-    /// assert_eq!(kind.value(), libc::SIGINT);
+    /// assert_eq!(kind.as_raw_value(), libc::SIGINT);
     /// ```
-    pub fn value(&self) -> std::os::raw::c_int {
+    pub fn as_raw_value(&self) -> std::os::raw::c_int {
         self.0
     }
 
@@ -209,7 +209,7 @@ impl From<std::os::raw::c_int> for SignalKind {
 
 impl From<SignalKind> for std::os::raw::c_int {
     fn from(kind: SignalKind) -> Self {
-        kind.value()
+        kind.as_raw_value()
     }
 }
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -86,7 +86,7 @@ impl SignalKind {
 
     /// Get the signal's numeric value.
     ///
-    /// ```rust,no_run
+    /// ```rust
     /// # use tokio::signal::unix::SignalKind;
     /// let kind = SignalKind::interrupt();
     /// assert_eq!(kind.as_raw_value(), libc::SIGINT);

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -209,7 +209,7 @@ impl From<std::os::raw::c_int> for SignalKind {
 
 impl From<SignalKind> for std::os::raw::c_int {
     fn from(kind: SignalKind) -> Self {
-        kind.0
+        kind.value()
     }
 }
 
@@ -496,5 +496,16 @@ mod tests {
             &Handle::default(),
         )
         .unwrap_err();
+    }
+
+    #[test]
+    fn from_c_int() {
+        assert_eq!(SignalKind::from(2), SignalKind::interrupt());
+    }
+
+    #[test]
+    fn into_c_int() {
+        let value: std::os::raw::c_int = SignalKind::interrupt().into();
+        assert_eq!(value, libc::SIGINT as _);
     }
 }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -60,7 +60,7 @@ impl Init for OsExtraData {
 }
 
 /// Represents the specific kind of signal to listen for.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct SignalKind(libc::c_int);
 
 impl SignalKind {
@@ -82,6 +82,17 @@ impl SignalKind {
     // See https://github.com/tokio-rs/tokio/issues/3767 for more.
     pub fn from_raw(signum: std::os::raw::c_int) -> Self {
         Self(signum as libc::c_int)
+    }
+
+    /// Get the signal's numeric value.
+    ///
+    /// ```rust,no_run
+    /// # use tokio::signal::unix::SignalKind;
+    /// let kind = SignalKind::interrupt();
+    /// assert_eq!(kind.value(), libc::SIGINT);
+    /// ```
+    pub fn value(&self) -> std::os::raw::c_int {
+        self.0
     }
 
     /// Represents the SIGALRM signal.
@@ -187,6 +198,18 @@ impl SignalKind {
     /// By default, this signal is ignored.
     pub fn window_change() -> Self {
         Self(libc::SIGWINCH)
+    }
+}
+
+impl From<std::os::raw::c_int> for SignalKind {
+    fn from(signum: std::os::raw::c_int) -> Self {
+        Self::from_raw(signum as libc::c_int)
+    }
+}
+
+impl From<SignalKind> for std::os::raw::c_int {
+    fn from(kind: SignalKind) -> Self {
+        kind.0
     }
 }
 


### PR DESCRIPTION
## Motivation

The type `tokio::signal::unix::SignalKind` corresponds to a `libc::c_int`. The newtype is missing some useful functionality:
* No `Hash`/`Eq` impls, so they can't be compared or used as map keys
* No ability to convert a `SignalKind` back into a `c_int`, which can be useful for interop

## Solution
* Add derived impls of `Hash`, `PartialEq`, and `Eq` to `SignalKind`
* Add `as_raw_value()` method and `From`/`Into`
* Add conversion tests
