### PR TITLE
rt: move internal clock fns out of context

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -24,22 +24,6 @@ pub(crate) fn current() -> Handle {
     }
 }
 
-cfg_time! {
-    cfg_test_util! {
-        pub(crate) fn clock() -> Option<crate::runtime::driver::Clock> {
-            match CONTEXT.try_with(|ctx| {
-                let ctx = ctx.borrow();
-                ctx
-                    .as_ref()
-                    .map(|ctx| ctx.inner.clock().clone())
-            }) {
-                Ok(clock) => clock,
-                Err(_) => panic!("{}", crate::util::error::THREAD_LOCAL_DESTROYED_ERROR),
-            }
-        }
-    }
-}
-
 /// Sets this [`Handle`] as the current active [`Handle`].
 ///
 /// [`Handle`]: Handle

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -33,7 +33,13 @@ cfg_test_util! {
 
     cfg_rt! {
         fn clock() -> Option<Clock> {
-            crate::runtime::context::clock()
+            use crate::runtime::Handle;
+
+            match Handle::try_current() {
+                Ok(handle) => Some(handle.inner.clock().clone()),
+                Err(ref e) if e.is_missing_context() => None,
+                Err(_) => panic!("{}", crate::util::error::THREAD_LOCAL_DESTROYED_ERROR),
+            }
         }
     }
 


### PR DESCRIPTION
A step towards getting rid of `runtime::context`. Internal functions
related to getting the current clock are moved to the time driver.
