### PR TITLE
rt: move signal driver to runtime module

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -297,6 +297,13 @@ macro_rules! cfg_signal_internal {
     }
 }
 
+macro_rules! cfg_signal_internal_and_unix {
+    ($($item:item)*) => {
+        #[cfg(unix)]
+        cfg_signal_internal! { $($item)* }
+    }
+}
+
 macro_rules! cfg_not_signal_internal {
     ($($item:item)*) => {
         $(

--- a/tokio/src/process/unix/driver.rs
+++ b/tokio/src/process/unix/driver.rs
@@ -3,7 +3,7 @@
 //! Process driver.
 
 use crate::process::unix::GlobalOrphanQueue;
-use crate::signal::unix::driver::{Driver as SignalDriver, Handle as SignalHandle};
+use crate::runtime::signal::{Driver as SignalDriver, Handle as SignalHandle};
 
 use std::time::Duration;
 

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -32,7 +32,7 @@ use reap::Reaper;
 use crate::io::{AsyncRead, AsyncWrite, PollEvented, ReadBuf};
 use crate::process::kill::Kill;
 use crate::process::SpawnedChild;
-use crate::signal::unix::driver::Handle as SignalHandle;
+use crate::runtime::signal::Handle as SignalHandle;
 use crate::signal::unix::{signal, Signal, SignalKind};
 
 use mio::event::Source;

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -1,5 +1,5 @@
 use crate::loom::sync::{Mutex, MutexGuard};
-use crate::signal::unix::driver::Handle as SignalHandle;
+use crate::runtime::signal::Handle as SignalHandle;
 use crate::signal::unix::{signal_with_handle, SignalKind};
 use crate::sync::watch;
 use std::io;

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -132,7 +132,7 @@ where
 pub(crate) mod test {
     use super::*;
     use crate::runtime::io::Driver as IoDriver;
-    use crate::signal::unix::driver::{Driver as SignalDriver, Handle as SignalHandle};
+    use crate::runtime::signal::{Driver as SignalDriver, Handle as SignalHandle};
     use crate::sync::watch;
     use std::cell::{Cell, RefCell};
     use std::io;

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -211,19 +211,12 @@ cfg_not_io_driver! {
 
 // ===== signal driver =====
 
-macro_rules! cfg_signal_internal_and_unix {
-    ($($item:item)*) => {
-        #[cfg(unix)]
-        cfg_signal_internal! { $($item)* }
-    }
-}
-
 cfg_signal_internal_and_unix! {
-    type SignalDriver = crate::signal::unix::driver::Driver;
-    pub(crate) type SignalHandle = Option<crate::signal::unix::driver::Handle>;
+    type SignalDriver = crate::runtime::signal::Driver;
+    pub(crate) type SignalHandle = Option<crate::runtime::signal::Handle>;
 
     fn create_signal_driver(io_driver: IoDriver) -> io::Result<(SignalDriver, SignalHandle)> {
-        let driver = crate::signal::unix::driver::Driver::new(io_driver)?;
+        let driver = crate::runtime::signal::Driver::new(io_driver)?;
         let handle = driver.handle();
         Ok((driver, Some(handle)))
     }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -188,6 +188,10 @@ cfg_time! {
     pub(crate) mod time;
 }
 
+cfg_signal_internal_and_unix! {
+    pub(crate) mod signal;
+}
+
 cfg_rt! {
     pub(crate) mod enter;
 

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -150,7 +150,7 @@ unsafe fn noop(_data: *const ()) {}
 // ===== impl Handle =====
 
 impl Handle {
-    pub(super) fn check_inner(&self) -> std_io::Result<()> {
+    pub(crate) fn check_inner(&self) -> std_io::Result<()> {
         if self.inner.strong_count() > 0 {
             Ok(())
         } else {
@@ -170,7 +170,7 @@ cfg_rt! {
         ///
         /// This function panics if there is no current signal driver set.
         #[track_caller]
-        pub(super) fn current() -> Self {
+        pub(crate) fn current() -> Self {
             crate::runtime::context::signal_handle().expect(
                 "there is no signal driver running, must be called from the context of Tokio runtime",
             )
@@ -186,7 +186,7 @@ cfg_not_rt! {
         ///
         /// This function panics if there is no current signal driver set.
         #[track_caller]
-        pub(super) fn current() -> Self {
+        pub(crate) fn current() -> Self {
             panic!(
                 "there is no signal driver running, must be called from the context of Tokio runtime or with\
                 `rt` enabled.",

--- a/tokio/src/signal/mod.rs
+++ b/tokio/src/signal/mod.rs
@@ -48,7 +48,7 @@ use std::task::{Context, Poll};
 mod ctrl_c;
 pub use ctrl_c::ctrl_c;
 
-mod registry;
+pub(crate) mod registry;
 
 mod os {
     #[cfg(unix)]

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -6,6 +6,7 @@
 #![cfg(unix)]
 #![cfg_attr(docsrs, doc(cfg(all(unix, feature = "signal"))))]
 
+use crate::runtime::signal::Handle;
 use crate::signal::registry::{globals, EventId, EventInfo, Globals, Init, Storage};
 use crate::signal::RxFuture;
 use crate::sync::watch;
@@ -16,9 +17,6 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::task::{Context, Poll};
-
-pub(crate) mod driver;
-use self::driver::Handle;
 
 pub(crate) type OsStorage = Vec<SignalInfo>;
 
@@ -52,7 +50,7 @@ impl Storage for OsStorage {
 #[derive(Debug)]
 pub(crate) struct OsExtraData {
     sender: UnixStream,
-    receiver: UnixStream,
+    pub(crate) receiver: UnixStream,
 }
 
 impl Init for OsExtraData {


### PR DESCRIPTION
The signal feature only requires a driver with unix platforms. The unix signal
driver uses the I/O driver. A future refactor would like to make the signal driver
use internal APIs of the I/O driver. To do this, the signal driver must be moved
to the runtime module.