### PR TITLE
doc: remove incorrect panic section for Builder::worker_threads

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -289,11 +289,7 @@ impl Builder {
     ///
     /// The default value is the number of cores available to the system.
     ///
-    /// # Panics
-    ///
-    /// When using the `current_thread` runtime this method will panic, since
-    /// those variants do not allow setting worker thread counts.
-    ///
+    /// When using the `current_thread` runtime this method has no effect.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation

The documentation for the function `Builder::worker_threads` states that if it is used
with `current_thread` runtime it will panic. However it doesn't panic, it appears to
ignore the value set by the call instead.

Documentation:
https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.worker_threads

While this is probably not going to catch a lot of people out, it would be better if it
was correct.

Also, this function documentation had 2 `Panics` sections in it. 🤷‍♀️

## Solution

The documentation for the runtime `Builder::worker_threads` function
incorrectly stated that it would panic if used when constructing a
`current_thread` runtime. In truth, the call to the function has no
effect.

Since adding the described panic to the code could cause new panics in
existing code using tokio, the documentation has been modified to
describe the existing behavior.

Fixes: #4773
