### PR TITLE
Reduce pthread key usage

### DIFF
--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -16,6 +16,7 @@ mod ready;
 mod thread_local;
 
 #[macro_use]
+#[cfg(any(feature = "rt", feature = "sync", feature = "macros"))]
 pub(crate) mod unified_tls;
 
 cfg_trace! {

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -15,6 +15,9 @@ mod ready;
 #[macro_use]
 mod thread_local;
 
+#[macro_use]
+pub(crate) mod unified_tls;
+
 cfg_trace! {
     #[macro_use]
     mod trace;

--- a/tokio/src/macros/unified_tls.rs
+++ b/tokio/src/macros/unified_tls.rs
@@ -1,0 +1,86 @@
+//! Unified thread local storage
+//!
+//! The number of `thread_local` on some operating systems is limited and may be small.
+//! In this case, it is necessary to reduce the usage of `thread_local`.
+//!
+//! This mod combines multiple `thread_local` into one struct,
+//! thus avoiding excessive use of pthread key resources.
+
+use std::fmt;
+use std::error::Error;
+use std::cell::RefCell;
+
+#[derive(Default)]
+pub(crate) struct UnifiedThreadLocal {
+    #[cfg(any(feature = "rt", feature = "sync"))]
+    pub(crate) thread_current_parker: RefCell<Option<crate::park::thread::ParkThread>>,
+
+    #[cfg(any(feature = "macros"))]
+    pub(crate) fast_rand: RefCell<Option<crate::util::rand::FastRand>>,
+}
+
+thread_local! {
+    pub(crate) static UNIFIED_THREAD_LOCAL: UnifiedThreadLocal =
+        UnifiedThreadLocal::default();
+}
+
+pub(crate) struct LocalKey<T: 'static> {
+    init: fn() -> T,
+    with: fn(&UnifiedThreadLocal) -> &RefCell<Option<T>>
+}
+
+macro_rules! unified_thread_local {
+    ( static $name:ident with $field:ident : $ty:ty = $init:expr ; ) => {
+        static $name : $crate::macros::unified_tls::LocalKey<$ty> =
+            $crate::macros::unified_tls::LocalKey::new(
+                || $init,
+                |utls| &utls.$field
+            );
+    }
+}
+
+impl<T: 'static> LocalKey<T> {
+    pub(crate) const fn new(init: fn() -> T, with: fn(&UnifiedThreadLocal) -> &RefCell<Option<T>>) -> LocalKey<T> {
+        LocalKey { init, with }
+    }
+
+    pub(crate) fn with<F, R>(&'static self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R,
+    {
+        self.try_with(f).expect(
+            "cannot access a Thread Local Storage value \
+             during or after destruction",
+        )
+    }
+
+    pub(crate) fn try_with<F, R>(&'static self, f: F) -> Result<R, AccessError>
+    where
+        F: FnOnce(&T) -> R,
+    {
+        UNIFIED_THREAD_LOCAL.try_with(|utls| {
+            let cell = (self.with)(utls);
+            let mut cell = cell.try_borrow_mut().map_err(|_| AccessError)?;
+            let cell = cell.get_or_insert_with(self.init);
+            Ok(f(cell))
+        })
+            .map_err(|_| AccessError)?
+    }
+}
+
+#[non_exhaustive]
+pub(crate) struct AccessError;
+
+impl fmt::Debug for AccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AccessError").finish()
+    }
+}
+
+impl fmt::Display for AccessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt("already destroyed", f)
+    }
+}
+
+impl Error for AccessError {}

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -31,8 +31,8 @@ const EMPTY: usize = 0;
 const PARKED: usize = 1;
 const NOTIFIED: usize = 2;
 
-thread_local! {
-    static CURRENT_PARKER: ParkThread = ParkThread::new();
+unified_thread_local! {
+    static CURRENT_PARKER with thread_current_parker: ParkThread = ParkThread::new();
 }
 
 // ==== impl ParkThread ====

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use wake_list::WakeList;
 pub(crate) mod linked_list;
 
 #[cfg(any(feature = "rt-multi-thread", feature = "macros"))]
-mod rand;
+pub(crate) mod rand;
 
 cfg_rt! {
     cfg_unstable! {

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -56,8 +56,8 @@ impl FastRand {
 #[doc(hidden)]
 #[cfg_attr(not(feature = "macros"), allow(unreachable_pub))]
 pub fn thread_rng_n(n: u32) -> u32 {
-    thread_local! {
-        static THREAD_RNG: FastRand = FastRand::new(crate::loom::rand::seed());
+    unified_thread_local! {
+        static THREAD_RNG with fast_rand: FastRand = FastRand::new(crate::loom::rand::seed());
     }
 
     THREAD_RNG.with(|rng| rng.fastrand_n(n))


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
On some system, the pthread keys number is quite limited, for example, the `PTHREAD_KEYS_MAX` of android is 128, and some embedded devices may be smaller to save memory.

`tokio` uses a lot of `thread_local!`, it would be nice to have some improve on this.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This PR unifies multiple `thread_local` variables into one `UnifiedThreadLocal` struct to avoid creating multiple pthread keys. and it provides the api compatible `unified_thread_local!` macro for migration.

It should be noted that before using `unified_thread_local!`, the type to be used needs to be defined in `UnifiedThreadLocal`.

The idea was briefly mentioned in chatroom, and the PR randomly selected two `thread_local` variables to migrate to see the actual effect.