### PR TITLE
ci: fix new error output from rustc 1.63.0

### DIFF
--- a/tests-build/README.md
+++ b/tests-build/README.md
@@ -1,2 +1,10 @@
 Tests the various combination of feature flags. This is broken out to a separate
 crate to work around limitations with cargo features.
+
+To run all of the tests in this directory, run the following commands:
+```
+cargo test --features full
+cargo test --features rt
+```
+If one of the tests fail, you can pass `TRYBUILD=overwrite` to the `cargo test`
+command that failed to have it regenerate the test output.

--- a/tests-build/tests/fail/macros_core_no_default.stderr
+++ b/tests-build/tests/fail/macros_core_no_default.stderr
@@ -1,5 +1,5 @@
 error: The default runtime flavor is `multi_thread`, but the `rt-multi-thread` feature is disabled.
- --> tests/fail/macros_core_no_default.rs:3:1
+ --> $DIR/macros_core_no_default.rs:3:1
   |
 3 | #[tokio::main]
   | ^^^^^^^^^^^^^^

--- a/tests-build/tests/fail/macros_dead_code.stderr
+++ b/tests-build/tests/fail/macros_dead_code.stderr
@@ -1,4 +1,4 @@
-error: function is never used: `f`
+error: function `f` is never used
  --> $DIR/macros_dead_code.rs:6:10
   |
 6 | async fn f() {}


### PR DESCRIPTION
The 1.63.0 release of rustc changed the output of some errors. This PR fixes our CI to reflect that.