### PR TITLE
Prepare tokio 1.14.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.14.1", features = ["full"] }
+tokio = { version = "1.14.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.14.2 (May 8, 2022)
+
+This is a backport of the change in 1.18.2.
+
+Add missing features for the `winapi` dependency. ([#4663])
+
+[#4663]: https://github.com/tokio-rs/tokio/pull/4663
+
 # 1.14.1 (January 30, 2022)
 
 This release backports a bug fix from 1.16.1

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -115,6 +115,7 @@ nix = { version = "0.22.0" }
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
+features = ["std", "winsock2", "mswsock", "handleapi", "ws2ipdef", "ws2tcpip"]
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -7,7 +7,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.14.1"
+version = "1.14.2"
 edition = "2018"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.14.1", features = ["full"] }
+tokio = { version = "1.14.2", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.14.2 (May 8, 2022)

This is a backport of the change in 1.18.2.

Add missing features for the `winapi` dependency. ([#4663])

[#4663]: https://github.com/tokio-rs/tokio/pull/4663