### PR TITLE
rt: fix new yield_now behavior with block_in_place

### DIFF
--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -415,6 +415,32 @@ fn coop_and_block_in_place() {
     });
 }
 
+#[test]
+fn yield_after_block_in_place() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        tokio::spawn(async move {
+            // Block in place then enter a new runtime
+            tokio::task::block_in_place(|| {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .build()
+                    .unwrap();
+
+                rt.block_on(async {});
+            });
+
+            // Yield, then complete
+            tokio::task::yield_now().await;
+        })
+        .await
+        .unwrap()
+    });
+}
+
 // Testing this does not panic
 #[test]
 fn max_blocking_threads() {


### PR DESCRIPTION
PR #5223 changed the behavior of `yield_now()` to store yielded tasks and notify them *after* polling the resource drivers. This PR fixes two bugs with this new behavior when combined with `block_in_place()`.

First, we must avoid freeing the deferred task queue when exiting a runtime if it is *not* the root runtime. Because `block_in_place()` allows a user to start a new runtime from within an existing task, this check is necessary.

Second, when a worker core is stolen from a thread during a `block_in_place()` call, we need to ensure that deferred tasks are notified.
