### PR TITLE
chore: update macro output tests for 1.61.0

### DIFF
--- a/tests-build/tests/fail/macros_dead_code.stderr
+++ b/tests-build/tests/fail/macros_dead_code.stderr
@@ -1,11 +1,11 @@
 error: function is never used: `f`
- --> tests/fail/macros_dead_code.rs:6:10
+ --> $DIR/macros_dead_code.rs:6:10
   |
 6 | async fn f() {}
   |          ^
   |
 note: the lint level is defined here
- --> tests/fail/macros_dead_code.rs:1:9
+ --> $DIR/macros_dead_code.rs:1:9
   |
 1 | #![deny(dead_code)]
   |         ^^^^^^^^^

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -1,101 +1,101 @@
 error: the `async` keyword is missing from the function declaration
- --> tests/fail/macros_invalid_input.rs:6:1
+ --> $DIR/macros_invalid_input.rs:6:1
   |
 6 | fn main_is_not_async() {}
   | ^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
- --> tests/fail/macros_invalid_input.rs:8:15
+ --> $DIR/macros_invalid_input.rs:8:15
   |
 8 | #[tokio::main(foo)]
   |               ^^^
 
 error: Must have specified ident
-  --> tests/fail/macros_invalid_input.rs:11:15
+  --> $DIR/macros_invalid_input.rs:11:15
    |
 11 | #[tokio::main(threadpool::bar)]
    |               ^^^^^^^^^^^^^^^
 
 error: the `async` keyword is missing from the function declaration
-  --> tests/fail/macros_invalid_input.rs:15:1
+  --> $DIR/macros_invalid_input.rs:15:1
    |
 15 | fn test_is_not_async() {}
    | ^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
-  --> tests/fail/macros_invalid_input.rs:17:15
+  --> $DIR/macros_invalid_input.rs:17:15
    |
 17 | #[tokio::test(foo)]
    |               ^^^
 
 error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
-  --> tests/fail/macros_invalid_input.rs:20:15
+  --> $DIR/macros_invalid_input.rs:20:15
    |
 20 | #[tokio::test(foo = 123)]
    |               ^^^^^^^^^
 
 error: Failed to parse value of `flavor` as string.
-  --> tests/fail/macros_invalid_input.rs:23:24
+  --> $DIR/macros_invalid_input.rs:23:24
    |
 23 | #[tokio::test(flavor = 123)]
    |                        ^^^
 
 error: No such runtime flavor `foo`. The runtime flavors are `current_thread` and `multi_thread`.
-  --> tests/fail/macros_invalid_input.rs:26:24
+  --> $DIR/macros_invalid_input.rs:26:24
    |
 26 | #[tokio::test(flavor = "foo")]
    |                        ^^^^^
 
 error: The `start_paused` option requires the `current_thread` runtime flavor. Use `#[tokio::test(flavor = "current_thread")]`
-  --> tests/fail/macros_invalid_input.rs:29:55
+  --> $DIR/macros_invalid_input.rs:29:55
    |
 29 | #[tokio::test(flavor = "multi_thread", start_paused = false)]
    |                                                       ^^^^^
 
 error: Failed to parse value of `worker_threads` as integer.
-  --> tests/fail/macros_invalid_input.rs:32:57
+  --> $DIR/macros_invalid_input.rs:32:57
    |
 32 | #[tokio::test(flavor = "multi_thread", worker_threads = "foo")]
    |                                                         ^^^^^
 
 error: The `worker_threads` option requires the `multi_thread` runtime flavor. Use `#[tokio::test(flavor = "multi_thread")]`
-  --> tests/fail/macros_invalid_input.rs:35:59
+  --> $DIR/macros_invalid_input.rs:35:59
    |
 35 | #[tokio::test(flavor = "current_thread", worker_threads = 4)]
    |                                                           ^
 
 error: Failed to parse value of `crate` as ident.
-  --> tests/fail/macros_invalid_input.rs:38:23
+  --> $DIR/macros_invalid_input.rs:38:23
    |
 38 | #[tokio::test(crate = 456)]
    |                       ^^^
 
 error: Failed to parse value of `crate` as ident: "456"
-  --> tests/fail/macros_invalid_input.rs:41:23
+  --> $DIR/macros_invalid_input.rs:41:23
    |
 41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
 error: Failed to parse value of `crate` as ident: "abc::edf"
-  --> tests/fail/macros_invalid_input.rs:44:23
+  --> $DIR/macros_invalid_input.rs:44:23
    |
 44 | #[tokio::test(crate = "abc::edf")]
    |                       ^^^^^^^^^^
 
 error: second test attribute is supplied
-  --> tests/fail/macros_invalid_input.rs:48:1
+  --> $DIR/macros_invalid_input.rs:48:1
    |
 48 | #[test]
    | ^^^^^^^
 
 error: duplicated attribute
-  --> tests/fail/macros_invalid_input.rs:48:1
+  --> $DIR/macros_invalid_input.rs:48:1
    |
 48 | #[test]
    | ^^^^^^^
    |
 note: the lint level is defined here
-  --> tests/fail/macros_invalid_input.rs:1:9
+  --> $DIR/macros_invalid_input.rs:1:9
    |
 1  | #![deny(duplicate_macro_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,8 +1,8 @@
 error[E0308]: mismatched types
- --> tests/fail/macros_type_mismatch.rs:5:5
+ --> $DIR/macros_type_mismatch.rs:5:5
   |
 4 | async fn missing_semicolon_or_return_type() {
-  |                                             - possibly return type missing here?
+  |                                             - help: a return type might be missing here: `-> _`
 5 |     Ok(())
   |     ^^^^^^ expected `()`, found enum `Result`
   |
@@ -10,10 +10,10 @@ error[E0308]: mismatched types
                   found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:10:5
+  --> $DIR/macros_type_mismatch.rs:10:5
    |
 9  | async fn missing_return_type() {
-   |                                - possibly return type missing here?
+   |                                - help: a return type might be missing here: `-> _`
 10 |     return Ok(());
    |     ^^^^^^^^^^^^^^ expected `()`, found enum `Result`
    |
@@ -21,7 +21,7 @@ error[E0308]: mismatched types
                    found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:23:5
+  --> $DIR/macros_type_mismatch.rs:23:5
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
    |                               -------------- expected `Result<(), ()>` because of return type
@@ -31,18 +31,17 @@ error[E0308]: mismatched types
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try wrapping the expression in a variant of `Result`
+help: try adding an expression at the end of the block
    |
-23 |     Ok(Ok(());)
-   |     +++       +
-23 |     Err(Ok(());)
-   |     ++++       +
+23 ~     Ok(());;
+24 +     Ok(())
+   |
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:32:5
+  --> $DIR/macros_type_mismatch.rs:32:5
    |
 30 | async fn issue_4635() {
-   |                       - possibly return type missing here?
+   |                       - help: try adding a return type: `-> i32`
 31 |     return 1;
 32 |     ;
    |     ^ expected `()`, found integer


### PR DESCRIPTION
Rust version 1.61.0 was just released, and it comes with some changes to how errors are formatted.