### PR TITLE
Unbounded receiver docs

### DIFF
--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -79,8 +79,14 @@ impl<T> UnboundedReceiver<T> {
 
     /// Receives the next value for this receiver.
     ///
-    /// `None` is returned when all `Sender` halves have dropped, indicating
-    /// that no further values can be sent on the channel.
+    /// This method returns `None` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer. This indicates that no
+    /// further values can ever be received from this `Receiver`. The channel is
+    /// closed when all senders have been dropped, or when [`close`] is called.
+    /// 
+    /// If there are no messages in the channel's buffer, but the channel has
+    /// not yet been closed, this method will sleep until a message is sent or
+    /// the channel is closed.
     ///
     /// # Cancel safety
     ///
@@ -207,6 +213,10 @@ impl<T> UnboundedReceiver<T> {
     ///
     /// This prevents any further messages from being sent on the channel while
     /// still enabling the receiver to drain messages that are buffered.
+    /// 
+    /// Since no more messages can be sent, the receiver will return `None` when
+    /// polled after the remaining messages have been drained, regardless of
+    /// whether or not all the senders have been dropped.
     pub fn close(&mut self) {
         self.chan.close();
     }

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -83,7 +83,7 @@ impl<T> UnboundedReceiver<T> {
     /// no remaining messages in the channel's buffer. This indicates that no
     /// further values can ever be received from this `Receiver`. The channel is
     /// closed when all senders have been dropped, or when [`close`] is called.
-    /// 
+    ///
     /// If there are no messages in the channel's buffer, but the channel has
     /// not yet been closed, this method will sleep until a message is sent or
     /// the channel is closed.
@@ -94,6 +94,8 @@ impl<T> UnboundedReceiver<T> {
     /// [`tokio::select!`](crate::select) statement and some other branch
     /// completes first, it is guaranteed that no messages were received on this
     /// channel.
+    ///
+    /// [`close`]: Self::close
     ///
     /// # Examples
     ///
@@ -213,7 +215,7 @@ impl<T> UnboundedReceiver<T> {
     ///
     /// This prevents any further messages from being sent on the channel while
     /// still enabling the receiver to drain messages that are buffered.
-    /// 
+    ///
     /// To guarantee that no messages are dropped, after calling `close()`,
     /// `recv()` must be called until `None` is returned.
     pub fn close(&mut self) {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -214,9 +214,8 @@ impl<T> UnboundedReceiver<T> {
     /// This prevents any further messages from being sent on the channel while
     /// still enabling the receiver to drain messages that are buffered.
     /// 
-    /// Since no more messages can be sent, the receiver will return `None` when
-    /// polled after the remaining messages have been drained, regardless of
-    /// whether or not all the senders have been dropped.
+    /// To guarantee that no messages are dropped, after calling `close()`,
+    /// `recv()` must be called until `None` is returned.
     pub fn close(&mut self) {
         self.chan.close();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

cc @Firstyear

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
The documentation for `tokio::sync::mpsc::UnboundedReceiver` is inconsistent with the bounded `Receiver` counterpart, lacking critical details including how calling `UnboundedReceiver::recv` returns `None` after `close` is called, even if there are remaining senders.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Copy and paste the relevant parts from the bounded `Receiver` documentation into `UnboundedReceiver`.
