### PR TITLE
Make `park_timeout` use `std::thread::sleep` for all wasm targets

### DIFF
--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -65,9 +65,9 @@ impl Park for ParkThread {
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         // Wasi doesn't have threads, so just sleep.
-        #[cfg(not(tokio_wasi))]
+        #[cfg(not(tokio_wasm))]
         self.inner.park_timeout(duration);
-        #[cfg(tokio_wasi)]
+        #[cfg(tokio_wasm)]
         std::thread::sleep(duration);
         Ok(())
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
