### PR TITLE
make `immediate_exit_on_error` less flaky

### DIFF
--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -117,11 +117,9 @@ async fn blocking_one_side_does_not_block_other() {
 #[tokio::test]
 async fn immediate_exit_on_error() {
     symmetric(|handle, mut a, mut b| async move {
-        block_write(&mut a).await;
-
-        // Fill up the b->copy->a path. We expect that this will _not_ drain
+        // Fill up the receiving buffers. We expect that this will _not_ drain
         // before we exit the copy task.
-        let _bytes_written = block_write(&mut b).await;
+        tokio::join!(block_write(&mut a), block_write(&mut b));
 
         // Drop b. We should not wait for a to consume the data buffered in the
         // copy loop, since b will be failing writes.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes: https://github.com/tokio-rs/tokio/issues/4900

## Solution

Extend timer duration to prevent it from preempting the `write`. More details [here](https://github.com/tokio-rs/tokio/issues/4900#issuecomment-1237451308).