### PR TITLE
examples: fix tinyhttp issues

### DIFF
--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -6,16 +6,16 @@
 //! than Tokio, if you'd like a "real world" HTTP library you likely want a
 //! crate like Hyper.
 //!
-//! Code here is based on the `echo-threads` example and implements two paths,
-//! the `/plaintext` and `/json` routes to respond with some text and json,
-//! respectively. By default this will run I/O on all the cores your system has
-//! available, and it doesn't support HTTP request bodies.
+//! Code here implements two paths, the `/plaintext` and `/json` routes to respond
+//! with some text and json, respectively. By default this will run I/O on all the
+//! cores your system has available, and it doesn't support HTTP request bodies.
 
 #![warn(rust_2018_idioms)]
 
 use bytes::BytesMut;
 use futures::SinkExt;
 use http::{header::HeaderValue, Request, Response, StatusCode};
+use std::str;
 #[macro_use]
 extern crate serde_derive;
 use std::{env, error::Error, fmt, io};
@@ -169,9 +169,13 @@ impl Decoder for Http {
             };
 
             let toslice = |a: &[u8]| {
-                let start = a.as_ptr() as usize - src.as_ptr() as usize;
-                assert!(start < src.len());
-                (start, start + a.len())
+                if (a.as_ptr() as usize) > (src.as_ptr() as usize) {
+                    let start = a.as_ptr() as usize - src.as_ptr() as usize;
+                    assert!(start < src.len());
+                    (start, start + a.len())
+                } else {
+                    (0, a.len())
+                }
             };
 
             for (i, header) in r.headers.iter().enumerate() {

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -167,13 +167,15 @@ impl Decoder for Http {
                 httparse::Status::Partial => return Ok(None),
             };
 
-            let toslice = |a: &[u8]| {
-                if (a.as_ptr() as usize) > (src.as_ptr() as usize) {
-                    let start = a.as_ptr() as usize - src.as_ptr() as usize;
+            let toslice = |input: &[u8]| {
+                if (input.as_ptr() as usize) > (src.as_ptr() as usize) {
+                    let start = input.as_ptr() as usize - src.as_ptr() as usize;
                     assert!(start < src.len());
-                    (start, start + a.len())
+                    (start, start + input.len())
                 } else {
-                    (0, a.len())
+                    let ret = src.windows(input.len()).position(|window| window == input);
+                    assert!(ret.is_some());
+                    (ret.unwrap(), ret.unwrap() + input.len())
                 }
             };
 

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -15,7 +15,6 @@
 use bytes::BytesMut;
 use futures::SinkExt;
 use http::{header::HeaderValue, Request, Response, StatusCode};
-use std::str;
 #[macro_use]
 extern crate serde_derive;
 use std::{env, error::Error, fmt, io};

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -186,8 +186,8 @@ impl Decoder for Http {
             }
 
             (
-                toslice(r.method.unwrap().as_bytes()),
-                toslice(r.path.unwrap().as_bytes()),
+                r.method.unwrap().as_bytes(),
+                r.path.unwrap().as_bytes(),
                 r.version.unwrap(),
                 amt,
             )
@@ -198,11 +198,12 @@ impl Decoder for Http {
                 "only HTTP/1.1 accepted",
             ));
         }
-        let data = src.split_to(amt).freeze();
+
         let mut ret = Request::builder();
-        ret = ret.method(&data[method.0..method.1]);
-        let s = data.slice(path.0..path.1);
+        ret = ret.method(method);
+        let s = path;
         let s = unsafe { String::from_utf8_unchecked(Vec::from(s.as_ref())) };
+        let data = src.split_to(amt).freeze();
         ret = ret.uri(s);
         ret = ret.version(http::Version::HTTP_11);
         for header in headers.iter() {


### PR DESCRIPTION
Signed-off-by: Loong <loong.dai@intel.com>

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The example fails when get a request via `curl localhost:8080/plaintext`:
```
root:[tokio]$ cargo run --example tinyhttp
   Compiling examples v0.0.0 (/root/github/tokio/examples)
    Finished dev [unoptimized + debuginfo] target(s) in 1.28s
     Running `target/debug/examples/tinyhttp`
Listening on: 127.0.0.1:8080
thread 'tokio-runtime-worker' panicked at 'attempt to subtract with overflow', examples/tinyhttp.rs:172:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Solution

Add subtract check, and update comments.
