### PR TITLE
chore: remove println from tests

### DIFF
--- a/tokio/src/runtime/tests/task_combinations.rs
+++ b/tokio/src/runtime/tests/task_combinations.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::future::Future;
 use std::panic;
 use std::pin::Pin;
@@ -149,6 +150,8 @@ fn test_combinations() {
     }
 }
 
+fn is_debug<T: fmt::Debug>(_: &T) {}
+
 #[allow(clippy::too_many_arguments)]
 fn test_combination(
     rt: CombiRuntime,
@@ -184,7 +187,15 @@ fn test_combination(
         return;
     }
 
-    println!("Runtime {:?}, LocalSet {:?}, Task {:?}, Output {:?}, JoinInterest {:?}, JoinHandle {:?}, AbortHandle {:?}, Abort {:?} ({:?})", rt, ls, task, output, ji, jh, ah, abort, abort_src);
+    is_debug(&rt);
+    is_debug(&ls);
+    is_debug(&task);
+    is_debug(&output);
+    is_debug(&ji);
+    is_debug(&jh);
+    is_debug(&ah);
+    is_debug(&abort);
+    is_debug(&abort_src);
 
     // A runtime optionally with a LocalSet
     struct Rt {

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -505,39 +505,30 @@ where
     F: Fn(),
 {
     {
-        println!("current thread runtime");
-
         let rt = new_current_thread();
         let _enter = rt.enter();
         f();
 
-        println!("current thread runtime after shutdown");
         rt.shutdown_timeout(Duration::from_secs(1000));
         f();
     }
 
     #[cfg(not(tokio_wasi))]
     {
-        println!("multi thread (1 thread) runtime");
-
         let rt = new_multi_thread(1);
         let _enter = rt.enter();
         f();
 
-        println!("multi thread runtime after shutdown");
         rt.shutdown_timeout(Duration::from_secs(1000));
         f();
     }
 
     #[cfg(not(tokio_wasi))]
     {
-        println!("multi thread (4 threads) runtime");
-
         let rt = new_multi_thread(4);
         let _enter = rt.enter();
         f();
 
-        println!("multi thread runtime after shutdown");
         rt.shutdown_timeout(Duration::from_secs(1000));
         f();
     }

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -480,9 +480,7 @@ fn wake_during_shutdown() {
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
             let me = Pin::into_inner(self);
             let mut lock = me.shared.lock().unwrap();
-            println!("poll {}", me.put_waker);
             if me.put_waker {
-                println!("putting");
                 lock.waker = Some(cx.waker().clone());
             }
             Poll::Pending
@@ -491,13 +489,11 @@ fn wake_during_shutdown() {
 
     impl Drop for MyFuture {
         fn drop(&mut self) {
-            println!("drop {} start", self.put_waker);
             let mut lock = self.shared.lock().unwrap();
             if !self.put_waker {
                 lock.waker.take().unwrap().wake();
             }
             drop(lock);
-            println!("drop {} stop", self.put_waker);
         }
     }
 

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -15,6 +15,7 @@ use tokio::sync::mpsc::{self, channel};
 use tokio::sync::oneshot;
 use tokio_test::*;
 
+use std::fmt;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::{Acquire, Release};
 use std::sync::Arc;
@@ -220,9 +221,9 @@ async fn no_t_bounds_buffer() {
     let (tx, mut rx) = mpsc::channel(100);
 
     // sender should be Debug even though T isn't Debug
-    println!("{:?}", tx);
+    is_debug(&tx);
     // same with Receiver
-    println!("{:?}", rx);
+    is_debug(&rx);
     // and sender should be Clone even though T isn't Clone
     assert!(tx.clone().try_send(NoImpls).is_ok());
 
@@ -236,9 +237,9 @@ async fn no_t_bounds_unbounded() {
     let (tx, mut rx) = mpsc::unbounded_channel();
 
     // sender should be Debug even though T isn't Debug
-    println!("{:?}", tx);
+    is_debug(&tx);
     // same with Receiver
-    println!("{:?}", rx);
+    is_debug(&rx);
     // and sender should be Clone even though T isn't Clone
     assert!(tx.clone().send(NoImpls).is_ok());
 
@@ -940,3 +941,5 @@ async fn test_tx_capacity() {
     assert_eq!(tx.capacity(), 8);
     assert_eq!(tx.max_capacity(), 10);
 }
+
+fn is_debug<T: fmt::Debug>(_: &T) {}

--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -26,10 +26,7 @@ fn test_abort_without_panic_3157() {
         .unwrap();
 
     rt.block_on(async move {
-        let handle = tokio::spawn(async move {
-            println!("task started");
-            tokio::time::sleep(Duration::new(100, 0)).await
-        });
+        let handle = tokio::spawn(async move { tokio::time::sleep(Duration::new(100, 0)).await });
 
         // wait for task to sleep.
         tokio::time::sleep(Duration::from_millis(10)).await;
@@ -159,7 +156,6 @@ fn test_abort_wakes_task_3964() {
         let handle = tokio::spawn(async move {
             // Make sure the Arc is moved into the task
             let _notify_dropped = notify_dropped;
-            println!("task started");
             tokio::time::sleep(Duration::new(100, 0)).await
         });
 
@@ -187,7 +183,6 @@ fn test_abort_task_that_panics_on_drop_contained() {
         let handle = tokio::spawn(async move {
             // Make sure the Arc is moved into the task
             let _panic_dropped = PanicOnDrop;
-            println!("task started");
             tokio::time::sleep(Duration::new(100, 0)).await
         });
 
@@ -211,7 +206,6 @@ fn test_abort_task_that_panics_on_drop_returned() {
         let handle = tokio::spawn(async move {
             // Make sure the Arc is moved into the task
             let _panic_dropped = PanicOnDrop;
-            println!("task started");
             tokio::time::sleep(Duration::new(100, 0)).await
         });
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -284,14 +284,12 @@ fn join_local_future_elsewhere() {
     local.block_on(&rt, async move {
         let (tx, rx) = oneshot::channel();
         let join = task::spawn_local(async move {
-            println!("hello world running...");
             assert!(
                 ON_RT_THREAD.with(|cell| cell.get()),
                 "local task must run on local thread, no matter where it is awaited"
             );
             rx.await.unwrap();
 
-            println!("hello world task done");
             "hello world"
         });
         let join2 = task::spawn(async move {
@@ -301,11 +299,8 @@ fn join_local_future_elsewhere() {
             );
 
             tx.send(()).expect("task shouldn't have ended yet");
-            println!("waking up hello world...");
 
             join.await.expect("task should complete successfully");
-
-            println!("hello world task joined");
         });
         join2.await.unwrap()
     });
@@ -395,9 +390,7 @@ fn with_timeout(timeout: Duration, f: impl FnOnce() + Send + 'static) {
         ),
         // Did the test thread panic? We'll find out for sure when we `join`
         // with it.
-        Err(RecvTimeoutError::Disconnected) => {
-            println!("done_rx dropped, did the test thread panic?");
-        }
+        Err(RecvTimeoutError::Disconnected) => {}
         // Test completed successfully!
         Ok(()) => {}
     }
@@ -510,7 +503,6 @@ async fn local_tasks_are_polled_after_tick_inner() {
                 time::sleep(Duration::from_millis(20)).await;
                 let rx1 = RX1.load(SeqCst);
                 let rx2 = RX2.load(SeqCst);
-                println!("EXPECT = {}; RX1 = {}; RX2 = {}", EXPECTED, rx1, rx2);
                 assert_eq!(EXPECTED, rx1);
                 assert_eq!(EXPECTED, rx2);
             });

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -189,10 +189,7 @@ async fn greater_than_max() {
 
 #[tokio::test]
 async fn short_sleeps() {
-    for i in 0..10000 {
-        if (i % 10) == 0 {
-            eprintln!("=== {}", i);
-        }
+    for _ in 0..10000 {
         tokio::time::sleep(std::time::Duration::from_millis(0)).await;
     }
 }

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -29,9 +29,7 @@ async fn echo() -> io::Result<()> {
     let server_socket = UnixDatagram::bind(server_path.clone())?;
 
     tokio::spawn(async move {
-        if let Err(e) = echo_server(server_socket).await {
-            eprintln!("Error in echo server: {}", e);
-        }
+        let _ = echo_server(server_socket).await;
     });
 
     {
@@ -55,9 +53,7 @@ async fn echo_from() -> io::Result<()> {
     let server_socket = UnixDatagram::bind(server_path.clone())?;
 
     tokio::spawn(async move {
-        if let Err(e) = echo_server(server_socket).await {
-            eprintln!("Error in echo server: {}", e);
-        }
+        let _ = echo_server(server_socket).await;
     });
 
     {


### PR DESCRIPTION
This patch removes println statements from tests. Some of these were used to test that types implement `fmt::Debug`. These println statements have been replaced with an equivalent test that does not output to STDOUT. The rest of the println statements are most likely left over from debugging sessions.