### PR TITLE
doc: update clippy command in contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ When updating this, also update:
 -->
 
 ```
-cargo +1.49.0 clippy --all-features
+cargo +1.49.0 clippy --all --tests --all-features
 ```
 
 When building documentation normally, the markers that list the features


### PR DESCRIPTION
## Motivation

When I submitted my first PR I followed the contribution guide, but still had it fail
on the clippy job because I hadn't run clippy on my tests locally (because I just
copy-pasted the commands and it didn't include the `--tests` flag). It's been at the
back of my mind since and so I finally created a PR to update the contribution guide.

## Solution

The contribution guide describes the Tokio code of conduct and gives a
list of steps to follow when contributing in different ways. In the
guide to contributing a pull request, commands are listed to be run by
the contributor locally to help ensure that the PR will pass on CI.

The command to run clippy isn't the same as the one run on CI,
specifically it the command doesn't check the tests. This commit changes
the command to match the one on CI, so that tests are checked by clippy
as well.
