### PR TITLE
rt: rm internal `Unpark` types for Handle types

### DIFF
--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -3,7 +3,6 @@
 //! Process driver.
 
 use crate::process::unix::GlobalOrphanQueue;
-use crate::runtime::io::Handle;
 use crate::signal::unix::driver::{Driver as SignalDriver, Handle as SignalHandle};
 
 use std::time::Duration;
@@ -26,10 +25,6 @@ impl Driver {
             park,
             signal_handle,
         }
-    }
-
-    pub(crate) fn unpark(&self) -> Handle {
-        self.park.unpark()
     }
 
     pub(crate) fn park(&mut self) {

--- a/tokio/src/runtime/io/mod.rs
+++ b/tokio/src/runtime/io/mod.rs
@@ -144,11 +144,6 @@ impl Driver {
         }
     }
 
-    // TODO: remove this in a later refactor
-    pub(crate) fn unpark(&self) -> Handle {
-        self.handle()
-    }
-
     pub(crate) fn park(&mut self) {
         self.turn(None);
     }

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -35,7 +35,7 @@ impl Handle {
     }
 
     pub(crate) fn shutdown(&self) {
-        self.shared.close();
+        self.close();
     }
 
     pub(super) fn bind_new_task<T>(me: &Arc<Self>, future: T, id: task::Id) -> JoinHandle<T::Output>
@@ -46,7 +46,7 @@ impl Handle {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
         if let Some(notified) = notified {
-            me.shared.schedule(notified, false);
+            me.schedule_task(notified, false);
         }
 
         handle

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -39,13 +39,11 @@ impl MultiThread {
         seed_generator: RngSeedGenerator,
         config: Config,
     ) -> (MultiThread, Launch) {
-        let driver_unpark = driver.unpark();
         let parker = Parker::new(driver);
         let (handle, launch) = worker::create(
             size,
             parker,
             driver_handle,
-            driver_unpark,
             blocking_spawner,
             seed_generator,
             config,

--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -96,7 +96,7 @@ impl Clone for Parker {
 }
 
 impl Unparker {
-    pub(crate) fn unpark(&self, driver: &driver::Unpark) {
+    pub(crate) fn unpark(&self, driver: &driver::Handle) {
         self.inner.unpark(driver);
     }
 }
@@ -195,7 +195,7 @@ impl Inner {
         }
     }
 
-    fn unpark(&self, driver: &driver::Unpark) {
+    fn unpark(&self, driver: &driver::Handle) {
         // To ensure the unparked thread will observe any writes we made before
         // this call, we must perform a release operation that `park` can
         // synchronize with. To do that we must write `NOTIFIED` even if `state`

--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -30,6 +30,14 @@ impl Handle {
     pub(super) fn is_shutdown(&self) -> bool {
         self.inner.is_shutdown()
     }
+
+    /// Track that the driver is being unparked
+    pub(crate) fn unpark(&self) {
+        #[cfg(feature = "test-util")]
+        self.inner
+            .did_wake
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    }
 }
 
 cfg_not_rt! {

--- a/tokio/src/signal/unix/driver.rs
+++ b/tokio/src/signal/unix/driver.rs
@@ -92,10 +92,6 @@ impl Driver {
         }
     }
 
-    pub(crate) fn unpark(&self) -> io::Handle {
-        self.park.unpark()
-    }
-
     pub(crate) fn park(&mut self) {
         self.park.park();
         self.process();


### PR DESCRIPTION
This patch removes all internal `Unpark` runtime types. The runtime now uses the `Handle` types (`runtime::io::Handle` and `runtime::time::Handle`) to signal threads to unpark.

Without separate `Unpark` types, future patches will be able to remove more `Arc`s used inside various drivers.

This depends on #5026