### PR TITLE
util: make tokio an optional dependency

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -18,7 +18,7 @@ categories = ["asynchronous"]
 
 [features]
 # No features on by default
-default = []
+default = ["tokio"]
 
 # Shorthand for enabling everything
 full = ["codec", "compat", "io-util", "time", "net", "rt"]
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.21.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.21.0", path = "../tokio", default-features = true, optional = true }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -24,14 +24,14 @@ default = ["tokio"]
 full = ["codec", "compat", "io-util", "time", "net", "rt"]
 
 net = ["tokio/net"]
-compat = ["futures-io",]
-codec = ["tracing"]
+compat = ["tokio", "futures-io",]
+codec = ["tokio", "tracing"]
 time = ["tokio/time","slab"]
-io = []
+io = ["tokio"]
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 
-__docs_rs = ["futures-util"]
+__docs_rs = ["tokio", "futures-util"]
 
 [dependencies]
 tokio = { version = "1.21.0", path = "../tokio", default-features = true, optional = true }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -31,7 +31,7 @@ io = ["tokio"]
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 
-__docs_rs = ["tokio", "futures-util"]
+__docs_rs = ["tokio/sync", "futures-util"]
 
 [dependencies]
 tokio = { version = "1.21.0", path = "../tokio", default-features = true, optional = true }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -17,21 +17,21 @@ Additional utilities for working with Tokio.
 categories = ["asynchronous"]
 
 [features]
-# No features on by default
-default = ["tokio/sync"]
+default = ["sync"]
 
 # Shorthand for enabling everything
-full = ["codec", "compat", "io-util", "time", "net", "rt"]
+full = ["codec", "compat", "io-util", "time", "net", "rt", "sync"]
 
 net = ["tokio/net"]
-compat = ["tokio/sync", "futures-io",]
-codec = ["tokio/sync", "tracing"]
+compat = ["tokio", "futures-io",]
+codec = ["tokio", "tracing"]
 time = ["tokio/time","slab"]
-io = ["tokio/sync"]
+io = ["tokio"]
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
+sync = ["tokio/sync"]
 
-__docs_rs = ["tokio/sync", "futures-util"]
+__docs_rs = ["futures-util"]
 
 [dependencies]
 tokio = { version = "1.21.0", path = "../tokio", default-features = true, optional = true }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -18,16 +18,16 @@ categories = ["asynchronous"]
 
 [features]
 # No features on by default
-default = ["tokio"]
+default = ["tokio/sync"]
 
 # Shorthand for enabling everything
 full = ["codec", "compat", "io-util", "time", "net", "rt"]
 
 net = ["tokio/net"]
-compat = ["tokio", "futures-io",]
-codec = ["tokio", "tracing"]
+compat = ["tokio/sync", "futures-io",]
+codec = ["tokio/sync", "tracing"]
 time = ["tokio/time","slab"]
-io = ["tokio"]
+io = ["tokio/sync"]
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 

--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -70,6 +70,16 @@ macro_rules! cfg_time {
     }
 }
 
+macro_rules! cfg_sync {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "sync")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_tokio {
     ($($item:item)*) => {
         $(

--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -69,3 +69,13 @@ macro_rules! cfg_time {
         )*
     }
 }
+
+macro_rules! cfg_tokio {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "tokio")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
+            $item
+        )*
+    }
+}

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -22,7 +22,7 @@
 #[macro_use]
 mod cfg;
 
-#[cfg(feature = "tokio")]
+#[cfg(feature = "sync")]
 mod loom;
 
 cfg_codec! {

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -22,6 +22,7 @@
 #[macro_use]
 mod cfg;
 
+#[cfg(feature = "tokio")]
 mod loom;
 
 cfg_codec! {
@@ -53,7 +54,9 @@ cfg_time! {
 
 pub mod sync;
 
-pub mod either;
+cfg_tokio! {
+    pub mod either;
+}
 
 #[cfg(any(feature = "io", feature = "codec"))]
 mod util {

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,18 +1,18 @@
 //! Synchronization primitives
 
-cfg_tokio! {
+cfg_sync! {
     mod cancellation_token;
     pub use cancellation_token::{
         guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
     };
 }
 
-cfg_tokio! {
+cfg_sync! {
     mod mpsc;
     pub use mpsc::{PollSendError, PollSender};
 }
 
-cfg_tokio! {
+cfg_sync! {
     mod poll_semaphore;
     pub use poll_semaphore::PollSemaphore;
 }

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -1,15 +1,21 @@
 //! Synchronization primitives
 
-mod cancellation_token;
-pub use cancellation_token::{
-    guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
-};
+cfg_tokio! {
+    mod cancellation_token;
+    pub use cancellation_token::{
+        guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
+    };
+}
 
-mod mpsc;
-pub use mpsc::{PollSendError, PollSender};
+cfg_tokio! {
+    mod mpsc;
+    pub use mpsc::{PollSendError, PollSender};
+}
 
-mod poll_semaphore;
-pub use poll_semaphore::PollSemaphore;
+cfg_tokio! {
+    mod poll_semaphore;
+    pub use poll_semaphore::PollSemaphore;
+}
 
 mod reusable_box;
 pub use reusable_box::ReusableBoxFuture;


### PR DESCRIPTION
This is primarily to allow for ReusableBoxFuture to be used without adding a tokio dependency.

## Motivation

I've been asked by a handful of people how to solve things that could benefit from using `ReusableBoxFuture` but for one reason or another they don't want to add a required `tokio` dependency. This change would allow such users to use it without requiring `tokio`.

Note that there is an unofficial extracted variant of it in the `reusable-box-future` crate which is an indicator of interest. IMO it's better to redirect such users to this ecosystem.

## Solution

Make `tokio` optional and feature flag uses.