### PR TITLE
Document and shrink some unsafe blocks in tokio-util

### DIFF
--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -115,6 +115,9 @@ mod util {
 
         let n = {
             let dst = buf.chunk_mut();
+
+            // Safety: `chunk_mut()` returns a `&mut UninitSlice`, and `UninitSlice` is a
+            // transparent wrapper around `[MaybeUninit<u8>]`.
             let dst = unsafe { &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]) };
             let mut buf = ReadBuf::uninit(dst);
             let ptr = buf.filled().as_ptr();


### PR DESCRIPTION
## Motivation

We are auditing a tokio update in https://fuchsia-review.googlesource.com/c/fuchsia/+/611683, and we thought it would save other auditors time if we documented and shrunk down some `unsafe {}` blocks.

## Solution

This documents why it is safe to convert `bytes::UninitSlice` to `&mut [MaybeUninit<u8>]`, and shrinks one of the unsafe blocks to make these functions easier to audit.

This also removes an out of date comment around converting a `&mut [MaybeUninit<u8>]` to a `&mut [u8]`, which predated the conversion over to `ReadBuf`, and is no longer applicable to the code.