### PR TITLE
ci: remove uses of unmaintained actions-rs actions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,15 +15,16 @@ permissions:
 jobs:
   security-audit:
     permissions:
-      checks: write  # for actions-rs/audit-check to create check
+      checks: write  # for rustsec/audit-check to create check
       contents: read  # for actions/checkout to fetch code
-      issues: write  # for actions-rs/audit-check to create issues
+      issues: write  # for rustsec/audit-check to create issues
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
       - uses: actions/checkout@v3
 
       - name: Audit Check
-        uses: actions-rs/audit-check@v1
+        # https://github.com/rustsec/audit-check/issues/2
+        uses: rustsec/audit-check@master
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,10 +73,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - name: Install Rust
         run: rustup update stable
       - uses: Swatinem/rust-cache@v1
@@ -123,10 +122,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - uses: Swatinem/rust-cache@v1
       - name: Enable parking_lot send_guard feature
         # Inserts the line "plsend = ["parking_lot/send_guard"]" right after [features]
@@ -140,10 +138,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - uses: Swatinem/rust-cache@v1
 
       - name: Install Valgrind
@@ -179,10 +176,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - uses: Swatinem/rust-cache@v1
       # Run `tokio` with "unstable" cfg flag.
       - name: test tokio full --cfg unstable
@@ -200,11 +196,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
           components: miri
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: miri
         # Many of tests in tokio/tests and doctests use #[tokio::test] or
@@ -224,10 +219,9 @@ jobs:
         # Required to resolve symbols in sanitizer output
         run: sudo apt-get install -y llvm
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: asan
         run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --tests -- --test-threads 1
@@ -250,16 +244,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
           target: ${{ matrix.target }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: check
-          args: --workspace --all-features --target ${{ matrix.target }}
+      - name: Install cross
+        uses: taiki-e/install-action@cross
+      - run: cross check --workspace --all-features --target ${{ matrix.target }}
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
@@ -280,28 +271,21 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust stable
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
           target: ${{ matrix.target }}
-          override: true
+      - name: Install cross
+        uses: taiki-e/install-action@cross
       # First run with all features (including parking_lot)
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: -p tokio --all-features --target ${{ matrix.target }} --tests
+      - run: cross test -p tokio --all-features --target ${{ matrix.target }} --tests
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 ${{ matrix.rustflags }}
       # Now run without parking_lot
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          # The `tokio_no_parking_lot` cfg is here to ensure the `sed` above does not silently break.
-          args: -p tokio --features full,test-util --target ${{ matrix.target }} --tests
+      # The `tokio_no_parking_lot` cfg is here to ensure the `sed` above does not silently break.
+      - run: cross test -p tokio --features full,test-util --target ${{ matrix.target }} --tests
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 --cfg tokio_no_parking_lot ${{ matrix.rustflags }}
 
@@ -312,11 +296,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
           components: rust-src
-          override: true
       # Install linker and libraries for i686-unknown-linux-gnu
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
@@ -331,11 +314,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
           target: ${{ matrix.target }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -353,10 +335,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_min }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_min }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       # First compile just the main tokio crate with minrust and newest version
       # of all dependencies, then pin once_cell and compile the rest of the
@@ -378,10 +359,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
@@ -410,10 +390,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
-          override: true
           components: rustfmt
       - uses: Swatinem/rust-cache@v1
       # Check fmt
@@ -431,10 +410,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_clippy }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_clippy }}
-          override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1
       # Run clippy
@@ -447,10 +425,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: "doc --lib --all-features"
         run: cargo doc --lib --no-deps --all-features --document-private-items
@@ -464,10 +441,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: build --cfg loom
         run: cargo test --no-run --lib --features full
@@ -499,10 +475,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Test hyper
         run: |
@@ -527,11 +502,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_nightly }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
           target: x86_64-fortanix-unknown-sgx
-          override: true
       - uses: Swatinem/rust-cache@v1
       # NOTE: Currently the only test we can run is to build tokio with rt and sync features.
       - name: build tokio
@@ -544,10 +518,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -561,10 +534,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_stable }}
-          override: true
       - uses: Swatinem/rust-cache@v1
 
       # Install dependencies
@@ -614,12 +586,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust nightly-2022-07-25
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           # `check-external-types` requires a specific Rust nightly version. See
           # the README for details: https://github.com/awslabs/cargo-check-external-types
           toolchain: nightly-2022-07-25
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: check-external-types
         run: |

--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -34,10 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - uses: Swatinem/rust-cache@v1
       - name: loom ${{ matrix.scope }}
         run: cargo test --lib --release --features full -- --nocapture $SCOPE

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -19,17 +19,10 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install cargo-audit
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-audit
+        run: cargo install cargo-audit
 
       - name: Generate lockfile
-        uses: actions-rs/cargo@v1
-        with:
-          command: generate-lockfile
+        run: cargo generate-lockfile
 
       - name: Audit dependencies
-        uses: actions-rs/cargo@v1
-        with:
-          command: audit
+        run: cargo audit

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -25,10 +25,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ env.rust_stable }}
-            override: true
       - uses: Swatinem/rust-cache@v1
       - name: Install Valgrind
         uses: taiki-e/install-action@valgrind


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

actions-rs actions are not maintained and will not be available in the future due to the use of node12.
https://github.com/actions-rs/toolchain/issues/216
https://old.reddit.com/r/rust/comments/vyx4oj/actionsrs_organization_became_unmaintained/ig54zv7/

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead of actions-rs/toolchain
- Use cargo/cross directly instead of actions-rs/cargo
- Use [rustsec/audit-check](https://github.com/rustsec/audit-check) (fork of actions-rs/audit-check) instead of actions-rs/audit-check

Also use [taiki-e/install-action](https://github.com/taiki-e/install-action) for installation of cross to avoid https://github.com/cross-rs/cross/issues/1177 and reduce CI time. (we already use this action for installations such as cargo-hack, wasmtime, valgrind)

Closes #5315