### PR TITLE
ci: use --feature-powerset --depth 2 in features check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,10 +280,10 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: check --feature-powerset
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps
+        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
       # Try with unstable feature flags
       - name: check --feature-powerset --unstable
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps
+        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,13 +279,11 @@ jobs:
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
-      - name: check --each-feature
-        run: cargo hack check --all --each-feature -Z avoid-dev-deps
-      - name: check net,time
-        run: cargo check -p tokio --no-default-features --features net,time -Z avoid-dev-deps
+      - name: check --feature-powerset
+        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps
       # Try with unstable feature flags
-      - name: check --each-feature --unstable
-        run: cargo hack check --all --each-feature -Z avoid-dev-deps
+      - name: check --feature-powerset --unstable
+        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
-        run: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
 
       # Run `tokio` with `full` features. This excludes testing utilities which
       # can alter the runtime behavior of Tokio.
@@ -278,7 +278,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
-        run: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: check --each-feature
         run: cargo hack check --all --each-feature -Z avoid-dev-deps
       - name: check net,time
@@ -315,7 +315,7 @@ jobs:
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
-        run: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
       - name: "check --all-features -Z minimal-versions"
         run: |
           # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
@@ -483,13 +483,13 @@ jobs:
 
       # Install dependencies
       - name: Install cargo-hack
-        run: cargo install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
 
       - name: Install wasm32-wasi target
         run: rustup target add wasm32-wasi
 
       - name: Install wasmtime
-        run: cargo install wasmtime-cli
+        uses: taiki-e/install-action@wasmtime
 
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
@@ -539,4 +539,3 @@ jobs:
           cargo install cargo-check-external-types --locked --version 0.1.3
           cargo check-external-types --all-features --config external-types.toml
         working-directory: tokio
-

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -28,8 +28,8 @@ impl Driver {
         }
     }
 
-    pub(crate) fn handle(&self) -> Handle {
-        self.park.io_handle()
+    pub(crate) fn unpark(&self) -> Handle {
+        self.park.unpark()
     }
 
     pub(crate) fn park(&mut self) {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -43,7 +43,7 @@ cfg_io_driver! {
     impl IoStack {
         pub(crate) fn unpark(&self) -> IoUnpark {
             match self {
-                IoStack::Enabled(v) => IoUnpark::Enabled(v.handle()),
+                IoStack::Enabled(v) => IoUnpark::Enabled(v.unpark()),
                 IoStack::Disabled(v) => IoUnpark::Disabled(v.unpark()),
             }
         }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -62,10 +62,12 @@ cfg_io_driver! {
             }
         }
 
-        pub(crate) fn shutdown(&mut self) {
-            match self {
-                IoStack::Enabled(v) => v.shutdown(),
-                IoStack::Disabled(v) => v.shutdown(),
+        cfg_rt_multi_thread! {
+            pub(crate) fn shutdown(&mut self) {
+                match self {
+                    IoStack::Enabled(v) => v.shutdown(),
+                    IoStack::Disabled(v) => v.shutdown(),
+                }
             }
         }
     }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -62,12 +62,10 @@ cfg_io_driver! {
             }
         }
 
-        cfg_rt_multi_thread! {
-            pub(crate) fn shutdown(&mut self) {
-                match self {
-                    IoStack::Enabled(v) => v.shutdown(),
-                    IoStack::Disabled(v) => v.shutdown(),
-                }
+        pub(crate) fn shutdown(&mut self) {
+            match self {
+                IoStack::Enabled(v) => v.shutdown(),
+                IoStack::Disabled(v) => v.shutdown(),
             }
         }
     }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -62,6 +62,7 @@ cfg_io_driver! {
             }
         }
 
+        #[cfg_attr(not(feature = "rt-multi-thread"), allow(dead_code))] // some features use this
         pub(crate) fn shutdown(&mut self) {
             match self {
                 IoStack::Enabled(v) => v.shutdown(),

--- a/tokio/src/runtime/io/mod.rs
+++ b/tokio/src/runtime/io/mod.rs
@@ -145,12 +145,8 @@ impl Driver {
     }
 
     // TODO: remove this in a later refactor
-    cfg_not_rt! {
-        cfg_time! {
-            pub(crate) fn unpark(&self) -> Handle {
-                self.handle()
-            }
-        }
+    pub(crate) fn unpark(&self) -> Handle {
+        self.handle()
     }
 
     pub(crate) fn park(&mut self) {

--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -92,8 +92,8 @@ impl Driver {
         }
     }
 
-    pub(crate) fn io_handle(&self) -> io::Handle {
-        self.park.handle()
+    pub(crate) fn unpark(&self) -> io::Handle {
+        self.park.unpark()
     }
 
     pub(crate) fn park(&mut self) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

As has been pointed out a few times in the past (e.g., https://github.com/tokio-rs/tokio/pull/4036#issuecomment-897252076), each-feature is not sufficient for features check.

Ideally, we'd like to check all combinations of features, but there are too many combinations.
So limit the max number of simultaneous feature flags to 2 by [`--depth` option](https://github.com/taiki-e/cargo-hack/pull/59). I think this should be sufficient in most cases as @carllerche said in https://github.com/taiki-e/cargo-hack/issues/58.
