### PR TITLE
Doc change for when timeouts may not fire.

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -21,9 +21,9 @@ use std::task::{self, Poll};
 /// value is returned. Otherwise, an error is returned and the future is
 /// canceled.
 ///
-/// Note that if the future does not yield during execution then it is possible
-/// for the future to complete and exceed the timeout _without_ returning an
-/// error.
+/// Note that the timeout is checked before polling the future, so if the future
+/// does not yield during execution then it is possible for the future to complete
+/// and exceed the timeout _without_ returning an error.
 ///
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -21,6 +21,10 @@ use std::task::{self, Poll};
 /// value is returned. Otherwise, an error is returned and the future is
 /// canceled.
 ///
+/// Note that if the future does not yield during execution then it is possible
+/// for the future to complete and exceed the timeout _without_ returning an
+/// error.
+///
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///


### PR DESCRIPTION
Document the case where timeouts may not fire for `tokio::time::timeout`, from discussion on #5119.

## Motivation

Ran into a situation where `timeout` was not always firing, despite exceeding the timeout - docs did not cover this situation.

## Solution

Updated the docs.
