### PR TITLE
stream: document that `throttle` operates on ms granularity

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -982,6 +982,8 @@ pub trait StreamExt: Stream {
 
     /// Slows down a stream by enforcing a delay between items.
     ///
+    /// The maximum granularity is milliseconds.
+    ///
     /// # Example
     ///
     /// Create a throttled stream.

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -982,7 +982,7 @@ pub trait StreamExt: Stream {
 
     /// Slows down a stream by enforcing a delay between items.
     ///
-    /// The maximum granularity is milliseconds.
+    /// The underlying timer behind this utility has a granularity of one millisecond.
     ///
     /// # Example
     ///


### PR DESCRIPTION
## Motivation

Was stuck here for some time debugging.

## Solution
Small documentation fix. `Throttle` uses `tokio::time::sleep_until` which states that it shouldn't be used for sub ms granularity.