### PR TITLE
Replace non-binding `if let` statements

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -501,7 +501,7 @@ impl Notify {
         // transition out of WAITING while the lock is held.
         let curr = self.state.load(SeqCst);
 
-        if let EMPTY | NOTIFIED = get_state(curr) {
+        if matches!(get_state(curr), EMPTY | NOTIFIED) {
             // There are no waiting tasks. All we need to do is increment the
             // number of times this method was called.
             atomic_inc_num_notify_waiters_calls(&self.state);
@@ -896,7 +896,7 @@ impl Drop for Notified<'_> {
         // This is where we ensure safety. The `Notified` value is being
         // dropped, which means we must ensure that the waiter entry is no
         // longer stored in the linked list.
-        if let Waiting = *state {
+        if matches!(*state, Waiting) {
             let mut waiters = notify.waiters.lock();
             let mut notify_state = notify.state.load(SeqCst);
 
@@ -907,7 +907,7 @@ impl Drop for Notified<'_> {
             unsafe { waiters.remove(NonNull::new_unchecked(waiter.get())) };
 
             if waiters.is_empty() {
-                if let WAITING = get_state(notify_state) {
+                if get_state(notify_state) == WAITING {
                     notify_state = set_state(notify_state, EMPTY);
                     notify.state.store(notify_state, SeqCst);
                 }
@@ -919,7 +919,7 @@ impl Drop for Notified<'_> {
             //
             // Safety: with the entry removed from the linked list, there can be
             // no concurrent access to the entry
-            if let Some(NotificationType::OneWaiter) = unsafe { (*waiter.get()).notified } {
+            if matches!(unsafe { (*waiter.get()).notified }, Some(NotificationType::OneWaiter)) {
                 if let Some(waker) = notify_locked(&mut waiters, &notify.state, notify_state) {
                     drop(waiters);
                     waker.wake();


### PR DESCRIPTION
## Motivation

Found some `if let` statements that don't actually bind any variables. This can make it somewhat confusing as to whether the pattern is binding the value or being matched against (note that irrefutable `if let` patterns are flagged by clippy).

## Solution

Switching to `matches!` and equality comparisons allow these to be removed.