### PR TITLE
Only use a single `to` in `AsyncSeekExt::rewind`'s documentation

### DIFF
--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -69,7 +69,7 @@ cfg_io_util! {
 
         /// Creates a future which will rewind to the beginning of the stream.
         ///
-        /// This is convenience method, equivalent to to `self.seek(SeekFrom::Start(0))`.
+        /// This is convenience method, equivalent to `self.seek(SeekFrom::Start(0))`.
         fn rewind(&mut self) -> Seek<'_, Self>
         where
             Self: Unpin,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

There are double `to`'s in `AsyncSeekExt::rewind`'s docs

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Remove a single `to` from the docs
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
