### PR TITLE
chore: fix tests for Rust 1.65 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-07-26
+  rust_nightly: nightly-2022-11-03
   rust_clippy: 1.56.0
   # When updating this, also update:
   # - README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,10 +555,12 @@ jobs:
           - ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust ${{ env.rust_nightly }}
+      - name: Install Rust nightly-2022-07-25
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: ${{ env.rust_nightly }}
+          # `check-external-types` requires a specific Rust nightly version. See
+          # the README for details: https://github.com/awslabs/cargo-check-external-types
+          toolchain: nightly-2022-07-25
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: check-external-types

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -564,6 +564,6 @@ jobs:
       - name: check-external-types
         run: |
           set -x
-          cargo install cargo-check-external-types --locked --version 0.1.3
+          cargo install cargo-check-external-types --locked --version 0.1.5
           cargo check-external-types --all-features --config external-types.toml
         working-directory: tokio

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -81,7 +81,7 @@ fn join_size() {
         let ready2 = future::ready(0i32);
         tokio::join!(ready1, ready2)
     };
-    assert_eq!(mem::size_of_val(&fut), 48);
+    assert_eq!(mem::size_of_val(&fut), 40);
 }
 
 async fn non_cooperative_task(permits: Arc<Semaphore>) -> usize {


### PR DESCRIPTION
Rust 1.65 reduces some struct sizes.