### PR TITLE
Prepare Tokio v1.18.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.3", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.18.3 (September 26, 2022)
+# 1.18.3 (September 27, 2022)
 
 This release removes the dependency on the `once_cell` crate to restore the MSRV
 of the 1.18.x LTS release. ([#5048])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.18.3 (September, 26, 2022)
+
+This release removes the dependency on the `once_cell` crate to restore the MSRV
+of the 1.18.x LTS release. ([#5048])
+
+[#5048]: https://github.com/tokio-rs/tokio/pull/5048
+
 # 1.18.2 (May 5, 2022)
 
 Add missing features for the `winapi` dependency. ([#4663])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.18.3 (September, 26, 2022)
+# 1.18.3 (September 26, 2022)
 
 This release removes the dependency on the `once_cell` crate to restore the MSRV
 of the 1.18.x LTS release. ([#5048])

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.18.2"
+version = "1.18.3"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.2", features = ["full"] }
+tokio = { version = "1.18.3", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.18.3 (September 27, 2022)

This release removes the dependency on the `once_cell` crate to restore the MSRV of the 1.18.x LTS release. ([#5048])

[#5048]: https://github.com/tokio-rs/tokio/pull/5048