### PR TITLE
macros: fix span of body variable

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -383,6 +383,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
 
     let body = &input.block;
     let brace_token = input.block.brace_token;
+    let body_ident = quote! { body };
     let block_expr = quote_spanned! {last_stmt_end_span=>
         #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
         {
@@ -390,7 +391,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")
-                .block_on(body);
+                .block_on(#body_ident);
         }
     };
 
@@ -479,7 +480,7 @@ pub(crate) fn test(args: TokenStream, item: TokenStream, rt_multi_thread: bool) 
     };
     let config = if let Some(attr) = input.attrs.iter().find(|attr| attr.path.is_ident("test")) {
         let msg = "second test attribute is supplied";
-        Err(syn::Error::new_spanned(&attr, msg))
+        Err(syn::Error::new_spanned(attr, msg))
     } else {
         AttributeArgs::parse_terminated
             .parse(args)

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -71,3 +71,18 @@ pub mod clippy_semicolon_if_nothing_returned {
         // To trigger clippy::semicolon_if_nothing_returned lint, the block needs to contain newline.
     }
 }
+
+// https://github.com/tokio-rs/tokio/issues/5243
+pub mod issue_5243 {
+    macro_rules! mac {
+        (async fn $name:ident() $b:block) => {
+            #[::tokio::test]
+            async fn $name() {
+                $b
+            }
+        };
+    }
+    mac!(
+        async fn foo() {}
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Fixes #5243
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This is basically the same problem as https://github.com/dtolnay/async-trait/issues/104 and https://github.com/dtolnay/async-trait/issues/46, and can be fixed by assigning a consistent span to the same variable. See also https://github.com/dtolnay/async-trait/pull/105#issuecomment-640348525. (The root cause is a compiler bug that overwrites spans of non-`:tt` metavariables during declarative macro expansion.)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
