### PR TITLE
chore: disable caching for cross jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,6 @@ jobs:
           toolchain: ${{ env.rust_stable }}
           target: ${{ matrix.target }}
           override: true
-      - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true


### PR DESCRIPTION
CI is running into https://github.com/cross-rs/cross/issues/724, which should be fixed if we clear the cache.