### PR TITLE
feat: decompose `macros` feature as `macros-decl` and `macros-proc`

### DIFF
--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "macros", feature = "rt"))]
+#![cfg(all(feature = "macros-proc", feature = "rt"))]
 
 #[tokio::main]
 async fn basic_main() -> usize {

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -45,7 +45,11 @@ fs = []
 io-util = ["memchr", "bytes"]
 # stdin, stdout, stderr
 io-std = []
-macros = ["tokio-macros"]
+
+macros = ["macros-decl", "macros-proc"]
+macros-decl = []               # Declarative Macros
+macros-proc = ["tokio-macros"] # Procedural Marcos
+
 net = [
   "libc",
   "mio/os-poll",

--- a/tokio/src/future/mod.rs
+++ b/tokio/src/future/mod.rs
@@ -1,8 +1,8 @@
-#![cfg_attr(not(feature = "macros"), allow(unreachable_pub))]
+#![cfg_attr(not(feature = "macros-decl"), allow(unreachable_pub))]
 
 //! Asynchronous values.
 
-#[cfg(any(feature = "macros", feature = "process"))]
+#[cfg(any(feature = "macros-decl", feature = "process"))]
 pub(crate) mod maybe_done;
 
 mod poll_fn;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -320,7 +320,9 @@
 //! - `time`: Enables `tokio::time` types and allows the schedulers to enable
 //!           the built in timer.
 //! - `process`: Enables `tokio::process` types.
-//! - `macros`: Enables `#[tokio::main]` and `#[tokio::test]` macros.
+//! - `macros`: Enables both `macros-decl` and `macros-proc` features (for convenience).
+//! - `macros-decl`: Enables the `join!`, `try_join!`, and `select!` declarative macros.
+//! - `macros-proc`: Enables `#[tokio::main]` and `#[tokio::test]` attribute macros.
 //! - `sync`: Enables all `tokio::sync` types.
 //! - `signal`: Enables all `tokio::signal` types.
 //! - `fs`: Enables `tokio::fs` types.

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -516,7 +516,7 @@ pub(crate) use self::doc::winapi;
 #[allow(unused)]
 pub(crate) use winapi;
 
-cfg_macros! {
+cfg_macros_proc! {
     /// Implementation detail of the `select!` macro. This macro is **not**
     /// intended to be used as part of the public API and is permitted to
     /// change.
@@ -532,12 +532,12 @@ cfg_macros! {
     cfg_rt! {
         #[cfg(feature = "rt-multi-thread")]
         #[cfg(not(test))] // Work around for rust-lang/rust#62127
-        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "macros-proc")))]
         #[doc(inline)]
         pub use tokio_macros::main;
 
         #[cfg(feature = "rt-multi-thread")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "macros-proc")))]
         #[doc(inline)]
         pub use tokio_macros::test;
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -164,11 +164,21 @@ macro_rules! cfg_not_loom {
     }
 }
 
-macro_rules! cfg_macros {
+macro_rules! cfg_macros_decl {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "macros")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+            #[cfg(feature = "macros-decl")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "macros-decl")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_macros_proc {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "macros-proc")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "macros-proc")))]
             $item
         )*
     }

--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -53,7 +53,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros-decl")))]
 macro_rules! join {
     (@ {
         // One `_` for each branch in the `join!` macro. This is not used once

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -24,7 +24,7 @@ cfg_trace! {
 #[cfg(feature = "rt")]
 pub(crate) mod scoped_tls;
 
-cfg_macros! {
+cfg_macros_decl! {
     #[macro_use]
     mod select;
 

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -390,7 +390,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros-decl")))]
 macro_rules! select {
     // Uses a declarative macro to do **most** of the work. While it is possible
     // to implement fully with a declarative macro, a procedural macro is used

--- a/tokio/src/macros/support.rs
+++ b/tokio/src/macros/support.rs
@@ -1,4 +1,4 @@
-cfg_macros! {
+cfg_macros_decl! {
     pub use crate::future::poll_fn;
     pub use crate::future::maybe_done::maybe_done;
     pub use crate::util::thread_rng_n;

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -99,7 +99,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "macros-decl")))]
 macro_rules! try_join {
     (@ {
         // One `_` for each branch in the `try_join!` macro. This is not used once

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -40,7 +40,7 @@ pub(crate) use wake_list::WakeList;
 ))]
 pub(crate) mod linked_list;
 
-#[cfg(any(feature = "rt-multi-thread", feature = "macros"))]
+#[cfg(any(feature = "rt-multi-thread", feature = "macros-decl"))]
 mod rand;
 
 cfg_rt! {
@@ -69,8 +69,8 @@ cfg_rt_multi_thread! {
 
 pub(crate) mod trace;
 
-#[cfg(any(feature = "macros"))]
-#[cfg_attr(not(feature = "macros"), allow(unreachable_pub))]
+#[cfg(any(feature = "macros-decl"))]
+#[cfg_attr(not(feature = "macros-decl"), allow(unreachable_pub))]
 pub use self::rand::thread_rng_n;
 
 #[cfg(any(

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -52,9 +52,9 @@ impl FastRand {
 }
 
 // Used by the select macro and `StreamMap`
-#[cfg(any(feature = "macros"))]
+#[cfg(any(feature = "macros-decl"))]
 #[doc(hidden)]
-#[cfg_attr(not(feature = "macros"), allow(unreachable_pub))]
+#[cfg_attr(not(feature = "macros-decl"), allow(unreachable_pub))]
 pub fn thread_rng_n(n: u32) -> u32 {
     thread_local! {
         static THREAD_RNG: FastRand = FastRand::new(crate::loom::rand::seed());


### PR DESCRIPTION
# Motivation
As its name suggests, the `macros` feature enables the use of various macros in Tokio. Among the most beloved are the `#[tokio::main]` and the `select!` macros.

However, one major difference between attribute macros and declarative macros is that the former requires the `tokio-macros` crate, which is the home for various procedural macros.

https://github.com/tokio-rs/tokio/blob/d8cad13fd92c4360031d5bac28514eebdf94ad1d/tokio/Cargo.toml#L48

In turn, a dependency on the `tokio-macros` crate also pulls in the (relatively heavy) `syn` and `quote` crates.

https://github.com/tokio-rs/tokio/blob/d8cad13fd92c4360031d5bac28514eebdf94ad1d/tokio-macros/Cargo.toml#L24-L27

The main issue arises when attribute macros are not needed, but the user still wishes to use the declarative macros (i.e. `select!`, `join!`, and `try_join!`). They are thus forced to enable the `macros` feature, which undesirably pulls in the attribute macros from the `tokio-macros` crate anyway.

# Solution
To avoid this issue, this PR decomposes the `macros` feature into two sub-features: `macros-decl` and `macros-proc`.[^naming] The `macros-decl` feature enables the declarative macros while the `macros-proc` feature enables the procedural macros. To maintain backwards-compatibility, the `macros` feature is now just an alias for `["macros-decl", "macros-proc"]`.

[^naming]: I'm open to changing the sub-feature names if anyone prefers otherwise. I figured that this was an appropriate naming convention since there is already precedent with `["io-std", "io-util"]` and `["rt", "rt-multi-thread"]`.

Most notably, the `macros-proc` feature enables `dep:tokio-macros`.[^msrv] The explicit decomposition allows the user to use the declarative macros without being forced to pull in the heavier attribute macros.[^pull]

[^msrv]: In the actual PR, I did not use the `dep:` prefix to respect the MSRV.

[^pull]: It is worth noting, however, that the `syn` and `quote` crates would have been pulled in by other crates, anyway. This is especially true for projects with many dependencies (most notably `serde_derive`). Nevertheless, it is still good to give the user extra control over the compilation of dependencies.

Please do let me know if there are any issues with my decomposition. In particular, I would love to resolve any compilation issues (if any) that arise due to outdated references to the old `macros` feature. Thanks! 🎉