### PR TITLE
Pin the future on the heap in tests to prevent stack overflows

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -390,7 +390,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")
-                .block_on(body);
+                .block_on(::std::boxed::Box::pin(body));
         }
     };
     input.block = syn::parse2(quote! {


### PR DESCRIPTION
## Motivation

When we switched from `async_std` to `tokio`, [some tests started overflowing their stack](https://github.com/deltachat/deltachat-core-rust/pull/3449#issuecomment-1165778948), which we fixed by setting `opt_level = 1` in `[profile.dev]` back then. This, however, increased the compilation times a lot, so it would be nice to be able to set `opt_level = 0` at least for tests. See https://github.com/tokio-rs/tokio/issues/2055 for an old issue about this, https://github.com/tokio-rs/tokio/pull/4009 for another PR for this issue, and https://github.com/deltachat/deltachat-core-rust/pull/3666 for a PR in our repo that would fix this by not using the macro and instead writing out the code that would be generated.

I don't know why this didn't happen with `async_std`.

## Solution

The first thing I tried was adding lots of `#[inline(always)]` as outlined by @blasrodri in https://github.com/tokio-rs/tokio/issues/2055#issuecomment-665235149, and boxing the future in more places similarly to https://github.com/tokio-rs/tokio/pull/4009/files. Both is in https://github.com/Hocuri/tokio/commit/14cad1a08e7892b7f08134e0cfd3412bb2a6a96e, but that didn't fix our tests.

Directly boxing the future, as done in this PR here, does fix our tests, however.

What do you think?