### PR TITLE
Improve the documentation for #[tokio::test]

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -286,6 +286,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 ///     assert!(true);
 /// }
 /// ```
+///
 /// The `worker_threads` option configures the number of worker threads, and
 /// defaults to the number of cpus on the system. This is the default
 /// flavor.
@@ -316,7 +317,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-///Equivalent code not using `#[tokio::test]`
+/// Equivalent code not using `#[tokio::test]`
 ///
 /// ```no_run
 /// #[test]
@@ -340,7 +341,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-///Equivalent code not using `#[tokio::test]`
+/// Equivalent code not using `#[tokio::test]`
 ///
 /// ```no_run
 /// #[test]
@@ -364,7 +365,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-///Equivalent code not using `#[tokio::test]`
+/// Equivalent code not using `#[tokio::test]`
 ///
 /// ```no_run
 /// #[test]
@@ -389,7 +390,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-///Equivalent code not using `#[tokio::test]`
+/// Equivalent code not using `#[tokio::test]`
 ///
 /// ```no_run
 /// #[test]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -305,14 +305,14 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// The `worker_threads` option configures the number of worker threads, and
-/// defaults to the number of cpus on the system. The dafault flavour is 
-/// one worker thread.
+/// The `worker_threads` option configures the number of worker threads,
+/// and defaults to the number of cpus on the system. The dafault
+/// flavour is one worker thread.
 ///
 /// ### Using default
 ///
-/// The default test runtime is single-threaded. Each test gets a separate
-/// current-thread runtime.
+/// The default test runtime is single-threaded. Each test gets a
+/// separate current-thread runtime.
 ///
 /// ```no_run
 /// #[tokio::test]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -276,14 +276,41 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// [Builder](../tokio/runtime/struct.Builder.html), which provides a more
 /// powerful interface.
 ///
-/// ## Usage
-///
-/// ### Multi-thread runtime
+/// # Multi-threaded runtime
 ///
 /// To use the multi-threaded runtime, the macro can be configured using
 ///
 /// ```no_run
-/// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+/// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+/// The `worker_threads` option configures the number of worker threads, and
+/// defaults to the number of cpus on the system. This is the default
+/// flavor.
+///
+/// Note: The multi-threaded runtime requires the `rt-multi-thread` feature
+/// flag.
+///
+/// # Current thread runtime
+///
+/// The default test runtime is single-threaded. Each test gets a
+/// separate current-thread runtime.
+///
+/// ```no_run
+/// #[tokio::test]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+///
+/// ## Usage
+///
+/// ### Using the multi-thread runtime
+///
+/// ```no_run
+/// #[tokio::test(flavor = "multi_thread")]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -295,7 +322,6 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// #[test]
 /// fn my_test() {
 ///     tokio::runtime::Builder::new_multi_thread()
-///         .worker_threads(2)
 ///         .enable_all()
 ///         .build()
 ///         .unwrap()
@@ -305,14 +331,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// The `worker_threads` option configures the number of worker threads,
-/// and defaults to the number of cpus on the system. The dafault
-/// flavour is one worker thread.
-///
-/// ### Using default
-///
-/// The default test runtime is single-threaded. Each test gets a
-/// separate current-thread runtime.
+/// ### Using current thread runtime
 ///
 /// ```no_run
 /// #[tokio::test]
@@ -327,6 +346,31 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// #[test]
 /// fn my_test() {
 ///     tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             assert!(true);
+///         })
+/// }
+/// ```
+///
+/// ### Set number of worker threads
+///
+/// ```no_run
+/// #[tokio::test(flavor ="multi_thread", worker_threads = 2)]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+///
+///Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     tokio::runtime::Builder::new_multi_thread()
+///         .worker_threads(2)
 ///         .enable_all()
 ///         .build()
 ///         .unwrap()

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -265,27 +265,74 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::main(args, item, false)
 }
 
-/// Marks async function to be executed by runtime, suitable to test environment
+/// Marks async function to be executed by runtime, suitable to test environment.
+/// This macro helps set up a `Runtime` without requiring the user to use
+/// [Runtime](../tokio/runtime/struct.Runtime.html) or
+/// [Builder](../tokio/runtime/struct.Builder.html) directly.
+///
+/// Note: This macro is designed to be simplistic and targets applications that
+/// do not require a complex setup. If the provided functionality is not
+/// sufficient, you may be interested in using
+/// [Builder](../tokio/runtime/struct.Builder.html), which provides a more
+/// powerful interface.
 ///
 /// ## Usage
 ///
 /// ### Multi-thread runtime
 ///
+/// To use the multi-threaded runtime, the macro can be configured using
+///
 /// ```no_run
-/// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+/// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
 /// ```
 ///
+///Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     tokio::runtime::Builder::new_multi_thread()
+///         .worker_threads(2)
+///         .enable_all()
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             assert!(true);
+///         })
+/// }
+/// ```
+///
+/// The `worker_threads` option configures the number of worker threads, and
+/// defaults to the number of cpus on the system. The dafault flavour is 
+/// one worker thread.
+///
 /// ### Using default
 ///
-/// The default test runtime is single-threaded.
+/// The default test runtime is single-threaded. Each test gets a separate
+/// current-thread runtime.
 ///
 /// ```no_run
 /// #[tokio::test]
 /// async fn my_test() {
 ///     assert!(true);
+/// }
+/// ```
+///
+///Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             assert!(true);
+///         })
 /// }
 /// ```
 ///
@@ -295,6 +342,22 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// #[tokio::test(start_paused = true)]
 /// async fn my_test() {
 ///     assert!(true);
+/// }
+/// ```
+///
+///Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .start_paused(true)
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             assert!(true);
+///         })
 /// }
 /// ```
 ///


### PR DESCRIPTION
Improved documentation for #[tokio::test] to mirror the #[tokio::main] one

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Fixing issue #4720 
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Mirrored the #[tokio::main] documentation + explained that each test gets a separate current-thread runtime.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
