### PR TITLE
Make doc test of _rt attributes use the appropriate attribute

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -193,7 +193,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Using default
 ///
 /// ```rust
-/// #[tokio::main(flavor = "current_thread")]
+/// #[tokio::main_rt(flavor = "current_thread")]
 /// async fn main() {
 ///     println!("Hello world");
 /// }
@@ -276,7 +276,7 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ## Usage
 ///
 /// ```no_run
-/// #[tokio::test]
+/// #[tokio::test_rt]
 /// async fn my_test() {
 ///     assert!(true);
 /// }


### PR DESCRIPTION
## Motivation

I'm unsure, but shouldn't the tests in the doc comment use the `_rt` attribute?
