### PR TITLE
chore: use target_family wasm instead of wasm32

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,7 +117,7 @@ mio = { version = "0.8.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(target_arch = "wasm"))'.dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
 socket2 = { version = "0.4.4", features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
@@ -150,14 +150,14 @@ mockall = "0.11.1"
 tempfile = "3.1.0"
 async-stream = "0.3"
 
-[target.'cfg(not(target_arch = "wasm"))'.dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 proptest = "1"
 socket2 = "0.4"
 
-[target.'cfg(not(all(target_arch = "wasm", target_os = "unknown")))'.dev-dependencies]
+[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
 rand = "0.8.0"
 
-[target.'cfg(all(target_arch = "wasm", not(target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,7 +117,7 @@ mio = { version = "0.8.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(target_arch = "wasm"))'.dependencies]
 socket2 = { version = "0.4.4", features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
@@ -150,14 +150,14 @@ mockall = "0.11.1"
 tempfile = "3.1.0"
 async-stream = "0.3"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(target_arch = "wasm"))'.dev-dependencies]
 proptest = "1"
 socket2 = "0.4"
 
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+[target.'cfg(not(all(target_arch = "wasm", target_os = "unknown")))'.dev-dependencies]
 rand = "0.8.0"
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -207,7 +207,7 @@ cfg_coop! {
 mod test {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     fn get() -> Budget {

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -207,7 +207,7 @@ cfg_coop! {
 mod test {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     fn get() -> Budget {

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -115,7 +115,7 @@ impl Registration {
 
     // Uses the poll path, requiring the caller to ensure mutual exclusion for
     // correctness. Only the last task to call this function is notified.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+    #[cfg(not(all(target_family = "wasm", target_os = "wasi")))]
     pub(crate) fn poll_read_io<R>(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -395,7 +395,7 @@ compile_error! {
 
 #[cfg(all(
     not(tokio_unstable),
-    target_arch = "wasm",
+    target_family = "wasm",
     any(
         feature = "fs",
         feature = "io-std",

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -395,7 +395,7 @@ compile_error! {
 
 #[cfg(all(
     not(tokio_unstable),
-    target_arch = "wasm32",
+    target_arch = "wasm",
     any(
         feature = "fs",
         feature = "io-std",

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -459,7 +459,7 @@ macro_rules! cfg_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm"
+                    target_family = "wasm"
                     )))]
             $item
         )*
@@ -474,7 +474,7 @@ macro_rules! cfg_not_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm"
+                    target_family = "wasm"
                     ))]
             $item
         )*
@@ -493,7 +493,7 @@ macro_rules! cfg_not_wasi {
 macro_rules! cfg_is_wasm_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+            #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
             $item
         )*
     }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -459,7 +459,7 @@ macro_rules! cfg_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm32"
+                    target_arch = "wasm"
                     )))]
             $item
         )*
@@ -474,7 +474,7 @@ macro_rules! cfg_not_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm32"
+                    target_arch = "wasm"
                     ))]
             $item
         )*
@@ -493,7 +493,7 @@ macro_rules! cfg_not_wasi {
 macro_rules! cfg_is_wasm_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+            #[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
             $item
         )*
     }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -174,7 +174,7 @@
 
 // At the top due to macros
 #[cfg(test)]
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 #[macro_use]
 mod tests;
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -174,7 +174,7 @@
 
 // At the top due to macros
 #[cfg(test)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm"))]
 #[macro_use]
 mod tests;
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -389,7 +389,7 @@ impl<S: Schedule> LocalNotified<S> {
 impl<S: Schedule> UnownedTask<S> {
     // Used in test of the inject queue.
     #[cfg(test)]
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    #[cfg_attr(target_arch = "wasm", allow(dead_code))]
     pub(super) fn into_notified(self) -> Notified<S> {
         Notified(self.into_task())
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -389,7 +389,7 @@ impl<S: Schedule> LocalNotified<S> {
 impl<S: Schedule> UnownedTask<S> {
     // Used in test of the inject queue.
     #[cfg(test)]
-    #[cfg_attr(target_arch = "wasm", allow(dead_code))]
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     pub(super) fn into_notified(self) -> Notified<S> {
         Notified(self.into_task())
     }

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -12,7 +12,7 @@ impl AssertSync for AtomicWaker {}
 impl AssertSend for Waker {}
 impl AssertSync for Waker {}
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -37,7 +37,7 @@ fn wake_without_register() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn atomic_waker_panic_safe() {
     use std::panic;
     use std::ptr;

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -12,7 +12,7 @@ impl AssertSync for AtomicWaker {}
 impl AssertSend for Waker {}
 impl AssertSync for Waker {}
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -37,7 +37,7 @@ fn wake_without_register() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn atomic_waker_panic_safe() {
     use std::panic;
     use std::ptr;

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -4,7 +4,7 @@ use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -63,7 +63,7 @@ fn notify_simple() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm"))]
 fn watch_test() {
     let rt = crate::runtime::Builder::new_current_thread()
         .build()

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -4,7 +4,7 @@ use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -63,7 +63,7 @@ fn notify_simple() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 fn watch_test() {
     let rt = crate::runtime::Builder::new_current_thread()
         .build()

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -1,7 +1,7 @@
 use crate::sync::batch_semaphore::Semaphore;
 use tokio_test::*;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -170,7 +170,7 @@ fn poll_acquire_one_zero_permits() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn validates_max_permits() {
     use std::usize;
     Semaphore::new((usize::MAX >> 2) + 1);

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -1,7 +1,7 @@
 use crate::sync::batch_semaphore::Semaphore;
 use tokio_test::*;
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -170,7 +170,7 @@ fn poll_acquire_one_zero_permits() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn validates_max_permits() {
     use std::usize;
     Semaphore::new((usize::MAX >> 2) + 1);

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -623,7 +623,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_arch = "wasm"))]
     proptest::proptest! {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {
@@ -631,7 +631,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(target_arch = "wasm"))]
     fn run_fuzz(ops: Vec<usize>) {
         use std::collections::VecDeque;
 

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -623,7 +623,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     proptest::proptest! {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {
@@ -631,7 +631,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm"))]
+    #[cfg(not(target_family = "wasm"))]
     fn run_fuzz(ops: Vec<usize>) {
         use std::collections::VecDeque;
 

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,2 +1,2 @@
-#![cfg(not(any(feature = "full", target_arch = "wasm32")))]
+#![cfg(not(any(feature = "full", target_arch = "wasm")))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,2 +1,2 @@
-#![cfg(not(any(feature = "full", target_arch = "wasm")))]
+#![cfg(not(any(feature = "full", target_family = "wasm")))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -2,12 +2,12 @@
 #![allow(clippy::blacklisted_name)]
 use std::sync::Arc;
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::{oneshot, Semaphore};

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -2,12 +2,12 @@
 #![allow(clippy::blacklisted_name)]
 use std::sync::Arc;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::{oneshot, Semaphore};

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "macros")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 async fn one() {}

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "macros")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 async fn one() {}

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "macros")]
 #![allow(clippy::blacklisted_name)]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "macros")]
 #![allow(clippy::blacklisted_name)]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, Semaphore};
 use tokio_test::{assert_pending, assert_ready, task};
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 #[maybe_tokio_test]

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, Semaphore};
 use tokio_test::{assert_pending, assert_ready, task};
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 #[maybe_tokio_test]

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Barrier;

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Barrier;

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::broadcast;
@@ -276,14 +276,14 @@ fn send_no_rx() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn zero_capacity() {
     broadcast::channel::<()>(0);
 }
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn capacity_too_big() {
     use std::usize;
 
@@ -291,7 +291,7 @@ fn capacity_too_big() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn panic_in_clone() {
     use std::panic::{self, AssertUnwindSafe};
 

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::broadcast;
@@ -276,14 +276,14 @@ fn send_no_rx() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn zero_capacity() {
     broadcast::channel::<()>(0);
 }
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn capacity_too_big() {
     use std::usize;
 
@@ -291,7 +291,7 @@ fn capacity_too_big() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn panic_in_clone() {
     use std::panic::{self, AssertUnwindSafe};
 

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 fn is_error<T: std::error::Error + Send + Sync>() {}

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 fn is_error<T: std::error::Error + Send + Sync>() {}

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -2,12 +2,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::mpsc;
@@ -16,7 +16,7 @@ use tokio_test::*;
 
 use std::sync::Arc;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_arch = "wasm"))]
 mod support {
     pub(crate) mod mpsc_stream;
 }
@@ -155,7 +155,7 @@ async fn start_send_past_cap() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn buffer_gteq_one() {
     mpsc::channel::<i32>(0);
 }
@@ -471,7 +471,7 @@ fn blocking_recv() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 async fn blocking_recv_async() {
     let (_tx, mut rx) = mpsc::channel::<()>(1);
     let _ = rx.blocking_recv();
@@ -496,7 +496,7 @@ fn blocking_send() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 async fn blocking_send_async() {
     let (tx, _rx) = mpsc::channel::<()>(1);
     let _ = tx.blocking_send(());
@@ -649,7 +649,7 @@ async fn recv_timeout() {
 
 #[test]
 #[should_panic = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn recv_timeout_panic() {
     use futures::future::FutureExt;
     use tokio::time::Duration;

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -2,12 +2,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::mpsc;
@@ -16,7 +16,7 @@ use tokio_test::*;
 
 use std::sync::Arc;
 
-#[cfg(not(target_arch = "wasm"))]
+#[cfg(not(target_family = "wasm"))]
 mod support {
     pub(crate) mod mpsc_stream;
 }
@@ -155,7 +155,7 @@ async fn start_send_past_cap() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn buffer_gteq_one() {
     mpsc::channel::<i32>(0);
 }
@@ -471,7 +471,7 @@ fn blocking_recv() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 async fn blocking_recv_async() {
     let (_tx, mut rx) = mpsc::channel::<()>(1);
     let _ = rx.blocking_recv();
@@ -496,7 +496,7 @@ fn blocking_send() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 async fn blocking_send_async() {
     let (tx, _rx) = mpsc::channel::<()>(1);
     let _ = tx.blocking_send(());
@@ -649,7 +649,7 @@ async fn recv_timeout() {
 
 #[test]
 #[should_panic = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn recv_timeout_panic() {
     use futures::future::FutureExt;
     use tokio::time::Duration;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Notify;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Notify;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;
@@ -179,7 +179,7 @@ fn explicit_close_try_recv() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn close_try_recv_poll() {
     let (_tx, rx) = oneshot::channel::<i32>();
     let mut rx = task::spawn(rx);

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;
@@ -179,7 +179,7 @@ fn explicit_close_try_recv() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn close_try_recv_poll() {
     let (_tx, rx) = oneshot::channel::<i32>();
     let mut rx = task::spawn(rx);

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use std::task::Poll;

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use std::task::Poll;

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;
@@ -93,7 +93,7 @@ fn add_max_amount_permits() {
     assert_eq!(s.available_permits(), usize::MAX >> 3);
 }
 
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 #[test]
 #[should_panic]
 fn add_more_than_max_amount_permits() {

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;
@@ -93,7 +93,7 @@ fn add_max_amount_permits() {
     assert_eq!(s.available_permits(), usize::MAX >> 3);
 }
 
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 #[test]
 #[should_panic]
 fn add_more_than_max_amount_permits() {

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::watch;
@@ -213,7 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");
 

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::watch;
@@ -213,7 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");
 


### PR DESCRIPTION
According to [this comment](https://github.com/tokio-rs/tokio/pull/4716#issuecomment-1182471863), this is the correct way to check for wasm.