### PR TITLE
ci: update required ci steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,16 +34,18 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
-      - test-unstable
       - test-parking_lot
+      - valgrind
+      - test-unstable
       - miri
+      - asan
       - cross
       - features
       - minrust
+      - minimal-versions
       - fmt
       - clippy
       - docs
-      - valgrind
       - loom-compile
       - check-readme
       - test-hyper


### PR DESCRIPTION
Some CI steps were not mentioned in the list of required CI steps. This causes the auto-merge feature to merge the PR even if those tests fail.

This PR also reorders the list to be in the same order as the steps themselves.