### PR TITLE
Add method that exposes the internal buffer of StreamReader

### DIFF
--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -84,8 +84,8 @@ where
     }
 
     /// Do we have a chunk and is it non-empty?
-    fn has_chunk(self: Pin<&mut Self>) -> bool {
-        if let Some(chunk) = self.project().chunk {
+    fn has_chunk(&self) -> bool {
+        if let Some(ref chunk) = self.chunk {
             chunk.remaining() > 0
         } else {
             false
@@ -96,13 +96,11 @@ where
     /// of the underlying stream and an Option of the interal buffer,
     /// which is Some in case the buffer contains elements.
     pub fn into_inner_with_chunk(self) -> (S, Option<B>) {
-        if let Some(chunk) = self.chunk {
-            if chunk.remaining() > 0 {
-                return (self.inner, Some(chunk));
-            }
+        if self.has_chunk() {
+            (self.inner, self.chunk)
+        } else {
+            (self.inner, None)
         }
-
-        (self.inner, None)
     }
 }
 

--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -91,6 +91,19 @@ where
             false
         }
     }
+
+    /// Consumes this `StreamReader`, returning a Tuple consisting
+    /// of the underlying stream and an Option of the interal buffer,
+    /// which is Some in case the buffer contains elements.
+    pub fn into_inner_with_chunk(self) -> (S, Option<B>) {
+        if let Some(chunk) = self.chunk {
+            if chunk.remaining() > 0 {
+                return (self.inner, Some(chunk));
+            }
+        }
+
+        (self.inner, None)
+    }
 }
 
 impl<S, B> StreamReader<S, B> {
@@ -118,6 +131,10 @@ impl<S, B> StreamReader<S, B> {
     /// Consumes this `BufWriter`, returning the underlying stream.
     ///
     /// Note that any leftover data in the internal buffer is lost.
+    /// If you additionally want access to the internal buffer use
+    /// [`into_inner_with_chunk`].
+    ///
+    /// [`into_inner_with_chunk`]: crate::io::StreamReader::into_inner_with_chunk
     pub fn into_inner(self) -> S {
         self.inner
     }


### PR DESCRIPTION
Attempt to fix https://github.com/tokio-rs/tokio/issues/4552 by exposing the internal buffer of `StreamReader`.