### PR TITLE
runtime: fix `unsync_load` on atomic types

### DIFF
--- a/tokio/src/loom/std/atomic_u16.rs
+++ b/tokio/src/loom/std/atomic_u16.rs
@@ -23,7 +23,7 @@ impl AtomicU16 {
     /// All mutations must have happened before the unsynchronized load.
     /// Additionally, there must be no concurrent mutations.
     pub(crate) unsafe fn unsync_load(&self) -> u16 {
-        *(*self.inner.get()).get_mut()
+        core::ptr::read(self.inner.get() as *const u16)
     }
 }
 

--- a/tokio/src/loom/std/atomic_u32.rs
+++ b/tokio/src/loom/std/atomic_u32.rs
@@ -23,7 +23,7 @@ impl AtomicU32 {
     /// All mutations must have happened before the unsynchronized load.
     /// Additionally, there must be no concurrent mutations.
     pub(crate) unsafe fn unsync_load(&self) -> u32 {
-        *(*self.inner.get()).get_mut()
+        core::ptr::read(self.inner.get() as *const u32)
     }
 }
 

--- a/tokio/src/loom/std/atomic_usize.rs
+++ b/tokio/src/loom/std/atomic_usize.rs
@@ -23,7 +23,7 @@ impl AtomicUsize {
     /// All mutations must have happened before the unsynchronized load.
     /// Additionally, there must be no concurrent mutations.
     pub(crate) unsafe fn unsync_load(&self) -> usize {
-        *(*self.inner.get()).get_mut()
+        core::ptr::read(self.inner.get() as *const usize)
     }
 
     pub(crate) fn with_mut<R>(&mut self, f: impl FnOnce(&mut usize) -> R) -> R {

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -111,7 +111,7 @@ const fn normal_or_miri(normal: usize, miri: usize) -> usize {
 
 #[test]
 fn stress1() {
-    const NUM_ITER: usize = 1;
+    const NUM_ITER: usize = 5;
     const NUM_STEAL: usize = normal_or_miri(1_000, 10);
     const NUM_LOCAL: usize = normal_or_miri(1_000, 10);
     const NUM_PUSH: usize = normal_or_miri(500, 10);


### PR DESCRIPTION
The `unsync_load` methods currently create a mutable reference to the atomic to perform the read. However, this is not allowed as it will sometimes race with other atomic loads. This occasionally causes the `stress1` test to fail with the following error:
```
error: Undefined Behavior: not granting access to tag <3613730> because that would remove [Unique for <3613708>] which is protected because it is an argument of call 1030169
   --> tokio/src/runtime/scheduler/multi_thread/queue.rs:386:28
    |
386 |             let src_tail = self.0.tail.load(Acquire);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^ not granting access to tag <3613730> because that would remove [Unique for <3613708>] which is protected because it is an argument of call 1030169
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <3613730> was created by a SharedReadWrite retag at offsets [0x20..0x24]
   --> tokio/src/runtime/scheduler/multi_thread/queue.rs:386:28
    |
386 |             let src_tail = self.0.tail.load(Acquire);
    |                            ^^^^^^^^^^^^^^^^^^^^^^^^^
help: <3613708> is this argument
   --> tokio/src/loom/std/atomic_u32.rs:26:10
    |
26  |         *(*self.inner.get()).get_mut()
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE:
    = note: inside `runtime::scheduler::multi_thread::queue::Steal::<runtime::blocking::schedule::NoopSchedule>::steal_into2` at tokio/src/runtime/scheduler/multi_thread/queue.rs:386:28
note: inside `runtime::scheduler::multi_thread::queue::Steal::<runtime::blocking::schedule::NoopSchedule>::steal_into` at tokio/src/runtime/scheduler/multi_thread/queue.rs:348:21
   --> tokio/src/runtime/scheduler/multi_thread/queue.rs:348:21
    |
348 |         let mut n = self.steal_into2(dst, dst_tail);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure at tokio/src/runtime/tests/queue.rs:132:20
   --> tokio/src/runtime/tests/queue.rs:132:20
    |
132 |                 if steal.steal_into(&mut local, &mut metrics).is_some() {
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace
```