### PR TITLE
signal: don't register write interest on signal pipe

### DIFF
--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -74,11 +74,8 @@ impl Driver {
         let original =
             ManuallyDrop::new(unsafe { std::os::unix::net::UnixStream::from_raw_fd(receiver_fd) });
         let receiver = UnixStream::from_std(original.try_clone()?);
-        let receiver = PollEvented::new_with_interest_and_handle(
-            receiver,
-            Interest::READABLE | Interest::WRITABLE,
-            park.handle(),
-        )?;
+        let receiver =
+            PollEvented::new_with_interest_and_handle(receiver, Interest::READABLE, park.handle())?;
 
         Ok(Self {
             park,

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -400,7 +400,7 @@ fn io_driver_ready_count() {
     let stream = tokio::net::TcpStream::connect("google.com:80");
     let _stream = rt.block_on(async move { stream.await.unwrap() });
 
-    assert_eq!(metrics.io_driver_ready_count(), 2);
+    assert_eq!(metrics.io_driver_ready_count(), 1);
 }
 
 fn basic() -> Runtime {


### PR DESCRIPTION
## Motivation

Our signal driver over-zealously subscribes to write readiness for the pipe used to wake when signals are delivered.

## Solution

Only register for read-readiness.

Fixes #4895 
