### PR TITLE
rewrite `immediate_exit_on_error` to use `io::Mock`

### DIFF
--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -111,18 +111,34 @@ async fn blocking_one_side_does_not_block_other() {
 }
 
 #[tokio::test]
-async fn immediate_exit_on_error() {
-    symmetric(|handle, mut a, mut b| async move {
-        block_write(&mut a).await;
+async fn immediate_exit_on_write_error() {
+    let payload = b"here, take this";
+    let error = || io::Error::new(io::ErrorKind::Other, "no thanks!");
 
-        // Fill up the b->copy->a path. We expect that this will _not_ drain
-        // before we exit the copy task.
-        let _bytes_written = block_write(&mut b).await;
+    let mut a = tokio_test::io::Builder::new()
+        .read(payload)
+        .write_error(error())
+        .build();
 
-        // Drop b. We should not wait for a to consume the data buffered in the
-        // copy loop, since b will be failing writes.
-        drop(b);
-        assert!(handle.await.unwrap().is_err());
-    })
-    .await
+    let mut b = tokio_test::io::Builder::new()
+        .read(payload)
+        .write_error(error())
+        .build();
+
+    assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
+}
+
+#[tokio::test]
+async fn immediate_exit_on_read_error() {
+    let error = || io::Error::new(io::ErrorKind::Other, "got nothing!");
+
+    let mut a = tokio_test::io::Builder::new()
+        .read_error(error())
+        .build();
+
+    let mut b = tokio_test::io::Builder::new()
+        .read_error(error())
+        .build();
+
+    assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
 }

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -132,13 +132,9 @@ async fn immediate_exit_on_write_error() {
 async fn immediate_exit_on_read_error() {
     let error = || io::Error::new(io::ErrorKind::Other, "got nothing!");
 
-    let mut a = tokio_test::io::Builder::new()
-        .read_error(error())
-        .build();
+    let mut a = tokio_test::io::Builder::new().read_error(error()).build();
 
-    let mut b = tokio_test::io::Builder::new()
-        .read_error(error())
-        .build();
+    let mut b = tokio_test::io::Builder::new().read_error(error()).build();
 
     assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes https://github.com/tokio-rs/tokio/issues/4900

## Solution

Mocked `Stream` to return write error instead of relying on filling up TCP buffers. As a side-effect, increased coverage to include errors from `read`.

Test tested by temporarily doing this:
![image](https://user-images.githubusercontent.com/2226778/188731170-1debb7fe-3009-41bb-9291-6739c45b2329.png)
and this:
![image](https://user-images.githubusercontent.com/2226778/188732090-75dd59e6-2ff5-479e-a722-7f67374e2c4b.png)

