### PR TITLE
Fix LengthDelimitedCodec buffer over-reservation.

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -522,15 +522,11 @@ impl LengthDelimitedCodec {
             }
         };
 
-        let num_skip = self.builder.get_num_skip();
-
-        if num_skip > 0 {
-            src.advance(num_skip);
-        }
+        src.advance(self.builder.get_num_skip());
 
         // Ensure that the buffer has enough space to read the incoming
         // payload
-        src.reserve(n);
+        src.reserve(n.saturating_sub(src.len()));
 
         Ok(Some(n))
     }
@@ -568,7 +564,7 @@ impl Decoder for LengthDelimitedCodec {
                 self.state = DecodeState::Head;
 
                 // Make sure the buffer has enough space to read the next head
-                src.reserve(self.builder.num_head_bytes());
+                src.reserve(self.builder.num_head_bytes().saturating_sub(src.len()));
 
                 Ok(Some(data))
             }


### PR DESCRIPTION
The `LengthDelimitedCodec` calls `BytesMut::reserve` on two occasions:
- after the header is read, to allocate memory for the expected frame
- after a frame is read, to allocate memory for another header that may follow

In both cases, the implementation currently calls `src.reserve(n)` which reserves the necessary `n` bytes for [**additional** data](https://docs.rs/bytes/latest/bytes/struct.BytesMut.html#method.reserve), disregarding the fact that the buffer might already have additional data present that just wasn't decoded yet.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This causes excess memory allocation, which might be quite substantial in certain cases.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Take into account the buffer's current length when calculating the amount of memory that should be reserved.

As a small drive-by cleanup, I also removed a check that `n != 0` before calling to `src.advance(n)`, since that is redundant according to [the docs](https://docs.rs/bytes/latest/bytes/trait.Buf.html#tymethod.advance):
> A call with cnt == 0 should never panic and be a no-op.

Not sure if/how to write tests for this, any feedback would be welcome.