### PR TITLE
process: use blocking threadpool for child stdio I/O

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -69,11 +69,11 @@ process = [
   "mio/net",
   "signal-hook-registry",
   "winapi/handleapi",
+  "winapi/minwindef",
   "winapi/processthreadsapi",
   "winapi/threadpoollegacyapiset",
   "winapi/winbase",
   "winapi/winnt",
-  "winapi/minwindef",
 ]
 # Includes basic task execution capabilities
 rt = ["once_cell"]

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -34,8 +34,9 @@ enum State<T> {
     Busy(sys::Blocking<(io::Result<usize>, Buf, T)>),
 }
 
-cfg_io_std! {
+cfg_io_blocking! {
     impl<T> Blocking<T> {
+        #[cfg_attr(feature = "fs", allow(dead_code))]
         pub(crate) fn new(inner: T) -> Blocking<T> {
             Blocking {
                 inner: Some(inner),

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -136,7 +136,7 @@ impl<E: Source> PollEvented<E> {
 }
 
 feature! {
-    #![any(feature = "net", feature = "process")]
+    #![any(feature = "net", all(unix, feature = "process"))]
 
     use crate::io::ReadBuf;
     use std::task::{Context, Poll};

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -431,7 +431,12 @@ cfg_process! {
     pub mod process;
 }
 
-#[cfg(any(feature = "net", feature = "fs", feature = "io-std"))]
+#[cfg(any(
+    feature = "fs",
+    feature = "io-std",
+    feature = "net",
+    all(windows, feature = "process"),
+))]
 mod blocking;
 
 cfg_rt! {

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -70,7 +70,11 @@ macro_rules! cfg_fs {
 
 macro_rules! cfg_io_blocking {
     ($($item:item)*) => {
-        $( #[cfg(any(feature = "io-std", feature = "fs"))] $item )*
+        $( #[cfg(any(
+                feature = "io-std",
+                feature = "fs",
+                all(windows, feature = "process"),
+        ))] $item )*
     }
 }
 
@@ -79,12 +83,12 @@ macro_rules! cfg_io_driver {
         $(
             #[cfg(any(
                 feature = "net",
-                feature = "process",
+                all(unix, feature = "process"),
                 all(unix, feature = "signal"),
             ))]
             #[cfg_attr(docsrs, doc(cfg(any(
                 feature = "net",
-                feature = "process",
+                all(unix, feature = "process"),
                 all(unix, feature = "signal"),
             ))))]
             $item
@@ -97,7 +101,7 @@ macro_rules! cfg_io_driver_impl {
         $(
             #[cfg(any(
                 feature = "net",
-                feature = "process",
+                all(unix, feature = "process"),
                 all(unix, feature = "signal"),
             ))]
             $item
@@ -110,7 +114,7 @@ macro_rules! cfg_not_io_driver {
         $(
             #[cfg(not(any(
                 feature = "net",
-                feature = "process",
+                all(unix, feature = "process"),
                 all(unix, feature = "signal"),
             )))]
             $item

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -245,7 +245,6 @@ mod kill;
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::process::kill::Kill;
 
-use pin_project_lite::pin_project;
 use std::convert::TryInto;
 use std::ffi::OsStr;
 use std::future::Future;
@@ -1212,40 +1211,31 @@ impl Child {
     }
 }
 
-pin_project! {
-    /// The standard input stream for spawned children.
-    ///
-    /// This type implements the `AsyncWrite` trait to pass data to the stdin handle of
-    /// handle of a child process asynchronously.
-    #[derive(Debug)]
-    pub struct ChildStdin {
-        #[pin]
-        inner: imp::ChildStdio,
-    }
+/// The standard input stream for spawned children.
+///
+/// This type implements the `AsyncWrite` trait to pass data to the stdin handle of
+/// handle of a child process asynchronously.
+#[derive(Debug)]
+pub struct ChildStdin {
+    inner: imp::ChildStdio,
 }
 
-pin_project! {
-    /// The standard output stream for spawned children.
-    ///
-    /// This type implements the `AsyncRead` trait to read data from the stdout
-    /// handle of a child process asynchronously.
-    #[derive(Debug)]
-    pub struct ChildStdout {
-        #[pin]
-        inner: imp::ChildStdio,
-    }
+/// The standard output stream for spawned children.
+///
+/// This type implements the `AsyncRead` trait to read data from the stdout
+/// handle of a child process asynchronously.
+#[derive(Debug)]
+pub struct ChildStdout {
+    inner: imp::ChildStdio,
 }
 
-pin_project! {
-    /// The standard error stream for spawned children.
-    ///
-    /// This type implements the `AsyncRead` trait to read data from the stderr
-    /// handle of a child process asynchronously.
-    #[derive(Debug)]
-    pub struct ChildStderr {
-        #[pin]
-        inner: imp::ChildStdio,
-    }
+/// The standard error stream for spawned children.
+///
+/// This type implements the `AsyncRead` trait to read data from the stderr
+/// handle of a child process asynchronously.
+#[derive(Debug)]
+pub struct ChildStderr {
+    inner: imp::ChildStdio,
 }
 
 impl ChildStdin {
@@ -1295,39 +1285,39 @@ impl ChildStderr {
 
 impl AsyncWrite for ChildStdin {
     fn poll_write(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        self.project().inner.poll_write(cx, buf)
+        Pin::new(&mut self.inner).poll_write(cx, buf)
     }
 
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.project().inner.poll_flush(cx)
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
     }
 
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.project().inner.poll_shutdown(cx)
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
     }
 }
 
 impl AsyncRead for ChildStdout {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        self.project().inner.poll_read(cx, buf)
+        Pin::new(&mut self.inner).poll_read(cx, buf)
     }
 }
 
 impl AsyncRead for ChildStderr {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        self.project().inner.poll_read(cx, buf)
+        Pin::new(&mut self.inner).poll_read(cx, buf)
     }
 }
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -272,7 +272,11 @@ impl Builder {
     ///     .unwrap();
     /// ```
     pub fn enable_all(&mut self) -> &mut Self {
-        #[cfg(any(feature = "net", feature = "process", all(unix, feature = "signal")))]
+        #[cfg(any(
+            feature = "net",
+            all(unix, feature = "process"),
+            all(unix, feature = "signal")
+        ))]
         self.enable_io();
         #[cfg(feature = "time")]
         self.enable_time();

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -23,7 +23,11 @@ pub struct Handle {
 pub(crate) struct HandleInner {
     /// Handles to the I/O drivers
     #[cfg_attr(
-        not(any(feature = "net", feature = "process", all(unix, feature = "signal"))),
+        not(any(
+            feature = "net",
+            all(unix, feature = "process"),
+            all(unix, feature = "signal"),
+        )),
         allow(dead_code)
     )]
     pub(super) io_handle: driver::IoHandle,


### PR DESCRIPTION
We can't mix async pipes and child process stdio on Windows. This switches our Windows process implementation to use the blocking threadpool instead of using an async named pipe as we did in the past.

Refs #4802
