### PR TITLE
tokio: fix function name in UdpSocket recv doc

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -740,7 +740,7 @@ impl UdpSocket {
     ///
     /// # Cancel safety
     ///
-    /// This method is cancel safe. If `recv_from` is used as the event in a
+    /// This method is cancel safe. If `recv` is used as the event in a
     /// [`tokio::select!`](crate::select) statement and some other branch
     /// completes first, it is guaranteed that no messages were received on this
     /// socket.


### PR DESCRIPTION
In the "cancellation safety" section of the UdpSocket recv function,
"recv_from" is referenced when it should be "recv"
