### PR TITLE
io: remove reference to missing functions from `Registration` docs

### DIFF
--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -57,10 +57,8 @@ unsafe impl Sync for Registration {}
 // ===== impl Registration =====
 
 impl Registration {
-    /// Registers the I/O resource with the default reactor, for a specific
-    /// `Interest`. `new_with_interest` should be used over `new` when you need
-    /// control over the readiness state, such as when a file descriptor only
-    /// allows reads. This does not add `hup` or `error` so if you are
+    /// Registers the I/O resource with the reactor for the provided handle, for
+    /// a specific `Interest`. This does not add `hup` or `error` so if you are
     /// interested in those states, you will need to add them to the readiness
     /// state passed to this function.
     ///


### PR DESCRIPTION
Fixes #3747

## Motivation

Internal docs on `Registration` struct mentioned functions which no longer
exist. This was brought up in an issue from over a year ago (linked) and
it would be nice to fix it.

## Solution

The docs for `Registration::new_with_interest_and_handle` (internal
function) included a reference to two old functions `new_with_interest`
and `new` on the same struct. These functions no longer exist, which
could be confusing.

Since there is currently only a single constructor function on
`Registration`, the misleading text has simply been removed.
