### PR TITLE
docs: add cancel-safety docs to StreamExt::next methods and types

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -113,6 +113,12 @@ pub trait StreamExt: Stream {
     /// pinning it to the stack using the `pin_mut!` macro from the `pin_utils`
     /// crate.
     ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. The returned future only
+    /// holds onto a reference to the underlying stream,
+    /// so dropping it will never lose a value.
+    ///
     /// # Examples
     ///
     /// ```
@@ -148,6 +154,12 @@ pub trait StreamExt: Stream {
     /// but returns a [`Result<Option<T>, E>`](Result) rather than
     /// an [`Option<Result<T, E>>`](Option), making for easy use
     /// with the [`?`](std::ops::Try) operator.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. The returned future only
+    /// holds onto a reference to the underlying stream,
+    /// so dropping it will never lose a value.
     ///
     /// # Examples
     ///

--- a/tokio-stream/src/stream_ext/next.rs
+++ b/tokio-stream/src/stream_ext/next.rs
@@ -8,6 +8,13 @@ use pin_project_lite::pin_project;
 
 pin_project! {
     /// Future for the [`next`](super::StreamExt::next) method.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. It only
+    /// holds onto a reference to the underlying stream,
+    /// so dropping it will never lose a value.
+    ///
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Next<'a, St: ?Sized> {

--- a/tokio-stream/src/stream_ext/try_next.rs
+++ b/tokio-stream/src/stream_ext/try_next.rs
@@ -9,6 +9,12 @@ use pin_project_lite::pin_project;
 
 pin_project! {
     /// Future for the [`try_next`](super::StreamExt::try_next) method.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe. It only
+    /// holds onto a reference to the underlying stream,
+    /// so dropping it will never lose a value.
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct TryNext<'a, St: ?Sized> {


### PR DESCRIPTION
## Motivation

Many futures are commonly used in `select!` (or similar) constructs, and people are interested to know which futures are cancel-safe. Two such common features are `next` and `try_next`, to get new values from a `Stream`. These only hold onto references to the underlying stream, and are therefor cancel-safe.

## Solution

Document the cancel-safety of the `StreamExt::next` and `StreamExt::try_next` methods (and their underlying future types)
