### PR TITLE
rt: remove handle reference from each scheduler

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -888,7 +888,7 @@ impl Builder {
         // there are no futures ready to do something, it'll let the timer or
         // the reactor to generate some new stimuli for the futures to continue
         // in their life.
-        let scheduler = CurrentThread::new(
+        let (scheduler, handle) = CurrentThread::new(
             driver,
             driver_handle,
             blocking_spawner,
@@ -906,7 +906,7 @@ impl Builder {
         );
 
         let handle = Handle {
-            inner: scheduler::Handle::CurrentThread(scheduler.handle().clone()),
+            inner: scheduler::Handle::CurrentThread(handle),
         };
 
         Ok(Runtime::from_parts(
@@ -1009,7 +1009,7 @@ cfg_rt_multi_thread! {
             let seed_generator_1 = self.seed_generator.next_generator();
             let seed_generator_2 = self.seed_generator.next_generator();
 
-            let (scheduler, launch) = MultiThread::new(
+            let (scheduler, handle, launch) = MultiThread::new(
                 core_threads,
                 driver,
                 driver_handle,
@@ -1027,8 +1027,7 @@ cfg_rt_multi_thread! {
                 },
             );
 
-            let handle = scheduler::Handle::MultiThread(scheduler.handle().clone());
-            let handle = Handle { inner: handle };
+            let handle = Handle { inner: scheduler::Handle::MultiThread(handle) };
 
             // Spawn the thread pool workers
             let _enter = handle.enter();

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -97,6 +97,14 @@ cfg_rt! {
                 Handle::MultiThread(h) => &h.seed_generator,
             }
         }
+
+        pub(crate) fn as_current_thread(&self) -> &Arc<current_thread::Handle> {
+            match self {
+                Handle::CurrentThread(handle) => handle,
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
+                _ => panic!("not a CurrentThread handle"),
+            }
+        }
     }
 
     cfg_metrics! {


### PR DESCRIPTION
Instead of each scheduler flavor holding a reference to the scheduler handle, the scheduler handle is passed in as needed. This removes a duplicate handle reference in the `Runtime` struct and lays the groundwork for further handle struct tweaks.