### PR TITLE
Display JoinMap on docs.rs

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.18.0", features = ["sync"] }
+tokio = { version = "1.18.0", path = "../tokio", features = ["sync"] }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
@@ -48,9 +48,9 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 hashbrown = { version = "0.12.0", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", features = ["full"] }
-tokio-test = { version = "0.4.0" }
-tokio-stream = { version = "0.1" }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 async-stream = "0.3.0"
 futures = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.18.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.18.0", features = ["sync"] }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
@@ -48,9 +48,9 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 hashbrown = { version = "0.12.0", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
-tokio-test = { version = "0.4.0", path = "../tokio-test" }
-tokio-stream = { version = "0.1", path = "../tokio-stream" }
+tokio = { version = "1.0.0", features = ["full"] }
+tokio-test = { version = "0.4.0" }
+tokio-stream = { version = "0.1" }
 
 async-stream = "0.3.0"
 futures = "0.3.0"
@@ -58,4 +58,8 @@ futures-test = "0.3.5"
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+# enable unstable features in the documentation
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
+# it's necessary to _also_ pass `--cfg tokio_unstable` to rustc, or else
+# dependencies will not be enabled, and the docs build will fail.
+rustc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]


### PR DESCRIPTION
Currently, the new `JoinMap` introduced by [#4640] would not be visible on [docs.rs] because we don't enable unstable features.

[#4640]: https://github.com/tokio-rs/tokio/pull/4640
[docs.rs]: https://docs.rs/tokio-util/