### PR TITLE
chore: update CI's clippy version to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2022-11-03
-  rust_clippy: 1.60.0
+  rust_clippy: 1.65.0
   # When updating this, also update:
   # - README.md
   # - tokio/README.md

--- a/tokio-macros/src/select.rs
+++ b/tokio-macros/src/select.rs
@@ -100,10 +100,10 @@ fn clean_pattern(pat: &mut syn::Pat) {
         }
         syn::Pat::Reference(reference) => {
             reference.mutability = None;
-            clean_pattern(&mut *reference.pat);
+            clean_pattern(&mut reference.pat);
         }
         syn::Pat::Type(type_pat) => {
-            clean_pattern(&mut *type_pat.pat);
+            clean_pattern(&mut type_pat.pat);
         }
         _ => {}
     }

--- a/tokio-stream/src/stream_ext/then.rs
+++ b/tokio-stream/src/stream_ext/then.rs
@@ -72,7 +72,7 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let future_len = if self.future.is_some() { 1 } else { 0 };
+        let future_len = usize::from(self.future.is_some());
         let (lower, upper) = self.stream.size_hint();
 
         let lower = lower.saturating_add(future_len);

--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -166,6 +166,6 @@ impl fmt::Debug for PollSemaphore {
 
 impl AsRef<Semaphore> for PollSemaphore {
     fn as_ref(&self) -> &Semaphore {
-        &*self.semaphore
+        &self.semaphore
     }
 }

--- a/tokio-util/tests/spawn_pinned.rs
+++ b/tokio-util/tests/spawn_pinned.rs
@@ -82,8 +82,8 @@ async fn task_panic_propagates() {
     assert!(result.is_err());
     let error = result.unwrap_err();
     assert!(error.is_panic());
-    let panic_str: &str = error.into_panic().downcast().unwrap();
-    assert_eq!(panic_str, "Test panic");
+    let panic_str = error.into_panic().downcast::<&'static str>().unwrap();
+    assert_eq!(*panic_str, "Test panic");
 
     // Trying again with a "safe" task still works
     let join_handle = pool.spawn_pinned(|| async { "test" });
@@ -108,8 +108,8 @@ async fn callback_panic_does_not_kill_worker() {
     assert!(result.is_err());
     let error = result.unwrap_err();
     assert!(error.is_panic());
-    let panic_str: &str = error.into_panic().downcast().unwrap();
-    assert_eq!(panic_str, "Test panic");
+    let panic_str = error.into_panic().downcast::<&'static str>().unwrap();
+    assert_eq!(*panic_str, "Test panic");
 
     // Trying again with a "safe" callback works
     let join_handle = pool.spawn_pinned(|| async { "test" });

--- a/tokio-util/tests/spawn_pinned.rs
+++ b/tokio-util/tests/spawn_pinned.rs
@@ -82,7 +82,7 @@ async fn task_panic_propagates() {
     assert!(result.is_err());
     let error = result.unwrap_err();
     assert!(error.is_panic());
-    let panic_str: &str = *error.into_panic().downcast().unwrap();
+    let panic_str: &str = error.into_panic().downcast().unwrap();
     assert_eq!(panic_str, "Test panic");
 
     // Trying again with a "safe" task still works
@@ -108,7 +108,7 @@ async fn callback_panic_does_not_kill_worker() {
     assert!(result.is_err());
     let error = result.unwrap_err();
     assert!(error.is_panic());
-    let panic_str: &str = *error.into_panic().downcast().unwrap();
+    let panic_str: &str = error.into_panic().downcast().unwrap();
     assert_eq!(panic_str, "Test panic");
 
     // Trying again with a "safe" callback works

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::disallowed_names)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/src/io/util/read.rs
+++ b/tokio/src/io/util/read.rs
@@ -48,7 +48,7 @@ where
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let me = self.project();
-        let mut buf = ReadBuf::new(*me.buf);
+        let mut buf = ReadBuf::new(me.buf);
         ready!(Pin::new(me.reader).poll_read(cx, &mut buf))?;
         Poll::Ready(Ok(buf.filled().len()))
     }

--- a/tokio/src/net/tcp/split_owned.rs
+++ b/tokio/src/net/tcp/split_owned.rs
@@ -490,12 +490,12 @@ impl AsyncWrite for OwnedWriteHalf {
 
 impl AsRef<TcpStream> for OwnedReadHalf {
     fn as_ref(&self) -> &TcpStream {
-        &*self.inner
+        &self.inner
     }
 }
 
 impl AsRef<TcpStream> for OwnedWriteHalf {
     fn as_ref(&self) -> &TcpStream {
-        &*self.inner
+        &self.inner
     }
 }

--- a/tokio/src/net/unix/split_owned.rs
+++ b/tokio/src/net/unix/split_owned.rs
@@ -398,12 +398,12 @@ impl AsyncWrite for OwnedWriteHalf {
 
 impl AsRef<UnixStream> for OwnedReadHalf {
     fn as_ref(&self) -> &UnixStream {
-        &*self.inner
+        &self.inner
     }
 }
 
 impl AsRef<UnixStream> for OwnedWriteHalf {
     fn as_ref(&self) -> &UnixStream {
-        &*self.inner
+        &self.inner
     }
 }

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -263,7 +263,7 @@ impl<T> Local<T> {
         // safety: The CAS above ensures that no consumer will look at these
         // values again, and we are the only producer.
         let batch_iter = BatchTaskIter {
-            buffer: &*self.inner.buffer,
+            buffer: &self.inner.buffer,
             head: head as UnsignedLong,
             i: 0,
         };

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -194,7 +194,7 @@ where
             TransitionToRunning::Success => {
                 let header_ptr = self.header_ptr();
                 let waker_ref = waker_ref::<T, S>(&header_ptr);
-                let cx = Context::from_waker(&*waker_ref);
+                let cx = Context::from_waker(&waker_ref);
                 let res = poll_future(self.core(), cx);
 
                 if res == Poll::Ready(()) {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -357,7 +357,7 @@ impl Sleep {
     fn reset_inner(self: Pin<&mut Self>, deadline: Instant) {
         let mut me = self.project();
         me.entry.as_mut().reset(deadline);
-        (*me.inner).deadline = deadline;
+        (me.inner).deadline = deadline;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         {

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -126,7 +126,7 @@ impl<L: Link> LinkedList<L, L::Target> {
     pub(crate) fn push_front(&mut self, val: L::Handle) {
         // The value should not be dropped, it is being inserted into the list
         let val = ManuallyDrop::new(val);
-        let ptr = L::as_raw(&*val);
+        let ptr = L::as_raw(&val);
         assert_ne!(self.head, Some(ptr));
         unsafe {
             L::pointers(ptr).as_mut().set_next(self.head);

--- a/tokio/tests/buffered.rs
+++ b/tokio/tests/buffered.rs
@@ -18,10 +18,10 @@ async fn echo_server() {
     let msg = "foo bar baz";
 
     let t = thread::spawn(move || {
-        let mut s = assert_ok!(TcpStream::connect(&addr));
+        let mut s = assert_ok!(TcpStream::connect(addr));
 
         let t2 = thread::spawn(move || {
-            let mut s = assert_ok!(TcpStream::connect(&addr));
+            let mut s = assert_ok!(TcpStream::connect(addr));
             let mut b = vec![0; msg.len() * N];
             assert_ok!(s.read_exact(&mut b));
             b

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -80,7 +80,7 @@ fn test_drop_on_notify() {
     drop(task);
 
     // Establish a connection to the acceptor
-    let _s = TcpStream::connect(&addr).unwrap();
+    let _s = TcpStream::connect(addr).unwrap();
 
     // Force the reactor to turn
     rt.block_on(async {});

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "macros")]
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::disallowed_names)]
 use std::sync::Arc;
 
 #[cfg(tokio_wasm_not_wasi)]

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "macros")]
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::disallowed_names)]
 
 #[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "macros")]
-#![allow(clippy::blacklisted_name)]
+#![allow(clippy::disallowed_names)]
 
 use std::sync::Arc;
 

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -661,7 +661,7 @@ rt_test! {
                 loop {
                     // Don't use Tokio's `yield_now()` to avoid special defer
                     // logic.
-                    let _: () = futures::future::poll_fn(|cx| {
+                    futures::future::poll_fn::<(), _>(|cx| {
                         cx.waker().wake_by_ref();
                         std::task::Poll::Pending
                     }).await;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -15,7 +15,7 @@ async fn peek() {
     let addr = listener.local_addr().unwrap();
     let t = thread::spawn(move || assert_ok!(listener.accept()).0);
 
-    let left = net::TcpStream::connect(&addr).unwrap();
+    let left = net::TcpStream::connect(addr).unwrap();
     let mut right = t.join().unwrap();
     let _ = right.write(&[1, 2, 3, 4]).unwrap();
 


### PR DESCRIPTION
We hardcode the Rust version used in CI to run clippy. This PR bumps it to the latest stable.