### PR TITLE
rt: remove a conditional compilation clause

### DIFF
--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -272,13 +272,6 @@ pin_project! {
     }
 }
 
-#[cfg(any(loom, tokio_no_const_thread_local))]
-tokio_thread_local!(static CURRENT: LocalData = LocalData {
-    thread_id: Cell::new(None),
-    ctx: RcCell::new(),
-});
-
-#[cfg(not(any(loom, tokio_no_const_thread_local)))]
 tokio_thread_local!(static CURRENT: LocalData = const { LocalData {
     thread_id: Cell::new(None),
     ctx: RcCell::new(),

--- a/tokio/src/util/rc_cell.rs
+++ b/tokio/src/util/rc_cell.rs
@@ -9,7 +9,7 @@ pub(crate) struct RcCell<T> {
 }
 
 impl<T> RcCell<T> {
-    #[cfg(not(loom))]
+    #[cfg(not(all(loom, test)))]
     pub(crate) const fn new() -> Self {
         Self {
             inner: UnsafeCell::new(None),
@@ -17,7 +17,7 @@ impl<T> RcCell<T> {
     }
 
     // The UnsafeCell in loom does not have a const `new` fn.
-    #[cfg(loom)]
+    #[cfg(all(loom, test))]
     pub(crate) fn new() -> Self {
         Self {
             inner: UnsafeCell::new(None),


### PR DESCRIPTION
The `LocalSet` implementation includes a conditional compilation clause that removes the `const` statement from the `thread_local` definition. However, there already is an internal macro that does this: `tokio_thread_local`.

This patch removes the conditional compilation in favor of using the `tokio_thread_local` macro. This also fixes a conditional compilation issue with an internal utility (`RcCell`).
