### PR TITLE
Change flags for having an atomic u64

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -467,14 +467,7 @@ macro_rules! cfg_has_atomic_u64 {
             ))]
             #[cfg_attr(
                 tokio_no_target_has_atomic,
-                cfg(not(any(
-                    target_arch = "arm",
-                    target_arch = "mips",
-                    target_arch = "powerpc",
-                    target_arch = "riscv32",
-                    tokio_wasm,
-                    tokio_no_atomic_u64,
-                )))
+                cfg(not(tokio_no_atomic_u64))
             )]
             $item
         )*
@@ -490,14 +483,7 @@ macro_rules! cfg_not_has_atomic_u64 {
             ))]
             #[cfg_attr(
                 tokio_no_target_has_atomic,
-                cfg(any(
-                    target_arch = "arm",
-                    target_arch = "mips",
-                    target_arch = "powerpc",
-                    target_arch = "riscv32",
-                    tokio_wasm,
-                    tokio_no_atomic_u64,
-                ))
+                cfg(tokio_no_atomic_u64)
             )]
             $item
         )*

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -461,14 +461,21 @@ macro_rules! cfg_not_coop {
 macro_rules! cfg_has_atomic_u64 {
     ($($item:item)*) => {
         $(
-            #[cfg(not(any(
-                target_arch = "arm",
-                target_arch = "mips",
-                target_arch = "powerpc",
-                target_arch = "riscv32",
-                tokio_wasm,
-                tokio_no_atomic_u64,
-            )))]
+            #[cfg_attr(
+                not(tokio_no_target_has_atomic),
+                cfg(all(target_has_atomic = "64", not(tokio_no_atomic_u64))
+            ))]
+            #[cfg_attr(
+                tokio_no_target_has_atomic,
+                cfg(not(any(
+                    target_arch = "arm",
+                    target_arch = "mips",
+                    target_arch = "powerpc",
+                    target_arch = "riscv32",
+                    tokio_wasm,
+                    tokio_no_atomic_u64,
+                )))
+            )]
             $item
         )*
     }
@@ -477,14 +484,21 @@ macro_rules! cfg_has_atomic_u64 {
 macro_rules! cfg_not_has_atomic_u64 {
     ($($item:item)*) => {
         $(
-            #[cfg(any(
-                target_arch = "arm",
-                target_arch = "mips",
-                target_arch = "powerpc",
-                target_arch = "riscv32",
-                tokio_wasm,
-                tokio_no_atomic_u64,
+            #[cfg_attr(
+                not(tokio_no_target_has_atomic),
+                cfg(any(not(target_has_atomic = "64"), tokio_no_atomic_u64)
             ))]
+            #[cfg_attr(
+                tokio_no_target_has_atomic,
+                cfg(any(
+                    target_arch = "arm",
+                    target_arch = "mips",
+                    target_arch = "powerpc",
+                    target_arch = "riscv32",
+                    tokio_wasm,
+                    tokio_no_atomic_u64,
+                ))
+            )]
             $item
         )*
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

See [this comment](https://github.com/tokio-rs/tokio/pull/5282#issuecomment-1345448329). 

## Solution

The aim of this PR is to use the `target_has_atomic` feature on Rust 1.60, in order to avoid using a less efficient strategy (e.g. mutexes) on platforms that do actually have atomic U64. It changes the `cfg_(not_)has_atomic_u64` to incorporate `target_has_atomic = "64"` based on a build flag.
