### PR TITLE
WIP: Add resubscribe functionality to broadcast::Receiver

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -648,7 +648,7 @@ impl<T> Sender<T> {
 }
 
 /// Create a new `Receiver` which reads starting from the tail if `next_pos` is not specified.
-fn new_receiver<T>(shared: Arc<Shared<T>>, next_pos: Option<u64>) -> Receiver<T> {
+fn new_receiver<T>(shared: Arc<Shared<T>>) -> Receiver<T> {
     let mut tail = shared.tail.lock();
 
     if tail.rx_cnt == MAX_RECEIVERS {
@@ -657,9 +657,10 @@ fn new_receiver<T>(shared: Arc<Shared<T>>, next_pos: Option<u64>) -> Receiver<T>
 
     tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
 
-    let next = next_pos.unwrap_or(tail.pos);
+    let next = tail.pos;
 
     drop(tail);
+
     Receiver { shared, next }
 }
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -557,7 +557,7 @@ impl<T> Sender<T> {
     /// ```
     pub fn subscribe(&self) -> Receiver<T> {
         let shared = self.shared.clone();
-        new_receiver(shared, None)
+        new_receiver(shared)
     }
 
     /// Returns the number of active receivers
@@ -647,7 +647,7 @@ impl<T> Sender<T> {
     }
 }
 
-/// Create a new `Receiver` which reads starting from the tail if `next_pos` is not specified.
+/// Create a new `Receiver` which reads starting from the tail.
 fn new_receiver<T>(shared: Arc<Shared<T>>) -> Receiver<T> {
     let mut tail = shared.tail.lock();
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1031,11 +1031,19 @@ impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
         let next = self.next;
         let shared = self.shared.clone();
+        let mut tail = shared.tail.lock();
 
-        // register interest in the slot that next points to
-        // let this be lock-free since we're not yet operating on the tail.
-        let tail_pos = shared.tail.lock().pos;
-        for n in next..tail_pos {
+        // register the new receiver with `Tail`
+        if tail.rx_cnt == MAX_RECEIVERS {
+            panic!("max receivers");
+        }
+        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
+
+        // Register interest in the slots from next to tail.pos.
+
+        // We need to hold the lock here to prevent a race with send2 where send2 overwrites
+        // next or moves past tail before we register interest in the slot.
+        for n in next..tail.pos {
             let idx = (n & shared.mask as u64) as usize;
             let slot = shared.buffer[idx].read().unwrap();
 
@@ -1045,21 +1053,6 @@ impl<T> Clone for Receiver<T> {
             // called concurrently.
             slot.rem.fetch_add(1, SeqCst);
         }
-        // tail pos may have changed, we need a locked section here to prevent a race with `Sender::send2`
-        let mut n = tail_pos.wrapping_sub(1);
-        let mut tail = shared.tail.lock();
-        while n <= tail.pos {
-            let idx = (n & shared.mask as u64) as usize;
-            let slot = self.shared.buffer[idx].read().unwrap();
-            slot.rem.fetch_add(1, SeqCst);
-            n = n.wrapping_add(1);
-        }
-
-        // register the new receiver with `Tail`
-        if tail.rx_cnt == MAX_RECEIVERS {
-            panic!("max receivers");
-        }
-        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
 
         drop(tail);
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -901,7 +901,8 @@ impl<T: Clone> Receiver<T> {
     ///   let mut rx2 = rx.resubscribe();
     ///   tx.send(2).unwrap();
     ///
-    ///   assert_eq!(rx.recv().await.unwrap(), rx2.recv().await.unwrap()); // 1 != 2
+    ///   assert_eq!(rx2.recv().await.unwrap(), 2);
+    ///   assert_eq!(rx.recv().await.unwrap(), 1);
     /// }
     /// ```
     pub fn resubscribe(&self) -> Self {

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -882,43 +882,31 @@ impl<T> Receiver<T> {
 }
 
 impl<T: Clone> Receiver<T> {
-    /// Re-subscribes to the channel starting from the current tail element (the last element passed to `Sender::send`.)
+    /// Re-subscribes to the channel starting from the current tail element.
+    ///
+    /// This [`Receiver`] handle will receive a clone of all values sent
+    /// **after** it has resubscribed. This will not include elements that are
+    /// in the queue of the current receiver. Consider the following example.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::broadcast;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///   let (tx, mut rx) = broadcast::channel(2);
+    ///
+    ///   tx.send(1).unwrap();
+    ///   let mut rx2 = rx.resubscribe();
+    ///   tx.send(2).unwrap();
+    ///
+    ///   assert_neq!(rx.recv().await.unwrap(), rx2.recv().await.unwrap()); // 1 != 2
+    /// }
+    /// ```
     pub fn resubscribe(&self) -> Self {
         let shared = self.shared.clone();
         new_receiver(shared)
-    }
-
-    /// Clones the receiver maintaining the current position of the queue. This operation is `O(n)`,
-    /// if you do not need to maintain the current position please use `Receiver::resubscribe`.
-    pub fn clone_at_position(&self) -> Self {
-        let next = self.next;
-        let shared = self.shared.clone();
-        let mut tail = shared.tail.lock();
-
-        // register the new receiver with `Tail`
-        if tail.rx_cnt == MAX_RECEIVERS {
-            panic!("max receivers");
-        }
-        tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
-
-        // Register interest in the slots from next to tail.pos.
-
-        // We need to hold the lock here to prevent a race with send2 where send2 overwrites
-        // next or moves past tail before we register interest in the slot.
-        for n in next..tail.pos {
-            let idx = (n & shared.mask as u64) as usize;
-            let slot = shared.buffer[idx].read().unwrap();
-
-            // a race with RecvGuard::drop would be bad, but is impossible since `self.next`
-            // is already incremented to the slot after the one that the `RecvGuard` points to. Additionally
-            // all methods that drop a `RecvGuard` require a &mut `Receiver` which ensures this method is not
-            // called concurrently.
-            slot.rem.fetch_add(1, SeqCst);
-        }
-
-        drop(tail);
-
-        Receiver { shared, next }
     }
     /// Receives the next value for this receiver.
     ///

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -901,7 +901,7 @@ impl<T: Clone> Receiver<T> {
     ///   let mut rx2 = rx.resubscribe();
     ///   tx.send(2).unwrap();
     ///
-    ///   assert_neq!(rx.recv().await.unwrap(), rx2.recv().await.unwrap()); // 1 != 2
+    ///   assert_eq!(rx.recv().await.unwrap(), rx2.recv().await.unwrap()); // 1 != 2
     /// }
     /// ```
     pub fn resubscribe(&self) -> Self {

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1029,8 +1029,32 @@ impl<T> Drop for Receiver<T> {
 
 impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
+        let next = self.next;
+        // register interest in the slot that next points to
+        {
+            for n in next..=self.shared.tail.lock().pos {
+                let idx = (n & self.shared.mask as u64) as usize;
+                let slot = self.shared.buffer[idx].read().unwrap();
+
+                // a race with RecvGuard::drop would be bad, but is impossible since `self.next`
+                // is already incremented to the slot after the one that the `RecvGuard` points to. Additionally
+                // all methods that drop a `RecvGuard` require a &mut `Receiver` which ensures this method is not
+                // called concurrently.
+                slot.rem.fetch_add(1, SeqCst);
+            }
+        }
         let shared = self.shared.clone();
-        new_receiver(shared, Some(self.next))
+        // register the new receiver with `Tail`
+        {
+            let mut tail = shared.tail.lock();
+
+            if tail.rx_cnt == MAX_RECEIVERS {
+                panic!("max receivers");
+            }
+            tail.rx_cnt = tail.rx_cnt.checked_add(1).expect("overflow");
+        }
+
+        Receiver { shared, next }
     }
 }
 

--- a/tokio/src/sync/tests/loom_broadcast.rs
+++ b/tokio/src/sync/tests/loom_broadcast.rs
@@ -97,7 +97,7 @@ fn broadcast_two() {
 fn broadcast_two_cloned() {
     loom::model(|| {
         let (tx, mut rx1) = broadcast::channel::<Arc<&'static str>>(16);
-        let mut rx2 = rx1.clone();
+        let mut rx2 = rx1.clone_at_position();
 
         let th1 = thread::spawn(move || {
             block_on(async {
@@ -228,7 +228,7 @@ fn drop_rx() {
 fn drop_cloned_rx() {
     loom::model(|| {
         let (tx, mut rx1) = broadcast::channel(16);
-        let rx2 = rx1.clone();
+        let rx2 = rx1.clone_at_position();
 
         let th1 = thread::spawn(move || {
             block_on(async {
@@ -294,7 +294,7 @@ fn drop_multiple_cloned_rx_with_overflow() {
     loom::model(move || {
         // It is essential to have multiple senders and receivers in this test case.
         let (tx, mut rx) = broadcast::channel(1);
-        let _rx2 = rx.clone();
+        let _rx2 = rx.clone_at_position();
 
         let _ = tx.send(());
         let tx2 = tx.clone();
@@ -318,17 +318,17 @@ fn drop_multiple_cloned_rx_with_overflow() {
 
 #[test]
 fn send_and_rx_clone() {
-    // test the interaction of Sender::send and Rx::clone
+    // test the interaction of Sender::send and Rx::clone_at_position
     loom::model(move || {
         let (tx, mut rx) = broadcast::channel(2);
 
         let th1 = thread::spawn(move || {
             block_on(async {
-                let mut rx2 = rx.clone();
+                let mut rx2 = rx.clone_at_position();
                 let v = assert_ok!(rx.recv().await);
                 assert_eq!(v, 1);
 
-                // this would return closed if rem was incr'd in clone between
+                // this would return closed if rem was incr'd in clone_at_position between
                 // read and write of rem for new tail entry.
                 let v2 = assert_ok!(rx2.recv().await);
                 assert_eq!(v2, 1);

--- a/tokio/src/sync/tests/loom_broadcast.rs
+++ b/tokio/src/sync/tests/loom_broadcast.rs
@@ -241,7 +241,6 @@ fn drop_cloned_rx() {
                 let v = assert_ok!(rx1.recv().await);
                 assert_eq!(v, "three");
 
-
                 match assert_err!(rx1.recv().await) {
                     Closed => {}
                     _ => panic!(),
@@ -262,7 +261,6 @@ fn drop_cloned_rx() {
         assert_ok!(th2.join());
     });
 }
-
 
 #[test]
 fn drop_multiple_rx_with_overflow() {
@@ -341,4 +339,3 @@ fn send_and_rx_clone() {
         assert_ok!(th1.join());
     });
 }
-

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -534,10 +534,10 @@ fn resubscribe_points_to_tail() {
     tx.send(1);
 
     let mut rx_resub = rx.resubscribe();
-    
+
     // verify we're one behind at the start
-    assert_empty!(rx_resub), 
-    assert_eq!(assert_recv!(rx), 1)
+    assert_empty!(rx_resub);
+    assert_eq!(assert_recv!(rx), 1);
 
     // verify we do not affect rx
     tx.send(2);
@@ -564,5 +564,4 @@ fn resubscribe_lagged() {
     assert_empty!(rx);
     assert_eq!(assert_recv!(rx_resub), 2);
     assert_empty!(rx_resub);
-
 }


### PR DESCRIPTION
Add subscribe method to broadcast::Receiver with the same functionality as the clone impl removed in #3020.