### PR TITLE
macros: always emit return statement

### DIFF
--- a/tests-build/tests/fail/macros_core_no_default.stderr
+++ b/tests-build/tests/fail/macros_core_no_default.stderr
@@ -1,5 +1,5 @@
 error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
- --> $DIR/macros_core_no_default.rs:3:1
+ --> tests/fail/macros_core_no_default.rs:3:1
   |
 3 | #[tokio::main]
   | ^^^^^^^^^^^^^^

--- a/tests-build/tests/fail/macros_dead_code.stderr
+++ b/tests-build/tests/fail/macros_dead_code.stderr
@@ -1,11 +1,11 @@
 error: function is never used: `f`
- --> $DIR/macros_dead_code.rs:6:10
+ --> tests/fail/macros_dead_code.rs:6:10
   |
 6 | async fn f() {}
   |          ^
   |
 note: the lint level is defined here
- --> $DIR/macros_dead_code.rs:1:9
+ --> tests/fail/macros_dead_code.rs:1:9
   |
 1 | #![deny(dead_code)]
   |         ^^^^^^^^^

--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -1,3 +1,5 @@
+#![deny(duplicate_macro_attributes)]
+
 use tests_build::tokio;
 
 #[tokio::main]

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -1,97 +1,101 @@
 error: the `async` keyword is missing from the function declaration
- --> $DIR/macros_invalid_input.rs:4:1
+ --> tests/fail/macros_invalid_input.rs:6:1
   |
-4 | fn main_is_not_async() {}
+6 | fn main_is_not_async() {}
   | ^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
- --> $DIR/macros_invalid_input.rs:6:15
+ --> tests/fail/macros_invalid_input.rs:8:15
   |
-6 | #[tokio::main(foo)]
+8 | #[tokio::main(foo)]
   |               ^^^
 
 error: Must have specified ident
- --> $DIR/macros_invalid_input.rs:9:15
-  |
-9 | #[tokio::main(threadpool::bar)]
-  |               ^^^^^^^^^^^^^^^
+  --> tests/fail/macros_invalid_input.rs:11:15
+   |
+11 | #[tokio::main(threadpool::bar)]
+   |               ^^^^^^^^^^^^^^^
 
 error: the `async` keyword is missing from the function declaration
-  --> $DIR/macros_invalid_input.rs:13:1
+  --> tests/fail/macros_invalid_input.rs:15:1
    |
-13 | fn test_is_not_async() {}
+15 | fn test_is_not_async() {}
    | ^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
-  --> $DIR/macros_invalid_input.rs:15:15
+  --> tests/fail/macros_invalid_input.rs:17:15
    |
-15 | #[tokio::test(foo)]
+17 | #[tokio::test(foo)]
    |               ^^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
-  --> $DIR/macros_invalid_input.rs:18:15
+  --> tests/fail/macros_invalid_input.rs:20:15
    |
-18 | #[tokio::test(foo = 123)]
+20 | #[tokio::test(foo = 123)]
    |               ^^^^^^^^^
 
 error: Failed to parse value of `flavor` as string.
-  --> $DIR/macros_invalid_input.rs:21:24
+  --> tests/fail/macros_invalid_input.rs:23:24
    |
-21 | #[tokio::test(flavor = 123)]
+23 | #[tokio::test(flavor = 123)]
    |                        ^^^
 
 error: No such runtime flavor `foo`. The runtime flavors are `current_thread` and `multi_thread`.
-  --> $DIR/macros_invalid_input.rs:24:24
+  --> tests/fail/macros_invalid_input.rs:26:24
    |
-24 | #[tokio::test(flavor = "foo")]
+26 | #[tokio::test(flavor = "foo")]
    |                        ^^^^^
 
 error: The `start_paused` option requires the `current_thread` runtime flavor. Use `#[tokio::test(flavor = "current_thread")]`
-  --> $DIR/macros_invalid_input.rs:27:55
+  --> tests/fail/macros_invalid_input.rs:29:55
    |
-27 | #[tokio::test(flavor = "multi_thread", start_paused = false)]
+29 | #[tokio::test(flavor = "multi_thread", start_paused = false)]
    |                                                       ^^^^^
 
 error: Failed to parse value of `worker_threads` as integer.
-  --> $DIR/macros_invalid_input.rs:30:57
+  --> tests/fail/macros_invalid_input.rs:32:57
    |
-30 | #[tokio::test(flavor = "multi_thread", worker_threads = "foo")]
+32 | #[tokio::test(flavor = "multi_thread", worker_threads = "foo")]
    |                                                         ^^^^^
 
 error: The `worker_threads` option requires the `multi_thread` runtime flavor. Use `#[tokio::test(flavor = "multi_thread")]`
-  --> $DIR/macros_invalid_input.rs:33:59
+  --> tests/fail/macros_invalid_input.rs:35:59
    |
-33 | #[tokio::test(flavor = "current_thread", worker_threads = 4)]
+35 | #[tokio::test(flavor = "current_thread", worker_threads = 4)]
    |                                                           ^
 
 error: Failed to parse value of `crate` as ident.
-  --> $DIR/macros_invalid_input.rs:36:23
+  --> tests/fail/macros_invalid_input.rs:38:23
    |
-36 | #[tokio::test(crate = 456)]
+38 | #[tokio::test(crate = 456)]
    |                       ^^^
 
 error: Failed to parse value of `crate` as ident: "456"
-  --> $DIR/macros_invalid_input.rs:39:23
+  --> tests/fail/macros_invalid_input.rs:41:23
    |
-39 | #[tokio::test(crate = "456")]
+41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
 error: Failed to parse value of `crate` as ident: "abc::edf"
-  --> $DIR/macros_invalid_input.rs:42:23
+  --> tests/fail/macros_invalid_input.rs:44:23
    |
-42 | #[tokio::test(crate = "abc::edf")]
+44 | #[tokio::test(crate = "abc::edf")]
    |                       ^^^^^^^^^^
 
 error: second test attribute is supplied
-  --> $DIR/macros_invalid_input.rs:46:1
+  --> tests/fail/macros_invalid_input.rs:48:1
    |
-46 | #[test]
+48 | #[test]
    | ^^^^^^^
 
 error: duplicated attribute
-  --> $DIR/macros_invalid_input.rs:46:1
+  --> tests/fail/macros_invalid_input.rs:48:1
    |
-46 | #[test]
+48 | #[test]
    | ^^^^^^^
    |
-   = note: `-D duplicate-macro-attributes` implied by `-D warnings`
+note: the lint level is defined here
+  --> tests/fail/macros_invalid_input.rs:1:9
+   |
+1  | #![deny(duplicate_macro_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-build/tests/fail/macros_type_mismatch.rs
+++ b/tests-build/tests/fail/macros_type_mismatch.rs
@@ -25,6 +25,7 @@ async fn extra_semicolon() -> Result<(), ()> {
 
 // https://github.com/tokio-rs/tokio/issues/4635
 #[allow(redundant_semicolons)]
+#[rustfmt::skip]
 #[tokio::main]
 async fn issue_4635() {
     return 1;

--- a/tests-build/tests/fail/macros_type_mismatch.rs
+++ b/tests-build/tests/fail/macros_type_mismatch.rs
@@ -23,4 +23,12 @@ async fn extra_semicolon() -> Result<(), ()> {
     Ok(());
 }
 
+// https://github.com/tokio-rs/tokio/issues/4635
+#[allow(redundant_semicolons)]
+#[tokio::main]
+async fn issue_4635() {
+    return 1;
+    ;
+}
+
 fn main() {}

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -4,9 +4,7 @@ error[E0308]: mismatched types
 4 | async fn missing_semicolon_or_return_type() {
   |                                             - possibly return type missing here?
 5 |     Ok(())
-  |     ^^^^^^- help: consider using a semicolon here: `;`
-  |     |
-  |     expected `()`, found enum `Result`
+  |     ^^^^^^ expected `()`, found enum `Result`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
@@ -33,16 +31,18 @@ error[E0308]: mismatched types
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try adding an expression at the end of the block
+help: try wrapping the expression in a variant of `Result`
    |
-23 ~     Ok(());;
-24 +     Ok(())
-   |
+23 |     Ok(Ok(());)
+   |     +++       +
+23 |     Err(Ok(());)
+   |     ++++       +
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:28:1
+  --> tests/fail/macros_type_mismatch.rs:31:5
    |
-28 | #[tokio::main]
-   | ^^^^^^^^^^^^^^ expected integer, found `()`
-   |
-   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
+29 | async fn issue_4635() {
+   |                       - possibly return type missing here?
+30 |     return 1;
+31 |     ;
+   |     ^ expected `()`, found integer

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/macros_type_mismatch.rs:5:5
+ --> tests/fail/macros_type_mismatch.rs:5:5
   |
 4 | async fn missing_semicolon_or_return_type() {
   |                                             - possibly return type missing here?
@@ -12,7 +12,7 @@ error[E0308]: mismatched types
                   found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:10:5
+  --> tests/fail/macros_type_mismatch.rs:10:5
    |
 9  | async fn missing_return_type() {
    |                                - possibly return type missing here?
@@ -23,7 +23,7 @@ error[E0308]: mismatched types
                    found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:23:5
+  --> tests/fail/macros_type_mismatch.rs:23:5
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
    |                               -------------- expected `Result<(), ()>` because of return type
@@ -38,3 +38,11 @@ help: try adding an expression at the end of the block
 23 ~     Ok(());;
 24 +     Ok(())
    |
+
+error[E0308]: mismatched types
+  --> tests/fail/macros_type_mismatch.rs:28:1
+   |
+28 | #[tokio::main]
+   | ^^^^^^^^^^^^^^ expected integer, found `()`
+   |
+   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -39,10 +39,10 @@ help: try wrapping the expression in a variant of `Result`
    |     ++++       +
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:31:5
+  --> tests/fail/macros_type_mismatch.rs:32:5
    |
-29 | async fn issue_4635() {
+30 | async fn issue_4635() {
    |                       - possibly return type missing here?
-30 |     return 1;
-31 |     ;
+31 |     return 1;
+32 |     ;
    |     ^ expected `()`, found integer

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -383,16 +383,16 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
 
     let body = &input.block;
     let brace_token = input.block.brace_token;
-    let (tail_return, tail_semicolon) = match body.stmts.last() {
+    let (tail_return_or_let, tail_semicolon) = match body.stmts.last() {
         Some(syn::Stmt::Semi(syn::Expr::Return(_), _)) => (quote! { return }, quote! { ; }),
         Some(syn::Stmt::Semi(..)) | Some(syn::Stmt::Local(..)) | None => {
             match &input.sig.output {
                 syn::ReturnType::Type(_, ty) if matches!(&**ty, syn::Type::Tuple(ty) if ty.elems.is_empty()) =>
                 {
-                    (quote! {}, quote! { ; }) // unit
+                    (quote! { let () = }, quote! { ; }) // unit
                 }
-                syn::ReturnType::Default => (quote! {}, quote! { ; }), // unit
-                syn::ReturnType::Type(..) => (quote! {}, quote! {}),   // ! or another
+                syn::ReturnType::Default => (quote! { let () = }, quote! { ; }), // unit
+                syn::ReturnType::Type(..) => (quote! {}, quote! {}),             // ! or another
             }
         }
         _ => (quote! {}, quote! {}),
@@ -401,7 +401,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
         {
             let body = async #body;
             #[allow(clippy::expect_used)]
-            #tail_return #rt
+            #tail_return_or_let #rt
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -386,12 +386,14 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     input.block = syn::parse2(quote_spanned! {last_stmt_end_span=>
         {
             let body = async #body;
-            #[allow(clippy::expect_used)]
-            return #rt
-                .enable_all()
-                .build()
-                .expect("Failed building the Runtime")
-                .block_on(body);
+            #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
+            {
+                return #rt
+                    .enable_all()
+                    .build()
+                    .expect("Failed building the Runtime")
+                    .block_on(body);
+            }
         }
     })
     .expect("Parsing failure");


### PR DESCRIPTION
Fixes #4635

There are two approaches, each divided into commits to compare.

The first commit is the `let () =` approach mentioned in https://github.com/tokio-rs/tokio/issues/4635#issuecomment-1107684720, which fixes #4635 while maintaining the current diagnostics. However, the diagnostics for #4635's case are not very good.

The second commit is a greatly simplified version of the current approach. There is small diagnostics regression, but it improves somewhat for #4635's case.

I tend to prefer the second one, but if other reviewers prefer the first one, I can revert the second commit.