### PR TITLE
rt: store driver handles next to scheduler handle

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -72,7 +72,7 @@ cfg_time! {
 
 cfg_rt! {
     pub(crate) fn spawn_handle() -> Option<crate::runtime::Spawner> {
-        match CONTEXT.try_with(|ctx| (*ctx.borrow()).as_ref().map(|ctx| ctx.spawner.clone())) {
+        match CONTEXT.try_with(|ctx| (*ctx.borrow()).as_ref().map(|ctx| ctx.inner.spawner.clone())) {
             Ok(spawner) => spawner,
             Err(_) => panic!("{}", crate::util::error::THREAD_LOCAL_DESTROYED_ERROR),
         }

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -39,7 +39,7 @@ impl RuntimeMetrics {
     /// }
     /// ```
     pub fn num_workers(&self) -> usize {
-        self.handle.spawner.num_workers()
+        self.handle.inner.spawner.num_workers()
     }
 
     /// Returns the number of tasks scheduled from **outside** of the runtime.
@@ -68,6 +68,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn remote_schedule_count(&self) -> u64 {
         self.handle
+            .inner
             .spawner
             .scheduler_metrics()
             .remote_schedule_count
@@ -111,6 +112,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_park_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .park_count
@@ -154,6 +156,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_noop_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .noop_count
@@ -199,6 +202,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_steal_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .steal_count
@@ -240,6 +244,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_poll_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .poll_count
@@ -285,6 +290,7 @@ impl RuntimeMetrics {
     pub fn worker_total_busy_duration(&self, worker: usize) -> Duration {
         let nanos = self
             .handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .busy_duration_total
@@ -331,6 +337,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_local_schedule_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .local_schedule_count
@@ -377,6 +384,7 @@ impl RuntimeMetrics {
     /// ```
     pub fn worker_overflow_count(&self, worker: usize) -> u64 {
         self.handle
+            .inner
             .spawner
             .worker_metrics(worker)
             .overflow_count
@@ -406,7 +414,7 @@ impl RuntimeMetrics {
     /// }
     /// ```
     pub fn injection_queue_depth(&self) -> usize {
-        self.handle.spawner.injection_queue_depth()
+        self.handle.inner.spawner.injection_queue_depth()
     }
 
     /// Returns the number of tasks currently scheduled in the given worker's
@@ -444,7 +452,7 @@ impl RuntimeMetrics {
     /// }
     /// ```
     pub fn worker_local_queue_depth(&self, worker: usize) -> usize {
-        self.handle.spawner.worker_local_queue_depth(worker)
+        self.handle.inner.spawner.worker_local_queue_depth(worker)
     }
 }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -570,7 +570,7 @@ cfg_rt! {
         /// ```
         pub fn shutdown_timeout(mut self, duration: Duration) {
             // Wakeup and shutdown all the worker threads
-            self.handle.clone().shutdown();
+            self.handle.shutdown();
             self.blocking_pool.shutdown(Some(duration));
         }
 

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -4,7 +4,7 @@ use crate::loom::sync::{Arc, Mutex};
 use crate::runtime::context::EnterGuard;
 use crate::runtime::driver::{Driver, Unpark};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
-use crate::runtime::{Config, HandleInner};
+use crate::runtime::Config;
 use crate::runtime::{MetricsBatch, SchedulerMetrics, WorkerMetrics};
 use crate::sync::notify::Notify;
 use crate::util::atomic_cell::AtomicCell;
@@ -81,9 +81,6 @@ struct Shared {
     /// Indicates whether the blocked on thread was woken.
     woken: AtomicBool,
 
-    /// Handle to I/O driver, timer, blocking pool, ...
-    handle_inner: HandleInner,
-
     /// Scheduler configuration options
     config: Config,
 
@@ -111,7 +108,7 @@ const INITIAL_CAPACITY: usize = 64;
 scoped_thread_local!(static CURRENT: Context);
 
 impl CurrentThread {
-    pub(crate) fn new(driver: Driver, handle_inner: HandleInner, config: Config) -> CurrentThread {
+    pub(crate) fn new(driver: Driver, config: Config) -> CurrentThread {
         let unpark = driver.unpark();
 
         let spawner = Spawner {
@@ -120,7 +117,6 @@ impl CurrentThread {
                 owned: OwnedTasks::new(),
                 unpark,
                 woken: AtomicBool::new(false),
-                handle_inner,
                 config,
                 scheduler_metrics: SchedulerMetrics::new(),
                 worker_metrics: WorkerMetrics::new(),
@@ -386,10 +382,6 @@ impl Spawner {
     // reset woken to false and return original value
     pub(crate) fn reset_woken(&self) -> bool {
         self.shared.woken.swap(false, AcqRel)
-    }
-
-    pub(crate) fn as_handle_inner(&self) -> &HandleInner {
-        &self.shared.handle_inner
     }
 }
 

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use worker::block_in_place;
 
 use crate::loom::sync::Arc;
 use crate::runtime::task::{self, JoinHandle};
-use crate::runtime::{Config, Driver, HandleInner};
+use crate::runtime::{Config, Driver};
 
 use std::fmt;
 use std::future::Future;
@@ -45,14 +45,9 @@ pub(crate) struct Spawner {
 // ===== impl MultiThread =====
 
 impl MultiThread {
-    pub(crate) fn new(
-        size: usize,
-        driver: Driver,
-        handle_inner: HandleInner,
-        config: Config,
-    ) -> (MultiThread, Launch) {
+    pub(crate) fn new(size: usize, driver: Driver, config: Config) -> (MultiThread, Launch) {
         let parker = Parker::new(driver);
-        let (shared, launch) = worker::create(size, parker, handle_inner, config);
+        let (shared, launch) = worker::create(size, parker, config);
         let spawner = Spawner { shared };
         let multi_thread = MultiThread { spawner };
 
@@ -104,12 +99,8 @@ impl Spawner {
         worker::Shared::bind_new_task(&self.shared, future, id)
     }
 
-    pub(crate) fn shutdown(&mut self) {
+    pub(crate) fn shutdown(&self) {
         self.shared.close();
-    }
-
-    pub(crate) fn as_handle_inner(&self) -> &HandleInner {
-        self.shared.as_handle_inner()
     }
 }
 

--- a/tokio/src/runtime/spawner.rs
+++ b/tokio/src/runtime/spawner.rs
@@ -1,7 +1,6 @@
 use crate::future::Future;
 use crate::runtime::scheduler::current_thread;
 use crate::runtime::task::Id;
-use crate::runtime::HandleInner;
 use crate::task::JoinHandle;
 
 cfg_rt_multi_thread! {
@@ -16,7 +15,7 @@ pub(crate) enum Spawner {
 }
 
 impl Spawner {
-    pub(crate) fn shutdown(&mut self) {
+    pub(crate) fn shutdown(&self) {
         #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
         {
             if let Spawner::MultiThread(spawner) = self {
@@ -34,14 +33,6 @@ impl Spawner {
             Spawner::CurrentThread(spawner) => spawner.spawn(future, id),
             #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             Spawner::MultiThread(spawner) => spawner.spawn(future, id),
-        }
-    }
-
-    pub(crate) fn as_handle_inner(&self) -> &HandleInner {
-        match self {
-            Spawner::CurrentThread(spawner) => spawner.as_handle_inner(),
-            #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
-            Spawner::MultiThread(spawner) => spawner.as_handle_inner(),
         }
     }
 }


### PR DESCRIPTION
In an earlier PR (#4629), driver handles were moved into the scheduler handle (`Spawner`). This was done to let the multi-threaded scheduler have direct access to the thread pool spawner.

However, we are now working on a greater decoupling of the runtime internals. All drivers and schedulers will be peers, stored in a single thread-local variable, and the scheduler will be passed the full runtime::Handle. This will achieve the original goal of giving the scheduler access to the thread-pool while also (hopefully) simplifying other aspects of the code.