### PR TITLE
Specify type returned when awaiting a oneshot::Receiver

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -331,7 +331,8 @@ pub mod error {
     use std::fmt;
 
     /// Error returned by the `Future` implementation for `Receiver`.
-    /// This error is returned when the sender is dropped without sending.
+    ///
+    /// This error is returned by the receiver when the sender is dropped without sending.
     #[derive(Debug, Eq, PartialEq, Clone)]
     pub struct RecvError(pub(super) ());
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
### 1
Currently the docs makes it sound like `.await`ing the `oneshot::Receiver` directly returns T.
This is however not the case.

If you know what you are doing you can check the `impl Future for Receiver` but its a little hidden.

### 2
Additionally the docs for RecvError dont mention when the error is returned, which adds to the confusion around errors here.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
### 1
I changed the phrase `value` to refer to the specific type, with a link to the RecvError docs.
The rendering of the adjacent code blocks is slightly wonky, but its good enough I think.
![image](https://user-images.githubusercontent.com/5120858/202082346-6cc824f9-38ee-4642-bf7d-f8c64f57c870.png)

I welcome suggestions for alternative approaches to make this clearer.

### 2
Added a sentence to the `RecvError` docs explaining when its returned.