### PR TITLE
rt: remove driver drop implementations

### DIFF
--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -62,7 +62,6 @@ cfg_io_driver! {
             }
         }
 
-        #[cfg_attr(not(feature = "rt-multi-thread"), allow(dead_code))] // some features use this
         pub(crate) fn shutdown(&mut self) {
             match self {
                 IoStack::Enabled(v) => v.shutdown(),
@@ -203,21 +202,10 @@ cfg_time! {
             }
         }
 
-        // TODO: tokio-rs/tokio#4990, should the `current_thread` scheduler call this?
-        cfg_rt_multi_thread! {
-            pub(crate) fn shutdown(&mut self) {
-                match self {
-                    TimeDriver::Enabled { driver, handle } => driver.shutdown(handle),
-                    TimeDriver::Disabled(v) => v.shutdown(),
-                }
-            }
-        }
-    }
-
-    impl Drop for TimeDriver {
-        fn drop(&mut self) {
-            if let TimeDriver::Enabled { driver, handle } = self {
-                driver.shutdown(handle);
+        pub(crate) fn shutdown(&mut self) {
+            match self {
+                TimeDriver::Enabled { driver, handle } => driver.shutdown(handle),
+                TimeDriver::Disabled(v) => v.shutdown(),
             }
         }
     }
@@ -307,10 +295,7 @@ impl Driver {
         self.inner.park_timeout(duration)
     }
 
-    // TODO: tokio-rs/tokio#4990, should the `current_thread` scheduler call this?
-    cfg_rt_multi_thread! {
-        pub(crate) fn shutdown(&mut self) {
-            self.inner.shutdown()
-        }
+    pub(crate) fn shutdown(&mut self) {
+        self.inner.shutdown()
     }
 }

--- a/tokio/src/runtime/io/mod.rs
+++ b/tokio/src/runtime/io/mod.rs
@@ -230,12 +230,6 @@ impl Driver {
     }
 }
 
-impl Drop for Driver {
-    fn drop(&mut self) {
-        self.shutdown();
-    }
-}
-
 impl fmt::Debug for Driver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Driver")

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -236,6 +236,11 @@ impl Drop for CurrentThread {
             // Submit metrics
             core.metrics.submit(&core.spawner.shared.worker_metrics);
 
+            // Shutdown the resource drivers
+            if let Some(driver) = core.driver.as_mut() {
+                driver.shutdown();
+            }
+
             (core, ())
         });
     }


### PR DESCRIPTION
Currently, drivers are responsible for cleaning themselves up when they are dropped. This is possible today because each driver struct holds a reference to its internal handle.

As part of an effort to decouple drivers from their handles, this patch removes the drop implementations for the time and IO driver in favor of having the scheduler explicitly call `shutdown()` as part of its shutdown process. The scheduler will hold a reference to both the driver and the driver handles, so in the future, it will be able to pass in the driver handles as part of the shutdown process.
