### PR TITLE
rt: unify entering a runtime with Handle::enter

### DIFF
--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -3,7 +3,12 @@ use std::future::Future;
 cfg_rt! {
     #[track_caller]
     pub(crate) fn block_on<F: Future>(f: F) -> F::Output {
-        let mut e = crate::runtime::enter::enter(false);
+        let mut e = crate::runtime::enter::try_enter_blocking_region().expect(
+            "Cannot block the current thread from within a runtime. This \
+            happens because a functionattempted to block the current \
+            thread while the thread is being used to drive asynchronous \
+            tasks."
+        );
         e.block_on(f).unwrap()
     }
 }

--- a/tokio/src/runtime/blocking/shutdown.rs
+++ b/tokio/src/runtime/blocking/shutdown.rs
@@ -35,13 +35,13 @@ impl Receiver {
     ///
     /// If the timeout has elapsed, it returns `false`, otherwise it returns `true`.
     pub(crate) fn wait(&mut self, timeout: Option<Duration>) -> bool {
-        use crate::runtime::enter::try_enter;
+        use crate::runtime::enter::try_enter_blocking_region;
 
         if timeout == Some(Duration::from_nanos(0)) {
             return false;
         }
 
-        let mut e = match try_enter(false) {
+        let mut e = match try_enter_blocking_region() {
             Some(enter) => enter,
             _ => {
                 if std::thread::panicking() {

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -256,14 +256,13 @@ impl Handle {
         let future =
             crate::util::trace::task(future, "block_on", None, super::task::Id::next().as_u64());
 
-        // Enter the **runtime** context. This configures spawning, the current I/O driver, ...
-        let _rt_enter = self.enter();
-
-        // Enter a **blocking** context. This prevents blocking from a runtime.
-        let mut blocking_enter = crate::runtime::enter(true);
+        // Enter the runtime context. This sets the current driver handles and
+        // prevents blocking an existing runtime.
+        let mut enter = crate::runtime::enter::enter_runtime(&self.inner, true);
 
         // Block on the future
-        blocking_enter
+        enter
+            .blocking
             .block_on(future)
             .expect("failed to park thread")
     }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -230,7 +230,7 @@ cfg_rt! {
         pub use crate::util::rand::RngSeed;
     }
 
-    use self::enter::enter;
+    use self::enter::enter_runtime;
 
     mod handle;
     pub use handle::{EnterGuard, Handle, TryCurrentError};

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -20,7 +20,7 @@ use crate::loom::sync::Arc;
 use crate::runtime::{
     blocking,
     driver::{self, Driver},
-    Config,
+    scheduler, Config,
 };
 use crate::util::RngSeedGenerator;
 
@@ -73,8 +73,12 @@ impl MultiThread {
     where
         F: Future,
     {
-        let mut enter = crate::runtime::enter(true);
-        enter.block_on(future).expect("failed to park thread")
+        let handle = scheduler::Handle::MultiThread(self.handle.clone());
+        let mut enter = crate::runtime::enter_runtime(&handle, true);
+        enter
+            .blocking
+            .block_on(future)
+            .expect("failed to park thread")
     }
 }
 


### PR DESCRIPTION
This is a first step towards unifying the concepts of "entering a runtime" and setting `Handle::current`.

Previously, these two operations were performed separately at each call site (runtime block_on, ...). This is error-prone and also requires multiple accesses to the thread-local variable. Additionally, "entering the runtime" conflated the concept of entering a blocking region. For example, calling `mpsc::Receiver::recv_blocking` performed the "enter the runtime" step. This was done to prevent blocking a runtime, as the operation will panic when called from an existing runtime.

To untangle these concepts, the patch splits each logical operation into a separate function. In total, there are three "enter" operations:

* `set_current_handle`
* `enter_runtime`
* `enter_blocking_region`

There are some behavior changes with each function, but they should not translate to public behavior changes. The most significant is `enter_blocking_region` does not change the value of the thread-local variable, which means the function can be re-entered. Since `enter_blocking_region` is an internal-only function and we do not re-enter, this has no public-facing impact.

Because `enter_runtime` takes a `&Handle` to combine the `set_current_handle` operation with entering a runtime, the patch exposes an annoyance with the current `scheduler::Handle` struct layout. A new instance of `scheduler::Handle` must be constructed at each call to `enter_runtime`. We can explore cleaning this up later.

This patch does not combine the "entered runtime" thread-local variable with the "context" thread-local variable. To keep the patch smaller, this has been punted to a follow-up change.
