### PR TITLE
net: be more specific about winapi features

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -122,11 +122,40 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 libc = { version = "0.2.42", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = { version = "0.2.42" }
+nix = { version = "0.24", default-features = false, features = ["fs", "socket"] }
+
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
 
 optional = true
+
+[target.'cfg(windows)'.dev-dependencies.ntapi]
+version = "0.3.6"
+
+[dev-dependencies]
+tokio-test = { version = "0.4.0", path = "../tokio-test" }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
+futures = { version = "0.3.0", features = ["async-await"] }
+mockall = "0.11.1"
+tempfile = "3.1.0"
+async-stream = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+proptest = "1"
+rand = "0.8.0"
+socket2 = "0.4"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3.0"
+
+[target.'cfg(target_os = "freebsd")'.dev-dependencies]
+mio-aio = { version = "0.6.0", features = ["tokio"] }
+
+[target.'cfg(loom)'.dev-dependencies]
+loom = { version = "0.5.2", features = ["futures", "checkpoint"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -52,8 +52,12 @@ net = [
   "mio/os-ext",
   "mio/net",
   "socket2",
-  "winapi/namedpipeapi",
   "winapi/std",
+  "winapi/fileapi",
+  "winapi/handleapi",
+  "winapi/namedpipeapi",
+  "winapi/winbase",
+  "winapi/winnt",
 ]
 process = [
   "bytes",
@@ -63,7 +67,12 @@ process = [
   "mio/os-ext",
   "mio/net",
   "signal-hook-registry",
+  "winapi/std",
+  "winapi/handleapi",
+  "winapi/processthreadsapi",
   "winapi/threadpoollegacyapiset",
+  "winapi/winbase",
+  "winapi/winnt",
 ]
 # Includes basic task execution capabilities
 rt = ["once_cell"]
@@ -79,6 +88,7 @@ signal = [
   "mio/os-ext",
   "signal-hook-registry",
   "winapi/consoleapi",
+  "winapi/wincon",
 ]
 sync = []
 test-util = ["rt", "sync", "time"]
@@ -112,40 +122,11 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 libc = { version = "0.2.42", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
 
-[target.'cfg(unix)'.dev-dependencies]
-libc = { version = "0.2.42" }
-nix = { version = "0.24", default-features = false, features = ["fs", "socket"] }
-
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
 
 optional = true
-
-[target.'cfg(windows)'.dev-dependencies.ntapi]
-version = "0.3.6"
-
-[dev-dependencies]
-tokio-test = { version = "0.4.0", path = "../tokio-test" }
-tokio-stream = { version = "0.1", path = "../tokio-stream" }
-futures = { version = "0.3.0", features = ["async-await"] }
-mockall = "0.11.1"
-tempfile = "3.1.0"
-async-stream = "0.3"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-proptest = "1"
-rand = "0.8.0"
-socket2 = "0.4"
-
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-wasm-bindgen-test = "0.3.0"
-
-[target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { version = "0.6.0", features = ["tokio"] }
-
-[target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.5.2", features = ["futures", "checkpoint"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -52,7 +52,6 @@ net = [
   "mio/os-ext",
   "mio/net",
   "socket2",
-  "winapi/std",
   "winapi/fileapi",
   "winapi/handleapi",
   "winapi/namedpipeapi",
@@ -67,12 +66,12 @@ process = [
   "mio/os-ext",
   "mio/net",
   "signal-hook-registry",
-  "winapi/std",
   "winapi/handleapi",
   "winapi/processthreadsapi",
   "winapi/threadpoollegacyapiset",
   "winapi/winbase",
   "winapi/winnt",
+  "winapi/minwindef",
 ]
 # Includes basic task execution capabilities
 rt = ["once_cell"]
@@ -129,7 +128,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
-
+features = ["std"]
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -53,6 +53,7 @@ net = [
   "mio/net",
   "socket2",
   "winapi/namedpipeapi",
+  "winapi/std",
 ]
 process = [
   "bytes",
@@ -118,7 +119,7 @@ nix = { version = "0.24", default-features = false, features = ["fs", "socket"] 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3.8"
 default-features = false
-features = ["std", "winsock2", "mswsock", "handleapi", "ws2ipdef", "ws2tcpip"]
+
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -57,6 +57,7 @@ net = [
   "winapi/namedpipeapi",
   "winapi/winbase",
   "winapi/winnt",
+  "winapi/minwindef",
 ]
 process = [
   "bytes",
@@ -88,6 +89,7 @@ signal = [
   "signal-hook-registry",
   "winapi/consoleapi",
   "winapi/wincon",
+  "winapi/minwindef",
 ]
 sync = []
 test-util = ["rt", "sync", "time"]


### PR DESCRIPTION
## Motivation
be more specific about winapi features (#4737)

## Solution
add  `winapi/std` dependency in `net` feature, remove features in `dependencies.winapi`.
Below run all OK on my windows 10 PC
```
cargo build --all-features
cargo check --all-features
cargo test --all-features
```
