### PR TITLE
docs: correct example in MissedTickBehavior::Burst

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -207,6 +207,9 @@ pub enum MissedTickBehavior {
     /// # async fn main() {
     /// let mut interval = interval(Duration::from_millis(50));
     ///
+    /// // First tick resolves immediately after creation
+    /// interval.tick().await;
+    ///
     /// task_that_takes_200_millis().await;
     /// // The `Interval` has missed a tick
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Hi there! While looking at the [docs for MissedTickBehavior](https://docs.rs/tokio/1.18.2/tokio/time/enum.MissedTickBehavior.html#variant.Burst), I noticed that the comments in the code example have a very small error.

```rust
use tokio::time::{interval, Duration};

let mut interval = interval(Duration::from_millis(50));

task_that_takes_200_millis().await;
// The `Interval` has missed a tick

// Since we have exceeded our timeout, this will resolve immediately
interval.tick().await;

// Since we are more than 100ms after the start of `interval`, this will
// also resolve immediately.
interval.tick().await;

// Also resolves immediately, because it was supposed to resolve at
// 150ms after the start of `interval`
interval.tick().await;

// Resolves immediately
interval.tick().await;

// Since we have gotten to 200ms after the start of `interval`, this
// will resolve after 50ms
interval.tick().await;
```

The code example forgets that the first `interval.tick()` resolves immediately after creation. So if you print out all of the elapsed times after each tick, you'll see that they all resolve immediately. 

Here's a [playground link](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1981aebae29f25555ae390079ca27782) that shows the issue. If you run this code then you'll see the following output:

```
1. 201.484664ms
2. 201.523575ms
3. 201.528885ms
4. 201.535065ms
5. 201.555235ms
```

However, if you uncomment line 11, which has the extra `interval.tick().await;` that this PR proposes, then the output changes to what would be expected in the docs:

```
1. 202.916324ms
2. 203.013206ms
3. 203.050227ms
4. 203.094128ms
5. 251.418813ms
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR fixes the issue by just adding one more line with `interval.tick().await` at the beginning of the example, before the long task.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
