### PR TITLE
rt: minor time driver refactors

### DIFF
--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -1,12 +1,12 @@
 use crate::loom::sync::Arc;
-use crate::runtime::time::ClockTime;
+use crate::runtime::time::TimeSource;
 use std::fmt;
 
 /// Handle to time driver instance.
 #[derive(Clone)]
 pub(crate) struct Handle {
-    time_source: ClockTime,
-    inner: Arc<super::Inner>,
+    time_source: TimeSource,
+    pub(super) inner: Arc<super::Inner>,
 }
 
 impl Handle {
@@ -17,7 +17,7 @@ impl Handle {
     }
 
     /// Returns the time source associated with this handle.
-    pub(crate) fn time_source(&self) -> &ClockTime {
+    pub(crate) fn time_source(&self) -> &TimeSource {
         &self.time_source
     }
 

--- a/tokio/src/runtime/time/source.rs
+++ b/tokio/src/runtime/time/source.rs
@@ -1,0 +1,42 @@
+use crate::time::{Clock, Duration, Instant};
+
+use std::convert::TryInto;
+
+/// A structure which handles conversion from Instants to u64 timestamps.
+#[derive(Debug, Clone)]
+pub(crate) struct TimeSource {
+    pub(crate) clock: Clock,
+    start_time: Instant,
+}
+
+impl TimeSource {
+    pub(crate) fn new(clock: Clock) -> Self {
+        Self {
+            start_time: clock.now(),
+            clock,
+        }
+    }
+
+    pub(crate) fn deadline_to_tick(&self, t: Instant) -> u64 {
+        // Round up to the end of a ms
+        self.instant_to_tick(t + Duration::from_nanos(999_999))
+    }
+
+    pub(crate) fn instant_to_tick(&self, t: Instant) -> u64 {
+        // round up
+        let dur: Duration = t
+            .checked_duration_since(self.start_time)
+            .unwrap_or_else(|| Duration::from_secs(0));
+        let ms = dur.as_millis();
+
+        ms.try_into().unwrap_or(u64::MAX)
+    }
+
+    pub(crate) fn tick_to_duration(&self, t: u64) -> Duration {
+        Duration::from_millis(t)
+    }
+
+    pub(crate) fn now(&self) -> u64 {
+        self.instant_to_tick(self.clock.now())
+    }
+}

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -49,7 +49,7 @@ fn model(f: impl Fn() + Send + Sync + 'static) {
 fn single_timer() {
     model(|| {
         let clock = crate::time::Clock::new(true, false);
-        let time_source = super::ClockTime::new(clock.clone());
+        let time_source = super::TimeSource::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
         let handle = Handle::new(Arc::new(inner));
@@ -80,7 +80,7 @@ fn single_timer() {
 fn drop_timer() {
     model(|| {
         let clock = crate::time::Clock::new(true, false);
-        let time_source = super::ClockTime::new(clock.clone());
+        let time_source = super::TimeSource::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
         let handle = Handle::new(Arc::new(inner));
@@ -111,7 +111,7 @@ fn drop_timer() {
 fn change_waker() {
     model(|| {
         let clock = crate::time::Clock::new(true, false);
-        let time_source = super::ClockTime::new(clock.clone());
+        let time_source = super::TimeSource::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
         let handle = Handle::new(Arc::new(inner));
@@ -146,7 +146,7 @@ fn reset_future() {
         let finished_early = Arc::new(AtomicBool::new(false));
 
         let clock = crate::time::Clock::new(true, false);
-        let time_source = super::ClockTime::new(clock.clone());
+        let time_source = super::TimeSource::new(clock.clone());
 
         let inner = super::Inner::new(time_source.clone(), MockUnpark::mock());
         let handle = Handle::new(Arc::new(inner));
@@ -204,7 +204,7 @@ fn poll_process_levels() {
     let clock = crate::time::Clock::new(true, false);
     clock.pause();
 
-    let time_source = super::ClockTime::new(clock.clone());
+    let time_source = super::TimeSource::new(clock.clone());
 
     let inner = super::Inner::new(time_source, MockUnpark::mock());
     let handle = Handle::new(Arc::new(inner));
@@ -245,7 +245,7 @@ fn poll_process_levels_targeted() {
     let clock = crate::time::Clock::new(true, false);
     clock.pause();
 
-    let time_source = super::ClockTime::new(clock.clone());
+    let time_source = super::TimeSource::new(clock.clone());
 
     let inner = super::Inner::new(time_source, MockUnpark::mock());
     let handle = Handle::new(Arc::new(inner));

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -1,5 +1,5 @@
 #[cfg(all(tokio_unstable, feature = "tracing"))]
-use crate::runtime::time::ClockTime;
+use crate::runtime::time::TimeSource;
 use crate::runtime::time::{Handle, TimerEntry};
 use crate::time::{error::Error, Duration, Instant};
 use crate::util::trace;

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -239,7 +239,7 @@ cfg_trace! {
     struct Inner {
         deadline: Instant,
         ctx: trace::AsyncOpTracingCtx,
-        time_source: ClockTime,
+        time_source: TimeSource,
     }
 }
 


### PR DESCRIPTION
This patch makes some minor refactors. It renames `ClockTime` to `TimeSource` since that is how all variables refer to it. It also moves the type into a new file.

Finally, it moves the `unpark` handle out of the mutex as it does not need to be there. Note, the call to `unpark` is still called while the mutex is held, so there is no functional change. Moving it out of the mutex is in preparation for moving the unpark handle entirely out of the time driver.