### PR TITLE
tests: complete TODOs in uds_stream.

### DIFF
--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -25,13 +25,13 @@ async fn accept_read_write() -> std::io::Result<()> {
     let connect = UnixStream::connect(&sock_path);
     let ((mut server, _), mut client) = try_join(accept, connect).await?;
 
-    // Write to the client. TODO: Switch to write_all.
-    let write_len = client.write(b"hello").await?;
-    assert_eq!(write_len, 5);
+    // Write to the client.
+    client.write_all(b"hello").await?;
     drop(client);
-    // Read from the server. TODO: Switch to read_to_end.
-    let mut buf = [0u8; 5];
-    server.read_exact(&mut buf).await?;
+
+    // Read from the server.
+    let mut buf = vec![];
+    server.read_to_end(&mut buf).await?;
     assert_eq!(&buf, b"hello");
     let len = server.read(&mut buf).await?;
     assert_eq!(len, 0);


### PR DESCRIPTION
This completes the TODOs in uds_stream `accept_read_write` test by
using `AsyncWriteExt::write_all` instead of `AsyncWriteExt::write` and
`AsyncReadExt::read_to_end` instead of `AsyncReadExt::read_exact`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Complete the TODOs in uds_stream `accept_read_write` test.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Use `AsyncWriteExt::write_all` instead of `AsyncWriteExt::write` and
`AsyncReadExt::read_to_end` instead of `AsyncReadExt::read_exact`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
