### PR TITLE
time: panic in release mode when `mark_pending` called illegally

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -174,7 +174,10 @@ impl StateCell {
         loop {
             // improve the error message for things like
             // https://github.com/tokio-rs/tokio/issues/3675
-            assert!(cur_state < STATE_MIN_VALUE, "mark_pending called when the timer entry is deregistered or in pending fire");
+            assert!(
+                cur_state < STATE_MIN_VALUE,
+                "mark_pending called when the timer entry is deregistered or in pending fire"
+            );
 
             if cur_state > not_after {
                 break Err(cur_state);

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -176,7 +176,7 @@ impl StateCell {
             // https://github.com/tokio-rs/tokio/issues/3675
             assert!(
                 cur_state < STATE_MIN_VALUE,
-                "mark_pending called when the timer entry is deregistered or in pending fire"
+                "mark_pending called when the timer entry is in an invalid state"
             );
 
             if cur_state > not_after {

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -172,7 +172,9 @@ impl StateCell {
         let mut cur_state = self.state.load(Ordering::Relaxed);
 
         loop {
-            debug_assert!(cur_state < STATE_MIN_VALUE);
+            // improve the error message for things like
+            // https://github.com/tokio-rs/tokio/issues/3675
+            assert!(cur_state < STATE_MIN_VALUE, "mark_pending called when the timer entry is deregistered or in pending fire");
 
             if cur_state > not_after {
                 break Err(cur_state);


### PR DESCRIPTION
## Motivation

The `debug_assert` can be triggered in release mode (https://github.com/tokio-rs/tokio/issues/3675).

## Solution

a) panic in release mode as well
b) have a better error message describing the problem. (I added the direct cause of the problem)

Previous PR: https://github.com/tokio-rs/tokio/pull/3681
Fixes https://github.com/tokio-rs/tokio/issues/3675