### PR TITLE
task: propagate attrs on task_local items to the generated items

### DIFF
--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -51,6 +51,7 @@ macro_rules! task_local {
 #[macro_export]
 macro_rules! __task_local_inner {
     ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty) => {
+        $(#[$attr])*
         $vis static $name: $crate::task::LocalKey<$t> = {
             std::thread_local! {
                 static __KEY: std::cell::RefCell<Option<$t>> = const { std::cell::RefCell::new(None) };
@@ -66,6 +67,7 @@ macro_rules! __task_local_inner {
 #[macro_export]
 macro_rules! __task_local_inner {
     ($(#[$attr:meta])* $vis:vis $name:ident, $t:ty) => {
+        $(#[$attr])*
         $vis static $name: $crate::task::LocalKey<$t> = {
             std::thread_local! {
                 static __KEY: std::cell::RefCell<Option<$t>> = std::cell::RefCell::new(None);


### PR DESCRIPTION
Discovered while trying to add a `#[allow]` to try to work around #4836

That is,

```rust
tokio::task_local! {
	#[allow(clippy::declare_interior_mutable_const)]
	pub(crate) static TASK_LOCAL_LOGGER: env_logger::Logger;
}
```

... did not suppress the clippy lint, since the macro was not propagating the attr to the generated `LocalKey`

I did not find any indication in the commit and PR discussion that added `task_local!` that this was done intentionally, so it seems to have just been missed.