### PR TITLE
chore(runtime): add `is_finished` method for `JoinHandle` and `AbortHandle`

### DIFF
--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -49,15 +49,12 @@ impl AbortHandle {
         }
     }
 
-    /// Checks if the task associated with the handle has finished(whether completed or cancelled).
-    /// Like [`JoinHandle::is_finished`], this function does not block.
+    /// Checks if the task associated with this `JoinHandle` has finished.
     ///
-    /// # Notes
-    ///
-    /// Cancelling a task may need some time to take effect. This function only returns true
-    /// when the task has completed the cancellation process.
-    ///
-    /// [`JoinHandle::is_finished`]: method@super::JoinHandle::is_finished
+    /// Please note that this method can return `false` even if `abort` has been
+    /// called on the task. This is because the cancellation process may take
+    /// some time, and this method does not return `true` until it has
+    /// completed.
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
     pub fn is_finished(&self) -> bool {
         if let Some(raw) = self.raw {

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -49,6 +49,22 @@ impl AbortHandle {
         }
     }
 
+    /// Checks if the task associated with the handle has finished(whether completed or cancelled).
+    /// Like [`JoinHandle::is_finished`] this function does not block.
+    /// Once this returns true, the task is expected to finish quickly,
+    /// without blocking for any significant amount of time.
+    ///
+    /// [`JoinHandle::is_finished`]: method@super::JoinHandle::is_finished
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+    pub fn is_finished(&self) -> bool {
+        if let Some(raw) = self.raw {
+            let state = raw.header().state.load();
+            state.is_complete() || state.is_cancelled()
+        } else {
+            true
+        }
+    }
+
     /// Returns a [task ID] that uniquely identifies this task relative to other
     /// currently spawned tasks.
     ///

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -50,16 +50,14 @@ impl AbortHandle {
     }
 
     /// Checks if the task associated with the handle has finished(whether completed or cancelled).
-    /// Like [`JoinHandle::is_finished`] this function does not block.
-    /// Once this returns true, the task is expected to finish quickly,
-    /// without blocking for any significant amount of time.
+    /// Like [`JoinHandle::is_finished`], this function does not block.
     ///
     /// [`JoinHandle::is_finished`]: method@super::JoinHandle::is_finished
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
     pub fn is_finished(&self) -> bool {
         if let Some(raw) = self.raw {
             let state = raw.header().state.load();
-            state.is_complete() || state.is_cancelled()
+            state.is_complete()
         } else {
             true
         }

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -52,6 +52,11 @@ impl AbortHandle {
     /// Checks if the task associated with the handle has finished(whether completed or cancelled).
     /// Like [`JoinHandle::is_finished`], this function does not block.
     ///
+    /// # Notes
+    ///
+    /// Cancelling a task may need some time to take effect. This function only returns true
+    /// when the task has completed the cancellation process.
+    ///
     /// [`JoinHandle::is_finished`]: method@super::JoinHandle::is_finished
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
     pub fn is_finished(&self) -> bool {

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -49,7 +49,7 @@ impl AbortHandle {
         }
     }
 
-    /// Checks if the task associated with this `JoinHandle` has finished.
+    /// Checks if the task associated with this `AbortHandle` has finished.
     ///
     /// Please note that this method can return `false` even if `abort` has been
     /// called on the task. This is because the cancellation process may take

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -214,21 +214,21 @@ impl<T> JoinHandle<T> {
     /// use tokio::time;
     ///
     /// # #[tokio::main(flavor = "current_thread")]
-    /// async fn main() {
-    /// #  time::pause();
-    ///    let handle1 = tokio::spawn(async {
-    ///        // do some stuff here
-    ///    });
-    ///    let handle2 = tokio::spawn(async {
-    ///        // do some other stuff here
-    ///        time::sleep(time::Duration::from_secs(10)).await;
-    ///    });
-    ///    // Wait for the task to finish
-    ///    handle2.abort();
-    ///    time::sleep(time::Duration::from_secs(1)).await;
-    ///    assert!(handle1.is_finished());
-    ///    assert!(handle2.is_finished());
-    /// }
+    /// # async fn main() {
+    /// # time::pause();
+    /// let handle1 = tokio::spawn(async {
+    ///     // do some stuff here
+    /// });
+    /// let handle2 = tokio::spawn(async {
+    ///     // do some other stuff here
+    ///     time::sleep(time::Duration::from_secs(10)).await;
+    /// });
+    /// // Wait for the task to finish
+    /// handle2.abort();
+    /// time::sleep(time::Duration::from_secs(1)).await;
+    /// assert!(handle1.is_finished());
+    /// assert!(handle2.is_finished());
+    /// # }
     /// ```
     /// [`abort`]: method@JoinHandle::abort
     pub fn is_finished(&self) -> bool {

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -219,9 +219,9 @@ impl<T> JoinHandle<T> {
     ///        time::sleep(time::Duration::from_secs(10)).await;
     ///    });
     ///    // Wait for the task to finish
+    ///    handle2.abort();
     ///    time::sleep(time::Duration::from_secs(1)).await;
     ///    assert!(handle1.is_finished());
-    ///    handle2.abort();
     ///    assert!(handle2.is_finished());
     /// }
     /// ```

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -204,8 +204,7 @@ impl<T> JoinHandle<T> {
     }
 
     /// Checks if the task associated with the handle has finished(whether completed or cancelled).
-    /// This function does not block. Once this returns true, the task is expected
-    /// to finish quickly, without blocking for any significant amount of time.
+    /// This function does not block.
     ///
     /// ```rust
     /// use tokio::time;
@@ -229,7 +228,7 @@ impl<T> JoinHandle<T> {
     pub fn is_finished(&self) -> bool {
         if let Some(raw) = self.raw {
             let state = raw.header().state.load();
-            state.is_complete() || state.is_cancelled()
+            state.is_complete()
         } else {
             true
         }

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -205,7 +205,7 @@ impl<T> JoinHandle<T> {
 
     /// Checks if the task associated with this `JoinHandle` has finished.
     ///
-    /// Please note that this method can return `false` even if `abort` has been
+    /// Please note that this method can return `false` even if [`abort`] has been
     /// called on the task. This is because the cancellation process may take
     /// some time, and this method does not return `true` until it has
     /// completed.

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -203,13 +203,12 @@ impl<T> JoinHandle<T> {
         }
     }
 
-    /// Checks if the task associated with the handle has finished(whether completed or cancelled).
-    /// This function does not block.
+    /// Checks if the task associated with this `JoinHandle` has finished.
     ///
-    /// # Notes
-    ///
-    /// Cancelling a task may need some time to take effect. This function only returns true
-    /// when the task has completed the cancellation process.
+    /// Please note that this method can return `false` even if `abort` has been
+    /// called on the task. This is because the cancellation process may take
+    /// some time, and this method does not return `true` until it has
+    /// completed.
     ///
     /// ```rust
     /// use tokio::time;
@@ -231,6 +230,7 @@ impl<T> JoinHandle<T> {
     ///    assert!(handle2.is_finished());
     /// }
     /// ```
+    /// [`abort`]: method@JoinHandle::abort
     pub fn is_finished(&self) -> bool {
         if let Some(raw) = self.raw {
             let state = raw.header().state.load();

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -206,11 +206,17 @@ impl<T> JoinHandle<T> {
     /// Checks if the task associated with the handle has finished(whether completed or cancelled).
     /// This function does not block.
     ///
+    /// # Notes
+    ///
+    /// Cancelling a task may need some time to take effect. This function only returns true
+    /// when the task has completed the cancellation process.
+    ///
     /// ```rust
     /// use tokio::time;
     ///
-    /// #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// async fn main() {
+    /// #  time::pause();
     ///    let handle1 = tokio::spawn(async {
     ///        // do some stuff here
     ///    });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

add `is_finished` method for `JoinHandle` and `AbortHandle` .
Close #4707
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Check task's state is whether `COMPLETE` or `CANCELLED`. 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
