### PR TITLE
Improve basic_scheduler block_on loop

### DIFF
--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -184,6 +184,7 @@ impl BasicScheduler {
 
                         Pending
                     }))
+                    .expect("Failed to `Enter::block_on`")
                 {
                     return out;
                 }

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -174,17 +174,16 @@ impl BasicScheduler {
 
                 if let Some(out) = enter
                     .block_on(poll_fn(|cx| {
+                        if let Ready(out) = future.as_mut().poll(cx) {
+                            return Ready(Some(out));
+                        }
+                        
                         if notified.as_mut().poll(cx).is_ready() {
                             return Ready(None);
                         }
 
-                        if let Ready(out) = future.as_mut().poll(cx) {
-                            return Ready(Some(out));
-                        }
-
                         Pending
                     }))
-                    .expect("Failed to `Enter::block_on`")
                 {
                     return out;
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Firstly, if result is available from the thread-local block_on, we should return `Ready(out)`, not assign it to Core even if it is available. That's a performance optimization
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Improve
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
