### PR TITLE
Merge 1.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     resource_class: arm.medium
     environment:
       # Change to pin rust version
-      RUST_STABLE: stable
+      RUST_STABLE: 1.62.1
     steps:
       - checkout
       - run:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 freebsd_instance:
   image: freebsd-12-3-release-amd64
 env:
-  RUST_STABLE: stable
+  RUST_STABLE: 1.62.1
   RUST_NIGHTLY: nightly-2022-03-21
   RUSTFLAGS: -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: 1.62.1
   rust_nightly: nightly-2022-04-18
-  rust_clippy: 1.52.0
+  rust_clippy: 1.56.0
   # When updating this, also update:
   # - README.md
   # - tokio/README.md
@@ -295,8 +295,9 @@ jobs:
           toolchain: ${{ env.rust_min }}
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: "test --workspace --all-features"
-        run: cargo check --workspace --all-features
+      - name: "test --all-features"
+        run: cargo check --all-features
+        working-directory: tokio
 
   minimal-versions:
     name: minimal-versions

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -11,7 +11,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: 1.62.1
 
 jobs:
   loom:

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -9,7 +9,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: 1.62.1
 
 jobs:
   stess-test:

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,7 +21,6 @@ serde_derive = "1.0"
 serde_json = "1.0"
 httparse = "1.0"
 httpdate = "1.0"
-once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.winapi]
@@ -70,11 +69,6 @@ path = "udp-codec.rs"
 [[example]]
 name = "tinyhttp"
 path = "tinyhttp.rs"
-
-[[example]]
-name = "custom-executor"
-path = "custom-executor.rs"
-
 
 [[example]]
 name = "custom-executor-tokio-context"

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -116,6 +116,13 @@ This release fixes a bug in `Notified::enable`. ([#4747])
 [#4729]: https://github.com/tokio-rs/tokio/pull/4729
 [#4739]: https://github.com/tokio-rs/tokio/pull/4739
 
+# 1.18.3 (September 27, 2022)
+
+This release removes the dependency on the `once_cell` crate to restore the MSRV
+of the 1.18.x LTS release. ([#5048])
+
+[#5048]: https://github.com/tokio-rs/tokio/pull/5048
+
 # 1.18.2 (May 5, 2022)
 
 Add missing features for the `winapi` dependency. ([#4663])

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -61,7 +61,6 @@ net = [
 ]
 process = [
   "bytes",
-  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/os-ext",
@@ -75,13 +74,12 @@ process = [
   "winapi/minwindef",
 ]
 # Includes basic task execution capabilities
-rt = ["once_cell"]
+rt = []
 rt-multi-thread = [
   "num_cpus",
   "rt",
 ]
 signal = [
-  "once_cell",
   "libc",
   "mio/os-poll",
   "mio/net",
@@ -110,7 +108,6 @@ pin-project-lite = "0.2.0"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
-once_cell = { version = "1.5.2", optional = true }
 memchr = { version = "2.2", optional = true }
 mio = { version = "0.8.1", optional = true }
 socket2 = { version = "0.4.4", optional = true, features = [ "all" ] }

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -52,7 +52,7 @@ impl<T> Mutex<T> {
     }
 
     #[inline]
-    #[cfg(all(feature = "parking_lot", not(all(loom, test)),))]
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "parking_lot",))))]
     pub(crate) const fn const_new(t: T) -> Mutex<T> {
         Mutex(PhantomData, parking_lot::const_mutex(t))

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -505,11 +505,17 @@ impl Id {
 
     cfg_not_has_atomic_u64! {
         pub(crate) fn next() -> Self {
-            use once_cell::sync::Lazy;
+            use crate::util::once_cell::OnceCell;
             use crate::loom::sync::Mutex;
 
-            static NEXT_ID: Lazy<Mutex<u64>> = Lazy::new(|| Mutex::new(1));
-            let mut lock = NEXT_ID.lock();
+            fn init_next_id() -> Mutex<u64> {
+                Mutex::new(1)
+            }
+
+            static NEXT_ID: OnceCell<Mutex<u64>> = OnceCell::new();
+
+            let next_id = NEXT_ID.get(init_next_id);
+            let mut lock = next_id.lock();
             let id = *lock;
             *lock += 1;
             Self(id)

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -6,6 +6,15 @@ cfg_io_driver! {
 #[cfg(feature = "rt")]
 pub(crate) mod atomic_cell;
 
+cfg_has_atomic_u64! {
+    #[cfg(any(feature = "signal", all(unix, feature = "process")))]
+    pub(crate) mod once_cell;
+}
+cfg_not_has_atomic_u64! {
+    #[cfg(any(feature = "rt", feature = "signal", all(unix, feature = "process")))]
+    pub(crate) mod once_cell;
+}
+
 #[cfg(any(
     // io driver uses `WakeList` directly
     feature = "net",

--- a/tokio/src/util/once_cell.rs
+++ b/tokio/src/util/once_cell.rs
@@ -1,0 +1,70 @@
+#![cfg_attr(loom, allow(dead_code))]
+use std::cell::UnsafeCell;
+use std::mem::MaybeUninit;
+use std::sync::Once;
+
+pub(crate) struct OnceCell<T> {
+    once: Once,
+    value: UnsafeCell<MaybeUninit<T>>,
+}
+
+unsafe impl<T: Send + Sync> Send for OnceCell<T> {}
+unsafe impl<T: Send + Sync> Sync for OnceCell<T> {}
+
+impl<T> OnceCell<T> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            once: Once::new(),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+
+    /// Get the value inside this cell, intiailizing it using the provided
+    /// function if necessary.
+    ///
+    /// If the `init` closure panics, then the `OnceCell` is poisoned and all
+    /// future calls to `get` will panic.
+    #[inline]
+    pub(crate) fn get(&self, init: fn() -> T) -> &T {
+        if !self.once.is_completed() {
+            self.do_init(init);
+        }
+
+        // Safety: The `std::sync::Once` guarantees that we can only reach this
+        // line if a `call_once` closure has been run exactly once and without
+        // panicking. Thus, the value is not uninitialized.
+        //
+        // There is also no race because the only `&self` method that modifies
+        // `value` is `do_init`, but if the `call_once` closure is still
+        // running, then no thread has gotten past the `call_once`.
+        unsafe { &*(self.value.get() as *const T) }
+    }
+
+    #[cold]
+    fn do_init(&self, init: fn() -> T) {
+        let value_ptr = self.value.get() as *mut T;
+
+        self.once.call_once(|| {
+            let set_to = init();
+
+            // Safety: The `std::sync::Once` guarantees that this initialization
+            // will run at most once, and that no thread can get past the
+            // `call_once` until it has run exactly once. Thus, we have
+            // exclusive access to `value`.
+            unsafe {
+                std::ptr::write(value_ptr, set_to);
+            }
+        });
+    }
+}
+
+impl<T> Drop for OnceCell<T> {
+    fn drop(&mut self) {
+        if self.once.is_completed() {
+            let value_ptr = self.value.get() as *mut T;
+            unsafe {
+                std::ptr::drop_in_place(value_ptr);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit merges #5051 into the tokio-1.20.x branch. The `rust_stable` pin is updated to 1.62.1 rather than 1.60.0 as part of the merge.

This PR must be merged from the command line!