### PR TITLE
rt: move unpark out of time driver

### DIFF
--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 
 cfg_io_driver! {
     pub(crate) type IoDriver = crate::runtime::io::Driver;
-    pub(crate) type IoHandle = Option<crate::runtime::io::Handle>;
+    pub(crate) type IoHandle = IoUnpark;
 
     #[derive(Debug)]
     pub(crate) enum IoStack {
@@ -21,6 +21,7 @@ cfg_io_driver! {
         Disabled(ParkThread),
     }
 
+    #[derive(Debug, Clone)]
     pub(crate) enum IoUnpark {
         Enabled(crate::runtime::io::Handle),
         Disabled(UnparkThread),
@@ -37,9 +38,11 @@ cfg_io_driver! {
             let (signal_driver, signal_handle) = create_signal_driver(io_driver)?;
             let process_driver = create_process_driver(signal_driver);
 
-            (IoStack::Enabled(process_driver), Some(io_handle), signal_handle)
+            (IoStack::Enabled(process_driver), IoUnpark::Enabled(io_handle), signal_handle)
         } else {
-            (IoStack::Disabled(ParkThread::new()), Default::default(), Default::default())
+            let park_thread = ParkThread::new();
+            let unpark_thread = park_thread.unpark();
+            (IoStack::Disabled(park_thread), IoUnpark::Disabled(unpark_thread), Default::default())
         };
 
         Ok(ret)
@@ -83,16 +86,35 @@ cfg_io_driver! {
                 IoUnpark::Disabled(v) => v.unpark(),
             }
         }
+
+        #[track_caller]
+        pub(crate) fn expect(self, msg: &'static str) -> crate::runtime::io::Handle {
+            match self {
+                IoUnpark::Enabled(v) => v,
+                IoUnpark::Disabled(..) => panic!("{}", msg),
+            }
+        }
+
+        cfg_unstable! {
+            pub(crate) fn as_ref(&self) -> Option<&crate::runtime::io::Handle> {
+                match self {
+                    IoUnpark::Enabled(v) => Some(v),
+                    IoUnpark::Disabled(..) => None,
+                }
+            }
+        }
     }
 }
 
 cfg_not_io_driver! {
-    pub(crate) type IoHandle = ();
+    pub(crate) type IoHandle = IoUnpark;
     pub(crate) type IoStack = ParkThread;
     pub(crate) type IoUnpark = UnparkThread;
 
     fn create_io_stack(_enabled: bool) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
-        Ok((ParkThread::new(), Default::default(), Default::default()))
+        let park_thread = ParkThread::new();
+        let unpark_thread = park_thread.unpark();
+        Ok((park_thread, unpark_thread, Default::default()))
     }
 }
 

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -549,7 +549,8 @@ impl TimerEntry {
         }
 
         unsafe {
-            self.driver().reregister(tick, self.inner().into());
+            self.driver()
+                .reregister(&self.driver.inner.io_handle, tick, self.inner().into());
         }
     }
 


### PR DESCRIPTION
Currently, the various resource drivers use a layered approach where each driver contains the next one. When the scheduler calls park on the top-most driver, it does work, then calls park on the inner driver. The handles do the same with unparking.

This patch is a step towards refactoring the runtime to move away from the nested approach towards keeping all drivers and handles together in a single runtime driver/handle. The unparker is removed from the time handle and placed in the runtime handle and passed into the time driver as needed.

Depends on #5012.