### PR TITLE
rt: remove rng_seed+mt test and update docs

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -836,22 +836,19 @@ impl Builder {
             self
         }
 
-        /// Specifies the random number generation seed to use within all threads associated
-        /// with the runtime being built.
+        /// Specifies the random number generation seed to use within all
+        /// threads associated with the runtime being built.
         ///
-        /// This option is intended to make certain parts of the runtime deterministic.
-        /// Specifically, it affects the [`tokio::select!`] macro and the work stealing
-        /// algorithm. In the case of [`tokio::select!`] it will ensure that the order that
-        /// branches are polled is deterministic.
+        /// This option is intended to make certain parts of the runtime
+        /// deterministic (e.g. the [`tokio::select!`] macro). In the case of
+        /// [`tokio::select!`] it will ensure that the order that branches are
+        /// polled is deterministic.
         ///
-        /// In the case of work stealing, it's a little more complicated. Each worker will
-        /// be given a deterministic seed so that the starting peer for each work stealing
-        /// search will be deterministic.
-        ///
-        /// In addition to the code specifying `rng_seed` and interacting with the runtime,
-        /// the internals of Tokio and the Rust compiler may affect the sequences of random
-        /// numbers. In order to ensure repeatable results, the version of Tokio, the versions
-        /// of all other dependencies that interact with Tokio, and the Rust compiler version
+        /// In addition to the code specifying `rng_seed` and interacting with
+        /// the runtime, the internals of Tokio and the Rust compiler may affect
+        /// the sequences of random numbers. In order to ensure repeatable
+        /// results, the version of Tokio, the versions of all other
+        /// dependencies that interact with Tokio, and the Rust compiler version
         /// should also all remain constant.
         ///
         /// # Examples

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -542,7 +542,6 @@ fn rt() -> runtime::Runtime {
 #[cfg(tokio_unstable)]
 mod unstable {
     use super::*;
-    use tokio::runtime::RngSeed;
 
     #[test]
     fn test_disable_lifo_slot() {

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -562,48 +562,4 @@ mod unstable {
             .unwrap();
         })
     }
-
-    #[test]
-    fn rng_seed() {
-        let seed = b"bytes used to generate seed";
-        let rt1 = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .rng_seed(RngSeed::from_bytes(seed))
-            .build()
-            .unwrap();
-        let rt1_values = rt1.block_on(async {
-            let rand_1 = tokio::macros::support::thread_rng_n(100);
-
-            let rand_2 = tokio::spawn(async {
-                // Because we only have a single worker thread, the
-                // RNG will be deterministic here as well.
-                tokio::macros::support::thread_rng_n(100)
-            })
-            .await
-            .unwrap();
-
-            (rand_1, rand_2)
-        });
-
-        let rt2 = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .rng_seed(RngSeed::from_bytes(seed))
-            .build()
-            .unwrap();
-        let rt2_values = rt2.block_on(async {
-            let rand_1 = tokio::macros::support::thread_rng_n(100);
-
-            let rand_2 = tokio::spawn(async {
-                // Because we only have a single worker thread, the
-                // RNG will be deterministic here as well.
-                tokio::macros::support::thread_rng_n(100)
-            })
-            .await
-            .unwrap();
-
-            (rand_1, rand_2)
-        });
-
-        assert_eq!(rt1_values, rt2_values);
-    }
 }


### PR DESCRIPTION
While setting the random number generator seed with the multi-threaded
scheduler does result in deterministic behavior related to the random
number generator, threads still introduce non-determinism, making it
hard (impossible?) to test this. There also is little value in doing so.

This patch also updates the docs to remove mention of work-stealing.
