### PR TITLE
add note about (de)allocation strategy

### DIFF
--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -24,6 +24,15 @@ cfg_rt! {
     /// the Tokio runtime are always inside its context, but you can also enter the context
     /// using the [`Runtime::enter`](crate::runtime::Runtime::enter()) method.
     ///
+    /// # Note
+    ///
+    /// The default Rust allocator will not release the memory back to the OS upon
+    /// completion of tasks, under the assumption that memory with the same layout will be
+    /// requested requested in the future. This will lead to an ever-increasing memory
+    /// consumption that might causes crashes at runtime.
+    /// To avert this issue, an allocator that can be configured to release memory back to
+    /// the OS more consistently may be used, like [jemallocator](https://github.com/tikv/jemallocator).
+    ///
     /// # Examples
     ///
     /// In this example, a server is started and `spawn` is used to start a new task

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -28,8 +28,8 @@ cfg_rt! {
     ///
     /// The default Rust allocator will not release the memory back to the OS upon
     /// completion of tasks, under the assumption that memory with the same layout will be
-    /// requested requested in the future. This will lead to an ever-increasing memory
-    /// consumption that might causes crashes at runtime.
+    /// requested in the future. This will lead to an ever-increasing memory consumption
+    /// that might causes crashes at runtime.
     /// To avert this issue, an allocator that can be configured to release memory back to
     /// the OS more consistently may be used, like [jemallocator](https://github.com/tikv/jemallocator).
     ///


### PR DESCRIPTION
## Motivation

This change aims to help users of `tokio` to eventually work around the behaviour of the Rust's default allocator, that could otherwise be falsely interpreted as a memory leak, so as to save time & resources.

## Solution

This new document section for `tokio::task::spawn` briefly explains why programs might not behave as expected (from the programmer's point of view) concerning the deallocation of tasks, in such a way that is difficult to determine even using profiling tools. It also hints at a possible solution to this problem, that I have tested (though within a close-source project, but it is fairly easy to replicate).