### PR TITLE
Impl `tokio_util::sync::WaitForCancellationFutureOwned`

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -71,7 +71,7 @@ pin_project! {
     /// A Future that is resolved once the corresponding [`CancellationToken`]
     /// is cancelled.
     ///
-    /// This is counterpart to [`WaitForCancellationFuture`] where it takes
+    /// This is the counterpart to [`WaitForCancellationFuture`] that takes
     /// [`CancellationToken`] by value instead of using a reference.
     #[must_use = "futures do nothing unless polled"]
     pub struct WaitForCancellationFutureOwned {

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -274,16 +274,18 @@ impl Future for WaitForCancellationFutureOwned {
                 return Poll::Ready(());
             }
 
-            // No wakeups can be lost here because there is always a call to
-            // `is_cancelled` between the creation of the future and the call to
-            // `poll`, and the code that sets the cancelled flag does so before
-            // waking the `Notified`.
-            if this
+            let future = this
                 .get_future_mut()
                 // Safety:
                 //
                 // `self` is pinned, so self.future is also pinned.
-                .map(|fut| unsafe { Pin::new_unchecked(fut) })
+                .map(|fut| unsafe { Pin::new_unchecked(fut) });
+
+            // No wakeups can be lost here because there is always a call to
+            // `is_cancelled` between the creation of the future and the call to
+            // `poll`, and the code that sets the cancelled flag does so before
+            // waking the `Notified`.
+            if future
                 .map(|fut| fut.poll(cx).is_pending())
                 .unwrap_or_default()
             {

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -297,6 +297,10 @@ impl Future for WaitForCancellationFutureOwned {
             //    since there's no 'static
             //  - self is pinned, so it's safe to have self-reference
             //    data structure.
+            //  - this.cancellation_token contains an Arc to TreeNode,
+            //    which is guaranteed to have stable dereference.
+            //    So even if `Notified` implements `Unpin` and `self`
+            //    get moved, it would still be valid.
             this.future = Some(unsafe { mem::transmute(notified) });
         }
     }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -275,7 +275,8 @@ impl Future for WaitForCancellationFutureOwned {
             }
 
             let future = this
-                .get_future_mut()
+                .future
+                .as_deref_mut()
                 // Safety:
                 //
                 // `self` is pinned, so self.future is also pinned.
@@ -331,18 +332,6 @@ impl WaitForCancellationFutureOwned {
 
             self.future = None;
         }
-    }
-
-    // Use explicit lifetime here just to be clear what this function is doing.
-    #[allow(clippy::needless_lifetimes)]
-    fn get_future_mut<'a>(&'a mut self) -> Option<&mut tokio::sync::futures::Notified<'a>> {
-        self.future
-            .as_mut()
-            // Safety:
-            //
-            // The future itself references cancellation_token, so its
-            // lifetime must be at least as long as 'a.
-            .map(|fut| unsafe { mem::transmute(fut) })
     }
 }
 

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -301,7 +301,7 @@ impl Future for WaitForCancellationFutureOwned {
 
             // Safety:
             //  - We transmute notified into Notified<'static>
-            //    since there's no 'static
+            //    since there's no 'self
             //  - self is pinned, so it's safe to have self-reference
             //    data structure.
             //  - this.cancellation_token contains an Arc to TreeNode,

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -313,7 +313,7 @@ impl Future for WaitForCancellationFutureOwned {
 
             // # Safety
             //
-            // cancellation_token is dropped after future due to order of field.
+            // cancellation_token is dropped after future due to the field ordering.
             this.future
                 .set(unsafe { Self::new_future(this.cancellation_token) });
         }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -5,6 +5,7 @@ mod tree_node;
 
 use crate::loom::sync::Arc;
 use core::future::Future;
+use core::mem;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
@@ -64,6 +65,19 @@ pin_project! {
         #[pin]
         future: tokio::sync::futures::Notified<'a>,
     }
+}
+
+/// A Future that is resolved once the corresponding [`CancellationToken`]
+/// is cancelled.
+///
+/// This is counterpart to [`WaitForCancellationFuture`] where it takes
+/// [`CancellationToken`] by value instead of using a reference.
+#[must_use = "futures do nothing unless polled"]
+pub struct WaitForCancellationFutureOwned {
+    cancellation_token: CancellationToken,
+
+    /// Use 'static lifetime here because we don't have 'this.
+    future: Option<tokio::sync::futures::Notified<'static>>,
 }
 
 // ===== impl CancellationToken =====
@@ -183,6 +197,24 @@ impl CancellationToken {
         }
     }
 
+    /// Returns a `Future` that gets fulfilled when cancellation is requested.
+    ///
+    /// The future will complete immediately if the token is already cancelled
+    /// when this method is called.
+    ///
+    /// The function takes self by value and returns a future that owns the
+    /// token.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is cancel safe.
+    pub fn cancelled_owned(self) -> WaitForCancellationFutureOwned {
+        WaitForCancellationFutureOwned {
+            cancellation_token: self,
+            future: None,
+        }
+    }
+
     /// Creates a `DropGuard` for this token.
     ///
     /// Returned guard will cancel this token (and all its children) on drop
@@ -220,5 +252,83 @@ impl<'a> Future for WaitForCancellationFuture<'a> {
 
             this.future.set(this.cancellation_token.inner.notified());
         }
+    }
+}
+
+// ===== impl WaitForCancellationFutureOwned =====
+
+impl core::fmt::Debug for WaitForCancellationFutureOwned {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WaitForCancellationFutureOwned").finish()
+    }
+}
+
+impl Future for WaitForCancellationFutureOwned {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        let this = unsafe { Pin::into_inner_unchecked(self) };
+
+        loop {
+            if this.cancellation_token.is_cancelled() {
+                return Poll::Ready(());
+            }
+
+            // No wakeups can be lost here because there is always a call to
+            // `is_cancelled` between the creation of the future and the call to
+            // `poll`, and the code that sets the cancelled flag does so before
+            // waking the `Notified`.
+            if this
+                .get_future_mut()
+                // Safety:
+                //
+                // `self` is pinned, so self.future is also pinned.
+                .map(|fut| unsafe { Pin::new_unchecked(fut) })
+                .map(|fut| fut.poll(cx).is_pending())
+                .unwrap_or_default()
+            {
+                return Poll::Pending;
+            }
+
+            let notified = this.cancellation_token.inner.notified();
+
+            // Safety:
+            //  - We transmute notified into Notified<'static>
+            //    since there's no 'static
+            //  - self is pinned, so it's safe to have self-reference
+            //    data structure.
+            this.future = Some(unsafe { mem::transmute(notified) });
+        }
+    }
+}
+
+impl WaitForCancellationFutureOwned {
+    fn do_drop<'a>(&'a mut self) {
+        if let Some(future) = self.future.take() {
+            // Safety:
+            //
+            // The future itself refererences cancellation_token, so its
+            // lifetime must be at least as long as 'a.
+            let future: tokio::sync::futures::Notified<'a> = unsafe { mem::transmute(future) };
+            drop(future);
+        }
+    }
+
+    // Use explicit lifetime here just to be clear what this function is doing.
+    #[allow(clippy::needless_lifetimes)]
+    fn get_future_mut<'a>(&'a mut self) -> Option<&mut tokio::sync::futures::Notified<'a>> {
+        self.future
+            .as_mut()
+            // Safety:
+            //
+            // The future itself references cancellation_token, so its
+            // lifetime must be at least as long as 'a.
+            .map(|fut| unsafe { mem::transmute(fut) })
+    }
+}
+
+impl Drop for WaitForCancellationFutureOwned {
+    fn drop(&mut self) {
+        self.do_drop();
     }
 }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -74,10 +74,9 @@ pin_project! {
 /// [`CancellationToken`] by value instead of using a reference.
 #[must_use = "futures do nothing unless polled"]
 pub struct WaitForCancellationFutureOwned {
+    // Since `future` is the first field, it is dropped before the cancellation token.
+    future: Option<tokio::sync::futures::Notified<'static>>,
     cancellation_token: CancellationToken,
-
-    /// Use 'static lifetime here because we don't have 'this.
-    future: Option<mem::ManuallyDrop<tokio::sync::futures::Notified<'static>>>,
 }
 
 // ===== impl CancellationToken =====

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -75,7 +75,7 @@ pin_project! {
     #[must_use = "futures do nothing unless polled"]
     pub struct WaitForCancellationFutureOwned {
         // Since `future` is the first field, it is dropped before the
-        // cancellation_token and always holds a valid reference to it.
+        // cancellation_token, thus always holds a valid reference to it.
         #[pin]
         future: tokio::sync::futures::Notified<'static>,
         cancellation_token: CancellationToken,
@@ -266,8 +266,8 @@ impl WaitForCancellationFutureOwned {
     fn new(cancellation_token: CancellationToken) -> Self {
         WaitForCancellationFutureOwned {
             // cancellation_token holds a heap allocation and is guaranteed to have a
-            // stable deref, thus it would be ok to move the future which holds a reference
-            // to it.
+            // stable deref, thus it would be ok to move the cancellation_token while
+            // the future which holds a reference to it.
             //
             // # Safety
             //

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -75,11 +75,6 @@ pin_project! {
     #[must_use = "futures do nothing unless polled"]
     pub struct WaitForCancellationFutureOwned {
         // Since `future` is the first field, it is dropped before the cancellation token.
-        //
-        // Also, cancellation_token holds a heap allocation and is guaranteed to have a
-        // stable deref.
-        //
-        // It would be ok to move it.
         #[pin]
         future: tokio::sync::futures::Notified<'static>,
         cancellation_token: CancellationToken,
@@ -269,6 +264,9 @@ impl core::fmt::Debug for WaitForCancellationFutureOwned {
 impl WaitForCancellationFutureOwned {
     fn new(cancellation_token: CancellationToken) -> Self {
         WaitForCancellationFutureOwned {
+            // Also, cancellation_token holds a heap allocation and is guaranteed to have a
+            // stable deref, thus it would be ok to move the future which holds a reference
+            // to it.
             future: unsafe { Self::new_future(&cancellation_token) },
             cancellation_token,
         }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -320,15 +320,8 @@ impl Future for WaitForCancellationFutureOwned {
 }
 
 impl WaitForCancellationFutureOwned {
-    fn do_drop_future<'a>(&'a mut self) {
+    fn do_drop_future(&mut self) {
         if let Some(future) = self.future.as_mut() {
-            // Safety:
-            //
-            // The future itself refererences cancellation_token, so its
-            // lifetime must be at least as long as 'a.
-            let future: &mut mem::ManuallyDrop<tokio::sync::futures::Notified<'a>> =
-                unsafe { mem::transmute(future) };
-
             // Safety:
             //
             //  - self.future will not be used anymore.

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -74,7 +74,8 @@ pin_project! {
     /// [`CancellationToken`] by value instead of using a reference.
     #[must_use = "futures do nothing unless polled"]
     pub struct WaitForCancellationFutureOwned {
-        // Since `future` is the first field, it is dropped before the cancellation token.
+        // Since `future` is the first field, it is dropped before the
+        // cancellation_token and always holds a valid reference to it.
         #[pin]
         future: tokio::sync::futures::Notified<'static>,
         cancellation_token: CancellationToken,
@@ -264,9 +265,13 @@ impl core::fmt::Debug for WaitForCancellationFutureOwned {
 impl WaitForCancellationFutureOwned {
     fn new(cancellation_token: CancellationToken) -> Self {
         WaitForCancellationFutureOwned {
-            // Also, cancellation_token holds a heap allocation and is guaranteed to have a
+            // cancellation_token holds a heap allocation and is guaranteed to have a
             // stable deref, thus it would be ok to move the future which holds a reference
             // to it.
+            //
+            // # Safety
+            //
+            // cancellation_token is dropped after future due to order of field.
             future: unsafe { Self::new_future(&cancellation_token) },
             cancellation_token,
         }
@@ -301,6 +306,9 @@ impl Future for WaitForCancellationFutureOwned {
                 return Poll::Pending;
             }
 
+            // # Safety
+            //
+            // cancellation_token is dropped after future due to order of field.
             this.future
                 .set(unsafe { Self::new_future(this.cancellation_token) });
         }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -269,14 +269,14 @@ impl core::fmt::Debug for WaitForCancellationFutureOwned {
 impl WaitForCancellationFutureOwned {
     fn new(cancellation_token: CancellationToken) -> Self {
         WaitForCancellationFutureOwned {
-            future: unsafe { Self::get_future(&cancellation_token) },
+            future: unsafe { Self::new_future(&cancellation_token) },
             cancellation_token,
         }
     }
 
     /// * `cancellation_token` - The strong count of cancellation_token.inner
     ///   must be larger than 0 as long as the returned future is still alive.
-    unsafe fn get_future(
+    unsafe fn new_future(
         cancellation_token: &CancellationToken,
     ) -> tokio::sync::futures::Notified<'static> {
         let inner_ptr = Arc::as_ptr(&cancellation_token.inner);
@@ -304,7 +304,7 @@ impl Future for WaitForCancellationFutureOwned {
             }
 
             this.future
-                .set(unsafe { Self::get_future(this.cancellation_token) });
+                .set(unsafe { Self::new_future(this.cancellation_token) });
         }
     }
 }

--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -309,9 +309,6 @@ impl Future for WaitForCancellationFutureOwned {
             //    which is guaranteed to have stable dereference.
             //    So even if `Notified` implements `Unpin` and `self`
             //    get moved, it would still be valid.
-            //  - We never use Notified<'static>.
-            //    Instead, it is transmuted back to Notified<'a>
-            //    where 'a is lifetime of self before being used.
             let notified: tokio::sync::futures::Notified<'static> =
                 unsafe { mem::transmute(notified) };
 

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,7 +1,9 @@
 //! Synchronization primitives
 
 mod cancellation_token;
-pub use cancellation_token::{guard::DropGuard, CancellationToken, WaitForCancellationFuture};
+pub use cancellation_token::{
+    guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
+};
 
 mod mpsc;
 pub use mpsc::{PollSendError, PollSender};

--- a/tokio-util/src/sync/tests/loom_cancellation_token.rs
+++ b/tokio-util/src/sync/tests/loom_cancellation_token.rs
@@ -25,6 +25,27 @@ fn cancel_token() {
 }
 
 #[test]
+fn cancel_token_owned() {
+    loom::model(|| {
+        let token = CancellationToken::new();
+        let token1 = token.clone();
+
+        let th1 = thread::spawn(move || {
+            block_on(async {
+                token1.cancelled_owned().await;
+            });
+        });
+
+        let th2 = thread::spawn(move || {
+            token.cancel();
+        });
+
+        assert_ok!(th1.join());
+        assert_ok!(th2.join());
+    });
+}
+
+#[test]
 fn cancel_with_child() {
     loom::model(|| {
         let token = CancellationToken::new();

--- a/tokio-util/tests/sync_cancellation_token.rs
+++ b/tokio-util/tests/sync_cancellation_token.rs
@@ -72,6 +72,24 @@ fn cancel_token_owned() {
 }
 
 #[test]
+fn cancel_token_owned_drop_test() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationToken::new();
+
+    let future = token.cancelled_owned();
+    pin!(future);
+
+    assert_eq!(
+        Poll::Pending,
+        future.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    // let future be dropped while pinned and under pending state to
+    // find potential memory related bugs.
+}
+
+#[test]
 fn cancel_child_token_through_parent() {
     let (waker, wake_counter) = new_count_waker();
     let token = CancellationToken::new();

--- a/tokio-util/tests/sync_cancellation_token.rs
+++ b/tokio-util/tests/sync_cancellation_token.rs
@@ -40,6 +40,38 @@ fn cancel_token() {
 }
 
 #[test]
+fn cancel_token_owned() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationToken::new();
+    assert!(!token.is_cancelled());
+
+    let wait_fut = token.clone().cancelled_owned();
+    pin!(wait_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    let wait_fut_2 = token.clone().cancelled_owned();
+    pin!(wait_fut_2);
+
+    token.cancel();
+    assert_eq!(wake_counter, 1);
+    assert!(token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(()),
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(()),
+        wait_fut_2.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
 fn cancel_child_token_through_parent() {
     let (waker, wake_counter) = new_count_waker();
     let token = CancellationToken::new();


### PR DESCRIPTION
Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>

## Motivation

`tokio_util::sync::WaitForCancellationFuture` takes a reference to the `CancellationToken`, which is hard to use in `struct`s where you don't want a lifetime.

## Solution

`tokio_util::sync::WaitForCancellationFutureOwned` provides an alternative where `CancellationToken` is taken by value so that `WaitForCancellationFutureOwned` does not contain any lifetime (but self-referenced) and can be used without worrying about lifetime.

## Alternatives

User use [ouroboros](https://lib.rs/crates/ouroboros) to create self-reference struct, but it is not zero-cost.
Other self-reference crates that are zero-cost are experimental (e.g. [self-reference](https://docs.rs/self-reference)).

Or the user can do:

```rust
let boxed_fut: Pin<Box<(dyn Future<Output = ()> + Send)>> = Box::pin(async move {
    cancellation_token.cancalled()
});
```

which isn't zero-cost since it requires one extra allocation and also a pointer to vtable for the trait `Future`.

User could also uses a `SmallBox` with pre-allocated space on stack to store the future, though it's more complicated and not zero-cost either (extra pointer to vtable and it might incur heap allocation if the pre-allocated space on stack is too small).

Fixes: #4466