### PR TITLE
rt: move budget state to context thread-local

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -177,7 +177,6 @@
 #[macro_use]
 mod tests;
 
-#[cfg(any(feature = "rt", feature = "macros"))]
 pub(crate) mod context;
 
 pub(crate) mod coop;


### PR DESCRIPTION
This patch consolidates the budget thread-local state with the `runtime::context` thread local. This reduces the number of thread-local variables used by Tokio by one.