### PR TITLE
sync: add `watch::Receiver::same_channel`

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -467,6 +467,22 @@ impl<T> Receiver<T> {
         }
     }
 
+    /// Returns `true` if receivers belong to the same channel.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let (tx, rx) = tokio::sync::watch::channel(true);
+    /// let rx2 = rx.clone();
+    /// assert!(rx.same_channel(&rx2));
+    ///
+    /// let (tx3, rx3) = tokio::sync::watch::channel(true);
+    /// assert!(!rx3.same_channel(&rx2));
+    /// ```
+    pub fn same_channel(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.shared, &other.shared)
+    }
+
     cfg_process_driver! {
         pub(crate) fn try_has_changed(&mut self) -> Option<Result<(), error::RecvError>> {
             maybe_changed(&self.shared, &mut self.version)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
I'd like to determine if two `watch::Receiver`s are part of the same channel (i.e. will receive values from the same `watch::Sender`.

Specifically, I'd like to have a `HashMap<K, watch::Receiver<V>>`, and then later be able to check if *my* entry is still there, or someone else has removed it (and potentially replaced it with a Receiver for a different Sender).

Closes: https://github.com/tokio-rs/tokio/issues/4579

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Add a `same_channel()` method which uses `Arc::ptr_eq` on `Receiver::shared`
