### PR TITLE
Implement `OnceCell::wait`

### DIFF
--- a/tokio/tests/sync_once_cell.rs
+++ b/tokio/tests/sync_once_cell.rs
@@ -3,10 +3,7 @@
 
 use std::mem;
 use std::ops::Drop;
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use tokio::runtime;
 use tokio::sync::{OnceCell, SetError};


### PR DESCRIPTION
This pull request implements `OnceCell::wait`, closing request #4788

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The `once_cell` crate provides a `OnceCell::wait` method, which blocks the current thread until a value has been set in the `OnceCell`, returning a reference to the stored value.

This is useful for situations where multiple tasks/threads need to wait on a value to be initialized before continuing, and that value only needs setting once.

This PR implements a future that resolves when a value has been set in the `OnceCell`, providing an async-runtime-friendly implementation of `once_cell`'s `OnceCell::wait` method.

I had a need for this when writing Discord bots, and I wanted to communicate the bot user ID to other tasks, like so:

```rust
use serenity::{async_trait, model::prelude::*, prelude::*};
use tokio::sync::OnceCell;

struct Handler {
    bot_id: OnceCell<UserId>,
}

#[async_trait]
impl EventHandler for Handler {
    async fn message(&self, ctx: Context, msg: Message) {
        msg.reply(&ctx.http, format!("My bot user ID is {}", self.bot_id.wait().await)).await.expect("Failed to reply to message");
    }

    async fn ready(&self, ctx: Context, ready: serenity::model::gateway::Ready) {
        self.bot_id.set(ready.user.id).expect("Failed to set bot ID");
    }
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The PR adds a `sync::Notify` field to the `OnceCell`, which it uses to subscribe tasks to wakeup events when the value is set in the cell.