### PR TITLE
io: add track_caller caller to no-rt io driver

### DIFF
--- a/tokio/src/io/driver/mod.rs
+++ b/tokio/src/io/driver/mod.rs
@@ -282,6 +282,7 @@ cfg_not_rt! {
         ///
         /// This function panics if there is no current reactor set, or if the `rt`
         /// feature flag is not enabled.
+        #[track_caller]
         pub(super) fn current() -> Self {
             panic!("{}", crate::util::error::CONTEXT_MISSING_ERROR)
         }


### PR DESCRIPTION
## Motivation

A single case was missed in the original PR #4793, which is where the `rt`
feature is not enabled. This case cannot be tested (because tests run with
all features enabled), but it's worth adding the `#[track_caller]` attribute
anyway.

## Solution

This change adds a case that was missing from the original PR, #4793.

The `io::driver::Handle::current` function was only covered by
`#[track_caller]` in the case that the `rt` feature  is enabled, however
it was missing in the case that the `rt` feture isn't enabled (in which
case a panic would be more common).

This particular case cannot be tested in the tokio tests as they always
run with all features enabled.

Refs: #4413