### PR TITLE
ci: run reusable_box tests with Miri

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_instance:
   image: freebsd-12-2-release-amd64
 env:
   RUST_STABLE: stable
-  RUST_NIGHTLY: nightly-2022-01-12
+  RUST_NIGHTLY: nightly-2022-03-21
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-01-12
+  rust_nightly: nightly-2022-03-21
   rust_clippy: 1.52.0
   rust_min: 1.49.0
 

--- a/tokio/src/signal/reusable_box.rs
+++ b/tokio/src/signal/reusable_box.rs
@@ -151,7 +151,6 @@ impl<T> fmt::Debug for ReusableBoxFuture<T> {
 }
 
 #[cfg(test)]
-#[cfg(not(miri))] // Miri breaks when you use Pin<&mut dyn Future>
 mod test {
     use super::ReusableBoxFuture;
     use futures::future::FutureExt;


### PR DESCRIPTION
Miri now supports trait objects with arbitrary-self receivers: https://github.com/rust-lang/rust/pull/95071