### PR TITLE
Update FreeBSD CI image to 12.3.  12.2 is EoL.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-2-release-amd64
+  image: freebsd-12-3-release-amd64
 env:
   RUST_STABLE: stable
   RUST_NIGHTLY: nightly-2022-03-21


### PR DESCRIPTION
## Motivation

FreeBSD 12.2 is EoL.  It has no support, and at some point soon pre-built packages might start depending on 12.3 features.

## Solution

Update the CI image.