### PR TITLE
tokio: rename internal thread_local macro

### DIFF
--- a/tokio/src/coop.rs
+++ b/tokio/src/coop.rs
@@ -31,7 +31,7 @@
 
 use std::cell::Cell;
 
-thread_local! {
+tokio_thread_local! {
     static CURRENT: Cell<Budget> = const { Cell::new(Budget::unconstrained()) };
 }
 

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -81,7 +81,7 @@ impl Write for &'_ MockFile {
     }
 }
 
-thread_local! {
+tokio_thread_local! {
     static QUEUE: RefCell<VecDeque<Box<dyn FnOnce() + Send>>> = RefCell::new(VecDeque::new())
 }
 

--- a/tokio/src/macros/scoped_tls.rs
+++ b/tokio/src/macros/scoped_tls.rs
@@ -10,7 +10,7 @@ macro_rules! scoped_thread_local {
         $vis static $name: $crate::macros::scoped_tls::ScopedKey<$ty>
             = $crate::macros::scoped_tls::ScopedKey {
                 inner: {
-                    thread_local!(static FOO: ::std::cell::Cell<*const ()> = const {
+                    tokio_thread_local!(static FOO: ::std::cell::Cell<*const ()> = const {
                         std::cell::Cell::new(::std::ptr::null())
                     });
                     &FOO

--- a/tokio/src/macros/thread_local.rs
+++ b/tokio/src/macros/thread_local.rs
@@ -1,5 +1,5 @@
 #[cfg(all(loom, test))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty = const { $expr:expr } $(;)?) => {
         loom::thread_local! {
             $(#[$attrs])*
@@ -12,13 +12,13 @@ macro_rules! thread_local {
 
 #[cfg(not(tokio_no_const_thread_local))]
 #[cfg(not(all(loom, test)))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($($tts:tt)+) => { ::std::thread_local!{ $($tts)+ } }
 }
 
 #[cfg(tokio_no_const_thread_local)]
 #[cfg(not(all(loom, test)))]
-macro_rules! thread_local {
+macro_rules! tokio_thread_local {
     ($(#[$attrs:meta])* $vis:vis static $name:ident: $ty:ty = const { $expr:expr } $(;)?) => {
         ::std::thread_local! {
             $(#[$attrs])*

--- a/tokio/src/park/thread.rs
+++ b/tokio/src/park/thread.rs
@@ -28,7 +28,7 @@ const EMPTY: usize = 0;
 const PARKED: usize = 1;
 const NOTIFIED: usize = 2;
 
-thread_local! {
+tokio_thread_local! {
     static CURRENT_PARKER: ParkThread = ParkThread::new();
 }
 

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -4,7 +4,7 @@ use crate::util::{replace_thread_rng, RngSeed};
 
 use std::cell::RefCell;
 
-thread_local! {
+tokio_thread_local! {
     static CONTEXT: RefCell<Option<Handle>> = const { RefCell::new(None) }
 }
 

--- a/tokio/src/runtime/enter.rs
+++ b/tokio/src/runtime/enter.rs
@@ -17,7 +17,7 @@ impl EnterContext {
     }
 }
 
-thread_local!(static ENTERED: Cell<EnterContext> = const { Cell::new(EnterContext::NotEntered) });
+tokio_thread_local!(static ENTERED: Cell<EnterContext> = const { Cell::new(EnterContext::NotEntered) });
 
 /// Represents an executor context.
 pub(crate) struct Enter {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -273,13 +273,13 @@ pin_project! {
 }
 
 #[cfg(any(loom, tokio_no_const_thread_local))]
-thread_local!(static CURRENT: LocalData = LocalData {
+tokio_thread_local!(static CURRENT: LocalData = LocalData {
     thread_id: Cell::new(None),
     ctx: RcCell::new(),
 });
 
 #[cfg(not(any(loom, tokio_no_const_thread_local)))]
-thread_local!(static CURRENT: LocalData = const { LocalData {
+tokio_thread_local!(static CURRENT: LocalData = const { LocalData {
     thread_id: Cell::new(None),
     ctx: RcCell::new(),
 } });

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -157,7 +157,7 @@ impl FastRand {
     }
 }
 
-thread_local! {
+tokio_thread_local! {
     static THREAD_RNG: FastRand = FastRand::new(RngSeed::new());
 }
 


### PR DESCRIPTION
Tokio maintains an internal thread_local macro that abstracts some conditional build logic. Before this patch, the macro was named the same as the `std` macro (`thread_local`). This resulted in confusion as to whether or not the internal macro or the std macro was being called.

This patch renames the internal macro to `tokio_thread_local`, making it more obvious.