### PR TITLE
ci: add `cargo-check-external-types` check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
       - test-hyper
       - wasm32-unknown-unknown
       - wasm32-wasi
+      - check-external-types
     steps:
       - run: exit 0
 
@@ -513,3 +514,27 @@ jobs:
         # TODO: this should become: `cargo hack wasi test --each-feature`
         run: cargo wasi test --test rt_yield --features wasi-rt
         working-directory: tests-integration
+
+  check-external-types:
+    name: check-external-types
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_nightly }}
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      - name: check-external-types
+        run: |
+          set -x
+          cargo install cargo-check-external-types --locked --version 0.1.3
+          cargo check-external-types --all-features --config external-types.toml
+        working-directory: tokio
+

--- a/tokio/external-types.toml
+++ b/tokio/external-types.toml
@@ -1,0 +1,16 @@
+# This config file is for the `cargo-check-external-types` tool that is run in CI.
+
+# The following are types that are allowed to be exposed in Tokio's public API.
+# The standard library is allowed by default.
+allowed_external_types = [
+   "bytes::buf::buf_impl::Buf",
+   "bytes::buf::buf_mut::BufMut",
+
+   "tokio_macros::*",
+
+   # TODO(https://github.com/tokio-rs/tokio/issues/4916): Remove the libc types
+   "libc::unix::gid_t",
+   "libc::unix::pid_t",
+   "libc::unix::uid_t",
+]
+


### PR DESCRIPTION
## Motivation

This PR adds `cargo-check-external-types` to CI for #4902.

## Solution

A new `check-external-types` CI step is added which pulls down a pinned nightly version of Rust, installs `cargo-check-external-types`, and then runs it against an `external-types.toml` config file which allow-lists types that are currently exposed in Tokio's public API.

If a PR exposes additional types that aren't listed in the config, then the CI job will output an error. To illustrate what this looks like, the following is the output if the `libc` entries are removed from `external-types.toml`:
```
error: Unapproved external type `libc::unix::uid_t` referenced in public API
  --> tokio/src/net/unix/ucred.rs:16:5
   |
16 |     pub fn uid(&self) -> uid_t {
   | ...
18 |     }␊
   |     ^
   |
   = in return value of `tokio::net::unix::UCred::uid`

error: Unapproved external type `libc::unix::gid_t` referenced in public API
  --> tokio/src/net/unix/ucred.rs:21:5
   |
21 |     pub fn gid(&self) -> gid_t {
   | ...
23 |     }␊
   |     ^
   |
   = in return value of `tokio::net::unix::UCred::gid`

error: Unapproved external type `libc::unix::pid_t` referenced in public API
  --> tokio/src/net/unix/ucred.rs:29:5
   |
29 |     pub fn pid(&self) -> Option<pid_t> {
   | ...
31 |     }␊
   |     ^
   |
   = in generic arg of `tokio::net::unix::UCred::pid`

3 errors emitted
```