### PR TITLE
docs: mention that Clippy must be run with the MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,10 @@ env:
   # - README.md
   # - tokio/README.md
   # - CONTRIBUTING.md
+  # - tokio/Cargo.toml
+  # - tokio-util/Cargo.toml
+  # - tokio-test/Cargo.toml
+  # - tokio-stream/Cargo.toml
   rust_min: 1.49.0
 
 defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2022-03-21
   rust_clippy: 1.52.0
+  # When updating this, also update:
+  # - README.md
+  # - tokio/README.md
+  # - CONTRIBUTING.md
   rust_min: 1.49.0
 
 defaults:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,20 @@ cargo check --all-features
 cargo test --all-features
 ```
 
+Clippy must be run using the MSRV, so Tokio can avoid having to `#[allow]` new
+lints whose fixes would be incompatible with the current MSRV:
+
+<!--
+When updating this, also update:
+- .github/workflows/ci.yml
+- README.md
+- tokio/README.md
+-->
+
+```
+cargo +1.49.0 clippy --all-features
+```
+
 When building documentation normally, the markers that list the features
 required for various parts of Tokio are missing. To build the documentation
 correctly, use this command:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,10 @@ When updating this, also update:
 - .github/workflows/ci.yml
 - README.md
 - tokio/README.md
+- tokio/Cargo.toml
+- tokio-util/Cargo.toml
+- tokio-test/Cargo.toml
+- tokio-stream/Cargo.toml
 -->
 
 ```

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ several other libraries, including:
 When updating this, also update:
 - .github/workflows/ci.yml
 - CONTRIBUTING.md
+- README.md
 - tokio/README.md
 - tokio/Cargo.toml
 - tokio-util/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -163,6 +163,12 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
+<!--
+When updating this, also update:
+- .github/workflows/ci.yml
+- CONTRIBUTING.md
+-->
+
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
 released at least six months ago. The current MSRV is 1.49.0.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ several other libraries, including:
 When updating this, also update:
 - .github/workflows/ci.yml
 - CONTRIBUTING.md
+- tokio/README.md
+- tokio/Cargo.toml
+- tokio-util/Cargo.toml
+- tokio-test/Cargo.toml
+- tokio-stream/Cargo.toml
 -->
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -167,6 +167,11 @@ several other libraries, including:
 When updating this, also update:
 - .github/workflows/ci.yml
 - CONTRIBUTING.md
+- README.md
+- tokio/Cargo.toml
+- tokio-util/Cargo.toml
+- tokio-test/Cargo.toml
+- tokio-stream/Cargo.toml
 -->
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -168,6 +168,7 @@ When updating this, also update:
 - .github/workflows/ci.yml
 - CONTRIBUTING.md
 - README.md
+- tokio/README.md
 - tokio/Cargo.toml
 - tokio-util/Cargo.toml
 - tokio-test/Cargo.toml

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -163,6 +163,12 @@ several other libraries, including:
 
 ## Supported Rust Versions
 
+<!--
+When updating this, also update:
+- .github/workflows/ci.yml
+- CONTRIBUTING.md
+-->
+
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
 released at least six months ago. The current MSRV is 1.49.0.


### PR DESCRIPTION
## Motivation

In #4675 I learnt the hard way that Tokio uses Clippy on its MSRV. 

## Solution

Document this in the contributor's guide.