### PR TITLE
tokio polling mode support

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -4,7 +4,7 @@ error: the `async` keyword is missing from the function declaration
 6 | fn main_is_not_async() {}
   | ^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `poll_mode`
  --> $DIR/macros_invalid_input.rs:8:15
   |
 8 | #[tokio::main(foo)]
@@ -22,13 +22,13 @@ error: the `async` keyword is missing from the function declaration
 15 | fn test_is_not_async() {}
    | ^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `poll_mode`
   --> $DIR/macros_invalid_input.rs:17:15
    |
 17 | #[tokio::test(foo)]
    |               ^^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `poll_mode`
   --> $DIR/macros_invalid_input.rs:20:15
    |
 20 | #[tokio::test(foo = 123)]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -194,6 +194,34 @@ use proc_macro::TokenStream;
 ///         })
 /// }
 /// ```
+///
+/// ### Configure the runtime to start with poll_mode
+///
+/// ```rust
+/// #[tokio::main(flavor = "current_thread", poll_mode = true)]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+///
+/// Equivalent code not using `#[tokio::main]`
+///
+/// ```rust
+/// fn main() {
+///     tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .poll_mode()
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             println!("Hello world");
+///         })
+/// }
+/// ```
+///
+/// Note that `poll_mode` current only support the current_thread runtime, later
+/// will support multi_thread runtime.
+/// poll_mode can use without enable_io/enable_all/enable_time.
 #[proc_macro_attribute]
 #[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -418,6 +446,36 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 ///     println!("Hello world");
 /// }
 /// ```
+///
+/// ### Configure the runtime to start with poll_mode
+///
+/// ```no_run
+/// #[tokio::test(poll_mode = true)]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+///
+/// Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .poll_mode()
+///         .build()
+///         .unwrap()
+///         .block_on(async {
+///             assert!(true);
+///         })
+/// }
+/// ```
+///
+/// Note that `poll_mode` current only support the current_thread runtime, later
+/// will support multi_thread runtime.
+/// poll_mode can use without enable_io/enable_all/enable_time.
+///
 #[proc_macro_attribute]
 pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::test(args, item, true)

--- a/tokio/src/park/either.rs
+++ b/tokio/src/park/either.rs
@@ -45,6 +45,13 @@ where
             Either::B(b) => b.shutdown(),
         }
     }
+
+    fn idle(&self) {
+        match self {
+            Either::A(a) => a.idle(),
+            Either::B(b) => b.idle(),
+        }
+    }
 }
 
 impl<A, B> Unpark for Either<A, B>
@@ -56,6 +63,12 @@ where
         match self {
             Either::A(a) => a.unpark(),
             Either::B(b) => b.unpark(),
+        }
+    }
+    fn wake(&self) {
+        match self {
+            Either::A(a) => a.wake(),
+            Either::B(b) => b.wake(),
         }
     }
 }

--- a/tokio/src/park/mod.rs
+++ b/tokio/src/park/mod.rs
@@ -87,6 +87,10 @@ pub(crate) trait Park {
 
     /// Releases all resources held by the parker for proper leak-free shutdown.
     fn shutdown(&mut self);
+
+    /// Idle state set, label park_timeout with scheduler have nothing tasks to
+    /// run, used in the time driver for time pause with polling mode.
+    fn idle(&self) {}
 }
 
 /// Unblock a thread blocked by the associated `Park` instance.
@@ -102,6 +106,11 @@ pub(crate) trait Unpark: Sync + Send + 'static {
     /// an implementation detail. Refer to the documentation for the specific
     /// `Unpark` implementation.
     fn unpark(&self);
+
+    /// Wake state set, when curren thread scheduler have been wake by some time or
+    /// io event, then call the wake() to set woken= true ,used in the time driver
+    /// for time pause fn with polling mode.
+    fn wake(&self) {}
 }
 
 impl Unpark for Box<dyn Unpark> {

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -42,7 +42,7 @@ async fn pause_time_in_spawn_threads() {
 }
 
 #[test]
-fn paused_time_is_deterministic() {
+fn paused_time_is_deterministic_with_polling() {
     let run_1 = paused_time_stress_run();
     let run_2 = paused_time_stress_run();
 
@@ -51,6 +51,28 @@ fn paused_time_is_deterministic() {
 
 #[tokio::main(flavor = "current_thread", start_paused = true)]
 async fn paused_time_stress_run() -> Vec<Duration> {
+    let mut rng = StdRng::seed_from_u64(1);
+
+    let mut times = vec![];
+    let start = Instant::now();
+    for _ in 0..10_000 {
+        let sleep = rng.gen_range(Duration::from_secs(0)..Duration::from_secs(1));
+        time::sleep(sleep).await;
+        times.push(start.elapsed());
+    }
+
+    times
+}
+#[test]
+fn paused_time_is_deterministic_without_polling() {
+    let run_1 = paused_time_stress_run_without_polling();
+    let run_2 = paused_time_stress_run_without_polling();
+
+    assert_eq!(run_1, run_2);
+}
+
+#[tokio::main(flavor = "current_thread", start_paused = true, poll_mode = true)]
+async fn paused_time_stress_run_without_polling() -> Vec<Duration> {
     let mut rng = StdRng::seed_from_u64(1);
 
     let mut times = vec![];


### PR DESCRIPTION
Now only support current_thread runtime.
Add main,test macro poll_mode config

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
To continually polling the local and remote queue of the scheduler， not to park /blocking 
the current scheduler thread or worker when no tasks remaining， and avoding the mio 
eventfd write and parkthread's condvar syscalls


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
How to test the polling mode by the cargo test? I need help.
Now i just hardcode to enable the pollmode in the code, and 
run the cargo test and loom and mir with/without tokio_unstable. 
Only three tests worker_park_count, worker_noop_count ,worker_total_busy_duration in tokio/tests/rt_metrics.rs
fail when with tokio_unstable.

For the cargo test ,we can test for non-pollmode which is default,  and  poll_mode.
But how we enable poll_mode for cargo test? Env or  a feature? 

 

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
