### PR TITLE
rt: use signal driver handle via scheduler::Handle

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -24,23 +24,6 @@ pub(crate) fn current() -> Handle {
     }
 }
 
-cfg_signal_internal! {
-    #[cfg(unix)]
-    pub(crate) fn signal_handle() -> crate::runtime::driver::SignalHandle {
-        match CONTEXT.try_with(|ctx| {
-            let ctx = ctx.borrow();
-            ctx.as_ref()
-                .expect(crate::util::error::CONTEXT_MISSING_ERROR)
-                .inner
-                .signal()
-                .clone()
-        }) {
-            Ok(signal_handle) => signal_handle,
-            Err(_) => panic!("{}", crate::util::error::THREAD_LOCAL_DESTROYED_ERROR),
-        }
-    }
-}
-
 cfg_time! {
     cfg_test_util! {
         pub(crate) fn clock() -> Option<crate::runtime::driver::Clock> {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -90,6 +90,15 @@ impl Handle {
         }
     }
 
+    cfg_signal_internal! {
+        #[track_caller]
+        pub(crate) fn signal(&self) -> &crate::runtime::signal::Handle {
+            self.signal
+                .as_ref()
+                .expect("there is no signal driver running, must be called from the context of Tokio runtime")
+        }
+    }
+
     cfg_time! {
         /// Returns a reference to the time driver handle.
         ///

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -90,7 +90,7 @@ impl Handle {
         }
     }
 
-    cfg_signal_internal! {
+    cfg_signal_internal_and_unix! {
         #[track_caller]
         pub(crate) fn signal(&self) -> &crate::runtime::signal::Handle {
             self.signal

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -113,13 +113,6 @@ cfg_rt! {
                 Handle::MultiThread(h) => &h.seed_generator,
             }
         }
-
-        #[cfg(unix)]
-        cfg_signal_internal! {
-            pub(crate) fn signal(&self) -> &driver::SignalHandle {
-                &self.driver().signal
-            }
-        }
     }
 
     cfg_metrics! {

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -24,16 +24,13 @@ pub(crate) struct Driver {
     receiver: UnixStream,
 
     /// Shared state
-    inner: Arc<Inner>,
+    inner: Arc<()>,
 }
 
-#[derive(Clone, Debug, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct Handle {
-    inner: Weak<Inner>,
+    inner: Weak<()>,
 }
-
-#[derive(Debug)]
-pub(super) struct Inner(());
 
 // ===== impl Driver =====
 
@@ -75,7 +72,7 @@ impl Driver {
         Ok(Self {
             io,
             receiver,
-            inner: Arc::new(Inner(())),
+            inner: Arc::new(()),
         })
     }
 
@@ -136,39 +133,6 @@ impl Handle {
                 std_io::ErrorKind::Other,
                 "signal driver gone",
             ))
-        }
-    }
-}
-
-cfg_rt! {
-    impl Handle {
-        /// Returns a handle to the current driver
-        ///
-        /// # Panics
-        ///
-        /// This function panics if there is no current signal driver set.
-        #[track_caller]
-        pub(crate) fn current() -> Self {
-            crate::runtime::context::signal_handle().expect(
-                "there is no signal driver running, must be called from the context of Tokio runtime",
-            )
-        }
-    }
-}
-
-cfg_not_rt! {
-    impl Handle {
-        /// Returns a handle to the current driver
-        ///
-        /// # Panics
-        ///
-        /// This function panics if there is no current signal driver set.
-        #[track_caller]
-        pub(crate) fn current() -> Self {
-            panic!(
-                "there is no signal driver running, must be called from the context of Tokio runtime or with\
-                `rt` enabled.",
-            )
         }
     }
 }

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -23,12 +23,16 @@ pub(crate) struct Driver {
     /// A pipe for receiving wake events from the signal handler
     receiver: UnixStream,
 
-    /// Shared state
+    /// Shared state. The driver keeps a strong ref and the handle keeps a weak
+    /// ref. The weak ref is used to check if the driver is still active before
+    /// trying to register a signal handler.
     inner: Arc<()>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct Handle {
+    /// Paired w/ the `Arc` above and is used to check if the driver is still
+    /// around before attempting to register a signal handler.
     inner: Weak<()>,
 }
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -6,6 +6,7 @@
 #![cfg(unix)]
 #![cfg_attr(docsrs, doc(cfg(all(unix, feature = "signal"))))]
 
+use crate::runtime::scheduler;
 use crate::runtime::signal::Handle;
 use crate::signal::registry::{globals, EventId, EventInfo, Globals, Init, Storage};
 use crate::signal::RxFuture;
@@ -389,7 +390,8 @@ pub struct Signal {
 /// feature flag is not enabled.
 #[track_caller]
 pub fn signal(kind: SignalKind) -> io::Result<Signal> {
-    let rx = signal_with_handle(kind, &Handle::current())?;
+    let handle = scheduler::Handle::current();
+    let rx = signal_with_handle(kind, handle.driver().signal())?;
 
     Ok(Signal {
         inner: RxFuture::new(rx),


### PR DESCRIPTION
The signal driver still uses an `Arc` internally to track if the driver
is still running, however, using the `scheduler::Handle` to access the
signal driver handle lets us delete some code.
