### PR TITLE
rt: start decoupling I/O driver and I/O handle

### DIFF
--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -21,8 +21,6 @@
 //! processes in general aren't scalable (e.g. millions) so it shouldn't be that
 //! bad in theory...
 
-pub(crate) mod driver;
-
 pub(crate) mod orphan;
 use orphan::{OrphanQueue, OrphanQueueImpl, Wait};
 
@@ -90,7 +88,7 @@ impl fmt::Debug for GlobalOrphanQueue {
 }
 
 impl GlobalOrphanQueue {
-    fn reap_orphans(handle: &SignalHandle) {
+    pub(crate) fn reap_orphans(handle: &SignalHandle) {
         get_orphan_queue().reap_orphans(handle)
     }
 }

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -294,7 +294,8 @@ pub(crate) mod test {
     #[cfg_attr(miri, ignore)] // Miri does not support epoll.
     #[test]
     fn does_not_register_signal_if_queue_empty() {
-        let signal_driver = IoDriver::new().and_then(SignalDriver::new).unwrap();
+        let (io_driver, io_handle) = IoDriver::new().unwrap();
+        let signal_driver = SignalDriver::new(io_driver, &io_handle).unwrap();
         let handle = signal_driver.handle();
 
         let orphanage = OrphanQueueImpl::new();

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -184,6 +184,10 @@ cfg_io_driver_impl! {
     pub(crate) mod io;
 }
 
+cfg_process_driver! {
+    mod process;
+}
+
 cfg_time! {
     pub(crate) mod time;
 }

--- a/tokio/src/runtime/process.rs
+++ b/tokio/src/runtime/process.rs
@@ -3,6 +3,7 @@
 //! Process driver.
 
 use crate::process::unix::GlobalOrphanQueue;
+use crate::runtime::driver;
 use crate::runtime::signal::{Driver as SignalDriver, Handle as SignalHandle};
 
 use std::time::Duration;
@@ -27,17 +28,17 @@ impl Driver {
         }
     }
 
-    pub(crate) fn park(&mut self) {
-        self.park.park();
+    pub(crate) fn park(&mut self, handle: &driver::Handle) {
+        self.park.park(handle);
         GlobalOrphanQueue::reap_orphans(&self.signal_handle);
     }
 
-    pub(crate) fn park_timeout(&mut self, duration: Duration) {
-        self.park.park_timeout(duration);
+    pub(crate) fn park_timeout(&mut self, handle: &driver::Handle, duration: Duration) {
+        self.park.park_timeout(handle, duration);
         GlobalOrphanQueue::reap_orphans(&self.signal_handle);
     }
 
-    pub(crate) fn shutdown(&mut self) {
-        self.park.shutdown()
+    pub(crate) fn shutdown(&mut self, handle: &driver::Handle) {
+        self.park.shutdown(handle)
     }
 }


### PR DESCRIPTION
This is the start of applying a similar treatment to the I/O driver as the time
driver. The I/O driver will no longer hold its own reference to the I/O handle.
Instead, the handle is passed in when needed.

This patch also moves the process driver to the `runtime` module.
