### PR TITLE
sync: doc of watch::Sender::send improved

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -610,8 +610,16 @@ impl<T> Sender<T> {
     /// isn't made available for future receivers (but returned with the
     /// [`SendError`]).
     ///
+    /// To always make a new value available for future receivers, even if no
+    /// receiver currently exists, one of the other send methods
+    /// ([`send_if_modified`], [`send_modify`], or [`send_replace`]) can be
+    /// used.
+    ///
     /// [`subscribe`]: Sender::subscribe
     /// [`SendError`]: error::SendError
+    /// [`send_if_modified`]: Sender::send_if_modified
+    /// [`send_modify`]: Sender::send_modify
+    /// [`send_replace`]: Sender::send_replace
     pub fn send(&self, value: T) -> Result<(), error::SendError<T>> {
         // This is pretty much only useful as a hint anyway, so synchronization isn't critical.
         if 0 == self.receiver_count() {

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -613,7 +613,7 @@ impl<T> Sender<T> {
     /// To always make a new value available for future receivers, even if no
     /// receiver currently exists, one of the other send methods
     /// ([`send_if_modified`], [`send_modify`], or [`send_replace`]) can be
-    /// used.
+    /// used instead.
     ///
     /// [`subscribe`]: Sender::subscribe
     /// [`SendError`]: error::SendError

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -604,8 +604,14 @@ impl<T> Drop for Receiver<T> {
 impl<T> Sender<T> {
     /// Sends a new value via the channel, notifying all receivers.
     ///
-    /// This method fails if the channel has been closed, which happens when
-    /// every receiver has been dropped.
+    /// This method fails if the channel is closed, which is the case when
+    /// every receiver has been dropped. It is possible to reopen the channel
+    /// using the [`subscribe`] method. However, when `send` fails, the value
+    /// isn't made available for future receivers (but returned with the
+    /// [`SendError`]).
+    ///
+    /// [`subscribe`]: Sender::subscribe
+    /// [`SendError`]: error::SendError
     pub fn send(&self, value: T) -> Result<(), error::SendError<T>> {
         // This is pretty much only useful as a hint anyway, so synchronization isn't critical.
         if 0 == self.receiver_count() {


### PR DESCRIPTION
Current documentation of `sync::watch::Sender::send` may be intepreted as the method failing if at some point in past the channel has been closed because every receiver has been dropped. This isn't true, however, as the channel could have been reopened by using `sync::watch::Sender::subscribe`.

This fix clarifies the behavior. Moreover, it is noted that on failure, the value isn't made available to future subscribers (but returned as part of the `SendError`).

Fixes #4957.