### PR TITLE
net: Add `take_error` to `TcpSocket` and `TcpStream`

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -424,6 +424,11 @@ impl TcpSocket {
         self.inner.local_addr().and_then(convert_address)
     }
 
+    /// Returns the value of the `SO_ERROR` option.
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        self.inner.take_error()
+    }
+
     /// Binds the socket to the given address.
     ///
     /// This calls the `bind(2)` operating-system function. Behavior is

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -264,6 +264,11 @@ impl TcpStream {
         self.io.local_addr()
     }
 
+    /// Returns the value of the `SO_ERROR` option.
+    pub fn take_error(&self) -> io::Result<Option<io::Error>> {
+        self.io.take_error()
+    }
+
     /// Returns the remote address that this stream is connected to.
     ///
     /// # Examples


### PR DESCRIPTION
## Motivation

When manually creating a `TcpSocket` or `TcpStream` e.g. via `tokio::net::TcpStream::try_from` one should be able to check for errors after awaiting the connection to be writable (`writable()`) before assuming the connection to be successfully established.

This is needed e.g. in rust-libp2p, see https://github.com/libp2p/rust-libp2p/pull/2458.

## Solution

The first commit reintroduces https://github.com/tokio-rs/tokio/pull/4364 which first merged but later on reverted in https://github.com/tokio-rs/tokio/pull/4392. See also https://github.com/tokio-rs/tokio/pull/4392#issuecomment-1035542164.

The second commit adds the same method to `TcpStream`.

Tagging @taiki-e as the initial author.
