### PR TITLE
stream: expose Timeout

### DIFF
--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -78,7 +78,7 @@ pub mod wrappers;
 mod stream_ext;
 pub use stream_ext::{collect::FromStream, StreamExt};
 cfg_time! {
-    pub use stream_ext::timeout::Elapsed;
+    pub use stream_ext::timeout::{Elapsed, Timeout};
 }
 
 mod empty;


### PR DESCRIPTION
Expose `Timeout` so users can refer to it in their code.