### PR TITLE
chore: fix ci by hard-coding nightly version for miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install Rust ${{ env.rust_nightly }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.rust_nightly }}
+          toolchain: nightly-2022-07-10
           components: miri
           override: true
       - uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
It would seem that the latest nightly is having issues, so I went with the one from yesterday (2022-7-10).