### PR TITLE
rt: improve `rng_seed` test robustness

### DIFF
--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -566,23 +566,40 @@ mod unstable {
     #[test]
     fn rng_seed() {
         let seed = b"bytes used to generate seed";
-        let rt = tokio::runtime::Builder::new_multi_thread()
+        let rt1 = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(1)
             .rng_seed(RngSeed::from_bytes(seed))
             .build()
             .unwrap();
-
-        rt.block_on(async {
+        let rt1_value = rt1.block_on(async {
             let random = tokio::macros::support::thread_rng_n(100);
             assert_eq!(random, 86);
 
             let _ = tokio::spawn(async {
                 // Because we only have a single worker thread, the
                 // RNG will be deterministic here as well.
-                let random = tokio::macros::support::thread_rng_n(100);
-                assert_eq!(random, 64);
+                tokio::macros::support::thread_rng_n(100);
             })
             .await;
         });
+
+        let rt2 = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .rng_seed(RngSeed::from_bytes(seed))
+            .build()
+            .unwrap();
+        let rt2_value = rt2.block_on(async {
+            let random = tokio::macros::support::thread_rng_n(100);
+            assert_eq!(random, 86);
+
+            let _ = tokio::spawn(async {
+                // Because we only have a single worker thread, the
+                // RNG will be deterministic here as well.
+                tokio::macros::support::thread_rng_n(100);
+            })
+            .await;
+        });
+
+        assert_eq!(rt1_value, rt2_value);
     }
 }


### PR DESCRIPTION
## Motivation

The original tests for the `Builder::rng_seed` added in #4910 were a bit fragile. There have already been a couple of instances where internal refactoring caused the tests to fail and need to be modified. While it is expected that internal refactoring may cause the random values to change, this shouldn't cause the tests to break.

## Solution

The tests should be more robust and not be affected by internal refactoring or changes in the Rust compiler version. The tests are changed to perform the same operation in 2 runtimes created with the same seed, the expectation is that the values that result from each runtime are the same.
