### PR TITLE
docs: Fix links in UnixStream

### DIFF
--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -22,8 +22,8 @@ cfg_io_util! {
 cfg_net_unix! {
     /// A structure representing a connected Unix socket.
     ///
-    /// This socket can be connected directly with `UnixStream::connect` or accepted
-    /// from a listener with `UnixListener::incoming`. Additionally, a pair of
+    /// This socket can be connected directly with [`UnixStream::connect`] or accepted
+    /// from a listener with [`UnixListener::accept`]. Additionally, a pair of
     /// anonymous Unix sockets can be created with `UnixStream::pair`.
     ///
     /// To shut down the stream in the write direction, you can call the
@@ -32,6 +32,7 @@ cfg_net_unix! {
     /// the stream in one direction.
     ///
     /// [`shutdown()`]: fn@crate::io::AsyncWriteExt::shutdown
+    /// [`UnixListener::accept`]: crate::net::UnixListener::accept
     pub struct UnixStream {
         io: PollEvented<mio::net::UnixStream>,
     }


### PR DESCRIPTION
## Motivation

The UnixStream docs say the socket can be "accepted from a listener with UnixListener::incoming" but no method incoming exists on UnixListener. I think it should say UnixListener::accept instead?

## Solution

Change the method cited in the docs. Also added a few other links to methods in that paragraph.
