### PR TITLE
Adds a comment to Interval.tick() example 

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -422,8 +422,9 @@ impl Interval {
     /// async fn main() {
     ///     let mut interval = time::interval(Duration::from_millis(10));
     ///
-    ///     interval.tick().await;
-    ///     interval.tick().await;
+    ///     interval.tick().await; 
+    ///     // approximately 0ms have elapsed. The first tick completes immediately.
+    ///     interval.tick().await; 
     ///     interval.tick().await;
     ///
     ///     // approximately 20ms have elapsed.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -422,9 +422,9 @@ impl Interval {
     /// async fn main() {
     ///     let mut interval = time::interval(Duration::from_millis(10));
     ///
-    ///     interval.tick().await; 
+    ///     interval.tick().await;
     ///     // approximately 0ms have elapsed. The first tick completes immediately.
-    ///     interval.tick().await; 
+    ///     interval.tick().await;
     ///     interval.tick().await;
     ///
     ///     // approximately 20ms have elapsed.


### PR DESCRIPTION
The comment simply reminds the reader that the first tick of an `Interval` completes immediately.


