### PR TITLE
ci: Add build test for x86_64-fortanix-unknown-sgx target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
       - loom-compile
       - check-readme
       - test-hyper
+      - x86_64-fortanix-unknown-sgx
       - wasm32-unknown-unknown
       - wasm32-wasi
       - check-external-types
@@ -451,6 +452,23 @@ jobs:
           echo 'tokio-test = { path = "../tokio-test" }' >>Cargo.toml
           git diff
           cargo test --features full
+
+  x86_64-fortanix-unknown-sgx:
+    name: build tokio for x86_64-fortanix-unknown-sgx
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ env.rust_nightly }}
+          target: x86_64-fortanix-unknown-sgx
+          override: true
+      - uses: Swatinem/rust-cache@v1
+      # NOTE: Currently the only test we can run is to build tokio with rt and sync features.
+      - name: build tokio
+        run: cargo build --target x86_64-fortanix-unknown-sgx --features rt,sync
+        working-directory: tokio
 
   wasm32-unknown-unknown:
     name: test tokio for wasm32-unknown-unknown


### PR DESCRIPTION
Adds (failing until #5000 is merged) test for build on `x86_64-fortanix-unknown-sgx` target (see #4999).