### PR TITLE
`is_closed` for `mpsc::{Receiver, UnboundedReceiver}`

### DIFF
--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -104,6 +104,15 @@ impl<T> Block<T> {
         other_index.wrapping_sub(self.start_index) / BLOCK_CAP
     }
 
+    /// Check to see if the given slot is a tx closed entry
+    pub(crate) fn is_closed(&self, slot_index: usize) -> bool {
+        let offset = offset(slot_index);
+
+        let ready_bits = self.ready_slots.load(Acquire);
+
+        !is_ready(ready_bits, offset) && is_tx_closed(ready_bits)
+    }
+
     /// Reads the value at the given offset.
     ///
     /// Returns `None` if the slot is empty.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -391,6 +391,13 @@ impl<T> Receiver<T> {
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
     }
+
+    /// Check to see if the channel has been closed and all messages sent before it
+    /// was closed have been received. This implies that there will never be more
+    /// messages to recieve on this channel.
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }
 
 impl<T> fmt::Debug for Receiver<T> {

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -335,6 +335,14 @@ impl<T, S: Semaphore> Rx<T, S> {
             }
         })
     }
+
+    /// Check to see if the channel is closed.
+    pub(crate) fn is_closed(&mut self) -> bool {
+        self.inner.rx_fields.with_mut(|rx_fields_ptr| {
+            let rx_fields = unsafe { &mut *rx_fields_ptr };
+            rx_fields.list.is_closed(&self.inner.tx)
+        })
+    }
 }
 
 impl<T, S: Semaphore> Drop for Rx<T, S> {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -247,6 +247,13 @@ impl<T> UnboundedReceiver<T> {
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         self.chan.recv(cx)
     }
+
+    /// Check to see if the channel has been closed and all messages sent before it
+    /// was closed have been received. This implies that there will never be more
+    /// messages to recieve on this channel.
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed()
+    }
 }
 
 impl<T> UnboundedSender<T> {


### PR DESCRIPTION
There's a use case for channels that wants to know up-front (before calling `recv` or `try_recv`)that there's a possibility of new messages coming in. Make it possible to check whether the channel is closed and empty, which implies that there will never be new messages on this channel.

Fixes: #4638

## Motivation

Taken from #4638 - if you're building a pipe-type abstraction over an MPSC channel carrying byte buffers, then it's useful to know that the pipe is now terminated without having to handle the possibility of data arriving when you do the check.

## Solution

Refactor so that I can see if the current block is closed without reading the value. I believe this avoids safety issues, since I never go near the actual data.

This is incomplete as-is, since it only allows you to look to see if the channel is closed, not check to see if there's data to be read, or to wait until data is available. I am working on those two items, to let you build a useful `TcpStream` equivalent from an MPSC channel.