### PR TITLE
Future-proof for FreeBSD 12

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -157,7 +157,7 @@ rand = "0.8.0"
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { version = "0.6.0", features = ["tokio"] }
+mio-aio = { version = "0.7.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.5.2", features = ["futures", "checkpoint"] }


### PR DESCRIPTION
Raise the mio-aio dev dependency, which transitively brings in Nix, to ensure that the tests will continue to compile if libc switches from a FreeBSD 11 ABI to a FreeBSD 12 one.

## Motivation

libc currently provides bindings for a FreeBSD 11 environment.  But someday it will switch to FreeBSD 12, which among other things changes `struct kevent`.  `mio-aio` 0.6 depending on `nix` 0.22, which was incompatible with the new `kevent`.  

## Solution

Raise it's version to fix that incompatibility.