### PR TITLE
chore: move conditional AtomicU64 impl to new file

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,4 +1,5 @@
 [build.env]
 passthrough = [
     "RUSTFLAGS",
+    "RUST_BACKTRACE",
 ]

--- a/tokio/src/loom/std/atomic_u64.rs
+++ b/tokio/src/loom/std/atomic_u64.rs
@@ -11,76 +11,8 @@ cfg_has_atomic_u64! {
 }
 
 cfg_not_has_atomic_u64! {
-    use crate::loom::sync::Mutex;
-    use std::sync::atomic::Ordering;
+    #[path = "atomic_u64_as_mutex.rs"]
+    mod atomic_u64_as_mutex;
 
-    #[derive(Debug)]
-    pub(crate) struct AtomicU64 {
-        inner: Mutex<u64>,
-    }
-
-    impl AtomicU64 {
-        pub(crate) fn new(val: u64) -> Self {
-            Self {
-                inner: Mutex::new(val),
-            }
-        }
-
-        pub(crate) fn load(&self, _: Ordering) -> u64 {
-            *self.inner.lock()
-        }
-
-        pub(crate) fn store(&self, val: u64, _: Ordering) {
-            *self.inner.lock() = val;
-        }
-
-        pub(crate) fn fetch_add(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.inner.lock();
-            let prev = *lock;
-            *lock = prev + val;
-            prev
-        }
-
-        pub(crate) fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
-            let mut lock = self.inner.lock();
-            let prev = *lock;
-            *lock = prev | val;
-            prev
-        }
-
-        pub(crate) fn compare_exchange(
-            &self,
-            current: u64,
-            new: u64,
-            _success: Ordering,
-            _failure: Ordering,
-        ) -> Result<u64, u64> {
-            let mut lock = self.inner.lock();
-
-            if *lock == current {
-                *lock = new;
-                Ok(current)
-            } else {
-                Err(*lock)
-            }
-        }
-
-        pub(crate) fn compare_exchange_weak(
-            &self,
-            current: u64,
-            new: u64,
-            success: Ordering,
-            failure: Ordering,
-        ) -> Result<u64, u64> {
-            self.compare_exchange(current, new, success, failure)
-        }
-    }
-
-    impl Default for AtomicU64 {
-        fn default() -> AtomicU64 {
-            Self {
-                inner: Mutex::new(0),
-            }
-        }
-    }
+    pub(crate) use atomic_u64_as_mutex::AtomicU64;
 }

--- a/tokio/src/loom/std/atomic_u64_as_mutex.rs
+++ b/tokio/src/loom/std/atomic_u64_as_mutex.rs
@@ -1,0 +1,70 @@
+use crate::loom::sync::Mutex;
+use std::sync::atomic::Ordering;
+
+#[derive(Debug)]
+pub(crate) struct AtomicU64 {
+    inner: Mutex<u64>,
+}
+
+impl AtomicU64 {
+    pub(crate) fn new(val: u64) -> Self {
+        Self {
+            inner: Mutex::new(val),
+        }
+    }
+
+    pub(crate) fn load(&self, _: Ordering) -> u64 {
+        *self.inner.lock()
+    }
+
+    pub(crate) fn store(&self, val: u64, _: Ordering) {
+        *self.inner.lock() = val;
+    }
+
+    pub(crate) fn fetch_add(&self, val: u64, _: Ordering) -> u64 {
+        let mut lock = self.inner.lock();
+        let prev = *lock;
+        *lock = prev + val;
+        prev
+    }
+
+    pub(crate) fn fetch_or(&self, val: u64, _: Ordering) -> u64 {
+        let mut lock = self.inner.lock();
+        let prev = *lock;
+        *lock = prev | val;
+        prev
+    }
+
+    pub(crate) fn compare_exchange(
+        &self,
+        current: u64,
+        new: u64,
+        _success: Ordering,
+        _failure: Ordering,
+    ) -> Result<u64, u64> {
+        let mut lock = self.inner.lock();
+
+        if *lock == current {
+            *lock = new;
+            Ok(current)
+        } else {
+            Err(*lock)
+        }
+    }
+
+    pub(crate) fn compare_exchange_weak(
+        &self,
+        current: u64,
+        new: u64,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<u64, u64> {
+        self.compare_exchange(current, new, success, failure)
+    }
+}
+
+impl Default for AtomicU64 {
+    fn default() -> AtomicU64 {
+        AtomicU64::new(u64::default())
+    }
+}


### PR DESCRIPTION
Keeping the implementation out of a macro lets rustfmt apply to it.

This is a really minor change. I made it as part of work that didn't end up panning out. I thought I would submit this change anyway.