### PR TITLE
Const new without parking_lot

### DIFF
--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -55,17 +55,17 @@ pub(crate) mod sync {
     // internal use. Note however that some are not _currently_ named by
     // consuming code.
 
-    #[cfg(feature = "parking_lot")]
+    #[cfg(all(feature = "parking_lot", tokio_no_const_mutex_new))]
     #[allow(unused_imports)]
     pub(crate) use crate::loom::std::parking_lot::{
         Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, WaitTimeoutResult,
     };
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(any(not(feature = "parking_lot"), not(tokio_no_const_mutex_new)))]
     #[allow(unused_imports)]
     pub(crate) use std::sync::{Condvar, MutexGuard, RwLock, RwLockReadGuard, WaitTimeoutResult};
 
-    #[cfg(not(feature = "parking_lot"))]
+    #[cfg(any(not(feature = "parking_lot"), not(tokio_no_const_mutex_new)))]
     pub(crate) use crate::loom::std::mutex::Mutex;
 
     pub(crate) mod atomic {

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -181,7 +181,10 @@ impl Semaphore {
     ///
     /// If the specified number of permits exceeds the maximum permit amount
     /// Then the value will get clamped to the maximum number of permits.
-    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test))))]
+    #[cfg(all(
+        any(feature = "parking_lot", not(tokio_no_const_mutex_new)),
+        not(all(loom, test))
+    ))]
     pub(crate) const fn const_new(mut permits: usize) -> Self {
         // NOTE: assertions and by extension panics are still being worked on: https://github.com/rust-lang/rust/issues/74925
         // currently we just clamp the permit count when it exceeds the max

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -181,7 +181,7 @@ impl Semaphore {
     ///
     /// If the specified number of permits exceeds the maximum permit amount
     /// Then the value will get clamped to the maximum number of permits.
-    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test))))]
     pub(crate) const fn const_new(mut permits: usize) -> Self {
         // NOTE: assertions and by extension panics are still being worked on: https://github.com/rust-lang/rust/issues/74925
         // currently we just clamp the permit count when it exceeds the max

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -299,8 +299,14 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// static LOCK: Mutex<i32> = Mutex::const_new(5);
     /// ```
-    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test)),))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new)))))]
+    #[cfg(all(
+        any(feature = "parking_lot", not(tokio_no_const_mutex_new)),
+        not(all(loom, test)),
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new))))
+    )]
     pub const fn const_new(t: T) -> Self
     where
         T: Sized,

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -299,8 +299,8 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// static LOCK: Mutex<i32> = Mutex::const_new(5);
     /// ```
-    #[cfg(all(feature = "parking_lot", not(all(loom, test)),))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test)),))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new)))))]
     pub const fn const_new(t: T) -> Self
     where
         T: Sized,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -336,8 +336,14 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// static LOCK: RwLock<i32> = RwLock::const_new(5);
     /// ```
-    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test))))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new)))))]
+    #[cfg(all(
+        any(feature = "parking_lot", not(tokio_no_const_mutex_new)),
+        not(all(loom, test))
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new))))
+    )]
     pub const fn const_new(value: T) -> RwLock<T>
     where
         T: Sized,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -336,8 +336,8 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// static LOCK: RwLock<i32> = RwLock::const_new(5);
     /// ```
-    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+    #[cfg(all(any(feature = "parking_lot", not(tokio_no_const_mutex_new)), not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "parking_lot", not(tokio_no_const_mutex_new)))))]
     pub const fn const_new(value: T) -> RwLock<T>
     where
         T: Sized,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

There's no need for `parking_lot` in Rust >= 1.63 for `const_new` Async[RwLock, Mutex], so this PR exposes `const_new` even without `parking_lot` if the compiler is new enough.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

When the compiler is new enough to support const mutexes the std mutexes are preferred over parking lot's in `loom`.

Tokio already has the flag `tokio_no_const_mutex_new` so this is used to detect const mutex support in std.

If either `parking_lot` or `not(tokio_no_const_mutex_new)`, then `const_new` is exposed. All of this of course requires the `sync` feature.
