### PR TITLE
tokio: use const `Mutex::new` for globals

### DIFF
--- a/tokio/src/loom/std/mutex.rs
+++ b/tokio/src/loom/std/mutex.rs
@@ -13,6 +13,12 @@ impl<T> Mutex<T> {
     }
 
     #[inline]
+    #[cfg(not(tokio_no_const_mutex_new))]
+    pub(crate) const fn const_new(t: T) -> Mutex<T> {
+        Mutex(sync::Mutex::new(t))
+    }
+
+    #[inline]
     pub(crate) fn lock(&self) -> MutexGuard<'_, T> {
         match self.0.lock() {
             Ok(guard) => guard,

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -481,6 +481,36 @@ macro_rules! cfg_not_has_atomic_u64 {
     }
 }
 
+macro_rules! cfg_has_const_mutex_new {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(
+                not(all(loom, test)),
+                any(
+                    feature = "parking_lot",
+                    not(tokio_no_const_mutex_new)
+                )
+            ))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_has_const_mutex_new {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(all(
+                not(all(loom, test)),
+                any(
+                    feature = "parking_lot",
+                    not(tokio_no_const_mutex_new)
+                )
+            )))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_not_wasi {
     ($($item:item)*) => {
         $(

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -34,7 +34,6 @@ use crate::process::kill::Kill;
 use crate::process::SpawnedChild;
 use crate::signal::unix::driver::Handle as SignalHandle;
 use crate::signal::unix::{signal, Signal, SignalKind};
-use crate::util::once_cell::OnceCell;
 
 use mio::event::Source;
 use mio::unix::SourceFd;
@@ -64,10 +63,22 @@ impl Kill for StdChild {
     }
 }
 
-fn get_orphan_queue() -> &'static OrphanQueueImpl<StdChild> {
-    static ORPHAN_QUEUE: OnceCell<OrphanQueueImpl<StdChild>> = OnceCell::new();
+cfg_not_has_const_mutex_new! {
+    fn get_orphan_queue() -> &'static OrphanQueueImpl<StdChild> {
+        use crate::util::once_cell::OnceCell;
 
-    ORPHAN_QUEUE.get(OrphanQueueImpl::new)
+        static ORPHAN_QUEUE: OnceCell<OrphanQueueImpl<StdChild>> = OnceCell::new();
+
+        ORPHAN_QUEUE.get(OrphanQueueImpl::new)
+    }
+}
+
+cfg_has_const_mutex_new! {
+    fn get_orphan_queue() -> &'static OrphanQueueImpl<StdChild> {
+        static ORPHAN_QUEUE: OrphanQueueImpl<StdChild> = OrphanQueueImpl::new();
+
+        &ORPHAN_QUEUE
+    }
 }
 
 pub(crate) struct GlobalOrphanQueue;

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -43,10 +43,21 @@ pub(crate) struct OrphanQueueImpl<T> {
 }
 
 impl<T> OrphanQueueImpl<T> {
-    pub(crate) fn new() -> Self {
-        Self {
-            sigchild: Mutex::new(None),
-            queue: Mutex::new(Vec::new()),
+    cfg_not_has_const_mutex_new! {
+        pub(crate) fn new() -> Self {
+            Self {
+                sigchild: Mutex::new(None),
+                queue: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    cfg_has_const_mutex_new! {
+        pub(crate) const fn new() -> Self {
+            Self {
+                sigchild: Mutex::const_new(None),
+                queue: Mutex::const_new(Vec::new()),
+            }
         }
     }
 

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -7,12 +7,24 @@ cfg_io_driver! {
 pub(crate) mod atomic_cell;
 
 cfg_has_atomic_u64! {
-    #[cfg(any(feature = "signal", all(unix, feature = "process")))]
-    pub(crate) mod once_cell;
+    cfg_has_const_mutex_new! {
+        #[cfg(feature = "signal")]
+        pub(crate) mod once_cell;
+    }
+    cfg_not_has_const_mutex_new! {
+        #[cfg(any(feature = "signal", all(unix, feature = "process")))]
+        pub(crate) mod once_cell;
+    }
 }
 cfg_not_has_atomic_u64! {
-    #[cfg(any(feature = "rt", feature = "signal", all(unix, feature = "process")))]
-    pub(crate) mod once_cell;
+    cfg_has_const_mutex_new! {
+        #[cfg(any(feature = "rt", feature = "signal"))]
+        pub(crate) mod once_cell;
+    }
+    cfg_not_has_const_mutex_new! {
+        #[cfg(any(feature = "rt", feature = "signal", all(unix, feature = "process")))]
+        pub(crate) mod once_cell;
+    }
 }
 
 #[cfg(any(

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -6,26 +6,8 @@ cfg_io_driver! {
 #[cfg(feature = "rt")]
 pub(crate) mod atomic_cell;
 
-cfg_has_atomic_u64! {
-    cfg_has_const_mutex_new! {
-        #[cfg(feature = "signal")]
-        pub(crate) mod once_cell;
-    }
-    cfg_not_has_const_mutex_new! {
-        #[cfg(any(feature = "signal", all(unix, feature = "process")))]
-        pub(crate) mod once_cell;
-    }
-}
-cfg_not_has_atomic_u64! {
-    cfg_has_const_mutex_new! {
-        #[cfg(any(feature = "rt", feature = "signal"))]
-        pub(crate) mod once_cell;
-    }
-    cfg_not_has_const_mutex_new! {
-        #[cfg(any(feature = "rt", feature = "signal", all(unix, feature = "process")))]
-        pub(crate) mod once_cell;
-    }
-}
+#[cfg(any(feature = "rt", feature = "signal", feature = "process"))]
+pub(crate) mod once_cell;
 
 #[cfg(any(
     // io driver uses `WakeList` directly

--- a/tokio/src/util/once_cell.rs
+++ b/tokio/src/util/once_cell.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(loom, allow(dead_code))]
+#![allow(dead_code)]
 use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 use std::sync::Once;


### PR DESCRIPTION
This PR removes `OnceCell` in favor of a const `Mutex::new` call when it is available (on sufficiently new rustc or with parking_lot).