### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,8 +9,15 @@ on:
   schedule:
     - cron: '0 2 * * *' # run at 2 AM UTC
 
+permissions:
+  contents: read
+
 jobs:
   security-audit:
+    permissions:
+      checks: write  # for actions-rs/audit-check to create check
+      contents: read  # for actions/checkout to fetch code
+      issues: write  # for actions-rs/audit-check to create issues
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  contents: read
+
 jobs:
   # Depends on all action sthat are required for a "successful" CI run.
   tests-pass:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,8 +4,14 @@ on:
 
 # See .github/labeler.yml file
 
+permissions:
+  contents: read
+
 jobs:
   triage:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     if: github.repository_owner == 'tokio-rs'
     steps:

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -13,6 +13,9 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
 
+permissions:
+  contents: read
+
 jobs:
   loom:
     name: loom

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - '**/Cargo.toml'
 
+permissions:
+  contents: read
+
 jobs:
   security-audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -11,6 +11,9 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
 
+permissions:
+  contents: read
+
 jobs:
   stress-test:
     name: Stress Test


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/tokio-rs/tokio/actions/runs/3169751968/jobs/5161876737#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- audit.yml
- ci.yml
- labeler.yml
- loom.yml
- pr-audit.yml
- stress-test.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>