### PR TITLE
chore: fix a bunch of annoying clippy lints

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -300,11 +300,7 @@ cfg_metrics! {
         where
             F: Fn(&IoDriverMetrics) -> R,
         {
-            if let Some(inner) = self.inner() {
-                Some(f(&inner.metrics))
-            } else {
-                None
-            }
+            self.inner().map(|inner| f(&inner.metrics))
         }
    }
 }

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -141,7 +141,10 @@ impl sealed::ToSocketAddrsPriv for &[SocketAddr] {
         // in order to ensure that the returned iterator is valid for the
         // `'static` lifetime, which the borrowed `slice::Iter` iterator would
         // not be.
-        #[allow(clippy::unnecessary_to_owned)]
+        // Note that we can't actually add an `allow` attribute for
+        // `clippy::unnecessary_to_owned` here, as Tokio's CI runs clippy lints
+        // on Rust 1.52 to avoid breaking LTS releases of Tokio. Users of newer
+        // Rust versions who see this lint should just ignore it.
         let iter = self.to_vec().into_iter();
         future::ready(Ok(iter))
     }

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -136,6 +136,12 @@ impl sealed::ToSocketAddrsPriv for &[SocketAddr] {
     type Future = ReadyFuture<Self::Iter>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
+        // Clippy doesn't like the `to_vec()` call here (as it will allocate,
+        // while `self.iter().copied()` would not), but it's actually necessary
+        // in order to ensure that the returned iterator is valid for the
+        // `'static` lifetime, which the borrowed `slice::Iter` iterator would
+        // not be.
+        #[allow(clippy::unnecessary_to_owned)]
         let iter = self.to_vec().into_iter();
         future::ready(Ok(iter))
     }

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -528,8 +528,7 @@ cfg_net! {
             self.handle
                 .io_handle
                 .as_ref()
-                .map(|h| h.with_io_driver_metrics(f))
-                .flatten()
+                .and_then(|h| h.with_io_driver_metrics(f))
                 .unwrap_or(0)
         }
     }

--- a/tokio/src/sync/barrier.rs
+++ b/tokio/src/sync/barrier.rs
@@ -105,7 +105,7 @@ impl Barrier {
             n,
             wait,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: resource_span,
+            resource_span,
         }
     }
 

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -582,7 +582,7 @@ impl<'a> Acquire<'a> {
 
                 tracing::trace!(
                     target: "runtime::resource::async_op::state_update",
-                    permits_obtained = 0 as usize,
+                    permits_obtained = 0usize,
                     permits.op = "override",
                 );
 

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -526,7 +526,7 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let rx = Receiver {
         inner: Some(inner),
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        resource_span: resource_span,
+        resource_span,
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         async_op_span,
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/time/driver/sleep.rs
+++ b/tokio/src/time/driver/sleep.rs
@@ -261,7 +261,7 @@ impl Sleep {
         let inner = {
             let time_source = handle.time_source().clone();
             let deadline_tick = time_source.deadline_to_tick(deadline);
-            let duration = deadline_tick.checked_sub(time_source.now()).unwrap_or(0);
+            let duration = deadline_tick.saturating_sub(time_source.now());
 
             let location = location.expect("should have location if tracing");
             let resource_span = tracing::trace_span!(
@@ -373,7 +373,7 @@ impl Sleep {
             let duration = {
                 let now = me.inner.time_source.now();
                 let deadline_tick = me.inner.time_source.deadline_to_tick(deadline);
-                deadline_tick.checked_sub(now).unwrap_or(0)
+                deadline_tick.saturating_sub(now)
             };
 
             tracing::trace!(

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -155,7 +155,7 @@ fn try_lock() {
         let g1 = m.try_lock();
         assert!(g1.is_ok());
         let g2 = m.try_lock();
-        assert!(!g2.is_ok());
+        assert!(g2.is_err());
     }
     let g3 = m.try_lock();
     assert!(g3.is_ok());

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -122,7 +122,7 @@ fn try_lock_owned() {
         let g1 = m.clone().try_lock_owned();
         assert!(g1.is_ok());
         let g2 = m.clone().try_lock_owned();
-        assert!(!g2.is_ok());
+        assert!(g2.is_err());
     }
     let g3 = m.try_lock_owned();
     assert!(g3.is_ok());


### PR DESCRIPTION
## Motivation

Recent Clippy releases have added some new lints that trigger on some
code in Tokio. These aren't a big deal, but seeing them in my editor is
mildly annoying.

## Solution

This branch fixes the following issues flagged by Clippy:

* manual `Option::map` implementation
* use of `.map(...).flatten(...)` that could be replaced with
  `.and_then(...)`
* manual implementation of saturating arithmetic on `Duration`s
* simplify some boolean expressions in assertions (`!res.is_ok()` can be
`res.is_err()`)
* fix redundant field names in initializers
* ~~allow the `clippy::unnecessary_to_owned` lint in `ToSocketAddrs` impl
  for `&[SocketAddr]` --- the "unnecessary" `to_vec()` call is actually
  necessary to ensure the iterator is `'static`~~
* replace an unnecessary cast to `usize` with an explicitly typed
  integer literal