### PR TITLE
tokio: make 1.20.x an LTS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ year. If you wish to use a fixed minor release in your project, we recommend
 that you use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.14.x` patch release, you
+example, to specify that you wish to use the newest `1.18.x` patch release, you
 can use the following dependency specification:
 ```text
 tokio = { version = "~1.18", features = [...] }

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ warrants a patch release with a fix for the bug, it will be backported and
 released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
- * `1.14.x` - LTS release until June 2022.
  * `1.18.x` - LTS release until January 2023
+ * `1.20.x` - LTS release until April 2023.
 
 Each LTS release will continue to receive backported fixes for at least half a
 year. If you wish to use a fixed minor release in your project, we recommend
@@ -213,7 +213,7 @@ To use a fixed minor version, you can specify the version with a tilde. For
 example, to specify that you wish to use the newest `1.14.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.14", features = [...] }
+tokio = { version = "~1.18", features = [...] }
 ```
 
 ## License

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -210,7 +210,7 @@ year. If you wish to use a fixed minor release in your project, we recommend
 that you use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.14.x` patch release, you
+example, to specify that you wish to use the newest `1.18.x` patch release, you
 can use the following dependency specification:
 ```text
 tokio = { version = "~1.18", features = [...] }

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -202,8 +202,8 @@ warrants a patch release with a fix for the bug, it will be backported and
 released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
- * `1.14.x` - LTS release until June 2022.
  * `1.18.x` - LTS release until January 2023
+ * `1.20.x` - LTS release until April 2023.
 
 Each LTS release will continue to receive backported fixes for at least half a
 year. If you wish to use a fixed minor release in your project, we recommend
@@ -213,7 +213,7 @@ To use a fixed minor version, you can specify the version with a tilde. For
 example, to specify that you wish to use the newest `1.14.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.14", features = [...] }
+tokio = { version = "~1.18", features = [...] }
 ```
 
 ## License


### PR DESCRIPTION
This adds a new LTS release and removes an expired one.