### PR TITLE
Make try_io methods call mio's try_io internally

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -97,7 +97,7 @@ pin-project-lite = "0.2.0"
 bytes = { version = "1.0.0", optional = true }
 once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
-mio = { version = "0.8.0", optional = true }
+mio = { version = "0.8.1", optional = true }
 socket2 = { version = "0.4.4", optional = true, features = [ "all" ] }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -968,7 +968,7 @@ impl TcpStream {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, f)
+        self.io.registration().try_io(interest, || self.io.try_io(f))
     }
 
     /// Receives data on the socket from the remote address to which it is

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -968,7 +968,9 @@ impl TcpStream {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, || self.io.try_io(f))
+        self.io
+            .registration()
+            .try_io(interest, || self.io.try_io(f))
     }
 
     /// Receives data on the socket from the remote address to which it is

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1272,7 +1272,9 @@ impl UdpSocket {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, || self.io.try_io(f))
+        self.io
+            .registration()
+            .try_io(interest, || self.io.try_io(f))
     }
 
     /// Receives data from the socket, without removing it from the input queue.

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1272,7 +1272,7 @@ impl UdpSocket {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, f)
+        self.io.registration().try_io(interest, || self.io.try_io(f))
     }
 
     /// Receives data from the socket, without removing it from the input queue.

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1241,7 +1241,9 @@ impl UnixDatagram {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, || self.io.try_io(f))
+        self.io
+            .registration()
+            .try_io(interest, || self.io.try_io(f))
     }
 
     /// Returns the local address that this socket is bound to.

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1241,7 +1241,7 @@ impl UnixDatagram {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, f)
+        self.io.registration().try_io(interest, || self.io.try_io(f))
     }
 
     /// Returns the local address that this socket is bound to.

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -685,7 +685,7 @@ impl UnixStream {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, f)
+        self.io.registration().try_io(interest, || self.io.try_io(f))
     }
 
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -685,7 +685,9 @@ impl UnixStream {
         interest: Interest,
         f: impl FnOnce() -> io::Result<R>,
     ) -> io::Result<R> {
-        self.io.registration().try_io(interest, || self.io.try_io(f))
+        self.io
+            .registration()
+            .try_io(interest, || self.io.try_io(f))
     }
 
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.


### PR DESCRIPTION
## Motivation

A user defined I/O closure should be called by mio's try_io to ensure that the I/O receives more events if it hits a WouldBlock error.

## Solution

Make tokio's try_io methods call mio's try_io method using a given closure.

Fixes: #4510 