### PR TITLE
task: add custom SpawnError

### DIFF
--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -1,4 +1,5 @@
 use crate::runtime::task::{self, Task};
+use std::convert::Infallible;
 
 /// `task::Schedule` implementation that does nothing. This is unique to the
 /// blocking scheduler as tasks scheduled are not really futures but blocking
@@ -9,11 +10,13 @@ use crate::runtime::task::{self, Task};
 pub(crate) struct NoopSchedule;
 
 impl task::Schedule for NoopSchedule {
+    type Error = Infallible;
+
     fn release(&self, _task: &Task<Self>) -> Option<Task<Self>> {
         None
     }
 
-    fn schedule(&self, _task: task::Notified<Self>) {
+    fn schedule(&self, _task: task::Notified<Self>) -> Result<(), Self::Error> {
         unreachable!();
     }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -61,7 +61,7 @@ pub(crate) struct HandleInner {
 }
 
 cfg_rt! {
-    use crate::runtime::task::JoinHandle;
+    use crate::runtime::task::{JoinHandle, SpawnResult, SpawnError};
     use crate::runtime::{blocking, context, Spawner};
     use crate::util::error::{CONTEXT_MISSING_ERROR, THREAD_LOCAL_DESTROYED_ERROR};
 
@@ -190,6 +190,7 @@ cfg_rt! {
             F::Output: Send + 'static,
         {
             self.spawn_named(future, None)
+                .unwrap_or_else(|e| e.handle)
         }
 
         /// Runs the provided function on an executor dedicated to blocking.
@@ -313,7 +314,7 @@ cfg_rt! {
         }
 
         #[track_caller]
-        pub(crate) fn spawn_named<F>(&self, future: F, _name: Option<&str>) -> JoinHandle<F::Output>
+        pub(crate) fn spawn_named<F>(&self, future: F, _name: Option<&str>) -> SpawnResult<F::Output, SpawnError>
         where
             F: Future + Send + 'static,
             F::Output: Send + 'static,

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -3,7 +3,9 @@ use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime::context::EnterGuard;
 use crate::runtime::driver::{Driver, Unpark};
-use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
+use crate::runtime::task::{
+    self, OwnedTasks, Schedule, SpawnError, SpawnFailure, SpawnResult, Task,
+};
 use crate::runtime::Config;
 use crate::runtime::{MetricsBatch, SchedulerMetrics, WorkerMetrics};
 use crate::sync::notify::Notify;
@@ -356,18 +358,24 @@ impl Context {
 
 impl Spawner {
     /// Spawns a future onto the `CurrentThread` scheduler
-    pub(crate) fn spawn<F>(&self, future: F, id: crate::runtime::task::Id) -> JoinHandle<F::Output>
+    pub(crate) fn spawn<F>(
+        &self,
+        future: F,
+        id: crate::runtime::task::Id,
+    ) -> SpawnResult<F::Output, SpawnError>
     where
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
         let (handle, notified) = self.shared.owned.bind(future, self.shared.clone(), id);
 
-        if let Some(notified) = notified {
-            self.shared.schedule(notified);
+        match notified {
+            Some(notified) => match self.shared.schedule(notified) {
+                Ok(()) => Ok(handle),
+                Err(e) => Err(SpawnFailure::new(handle, e)),
+            },
+            None => Err(SpawnFailure::new(handle, SpawnError::shutdown())),
         }
-
-        handle
     }
 
     fn pop(&self) -> Option<task::Notified<Arc<Shared>>> {
@@ -421,35 +429,39 @@ impl fmt::Debug for Spawner {
 // ===== impl Shared =====
 
 impl Schedule for Arc<Shared> {
+    type Error = SpawnError;
+
     fn release(&self, task: &Task<Self>) -> Option<Task<Self>> {
         self.owned.remove(task)
     }
 
-    fn schedule(&self, task: task::Notified<Self>) {
+    fn schedule(&self, task: task::Notified<Self>) -> Result<(), Self::Error> {
         CURRENT.with(|maybe_cx| match maybe_cx {
             Some(cx) if Arc::ptr_eq(self, &cx.spawner.shared) => {
                 let mut core = cx.core.borrow_mut();
-
-                // If `None`, the runtime is shutting down, so there is no need
-                // to schedule the task.
-                if let Some(core) = core.as_mut() {
-                    core.push_task(task);
+                match core.as_mut() {
+                    Some(core) => {
+                        core.push_task(task);
+                        Ok(())
+                    }
+                    None => Err(SpawnError::shutdown()),
                 }
             }
             _ => {
                 // Track that a task was scheduled from **outside** of the runtime.
                 self.scheduler_metrics.inc_remote_schedule_count();
-
-                // If the queue is None, then the runtime has shut down. We
-                // don't need to do anything with the notification in that case.
                 let mut guard = self.queue.lock();
-                if let Some(queue) = guard.as_mut() {
-                    queue.push_back(task);
-                    drop(guard);
-                    self.unpark.unpark();
+                match guard.as_mut() {
+                    Some(queue) => {
+                        queue.push_back(task);
+                        drop(guard);
+                        self.unpark.unpark();
+                        Ok(())
+                    }
+                    None => Err(SpawnError::shutdown()),
                 }
             }
-        });
+        })
     }
 
     cfg_unstable! {

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use worker::Launch;
 pub(crate) use worker::block_in_place;
 
 use crate::loom::sync::Arc;
-use crate::runtime::task::{self, JoinHandle};
+use crate::runtime::task::{self, SpawnError, SpawnResult};
 use crate::runtime::{Config, Driver};
 
 use std::fmt;
@@ -91,7 +91,7 @@ impl Drop for MultiThread {
 
 impl Spawner {
     /// Spawns a future onto the thread pool
-    pub(crate) fn spawn<F>(&self, future: F, id: task::Id) -> JoinHandle<F::Output>
+    pub(crate) fn spawn<F>(&self, future: F, id: task::Id) -> SpawnResult<F::Output, SpawnError>
     where
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -1,7 +1,6 @@
 use crate::future::Future;
 use crate::runtime::scheduler::current_thread;
-use crate::runtime::task::Id;
-use crate::task::JoinHandle;
+use crate::runtime::task::{Id, SpawnError, SpawnResult};
 
 cfg_rt_multi_thread! {
     use crate::runtime::scheduler::multi_thread;
@@ -24,7 +23,7 @@ impl Spawner {
         }
     }
 
-    pub(crate) fn spawn<F>(&self, future: F, id: Id) -> JoinHandle<F::Output>
+    pub(crate) fn spawn<F>(&self, future: F, id: Id) -> SpawnResult<F::Output, SpawnError>
     where
         F: Future + Send + 'static,
         F::Output: Send + 'static,

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::fmt;
 use std::io;
 
-use super::Id;
+use super::{Id, JoinHandle};
 use crate::util::SyncWrapper;
 cfg_rt! {
     /// Task failed to execute to completion.
@@ -163,3 +163,193 @@ impl From<JoinError> for io::Error {
         )
     }
 }
+
+cfg_rt! {
+    /// Failed to spawn a task
+    #[derive(Debug)]
+    pub struct SpawnError {
+        pub(crate) kind: SpawnErrorKind,
+    }
+
+    /// Failed to spawn a blocking task
+    #[derive(Debug)]
+    pub struct SpawnBlockingError {
+        pub(crate) kind: SpawnBlockingErrorKind,
+    }
+
+    /// Failed to spawn a blocking task
+    #[derive(Debug)]
+    pub struct SpawnLocalError {
+        pub(crate) kind: SpawnLocalErrorKind,
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SpawnErrorKind {
+    /// Pool is shutting down and the task was not scheduled
+    Shutdown,
+}
+
+#[derive(Debug)]
+pub(crate) enum SpawnBlockingErrorKind {
+    /// Pool is shutting down and the task was not scheduled
+    Shutdown,
+    /// There are no worker threads available to take the task
+    /// and the OS failed to spawn a new one
+    NoBlockingThreads(io::Error),
+}
+
+#[derive(Debug)]
+pub(crate) enum SpawnLocalErrorKind {
+    /// Pool is shutting down and the task was not scheduled
+    Shutdown,
+}
+
+impl SpawnError {
+    pub(crate) fn shutdown() -> Self {
+        Self {
+            kind: SpawnErrorKind::Shutdown,
+        }
+    }
+
+    /// Returns `true` if the error was caused by the runtime being shutdown.
+    pub fn is_shutdown(&self) -> bool {
+        matches!(&self.kind, SpawnErrorKind::Shutdown)
+    }
+}
+
+impl From<SpawnError> for io::Error {
+    fn from(src: SpawnError) -> Self {
+        match src.kind {
+            SpawnErrorKind::Shutdown => {
+                io::Error::new(io::ErrorKind::Other, "runtime shutting down")
+            }
+        }
+    }
+}
+
+impl fmt::Display for SpawnError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            SpawnErrorKind::Shutdown => fmt.write_str("runtime shutting down"),
+        }
+    }
+}
+
+impl std::error::Error for SpawnError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SpawnErrorKind::Shutdown => None,
+        }
+    }
+}
+
+impl SpawnBlockingError {
+    pub(crate) fn shutdown() -> Self {
+        Self {
+            kind: SpawnBlockingErrorKind::Shutdown,
+        }
+    }
+
+    pub(crate) fn no_blocking_threads(e: io::Error) -> Self {
+        Self {
+            kind: SpawnBlockingErrorKind::NoBlockingThreads(e),
+        }
+    }
+
+    /// Returns `true` if the error was caused by the runtime being shutdown.
+    pub fn is_shutdown(&self) -> bool {
+        matches!(&self.kind, SpawnBlockingErrorKind::Shutdown)
+    }
+
+    /// Returns `true` if the error was caused by a blocking spawn failing
+    /// because the blocking threadpool was unable to spawn additional threads.
+    pub fn is_no_blocking_threads(&self) -> bool {
+        matches!(&self.kind, SpawnBlockingErrorKind::NoBlockingThreads(_))
+    }
+}
+
+impl From<SpawnBlockingError> for io::Error {
+    fn from(src: SpawnBlockingError) -> Self {
+        match src.kind {
+            SpawnBlockingErrorKind::Shutdown => {
+                io::Error::new(io::ErrorKind::Other, "runtime shutting down")
+            }
+            SpawnBlockingErrorKind::NoBlockingThreads(e) => e,
+        }
+    }
+}
+
+impl fmt::Display for SpawnBlockingError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            SpawnBlockingErrorKind::Shutdown => fmt.write_str("runtime shutting down"),
+            SpawnBlockingErrorKind::NoBlockingThreads(_) => {
+                fmt.write_str("unable to spawn blocking thread")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SpawnBlockingError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SpawnBlockingErrorKind::Shutdown => None,
+            SpawnBlockingErrorKind::NoBlockingThreads(e) => Some(e),
+        }
+    }
+}
+
+impl SpawnLocalError {
+    pub(crate) fn shutdown() -> Self {
+        Self {
+            kind: SpawnLocalErrorKind::Shutdown,
+        }
+    }
+
+    /// Returns `true` if the error was caused by the runtime being shutdown.
+    pub fn is_shutdown(&self) -> bool {
+        matches!(&self.kind, SpawnLocalErrorKind::Shutdown)
+    }
+}
+
+impl From<SpawnLocalError> for io::Error {
+    fn from(src: SpawnLocalError) -> Self {
+        match src.kind {
+            SpawnLocalErrorKind::Shutdown => {
+                io::Error::new(io::ErrorKind::Other, "runtime shutting down")
+            }
+        }
+    }
+}
+
+impl fmt::Display for SpawnLocalError {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.kind {
+            SpawnLocalErrorKind::Shutdown => fmt.write_str("runtime shutting down"),
+        }
+    }
+}
+
+impl std::error::Error for SpawnLocalError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match &self.kind {
+            SpawnLocalErrorKind::Shutdown => None,
+        }
+    }
+}
+
+// Internal type for making it easier to return an error and JoinHandle
+// while maintaining API compatibility
+pub(crate) struct SpawnFailure<T, E> {
+    pub(crate) handle: JoinHandle<T>,
+    pub(crate) inner: E,
+}
+
+impl<T, E> SpawnFailure<T, E> {
+    pub(crate) fn new(handle: JoinHandle<T>, inner: E) -> Self {
+        Self { handle, inner }
+    }
+}
+
+pub(crate) type SpawnResult<T, E> = Result<JoinHandle<T>, SpawnFailure<T, E>>;

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -221,7 +221,8 @@ where
             // Since the caller holds a ref-count, the task cannot be destroyed
             // before the call to `schedule` returns even if the call drops the
             // `Notified` internally.
-            self.core()
+            let _ = self
+                .core()
                 .scheduler
                 .schedule(Notified(self.get_new_task()));
         }
@@ -246,7 +247,8 @@ where
                 // The old ref-count is retained for now to ensure that the task
                 // is not dropped during the call to `schedule` if the call
                 // drops the task it was given.
-                self.core()
+                let _ = self
+                    .core()
                     .scheduler
                     .schedule(Notified(self.get_new_task()));
 
@@ -273,7 +275,8 @@ where
                 // and the caller also holds a ref-count. The caller's ref-count
                 // ensures that the task is not destroyed even if the new task
                 // is dropped before `schedule` returns.
-                self.core()
+                let _ = self
+                    .core()
                     .scheduler
                     .schedule(Notified(self.get_new_task()));
             }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -145,7 +145,8 @@ use self::core::Header;
 
 mod error;
 #[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
-pub use self::error::JoinError;
+pub use self::error::{JoinError, SpawnBlockingError, SpawnError, SpawnLocalError};
+pub(crate) use self::error::{SpawnBlockingErrorKind, SpawnFailure, SpawnResult};
 
 mod harness;
 use self::harness::Harness;
@@ -247,6 +248,9 @@ unsafe impl<S> Sync for UnownedTask<S> {}
 pub(crate) type Result<T> = std::result::Result<T, JoinError>;
 
 pub(crate) trait Schedule: Sync + Sized + 'static {
+    /// Error type representing spawn failures
+    type Error;
+
     /// The task has completed work and is ready to be released. The scheduler
     /// should release it immediately and return it. The task module will batch
     /// the ref-dec with setting other options.
@@ -255,12 +259,12 @@ pub(crate) trait Schedule: Sync + Sized + 'static {
     fn release(&self, task: &Task<Self>) -> Option<Task<Self>>;
 
     /// Schedule the task
-    fn schedule(&self, task: Notified<Self>);
+    fn schedule(&self, task: Notified<Self>) -> std::result::Result<(), Self::Error>;
 
     /// Schedule the task to run in the near future, yielding the thread to
     /// other tasks.
     fn yield_now(&self, task: Notified<Self>) {
-        self.schedule(task);
+        let _ = self.schedule(task);
     }
 
     /// Polling the task resulted in a panic. Should the runtime shutdown?

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -2,6 +2,7 @@ use crate::runtime::scheduler::multi_thread::queue;
 use crate::runtime::task::{self, Inject, Schedule, Task};
 use crate::runtime::MetricsBatch;
 
+use std::convert::Infallible;
 use std::thread;
 use std::time::Duration;
 
@@ -238,11 +239,13 @@ fn stress2() {
 struct Runtime;
 
 impl Schedule for Runtime {
+    type Error = Infallible;
+
     fn release(&self, _task: &Task<Self>) -> Option<Task<Self>> {
         None
     }
 
-    fn schedule(&self, _task: task::Notified<Self>) {
+    fn schedule(&self, _task: task::Notified<Self>) -> Result<(), Self::Error> {
         unreachable!();
     }
 }

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -276,7 +276,7 @@
 //! [`poll`]: method@std::future::Future::poll
 
 cfg_rt! {
-    pub use crate::runtime::task::{JoinError, JoinHandle};
+    pub use crate::runtime::task::{JoinError, JoinHandle, SpawnError, SpawnBlockingError, SpawnLocalError};
 
     cfg_not_wasi! {
         mod blocking;

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -1,3 +1,4 @@
+use crate::runtime::task::{SpawnError, SpawnResult};
 use crate::{task::JoinHandle, util::error::CONTEXT_MISSING_ERROR};
 
 use std::future::Future;
@@ -129,15 +130,18 @@ cfg_rt! {
     {
         // preventing stack overflows on debug mode, by quickly sending the
         // task to the heap.
-        if cfg!(debug_assertions) && std::mem::size_of::<T>() > 2048 {
+        let res = if cfg!(debug_assertions) && std::mem::size_of::<T>() > 2048 {
             spawn_inner(Box::pin(future), None)
         } else {
             spawn_inner(future, None)
-        }
+        };
+
+        // Compat: ignore errors here
+        res.unwrap_or_else(|e| e.handle)
     }
 
     #[track_caller]
-    pub(super) fn spawn_inner<T>(future: T, name: Option<&str>) -> JoinHandle<T::Output>
+    pub(super) fn spawn_inner<T>(future: T, name: Option<&str>) -> SpawnResult<T::Output, SpawnError>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,


### PR DESCRIPTION
Define a custom `SpawnError` to be used by `task::Builder` instead of using `io::Error`

Refs #4850

Open question: should we have separate errors for `spawn_blocking` and `spawn_local`? Seemed overkill to me so I went with a single type