### PR TITLE
wasm: add documentation for wasm support

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -409,7 +409,7 @@
 //!
 //! Using this flag enables the use of `tokio::net` on the wasm32-wasi target.
 //! However, not all methods are available on the networking types as WASI
-//! currently does not support the creation of new sockets from within wasm.
+//! currently does not support the creation of new sockets from within WASM.
 //! Because of this, sockets must currently be created via the `FromRawFd`
 //! trait.
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -379,6 +379,39 @@
 //!
 //! [unstable features]: https://internals.rust-lang.org/t/feature-request-unstable-opt-in-non-transitive-crate-features/16193#why-not-a-crate-feature-2
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
+//!
+//! ## WASM support
+//!
+//! Tokio has some limited support for the WASM platform. Without the
+//! `tokio_unstable` flag, the following features are supported:
+//!
+//!  * `sync`
+//!  * `macros`
+//!  * `io-util`
+//!  * `rt`
+//!  * `time`
+//!
+//! Enabling any other feature (including `full`) will cause a compilation
+//! failure.
+//!
+//! The `time` module will only work on WASM platforms that have support for
+//! timers (e.g. wasm32-wasi). The timing functions will panic if used on a WASM
+//! platform that does not support timers.
+//!
+//! Note also that if the runtime becomes indefinitely idle, it will panic
+//! immediately instead of blocking forever. On platforms that don't support
+//! time, this means that the runtime can never be idle in any way.
+//!
+//! ### Unstable WASM support
+//!
+//! Tokio also has unstable support for some additional WASM features. This
+//! requires the use of the `tokio_unstable` flag.
+//!
+//! Using this flag enables the use of `tokio::net` on the wasm32-wasi target.
+//! However, not all methods are available on the networking types as WASI
+//! currently does not support the creation of new sockets from within wasm.
+//! Because of this, sockets must currently be created via the `FromRawFd`
+//! trait.
 
 // Test that pointer width is compatible. This asserts that e.g. usize is at
 // least 32 bits, which a lot of components in Tokio currently assumes.
@@ -422,7 +455,7 @@ compile_error!("Tokio's build script has incorrectly detected wasm.");
         feature = "signal"
     )
 ))]
-compile_error!("Only features sync,macros,io-util,rt are supported on wasm.");
+compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
 
 // Includes re-exports used by macros.
 //


### PR DESCRIPTION
We are adding WASM support in the next release, but we have no documentation about it what-so-ever. This PR adds some documentation.