### PR TITLE
net: add peer_addr to UdpSocket

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -278,6 +278,28 @@ impl UdpSocket {
         self.io.local_addr()
     }
 
+    /// Returns the socket address of the remote peer this socket was connected to.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::net::UdpSocket;
+    ///
+    /// # use std::{io, net::SocketAddr};
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
+    /// let peer = "127.0.0.1:11100".parse::<SocketAddr>().unwrap();
+    /// let sock = UdpSocket::bind(addr).await?;
+    /// sock.connect(peer).await?;
+    /// assert_eq!(peer, sock.peer_addr()?);
+    /// #    Ok(())
+    /// # }
+    /// ```
+    pub fn peer_addr(&self) -> io::Result<SocketAddr> {
+        self.io.peer_addr()
+    }
+
     /// Connects the UDP socket setting the default destination for send() and
     /// limiting packets that are read via recv from the address specified in
     /// `addr`.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The std [UdpSocket](https://doc.rust-lang.org/stable/std/net/struct.UdpSocket.html) exposes the method [peer_addr](https://doc.rust-lang.org/stable/std/net/struct.UdpSocket.html#method.peer_addr) to get the address of the remote peer the socket is connected to but tokio `UdpSocket` does not.

There are other ways to get the peer address as mentioned in #4609 but `peer_addr` makes it convenient.

Fixes: #4609

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `peer_addr` for `UdpSocket` and forward the call to [mio](https://github.com/tokio-rs/mio).