### PR TITLE
rt: misc time driver cleanup

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -576,7 +576,7 @@ impl TimerEntry {
         this.inner().state.poll(cx.waker())
     }
 
-    fn driver(&self) -> &super::Handle {
+    pub(crate) fn driver(&self) -> &super::Handle {
         self.driver.time()
     }
 }

--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -1,29 +1,16 @@
-use crate::loom::sync::Arc;
 use crate::runtime::time::TimeSource;
 use std::fmt;
 
 /// Handle to time driver instance.
-#[derive(Clone)]
 pub(crate) struct Handle {
-    time_source: TimeSource,
-    pub(super) inner: Arc<super::Inner>,
+    pub(super) time_source: TimeSource,
+    pub(super) inner: super::Inner,
 }
 
 impl Handle {
-    /// Creates a new timer `Handle` from a shared `Inner` timer state.
-    pub(super) fn new(inner: Arc<super::Inner>) -> Self {
-        let time_source = inner.state.lock().time_source.clone();
-        Handle { time_source, inner }
-    }
-
     /// Returns the time source associated with this handle.
     pub(crate) fn time_source(&self) -> &TimeSource {
         &self.time_source
-    }
-
-    /// Access the driver's inner structure.
-    pub(super) fn get(&self) -> &super::Inner {
-        &*self.inner
     }
 
     /// Checks whether the driver has been shutdown.

--- a/tokio/src/runtime/time/source.rs
+++ b/tokio/src/runtime/time/source.rs
@@ -3,7 +3,7 @@ use crate::time::{Clock, Duration, Instant};
 use std::convert::TryInto;
 
 /// A structure which handles conversion from Instants to u64 timestamps.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct TimeSource {
     pub(crate) clock: Clock,
     start_time: Instant,


### PR DESCRIPTION
Removes an unnecessary `Arc` and reduces internal state clones.
