### PR TITLE
ci: use setup-cross-toolchain-action instead of cross

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,32 +239,48 @@ jobs:
     strategy:
       matrix:
         target:
+          - aarch64-unknown-linux-gnu
+          - armv7-unknown-linux-gnueabihf
           - i686-unknown-linux-gnu
-          - powerpc-unknown-linux-gnu
-          - powerpc64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
-          - arm-linux-androideabi
-          - mipsel-unknown-linux-musl
+          - mips64el-unknown-linux-gnuabi64
+          - mipsel-unknown-linux-gnu
+          - powerpc64le-unknown-linux-gnu
+          - riscv64gc-unknown-linux-gnu
+          - s390x-unknown-linux-gnu
+        # setup-cross-toolchain-action doesn't support testing of them
+        include:
+          - target: arm-linux-androideabi
+            cmd: check
+          - target: aarch64-pc-windows-msvc
+            cmd: check
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust ${{ env.rust_stable }}
+      # Use nightly to cross-testing doctest
+      - name: Install Rust ${{ env.rust_nightly }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_nightly }}
           target: ${{ matrix.target }}
           override: true
-      - uses: actions-rs/cargo@v1
+      - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
-          use-cross: true
-          command: check
-          args: --workspace --all-features --target ${{ matrix.target }}
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: check
-          args: --workspace --all-features --target ${{ matrix.target }}
+          target: ${{ matrix.target }}
+        if: matrix.cmd != 'check'
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo test -v --workspace --all-features --target ${{ matrix.target }} $DOCTEST_XCOMPILE
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg qemu
+        if: matrix.cmd != 'check'
+      - run: cargo test -v --workspace --all-features --target ${{ matrix.target }} $DOCTEST_XCOMPILE
+        env:
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg qemu --cfg tokio_unstable
+        if: matrix.cmd != 'check'
+      - run: cargo ${{ matrix.cmd }} -v --workspace --all-features --target ${{ matrix.target }}
+        if: matrix.cmd == 'check'
+      - run: cargo ${{ matrix.cmd }} -v --workspace --all-features --target ${{ matrix.target }}
+        env:
+          RUSTFLAGS: ${{ env.RUSTFLAGS }} --cfg tokio_unstable
+        if: matrix.cmd == 'check'
 
   features:
     name: features

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -455,6 +455,7 @@ fn local_tasks_wake_join_all() {
 
 #[cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 #[test]
+#[cfg_attr(qemu, ignore)] // qemu is slow
 fn local_tasks_are_polled_after_tick() {
     // This test depends on timing, so we run it up to five times.
     for _ in 0..4 {

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -382,6 +382,11 @@ async fn try_read_buf() -> std::io::Result<()> {
 
 // https://github.com/tokio-rs/tokio/issues/3879
 #[tokio::test]
+// TODO
+// thread 'epollhup' panicked at 'assertion failed: `(left == right)`
+//   left: `Uncategorized`,
+//  right: `ConnectionReset`', tokio/tests/uds_stream.rs:409:5
+#[cfg_attr(any(target_arch = "mips", target_arch = "mips64"), ignore)]
 #[cfg(not(target_os = "macos"))]
 async fn epollhup() -> io::Result<()> {
     let dir = tempfile::Builder::new()


### PR DESCRIPTION
We are currently using `cross`, which [does not work with the tokio test suite](https://github.com/tokio-rs/tokio/pull/3424).

[setup-cross-toolchain-action](https://github.com/taiki-e/setup-cross-toolchain-action) is a GitHub Action to set up CI environment for cross-testing, including doctest, without dockers.

This allows our CI to run tests for various architectures. 

This patch includes:

- Run test and doctest for aarch64, arm, i686, powerpc64le, mipsel, mips64el, riscv64gc, s390x linux. (Previously, it was build only.)
  - Tested targets are based on architectures officially supported by debian,ubuntu,fedora
  
     debian: https://wiki.debian.org/SupportedArchitectures (the following list doesn't include unofficially supported arch)
    - x86
    - x86_64
    - arm (v5t, v7hf)
    - aarch64
    - mips64el
    - mips ([deprecated in debian 10](https://wiki.debian.org/MIPSPort#Support))
    - mipsel
    - powerpc64le
    - s390x

    ubuntu: https://help.ubuntu.com/community/SupportedArchitectures
    - x86
    - x86_64
    - arm (v7hf)
    - aarch64
    - powerpc64le
    - s390x

    fedora: https://fedoraproject.org/wiki/Architectures
    - x86_64 (Primary Architecture)
    - arm (v7hf, Primary Architecture)
    - aarch64 (Primary Architecture)
    - mips64el 
    - mipsel
    - powerpc64le
    - riscv64gc
    - s390x

- Build for android and aarch64 windows. (setup-cross-toolchain-action doesn't support testing of them)

Closes #3424
Closes #2985 (aarch64 windows)
Closes #4454 (mipsel linux meets this)
