### PR TITLE
macros: rename `thread_local!` to `tokio_thread_local!`

### DIFF
--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -31,7 +31,7 @@
 
 use std::cell::Cell;
 
-thread_local! {
+tokio_thread_local! {
     static CURRENT: Cell<Budget> = const { Cell::new(Budget::unconstrained()) };
 }
 

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -81,7 +81,7 @@ impl Write for &'_ MockFile {
     }
 }
 
-thread_local! {
+tokio_thread_local! {
     static QUEUE: RefCell<VecDeque<Box<dyn FnOnce() + Send>>> = RefCell::new(VecDeque::new())
 }
 

--- a/tokio/src/macros/scoped_tls.rs
+++ b/tokio/src/macros/scoped_tls.rs
@@ -10,7 +10,7 @@ macro_rules! scoped_thread_local {
         $vis static $name: $crate::macros::scoped_tls::ScopedKey<$ty>
             = $crate::macros::scoped_tls::ScopedKey {
                 inner: {
-                    thread_local!(static FOO: ::std::cell::Cell<*const ()> = const {
+                    tokio_thread_local!(static FOO: ::std::cell::Cell<*const ()> = const {
                         std::cell::Cell::new(::std::ptr::null())
                     });
                     &FOO

--- a/tokio/src/macros/thread_local.rs
+++ b/tokio/src/macros/thread_local.rs
@@ -1,5 +1,5 @@
 #[cfg(all(loom, test))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty = const { $expr:expr } $(;)?) => {
         loom::thread_local! {
             $(#[$attrs])*
@@ -12,13 +12,13 @@ macro_rules! thread_local {
 
 #[cfg(not(tokio_no_const_thread_local))]
 #[cfg(not(all(loom, test)))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($($tts:tt)+) => { ::std::thread_local!{ $($tts)+ } }
 }
 
 #[cfg(tokio_no_const_thread_local)]
 #[cfg(not(all(loom, test)))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty = const { $expr:expr } $(;)?) => {
         ::std::thread_local! {
             $(#[$attrs])*

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -28,7 +28,7 @@ const EMPTY: usize = 0;
 const PARKED: usize = 1;
 const NOTIFIED: usize = 2;
 
-thread_local! {
+tokio_thread_local! {
     static CURRENT_PARKER: ParkThread = ParkThread::new();
 }
 

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -4,7 +4,7 @@ use crate::util::{replace_thread_rng, RngSeed};
 
 use std::cell::RefCell;
 
-thread_local! {
+tokio_thread_local! {
     static CONTEXT: RefCell<Option<Handle>> = const { RefCell::new(None) }
 }
 

--- a/tokio/src/runtime/enter.rs
+++ b/tokio/src/runtime/enter.rs
@@ -17,7 +17,7 @@ impl EnterContext {
     }
 }
 
-thread_local!(static ENTERED: Cell<EnterContext> = const { Cell::new(EnterContext::NotEntered) });
+tokio_thread_local!(static ENTERED: Cell<EnterContext> = const { Cell::new(EnterContext::NotEntered) });
 
 /// Represents an executor context.
 pub(crate) struct Enter {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -261,11 +261,7 @@ pin_project! {
     }
 }
 
-#[cfg(any(loom, tokio_no_const_thread_local))]
-thread_local!(static CURRENT: RcCell<Context> = RcCell::new());
-
-#[cfg(not(any(loom, tokio_no_const_thread_local)))]
-thread_local!(static CURRENT: RcCell<Context> = const { RcCell::new() });
+tokio_thread_local!(static CURRENT: RcCell<Context> = const { RcCell::new() });
 
 cfg_rt! {
     /// Spawns a `!Send` future on the local task set.

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -157,7 +157,7 @@ impl FastRand {
     }
 }
 
-thread_local! {
+tokio_thread_local! {
     static THREAD_RNG: FastRand = FastRand::new(RngSeed::new());
 }
 

--- a/tokio/src/util/rc_cell.rs
+++ b/tokio/src/util/rc_cell.rs
@@ -9,7 +9,7 @@ pub(crate) struct RcCell<T> {
 }
 
 impl<T> RcCell<T> {
-    #[cfg(not(loom))]
+    #[cfg(not(all(loom, test)))]
     pub(crate) const fn new() -> Self {
         Self {
             inner: UnsafeCell::new(None),
@@ -17,7 +17,7 @@ impl<T> RcCell<T> {
     }
 
     // The UnsafeCell in loom does not have a const `new` fn.
-    #[cfg(loom)]
+    #[cfg(all(loom, test))]
     pub(crate) fn new() -> Self {
         Self {
             inner: UnsafeCell::new(None),


### PR DESCRIPTION
## Motivation

Currently, Tokio uses an internal `thread_local!` macro which compiles to either `std::thread_local!` or `loom::thread_local!`, and switches between using `const` expressions in thread locals or not based on cfg attributes. Because this macro has the same name as `std::thread_local!`, though, which is ambiently available, it's not always clear which macro is being used, and it seems like there are sometimes name resolution issues that can result in the redefined macro not being used as we'd expect.

## Solution

This branch renames the internal macro to `tokio_thread_local!` to make it explicit that we want to use it, rather than `std::thread_local!`. I've removed some `cfg` attributes in `local_set.rs` that shouldn't be necessary, since our macro *should* handle that already.