### PR TITLE
add required winapi features

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -39,6 +39,9 @@ full = [
   "signal",
   "sync",
   "time",
+  "winapi/fileapi",
+  "winapi/handleapi",
+  "winapi/std",
 ]
 
 fs = []
@@ -63,6 +66,7 @@ process = [
   "mio/net",
   "signal-hook-registry",
   "winapi/threadpoollegacyapiset",
+  "winapi/winbase",
 ]
 # Includes basic task execution capabilities
 rt = ["once_cell"]


### PR DESCRIPTION
there are a bunch of features that tokio source uses but not enable itself. this appear to be being enabled through dev-dependencies and the new feature resolution results in them not being on and the code not building in release

fixes #4662

not sure how to test this though... i did it manually by removing all the dev-dependencies and changing to rust 2021
