### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/tokio/src/future/poll_fn.rs
+++ b/tokio/src/future/poll_fn.rs
@@ -35,6 +35,6 @@ where
     type Output = T;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
-        (&mut self.f)(cx)
+        (self.f)(cx)
     }
 }

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -136,16 +136,22 @@ impl sealed::ToSocketAddrsPriv for &[SocketAddr] {
     type Future = ReadyFuture<Self::Iter>;
 
     fn to_socket_addrs(&self, _: sealed::Internal) -> Self::Future {
-        // Clippy doesn't like the `to_vec()` call here (as it will allocate,
-        // while `self.iter().copied()` would not), but it's actually necessary
-        // in order to ensure that the returned iterator is valid for the
-        // `'static` lifetime, which the borrowed `slice::Iter` iterator would
-        // not be.
+        #[inline]
+        fn slice_to_vec(addrs: &[SocketAddr]) -> Vec<SocketAddr> {
+            addrs.to_vec()
+        }
+
+        // This uses a helper method because clippy doesn't like the `to_vec()`
+        // call here (it will allocate, whereas `self.iter().copied()` would
+        // not), but it's actually necessary in order to ensure that the
+        // returned iterator is valid for the `'static` lifetime, which the
+        // borrowed `slice::Iter` iterator would not be.
+        //
         // Note that we can't actually add an `allow` attribute for
         // `clippy::unnecessary_to_owned` here, as Tokio's CI runs clippy lints
         // on Rust 1.52 to avoid breaking LTS releases of Tokio. Users of newer
         // Rust versions who see this lint should just ignore it.
-        let iter = self.to_vec().into_iter();
+        let iter = slice_to_vec(self).into_iter();
         future::ready(Ok(iter))
     }
 }


### PR DESCRIPTION
This fixes the following clippy warnings. (They don't appear in CI because CI uses an older clippy.)
```text
warning: this expression borrows a value the compiler would automatically borrow
  --> tokio/src/future/poll_fn.rs:38:9
   |
38 |         (&mut self.f)(cx)
   |         ^^^^^^^^^^^^^ help: change this to: `self.f`
   |
   = note: `#[warn(clippy::needless_borrow)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: methods called `is_*` usually take `self` by reference or no `self`
  --> tokio/src/io/util/vec_with_initialized.rs:67:28
   |
67 |     pub(crate) fn is_empty(&mut self) -> bool {
   |                            ^^^^^^^^^
   |
   = note: `#[warn(clippy::wrong_self_convention)]` on by default
   = help: consider choosing a less ambiguous name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

warning: unnecessary use of `to_vec`
   --> tokio/src/net/addr.rs:148:20
    |
148 |         let iter = self.to_vec().into_iter();
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use: `self.iter().copied()`
    |
    = note: `#[warn(clippy::unnecessary_to_owned)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_to_owned
```