### PR TITLE
chore: add a regression test for WASI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
       - check-readme
       - test-hyper
       - wasm32-unknown-unknown
+      - wasm32-wasi
     steps:
       - run: exit 0
 
@@ -462,3 +463,34 @@ jobs:
       - name: test tokio
         run: wasm-pack test --node -- --features "macros sync"
         working-directory: tokio
+
+  wasm32-wasi:
+    name: wasm32-wasi
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_stable }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+
+      # Install dependencies
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
+      - name: Install wasm32-wasi target
+        run: rustup target add wasm32-wasi
+
+      - name: Install wasmtime
+        run: cargo install wasmtime-cli
+
+      # TODO: Expand this when full WASI support lands.
+      #   Currently, this is a bare bones regression test
+      #   for features that work today with wasi.
+
+      - name: test tests-integration --features wasi-rt
+        # TODO: this should become: `cargo hack wasi test --each-feature`
+        run: cargo wasi test --test rt_yield --features wasi-rt
+        working-directory: tests-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,8 +483,8 @@ jobs:
       - name: Install wasm32-wasi target
         run: rustup target add wasm32-wasi
 
-      - name: Install wasmtime
-        run: cargo install wasmtime-cli
+      - name: Install cargo-wasi
+        run: cargo install cargo-wasi
 
       # TODO: Expand this when full WASI support lands.
       #   Currently, this is a bare bones regression test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,9 @@ jobs:
       - name: Install wasm32-wasi target
         run: rustup target add wasm32-wasi
 
+      - name: Install wasmtime
+        run: cargo install wasmtime-cli
+
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
 

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -17,12 +17,30 @@ required-features = ["rt-net"]
 name = "test-process-signal"
 required-features = ["rt-process-signal"]
 
+[[test]]
+name = "macros_main"
+
+[[test]]
+name = "macros_pin"
+
+[[test]]
+name = "macros_select"
+
+[[test]]
+name = "rt_yield"
+required-features = ["rt", "macros", "sync"]
+
 [features]
 rt-process-io-util = ["tokio/rt", "tokio/macros", "tokio/process", "tokio/io-util", "tokio/io-std"]
 # For mem check
 rt-net = ["tokio/rt", "tokio/rt-multi-thread", "tokio/net"]
 # For test-process-signal
 rt-process-signal = ["rt-net", "tokio/process", "tokio/signal"]
+# For testing wasi + rt/macros/sync features
+#
+# This is an explicit feature so we can use `cargo hack` testing single features
+# instead of all possible permutations.
+wasi-rt = ["rt", "macros", "sync"]
 
 full = [
     "macros",

--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "macros", feature = "rt"))]
+#![cfg(all(feature = "macros", feature = "rt-multi-thread"))]
 
 #[tokio::main]
 async fn basic_main() -> usize {

--- a/tests-integration/tests/rt_yield.rs
+++ b/tests-integration/tests/rt_yield.rs
@@ -1,5 +1,5 @@
-use tokio::task;
 use tokio::sync::oneshot;
+use tokio::task;
 
 async fn spawn_send() {
     let (tx, rx) = oneshot::channel();

--- a/tests-integration/tests/rt_yield.rs
+++ b/tests-integration/tests/rt_yield.rs
@@ -1,0 +1,41 @@
+use tokio::task;
+use tokio::sync::oneshot;
+
+async fn spawn_send() {
+    let (tx, rx) = oneshot::channel();
+
+    let task = tokio::spawn(async {
+        for _ in 0..10 {
+            task::yield_now().await;
+        }
+
+        tx.send("done").unwrap();
+    });
+
+    assert_eq!("done", rx.await.unwrap());
+    task.await.unwrap();
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn entry_point() {
+    spawn_send().await;
+}
+
+#[tokio::test]
+async fn test_macro() {
+    spawn_send().await;
+}
+
+#[test]
+fn main_macro() {
+    entry_point();
+}
+
+#[test]
+fn manual_rt() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    rt.block_on(async { spawn_send().await });
+}


### PR DESCRIPTION
Currently, we only have WASM regression tests that run without WASI.
However, rust provides a WASI specific target which enables code to
special case WASI. This PR adds a basic test to cover that case.

This is an initial addition to help land tokio-rs/tokio#4716.
