### PR TITLE
signal: remove redundant Pin around globals

### DIFF
--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -5,7 +5,6 @@ use crate::sync::watch;
 use crate::util::once_cell::OnceCell;
 
 use std::ops;
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 pub(crate) type EventId = usize;
@@ -162,14 +161,14 @@ where
     }
 }
 
-pub(crate) fn globals() -> Pin<&'static Globals>
+pub(crate) fn globals() -> &'static Globals
 where
     OsExtraData: 'static + Send + Sync + Init,
     OsStorage: 'static + Send + Sync + Init,
 {
     static GLOBALS: OnceCell<Globals> = OnceCell::new();
 
-    Pin::new(GLOBALS.get(globals_init))
+    GLOBALS.get(globals_init)
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -14,7 +14,6 @@ use crate::sync::watch;
 
 use mio::net::UnixStream;
 use std::io::{self, Error, ErrorKind, Write};
-use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::task::{Context, Poll};
@@ -240,7 +239,7 @@ impl Default for SignalInfo {
 /// 2. Wake up the driver by writing a byte to a pipe
 ///
 /// Those two operations should both be async-signal safe.
-fn action(globals: Pin<&'static Globals>, signal: libc::c_int) {
+fn action(globals: &'static Globals, signal: libc::c_int) {
     globals.record_event(signal as EventId);
 
     // Send a wakeup, ignore any errors (anything reasonably possible is


### PR DESCRIPTION
Not sure why it's here in the first place, but it doesn't do anything since `Globals` is `Unpin`.