### PR TITLE
tokio-util: Remove Encoder bound on FramedParts constructor

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -368,10 +368,7 @@ pub struct FramedParts<T, U> {
 
 impl<T, U> FramedParts<T, U> {
     /// Create a new, default, `FramedParts`
-    pub fn new<I>(io: T, codec: U) -> FramedParts<T, U>
-    where
-        U: Encoder<I>,
-    {
+    pub fn new(io: T, codec: U) -> FramedParts<T, U> {
         FramedParts {
             io,
             codec,


### PR DESCRIPTION
## Motivation

I cannot construct `FramedParts` in order to construct `Framed` if my codec doesn't implement `Encoder<I>` for some `I`, despite the fact that I can create a `Framed` for the same codec, and it will simply not implement `Sink`.

## Solution

Remove the bound.