### PR TITLE
task: define task_local in underlying future Drop

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -91,7 +91,7 @@ stats = []
 [dependencies]
 tokio-macros = { version = "1.7.0", path = "../tokio-macros", optional = true }
 
-pin-project-lite = "0.2.0"
+pin-project-lite = "0.2.7"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }


### PR DESCRIPTION

## Motivation

Currently task_local-s cannot be accessed at the `Drop::drop`, which seems quite strange behavior.

## Solution

Current solution wraps the underlying future with `ManuallyDrop` and requires some unsafe (not really sure about soundness). Other option is using `Option<Fut>` that have additional overhead though requires no unsafe blocks.

For some reason, a test within tokio doesn't reproduce the issue but it works for playground/separate crate (thanks @loyd for that one), [link](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=5bb312dde5140ca42376619725943519).