### PR TITLE
tokio: add support for signals up to SIGRTMAX

### DIFF
--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -237,7 +237,7 @@ mod tests {
     #[test]
     fn record_invalid_event_does_nothing() {
         let registry = Registry::new(vec![EventInfo::default()]);
-        registry.record_event(42);
+        registry.record_event(1302);
     }
 
     #[test]

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -32,9 +32,7 @@ impl Init for OsStorage {
         #[cfg(target_os = "linux")]
         let possible = 0..=libc::SIGRTMAX();
 
-        possible
-            .map(|_| SignalInfo::default())
-            .collect()
+        possible.map(|_| SignalInfo::default()).collect()
     }
 }
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -24,7 +24,15 @@ pub(crate) type OsStorage = Vec<SignalInfo>;
 
 impl Init for OsStorage {
     fn init() -> Self {
-        (0..libc::SIGRTMAX())
+        // There are at least 33 reliable signals available on every Unix platform.
+        #[cfg(not(target_os = "linux"))]
+        let possible = 0..33;
+
+        // On Linux, there are additional real-time signals available.
+        #[cfg(target_os = "linux")]
+        let possible = 0..libc::SIGRTMAX();
+
+        possible
             .map(|_| SignalInfo::default())
             .collect()
     }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -24,13 +24,13 @@ pub(crate) type OsStorage = Vec<SignalInfo>;
 
 impl Init for OsStorage {
     fn init() -> Self {
-        // There are at least 33 reliable signals available on every Unix platform.
+        // There are reliable signals ranging from 1 to 33 available on every Unix platform.
         #[cfg(not(target_os = "linux"))]
-        let possible = 0..33;
+        let possible = 0..=33;
 
         // On Linux, there are additional real-time signals available.
         #[cfg(target_os = "linux")]
-        let possible = 0..libc::SIGRTMAX();
+        let possible = 0..=libc::SIGRTMAX();
 
         possible
             .map(|_| SignalInfo::default())

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -22,13 +22,11 @@ use self::driver::Handle;
 
 pub(crate) type OsStorage = Vec<SignalInfo>;
 
-// Number of different unix signals
-// (FreeBSD has 33)
-const SIGNUM: usize = 33;
-
 impl Init for OsStorage {
     fn init() -> Self {
-        (0..SIGNUM).map(|_| SignalInfo::default()).collect()
+        (0..libc::SIGRTMAX())
+            .map(|_| SignalInfo::default())
+            .collect()
     }
 }
 


### PR DESCRIPTION
The POSIX standard not only supports "reliable signals", but also
"real-time signals". This commit adds support for the latter.

Fixes: #4554