### PR TITLE
Add note about current_thread + Handle::block_on

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -138,6 +138,9 @@ impl Runtime {
     /// The returned handle can be used to spawn tasks that run on this runtime, and can
     /// be cloned to allow moving the `Handle` to other threads.
     ///
+    /// Calling [`Handle::block_on`] on a handle to a `current_thread` runtime is error-prone.
+    /// Refer to the documentation of [`Handle::block_on`] for more.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
A friend ran into the `current_thread` + `Handle::block_on` IO-bound task issue today; I figured an additional note about it in the docs may be helpful.

There's already an existing warning about this combination in the documentation for `Handle::block_on`. This PR adds a warning in the docs for `Runtime::handle` and points to `Handle::block_on` for more info.

If this isn't something y'all are interested in, I would totally understand - I figured it doesn't take long to make a PR, so it's easier to discuss here :)