### PR TITLE
stream: add StreamExt#chunks_timeout

### DIFF
--- a/tokio-stream/src/stream_ext/chunks_timeout.rs
+++ b/tokio-stream/src/stream_ext/chunks_timeout.rs
@@ -1,0 +1,93 @@
+use crate::stream_ext::Fuse;
+use crate::Stream;
+use tokio::time::Sleep;
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+use std::time::Duration;
+
+pin_project! {
+    /// Stream returned by the [`chunks_timeout`](super::StreamExt::chunks_timeout) method.
+    #[must_use = "streams do nothing unless polled"]
+    #[derive(Debug)]
+    pub struct ChunksTimeout<S: Stream> {
+        #[pin]
+        stream: Fuse<S>,
+        #[pin]
+        deadline: Sleep,
+        duration: Duration,
+        items: Vec<S::Item>,
+        cap: usize, // https://github.com/rust-lang/futures-rs/issues/1475
+    }
+}
+
+impl<S: Stream> ChunksTimeout<S> {
+    pub(super) fn new(stream: S, capacity: usize, duration: Duration) -> Self {
+        ChunksTimeout {
+            stream: Fuse::new(stream),
+            deadline: tokio::time::sleep(duration),
+            duration,
+            items: Vec::with_capacity(capacity),
+            cap: capacity,
+        }
+    }
+
+    fn take(mut self: Pin<&mut Self>) -> Vec<S::Item> {
+        let duration = self.duration;
+        let cap = self.cap;
+        let this = self.as_mut().project();
+        this.deadline.reset(tokio::time::Instant::now() + duration);
+
+        std::mem::replace(this.items, Vec::with_capacity(cap))
+    }
+}
+
+impl<S: Stream> Stream for ChunksTimeout<S> {
+    type Item = Vec<S::Item>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.as_mut().project();
+        loop {
+            match me.stream.as_mut().poll_next(cx) {
+                Poll::Pending => {}
+                Poll::Ready(Some(item)) => {
+                    me.items.push(item);
+                    if me.items.len() >= *me.cap {
+                        return Poll::Ready(Some(self.take()));
+                    }
+                }
+
+                Poll::Ready(None) => {
+                    let last = if me.items.is_empty() {
+                        None
+                    } else {
+                        let full_buf = std::mem::take(me.items);
+                        Some(full_buf)
+                    };
+
+                    return Poll::Ready(last);
+                }
+            }
+
+            match me.deadline.as_mut().poll(cx) {
+                Poll::Pending => {}
+                Poll::Ready(()) => {
+                    return Poll::Ready(Some(self.take()));
+                }
+            }
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let chunk_len = if self.items.is_empty() { 0 } else { 1 };
+        let (lower, upper) = self.stream.size_hint();
+        let lower = lower.saturating_add(chunk_len);
+        let upper = match upper {
+            Some(x) => x.checked_add(chunk_len),
+            None => None,
+        };
+        (lower, upper)
+    }
+}

--- a/tokio-stream/tests/chunks_timeout.rs
+++ b/tokio-stream/tests/chunks_timeout.rs
@@ -1,0 +1,27 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "time", feature = "sync", feature = "io-util"))]
+
+use tokio::time;
+use tokio_stream::{self as stream, StreamExt};
+
+use futures::FutureExt;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn usage() {
+    let iter = vec![1, 2, 3].into_iter();
+    let stream0 = stream::iter(iter);
+
+    let iter = vec![4].into_iter();
+    let stream1 = stream::iter(iter)
+         .then(move |n| time::sleep(Duration::from_secs(2)).map(move |_| n));
+
+    let chunk_stream = stream0
+        .chain(stream1)
+        .chunks_timeout(4, Duration::from_secs(1));
+
+    tokio::pin!(chunk_stream);
+
+    assert_eq!(chunk_stream.next().await, Some(vec![1,2,3]));
+    assert_eq!(chunk_stream.next().await, Some(vec![4]));
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes https://github.com/tokio-rs/tokio/issues/4694. Name is still up for suggestions!

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This is essentially just adds a tokio timer on the futures_util [Chunks](https://github.com/rust-lang/futures-rs/blob/master/futures-util/src/stream/stream/chunks.rs).
Takes influence from https://github.com/mre/futures-batch which moved off the tokio timer API because it needed sub millisecond precision, however i don't think that's necessary here? 
