### PR TITLE
Remove libc types from external types allow list

### DIFF
--- a/tokio/external-types.toml
+++ b/tokio/external-types.toml
@@ -7,10 +7,5 @@ allowed_external_types = [
    "bytes::buf::buf_mut::BufMut",
 
    "tokio_macros::*",
-
-   # TODO(https://github.com/tokio-rs/tokio/issues/4916): Remove the libc types
-   "libc::unix::gid_t",
-   "libc::unix::pid_t",
-   "libc::unix::uid_t",
 ]
 


### PR DESCRIPTION
## Motivation

Exposure of the libc ID types was removed in #5191. This change removes them from the allow list
in the `cargo-check-external-types` config.