### PR TITLE
sync: fix copy-paste error for `AtomicWaker`

### DIFF
--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -4,7 +4,7 @@ use tokio_test::task;
 use std::task::Waker;
 
 trait AssertSend: Send {}
-trait AssertSync: Send {}
+trait AssertSync: Sync {}
 
 impl AssertSend for AtomicWaker {}
 impl AssertSync for AtomicWaker {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

It seems like a typo?

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
