### PR TITLE
task: add track_caller to `block_in_place` and `spawn_local`

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -633,6 +633,7 @@ impl<T> Sender<T> {
     ///     }
     /// }
     /// ```
+    #[track_caller]
     #[cfg(feature = "time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
     pub async fn send_timeout(

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -633,7 +633,6 @@ impl<T> Sender<T> {
     ///     }
     /// }
     /// ```
-    #[track_caller]
     #[cfg(feature = "time")]
     #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
     pub async fn send_timeout(

--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -70,6 +70,7 @@ cfg_rt_multi_thread! {
     /// This function panics if called from a [`current_thread`] runtime.
     ///
     /// [`current_thread`]: fn@crate::runtime::Builder::new_current_thread
+    #[track_caller]
     pub fn block_in_place<F, R>(f: F) -> R
     where
         F: FnOnce() -> R,

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -314,12 +314,10 @@ cfg_rt! {
     where F: Future + 'static,
           F::Output: 'static
     {
-        CURRENT.with(|maybe_cx| {
-            match maybe_cx.get() {
-                None => panic!("`spawn_local` called from outside of a `task::LocalSet`"),
-                Some(cx) => cx.spawn(future, name)
-            }
-        })
+        match CURRENT.with(|maybe_cx| maybe_cx.get()) {
+            None => panic!("`spawn_local` called from outside of a `task::LocalSet`"),
+            Some(cx) => cx.spawn(future, name)
+       }
     }
 }
 

--- a/tokio/tests/task_panic.rs
+++ b/tokio/tests/task_panic.rs
@@ -3,12 +3,42 @@
 
 use futures::future;
 use std::error::Error;
-use tokio::{runtime::Builder, spawn, task};
+use tokio::runtime::Builder;
+use tokio::task::{self, block_in_place};
 
 mod support {
     pub mod panic;
 }
 use support::panic::test_panic;
+
+#[test]
+fn block_in_place_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
+        rt.block_on(async {
+            block_in_place(|| {});
+        });
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
+fn local_set_spawn_local_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _local = task::LocalSet::new();
+
+        let _ = task::spawn_local(async {});
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
 
 #[test]
 fn local_set_block_on_panic_caller() -> Result<(), Box<dyn Error>> {
@@ -30,7 +60,7 @@ fn local_set_block_on_panic_caller() -> Result<(), Box<dyn Error>> {
 #[test]
 fn spawn_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
-        spawn(future::pending::<()>());
+        tokio::spawn(future::pending::<()>());
     });
 
     // The panic location should be in this file


### PR DESCRIPTION
## Motivation

Most of the public APIs in the `task` module were covered with the `#[track_caller]`
attribute in #4848. However, two functions were skipped because the call stack
leading to the panic passed through a closure (rust-lang/rust#87417).

The fact that this is missing was brought up again in #5030. At that point, a work around
solution was collectively worked out for that use case, bringing the panic call outside the
closure.

## Solution

Functions that may panic can be annotated with `#[track_caller]` so that in the event of a panic, the function where the user called the panicking function is shown instead of the file and line within Tokio source.

This change adds `#[track_caller]` to two public APIs in tokio task module which weren't added in #4848.
* `tokio::task::block_in_place`
* `tokio::task::spawn_local`

These APIs had call stacks that went through closures, which is a use case not supported by `#[track_caller]`. These two cases have been refactored so that the `panic!` call is no longer inside a closure.

Tests have been added for these two new cases.

Refs: #4413
