### PR TITLE
net: fix doc typos for TCP and UDP set_tos methods

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -428,8 +428,8 @@ impl TcpSocket {
 
     /// Sets the value for the `IP_TOS` option on this socket.
     ///
-    /// This value sets the time-to-live field that is used in every packet sent
-    /// from this socket.
+    /// This value sets the type-of-service field that is used in every packet
+    /// sent from this socket.
     ///
     /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1544,8 +1544,8 @@ impl UdpSocket {
 
     /// Sets the value for the `IP_TOS` option on this socket.
     ///
-    /// This value sets the time-to-live field that is used in every packet sent
-    /// from this socket.
+    /// This value sets the type-of-service field that is used in every packet
+    /// sent from this socket.
     ///
     /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)


### PR DESCRIPTION
This PR updates the documentation for the `set_tos` methods on `tokio::net::{TcpSocket, UdpSocket}`, which is currently stating to set the _time-to-live_ field of packets sent from the socket. This should be corrected, since it actually sets the _type-of-service_ field.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I was reading the documentation and noticed the inconsistency.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update the documentation to avoid confusion.