### PR TITLE
notify: make sequential notify_one calls behave like a single call.

### DIFF
--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -225,3 +225,17 @@ fn test_waker_update() {
 
     assert!(future.is_woken());
 }
+
+#[test]
+fn test_two_notify_one_after_poll() {
+    let notify = Notify::new();
+    let mut future = spawn(notify.notified());
+    assert_pending!(future.poll());
+
+    notify.notify_one();
+    notify.notify_one();
+
+    assert_ready!(future.poll());
+    let mut future = spawn(notify.notified());
+    assert_pending!(future.poll());
+}


### PR DESCRIPTION
## Motivation

According to the docs `notify_one()` sets a permit if there currently are no available permits and the permit should be consumed only by `notified().await`.
Before this commit, if only a single `notified().await` was called before `notify_one()`, then `notify_one()` consumed its own permit by setting the state to EMPTY. A subsequent call to `notify_one()` would then set a new permit even though the previous permit was not yet consumed by the `notified().await`.

## Solution

This commit solves the issue by transferring the responsibility of setting the state to EMPTY to the notified instead of the notifier.

Made together with @nihohit