### PR TITLE
chore: fix typo in `process::imp::Pipe` comment

### DIFF
--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -156,7 +156,7 @@ impl Future for Child {
 
 #[derive(Debug)]
 pub(crate) struct Pipe {
-    // Actually a pipe and not a File. However, we are reusing `File` to get
+    // Actually a pipe is not a File. However, we are reusing `File` to get
     // close on drop. This is a similar trick as `mio`.
     fd: File,
 }


### PR DESCRIPTION
"Actually a pipe __and__ not a File."  -> "Actually a pipe __is__ not a File."

Signed-off-by: Changyuan Lyu <changyuanl@google.com>