### PR TITLE
windows: add feature std for winapi

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
-features = ["std"]
+features = ["std", "winsock2", "mswsock", "handleapi", "ws2ipdef", "ws2tcpip"]
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,6 +118,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
+features = []
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
-features = []
+features = ["std"]
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]


### PR DESCRIPTION
Switching from winapi to windows-sys in mio means that the `std` feature of winapi is no longer enabled when compiling Tokio on windows. However, in this case, the `c_void` type is not the same as the `c_void` type in the standard library, which causes some compiler errors in various places.

(The first commit to this PR does not add the feature to verify that CI catches the issue when its not fixed.)

Closes: #4662