### PR TITLE
chore: prepare tokio-macros v1.8.2

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,8 +1,16 @@
+# 1.8.2 (November 30th, 2022)
+
+- fix a regression introduced in 1.8.1 ([#5244])
+
+[#5244]: https://github.com/tokio-rs/tokio/pull/5244
+
 # 1.8.1 (November 29th, 2022)
 
-- macros: Pin Futures in #[tokio::test] to stack ([#5205])
+(yanked)
+
+- macros: Pin Futures in `#[tokio::test]` to stack ([#5205])
 - macros: Reduce usage of last statement spans in proc-macros ([#5092])
-- macros: Improve the documentation for #[tokio::test] ([#4761])
+- macros: Improve the documentation for `#[tokio::test]` ([#4761])
 
 [#5205]: https://github.com/tokio-rs/tokio/pull/5205
 [#5092]: https://github.com/tokio-rs/tokio/pull/5092

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -3,8 +3,8 @@ name = "tokio-macros"
 # When releasing to crates.io:
 # - Remove path dependencies
 # - Update CHANGELOG.md.
-# - Create "tokio-macros-1.0.x" git tag.
-version = "1.8.1"
+# - Create "tokio-macros-1.x.y" git tag.
+version = "1.8.2"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio"
 # - Update doc url
 #   - README.md
 # - Update CHANGELOG.md.
-# - Create "v1.0.x" git tag.
+# - Create "v1.x.y" git tag.
 version = "1.22.0"
 edition = "2018"
 rust-version = "1.49"


### PR DESCRIPTION
# 1.8.2 (November 30th, 2022)

- fix a regression introduced in 1.8.1 ([#5244])

[#5244]: https://github.com/tokio-rs/tokio/pull/5244