### PR TITLE
Add `SinkWriter` in analogy to `StreamReader` to `tokio_util`

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -522,15 +522,11 @@ impl LengthDelimitedCodec {
             }
         };
 
-        let num_skip = self.builder.get_num_skip();
-
-        if num_skip > 0 {
-            src.advance(num_skip);
-        }
+        src.advance(self.builder.get_num_skip());
 
         // Ensure that the buffer has enough space to read the incoming
         // payload
-        src.reserve(n);
+        src.reserve(n.saturating_sub(src.len()));
 
         Ok(Some(n))
     }
@@ -568,7 +564,7 @@ impl Decoder for LengthDelimitedCodec {
                 self.state = DecodeState::Head;
 
                 // Make sure the buffer has enough space to read the next head
-                src.reserve(self.builder.num_head_bytes());
+                src.reserve(self.builder.num_head_bytes().saturating_sub(src.len()));
 
                 Ok(Some(data))
             }

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -13,6 +13,7 @@
 mod read_buf;
 mod reader_stream;
 mod stream_reader;
+pub mod sink_writer;
 cfg_io_util! {
     mod sync_bridge;
     pub use self::sync_bridge::SyncIoBridge;
@@ -21,4 +22,5 @@ cfg_io_util! {
 pub use self::read_buf::read_buf;
 pub use self::reader_stream::ReaderStream;
 pub use self::stream_reader::StreamReader;
+pub use self::sink_writer::SinkWriter;
 pub use crate::util::{poll_read_buf, poll_write_buf};

--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! The stream types are often used in combination with hyper or reqwest, as they
 //! allow converting between a hyper [`Body`] and [`AsyncRead`].
+//! The sink wrappers are helpful to treat sink-like interfaces as file-like objects with [`AsyncWrite`].
 //!
 //! The [`SyncIoBridge`] type converts from the world of async I/O
 //! to synchronous I/O; this may often come up when using synchronous APIs
@@ -9,11 +10,12 @@
 //!
 //! [`Body`]: https://docs.rs/hyper/0.13/hyper/struct.Body.html
 //! [`AsyncRead`]: tokio::io::AsyncRead
+//! [`AsyncWrite`]: tokio::io::AsyncWrite
 
 mod read_buf;
 mod reader_stream;
+mod sink_writer;
 mod stream_reader;
-pub mod sink_writer;
 cfg_io_util! {
     mod sync_bridge;
     pub use self::sync_bridge::SyncIoBridge;
@@ -21,6 +23,6 @@ cfg_io_util! {
 
 pub use self::read_buf::read_buf;
 pub use self::reader_stream::ReaderStream;
-pub use self::stream_reader::StreamReader;
 pub use self::sink_writer::SinkWriter;
+pub use self::stream_reader::StreamReader;
 pub use crate::util::{poll_read_buf, poll_write_buf};

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -55,6 +55,11 @@ impl CachedState {
     fn has_cached_elements(&self) -> bool {
         !self.unsent_items.is_empty()
     }
+
+    fn get_unsent_items_as_slice(&self) -> &[u8] {
+        let (b, f) = self.unsent_items.as_slices();
+        [b, f].concat().as_slice()
+    }
 }
 
 pin_project! {
@@ -144,6 +149,10 @@ where
     /// It is inadvisable to directly write to the underlying sink.
     pub fn into_inner(self) -> S {
         self.inner
+    }
+
+    pub fn remaining_unsent_buffer(&self) -> &[u8] {
+        self.cache.get_unsent_items_as_slice()
     }
 }
 

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -56,9 +56,10 @@ impl CachedState {
         !self.unsent_items.is_empty()
     }
 
-    fn get_unsent_items_as_slice(&self) -> &[u8] {
+    /// Returns the cached items of this [`CachedState`].
+    fn get_unsent_items(&self) -> Vec<u8> {
         let (b, f) = self.unsent_items.as_slices();
-        [b, f].concat().as_slice()
+        [b, f].concat()
     }
 }
 
@@ -151,8 +152,9 @@ where
         self.inner
     }
 
-    pub fn remaining_unsent_buffer(&self) -> &[u8] {
-        self.cache.get_unsent_items_as_slice()
+    /// Returns the remaining unsent buffer of this [`SinkWriter<S, T>`].
+    pub fn remaining_unsent_buffer(&self) -> Vec<u8> {
+        self.cache.get_unsent_items()
     }
 }
 

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -1,7 +1,6 @@
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use std::collections::VecDeque;
-use std::fmt::Display;
 use std::io;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -161,7 +160,7 @@ where
 impl<S, E, T> AsyncWrite for SinkWriter<S, T>
 where
     S: Sink<T, Error = E>,
-    E: Into<io::Error> + std::fmt::Debug,
+    E: Into<io::Error>,
     T: From<u8>,
 {
     fn poll_write(

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -1,45 +1,97 @@
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
+use std::collections::VecDeque;
+use std::fmt::Display;
 use std::io;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::AsyncWrite;
 
+/// A helper structure to manage unfinished sink writes.
+/// This structures carries elements which are yet to be sent and
+/// has a counter for elements which have been sent but are not flushed yet.
+#[derive(Debug)]
+struct CachedState {
+    unflushed_bytes: usize,
+    unsent_items: VecDeque<u8>,
+}
+
+impl CachedState {
+    /// Creates a new [`CachedState<T>`].
+    fn new() -> Self {
+        Self {
+            unflushed_bytes: 0,
+            unsent_items: VecDeque::new(),
+        }
+    }
+
+    /// Returns the unflushed bytes of this [`CachedState`].
+    fn get_unflushed_bytes(&self) -> usize {
+        self.unflushed_bytes
+    }
+
+    /// Resets the unflushed bytes of this [`CachedState`].
+    fn reset_unflushed_bytes(&mut self) {
+        self.unflushed_bytes = 0
+    }
+    /// Adds number of unflushed bytes to cache.
+    fn add_unflushed_bytes(&mut self, n: usize) {
+        self.unflushed_bytes += n
+    }
+
+    /// Returns the next cached element of this [`CachedState`].
+    fn next_cache_element(&mut self) -> Option<u8> {
+        self.unsent_items.pop_front()
+    }
+
+    /// Adds slice to cache of this [`CachedState`].
+    fn add_elements_to_cache(&mut self, buf: &[u8]) {
+        self.unsent_items
+            .append(&mut buf.iter().copied().collect::<VecDeque<_>>())
+    }
+
+    /// Checks whether this [`CachedState`] contains sendable elements.
+    fn has_cached_elements(&self) -> bool {
+        !self.unsent_items.is_empty()
+    }
+}
+
 pin_project! {
     /// Convert a [`Sink`] of byte chunks into an [`AsyncWrite`].
-    ///
-    /// For the inverse operation define a [`codec`].
+    /// Bytes are sent into the sink and the sink is flushed once all bytes are sent. If an error occurs during the sending progress,
+    /// the number of sent but unflushed bytes are saved in case the flushing operation stays unsuccessful.
+    /// For the inverse operation of defining an [`AsyncWrite`] from a [`Sink`] you need to define a [`codec`].
     ///
     /// # Example
     ///
     /// ```
-    /// use crate::sync::PollSender;
     /// use futures_util::SinkExt;
-    /// use tokio::io::AsyncWriteExt;
     /// use std::io::{Error, ErrorKind};
+    /// use tokio::io::AsyncWriteExt;
+    /// use tokio_util::io::SinkWriter;
+    /// use tokio_util::sync::PollSender;
+    ///
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Error> {
-    ///    // Construct a channel pair to send data across and wrap a pollable sink.
-    ///    // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
-    ///    // as its error type.
-    ///    let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(10);
-    ///    let mut writer = SinkWriter::new(
-    ///        PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)),
-    ///    );
+    ///  // Construct a channel pair to send data across and wrap a pollable sink.
+    ///  // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
+    ///  // as its error type.
+    ///  let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(10);
+    ///  let mut writer = SinkWriter::new(
+    ///      PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)),
+    ///  );
+    ///  // Write data to our interface...
+    ///  let data: [u8; 4] = [1, 2, 3, 4];
+    ///  let _ = writer.write(&data).await?;
+    ///  // ... and receive it.
+    ///  let mut received = Vec::new();
+    ///  for _ in 0..4 {
+    ///      received.push(rx.recv().await.unwrap());
+    ///  }
+    /// assert_eq!(&data, received.as_slice());
     ///
-    ///    // Write data to our interface...
-    ///    let data: [u8; 4] = [1, 2, 3, 4];
-    ///    writer.write(&data).await?;
-    ///
-    ///    // ... and receive it.
-    ///    let mut received = Vec::new();
-    ///    for _ in 0..4 {
-    ///        received.push(rx.recv().await.unwrap());
-    ///    }
-    ///    assert_eq!(&data, received.as_slice());
-    ///
-    ///    # Ok(())
+    /// # Ok(())
     /// # }
     /// ```
     ///
@@ -48,9 +100,14 @@ pin_project! {
     /// [`Sink`]: futures_sink::Sink
     /// [`codec`]: tokio_util::codec
     #[derive(Debug)]
-    struct SinkWriter<S, T> {
+    pub struct SinkWriter<S, T>
+    where
+        S: Sink<T>,
+        T: From<u8>
+    {
         #[pin]
         inner: S,
+        cache: CachedState,
         phantom: PhantomData<T>
     }
 }
@@ -59,9 +116,11 @@ where
     S: Sink<T>,
     T: From<u8>,
 {
-    fn new(sink: S) -> Self {
+    /// Creates a new [`SinkWriter`].
+    pub fn new(sink: S) -> Self {
         Self {
             inner: sink,
+            cache: CachedState::new(),
             phantom: PhantomData,
         }
     }
@@ -80,13 +139,6 @@ where
         &mut self.inner
     }
 
-    /// Gets a pinned mutable reference to the underlying sink.
-    ///
-    /// It is inadvisable to directly write to the underlying sink.
-    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut S> {
-        self.project().inner
-    }
-
     /// Consumes this `SinkWriter`, returning the underlying sink.
     ///
     /// It is inadvisable to directly write to the underlying sink.
@@ -98,39 +150,132 @@ where
 impl<S, E, T> AsyncWrite for SinkWriter<S, T>
 where
     S: Sink<T, Error = E>,
-    E: Into<io::Error>,
+    E: Into<io::Error> + std::fmt::Debug,
     T: From<u8>,
 {
     fn poll_write(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        let sink = self.get_pin_mut();
-        match sink.poll_ready(cx) {
-            Poll::Ready(Ok(())) => {
-                let p = {
-                    for (i, b) in buf.into_iter().enumerate() {
-                        if let Err(_) = sink.start_send(From::from(*b)) {
-                            return Poll::Ready(Ok(i + 1));
+        match self.as_mut().project().inner.poll_ready(cx) {
+            Poll::Ready(Ok(_)) => {
+                // We start with trying to empty potentially unsent items.
+                let cache_bytes_written = if self.as_mut().project().cache.has_cached_elements() {
+                    let len_cache = self.as_mut().project().cache.unsent_items.len();
+                    let mut last_from_cache = 0;
+                    loop {
+                        // In case the sink is ready to receive items, try to send the next item through.
+                        // If not, add remaining items to the buffer and return immediately.
+                        let p = self.as_mut().project().inner.poll_ready(cx);
+                        println!("Sink ready for cache? {:#?}", p);
+                        match p {
+                            Poll::Ready(Ok(())) => {
+                                if let Some(b) = self.as_mut().project().cache.next_cache_element()
+                                {
+                                    if self.as_mut().project().inner.start_send(b.into()).is_err() {
+                                        break last_from_cache;
+                                    }
+                                } else {
+                                    // After sending items from the cache, return the number of unflushed bytes that were sent.
+                                    break len_cache;
+                                }
+                            }
+                            Poll::Ready(Err(e)) => {
+                                let cache = self.as_mut().project().cache;
+                                cache.add_elements_to_cache(buf);
+                                cache.add_unflushed_bytes(last_from_cache);
+                                return Poll::Ready(Err(e.into()));
+                            }
+                            Poll::Pending => {
+                                let cache = self.as_mut().project().cache;
+                                cache.add_elements_to_cache(buf);
+                                cache.add_unflushed_bytes(last_from_cache);
+                                cx.waker().wake_by_ref();
+                                return Poll::Pending;
+                            }
                         };
+
+                        last_from_cache += 1;
                     }
-                    Poll::Ready(Ok(buf.len()))
+                } else {
+                    0
                 };
 
-                sink.poll_flush(cx);
-                p
+                let buf_bytes_written = {
+                    let mut written_until_problem = None;
+                    for (i, b) in buf.iter().enumerate() {
+                        match self.as_mut().project().inner.poll_ready(cx) {
+                            Poll::Ready(Ok(())) => {
+                                if self
+                                    .as_mut()
+                                    .project()
+                                    .inner
+                                    .start_send(From::from(*b))
+                                    .is_err()
+                                {
+                                    let _ = written_until_problem.insert(i);
+                                    break;
+                                };
+                            }
+                            Poll::Ready(Err(e)) => {
+                                let cache = self.as_mut().project().cache;
+                                cache.add_elements_to_cache(&buf[i..]);
+                                cache
+                                    .add_unflushed_bytes(written_until_problem.unwrap_or_default());
+                                return Poll::Ready(Err(e.into()));
+                            }
+                            Poll::Pending => {
+                                let cache = self.as_mut().project().cache;
+                                cache.add_elements_to_cache(&buf[i..]);
+                                cache
+                                    .add_unflushed_bytes(written_until_problem.unwrap_or_default());
+                                cx.waker().wake_by_ref();
+                                return Poll::Pending;
+                            }
+                        }
+                    }
+                    written_until_problem.unwrap_or(buf.len())
+                };
+
+                let bytes_written = buf_bytes_written + cache_bytes_written;
+                match self.as_mut().project().inner.poll_flush(cx) {
+                    Poll::Ready(Ok(_)) => {
+                        let c = self.as_mut().project().cache;
+                        let summed_bytes = bytes_written + c.get_unflushed_bytes();
+                        c.reset_unflushed_bytes();
+                        Poll::Ready(Ok(summed_bytes))
+                    }
+                    Poll::Ready(Err(e)) => {
+                        self.as_mut()
+                            .project()
+                            .cache
+                            .add_unflushed_bytes(bytes_written);
+                        Poll::Ready(Err(e.into()))
+                    }
+                    Poll::Pending => {
+                        self.as_mut()
+                            .project()
+                            .cache
+                            .add_unflushed_bytes(bytes_written);
+                        cx.waker().wake_by_ref();
+                        Poll::Pending
+                    }
+                }
             }
             Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
-            Poll::Pending => Poll::Pending,
+            Poll::Pending => {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
         }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.get_pin_mut().poll_flush(cx).map_err(Into::into)
+        self.project().inner.poll_flush(cx).map_err(Into::into)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        self.get_pin_mut().poll_close(cx).map_err(Into::into)
+        self.project().inner.poll_close(cx).map_err(Into::into)
     }
 }

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -1,0 +1,136 @@
+use futures_sink::Sink;
+use pin_project_lite::pin_project;
+use std::io;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::io::AsyncWrite;
+
+pin_project! {
+    /// Convert a [`Sink`] of byte chunks into an [`AsyncWrite`].
+    ///
+    /// For the inverse operation define a [`codec`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use crate::sync::PollSender;
+    /// use futures_util::SinkExt;
+    /// use tokio::io::AsyncWriteExt;
+    /// use std::io::{Error, ErrorKind};
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Error> {
+    ///    // Construct a channel pair to send data across and wrap a pollable sink.
+    ///    // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
+    ///    // as its error type.
+    ///    let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(10);
+    ///    let mut writer = SinkWriter::new(
+    ///        PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)),
+    ///    );
+    ///
+    ///    // Write data to our interface...
+    ///    let data: [u8; 4] = [1, 2, 3, 4];
+    ///    writer.write(&data).await?;
+    ///
+    ///    // ... and receive it.
+    ///    let mut received = Vec::new();
+    ///    for _ in 0..4 {
+    ///        received.push(rx.recv().await.unwrap());
+    ///    }
+    ///    assert_eq!(&data, received.as_slice());
+    ///
+    ///    # Ok(())
+    /// # }
+    /// ```
+    ///
+    ///
+    /// [`AsyncWrite`]: tokio::io::AsyncWrite
+    /// [`Sink`]: futures_sink::Sink
+    /// [`codec`]: tokio_util::codec
+    #[derive(Debug)]
+    struct SinkWriter<S, T> {
+        #[pin]
+        inner: S,
+        phantom: PhantomData<T>
+    }
+}
+impl<S, T> SinkWriter<S, T>
+where
+    S: Sink<T>,
+    T: From<u8>,
+{
+    fn new(sink: S) -> Self {
+        Self {
+            inner: sink,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Gets a reference to the underlying sink.
+    ///
+    /// It is inadvisable to directly write to the underlying sink.
+    pub fn get_ref(&self) -> &S {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying sink.
+    ///
+    /// It is inadvisable to directly write to the underlying sink.
+    pub fn get_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying sink.
+    ///
+    /// It is inadvisable to directly write to the underlying sink.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut S> {
+        self.project().inner
+    }
+
+    /// Consumes this `SinkWriter`, returning the underlying sink.
+    ///
+    /// It is inadvisable to directly write to the underlying sink.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S, E, T> AsyncWrite for SinkWriter<S, T>
+where
+    S: Sink<T, Error = E>,
+    E: Into<io::Error>,
+    T: From<u8>,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let sink = self.get_pin_mut();
+        match sink.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                let p = {
+                    for (i, b) in buf.into_iter().enumerate() {
+                        if let Err(_) = sink.start_send(From::from(*b)) {
+                            return Poll::Ready(Ok(i + 1));
+                        };
+                    }
+                    Poll::Ready(Ok(buf.len()))
+                };
+
+                sink.poll_flush(cx);
+                p
+            }
+            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.get_pin_mut().poll_flush(cx).map_err(Into::into)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.get_pin_mut().poll_close(cx).map_err(Into::into)
+    }
+}

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -167,9 +167,7 @@ where
                     loop {
                         // In case the sink is ready to receive items, try to send the next item through.
                         // If not, add remaining items to the buffer and return immediately.
-                        let p = self.as_mut().project().inner.poll_ready(cx);
-                        println!("Sink ready for cache? {:#?}", p);
-                        match p {
+                        match self.as_mut().project().inner.poll_ready(cx) {
                             Poll::Ready(Ok(())) => {
                                 if let Some(b) = self.as_mut().project().cache.next_cache_element()
                                 {

--- a/tokio-util/tests/io_sink_writer.rs
+++ b/tokio-util/tests/io_sink_writer.rs
@@ -23,7 +23,6 @@ async fn test_sink_writer() -> Result<(), Error> {
     let mut received = Vec::new();
     for _ in 0..4 {
         if let Some(b) = rx.recv().await {
-            println!("{}", b);
             received.push(b);
         }
     }

--- a/tokio-util/tests/io_sink_writer.rs
+++ b/tokio-util/tests/io_sink_writer.rs
@@ -1,30 +1,33 @@
 #![warn(rust_2018_idioms)]
 
-use tokio_util::sync::PollSender;
-use tokio_util::io::SinkWriter;
 use futures_util::SinkExt;
-use tokio::io::AsyncWriteExt;
 use std::io::{Error, ErrorKind};
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::SinkWriter;
+use tokio_util::sync::PollSender;
 
 #[tokio::test]
 async fn test_sink_writer() -> Result<(), Error> {
-   // Construct a channel pair to send data across and wrap a pollable sink.
-   // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
-   // as its error type.
-   let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(10);
-   let mut writer = SinkWriter::new(
-       PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)),
-   );
+    // Construct a channel pair to send data across and wrap a pollable sink.
+    // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
+    // as its error type.
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(4);
+    let mut writer =
+        SinkWriter::new(PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)));
 
-   // Write data to our interface...
-   let data: [u8; 4] = [1, 2, 3, 4];
-   writer.write(&data).await?;
+    // Write data to our interface...
+    let data: [u8; 4] = [1, 2, 3, 4];
+    let _ = writer.write(&data).await?;
 
-   // ... and receive it.
-   let mut received = Vec::new();
-   for _ in 0..4 {
-       received.push(rx.recv().await.unwrap());
-   }
-   assert_eq!(&data, received.as_slice());
-   Ok(())
+    // ... and receive it.
+    let mut received = Vec::new();
+    for _ in 0..4 {
+        if let Some(b) = rx.recv().await {
+            println!("{}", b);
+            received.push(b);
+        }
+    }
+    assert_eq!(&data, received.as_slice());
+
+    Ok(())
 }

--- a/tokio-util/tests/io_sink_writer.rs
+++ b/tokio-util/tests/io_sink_writer.rs
@@ -1,0 +1,30 @@
+#![warn(rust_2018_idioms)]
+
+use tokio_util::sync::PollSender;
+use tokio_util::io::SinkWriter;
+use futures_util::SinkExt;
+use tokio::io::AsyncWriteExt;
+use std::io::{Error, ErrorKind};
+
+#[tokio::test]
+async fn test_sink_writer() -> Result<(), Error> {
+   // Construct a channel pair to send data across and wrap a pollable sink.
+   // Note that the sink must mimic a writable object, e.g. have `std::io::Error`
+   // as its error type.
+   let (tx, mut rx) = tokio::sync::mpsc::channel::<u8>(10);
+   let mut writer = SinkWriter::new(
+       PollSender::new(tx).sink_map_err(|_| Error::from(ErrorKind::Other)),
+   );
+
+   // Write data to our interface...
+   let data: [u8; 4] = [1, 2, 3, 4];
+   writer.write(&data).await?;
+
+   // ... and receive it.
+   let mut received = Vec::new();
+   for _ in 0..4 {
+       received.push(rx.recv().await.unwrap());
+   }
+   assert_eq!(&data, received.as_slice());
+   Ok(())
+}


### PR DESCRIPTION
## Motivation
Tokio provides `StreamReader`, enabling us to treat streams as file-like interfaces through `AsyncRead`. This however only exists for streams, not for general sinks, for which this PR provides an implementation.

## Solution
The solution is a wrapper which acts as a buffer that sends and flushes provided bytes into the sink. Should a fully successful sending operation not be possible, the buffer is added to an internal buffer which is handled with a higher priority once another sending operation is attempted again.
A vectorized write is not provided - this operation flushes only at the end and the default implementation is about as effective as a generic sink can be I believe.

There are two points to discuss: in case the `start_send` operation fails, the polling method returns `Ok` with the number of bytes sent since part of the operation was indeed successful. As such an error would most likely come from a close, another attempt to send data would then lead to an error. This is a compromise of being able to return the number of bytes sent and forwarding the error in a low-friction way. A second item would be the question whether this solution is not "too eager" in waking up the context, which I'm not sure about.
