### PR TITLE
Fix join! size testcase by making it platform-dependent

### DIFF
--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -72,14 +72,24 @@ fn join_size() {
         let ready = future::ready(0i32);
         tokio::join!(ready)
     };
+
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     assert_eq!(mem::size_of_val(&fut), 20);
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    assert_eq!(mem::size_of_val(&fut), 16);
 
     let fut = async {
         let ready1 = future::ready(0i32);
         let ready2 = future::ready(0i32);
         tokio::join!(ready1, ready2)
     };
+
+    #[cfg(not(all(target_arch = "aarch64", target_os = "macos")))]
     assert_eq!(mem::size_of_val(&fut), 32);
+
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    assert_eq!(mem::size_of_val(&fut), 24);
 }
 
 async fn non_cooperative_task(permits: Arc<Semaphore>) -> usize {


### PR DESCRIPTION
## Motivation

Tests are not passing for on a M1 macbook. Tested with Tokio version ae0d49d59c0c63efafde73306af5d0d94046b50d, see details below.

The test case `join_size` tests for the size-in-memory of `tokio::join!` against hardcoded values. I assume this is mainly to notice regressions. On other targets, the values are indeed correct. However, for Apple silicon platforms, the values are too large. I'm not sure how exactly, but `impl Future<...>` is 4 bytes smaller on my machine. 

## Solution

In this PR I'm simply hardcoding the values for `aarch64`, and using `cfg` to get the right value for the current platform..

## Technical details for reproducing


Hardware: Apple M1
OS: macOS 11.3.1
rustc 1.66.0-nightly (81f391930 2022-10-09)
