### PR TITLE
rt: rename some confusing internal variables/fns

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -636,7 +636,7 @@ cfg_rt! {
                 Scheduler::CurrentThread(current_thread) => {
                     // This ensures that tasks spawned on the current-thread
                     // runtime are dropped inside the runtime's context.
-                    match context::try_enter(&self.handle.inner) {
+                    match context::try_set_current(&self.handle.inner) {
                         Some(guard) => current_thread.set_context_guard(guard),
                         None => {
                             // The context thread-local has already been destroyed.

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -1,7 +1,7 @@
 use crate::future::poll_fn;
 use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::{Arc, Mutex};
-use crate::runtime::context::EnterGuard;
+use crate::runtime::context::SetCurrentGuard;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
 use crate::runtime::{blocking, Config};
@@ -34,7 +34,7 @@ pub(crate) struct CurrentThread {
     /// scheduler, it is changed to `Some` with the context being the runtime's
     /// own context. This ensures that any tasks dropped in the `CurrentThread`'s
     /// destructor run in that runtime's context.
-    context_guard: Option<EnterGuard>,
+    context_guard: Option<SetCurrentGuard>,
 }
 
 /// Handle to the current thread scheduler
@@ -201,7 +201,7 @@ impl CurrentThread {
         })
     }
 
-    pub(crate) fn set_context_guard(&mut self, guard: EnterGuard) {
+    pub(crate) fn set_context_guard(&mut self, guard: SetCurrentGuard) {
         self.context_guard = Some(guard);
     }
 }

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -45,7 +45,7 @@ cfg_rt! {
     use crate::future::Future;
     use crate::loom::sync::Arc;
     use crate::runtime::{blocking, task::Id};
-    use crate::runtime::context::{self, EnterGuard};
+    use crate::runtime::context;
     use crate::task::JoinHandle;
     use crate::util::RngSeedGenerator;
 
@@ -55,16 +55,6 @@ cfg_rt! {
             match context::try_current() {
                 Ok(handle) => handle,
                 Err(e) => panic!("{}", e),
-            }
-        }
-
-        /// Sets this [`Handle`] as the current active [`Handle`].
-        ///
-        /// [`Handle`]: Handle
-        pub(crate) fn enter(&self) -> EnterGuard {
-            match context::try_enter(self) {
-                Some(guard) => guard,
-                None => panic!("{}", crate::util::error::THREAD_LOCAL_DESTROYED_ERROR),
             }
         }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -283,11 +283,16 @@ where
                 // set up blocking.
                 had_entered = true;
             }
-            (EnterContext::Entered { allow_blocking }, false) => {
+            (
+                EnterContext::Entered {
+                    allow_block_in_place,
+                },
+                false,
+            ) => {
                 // We are on an executor, but _not_ on the thread pool.  That is
                 // _only_ okay if we are in a thread pool runtime's block_on
                 // method:
-                if allow_blocking {
+                if allow_block_in_place {
                     had_entered = true;
                     return Ok(());
                 } else {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -890,7 +890,7 @@ impl<T: Future> Future for RunUntil<'_, T> {
                 .waker
                 .register_by_ref(cx.waker());
 
-            let _no_blocking = crate::runtime::enter::disallow_blocking();
+            let _no_blocking = crate::runtime::enter::disallow_block_in_place();
             let f = me.future;
 
             if let Poll::Ready(output) = crate::coop::budget(|| f.poll(cx)) {


### PR DESCRIPTION
This patch does some internal renames to remove some confusion.

* `allow_blocking` is renamed to `allow_block_in_place` to indicate that the variable only impacts the `block_in_place()` function.

* `context::try_enter` is renamed to `context::try_set_current` to disambiguate between the various "enter" functions. This function only sets the runtime handle used by Tokio's public APIs. Entering a runtime is a separate operation.  # Please enter the commit message for your changes.

* `scheduler::Handle::enter()` is removed to consolidate methods that set the current context.
