### PR TITLE
Import tracing without the default attributes feature

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -43,7 +43,7 @@ futures-io = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", optional = true }
 pin-project-lite = "0.2.0"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
-tracing = { version = "0.1.25", optional = true }
+tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }


### PR DESCRIPTION
## Motivation

tracing enables the `attributes` feature by default, which we don't need here. I'd like to keep a close eye on the proc macro crates in my dependency tree.

## Solution

Disable default features and enable only the ones we need.