### PR TITLE
ci: improve minrust check and reenable example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,9 +297,19 @@ jobs:
           toolchain: ${{ env.rust_min }}
           override: true
       - uses: Swatinem/rust-cache@v1
-      - name: "test --all-features"
-        run: cargo check --all-features
-        working-directory: tokio
+      # First compile just the main tokio crate with minrust and newest version
+      # of all dependencies, then pin once_cell and compile the rest of the
+      # crates with the pinned once_cell version.
+      #
+      # This is necessary because tokio-util transitively depends on once_cell,
+      # which is not compatible with the current minrust after the 1.15.0
+      # release.
+      - name: "check -p tokio --all-features"
+        run: cargo check -p tokio --all-features
+      - name: "pin once_cell version"
+        run: cargo update -p once_cell --precise 1.14.0
+      - name: "check --workspace --all-features"
+        run: cargo check --workspace --all-features
 
   minimal-versions:
     name: minimal-versions

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,6 +21,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 httparse = "1.0"
 httpdate = "1.0"
+once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.winapi]
@@ -69,6 +70,10 @@ path = "udp-codec.rs"
 [[example]]
 name = "tinyhttp"
 path = "tinyhttp.rs"
+
+[[example]]
+name = "custom-executor"
+path = "custom-executor.rs"
 
 [[example]]
 name = "custom-executor-tokio-context"


### PR DESCRIPTION
Currently the minrust check only looks at the main tokio crate, but we should look at all crates. This also re-enables an example that was disabled.

Fixes #5049.