### PR TITLE
chore: release tokio-stream 0.1.11

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.1.11 (October 11, 2022)
+
+- time: allow `StreamExt::chunks_timeout` outside of a runtime ([#5036])
+
+[#5036]: https://github.com/tokio-rs/tokio/pull/5036
+
 # 0.1.10 (Sept 18, 2022)
 
 - time: add `StreamExt::chunks_timeout` ([#4695])

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.10"
+version = "0.1.11"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.1.11 (October 11, 2022)

- time: allow `StreamExt::chunks_timeout` outside of a runtime ([#5036])

[#5036]: https://github.com/tokio-rs/tokio/pull/5036