### PR TITLE
Doc: add example of how to convert to error type

### DIFF
--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -14,12 +14,18 @@ pin_project! {
     /// # Example
     ///
     /// ```
+    /// use reqwest;
     /// use bytes::Bytes;
     /// use tokio::io::{AsyncReadExt, Result};
     /// use tokio_util::io::StreamReader;
+    ///
+    /// // How to convert to an io::Error type.
+    /// fn reqwest_to_io_error(err: reqwest::Error) -> std::io::Error {
+    ///     todo!()
+    /// }
+    ///
     /// # #[tokio::main]
     /// # async fn main() -> std::io::Result<()> {
-    ///
     /// // Create a stream from an iterator.
     /// let stream = tokio_stream::iter(vec![
     ///     Result::Ok(Bytes::from_static(&[0, 1, 2, 3])),


### PR DESCRIPTION
## Motivation
Add doc example in reference to #4954. 

## Solution
Added a function example for the conversion of the error type `reqwest::Error` to `std::io::Error`.