### PR TITLE
Use build script to detect wasm

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,7 +117,7 @@ mio = { version = "0.8.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
 socket2 = { version = "0.4.4", features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
@@ -150,14 +150,14 @@ mockall = "0.11.1"
 tempfile = "3.1.0"
 async-stream = "0.3"
 
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+[target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dev-dependencies]
 proptest = "1"
 socket2 = "0.4"
 
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
+[target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dev-dependencies]
 rand = "0.8.0"
 
-[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,7 +117,7 @@ mio = { version = "0.8.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 socket2 = { version = "0.4.4", features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
@@ -150,14 +150,14 @@ mockall = "0.11.1"
 tempfile = "3.1.0"
 async-stream = "0.3"
 
-[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 proptest = "1"
 socket2 = "0.4"
 
-[target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 rand = "0.8.0"
 
-[target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dev-dependencies]
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -86,8 +86,8 @@ fn main() {
         autocfg::emit("tokio_no_addr_of")
     }
 
-    let target = ::std::env::var("TARGET").unwrap_or(String::new());
-    
+    let target = ::std::env::var("TARGET").unwrap_or_default();
+
     if target.starts_with("wasm") {
         autocfg::emit("tokio_wasm");
         if target.contains("wasi") {

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -85,4 +85,15 @@ fn main() {
         // RUSTFLAGS="--cfg tokio_no_addr_of"
         autocfg::emit("tokio_no_addr_of")
     }
+
+    let target = ::std::env::var("TARGET").unwrap_or(String::new());
+    
+    if target.starts_with("wasm") {
+        autocfg::emit("tokio_wasm");
+        if target.contains("wasi") {
+            autocfg::emit("tokio_wasi");
+        } else {
+            autocfg::emit("tokio_wasm_not_wasi");
+        }
+    }
 }

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -88,6 +88,8 @@ fn main() {
 
     let target = ::std::env::var("TARGET").unwrap_or_default();
 
+    // We emit cfgs instead of using `target_family = "wasm"` that requires Rust 1.54.
+    // Note that these cfgs are unavailable in `Cargo.toml`.
     if target.starts_with("wasm") {
         autocfg::emit("tokio_wasm");
         if target.contains("wasi") {

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -207,7 +207,7 @@ cfg_coop! {
 mod test {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    #[cfg(tokio_wasm_not_wasi)]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     fn get() -> Budget {

--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -207,7 +207,7 @@ cfg_coop! {
 mod test {
     use super::*;
 
-    #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
     use wasm_bindgen_test::wasm_bindgen_test as test;
 
     fn get() -> Budget {

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -115,7 +115,7 @@ impl Registration {
 
     // Uses the poll path, requiring the caller to ensure mutual exclusion for
     // correctness. Only the last task to call this function is notified.
-    #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+    #[cfg(not(tokio_wasi))]
     pub(crate) fn poll_read_io<R>(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/src/io/driver/registration.rs
+++ b/tokio/src/io/driver/registration.rs
@@ -115,7 +115,7 @@ impl Registration {
 
     // Uses the poll path, requiring the caller to ensure mutual exclusion for
     // correctness. Only the last task to call this function is notified.
-    #[cfg(not(all(target_family = "wasm", target_os = "wasi")))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
     pub(crate) fn poll_read_io<R>(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -211,11 +211,11 @@ cfg_io_driver_impl! {
         pub use driver::{Interest, Ready};
     }
 
-    #[cfg_attr(target_os = "wasi", allow(unused_imports))]
+    #[cfg_attr(tokio_wasi, allow(unused_imports))]
     mod poll_evented;
 
     #[cfg(not(loom))]
-    #[cfg_attr(target_os = "wasi", allow(unused_imports))]
+    #[cfg_attr(tokio_wasi, allow(unused_imports))]
     pub(crate) use poll_evented::PollEvented;
 }
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -404,7 +404,7 @@ compile_error! {
     all(target_os = "wasi", not(tokio_wasm)),
     all(target_os = "wasi", not(tokio_wasi)),
     all(target_os = "wasi", tokio_wasm_not_wasi),
-    all(tokio_wasm, not(any(target_arch = "wasm32", target_arch = "wasm64")))
+    all(tokio_wasm, not(any(target_arch = "wasm32", target_arch = "wasm64"))),
     all(tokio_wasm_not_wasi, not(tokio_wasm)),
     all(tokio_wasi, not(tokio_wasm))
 ))]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -395,7 +395,7 @@ compile_error! {
 
 #[cfg(all(
     not(tokio_unstable),
-    target_family = "wasm",
+    target_arch = "wasm32",
     any(
         feature = "fs",
         feature = "io-std",

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -424,10 +424,6 @@ compile_error!("Tokio's build script has incorrectly detected wasm.");
 ))]
 compile_error!("Only features sync,macros,io-util,rt are supported on wasm.");
 
-// See <https://github.com/tokio-rs/tokio/pull/4865> for more info.
-#[cfg(target_arch = "wasm64")]
-compile_error!("Only wasm32 is currently supported.");
-
 // Includes re-exports used by macros.
 //
 // This module is not intended to be part of the public API. In general, any

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -393,9 +393,26 @@ compile_error! {
     "Tokio requires the platform pointer width to be 32, 64, or 128 bits"
 }
 
+// Ensure that our build script has correctly set cfg flags for wasm.
+//
+// Each condition is written all(a, not(b)). This should be read as
+// "if a, then we must also have b".
+#[cfg(any(
+    all(target_arch = "wasm32", not(tokio_wasm)),
+    all(target_arch = "wasm64", not(tokio_wasm)),
+    all(target_family = "wasm", not(tokio_wasm)),
+    all(target_os = "wasi", not(tokio_wasm)),
+    all(target_os = "wasi", not(tokio_wasi)),
+    all(target_os = "wasi", tokio_wasm_not_wasi),
+    all(tokio_wasm, not(any(target_arch = "wasm32", target_arch = "wasm64")))
+    all(tokio_wasm_not_wasi, not(tokio_wasm)),
+    all(tokio_wasi, not(tokio_wasm))
+))]
+compile_error!("Tokio's build script has incorrectly detected wasm.");
+
 #[cfg(all(
     not(tokio_unstable),
-    target_arch = "wasm32",
+    tokio_wasm,
     any(
         feature = "fs",
         feature = "io-std",
@@ -406,6 +423,10 @@ compile_error! {
     )
 ))]
 compile_error!("Only features sync,macros,io-util,rt are supported on wasm.");
+
+// See <https://github.com/tokio-rs/tokio/pull/4865> for more info.
+#[cfg(target_arch = "wasm64")]
+compile_error!("Only wasm32 is currently supported.");
 
 // Includes re-exports used by macros.
 //

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -61,7 +61,7 @@ macro_rules! cfg_fs {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "fs")]
-            #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(tokio_wasi))]
             #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
             $item
         )*
@@ -252,7 +252,7 @@ macro_rules! cfg_process {
             #[cfg(feature = "process")]
             #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
             #[cfg(not(loom))]
-            #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(tokio_wasi))]
             $item
         )*
     }
@@ -281,7 +281,7 @@ macro_rules! cfg_signal {
             #[cfg(feature = "signal")]
             #[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
             #[cfg(not(loom))]
-            #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(tokio_wasi))]
             $item
         )*
     }
@@ -341,7 +341,7 @@ macro_rules! cfg_not_rt {
 macro_rules! cfg_rt_multi_thread {
     ($($item:item)*) => {
         $(
-            #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+            #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
             $item
         )*
@@ -459,7 +459,7 @@ macro_rules! cfg_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm32"
+                    tokio_wasm
                     )))]
             $item
         )*
@@ -474,7 +474,7 @@ macro_rules! cfg_not_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_arch = "wasm32"
+                    tokio_wasm
                     ))]
             $item
         )*
@@ -484,7 +484,7 @@ macro_rules! cfg_not_has_atomic_u64 {
 macro_rules! cfg_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(tokio_wasi))]
             $item
         )*
     }
@@ -493,7 +493,7 @@ macro_rules! cfg_not_wasi {
 macro_rules! cfg_is_wasm_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+            #[cfg(tokio_wasm_not_wasi)]
             $item
         )*
     }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -459,7 +459,7 @@ macro_rules! cfg_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_family = "wasm"
+                    target_arch = "wasm32"
                     )))]
             $item
         )*
@@ -474,7 +474,7 @@ macro_rules! cfg_not_has_atomic_u64 {
                     target_arch = "mips",
                     target_arch = "powerpc",
                     target_arch = "riscv32",
-                    target_family = "wasm"
+                    target_arch = "wasm32"
                     ))]
             $item
         )*
@@ -493,7 +493,7 @@ macro_rules! cfg_not_wasi {
 macro_rules! cfg_is_wasm_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+            #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
             $item
         )*
     }

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -275,7 +275,7 @@ impl TcpListener {
                 .map(|raw_socket| unsafe { std::net::TcpListener::from_raw_socket(raw_socket) })
         }
 
-        #[cfg(target_os = "wasi")]
+        #[cfg(tokio_wasi)]
         {
             use std::os::wasi::io::{FromRawFd, IntoRawFd};
             self.io
@@ -403,7 +403,7 @@ mod sys {
 }
 
 cfg_unstable! {
-    #[cfg(target_os = "wasi")]
+    #[cfg(tokio_wasi)]
     mod sys {
         use super::TcpListener;
         use std::os::wasi::prelude::*;

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -252,7 +252,7 @@ impl TcpStream {
                 .map(|raw_socket| unsafe { std::net::TcpStream::from_raw_socket(raw_socket) })
         }
 
-        #[cfg(target_os = "wasi")]
+        #[cfg(tokio_wasi)]
         {
             use std::os::wasi::io::{FromRawFd, IntoRawFd};
             self.io
@@ -1334,7 +1334,7 @@ mod sys {
     }
 }
 
-#[cfg(all(tokio_unstable, target_os = "wasi"))]
+#[cfg(all(tokio_unstable, tokio_wasi))]
 mod sys {
     use super::TcpStream;
     use std::os::wasi::prelude::*;

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -65,9 +65,9 @@ impl Park for ParkThread {
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         // Wasi doesn't have threads, so just sleep.
-        #[cfg(not(target_os = "wasi"))]
+        #[cfg(not(tokio_wasi))]
         self.inner.park_timeout(duration);
-        #[cfg(target_os = "wasi")]
+        #[cfg(tokio_wasi)]
         std::thread::sleep(duration);
         Ok(())
     }

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -125,7 +125,7 @@ const KEEP_ALIVE: Duration = Duration::from_secs(10);
 /// Tasks will be scheduled as non-mandatory, meaning they may not get executed
 /// in case of runtime shutdown.
 #[track_caller]
-#[cfg_attr(target_os = "wasi", allow(dead_code))]
+#[cfg_attr(tokio_wasi, allow(dead_code))]
 pub(crate) fn spawn_blocking<F, R>(func: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -174,7 +174,7 @@ pub(crate) type ThreadNameFn = std::sync::Arc<dyn Fn() -> String + Send + Sync +
 
 pub(crate) enum Kind {
     CurrentThread,
-    #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+    #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
     MultiThread,
 }
 
@@ -619,7 +619,7 @@ impl Builder {
     pub fn build(&mut self) -> io::Result<Runtime> {
         match &self.kind {
             Kind::CurrentThread => self.build_basic_runtime(),
-            #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+            #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             Kind::MultiThread => self.build_threaded_runtime(),
         }
     }
@@ -628,7 +628,7 @@ impl Builder {
         driver::Cfg {
             enable_pause_time: match self.kind {
                 Kind::CurrentThread => true,
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Kind::MultiThread => false,
             },
             enable_io: self.enable_io,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -174,7 +174,7 @@
 
 // At the top due to macros
 #[cfg(test)]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(tokio_wasm))]
 #[macro_use]
 mod tests;
 
@@ -204,7 +204,7 @@ cfg_rt! {
 
     mod blocking;
     use blocking::BlockingPool;
-    #[cfg_attr(target_os = "wasi", allow(unused_imports))]
+    #[cfg_attr(tokio_wasi, allow(unused_imports))]
     pub(crate) use blocking::spawn_blocking;
 
     cfg_trace! {
@@ -304,7 +304,7 @@ cfg_rt! {
         CurrentThread(BasicScheduler),
 
         /// Execute tasks across multiple threads.
-        #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+        #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
         ThreadPool(ThreadPool),
     }
 
@@ -484,7 +484,7 @@ cfg_rt! {
 
             match &self.kind {
                 Kind::CurrentThread(exec) => exec.block_on(future),
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Kind::ThreadPool(exec) => exec.block_on(future),
             }
         }
@@ -614,7 +614,7 @@ cfg_rt! {
                         },
                     }
                 },
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Kind::ThreadPool(_) => {
                     // The threaded scheduler drops its tasks on its worker threads, which is
                     // already in the runtime's context.

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -174,7 +174,7 @@
 
 // At the top due to macros
 #[cfg(test)]
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 mod tests;
 

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -10,13 +10,13 @@ cfg_rt_multi_thread! {
 #[derive(Debug, Clone)]
 pub(crate) enum Spawner {
     Basic(basic_scheduler::Spawner),
-    #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+    #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
     ThreadPool(thread_pool::Spawner),
 }
 
 impl Spawner {
     pub(crate) fn shutdown(&mut self) {
-        #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+        #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
         {
             if let Spawner::ThreadPool(spawner) = self {
                 spawner.shutdown();
@@ -31,7 +31,7 @@ impl Spawner {
     {
         match self {
             Spawner::Basic(spawner) => spawner.spawn(future, id),
-            #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+            #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             Spawner::ThreadPool(spawner) => spawner.spawn(future, id),
         }
     }
@@ -39,7 +39,7 @@ impl Spawner {
     pub(crate) fn as_handle_inner(&self) -> &HandleInner {
         match self {
             Spawner::Basic(spawner) => spawner.as_handle_inner(),
-            #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+            #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             Spawner::ThreadPool(spawner) => spawner.as_handle_inner(),
         }
     }
@@ -52,7 +52,7 @@ cfg_metrics! {
         pub(crate) fn num_workers(&self) -> usize {
             match self {
                 Spawner::Basic(_) => 1,
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Spawner::ThreadPool(spawner) => spawner.num_workers(),
             }
         }
@@ -60,7 +60,7 @@ cfg_metrics! {
         pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {
             match self {
                 Spawner::Basic(spawner) => spawner.scheduler_metrics(),
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Spawner::ThreadPool(spawner) => spawner.scheduler_metrics(),
             }
         }
@@ -68,7 +68,7 @@ cfg_metrics! {
         pub(crate) fn worker_metrics(&self, worker: usize) -> &WorkerMetrics {
             match self {
                 Spawner::Basic(spawner) => spawner.worker_metrics(worker),
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Spawner::ThreadPool(spawner) => spawner.worker_metrics(worker),
             }
         }
@@ -76,7 +76,7 @@ cfg_metrics! {
         pub(crate) fn injection_queue_depth(&self) -> usize {
             match self {
                 Spawner::Basic(spawner) => spawner.injection_queue_depth(),
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Spawner::ThreadPool(spawner) => spawner.injection_queue_depth(),
             }
         }
@@ -84,7 +84,7 @@ cfg_metrics! {
         pub(crate) fn worker_local_queue_depth(&self, worker: usize) -> usize {
             match self {
                 Spawner::Basic(spawner) => spawner.worker_metrics(worker).queue_depth(),
-                #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 Spawner::ThreadPool(spawner) => spawner.worker_local_queue_depth(worker),
             }
         }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -389,7 +389,7 @@ impl<S: Schedule> LocalNotified<S> {
 impl<S: Schedule> UnownedTask<S> {
     // Used in test of the inject queue.
     #[cfg(test)]
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    #[cfg_attr(tokio_wasm, allow(dead_code))]
     pub(super) fn into_notified(self) -> Notified<S> {
         Notified(self.into_task())
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -389,7 +389,7 @@ impl<S: Schedule> LocalNotified<S> {
 impl<S: Schedule> UnownedTask<S> {
     // Used in test of the inject queue.
     #[cfg(test)]
-    #[cfg_attr(target_family = "wasm", allow(dead_code))]
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     pub(super) fn into_notified(self) -> Notified<S> {
         Notified(self.into_task())
     }

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -12,7 +12,7 @@ impl AssertSync for AtomicWaker {}
 impl AssertSend for Waker {}
 impl AssertSync for Waker {}
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -37,7 +37,7 @@ fn wake_without_register() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn atomic_waker_panic_safe() {
     use std::panic;
     use std::ptr;

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -12,7 +12,7 @@ impl AssertSync for AtomicWaker {}
 impl AssertSend for Waker {}
 impl AssertSync for Waker {}
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -37,7 +37,7 @@ fn wake_without_register() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn atomic_waker_panic_safe() {
     use std::panic;
     use std::ptr;

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -4,7 +4,7 @@ use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -63,7 +63,7 @@ fn notify_simple() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(tokio_wasm))]
 fn watch_test() {
     let rt = crate::runtime::Builder::new_current_thread()
         .build()

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -4,7 +4,7 @@ use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -63,7 +63,7 @@ fn notify_simple() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 fn watch_test() {
     let rt = crate::runtime::Builder::new_current_thread()
         .build()

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -1,7 +1,7 @@
 use crate::sync::batch_semaphore::Semaphore;
 use tokio_test::*;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -170,7 +170,7 @@ fn poll_acquire_one_zero_permits() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn validates_max_permits() {
     use std::usize;
     Semaphore::new((usize::MAX >> 2) + 1);

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -1,7 +1,7 @@
 use crate::sync::batch_semaphore::Semaphore;
 use tokio_test::*;
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]
@@ -170,7 +170,7 @@ fn poll_acquire_one_zero_permits() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn validates_max_permits() {
     use std::usize;
     Semaphore::new((usize::MAX >> 2) + 1);

--- a/tokio/src/time/driver/tests/mod.rs
+++ b/tokio/src/time/driver/tests/mod.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_os = "wasi"))]
+#![cfg(not(tokio_wasi))]
 
 use std::{task::Context, time::Duration};
 

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -623,7 +623,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(tokio_wasm))]
     proptest::proptest! {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {
@@ -631,7 +631,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(tokio_wasm))]
     fn run_fuzz(ops: Vec<usize>) {
         use std::collections::VecDeque;
 

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -623,7 +623,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     proptest::proptest! {
         #[test]
         fn fuzz_linked_list(ops: Vec<usize>) {
@@ -631,7 +631,7 @@ mod tests {
         }
     }
 
-    #[cfg(not(target_family = "wasm"))]
+    #[cfg(not(target_arch = "wasm32"))]
     fn run_fuzz(ops: Vec<usize>) {
         use std::collections::VecDeque;
 

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,2 +1,2 @@
-#![cfg(not(any(feature = "full", target_arch = "wasm32")))]
+#![cfg(not(any(feature = "full", tokio_wasm)))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,2 +1,2 @@
-#![cfg(not(any(feature = "full", target_family = "wasm")))]
+#![cfg(not(any(feature = "full", target_arch = "wasm32")))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -130,7 +130,7 @@ macro_rules! assert_value {
 macro_rules! cfg_not_wasi {
     ($($item:item)*) => {
         $(
-            #[cfg(not(target_os = "wasi"))]
+            #[cfg(not(tokio_wasi))]
             $item
         )*
     }

--- a/tokio/tests/buffered.rs
+++ b/tokio/tests/buffered.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind()
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind()
 
 use tokio::net::TcpListener;
 use tokio_test::assert_ok;

--- a/tokio/tests/fs.rs
+++ b/tokio/tests/fs.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support file operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
 
 use tokio::fs;
 use tokio_test::assert_ok;

--- a/tokio/tests/fs_copy.rs
+++ b/tokio/tests/fs_copy.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support file operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
 
 use tempfile::tempdir;
 use tokio::fs;

--- a/tokio/tests/fs_dir.rs
+++ b/tokio/tests/fs_dir.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support directory operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support directory operations
 
 use tokio::fs;
 use tokio_test::{assert_err, assert_ok};

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support file operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
 
 use std::io::prelude::*;
 use tempfile::NamedTempFile;

--- a/tokio/tests/fs_link.rs
+++ b/tokio/tests/fs_link.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support file operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
 
 use tokio::fs;
 

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind()
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind()
 
 use std::time::Duration;
 use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 // Wasi does not support panic recovery or threading
-#![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(all(feature = "full", not(tokio_wasi)))]
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_fill_buf.rs
+++ b/tokio/tests/io_fill_buf.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support file operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
 
 use tempfile::NamedTempFile;
 use tokio::fs::File;

--- a/tokio/tests/io_panic.rs
+++ b/tokio/tests/io_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use std::task::{Context, Poll};
 use std::{error::Error, pin::Pin};

--- a/tokio/tests/io_read.rs
+++ b/tokio/tests/io_read.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio_test::assert_ok;

--- a/tokio/tests/io_split.rs
+++ b/tokio/tests/io_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use tokio::io::{split, AsyncRead, AsyncWrite, ReadBuf, ReadHalf, WriteHalf};
 

--- a/tokio/tests/io_take.rs
+++ b/tokio/tests/io_take.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/join_handle_panic.rs
+++ b/tokio/tests/join_handle_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 struct PanicsOnDrop;
 

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -2,12 +2,12 @@
 #![allow(clippy::blacklisted_name)]
 use std::sync::Arc;
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::{oneshot, Semaphore};

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -2,12 +2,12 @@
 #![allow(clippy::blacklisted_name)]
 use std::sync::Arc;
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::{oneshot, Semaphore};

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "macros")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 async fn one() {}

--- a/tokio/tests/macros_pin.rs
+++ b/tokio/tests/macros_pin.rs
@@ -1,9 +1,9 @@
 #![cfg(feature = "macros")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 async fn one() {}

--- a/tokio/tests/macros_rename_test.rs
+++ b/tokio/tests/macros_rename_test.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threading
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threading
 
 #[allow(unused_imports)]
 use std as tokio;

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "macros")]
 #![allow(clippy::blacklisted_name)]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,10 +1,10 @@
 #![cfg(feature = "macros")]
 #![allow(clippy::blacklisted_name)]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threading
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threading
 
 use tokio::test;
 

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, Semaphore};
 use tokio_test::{assert_pending, assert_ready, task};
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 #[maybe_tokio_test]

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -6,10 +6,10 @@ use std::sync::Arc;
 use tokio::sync::{oneshot, Semaphore};
 use tokio_test::{assert_pending, assert_ready, task};
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 #[maybe_tokio_test]

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery or bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support panic recovery or bind
 
 use tokio::net::TcpListener;
 

--- a/tokio/tests/net_lookup_host.rs
+++ b/tokio/tests/net_lookup_host.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support direct socket operations
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support direct socket operations
 
 use tokio::net;
 use tokio_test::assert_ok;

--- a/tokio/tests/net_panic.rs
+++ b/tokio/tests/net_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(all(feature = "full", not(tokio_wasi)))]
 
 use std::error::Error;
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;

--- a/tokio/tests/process_smoke.rs
+++ b/tokio/tests/process_smoke.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi cannot run system commands
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi cannot run system commands
 
 use tokio::process::Command;
 use tokio_test::assert_ok;

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -178,7 +178,7 @@ fn drop_tasks_in_context() {
 }
 
 #[test]
-#[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+#[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
 #[should_panic(expected = "boom")]
 fn wake_in_drop_after_panic() {
     let (tx, rx) = oneshot::channel::<()>();
@@ -239,7 +239,7 @@ fn spawn_two() {
     }
 }
 
-#[cfg_attr(target_os = "wasi", ignore = "WASI: std::thread::spawn not supported")]
+#[cfg_attr(tokio_wasi, ignore = "WASI: std::thread::spawn not supported")]
 #[test]
 fn spawn_remote() {
     let rt = rt();
@@ -276,7 +276,7 @@ fn spawn_remote() {
 }
 
 #[test]
-#[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+#[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
 #[should_panic(
     expected = "A Tokio 1.x context was found, but timers are disabled. Call `enable_time` on the runtime builder to enable timers."
 )]
@@ -315,7 +315,7 @@ mod unstable {
     }
 
     #[test]
-    #[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+    #[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
     fn spawns_do_nothing() {
         use std::sync::Arc;
 
@@ -344,7 +344,7 @@ mod unstable {
     }
 
     #[test]
-    #[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+    #[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
     fn shutdown_all_concurrent_block_on() {
         const N: usize = 2;
         use std::sync::{mpsc, Arc};

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -18,7 +18,7 @@ macro_rules! rt_test {
             }
         }
 
-        #[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+        #[cfg(not(tokio_wasi))] // Wasi doesn't support threads
         mod threaded_scheduler_4_threads {
             $($t)*
 
@@ -32,7 +32,7 @@ macro_rules! rt_test {
             }
         }
 
-        #[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+        #[cfg(not(tokio_wasi))] // Wasi doesn't support threads
         mod threaded_scheduler_1_thread {
             $($t)*
 
@@ -675,7 +675,7 @@ rt_test! {
         assert_err!(rx.try_recv());
     }
 
-    #[cfg_attr(target_os = "wasi", ignore = "Wasi does not support threads or panic recovery")]
+    #[cfg_attr(tokio_wasi, ignore = "Wasi does not support threads or panic recovery")]
     #[test]
     fn panic_in_task() {
         let rt = rt();
@@ -704,7 +704,7 @@ rt_test! {
 
     #[test]
     #[should_panic]
-    #[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+    #[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
     fn panic_in_block_on() {
         let rt = rt();
         rt.block_on(async { panic!() });
@@ -935,7 +935,7 @@ rt_test! {
     // See https://github.com/rust-lang/rust/issues/74875
     #[test]
     #[cfg(not(windows))]
-    #[cfg_attr(target_os = "wasi", ignore = "Wasi does not support threads")]
+    #[cfg_attr(tokio_wasi, ignore = "Wasi does not support threads")]
     fn runtime_in_thread_local() {
         use std::cell::RefCell;
         use std::thread;
@@ -980,7 +980,7 @@ rt_test! {
         tx.send(()).unwrap();
     }
 
-    #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
+    #[cfg(not(tokio_wasi))] // Wasi does not support bind
     #[test]
     fn local_set_block_on_socket() {
         let rt = rt();
@@ -1002,7 +1002,7 @@ rt_test! {
         });
     }
 
-    #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
+    #[cfg(not(tokio_wasi))] // Wasi does not support bind
     #[test]
     fn local_set_client_server_block_on() {
         let rt = rt();
@@ -1016,7 +1016,7 @@ rt_test! {
         assert_err!(rx.try_recv());
     }
 
-    #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
+    #[cfg(not(tokio_wasi))] // Wasi does not support bind
     async fn client_server_local(tx: mpsc::Sender<()>) {
         let server = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
 

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -10,10 +10,10 @@
 use std::time::Duration;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 use tokio::{net, time};
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 macro_rules! multi_threaded_rt_test {
     ($($t:tt)*) => {
         mod threaded_scheduler_4_threads_only {
@@ -46,7 +46,7 @@ macro_rules! multi_threaded_rt_test {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 macro_rules! rt_test {
     ($($t:tt)*) => {
         mod current_thread_scheduler {
@@ -126,7 +126,7 @@ fn unbounded_mpsc_channel() {
     })
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support file operations or bind
+#[cfg(not(tokio_wasi))] // Wasi doesn't support file operations or bind
 rt_test! {
     use tokio::fs;
     // ==== spawn blocking futures ======
@@ -419,7 +419,7 @@ rt_test! {
     }
 }
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 multi_threaded_rt_test! {
     #[cfg(unix)]
     #[test]
@@ -482,7 +482,7 @@ multi_threaded_rt_test! {
 // ==== utils ======
 
 /// Create a new multi threaded runtime
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 fn new_multi_thread(n: usize) -> Runtime {
     tokio::runtime::Builder::new_multi_thread()
         .worker_threads(n)
@@ -516,7 +516,7 @@ where
         f();
     }
 
-    #[cfg(not(target_os = "wasi"))]
+    #[cfg(not(tokio_wasi))]
     {
         println!("multi thread (1 thread) runtime");
 
@@ -529,7 +529,7 @@ where
         f();
     }
 
-    #[cfg(not(target_os = "wasi"))]
+    #[cfg(not(tokio_wasi))]
     {
         println!("multi thread (4 threads) runtime");
 

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", tokio_unstable, not(target_os = "wasi")))]
+#![cfg(all(feature = "full", tokio_unstable, not(tokio_wasi)))]
 
 use tokio::runtime::Runtime;
 use tokio::time::{self, Duration};

--- a/tokio/tests/rt_panic.rs
+++ b/tokio/tests/rt_panic.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
-#![cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#![cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 
 use futures::future;
 use std::error::Error;

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(all(feature = "full", not(tokio_wasi)))]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/signal_no_rt.rs
+++ b/tokio/tests/signal_no_rt.rs
@@ -4,7 +4,7 @@
 
 use tokio::signal::unix::{signal, SignalKind};
 
-#[cfg_attr(target_os = "wasi", ignore = "Wasi does not support panic recovery")]
+#[cfg_attr(tokio_wasi, ignore = "Wasi does not support panic recovery")]
 #[test]
 #[should_panic]
 fn no_runtime_panics_creating_signals() {

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Barrier;

--- a/tokio/tests/sync_barrier.rs
+++ b/tokio/tests/sync_barrier.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Barrier;

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::broadcast;
@@ -276,14 +276,14 @@ fn send_no_rx() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn zero_capacity() {
     broadcast::channel::<()>(0);
 }
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn capacity_too_big() {
     use std::usize;
 
@@ -291,7 +291,7 @@ fn capacity_too_big() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn panic_in_clone() {
     use std::panic::{self, AssertUnwindSafe};
 

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::broadcast;
@@ -276,14 +276,14 @@ fn send_no_rx() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn zero_capacity() {
     broadcast::channel::<()>(0);
 }
 
 #[test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn capacity_too_big() {
     use std::usize;
 
@@ -291,7 +291,7 @@ fn capacity_too_big() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn panic_in_clone() {
     use std::panic::{self, AssertUnwindSafe};
 

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 fn is_error<T: std::error::Error + Send + Sync>() {}

--- a/tokio/tests/sync_errors.rs
+++ b/tokio/tests/sync_errors.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 fn is_error<T: std::error::Error + Send + Sync>() {}

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -2,12 +2,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::mpsc;
@@ -16,7 +16,7 @@ use tokio_test::*;
 
 use std::sync::Arc;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(tokio_wasm))]
 mod support {
     pub(crate) mod mpsc_stream;
 }
@@ -88,7 +88,7 @@ async fn reserve_disarm() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 async fn send_recv_stream_with_buffer() {
     use tokio_stream::StreamExt;
 
@@ -155,7 +155,7 @@ async fn start_send_past_cap() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn buffer_gteq_one() {
     mpsc::channel::<i32>(0);
 }
@@ -192,7 +192,7 @@ async fn async_send_recv_unbounded() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 async fn send_recv_stream_unbounded() {
     use tokio_stream::StreamExt;
 
@@ -453,7 +453,7 @@ fn unconsumed_messages_are_dropped() {
 }
 
 #[test]
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 fn blocking_recv() {
     let (tx, mut rx) = mpsc::channel::<u8>(1);
 
@@ -471,14 +471,14 @@ fn blocking_recv() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 async fn blocking_recv_async() {
     let (_tx, mut rx) = mpsc::channel::<()>(1);
     let _ = rx.blocking_recv();
 }
 
 #[test]
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 fn blocking_send() {
     let (tx, mut rx) = mpsc::channel::<u8>(1);
 
@@ -496,7 +496,7 @@ fn blocking_send() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 async fn blocking_send_async() {
     let (tx, _rx) = mpsc::channel::<()>(1);
     let _ = tx.blocking_send(());
@@ -649,7 +649,7 @@ async fn recv_timeout() {
 
 #[test]
 #[should_panic = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn recv_timeout_panic() {
     use futures::future::FutureExt;
     use tokio::time::Duration;

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -2,12 +2,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::mpsc;
@@ -16,7 +16,7 @@ use tokio_test::*;
 
 use std::sync::Arc;
 
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod support {
     pub(crate) mod mpsc_stream;
 }
@@ -155,7 +155,7 @@ async fn start_send_past_cap() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn buffer_gteq_one() {
     mpsc::channel::<i32>(0);
 }
@@ -471,7 +471,7 @@ fn blocking_recv() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 async fn blocking_recv_async() {
     let (_tx, mut rx) = mpsc::channel::<()>(1);
     let _ = rx.blocking_recv();
@@ -496,7 +496,7 @@ fn blocking_send() {
 
 #[tokio::test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 async fn blocking_send_async() {
     let (tx, _rx) = mpsc::channel::<()>(1);
     let _ = tx.blocking_send(());
@@ -649,7 +649,7 @@ async fn recv_timeout() {
 
 #[test]
 #[should_panic = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn recv_timeout_panic() {
     use futures::future::FutureExt;
     use tokio::time::Duration;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::Mutex;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Notify;

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::Notify;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;
@@ -179,7 +179,7 @@ fn explicit_close_try_recv() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn close_try_recv_poll() {
     let (_tx, rx) = oneshot::channel::<i32>();
     let mut rx = task::spawn(rx);

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use tokio::sync::oneshot;
@@ -179,7 +179,7 @@ fn explicit_close_try_recv() {
 
 #[test]
 #[should_panic]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn close_try_recv_poll() {
     let (_tx, rx) = oneshot::channel::<i32>();
     let mut rx = task::spawn(rx);

--- a/tokio/tests/sync_panic.rs
+++ b/tokio/tests/sync_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(all(feature = "full", not(tokio_wasi)))]
 
 use std::error::Error;
 use tokio::{

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
+#[cfg(not(tokio_wasm_not_wasi))]
 use tokio::test as maybe_tokio_test;
 
 use std::task::Poll;
@@ -172,7 +172,7 @@ async fn write_order() {
 }
 
 // A single RwLock is contested by tasks in multiple threads
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn multithreaded() {
     use futures::stream::{self, StreamExt};

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -1,12 +1,12 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 
-#[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
+#[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
 use std::task::Poll;

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;
@@ -93,7 +93,7 @@ fn add_max_amount_permits() {
     assert_eq!(s.available_permits(), usize::MAX >> 3);
 }
 
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 #[test]
 #[should_panic]
 fn add_more_than_max_amount_permits() {

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;
@@ -93,7 +93,7 @@ fn add_max_amount_permits() {
     assert_eq!(s.available_permits(), usize::MAX >> 3);
 }
 
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 #[test]
 #[should_panic]
 fn add_more_than_max_amount_permits() {

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use std::sync::Arc;

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+#[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::watch;
@@ -213,7 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
-#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
+#[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");
 

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -2,7 +2,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
 
-#[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
+#[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 use tokio::sync::watch;
@@ -213,7 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[cfg(not(target_arch = "wasm32"))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");
 

--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support panic recovery
 
 use std::sync::Arc;
 use std::thread::sleep;

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 
 use tokio::{runtime, task};
 use tokio_test::assert_ok;

--- a/tokio/tests/task_local.rs
+++ b/tokio/tests/task_local.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -11,13 +11,13 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::{self, LocalSet};
 use tokio::time;
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 use std::cell::Cell;
 use std::sync::atomic::AtomicBool;
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 use std::sync::atomic::Ordering::SeqCst;
 use std::time::Duration;
 
@@ -30,7 +30,7 @@ async fn local_basic_scheduler() {
         .await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool() {
     thread_local! {
@@ -51,7 +51,7 @@ async fn local_threadpool() {
         .await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn localset_future_threadpool() {
     thread_local! {
@@ -67,7 +67,7 @@ async fn localset_future_threadpool() {
     local.await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn localset_future_timers() {
     static RAN1: AtomicBool = AtomicBool::new(false);
@@ -112,7 +112,7 @@ async fn localset_future_drives_all_local_futs() {
     assert!(RAN3.load(Ordering::SeqCst));
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool_timer() {
     // This test ensures that runtime services like the timer are properly
@@ -151,7 +151,7 @@ fn enter_guard_spawn() {
     });
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#[cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 #[test]
 // This will panic, since the thread that calls `block_on` cannot use
 // in-place blocking inside of `block_on`.
@@ -178,7 +178,7 @@ fn local_threadpool_blocking_in_place() {
     });
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool_blocking_run() {
     thread_local! {
@@ -207,7 +207,7 @@ async fn local_threadpool_blocking_run() {
         .await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn all_spawns_are_local() {
     use futures::future;
@@ -234,7 +234,7 @@ async fn all_spawns_are_local() {
         .await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_spawn_is_local() {
     thread_local! {
@@ -270,7 +270,7 @@ async fn nested_spawn_is_local() {
         .await;
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[test]
 fn join_local_future_elsewhere() {
     thread_local! {
@@ -385,7 +385,7 @@ fn with_timeout(timeout: Duration, f: impl FnOnce() + Send + 'static) {
 }
 
 #[cfg_attr(
-    target_os = "wasi",
+    tokio_wasi,
     ignore = "`unwrap()` in `with_timeout()` panics on Wasi"
 )]
 #[test]
@@ -411,7 +411,7 @@ fn drop_cancels_remote_tasks() {
 }
 
 #[cfg_attr(
-    target_os = "wasi",
+    tokio_wasi,
     ignore = "FIXME: `task::spawn_local().await.unwrap()` panics on Wasi"
 )]
 #[test]
@@ -435,7 +435,7 @@ fn local_tasks_wake_join_all() {
     });
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#[cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 #[test]
 fn local_tasks_are_polled_after_tick() {
     // This test depends on timing, so we run it up to five times.
@@ -452,7 +452,7 @@ fn local_tasks_are_polled_after_tick() {
     local_tasks_are_polled_after_tick_inner();
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#[cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 #[tokio::main(flavor = "current_thread")]
 async fn local_tasks_are_polled_after_tick_inner() {
     // Reproduces issues #1899 and #1900

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -384,10 +384,7 @@ fn with_timeout(timeout: Duration, f: impl FnOnce() + Send + 'static) {
     thread.join().expect("test thread should not panic!")
 }
 
-#[cfg_attr(
-    tokio_wasi,
-    ignore = "`unwrap()` in `with_timeout()` panics on Wasi"
-)]
+#[cfg_attr(tokio_wasi, ignore = "`unwrap()` in `with_timeout()` panics on Wasi")]
 #[test]
 fn drop_cancels_remote_tasks() {
     // This test reproduces issue #1885.

--- a/tokio/tests/task_panic.rs
+++ b/tokio/tests/task_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(all(feature = "full", not(tokio_wasi)))]
 
 use futures::future;
 use std::error::Error;

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use std::io::Read;
 use std::io::Result;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use std::time::Duration;
 use tokio::net::TcpSocket;

--- a/tokio/tests/tcp_split.rs
+++ b/tokio/tests/tcp_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use std::io::Result;
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, Interest};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/time_panic.rs
+++ b/tokio/tests/time_panic.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support panic recovery
 
 use futures::future;
 use std::error::Error;

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -6,7 +6,7 @@ use rand::{rngs::StdRng, Rng};
 use tokio::time::{self, Duration, Instant, Sleep};
 use tokio_test::{assert_elapsed, assert_pending, assert_ready, assert_ready_eq, task};
 
-#[cfg(not(target_os = "wasi"))]
+#[cfg(not(tokio_wasi))]
 use tokio_test::assert_err;
 
 use std::{
@@ -29,14 +29,14 @@ async fn pause_time_in_task() {
     t.await.unwrap();
 }
 
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[should_panic]
 async fn pause_time_in_main_threads() {
     tokio::time::pause();
 }
 
-#[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn pause_time_in_spawn_threads() {
     let t = tokio::spawn(async {

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -5,7 +5,7 @@ use tokio::time::*;
 
 use std::sync::mpsc;
 
-#[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))] // Wasi doesn't support threads
+#[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))] // Wasi doesn't support threads
 #[test]
 fn timer_with_threaded_runtime() {
     use tokio::runtime::Runtime;

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -168,7 +168,7 @@ async fn reset_sleep_to_past() {
     assert_ready!(sleep.poll());
 }
 
-#[cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#[cfg(not(tokio_wasi))] // Wasi doesn't support panic recovery
 #[test]
 #[should_panic]
 fn creating_sleep_outside_of_context() {

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -17,7 +17,7 @@ async fn simultaneous_deadline_future_completion() {
     assert_ready_ok!(fut.poll());
 }
 
-#[cfg_attr(target_os = "wasi", ignore = "FIXME: `fut.poll()` panics on Wasi")]
+#[cfg_attr(tokio_wasi, ignore = "FIXME: `fut.poll()` panics on Wasi")]
 #[tokio::test]
 async fn completed_future_past_deadline() {
     // Wrap it with a deadline

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind or UDP
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind or UDP
 
 use futures::future::poll_fn;
 use std::io;

--- a/tokio/tests/unwindsafe.rs
+++ b/tokio/tests/unwindsafe.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
 
 use std::panic::{RefUnwindSafe, UnwindSafe};
 


### PR DESCRIPTION
This PR reverts #4864 (see comments on PR) and uses a different strategy for wasm detection.