### PR TITLE
wasm: use `thread::sleep` on non-wasi wasm too

### DIFF
--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -65,9 +65,9 @@ impl Park for ParkThread {
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
         // Wasi doesn't have threads, so just sleep.
-        #[cfg(not(tokio_wasi))]
+        #[cfg(not(tokio_wasm))]
         self.inner.park_timeout(duration);
-        #[cfg(tokio_wasi)]
+        #[cfg(tokio_wasm)]
         std::thread::sleep(duration);
         Ok(())
     }

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -64,7 +64,7 @@ impl Park for ParkThread {
     }
 
     fn park_timeout(&mut self, duration: Duration) -> Result<(), Self::Error> {
-        // Wasi doesn't have threads, so just sleep.
+        // Wasm doesn't have threads, so just sleep.
         #[cfg(not(tokio_wasm))]
         self.inner.park_timeout(duration);
         #[cfg(tokio_wasm)]


### PR DESCRIPTION
There's no reason to limit this cfg to wasi. Other types of wasm then wasi may also support `thread::sleep`.