### PR TITLE
remove frequent global is_shutdown flag check on timer operations

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -126,7 +126,7 @@ impl StateCell {
     fn when(&self) -> Option<u64> {
         let cur_state = self.state.load(Ordering::Relaxed);
 
-        if cur_state == u64::MAX {
+        if cur_state >= STATE_MIN_VALUE {
             None
         } else {
             Some(cur_state)
@@ -563,10 +563,6 @@ impl TimerEntry {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), super::Error>> {
-        if self.driver().is_shutdown() {
-            panic!("{}", crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
-        }
-
         if let Some(deadline) = self.initial_deadline {
             self.as_mut().reset(deadline);
         }

--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -13,11 +13,6 @@ impl Handle {
         &self.time_source
     }
 
-    /// Checks whether the driver has been shutdown.
-    pub(super) fn is_shutdown(&self) -> bool {
-        self.inner.is_shutdown()
-    }
-
     /// Track that the driver is being unparked
     pub(crate) fn unpark(&self) {
         #[cfg(feature = "test-util")]

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -18,6 +18,7 @@ pub(crate) use source::TimeSource;
 
 mod wheel;
 
+#[cfg(feature = "test-util")]
 use crate::loom::sync::atomic::{AtomicBool, Ordering};
 use crate::loom::sync::Mutex;
 use crate::runtime::driver::{self, IoHandle, IoStack};

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -67,7 +67,7 @@ fn single_timer() {
         // This may or may not return Some (depending on how it races with the
         // thread). If it does return None, however, the timer should complete
         // synchronously.
-        handle.process_at_time(handle.time_source().now() + 2_000_000_000);
+        handle.process_at_time(Some(handle.time_source().now() + 2_000_000_000));
 
         jh.join().unwrap();
     })
@@ -100,7 +100,7 @@ fn drop_timer() {
         let handle = handle.inner.driver().time();
 
         // advance 2s in the future.
-        handle.process_at_time(handle.time_source().now() + 2_000_000_000);
+        handle.process_at_time(Some(handle.time_source().now() + 2_000_000_000));
 
         jh.join().unwrap();
     })
@@ -135,7 +135,7 @@ fn change_waker() {
         let handle = handle.inner.driver().time();
 
         // advance 2s
-        handle.process_at_time(handle.time_source().now() + 2_000_000_000);
+        handle.process_at_time(Some(handle.time_source().now() + 2_000_000_000));
 
         jh.join().unwrap();
     })
@@ -177,19 +177,19 @@ fn reset_future() {
         let handle = handle.inner.driver().time();
 
         // This may or may not return a wakeup time.
-        handle.process_at_time(
+        handle.process_at_time(Some(
             handle
                 .time_source()
                 .instant_to_tick(start + Duration::from_millis(1500)),
-        );
+        ));
 
         assert!(!finished_early.load(Ordering::Relaxed));
 
-        handle.process_at_time(
+        handle.process_at_time(Some(
             handle
                 .time_source()
                 .instant_to_tick(start + Duration::from_millis(2500)),
-        );
+        ));
 
         jh.join().unwrap();
 
@@ -228,7 +228,7 @@ fn poll_process_levels() {
     }
 
     for t in 1..normal_or_miri(1024, 64) {
-        handle.inner.driver().time().process_at_time(t as u64);
+        handle.inner.driver().time().process_at_time(Some(t as u64));
 
         for (deadline, future) in entries.iter_mut().enumerate() {
             let mut context = Context::from_waker(noop_waker_ref());
@@ -257,8 +257,8 @@ fn poll_process_levels_targeted() {
 
     let handle = handle.inner.driver().time();
 
-    handle.process_at_time(62);
+    handle.process_at_time(Some(62));
     assert!(e1.as_mut().poll_elapsed(&mut context).is_pending());
-    handle.process_at_time(192);
-    handle.process_at_time(192);
+    handle.process_at_time(Some(192));
+    handle.process_at_time(Some(192));
 }

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -92,7 +92,7 @@ impl fmt::Display for Error {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::Kind::*;
         let descr = match self.0 {
-            Shutdown => "the timer is shutdown, must be called from the context of Tokio runtime",
+            Shutdown => crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR,
             AtCapacity => "timer is at capacity and cannot create a new entry",
             Invalid => "timer duration exceeds maximum duration",
         };


### PR DESCRIPTION
Make timer driver's is_shutdown flag nonatomic and move it into the driver lock. On shtudown, the driver wake the all pending timer with shutdown error.

Simillar to the #5300, but for timer driver not io driver.

Refs: #5227, #5300

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The idea is based on @carllerche's [suggestion](https://github.com/tokio-rs/tokio/issues/5227#issuecomment-1337758117), and @Darksonn mentioned that the timer driver has a similar issue.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

It's virtually same change with #5300 but for this case the flag was already an atomic flag so I'm not sure how much perf improvement it actually brings. I think it's worth on its own having same structure between timer and io drivers though. I tried to reuse benchmark I've used for #5300 by wrapping each tasks with `select!{biased; _ = sleep(1h)` but it doesn't show any noticeable difference, which is not surprising as it's comparing atomic loads with (nonblocking) IO. 

Edit: "I believe it's worth" -> "I think it's worth" since "believe" sounds too strong. At this point This PR is more like refactoring than optimization.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
