### PR TITLE
rt: add unstable option to disable the LIFO slot

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -85,13 +85,13 @@ pub struct Builder {
     /// How many ticks before yielding to the driver for timer and I/O events?
     pub(super) event_interval: u32,
 
-    #[cfg(tokio_unstable)]
-    pub(super) unhandled_panic: UnhandledPanic,
-
     /// When true, the multi-threade scheduler LIFO slot should not be used.
     ///
     /// This option should only be exposed as unstable.
     pub(super) disable_lifo_slot: bool,
+
+    #[cfg(tokio_unstable)]
+    pub(super) unhandled_panic: UnhandledPanic,
 }
 
 cfg_unstable! {

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -820,7 +820,7 @@ impl Builder {
         /// ```
         /// use tokio::runtime;
         ///
-        /// let rt = runtime::Builder::new_multi_threaded()
+        /// let rt = runtime::Builder::new_multi_thread()
         ///     .disable_lifo_slot
         ///     .build()
         ///     .unwrap();

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -804,8 +804,18 @@ impl Builder {
         /// all scheduled tasks being pushed into the worker-local queue, which
         /// is stealable.
         ///
-        /// Eventually, the LIFO slot will become stealable and this option will
-        /// probably go away.
+        /// Consider trying this option when the task "scheduled" time is high
+        /// but the runtime is underutilized. Use tokio-rs/tokio-metrics to
+        /// collect this data.
+        ///
+        /// # Unstable
+        ///
+        /// This configuration option is considered a workaround for the LIFO
+        /// slot not being stealable. When the slot becomes stealable, we will
+        /// revisit whther or not this option is necessary. See
+        /// tokio-rs/tokio#4941.
+        ///
+        /// # Examples
         ///
         /// ```
         /// use tokio::runtime;

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -821,7 +821,7 @@ impl Builder {
         /// use tokio::runtime;
         ///
         /// let rt = runtime::Builder::new_multi_thread()
-        ///     .disable_lifo_slot
+        ///     .disable_lifo_slot()
         ///     .build()
         ///     .unwrap();
         /// ```

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -16,4 +16,13 @@ pub(crate) struct Config {
     #[cfg(tokio_unstable)]
     /// How to respond to unhandled task panics.
     pub(crate) unhandled_panic: crate::runtime::UnhandledPanic,
+
+    /// The multi-threaded scheduler includes a per-worker LIFO slot used to
+    /// store the last scheduled task. This can improve certain usage patterns,
+    /// especially message passing between tasks. However, this LIFO slot is not
+    /// currently stealable.
+    ///
+    /// Eventually, the LIFO slot **will** become stealable, however as a
+    /// stop-gap, this unstable option lets users disable the LIFO task.
+    pub(crate) disable_lifo_slot: bool,
 }

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(feature = "full"), allow(dead_code))]
 use crate::runtime::Callback;
 
 pub(crate) struct Config {

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(feature = "full"), allow(dead_code))]
+#![cfg_attr(any(not(feature = "full"), tokio_wasm), allow(dead_code))]
 use crate::runtime::Callback;
 
 pub(crate) struct Config {

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -21,7 +21,6 @@ pub(crate) struct Config {
     ///
     /// Eventually, the LIFO slot **will** become stealable, however as a
     /// stop-gap, this unstable option lets users disable the LIFO task.
-    #[cfg(not(tokio_wasm))]
     pub(crate) disable_lifo_slot: bool,
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -13,10 +13,6 @@ pub(crate) struct Config {
     /// Callback for a worker unparking itself
     pub(crate) after_unpark: Option<Callback>,
 
-    #[cfg(tokio_unstable)]
-    /// How to respond to unhandled task panics.
-    pub(crate) unhandled_panic: crate::runtime::UnhandledPanic,
-
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,
     /// especially message passing between tasks. However, this LIFO slot is not
@@ -25,4 +21,8 @@ pub(crate) struct Config {
     /// Eventually, the LIFO slot **will** become stealable, however as a
     /// stop-gap, this unstable option lets users disable the LIFO task.
     pub(crate) disable_lifo_slot: bool,
+
+    #[cfg(tokio_unstable)]
+    /// How to respond to unhandled task panics.
+    pub(crate) unhandled_panic: crate::runtime::UnhandledPanic,
 }

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -20,6 +20,7 @@ pub(crate) struct Config {
     ///
     /// Eventually, the LIFO slot **will** become stealable, however as a
     /// stop-gap, this unstable option lets users disable the LIFO task.
+    #[cfg(not(tokio_wasm))]
     pub(crate) disable_lifo_slot: bool,
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/thread_pool/worker.rs
+++ b/tokio/src/runtime/thread_pool/worker.rs
@@ -758,7 +758,7 @@ impl Shared {
         // task must always be pushed to the back of the queue, enabling other
         // tasks to be executed. If **not** a yield, then there is more
         // flexibility and the task may go to the front of the queue.
-        let should_notify = if is_yield {
+        let should_notify = if is_yield || self.config.disable_lifo_slot {
             core.run_queue
                 .push_back(task, &self.inject, &mut core.metrics);
             true

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -542,3 +542,27 @@ async fn test_block_in_place4() {
 fn rt() -> runtime::Runtime {
     runtime::Runtime::new().unwrap()
 }
+
+#[cfg(tokio_unstable)]
+mod unstable {
+    use super::*;
+
+    #[test]
+    fn test_disable_lifo_slot() {
+        let rt = runtime::Builder::new_multi_thread()
+            .disable_lifo_slot()
+            .worker_threads(2)
+            .build()
+            .unwrap();
+
+        rt.block_on(async {
+            tokio::spawn(async {
+                // Spawn another task and block the thread until completion. If the LIFO slot
+                // is used then the test doesn't complete.
+                futures::executor::block_on(tokio::spawn(async {})).unwrap();
+            })
+            .await
+            .unwrap();
+        })
+    }
+}


### PR DESCRIPTION
Depends on: #4935

The multi-threaded scheduler includes a per-worker LIFO slot to
store the last scheduled task. This can improve certain usage patterns,
especially message passing between tasks. However, this LIFO slot is not
currently stealable.

Eventually, the LIFO slot **will** become stealable. However, as a
stop-gap, this unstable option lets users disable the LIFO task when
doing so improves their application's overall performance.