### PR TITLE
Fix #4815 by adjusting length `n` before checking overflow

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -493,13 +493,6 @@ impl LengthDelimitedCodec {
                 src.get_uint_le(field_len)
             };
 
-            if n > self.builder.max_frame_len as u64 {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    LengthDelimitedCodecError { _priv: () },
-                ));
-            }
-
             // The check above ensures there is no overflow
             let n = n as usize;
 
@@ -512,7 +505,15 @@ impl LengthDelimitedCodec {
 
             // Error handling
             match n {
-                Some(n) => n,
+                Some(n) => {
+                    if n > self.builder.max_frame_len as usize {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            LengthDelimitedCodecError { _priv: () },
+                        ));
+                    }
+                    n
+                },
                 None => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -493,7 +493,7 @@ impl LengthDelimitedCodec {
                 src.get_uint_le(field_len)
             };
 
-            let n = n as usize;
+            let n = usize::try_from(n).ok();
 
             // Adjust `n` with bounds checking
             let n = if self.builder.length_adjustment < 0 {

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -493,7 +493,6 @@ impl LengthDelimitedCodec {
                 src.get_uint_le(field_len)
             };
 
-            // The check above ensures there is no overflow
             let n = n as usize;
 
             // Adjust `n` with bounds checking
@@ -506,6 +505,7 @@ impl LengthDelimitedCodec {
             // Error handling
             match n {
                 Some(n) => {
+                    // Ensure there is no overflow
                     if n > self.builder.max_frame_len as usize {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidData,

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -401,7 +401,25 @@ fn read_single_frame_negative_length_adjusted_and_max_sized() {
         .length_field_length(4)
         .max_frame_length(11)
         .length_adjustment(-4)
-        .num_skip(4)
+        .new_read(mock! {
+            data(&d),
+        });
+    pin_mut!(io);
+
+    assert_next_eq!(io, b"Hello world");
+    assert_done!(io);
+}
+
+#[test]
+fn read_single_frame_positive_length_adjusted_and_max_sized() {
+    let mut d: Vec<u8> = vec![];
+    d.extend_from_slice(b"\x00\x00\x00\x07Hello world");
+
+    let io = length_delimited::Builder::new()
+        .length_field_offset(0)
+        .length_field_length(4)
+        .max_frame_length(11)
+        .length_adjustment(4)
         .new_read(mock! {
             data(&d),
         });

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -392,6 +392,26 @@ fn read_single_frame_length_adjusted() {
 }
 
 #[test]
+fn read_single_frame_negative_length_adjusted_and_max_sized() {
+    let mut d: Vec<u8> = vec![];
+    d.extend_from_slice(b"\x00\x00\x00\x0fHello world");
+
+    let io = length_delimited::Builder::new()
+        .length_field_offset(0)
+        .length_field_length(4)
+        .max_frame_length(11)
+        .length_adjustment(-4)
+        .num_skip(4)
+        .new_read(mock! {
+            data(&d),
+        });
+    pin_mut!(io);
+
+    assert_next_eq!(io, b"Hello world");
+    assert_done!(io);
+}
+
+#[test]
 fn read_single_multi_frame_one_packet_length_includes_head() {
     let mut d: Vec<u8> = vec![];
     d.extend_from_slice(b"\x00\x0babcdefghi");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This is to solve the issue #4815, which finds that the encoded bytes of a max-sized frame with a negative-valued length adjustment cannot be decoded with the codec.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The problem is caused by checking overflow before making length adjustment to the decoded length `n` (https://github.com/tokio-rs/tokio/issues/4815#issuecomment-1178399854). This PR simply reverses the order (ie. it now makes adjustment to the length `n` before checking overflow).

A new unit test `read_single_frame_negative_length_adjusted_and_max_sized` has been added to `tokio-util/tests/length_delimited.rs` to test this scenario.
