### PR TITLE
Upgrade nix to 0.24, limit features

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -113,7 +113,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.42" }
-nix = { version = "0.23" }
+nix = { version = "0.24", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"


### PR DESCRIPTION
## Motivation

This reduces tokio's test compile time by a few seconds.

## Solution

Upgrade nix to 0.24, which split nix into multiple features. Opt out of the default features and request just the ones required for tokio.