### PR TITLE
Implement a function that gives access to ID of currently executed task

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -1,15 +1,24 @@
 //! Thread local runtime context
+use crate::runtime::task::Id;
 use crate::runtime::{Handle, TryCurrentError};
 use crate::util::{replace_thread_rng, RngSeed};
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 
-tokio_thread_local! {
-    static CONTEXT: RefCell<Option<Handle>> = const { RefCell::new(None) }
+struct Context {
+    handle: RefCell<Option<Handle>>,
+    task_id: Cell<Option<Id>>,
+}
+
+thread_local! {
+    static CONTEXT: Context = const { Context {
+        handle: RefCell::new(None),
+        task_id: Cell::new(None),
+    }}
 }
 
 pub(crate) fn try_current() -> Result<Handle, crate::runtime::TryCurrentError> {
-    match CONTEXT.try_with(|ctx| ctx.borrow().clone()) {
+    match CONTEXT.try_with(|ctx| ctx.handle.borrow().clone()) {
         Ok(Some(handle)) => Ok(handle),
         Ok(None) => Err(TryCurrentError::new_no_context()),
         Err(_access_error) => Err(TryCurrentError::new_thread_local_destroyed()),
@@ -24,11 +33,22 @@ pub(crate) fn current() -> Handle {
     }
 }
 
+pub(crate) fn set_current_task_id(id: Option<Id>) -> Option<Id> {
+    CONTEXT.with(|ctxt| ctxt.task_id.replace(id))
+}
+
+pub(crate) fn current_task_id() -> Id {
+    match CONTEXT.with(|ctxt| ctxt.task_id.get()) {
+        Some(id) => id,
+        _ => panic!("tried to get current task id from outside of task"),
+    }
+}
+
 cfg_io_driver! {
     #[track_caller]
     pub(crate) fn io_handle() -> crate::runtime::driver::IoHandle {
         match CONTEXT.try_with(|ctx| {
-            let ctx = ctx.borrow();
+            let ctx = ctx.handle.borrow();
             ctx.as_ref()
                 .expect(crate::util::error::CONTEXT_MISSING_ERROR)
                 .inner
@@ -46,7 +66,7 @@ cfg_signal_internal! {
     #[cfg(unix)]
     pub(crate) fn signal_handle() -> crate::runtime::driver::SignalHandle {
         match CONTEXT.try_with(|ctx| {
-            let ctx = ctx.borrow();
+            let ctx = ctx.handle.borrow();
             ctx.as_ref()
                 .expect(crate::util::error::CONTEXT_MISSING_ERROR)
                 .inner
@@ -63,7 +83,7 @@ cfg_time! {
     cfg_test_util! {
         pub(crate) fn clock() -> Option<crate::runtime::driver::Clock> {
             match CONTEXT.try_with(|ctx| {
-                let ctx = ctx.borrow();
+                let ctx = ctx.handle.borrow();
                 ctx
                     .as_ref()
                     .map(|ctx| ctx.inner.clock().clone())
@@ -90,7 +110,7 @@ pub(crate) fn enter(new: Handle) -> EnterGuard {
 /// [`Handle`]: Handle
 pub(crate) fn try_enter(new: Handle) -> Option<EnterGuard> {
     let rng_seed = new.inner.seed_generator().next_seed();
-    let old_handle = CONTEXT.try_with(|ctx| ctx.borrow_mut().replace(new)).ok()?;
+    let old_handle = CONTEXT.try_with(|ctx| ctx.handle.borrow_mut().replace(new)).ok()?;
 
     let old_seed = replace_thread_rng(rng_seed);
 
@@ -109,7 +129,7 @@ pub(crate) struct EnterGuard {
 impl Drop for EnterGuard {
     fn drop(&mut self) {
         CONTEXT.with(|ctx| {
-            *ctx.borrow_mut() = self.old_handle.take();
+            *ctx.handle.borrow_mut() = self.old_handle.take();
         });
         // We discard the RngSeed associated with this guard
         let _ = replace_thread_rng(self.old_seed.clone());

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -3,7 +3,7 @@ use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime::context::EnterGuard;
 use crate::runtime::driver::{self, Driver};
-use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
+use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task, TaskIdGuard};
 use crate::runtime::{blocking, Config};
 use crate::runtime::{MetricsBatch, SchedulerMetrics, WorkerMetrics};
 use crate::sync::notify::Notify;
@@ -569,6 +569,8 @@ impl CoreGuard<'_> {
                         }
                     };
 
+                    let task_id = task.get_task_id();
+                    let _task_id_guard = TaskIdGuard::new(task_id);
                     let task = context.handle.shared.owned.assert_owner(task);
 
                     let (c, _) = context.run_task(core, || {

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -67,7 +67,7 @@ impl AbortHandle {
     #[cfg(tokio_unstable)]
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> super::Id {
-        self.id.clone()
+        self.id
     }
 }
 

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -128,7 +128,7 @@ impl JoinError {
     #[cfg(tokio_unstable)]
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> Id {
-        self.id.clone()
+        self.id
     }
 }
 

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -265,7 +265,7 @@ impl<T> JoinHandle<T> {
             raw.ref_inc();
             raw
         });
-        super::AbortHandle::new(raw, self.id.clone())
+        super::AbortHandle::new(raw, self.id)
     }
 
     /// Returns a [task ID] that uniquely identifies this task relative to other
@@ -280,7 +280,7 @@ impl<T> JoinHandle<T> {
     #[cfg(tokio_unstable)]
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> super::Id {
-        self.id.clone()
+        self.id
     }
 }
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -213,7 +213,6 @@ pub struct Id(u64);
 ///
 #[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
-#[allow(dead_code)]
 pub fn current_id() -> Id {
     use crate::runtime::context;
     context::current_task_id()

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -205,6 +205,20 @@ use std::{fmt, mem};
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
 pub struct Id(u64);
 
+/// Returns the `Id` of the currently executing task.
+///
+/// # Panics
+///
+/// This function panics if called from outside a task context
+///
+#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+#[allow(dead_code)]
+pub fn current_id() -> Id {
+    use crate::runtime::context;
+    context::current_task_id()
+}
+
 /// An owned handle to the task, tracked by ref count.
 #[repr(transparent)]
 pub(crate) struct Task<S: 'static> {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -213,6 +213,7 @@ pub struct Id(u64);
 ///
 #[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+#[track_caller]
 pub fn current_id() -> Id {
     use crate::runtime::context;
     context::current_task_id()

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -179,6 +179,10 @@ impl RawTask {
     pub(super) fn ref_inc(self) {
         self.header().state.ref_inc();
     }
+
+    pub(crate) fn get_task_id(&self) -> Id {
+        self.header().task_id
+    }
 }
 
 impl Clone for RawTask {

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -322,7 +322,6 @@ cfg_rt! {
         pub use crate::runtime::task::current_id;
     }
 
-
     cfg_trace! {
         mod builder;
         pub use builder::Builder;
@@ -332,6 +331,4 @@ cfg_rt! {
     pub mod futures {
         pub use super::task_local::TaskLocalFuture;
     }
-
-
 }

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -319,7 +319,7 @@ cfg_rt! {
 
     cfg_unstable! {
         pub use crate::runtime::task::Id;
-        pub use task_local::current_id;
+        pub use crate::runtime::task::current_id;
     }
 
 

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -319,7 +319,9 @@ cfg_rt! {
 
     cfg_unstable! {
         pub use crate::runtime::task::Id;
+        pub use task_local::current_id;
     }
+
 
     cfg_trace! {
         mod builder;
@@ -330,4 +332,6 @@ cfg_rt! {
     pub mod futures {
         pub use super::task_local::TaskLocalFuture;
     }
+
+
 }

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -1,4 +1,3 @@
-use crate::runtime::task::Id;
 use std::cell::RefCell;
 use std::error::Error;
 use std::future::Future;
@@ -446,18 +445,4 @@ impl From<std::thread::AccessError> for ScopeInnerErr {
     fn from(_: std::thread::AccessError) -> Self {
         Self::AccessError
     }
-}
-
-/// Returns the `Id` of the currently executing task.
-///
-/// # Panics
-///
-/// This function panics if called from outside a task context
-///
-#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
-#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
-#[allow(dead_code)]
-pub fn current_id() -> Id {
-    use crate::runtime::context;
-    context::current_task_id()
 }

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -1,3 +1,4 @@
+use crate::runtime::task::Id;
 use std::cell::RefCell;
 use std::error::Error;
 use std::future::Future;
@@ -445,4 +446,18 @@ impl From<std::thread::AccessError> for ScopeInnerErr {
     fn from(_: std::thread::AccessError) -> Self {
         Self::AccessError
     }
+}
+
+/// Returns the `Id` of the currently executing task.
+///
+/// # Panics
+///
+/// This function panics if called from outside a task context
+///
+#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+#[allow(dead_code)]
+pub fn current_id() -> Id {
+    use crate::runtime::context;
+    context::current_task_id()
 }

--- a/tokio/tests/task_panic.rs
+++ b/tokio/tests/task_panic.rs
@@ -120,3 +120,16 @@ fn local_key_get_panic_caller() -> Result<(), Box<dyn Error>> {
 
     Ok(())
 }
+
+#[cfg(tokio_unstable)]
+#[test]
+fn current_id_handle_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _ = task::current_id();
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes https://github.com/tokio-rs/tokio/issues/1996

This PR introduces a `tokio-unstable` function that allows one to get the `ID` of the currently executed task.

This introduces a new thread local `TASK_ID`, which is set before tasks are executed, to track which `Id` is currently executed on a worker. Had to move `task_id` from `Core` to `Header` in order to allow access to the id in a `RawTask`.