### PR TITLE
ci: run doctests for unstable APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,9 @@ jobs:
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          # in order to run doctests for unstable features, we must also pass
+          # the unstable cfg to RustDoc
+          RUSTDOCFLAGS: --cfg tokio_unstable
 
   miri:
     name: miri

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -465,7 +465,7 @@ cfg_net! {
         ///     let registered_fds = metrics.io_driver_fd_registered_count();
         ///     println!("{} fds have been registered with the runtime's I/O driver.", registered_fds);
         ///
-        ///     let deregistered_fds = metrics.io_fd_deregistered_count();
+        ///     let deregistered_fds = metrics.io_driver_fd_deregistered_count();
         ///
         ///     let current_fd_count = registered_fds - deregistered_fds;
         ///     println!("{} fds are currently registered by the runtime's I/O driver.", current_fd_count);
@@ -489,7 +489,7 @@ cfg_net! {
         /// async fn main() {
         ///     let metrics = Handle::current().metrics();
         ///
-        ///     let n = metrics.io_driver_deregistered_fd_count();
+        ///     let n = metrics.io_driver_fd_deregistered_count();
         ///     println!("{} fds have been deregistered by the runtime's I/O driver.", n);
         /// }
         /// ```

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -489,7 +489,7 @@ cfg_net! {
         /// async fn main() {
         ///     let metrics = Handle::current().metrics();
         ///
-        ///     let n = metrics.io_driver_deregisteredd_fd_count();
+        ///     let n = metrics.io_driver_deregistered_fd_count();
         ///     println!("{} fds have been deregistered by the runtime's I/O driver.", n);
         /// }
         /// ```


### PR DESCRIPTION
It turns out that the CI job for testing `tokio_unstable` features isn't
actually running doctests for `tokio_unstable`, just lib and integration
tests. This is because RustDoc is responsible for running doctests, and
it needs the unstable cfg passed to it separately from `RUSTFLAGS`.

This means that if the examples for unstable APIs are broken, CI won't
catch this, which is not great!

This commit changes the `test-unstable` CI job to pass `--cfg
tokio_unstable` in `RUSTDOCFLAGS` as well as `RUSTFLAGS`. This way,
doctests for unstable APIs should actually run.