### PR TITLE
Increase max I/O buffer size to 128 MiB, and DRY the constant in stdio_common tests

### DIFF
--- a/tokio/src/fs/file/tests.rs
+++ b/tokio/src/fs/file/tests.rs
@@ -231,12 +231,12 @@ fn flush_while_idle() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn read_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = 16 * 1024;
+    let chunk_a = crate::io::blocking::MAX_BUF;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;
 
-    assert_eq!(chunk_d / 1024, 64);
+    assert_eq!(chunk_d / 1024 / 1024, 512);
 
     let mut data = vec![];
     for i in 0..(chunk_d - 1) {
@@ -303,12 +303,12 @@ fn read_with_buffer_larger_than_max() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn write_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = 16 * 1024;
+    let chunk_a = crate::io::blocking::MAX_BUF;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;
 
-    assert_eq!(chunk_d / 1024, 64);
+    assert_eq!(chunk_d / 1024 / 1024, 512);
 
     let mut data = vec![];
     for i in 0..(chunk_d - 1) {

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -26,7 +26,7 @@ pub(crate) struct Buf {
     pos: usize,
 }
 
-pub(crate) const MAX_BUF: usize = 16 * 1024;
+pub(crate) const MAX_BUF: usize = 128 * 1024 * 1024;
 
 #[derive(Debug)]
 enum State<T> {

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -114,7 +114,7 @@ mod tests {
     use std::task::Context;
     use std::task::Poll;
 
-    const MAX_BUF: usize = 16 * 1024;
+    use crate::io::blocking::MAX_BUF;
 
     struct TextMockWriter;
 


### PR DESCRIPTION
## Motivation

A very rudimentary solution to #1976 :) the maximum number of bytes we can currently read/write through `tokio`'s I/O subsystem in a single operation is 16KiB.  This increases that maximum to 128MiB.

## Solution

It doesn't give us direct configurability of the maximum buffer size, but since (unless I'm misunderstanding the code in that module) calling code can create and supply smaller buffers, it seems like simply increasing the hardcoded number is a reasonable starting point
