### PR TITLE
chore: test more features with Miri

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
   image_family: freebsd-12-4
 env:
   RUST_STABLE: stable
-  RUST_NIGHTLY: nightly-2022-12-27
+  RUST_NIGHTLY: nightly-2023-02-13
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_instance:
   image: freebsd-12-4-release-amd64
 env:
   RUST_STABLE: stable
-  RUST_NIGHTLY: nightly-2022-10-25
+  RUST_NIGHTLY: nightly-2022-12-27
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,11 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
           components: miri
       - uses: Swatinem/rust-cache@v2
+      - run: |
+          echo '[patch.crates-io]' >>Cargo.toml
+          echo 'parking_lot_core = { git = "https://github.com/taiki-e/parking_lot.git", branch = "strict-provenance" }' >>Cargo.toml
+          git diff
+          cargo update
       - name: miri
         # Ignore doctest because many features don't work with Miri yet.
         run: cargo miri test --features full --no-fail-fast --tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
           components: miri
       - uses: Swatinem/rust-cache@v2
       - name: miri
-        run: cargo miri test --features full --no-fail-fast
+        run: cargo miri test --features full --no-fail-fast --tests
         working-directory: tokio
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-retag-fields

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,9 +202,7 @@ jobs:
           components: miri
       - uses: Swatinem/rust-cache@v2
       - name: miri
-        # Many of tests in tokio/tests and doctests use #[tokio::test] or
-        # #[tokio::main] that calls epoll_create1 that Miri does not support.
-        run: cargo miri test --features full --lib --no-fail-fast
+        run: cargo miri test --features full --no-fail-fast
         working-directory: tokio
         env:
           MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-retag-fields

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-12-27
+  rust_nightly: nightly-2023-02-13
   rust_clippy: 1.65.0
   # When updating this, also update:
   # - README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
           components: miri
       - uses: Swatinem/rust-cache@v2
       - name: miri
+        # Ignore doctest because many features don't work with Miri yet.
         run: cargo miri test --features full --no-fail-fast --tests
         working-directory: tokio
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2022-11-03
+  rust_nightly: nightly-2022-12-27
   rust_clippy: 1.65.0
   # When updating this, also update:
   # - README.md

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -291,7 +291,6 @@ pub(crate) mod test {
         drop(signal_guard);
     }
 
-    #[cfg_attr(miri, ignore)] // Miri does not support epoll.
     #[test]
     fn does_not_register_signal_if_queue_empty() {
         let (io_driver, io_handle) = IoDriver::new(1024).unwrap();

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -292,6 +292,7 @@ pub(crate) mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri doesn't support sigaction
     fn does_not_register_signal_if_queue_empty() {
         let (io_driver, io_handle) = IoDriver::new(1024).unwrap();
         let signal_driver = SignalDriver::new(io_driver, &io_handle).unwrap();

--- a/tokio/tests/buffered.rs
+++ b/tokio/tests/buffered.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind()
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::TcpListener;
 use tokio_test::assert_ok;

--- a/tokio/tests/fs.rs
+++ b/tokio/tests/fs.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::fs;
 use tokio_test::assert_ok;

--- a/tokio/tests/fs_copy.rs
+++ b/tokio/tests/fs_copy.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tempfile::tempdir;
 use tokio::fs;

--- a/tokio/tests/fs_dir.rs
+++ b/tokio/tests/fs_dir.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support directory operations
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::fs;
 use tokio_test::{assert_err, assert_ok};

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
-#![cfg(not(miri))] // Miri doesn't support opening file with non-default mode (inside NamedTempFile::new)
+#![cfg(not(miri))] // Miri doesn't support creating file with non-default mode (inside NamedTempFile::new): https://github.com/rust-lang/miri/pull/2720
 
 use std::io::prelude::*;
 use tempfile::NamedTempFile;

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
+#![cfg(not(miri))] // Miri doesn't support opening file with non-default mode (inside NamedTempFile::new)
 
 use std::io::prelude::*;
 use tempfile::NamedTempFile;

--- a/tokio/tests/fs_link.rs
+++ b/tokio/tests/fs_link.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::fs;
 

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(unix, feature = "full"))]
+#![cfg(not(miri))] // Miri doesn't support 0x3 command for fcntl
 
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{

--- a/tokio/tests/io_buf_reader.rs
+++ b/tokio/tests/io_buf_reader.rs
@@ -223,6 +223,7 @@ async fn test_short_reads() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending() {
     let inner: &[u8] = &[5, 6, 7, 0, 1, 2, 3, 4];
     let mut reader = BufReader::with_capacity(2, MaybePending::new(inner));
@@ -260,6 +261,7 @@ async fn maybe_pending() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending_buf_read() {
     let inner = MaybePending::new(&[0, 1, 2, 3, 1, 0]);
     let mut reader = BufReader::with_capacity(2, inner);
@@ -279,6 +281,7 @@ async fn maybe_pending_buf_read() {
 
 // https://github.com/rust-lang/futures-rs/pull/1573#discussion_r281162309
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending_seek() {
     struct MaybePendingSeek<'a> {
         inner: Cursor<&'a [u8]>,

--- a/tokio/tests/io_buf_writer.rs
+++ b/tokio/tests/io_buf_writer.rs
@@ -132,6 +132,7 @@ async fn buf_writer_seek() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending_buf_writer() {
     let mut writer = BufWriter::with_capacity(2, MaybePending::new(Vec::new()));
 
@@ -180,6 +181,7 @@ async fn maybe_pending_buf_writer() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending_buf_writer_inner_flushes() {
     let mut w = BufWriter::with_capacity(3, MaybePending::new(Vec::new()));
     assert_eq!(w.write(&[0, 1]).await.unwrap(), 2);
@@ -190,6 +192,7 @@ async fn maybe_pending_buf_writer_inner_flushes() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn maybe_pending_buf_writer_seek() {
     struct MaybePendingSeek {
         inner: Cursor<Vec<u8>>,

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -38,6 +38,7 @@ async fn copy() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn proxy() {
     struct BufferedWd {
         buf: BytesMut,

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind()
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::time::Duration;
 use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 // Wasi does not support panic recovery or threading
 #![cfg(all(feature = "full", not(tokio_wasi)))]
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::TcpListener;
 use tokio::runtime;

--- a/tokio/tests/io_fill_buf.rs
+++ b/tokio/tests/io_fill_buf.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
-#![cfg(not(miri))] // Miri doesn't support opening file with non-default mode (inside NamedTempFile::new)
+#![cfg(not(miri))] // Miri doesn't support creating file with non-default mode (inside NamedTempFile::new): https://github.com/rust-lang/miri/pull/2720
 
 use tempfile::NamedTempFile;
 use tokio::fs::File;

--- a/tokio/tests/io_fill_buf.rs
+++ b/tokio/tests/io_fill_buf.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support file operations
+#![cfg(not(miri))] // Miri doesn't support opening file with non-default mode (inside NamedTempFile::new)
 
 use tempfile::NamedTempFile;
 use tokio::fs::File;

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
 

--- a/tokio/tests/io_util_empty.rs
+++ b/tokio/tests/io_util_empty.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "full")]
+
 use tokio::io::{AsyncBufReadExt, AsyncReadExt};
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn empty_read_is_cooperative() {
     tokio::select! {
         biased;
@@ -17,6 +19,7 @@ async fn empty_read_is_cooperative() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn empty_buf_reads_are_cooperative() {
     tokio::select! {
         biased;

--- a/tokio/tests/join_handle_panic.rs
+++ b/tokio/tests/join_handle_panic.rs
@@ -10,6 +10,7 @@ impl Drop for PanicsOnDrop {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn test_panics_do_not_propagate_when_dropping_join_handle() {
     let join_handle = tokio::spawn(async move { PanicsOnDrop });
 

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -111,6 +111,7 @@ async fn poor_little_task(permits: Arc<Semaphore>) -> usize {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn join_does_not_allow_tasks_to_starve() {
     let permits = Arc::new(Semaphore::new(1));
 

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -125,6 +125,7 @@ async fn join_does_not_allow_tasks_to_starve() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
 async fn a_different_future_is_polled_first_every_time_poll_fn_is_polled() {
     let poll_order = Arc::new(std::sync::Mutex::new(vec![]));
 

--- a/tokio/tests/macros_rename_test.rs
+++ b/tokio/tests/macros_rename_test.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threading
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 #[allow(unused_imports)]
 use std as tokio;

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -127,6 +127,7 @@ async fn one_ready() {
 
 #[maybe_tokio_test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn select_streams() {
     use tokio::sync::mpsc;
 

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -3,11 +3,13 @@
 use tokio::test;
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn test_macro_can_be_used_via_use() {
     tokio::spawn(async {}).await.unwrap();
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn test_macro_is_resilient_to_shadowing() {
     tokio::spawn(async {}).await.unwrap();
 }

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -139,6 +139,7 @@ async fn poor_little_task(permits: Arc<Semaphore>) -> Result<usize, String> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn try_join_does_not_allow_tasks_to_starve() {
     let permits = Arc::new(Semaphore::new(10));
 

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -155,6 +155,7 @@ async fn try_join_does_not_allow_tasks_to_starve() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
 async fn a_different_future_is_polled_first_every_time_poll_fn_is_polled() {
     let poll_order = Arc::new(std::sync::Mutex::new(vec![]));
 

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support panic recovery or bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::TcpListener;
 

--- a/tokio/tests/net_lookup_host.rs
+++ b/tokio/tests/net_lookup_host.rs
@@ -23,6 +23,7 @@ async fn lookup_str_socket_addr() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support getaddrinfo
 async fn resolve_dns() -> io::Result<()> {
     let mut hosts = net::lookup_host("localhost:3000").await?;
     let host = hosts.next().unwrap();

--- a/tokio/tests/net_panic.rs
+++ b/tokio/tests/net_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))]
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::error::Error;
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -1,4 +1,5 @@
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::TcpStream;
 use tokio::sync::oneshot;

--- a/tokio/tests/process_arg0.rs
+++ b/tokio/tests/process_arg0.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", unix))]
+#![cfg(not(miri))] // Miri doesn't support pipe2
 
 use tokio::process::Command;
 

--- a/tokio/tests/process_issue_2174.rs
+++ b/tokio/tests/process_issue_2174.rs
@@ -8,6 +8,7 @@
 // `EV_EOF` or `EV_ERROR` flag set. If either flag is set a write would be
 // attempted, but that does not seem to occur.
 #![cfg(all(unix, not(target_os = "freebsd")))]
+#![cfg(not(miri))] // Miri doesn't support pipe2
 
 use std::process::Stdio;
 use std::time::Duration;

--- a/tokio/tests/process_issue_42.rs
+++ b/tokio/tests/process_issue_42.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support gnu_get_libc_version
 
 use futures::future::join_all;
 use std::process::Stdio;

--- a/tokio/tests/process_kill_on_drop.rs
+++ b/tokio/tests/process_kill_on_drop.rs
@@ -1,5 +1,6 @@
 #![cfg(all(unix, feature = "process"))]
 #![warn(rust_2018_idioms)]
+#![cfg(not(miri))] // Miri doesn't support pipe2
 
 use std::io::ErrorKind;
 use std::process::Stdio;

--- a/tokio/tests/process_smoke.rs
+++ b/tokio/tests/process_smoke.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi cannot run system commands
+#![cfg(not(miri))] // Miri doesn't support gnu_get_libc_version
 
 use tokio::process::Command;
 use tokio_test::assert_ok;

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -45,6 +45,7 @@ fn spawned_task_does_not_progress_without_block_on() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn no_extra_poll() {
     use pin_project_lite::pin_project;
     use std::pin::Pin;

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -113,6 +113,7 @@ fn no_extra_poll() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn acquire_mutex_in_drop() {
     use futures::future::pending;
     use tokio::task;
@@ -149,6 +150,7 @@ fn acquire_mutex_in_drop() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn drop_tasks_in_context() {
     static SUCCESS: AtomicBool = AtomicBool::new(false);
 

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot;
@@ -45,7 +46,6 @@ fn spawned_task_does_not_progress_without_block_on() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn no_extra_poll() {
     use pin_project_lite::pin_project;
     use std::pin::Pin;
@@ -114,7 +114,6 @@ fn no_extra_poll() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn acquire_mutex_in_drop() {
     use futures::future::pending;
     use tokio::task;
@@ -151,7 +150,6 @@ fn acquire_mutex_in_drop() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn drop_tasks_in_context() {
     static SUCCESS: AtomicBool = AtomicBool::new(false);
 

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 // Tests to run on both current-thread & multi-thread runtime variants.
 
@@ -106,7 +107,6 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))]
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
     fn block_on_async() {
         let rt = rt();
 
@@ -607,7 +607,6 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
     fn always_active_parker() {
         // This test it to show that we will always have
         // an active parker even if we call block_on concurrently

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -606,6 +606,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
     fn always_active_parker() {
         // This test it to show that we will always have
         // an active parker even if we call block_on concurrently

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -106,6 +106,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))]
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
     fn block_on_async() {
         let rt = rt();
 

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 // All io tests that deal with shutdown is currently ignored because there are known bugs in with
 // shutting down the io driver while concurrently registering new resources. See

--- a/tokio/tests/rt_panic.rs
+++ b/tokio/tests/rt_panic.rs
@@ -24,6 +24,7 @@ fn current_handle_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 fn into_panic_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(move || {
         let rt = current_thread();

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/signal_ctrl_c.rs
+++ b/tokio/tests/signal_ctrl_c.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_recv.rs
+++ b/tokio/tests/signal_drop_recv.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_rt.rs
+++ b/tokio/tests/signal_drop_rt.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_drop_signal.rs
+++ b/tokio/tests/signal_drop_signal.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_multi_rt.rs
+++ b/tokio/tests/signal_multi_rt.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_notify_both.rs
+++ b/tokio/tests/signal_notify_both.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_twice.rs
+++ b/tokio/tests/signal_twice.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/signal_usr1.rs
+++ b/tokio/tests/signal_usr1.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support sigaction
 
 mod support {
     pub mod signal;

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -106,6 +106,7 @@ async fn send_recv_stream_with_buffer() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn async_send_recv_with_buffer() {
     let (tx, mut rx) = mpsc::channel(16);
 
@@ -177,6 +178,7 @@ async fn send_recv_unbounded() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn async_send_recv_unbounded() {
     let (tx, mut rx) = mpsc::unbounded_channel();
 

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::redundant_clone)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "sync")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 #[cfg(tokio_wasm_not_wasi)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -106,7 +107,6 @@ async fn send_recv_stream_with_buffer() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn async_send_recv_with_buffer() {
     let (tx, mut rx) = mpsc::channel(16);
 
@@ -178,7 +178,6 @@ async fn send_recv_unbounded() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn async_send_recv_unbounded() {
     let (tx, mut rx) = mpsc::unbounded_channel();
 

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -92,6 +92,7 @@ fn lock() {
 /// is aborted prematurely.
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn aborted_future_1() {
     use std::time::Duration;
     use tokio::time::{interval, timeout};
@@ -122,6 +123,7 @@ async fn aborted_future_1() {
 /// aborted future is waiting for the lock.
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn aborted_future_2() {
     use std::time::Duration;
     use tokio::time::timeout;

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -59,6 +59,7 @@ fn readiness() {
 /// is aborted prematurely.
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn aborted_future_1() {
     use std::time::Duration;
     use tokio::time::{interval, timeout};
@@ -89,6 +90,7 @@ async fn aborted_future_1() {
 /// aborted future is waiting for the lock.
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn aborted_future_2() {
     use std::time::Duration;
     use tokio::time::timeout;

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -95,6 +95,7 @@ fn close_rx() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn async_rx_closed() {
     let (mut tx, rx) = oneshot::channel::<()>();
 

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -174,6 +174,7 @@ async fn write_order() {
 // A single RwLock is contested by tasks in multiple threads
 #[cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[cfg_attr(miri, ignore)] // Miri doesn't support epoll_wait
 async fn multithreaded() {
     use futures::stream::{self, StreamExt};
     use std::sync::Arc;

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -27,6 +27,7 @@ fn try_acquire() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn acquire() {
     let sem = Arc::new(Semaphore::new(1));
     let p1 = sem.try_acquire().unwrap();
@@ -40,6 +41,7 @@ async fn acquire() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn add_permits() {
     let sem = Arc::new(Semaphore::new(0));
     let sem_clone = sem.clone();
@@ -90,6 +92,7 @@ fn merge_unrelated_permits() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn stress_test() {
     let sem = Arc::new(Semaphore::new(5));
     let mut join_handles = Vec::new();

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -37,6 +37,7 @@ fn try_acquire_many() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn acquire() {
     let sem = Arc::new(Semaphore::new(1));
     let p1 = sem.clone().try_acquire_owned().unwrap();
@@ -66,6 +67,7 @@ async fn acquire_many() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn add_permits() {
     let sem = Arc::new(Semaphore::new(0));
     let sem_clone = sem.clone();
@@ -116,6 +118,7 @@ fn merge_unrelated_permits() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn stress_test() {
     let sem = Arc::new(Semaphore::new(5));
     let mut join_handles = Vec::new();

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -51,6 +51,7 @@ async fn acquire() {
 
 #[tokio::test]
 #[cfg(feature = "full")]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn acquire_many() {
     let semaphore = Arc::new(Semaphore::new(42));
     let permit32 = semaphore.clone().try_acquire_many_owned(32).unwrap();

--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support panic recovery
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use std::sync::Arc;
 use std::thread::sleep;

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::{runtime, task, time};
 use tokio_test::assert_ok;

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full"))]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use tokio::sync::oneshot;
 use tokio::task::JoinSet;

--- a/tokio/tests/task_local.rs
+++ b/tokio/tests/task_local.rs
@@ -1,5 +1,7 @@
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support threads
 #![allow(clippy::declare_interior_mutable_const)]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use futures::{
     future::{pending, ready},

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::io::Read;
 use std::io::Result;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::time::Duration;
 use tokio::net::TcpSocket;

--- a/tokio/tests/tcp_split.rs
+++ b/tokio/tests/tcp_split.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::io::Result;
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi doesn't support bind
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, Interest};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/test_clock.rs
+++ b/tokio/tests/test_clock.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::time::{self, Duration, Instant};
 

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::time::{self, Duration, Instant, MissedTickBehavior};
 use tokio_test::{assert_pending, assert_ready_eq, task};

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use rand::SeedableRng;
 use rand::{rngs::StdRng, Rng};

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use tokio::time::*;
 

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 
 use std::future::Future;
 use std::task::Context;

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -119,6 +119,7 @@ async fn deadline_now_elapses() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn deadline_future_elapses() {
     time::pause();
 

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::sync::oneshot;
 use tokio::time::{self, timeout, timeout_at, Instant};
@@ -119,7 +120,6 @@ async fn deadline_now_elapses() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri doesn't support write to event (inside mio::waker::Waker::wake)
 async fn deadline_future_elapses() {
     time::pause();
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support bind or UDP
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use futures::future::poll_fn;
 use std::io;

--- a/tokio/tests/uds_cred.rs
+++ b/tokio/tests/uds_cred.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(all(unix, not(target_os = "dragonfly")))]
+#![cfg(not(miri))] // Miri doesn't support getsockopt
 
 use tokio::net::UnixStream;
 

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use futures::future::poll_fn;
 use tokio::io::ReadBuf;

--- a/tokio/tests/uds_split.rs
+++ b/tokio/tests/uds_split.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support epoll_wait
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UnixStream;

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "full")]
 #![warn(rust_2018_idioms)]
 #![cfg(unix)]
+#![cfg(not(miri))] // Miri doesn't support socket
 
 use std::io;
 use std::task::Poll;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

It seems Miri recently added support for epoll_create1: https://github.com/rust-lang/miri/pull/2357

## Reported errors

### SB violations

<details>
<summary>--lib --  runtime::time::tests::poll_process_levels (tokio/src/runtime/time/tests/mod.rs:211:26, SB violation)</summary>

```
error: Undefined Behavior: trying to retag from <6548693> for SharedReadWrite permission at alloc2623231[0x0], but that tag does not exist in the borrow stack for this location
   --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:385:18
    |
385 |         unsafe { &*self.as_ptr() }
    |                  ^^^^^^^^^^^^^^^
    |                  |
    |                  trying to retag from <6548693> for SharedReadWrite permission at alloc2623231[0x0], but that tag does not exist in the borrow stack for this location
    |                  this error occurs as part of retag at alloc2623231[0x0..0x10]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <6548693> was created by a SharedReadWrite retag at offsets [0x0..0x20]
   --> tokio/src/runtime/time/entry.rs:419:20
    |
419 |             inner: NonNull::from(self),
    |                    ^^^^^^^^^^^^^^^^^^^
help: <6548693> was later invalidated at offsets [0x0..0x200] by a Unique retag
   --> tokio/src/runtime/time/tests/mod.rs:227:22
    |
227 |         entries.push(entry);
    |                      ^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside `std::ptr::NonNull::<util::linked_list::Pointers<runtime::time::entry::TimerShared>>::as_ref::<'_>` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:385:18: 385:33
note: inside `util::linked_list::LinkedList::<runtime::time::entry::TimerShared, <runtime::time::entry::TimerShared as util::linked_list::Link>::Target>::pop_back`
   --> tokio/src/util/linked_list.rs:152:25
    |
152 |             self.tail = L::pointers(last).as_ref().get_prev();
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `runtime::time::wheel::Wheel::process_expiration`
   --> tokio/src/runtime/time/wheel/mod.rs:244:32
    |
244 |         while let Some(item) = entries.pop_back() {
    |                                ^^^^^^^^^^^^^^^^^^
note: inside `runtime::time::wheel::Wheel::poll`
   --> tokio/src/runtime/time/wheel/mod.rs:163:21
    |
163 |                     self.process_expiration(expiration);
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `runtime::time::<impl runtime::time::handle::Handle>::process_at_time`
   --> tokio/src/runtime/time/mod.rs:[273](https://github.com/tokio-rs/tokio/actions/runs/3789042247/jobs/6442417285#step:6:274):33
    |
273 |         while let Some(entry) = lock.wheel.poll(now) {
    |                                 ^^^^^^^^^^^^^^^^^^^^
note: inside `runtime::time::tests::poll_process_levels`
   --> tokio/src/runtime/time/tests/mod.rs:231:9
    |
231 |         handle.inner.driver().time().process_at_time(t as u64);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> tokio/src/runtime/time/tests/mod.rs:211:26
    |
209 | #[test]
    | ------- in this procedural macro expansion
210 | #[cfg(not(loom))]
211 | fn poll_process_levels() {
    |                          ^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error

error: test failed, to rerun pass `--lib`

Caused by:
  process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/bin/cargo-miri runner /home/runner/work/tokio/tokio/target/miri/x86_64-unknown-linux-gnu/debug/deps/tokio-e894b5abc4d6b773` (exit status: 1)
```

</details>


<details>
<summary>--test sync_barrier -- lots (tokio/tests/sync_barrier.rs:73:11, SB violation)</summary>

```
error: Undefined Behavior: trying to retag from <234728> for SharedReadWrite permission at alloc95758[0x28], but that tag does not exist in the borrow stack for this location
   --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:436:18
    |
436 |         unsafe { &mut *self.as_ptr() }
    |                  ^^^^^^^^^^^^^^^^^^^
    |                  |
    |                  trying to retag from <234728> for SharedReadWrite permission at alloc95758[0x28], but that tag does not exist in the borrow stack for this location
    |                  this error occurs as part of retag at alloc95758[0x28..0x38]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <234728> was created by a SharedReadWrite retag at offsets [0x28..0x50]
   --> /home/runner/work/tokio/tokio/tokio/src/sync/notify.rs:842:72
    |
842 |                     waiters.push_front(unsafe { NonNull::new_unchecked(waiter.get()) });
    |                                                                        ^^^^^^^^^^^^
help: <234728> was later invalidated at offsets [0x0..0x90] by a Unique retag
   --> tokio/tests/sync_barrier.rs:81:23
    |
81  |             wait.push(w);
    |                       ^
    = note: BACKTRACE (of the first span):
    = note: inside `std::ptr::NonNull::<tokio::util::linked_list::Pointers<tokio::sync::notify::Waiter>>::as_mut::<'_>` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:436:18: 436:37
note: inside `tokio::util::linked_list::LinkedList::<tokio::sync::notify::Waiter, <tokio::sync::notify::Waiter as tokio::util::linked_list::Link>::Target>::push_front`
   --> /home/runner/work/tokio/tokio/tokio/src/util/linked_list.rs:136:17
    |
136 |                 L::pointers(head).as_mut().set_prev(Some(ptr));
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::sync::futures::Notified::<'_>::poll_notified`
   --> /home/runner/work/tokio/tokio/tokio/src/sync/notify.rs:842:21
    |
842 |                     waiters.push_front(unsafe { NonNull::new_unchecked(waiter.get()) });
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `<tokio::sync::futures::Notified<'_> as std::future::Future>::poll`
   --> /home/runner/work/tokio/tokio/tokio/src/sync/notify.rs:900:9
    |
900 |         self.poll_notified(Some(cx.waker()))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/sync/watch.rs:537:21
    |
537 |             notified.await;
    |                     ^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/sync/barrier.rs:181:35
    |
181 |             let _ = wait.changed().await;
    |                                   ^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/sync/barrier.rs:132:36
    |
132 |         return self.wait_internal().await;
    |                                    ^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio-test/src/task.rs:125:30
    |
125 |         self.task.enter(|cx| fut.poll(cx))
    |                              ^^^^^^^^^^^^
note: inside `tokio_test::task::MockTask::enter::<[closure@tokio_test::task::Spawn<[async fn body@tokio::sync::Barrier::wait::{closure#0}]>::poll::{closure#0}], std::task::Poll<tokio::sync::BarrierWaitResult>>`
   --> /home/runner/work/tokio/tokio/tokio-test/src/task.rs:174:9
    |
174 |         f(&mut cx)
    |         ^^^^^^^^^^
note: inside `tokio_test::task::Spawn::<[async fn body@tokio::sync::Barrier::wait::{closure#0}]>::poll`
   --> /home/runner/work/tokio/tokio/tokio-test/src/task.rs:125:9
    |
125 |         self.task.enter(|cx| fut.poll(cx))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `lots`
   --> tokio/tests/sync_barrier.rs:80:29
    |
80  |             assert_pending!(w.poll());
    |                             ^^^^^^^^
note: inside closure
   --> tokio/tests/sync_barrier.rs:73:11
    |
72  | #[test]
    | ------- in this procedural macro expansion
73  | fn lots() {
    |           ^
    = note: this error originates in the attribute macro `test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error

error: test failed, to rerun pass `--test sync_barrier`

Caused by:
  process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/bin/cargo-miri runner /home/runner/work/tokio/tokio/target/miri/x86_64-unknown-linux-gnu/debug/deps/sync_barrier-c28f7d5935088139` (exit status: 1)
```

</details>


<details>
<summary>--test sync_mpsc_weak -- actor_weak_sender (tokio/tests/sync_mpsc_weak.rs:59:30, SB violation)</summary>

```
error: Undefined Behavior: trying to retag from <269941> for SharedReadWrite permission at alloc113145[0x12c], but that tag does not exist in the borrow stack for this location
   --> tokio/tests/sync_mpsc_weak.rs:117:17
    |
117 |                 self.handle_message(msg);
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^
    |                 |
    |                 trying to retag from <269941> for SharedReadWrite permission at alloc113145[0x12c], but that tag does not exist in the borrow stack for this location
    |                 this error occurs as part of two-phase retag at alloc113145[0x118..0x130]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <269941> was created by a Unique retag at offsets [0x118..0x130]
   --> tokio/tests/sync_mpsc_weak.rs:157:61
    |
157 |     let actor_handle = tokio::spawn(async move { actor.run().await });
    |                                                             ^^^^^^
help: <269941> was later invalidated at offsets [0x12c..0x12d] by a read access
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/core.rs:214:36
    |
214 |                 let future = match unsafe { &mut *ptr } {
    |                                    ^^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span):
    = note: inside closure at tokio/tests/sync_mpsc_weak.rs:117:17: 117:41
note: inside closure
   --> tokio/tests/sync_mpsc_weak.rs:157:61
    |
157 |     let actor_handle = tokio::spawn(async move { actor.run().await });
    |                                                             ^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/core.rs:223:17
    |
223 |                 future.poll(&mut cx)
    |                 ^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::loom::std::unsafe_cell::UnsafeCell::<tokio::runtime::task::core::Stage<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69]>>::with_mut::<std::task::Poll<()>, [closure@tokio::runtime::task::core::Core<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::poll::{closure#0}]>`
   --> /home/runner/work/tokio/tokio/tokio/src/loom/std/unsafe_cell.rs:14:9
    |
14  |         f(self.0.get())
    |         ^^^^^^^^^^^^^^^
note: inside `tokio::runtime::task::core::Core::<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::poll`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/core.rs:212:13
    |
212 | /             self.stage.stage.with_mut(|ptr| {
213 | |                 // Safety: The caller ensures mutual exclusion to the field.
214 | |                 let future = match unsafe { &mut *ptr } {
215 | |                     Stage::Running(future) => future,
...   |
223 | |                 future.poll(&mut cx)
224 | |             })
    | |______________^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/harness.rs:476:19
    |
476 |         let res = guard.core.poll(cx);
    |                   ^^^^^^^^^^^^^^^^^^^
    = note: inside `<std::panic::AssertUnwindSafe<[closure@tokio::runtime::task::harness::poll_future<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::{closure#0}]> as std::ops::FnOnce<()>>::call_once` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/panic/unwind_safe.rs:271:9: 271:19
    = note: inside `std::panicking::r#try::do_call::<std::panic::AssertUnwindSafe<[closure@tokio::runtime::task::harness::poll_future<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::{closure#0}]>, std::task::Poll<()>>` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:483:40: 483:43
    = note: inside `std::panicking::r#try::<std::task::Poll<()>, std::panic::AssertUnwindSafe<[closure@tokio::runtime::task::harness::poll_future<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::{closure#0}]>>` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panicking.rs:447:19: 447:81
    = note: inside `std::panic::catch_unwind::<std::panic::AssertUnwindSafe<[closure@tokio::runtime::task::harness::poll_future<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::{closure#0}]>, std::task::Poll<()>>` at /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/panic.rs:137:14: 137:33
note: inside `tokio::runtime::task::harness::poll_future::<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/harness.rs:464:18
    |
464 |       let output = panic::catch_unwind(panic::AssertUnwindSafe(|| {
    |  __________________^
465 | |         struct Guard<'a, T: Future, S: Schedule> {
466 | |             core: &'a Core<T, S>,
467 | |         }
...   |
478 | |         res
479 | |     }));
    | |_______^
note: inside `tokio::runtime::task::harness::Harness::<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::poll_inner`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/harness.rs:198:27
    |
198 |                 let res = poll_future(self.core(), cx);
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::runtime::task::harness::Harness::<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::poll`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/harness.rs:152:15
    |
152 |         match self.poll_inner() {
    |               ^^^^^^^^^^^^^^^^^
note: inside `tokio::runtime::task::raw::poll::<[async block@tokio/tests/sync_mpsc_weak.rs:157:37: 157:69], std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/raw.rs:255:5
    |
255 |     harness.poll();
    |     ^^^^^^^^^^^^^^
note: inside `tokio::runtime::task::raw::RawTask::poll`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/raw.rs:200:18
    |
200 |         unsafe { (vtable.poll)(self.ptr) }
    |                  ^^^^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::runtime::task::LocalNotified::<std::sync::Arc<tokio::runtime::scheduler::current_thread::Handle>>::run`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/task/mod.rs:459:9
    |
459 |         raw.poll();
    |         ^^^^^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:584:25
    |
584 |                         task.run();
    |                         ^^^^^^^^^^
note: inside `tokio::runtime::coop::with_budget::<(), [closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}::{closure#3}]>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/coop.rs:102:5
    |
102 |     f()
    |     ^^^
note: inside `tokio::runtime::coop::budget::<(), [closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}::{closure#3}]>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/coop.rs:68:5
    |
68  |     with_budget(Budget::initial(), f)
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:285:29
    |
285 |         self.enter(core, || crate::runtime::coop::budget(f))
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::runtime::scheduler::current_thread::Context::enter::<(), [closure@tokio::runtime::scheduler::current_thread::Context::run_task<(), [closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}::{closure#3}]>::{closure#0}]>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:350:19
    |
350 |         let ret = f();
    |                   ^^^
note: inside `tokio::runtime::scheduler::current_thread::Context::run_task::<(), [closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}::{closure#3}]>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:285:9
    |
285 |         self.enter(core, || crate::runtime::coop::budget(f))
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:583:34
    |
583 |                       let (c, _) = context.run_task(core, || {
    |  __________________________________^
584 | |                         task.run();
585 | |                     });
    | |______________________^
note: inside closure
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:615:57
    |
615 |         let (core, ret) = CURRENT.set(&self.context, || f(core, &self.context));
    |                                                         ^^^^^^^^^^^^^^^^^^^^^^
note: inside `tokio::macros::scoped_tls::ScopedKey::<tokio::runtime::scheduler::current_thread::Context>::set::<[closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::enter<[closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}], std::option::Option<()>>::{closure#0}], (std::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, std::option::Option<()>)>`
   --> /home/runner/work/tokio/tokio/tokio/src/macros/scoped_tls.rs:61:9
    |
61  |         f()
    |         ^^^
note: inside `tokio::runtime::scheduler::current_thread::CoreGuard::<'_>::enter::<[closure@tokio::runtime::scheduler::current_thread::CoreGuard<'_>::block_on<std::pin::Pin<&mut std::pin::Pin<&mut dyn std::future::Future<Output = ()>>>>::{closure#0}], std::option::Option<()>>`
   --> /home/runner/work/tokio/tokio/tokio/src/runtime/scheduler/current_thread.rs:615:27
    |
615 |         let (core, ret) = CURRENT.set(&self.context, || f(core, &self.context));
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside `actor_weak_sender`
   --> tokio/tests/sync_mpsc_weak.rs:165:5
    |
165 |     let _ = actor_handle.await;
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
note: inside closure
   --> tokio/tests/sync_mpsc_weak.rs:59:30
    |
58  | #[tokio::test]
    | -------------- in this procedural macro expansion
59  | async fn actor_weak_sender() {
    |                              ^
    = note: this error originates in the attribute macro `::core::prelude::v1::test` which comes from the expansion of the attribute macro `tokio::test` (in Nightly builds, run with -Z macro-backtrace for more info)

note: some details are omitted, run with `MIRIFLAGS=-Zmiri-backtrace=full` for a verbose backtrace

error: aborting due to previous error

error: test failed, to rerun pass `--test sync_mpsc_weak`

Caused by:
  process didn't exit successfully: `/home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/bin/cargo-miri runner /home/runner/work/tokio/tokio/target/miri/x86_64-unknown-linux-gnu/debug/deps/sync_mpsc_weak-c1d4456ce3ebf68a` (exit status: 1)
```

</details>

~~--test io_read -- read_buf_bad_async_read (tokio/tests/io_read.rs:72:36, SB violation in test helper)~~; addressed in #5322



### Unsupported errors

<details>
<summary>click to show</summary>

all code calling `wake()` (inside mio::waker::Waker::wake):

```
error: unsupported operation: cannot write to event
    --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/fd.rs:152:13
     |
152  | /             libc::write(
153  | |                 self.as_raw_fd(),
154  | |                 buf.as_ptr() as *const libc::c_void,
155  | |                 cmp::min(buf.len(), READ_LIMIT),
156  | |             )
     | |_____________^ cannot write to event
     |
```

fs/io/time etc.: (fixed in unreleased https://github.com/rust-lang/miri/pull/2764)

```
error: unsupported operation: can't call foreign function: epoll_wait
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.5/src/sys/unix/selector/epoll.rs:106:9
    |
106 | /         syscall!(epoll_wait(
107 | |             self.ep,
108 | |             events.as_mut_ptr(),
109 | |             events.capacity() as i32,
110 | |             timeout,
111 | |         ))
    | |__________^ can't call foreign function: epoll_wait
    |
```

net related:

```
error: unsupported operation: can't call foreign function: socket
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/mio-0.8.5/src/sys/unix/net.rs:29:18
    |
29  |     let socket = syscall!(socket(domain, socket_type, 0));
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: socket
    |
```

process related:

```
error: unsupported operation: can't call foreign function: gnu_get_libc_version
   --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/os.rs:660:48
    |
660 |     let version_cstr = unsafe { CStr::from_ptr(gnu_get_libc_version()) };
    |                                                ^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: gnu_get_libc_version
    |
```

```
error: unsupported operation: can't call foreign function: pipe2
   --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/unix/pipe.rs:30:21
    |
30  |                 cvt(libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC))?;
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: pipe2
    |
```


signal related:

```
error: unsupported operation: can't call foreign function: sigaction
   --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/signal-hook-registry-1.4.0/src/lib.rs:214:21
    |
214 |         if unsafe { libc::sigaction(signal, ptr::null(), &mut old) } != 0 {
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: sigaction
    |
```

tokio/tests/net_lookup_host.rs:

```
error: unsupported operation: can't call foreign function: getaddrinfo
   --> /home/runner/.rustup/toolchains/nightly-2022-12-27-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys_common/net.rs:206:25
    |
206 |                 cvt_gai(c::getaddrinfo(c_host.as_ptr(), ptr::null(), &hints, &mut res))
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't call foreign function: getaddrinfo
    |
```

tokio/tests/uds_cred.rs:

```
error: unsupported operation: can't call foreign function: getsockopt
   --> /home/runner/work/tokio/tokio/tokio/src/net/unix/ucred.rs:81:23
    |
81  |               let ret = getsockopt(
    |  _______________________^
82  | |                 raw_fd,
83  | |                 SOL_SOCKET,
84  | |                 SO_PEERCRED,
85  | |                 &mut ucred as *mut ucred as *mut c_void,
86  | |                 &mut ucred_size,
87  | |             );
    | |_____________^ can't call foreign function: getsockopt
    |
```

tempfile related (will be fixed in https://github.com/rust-lang/miri/pull/2720):

```
error: unsupported operation: non-default mode 0o600 is not supported
```

</details>