### PR TITLE
rt: remove internal runtime::ToHandle trait

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -54,11 +54,6 @@ pub(crate) struct HandleInner {
     pub(crate) blocking_spawner: blocking::Spawner,
 }
 
-/// Create a new runtime handle.
-pub(crate) trait ToHandle {
-    fn to_handle(&self) -> Handle;
-}
-
 /// Runtime context guard.
 ///
 /// Returned by [`Runtime::enter`] and [`Handle::enter`], the context guard exits
@@ -316,12 +311,6 @@ impl Handle {
 
     pub(crate) fn shutdown(mut self) {
         self.spawner.shutdown();
-    }
-}
-
-impl ToHandle for Handle {
-    fn to_handle(&self) -> Handle {
-        self.clone()
     }
 }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -222,7 +222,7 @@ cfg_rt! {
 
     mod handle;
     pub use handle::{EnterGuard, Handle, TryCurrentError};
-    pub(crate) use handle::{HandleInner, ToHandle};
+    pub(crate) use handle::HandleInner;
 
     mod spawner;
     use self::spawner::Spawner;

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -854,19 +854,6 @@ impl Shared {
     }
 }
 
-impl crate::runtime::ToHandle for Arc<Shared> {
-    fn to_handle(&self) -> crate::runtime::Handle {
-        use crate::runtime::scheduler::multi_thread::Spawner;
-        use crate::runtime::{self, Handle};
-
-        Handle {
-            spawner: runtime::Spawner::MultiThread(Spawner {
-                shared: self.clone(),
-            }),
-        }
-    }
-}
-
 cfg_metrics! {
     impl Shared {
         pub(super) fn injection_queue_depth(&self) -> usize {


### PR DESCRIPTION
The internal `runtime::ToHandle` trait is no longer needed as the runtime handle is used everywhere now.