### PR TITLE
Prepare tokio 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.1", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.18.2 (May 5, 2022)
+
+Add missing features for the `winapi` dependency. ([#4663])
+
+[#4663]: https://github.com/tokio-rs/tokio/pull/4663
+
 # 1.18.1 (May 2, 2022)
 
 The 1.18.0 release broke the build for targets without 64-bit atomics when

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,6 +118,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
+features = ["std", "winsock2", "mswsock", "handleapi", "ws2ipdef", "ws2tcpip"]
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.18.1"
+version = "1.18.2"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.1", features = ["full"] }
+tokio = { version = "1.18.2", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.18.2 (May 5, 2022)

Add missing features for the `winapi` dependency. ([#4663])

[#4663]: https://github.com/tokio-rs/tokio/pull/4663