### PR TITLE
Remove unused lifetime on Semaphore impl

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -631,7 +631,7 @@ impl OwnedSemaphorePermit {
     }
 }
 
-impl<'a> Drop for SemaphorePermit<'_> {
+impl Drop for SemaphorePermit<'_> {
     fn drop(&mut self) {
         self.sem.add_permits(self.permits as usize);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Fixes #4891 which mentions this change is required to eventually update clippy

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Removes the unused lifetime parameter on the impl block for `SemaphorePermit::drop`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

----

~~Recent clippy versions also emit numerous warnings for https://rust-lang.github.io/rust-clippy/master/index.html#declare_interior_mutable_const but should probably be tracked & fixed in a different issue~~

https://github.com/tokio-rs/tokio/issues/4872 tracks this already and it's false positives
