### PR TITLE
Make global queue and event polling intervals configurable

### DIFF
--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -57,6 +57,12 @@ struct Core {
 
     /// Metrics batch
     metrics: MetricsBatch,
+
+    /// How many ticks before pulling a task from the global/remote queue?
+    global_queue_interval: u8,
+
+    /// How many ticks before yielding to the driver for timer and I/O events?
+    event_interval: u8,
 }
 
 #[derive(Clone)]
@@ -107,15 +113,6 @@ struct Context {
 /// Initial queue capacity.
 const INITIAL_CAPACITY: usize = 64;
 
-/// Max number of tasks to poll per tick.
-#[cfg(loom)]
-const MAX_TASKS_PER_TICK: usize = 4;
-#[cfg(not(loom))]
-const MAX_TASKS_PER_TICK: usize = 61;
-
-/// How often to check the remote queue first.
-const REMOTE_FIRST_INTERVAL: u8 = 31;
-
 // Tracks the current BasicScheduler.
 scoped_thread_local!(static CURRENT: Context);
 
@@ -125,6 +122,8 @@ impl BasicScheduler {
         handle_inner: HandleInner,
         before_park: Option<Callback>,
         after_unpark: Option<Callback>,
+        global_queue_interval: u8,
+        event_interval: u8,
     ) -> BasicScheduler {
         let unpark = driver.unpark();
 
@@ -148,6 +147,8 @@ impl BasicScheduler {
             tick: 0,
             driver: Some(driver),
             metrics: MetricsBatch::new(),
+            global_queue_interval,
+            event_interval,
         })));
 
         BasicScheduler {
@@ -514,12 +515,12 @@ impl CoreGuard<'_> {
                     }
                 }
 
-                for _ in 0..MAX_TASKS_PER_TICK {
+                for _ in 0..core.event_interval {
                     // Get and increment the current tick
                     let tick = core.tick;
                     core.tick = core.tick.wrapping_add(1);
 
-                    let entry = if tick % REMOTE_FIRST_INTERVAL == 0 {
+                    let entry = if tick % core.global_queue_interval == 0 {
                         core.spawner.pop().or_else(|| core.tasks.pop_front())
                     } else {
                         core.tasks.pop_front().or_else(|| core.spawner.pop())

--- a/tokio/src/runtime/basic_scheduler.rs
+++ b/tokio/src/runtime/basic_scheduler.rs
@@ -48,7 +48,7 @@ struct Core {
     spawner: Spawner,
 
     /// Current tick
-    tick: u8,
+    tick: u32,
 
     /// Runtime driver
     ///
@@ -59,10 +59,10 @@ struct Core {
     metrics: MetricsBatch,
 
     /// How many ticks before pulling a task from the global/remote queue?
-    global_queue_interval: u8,
+    global_queue_interval: u32,
 
     /// How many ticks before yielding to the driver for timer and I/O events?
-    event_interval: u8,
+    event_interval: u32,
 }
 
 #[derive(Clone)]
@@ -122,8 +122,8 @@ impl BasicScheduler {
         handle_inner: HandleInner,
         before_park: Option<Callback>,
         after_unpark: Option<Callback>,
-        global_queue_interval: u8,
-        event_interval: u8,
+        global_queue_interval: u32,
+        event_interval: u32,
     ) -> BasicScheduler {
         let unpark = driver.unpark();
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -322,7 +322,6 @@ impl Builder {
     /// ```
     /// # use tokio::runtime;
     /// # use std::sync::atomic::{AtomicUsize, Ordering};
-    ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
     ///     .thread_name_fn(|| {
@@ -374,7 +373,6 @@ impl Builder {
     ///
     /// ```
     /// # use tokio::runtime;
-    ///
     /// # pub fn main() {
     /// let runtime = runtime::Builder::new_multi_thread()
     ///     .on_thread_start(|| {
@@ -400,7 +398,6 @@ impl Builder {
     ///
     /// ```
     /// # use tokio::runtime;
-    ///
     /// # pub fn main() {
     /// let runtime = runtime::Builder::new_multi_thread()
     ///     .on_thread_stop(|| {
@@ -509,7 +506,6 @@ impl Builder {
     ///
     /// ```
     /// # use tokio::runtime;
-    ///
     /// # pub fn main() {
     /// let runtime = runtime::Builder::new_multi_thread()
     ///     .on_thread_unpark(|| {
@@ -578,7 +574,6 @@ impl Builder {
     /// ```
     /// # use tokio::runtime;
     /// # use std::time::Duration;
-    ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
     ///     .thread_keep_alive(Duration::from_millis(100))
@@ -606,7 +601,6 @@ impl Builder {
     ///
     /// ```
     /// # use tokio::runtime;
-    ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
     ///     .global_queue_interval(31)
@@ -637,7 +631,6 @@ impl Builder {
     ///
     /// ```
     /// # use tokio::runtime;
-    ///
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
     ///     .event_interval(31)

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -51,8 +51,8 @@ impl ThreadPool {
         handle_inner: HandleInner,
         before_park: Option<Callback>,
         after_unpark: Option<Callback>,
-        global_queue_interval: u8,
-        event_interval: u8,
+        global_queue_interval: u32,
+        event_interval: u32,
     ) -> (ThreadPool, Launch) {
         let parker = Parker::new(driver);
         let (shared, launch) = worker::create(

--- a/tokio/src/runtime/thread_pool/mod.rs
+++ b/tokio/src/runtime/thread_pool/mod.rs
@@ -51,10 +51,19 @@ impl ThreadPool {
         handle_inner: HandleInner,
         before_park: Option<Callback>,
         after_unpark: Option<Callback>,
+        global_queue_interval: u8,
+        event_interval: u8,
     ) -> (ThreadPool, Launch) {
         let parker = Parker::new(driver);
-        let (shared, launch) =
-            worker::create(size, parker, handle_inner, before_park, after_unpark);
+        let (shared, launch) = worker::create(
+            size,
+            parker,
+            handle_inner,
+            before_park,
+            after_unpark,
+            global_queue_interval,
+            event_interval,
+        );
         let spawner = Spawner { shared };
         let thread_pool = ThreadPool { spawner };
 

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -117,6 +117,12 @@ struct Core {
 
     /// Fast random number generator.
     rand: FastRand,
+
+    /// How many ticks before pulling a task from the global/remote queue?
+    global_queue_interval: u8,
+
+    /// How many ticks before yielding to the driver for timer and I/O events?
+    event_interval: u8,
 }
 
 /// State shared across all workers
@@ -198,6 +204,8 @@ pub(super) fn create(
     handle_inner: HandleInner,
     before_park: Option<Callback>,
     after_unpark: Option<Callback>,
+    global_queue_interval: u8,
+    event_interval: u8,
 ) -> (Arc<Shared>, Launch) {
     let mut cores = Vec::with_capacity(size);
     let mut remotes = Vec::with_capacity(size);
@@ -219,6 +227,8 @@ pub(super) fn create(
             park: Some(park),
             metrics: MetricsBatch::new(),
             rand: FastRand::new(seed()),
+            global_queue_interval,
+            event_interval,
         }));
 
         remotes.push(Remote { steal, unpark });
@@ -346,12 +356,6 @@ where
     }
 }
 
-/// After how many ticks is the global queue polled. This helps to ensure
-/// fairness.
-///
-/// The number is fairly arbitrary. I believe this value was copied from golang.
-const GLOBAL_POLL_INTERVAL: u8 = 61;
-
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
@@ -464,7 +468,7 @@ impl Context {
     }
 
     fn maintenance(&self, mut core: Box<Core>) -> Box<Core> {
-        if core.tick % GLOBAL_POLL_INTERVAL == 0 {
+        if core.tick % core.event_interval == 0 {
             // Call `park` with a 0 timeout. This enables the I/O driver, timer, ...
             // to run without actually putting the thread to sleep.
             core = self.park_timeout(core, Some(Duration::from_millis(0)));
@@ -551,7 +555,7 @@ impl Core {
 
     /// Return the next notified task available to this worker.
     fn next_task(&mut self, worker: &Worker) -> Option<Notified> {
-        if self.tick % GLOBAL_POLL_INTERVAL == 0 {
+        if self.tick % self.global_queue_interval == 0 {
             worker.inject().pop().or_else(|| self.next_local_task())
         } else {
             self.next_local_task().or_else(|| worker.inject().pop())

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -87,7 +87,7 @@ pub(super) struct Worker {
 /// Core data
 struct Core {
     /// Used to schedule bookkeeping tasks every so often.
-    tick: u8,
+    tick: u32,
 
     /// When a task is scheduled from a worker, it is stored in this slot. The
     /// worker will check this slot for a task **before** checking the run
@@ -119,10 +119,10 @@ struct Core {
     rand: FastRand,
 
     /// How many ticks before pulling a task from the global/remote queue?
-    global_queue_interval: u8,
+    global_queue_interval: u32,
 
     /// How many ticks before yielding to the driver for timer and I/O events?
-    event_interval: u8,
+    event_interval: u32,
 }
 
 /// State shared across all workers
@@ -204,8 +204,8 @@ pub(super) fn create(
     handle_inner: HandleInner,
     before_park: Option<Callback>,
     after_unpark: Option<Callback>,
-    global_queue_interval: u8,
-    event_interval: u8,
+    global_queue_interval: u32,
+    event_interval: u32,
 ) -> (Arc<Shared>, Launch) {
     let mut cores = Vec::with_capacity(size);
     let mut remotes = Vec::with_capacity(size);


### PR DESCRIPTION
Closes #4651

# Motivation

Some workloads strongly benefit from changing the scheduler constants that control:

* Global queue polling
* Event polling (the driver: timer, process, and I/O events)

# Solution

Adds knobs to the runtime builder to control the number of ticks between polling the global task queue (fairness) and the event driver (I/O prioritization). The default values for these knobs are determined based on what scheduler kind the builder is started with.

Both varieties of scheduler already supported these intervals, but they were defined by private constants. This PR moves the constants into the `Core` struct, where they can be supplied by the builder configuration.