### PR TITLE
sync: make Notify panic safe

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -13,6 +13,7 @@ use crate::util::WakeList;
 use std::cell::UnsafeCell;
 use std::future::Future;
 use std::marker::PhantomPinned;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::SeqCst;
@@ -565,6 +566,9 @@ impl Default for Notify {
         Notify::new()
     }
 }
+
+impl UnwindSafe for Notify {}
+impl RefUnwindSafe for Notify {}
 
 fn notify_locked(waiters: &mut WaitList, state: &AtomicUsize, curr: usize) -> Option<Waker> {
     loop {

--- a/tokio/tests/unwindsafe.rs
+++ b/tokio/tests/unwindsafe.rs
@@ -4,6 +4,11 @@
 use std::panic::{RefUnwindSafe, UnwindSafe};
 
 #[test]
+fn notify_is_unwind_safe() {
+    is_unwind_safe::<tokio::sync::Notify>();
+}
+
+#[test]
 fn join_handle_is_unwind_safe() {
     is_unwind_safe::<tokio::task::JoinHandle<()>>();
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

make Notify panic safe.

close #5122

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
