### PR TITLE
ci: upgrade nightly to `nightly-2022-07-25`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-04-18
+  rust_nightly: nightly-2022-07-25
   rust_clippy: 1.52.0
   # When updating this, also update:
   # - README.md


### PR DESCRIPTION
## Motivation

The current nightly (2022-04-18) used in CI leads to an ICE when producing rustdoc JSON for Tokio. The rustdoc JSON output is required to successfully add `cargo-check-external-types` to CI for #4902.

## Solution

Upgrade the nightly to a version that works with all of miri, cargo-hack, minimal-versions, and cargo-check-external-types.

Note: I wasn't able to test the `asan` CI step locally since I'm not on the right CPU architecture, so that may fail when CI runs for the PR. The others seemed to work locally.