### PR TITLE
rt: signal driver now uses I/O driver directly

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -178,6 +178,12 @@
 //! [`Sink`]: https://docs.rs/futures/0.3/futures/sink/trait.Sink.html
 //! [`Stream`]: https://docs.rs/futures/0.3/futures/stream/trait.Stream.html
 //! [`Write`]: std::io::Write
+
+#![cfg_attr(
+    not(all(feature = "rt", feature = "net")),
+    allow(dead_code, unused_imports)
+)]
+
 cfg_io_blocking! {
     pub(crate) mod blocking;
 }

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -119,11 +119,7 @@ impl<E: Source> PollEvented<E> {
     }
 
     /// Returns a reference to the registration.
-    #[cfg(any(
-        feature = "net",
-        all(unix, feature = "process"),
-        all(unix, feature = "signal"),
-    ))]
+    #[cfg(any(feature = "net"))]
     pub(crate) fn registration(&self) -> &Registration {
         &self.registration
     }


### PR DESCRIPTION
The signal driver uses a `UnixStream` to receive signal events. Previously, the
signal driver used `PollEvented` internally in order to receive events on the
`UnixStream`. However, using `PollEvented` from within a runtime driver created
a circular link between the runtime and the `PollEvented` instance.

This patch replaces `PollEvented` usage in favor of accessing the I/O driver
directly. The I/O driver now reserves a token for signal-related events and
tracks signal readiness internally. The signal driver queries the I/O driver to
check for signal-related readiness.