### PR TITLE
sync: fix `will_wake` usage in `Notify`

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -856,7 +856,7 @@ impl Notified<'_> {
                         // Update the waker, if necessary.
                         if let Some(waker) = waker {
                             let should_update = match w.waker.as_ref() {
-                                Some(current_waker) => current_waker.will_wake(waker),
+                                Some(current_waker) => !current_waker.will_wake(waker),
                                 None => true,
                             };
                             if should_update {

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -207,3 +207,21 @@ fn test_enable_consumes_permit() {
     let mut future2 = spawn(notify.notified());
     future2.enter(|_, fut| assert!(!fut.enable()));
 }
+
+#[test]
+fn test_waker_update() {
+    use futures::task::noop_waker;
+    use std::future::Future;
+    use std::task::Context;
+
+    let notify = Notify::new();
+    let mut future = spawn(notify.notified());
+
+    let noop = noop_waker();
+    future.enter(|_, fut| assert_pending!(fut.poll(&mut Context::from_waker(&noop))));
+
+    assert_pending!(future.poll());
+    notify.notify_one();
+
+    assert!(future.is_woken());
+}


### PR DESCRIPTION
This fixes a bug introduced by #4747.

The `will_wake` function is really tricky :(