### PR TITLE
ci: upgrade to `nightly-2022-07-26` and pin `miri` nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-07-25
+  rust_nightly: nightly-2022-07-26
   rust_clippy: 1.52.0
   # When updating this, also update:
   # - README.md
@@ -197,7 +197,7 @@ jobs:
       - name: Install Rust ${{ env.rust_nightly }}
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: ${{ env.rust_nightly }}
           components: miri
           override: true
       - uses: Swatinem/rust-cache@v1


### PR DESCRIPTION
## Motivation

As discovered in #4914, the `miri` CI check wasn't pinned to a specific nightly, and the nightly chosen in #4903 didn't have a `miri` component.

## Solution

This PR pins the `miri` check to the `rust_nightly` env value and updates the nightly to a version that is compatible with everything else.