### PR TITLE
runtime: move owned field to Trailer

### DIFF
--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -60,8 +60,6 @@ pub(crate) struct Header {
     /// Task state.
     pub(super) state: State,
 
-    pub(super) owned: linked_list::Pointers<Header>,
-
     /// Pointer to next task, used with the injection queue.
     pub(super) queue_next: UnsafeCell<Option<NonNull<Header>>>,
 
@@ -86,21 +84,24 @@ pub(crate) struct Header {
     pub(super) id: Option<tracing::Id>,
 }
 
+unsafe impl Send for Header {}
+unsafe impl Sync for Header {}
+
+/// Cold data is stored after the future. Data is considered cold if it is only
+/// used during creation or shutdown of the task.
+pub(super) struct Trailer {
+    /// Pointers for the linked list in the `OwnedTasks` that owns this task.
+    pub(super) owned: linked_list::Pointers<Header>,
+    /// Consumer task waiting on completion of this task.
+    pub(super) waker: UnsafeCell<Option<Waker>>,
+}
+
 generate_addr_of_methods! {
-    impl<> Header {
+    impl<> Trailer {
         pub(super) unsafe fn addr_of_owned(self: NonNull<Self>) -> NonNull<linked_list::Pointers<Header>> {
             &self.owned
         }
     }
-}
-
-unsafe impl Send for Header {}
-unsafe impl Sync for Header {}
-
-/// Cold data is stored after the future.
-pub(super) struct Trailer {
-    /// Consumer task waiting on completion of this task.
-    pub(super) waker: UnsafeCell<Option<Waker>>,
 }
 
 /// Either the future or the output.
@@ -116,10 +117,9 @@ impl<T: Future, S: Schedule> Cell<T, S> {
     pub(super) fn new(future: T, scheduler: S, state: State, task_id: Id) -> Box<Cell<T, S>> {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let id = future.id();
-        Box::new(Cell {
+        let result = Box::new(Cell {
             header: Header {
                 state,
-                owned: linked_list::Pointers::new(),
                 queue_next: UnsafeCell::new(None),
                 vtable: raw::vtable::<T, S>(),
                 owner_id: UnsafeCell::new(0),
@@ -135,8 +135,21 @@ impl<T: Future, S: Schedule> Cell<T, S> {
             },
             trailer: Trailer {
                 waker: UnsafeCell::new(None),
+                owned: linked_list::Pointers::new(),
             },
-        })
+        });
+
+        #[cfg(debug_assertions)]
+        {
+            let trailer_addr = (&result.trailer) as *const Trailer as usize;
+            let trailer_ptr = unsafe {
+                Header::get_trailer(NonNull::from(&result.header))
+            };
+
+            assert_eq!(trailer_addr, trailer_ptr.as_ptr() as usize);
+        }
+
+        result
     }
 }
 
@@ -247,6 +260,17 @@ impl Header {
         // safety: If there are concurrent writes, then that write has violated
         // the safety requirements on `set_owner_id`.
         unsafe { self.owner_id.with(|ptr| *ptr) }
+    }
+
+    /// Gets a pointer to the `Trailer` of the task containing this `Header`.
+    ///
+    /// # Safety
+    ///
+    /// The provided raw pointer must point at the header of a task.
+    pub(super) unsafe fn get_trailer(me: NonNull<Header>) -> NonNull<Trailer> {
+        let offset = me.as_ref().vtable.trailer_offset;
+        let trailer = me.as_ptr().cast::<u8>().add(offset).cast::<Trailer>();
+        NonNull::new_unchecked(trailer)
     }
 }
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -142,9 +142,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         #[cfg(debug_assertions)]
         {
             let trailer_addr = (&result.trailer) as *const Trailer as usize;
-            let trailer_ptr = unsafe {
-                Header::get_trailer(NonNull::from(&result.header))
-            };
+            let trailer_ptr = unsafe { Header::get_trailer(NonNull::from(&result.header)) };
 
             assert_eq!(trailer_addr, trailer_ptr.as_ptr() as usize);
         }

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -164,7 +164,7 @@ impl<S: 'static> OwnedTasks<S> {
 
         // safety: We just checked that the provided task is not in some other
         // linked list.
-        unsafe { self.inner.lock().list.remove(task.header().into()) }
+        unsafe { self.inner.lock().list.remove(task.header_ptr()) }
     }
 
     pub(crate) fn is_empty(&self) -> bool {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -334,6 +334,10 @@ impl<S: 'static> Task<S> {
     fn header(&self) -> &Header {
         self.raw.header()
     }
+
+    fn header_ptr(&self) -> NonNull<Header> {
+        self.raw.header_ptr()
+    }
 }
 
 impl<S: 'static> Notified<S> {
@@ -473,7 +477,7 @@ unsafe impl<S> linked_list::Link for Task<S> {
     }
 
     unsafe fn pointers(target: NonNull<Header>) -> NonNull<linked_list::Pointers<Header>> {
-        Header::addr_of_owned(target)
+        self::core::Trailer::addr_of_owned(Header::get_trailer(target))
     }
 }
 

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -1,6 +1,6 @@
 use crate::future::Future;
-use crate::runtime::task::{Cell, Harness, Header, Id, Schedule, State};
 use crate::runtime::task::core::{Core, Trailer};
+use crate::runtime::task::{Cell, Harness, Header, Id, Schedule, State};
 
 use std::ptr::NonNull;
 use std::task::{Poll, Waker};


### PR DESCRIPTION
This PR moves the `owned` field from the task header to the trailer. 

**Motivation.** Various other PRs have run into trouble with the header not having enough space to add new fields. This PR exists to make more space in the header for those other PRs.

**Why is this ok?** The purpose of the trailer is to store fields only needed during shutdown of the task, and the `owned` field is only accessed during shutdown (and creation) of tasks, and during shutdown of the runtime. Thus, it is only rarely accessed. This makes it ok to store the field in cold memory.