### PR TITLE
chore: release tokio-stream 0.1.10

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.1.10 (Sept 18, 2022)
+
+- time: add `StreamExt::chunks_timeout` ([#4695])
+- stream: add track_caller to public APIs ([#4786])
+
+[#4695]: https://github.com/tokio-rs/tokio/pull/4695
+[#4786]: https://github.com/tokio-rs/tokio/pull/4786
+
 # 0.1.9 (June 4, 2022)
 
 - deps: upgrade `tokio-util` dependency to `0.7.x` ([#3762])

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.9"
+version = "0.1.10"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
Closes #5011
