### PR TITLE
Rename `tokio::select!`'s internal `util` module to `__tokio_select_util`

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -429,7 +429,8 @@ macro_rules! select {
         //
         // This module is defined within a scope and should not leak out of this
         // macro.
-        mod util {
+        #[doc(hidden)]
+        mod __tokio_select_util {
             // Generate an enum with one variant per select branch
             $crate::select_priv_declare_output_enum!( ( $($count)* ) );
         }
@@ -442,13 +443,13 @@ macro_rules! select {
 
         const BRANCHES: u32 = $crate::count!( $($count)* );
 
-        let mut disabled: util::Mask = Default::default();
+        let mut disabled: __tokio_select_util::Mask = Default::default();
 
         // First, invoke all the pre-conditions. For any that return true,
         // set the appropriate bit in `disabled`.
         $(
             if !$c {
-                let mask: util::Mask = 1 << $crate::count!( $($skip)* );
+                let mask: __tokio_select_util::Mask = 1 << $crate::count!( $($skip)* );
                 disabled |= mask;
             }
         )*
@@ -525,7 +526,7 @@ macro_rules! select {
                                 }
 
                                 // The select is complete, return the value
-                                return Ready($crate::select_variant!(util::Out, ($($skip)*))(out));
+                                return Ready($crate::select_variant!(__tokio_select_util::Out, ($($skip)*))(out));
                             }
                         )*
                         _ => unreachable!("reaching this means there probably is an off by one bug"),
@@ -536,16 +537,16 @@ macro_rules! select {
                     Pending
                 } else {
                     // All branches have been disabled.
-                    Ready(util::Out::Disabled)
+                    Ready(__tokio_select_util::Out::Disabled)
                 }
             }).await
         };
 
         match output {
             $(
-                $crate::select_variant!(util::Out, ($($skip)*) ($bind)) => $handle,
+                $crate::select_variant!(__tokio_select_util::Out, ($($skip)*) ($bind)) => $handle,
             )*
-            util::Out::Disabled => $else,
+            __tokio_select_util::Out::Disabled => $else,
             _ => unreachable!("failed to match bind"),
         }
     }};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This internal module's identifier can clash with existing identifiers in library users' code and produce confusing error messages.

```rust
mod util {
    pub fn hello_world() {
        println!("Hello, world!");
    }
}

#[tokio::main]
async fn main() {
    let f1 = async {};
    let f2 = async {};

    tokio::select! {
        _ = f1 => {
            // The following line would fix the compile error, showing that Tokio is creating an internal identifier called `util` which is clashing
            // use crate::util;

            util::hello_world();
        },

        _ = f2 => {}
    }
}
```

```rust
error[[E0425]](https://doc.rust-lang.org/stable/error-index.html#E0425): cannot find function `hello_world` in module `util`
  --> src/main.rs:14:19
   |
14 |             util::hello_world();
   |                   ^^^^^^^^^^^ not found in `util`
   |
help: consider importing this function
   |
1  | [use crate::util::hello_world;](https://play.rust-lang.org/#)
   |

For more information about this error, try `rustc --explain E0425`.
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I have renamed the `util` module in `tokio::select!` to `__tokio_util` to prevent any identifier clashes.

Additionally, I also added `#[doc(hidden)]` to the module.