### PR TITLE
task: ignore failure to set TLS in LocalSet Drop

### DIFF
--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -633,6 +633,37 @@ impl LocalSet {
             f()
         })
     }
+
+    /// This method is like `with`, but it just calls `f` without setting the thread-local if that
+    /// fails.
+    fn with_if_possible<T>(&self, f: impl FnOnce() -> T) -> T {
+        let mut f = Some(f);
+
+        let res = CURRENT.try_with(|ctx| {
+            struct Reset<'a> {
+                ctx_ref: &'a Cell<Option<Rc<Context>>>,
+                val: Option<Rc<Context>>,
+            }
+            impl<'a> Drop for Reset<'a> {
+                fn drop(&mut self) {
+                    self.ctx_ref.replace(self.val.take());
+                }
+            }
+            let old = ctx.replace(Some(self.context.clone()));
+
+            let _reset = Reset {
+                ctx_ref: ctx,
+                val: old,
+            };
+
+            (f.take().unwrap())()
+        });
+
+        match res {
+            Ok(res) => res,
+            Err(_access_error) => (f.take().unwrap())(),
+        }
+    }
 }
 
 cfg_unstable! {
@@ -744,7 +775,7 @@ impl Default for LocalSet {
 
 impl Drop for LocalSet {
     fn drop(&mut self) {
-        self.with(|| {
+        self.with_if_possible(|| {
             // Shut down all tasks in the LocalOwnedTasks and close it to
             // prevent new tasks from ever being added.
             self.context.owned.close_and_shutdown_all();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -311,6 +311,26 @@ fn join_local_future_elsewhere() {
     });
 }
 
+// Tests for <https://github.com/tokio-rs/tokio/issues/4973>
+#[tokio::test(flavor = "multi_thread")]
+async fn localset_in_thread_local() {
+    thread_local! {
+        static LOCAL_SET: LocalSet = LocalSet::new();
+    }
+
+    // holds runtime thread until end of main fn.
+    let (_tx, rx) = oneshot::channel::<()>();
+    let handle = tokio::runtime::Handle::current();
+
+    std::thread::spawn(move || {
+        LOCAL_SET.with(|local_set| {
+            handle.block_on(local_set.run_until(async move {
+                let _ = rx.await;
+            }))
+        });
+    });
+}
+
 #[test]
 fn drop_cancels_tasks() {
     use std::rc::Rc;

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -312,6 +312,7 @@ fn join_local_future_elsewhere() {
 }
 
 // Tests for <https://github.com/tokio-rs/tokio/issues/4973>
+#[cfg(not(tokio_wasi))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread")]
 async fn localset_in_thread_local() {
     thread_local! {


### PR DESCRIPTION
If we can't set the thread-local when destroying a `LocalSet`, then we just ignore it and proceed as normal. This means that task destructors wont be able to access the thread-local, but they wouldn't be able to do that previously either.

Closes: #4973