### PR TITLE
chore: allow miri to use latest nightly once again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install Rust ${{ env.rust_nightly }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2022-07-10
+          toolchain: nightly
           components: miri
           override: true
       - uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
This reverts [#4825], as miri seems to be working again on the latest nightly.

I had originally thought it was this issue with rustup which was to blame, but this seems to be wrong: https://github.com/rust-lang/rustup/issues/3031

[#4825]: https://github.com/tokio-rs/tokio/pull/4825