### PR TITLE
remove frequent global is_shutdown flag check on io operations

### DIFF
--- a/tokio/docs/reactor-refactor.md
+++ b/tokio/docs/reactor-refactor.md
@@ -188,12 +188,12 @@ readiness, the driver's tick is packed into the atomic `usize`.
 The `ScheduledIo` readiness `AtomicUsize` is structured as:
 
 ```
-| reserved | generation |  driver tick | readiness |
+| shutdown | generation |  driver tick | readiness |
 |----------+------------+--------------+-----------|
 |   1 bit  |   7 bits   +    8 bits    +  16 bits  |
 ```
 
-The `reserved` and `generation` components exist today.
+The `shutdown` and `generation` components exist today.
 
 The `readiness()` function returns a `ReadyEvent` value. This value includes the
 `tick` component read with the resource's readiness value. When

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -226,15 +226,7 @@ fn gone() -> io::Error {
 cfg_io_readiness! {
     impl Registration {
         pub(crate) async fn readiness(&self, interest: Interest) -> io::Result<ReadyEvent> {
-            use std::future::Future;
-            use std::pin::Pin;
-
-            let fut = self.shared.readiness(interest);
-            pin!(fut);
-
-            let ev = crate::future::poll_fn(|cx| {
-                Pin::new(&mut fut).poll(cx)
-            }).await;
+            let ev = self.shared.readiness(interest).await;
 
             if ev.is_shutdown {
                 return Err(gone())


### PR DESCRIPTION
The global flag is still remaining, and used to prevent duplicated shutdown and new io operations after shutdown.

On shutdown, the driver flip the shutdown flag of every pending io operations and wake them to fail with shutdown error.

Fixes: #5227

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I was load testing my tokio based RTMP ingestion server by attaching ffmpeg publishers each emits 4Mbps TCP traffic on AWS c5.4xlarge 16vcpu instance. With 100 publishers its CPU usage is about 7%. With 1k publishers(4Gbps) it's full 100%. Below is a flamegraph I've take from the scenario.

<img width="1629" alt="flamegraph before" src="https://user-images.githubusercontent.com/11769971/208227432-6f8d3302-9082-44cd-8582-86c077e72069.png">

Here's a flamegraph from same 1k scenario after applying this PR. Its CPU usage is about 80%.

<img width="1629" alt="flamegraph after" src="https://user-images.githubusercontent.com/11769971/208227565-77a7125e-3ab2-48a5-831c-09c2cab0b4da.png">


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

It's an implementation of @carllerche's [suggestion](https://github.com/tokio-rs/tokio/issues/5227#issuecomment-1337758117) from the issue. The global flag still exist but it's only checked on allocating IO handle, in which case you need to lock the IO driver anyway.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
