### PR TITLE
chore: prepare tokio-util 0.7.3

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.7.3 (June 4, 2022)
+
+### Changed
+
+- tracing: don't require default tracing features ([#4592])
+- util: simplify implementation of `ReusableBoxFuture` ([#4675])
+
+### Added (unstable)
+
+- task: add `JoinMap` ([#4640], [#4697])
+
+[#4592]: https://github.com/tokio-rs/tokio/pull/4592
+[#4640]: https://github.com/tokio-rs/tokio/pull/4640
+[#4675]: https://github.com/tokio-rs/tokio/pull/4675
+[#4697]: https://github.com/tokio-rs/tokio/pull/4697
+
 # 0.7.2 (May 14, 2022)
 
 This release contains a rewrite of `CancellationToken` that fixes a memory leak. ([#4652])

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.18.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.19.0", path = "../tokio", features = ["sync"] }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.2"
+version = "0.7.3"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.7.3 (June 4, 2022)

### Changed

- tracing: don't require default tracing features ([#4592])
- util: simplify implementation of `ReusableBoxFuture` ([#4675])

### Added (unstable)

- task: add `JoinMap` ([#4640], [#4697])

[#4592]: https://github.com/tokio-rs/tokio/pull/4592
[#4640]: https://github.com/tokio-rs/tokio/pull/4640
[#4675]: https://github.com/tokio-rs/tokio/pull/4675
[#4697]: https://github.com/tokio-rs/tokio/pull/4697