### PR TITLE
tests: alter integration tests for stdio to not use a handrolled cat implementation

### DIFF
--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [[bin]]
 name = "test-cat"
+required-features = ["rt-process-io-util"]
 
 [[bin]]
 name = "test-mem"
@@ -17,6 +18,7 @@ name = "test-process-signal"
 required-features = ["rt-process-signal"]
 
 [features]
+rt-process-io-util = ["tokio/rt", "tokio/macros", "tokio/process", "tokio/io-util", "tokio/io-std"]
 # For mem check
 rt-net = ["tokio/rt", "tokio/rt-multi-thread", "tokio/net"]
 # For test-process-signal

--- a/tests-integration/src/bin/test-cat.rs
+++ b/tests-integration/src/bin/test-cat.rs
@@ -1,20 +1,14 @@
 //! A cat-like utility that can be used as a subprocess to test I/O
 //! stream communication.
 
-use std::io;
-use std::io::Write;
+use tokio::io::AsyncWriteExt;
 
-fn main() {
-    let stdin = io::stdin();
-    let mut stdout = io::stdout();
-    let mut line = String::new();
-    loop {
-        line.clear();
-        stdin.read_line(&mut line).unwrap();
-        if line.is_empty() {
-            break;
-        }
-        stdout.write_all(line.as_bytes()).unwrap();
-    }
-    stdout.flush().unwrap();
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+
+    tokio::io::copy(&mut stdin, &mut stdout).await.unwrap();
+
+    stdout.flush().await.unwrap();
 }

--- a/tests-integration/tests/process_stdio.rs
+++ b/tests-integration/tests/process_stdio.rs
@@ -8,12 +8,22 @@ use tokio_test::assert_ok;
 
 use futures::future::{self, FutureExt};
 use std::convert::TryInto;
-use std::env;
 use std::io;
 use std::process::{ExitStatus, Stdio};
 
+// so, we need to change this back as a test, but for now this doesn't work because of:
+// https://github.com/rust-lang/rust/pull/95469
+//
+// undo when this is closed: https://github.com/tokio-rs/tokio/issues/4802
+
+// fn cat() -> Command {
+//     let mut cmd = Command::new(std::env!("CARGO_BIN_EXE_test-cat"));
+//     cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
+//     cmd
+// }
+
 fn cat() -> Command {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_test-cat"));
+    let mut cmd = Command::new("cat");
     cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
     cmd
 }


### PR DESCRIPTION
This fixes #4801, where, as a result of https://github.com/rust-lang/rust/pull/95469, our implementation of cat used for this test no longer works, as stdio functions on windows now can abort the process if the pipe is set to nonblocking mode.

Unfortunately in windows, setting one end of the pipe to be nonblocking makes the whole thing nonblocking, so when, in tokio::process we set the child pipes to nonblocking mode, it causes serious problems for any rust program at the other end.

Fixing this issue is for another day, but fixing the tests is for today.