### PR TITLE
process: revert test_cat to use blocking I/O

### DIFF
--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [[bin]]
 name = "test-cat"
-required-features = ["rt-process-io-util"]
 
 [[bin]]
 name = "test-mem"
@@ -31,7 +30,6 @@ name = "rt_yield"
 required-features = ["rt", "macros", "sync"]
 
 [features]
-rt-process-io-util = ["tokio/rt", "tokio/macros", "tokio/process", "tokio/io-util", "tokio/io-std"]
 # For mem check
 rt-net = ["tokio/rt", "tokio/rt-multi-thread", "tokio/net"]
 # For test-process-signal

--- a/tests-integration/src/bin/test-cat.rs
+++ b/tests-integration/src/bin/test-cat.rs
@@ -1,14 +1,20 @@
 //! A cat-like utility that can be used as a subprocess to test I/O
 //! stream communication.
 
-use tokio::io::AsyncWriteExt;
+use std::io;
+use std::io::Write;
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    let mut stdin = tokio::io::stdin();
-    let mut stdout = tokio::io::stdout();
-
-    tokio::io::copy(&mut stdin, &mut stdout).await.unwrap();
-
-    stdout.flush().await.unwrap();
+fn main() {
+    let stdin = io::stdin();
+    let mut stdout = io::stdout();
+    let mut line = String::new();
+    loop {
+        line.clear();
+        stdin.read_line(&mut line).unwrap();
+        if line.is_empty() {
+            break;
+        }
+        stdout.write_all(line.as_bytes()).unwrap();
+    }
+    stdout.flush().unwrap();
 }

--- a/tests-integration/tests/process_stdio.rs
+++ b/tests-integration/tests/process_stdio.rs
@@ -8,22 +8,12 @@ use tokio_test::assert_ok;
 
 use futures::future::{self, FutureExt};
 use std::convert::TryInto;
+use std::env;
 use std::io;
 use std::process::{ExitStatus, Stdio};
 
-// so, we need to change this back as a test, but for now this doesn't work because of:
-// https://github.com/rust-lang/rust/pull/95469
-//
-// undo when this is closed: https://github.com/tokio-rs/tokio/issues/4802
-
-// fn cat() -> Command {
-//     let mut cmd = Command::new(std::env!("CARGO_BIN_EXE_test-cat"));
-//     cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
-//     cmd
-// }
-
 fn cat() -> Command {
-    let mut cmd = Command::new("cat");
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_test-cat"));
     cmd.stdin(Stdio::piped()).stdout(Stdio::piped());
     cmd
 }


### PR DESCRIPTION
Now that the issue has been resolved with doing async I/O with child processes, we can revert our testing `cat` process to using blocking I/O as before (i.e. test how most child processes would handle I/O by default)

Fixes #4802 