### PR TITLE
chore: move some return statements upper.

### DIFF
--- a/tokio-stream/src/stream_ext/then.rs
+++ b/tokio-stream/src/stream_ext/then.rs
@@ -52,12 +52,12 @@ where
 
         loop {
             if let Some(future) = me.future.as_mut().as_pin_mut() {
-                match future.poll(cx) {
+                return match future.poll(cx) {
                     Poll::Ready(item) => {
                         me.future.set(None);
-                        return Poll::Ready(Some(item));
+                        Poll::Ready(Some(item))
                     }
-                    Poll::Pending => return Poll::Pending,
+                    Poll::Pending => Poll::Pending,
                 }
             }
 

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -79,17 +79,17 @@ where
                     let (res, mut buf, inner) = ready!(Pin::new(rx).poll(cx))?;
                     self.inner = Some(inner);
 
-                    match res {
+                    return match res {
                         Ok(_) => {
                             buf.copy_to(dst);
                             self.state = Idle(Some(buf));
-                            return Ready(Ok(()));
+                            Ready(Ok(()))
                         }
                         Err(e) => {
                             assert!(buf.is_empty());
 
                             self.state = Idle(Some(buf));
-                            return Ready(Err(e));
+                            Ready(Err(e))
                         }
                     }
                 }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -294,15 +294,15 @@ where
                 // We are on an executor, but _not_ on the thread pool.  That is
                 // _only_ okay if we are in a thread pool runtime's block_on
                 // method:
-                if allow_block_in_place {
+                return if allow_block_in_place {
                     had_entered = true;
-                    return Ok(());
+                    Ok(())
                 } else {
                     // This probably means we are on the current_thread runtime or in a
                     // LocalSet, where it is _not_ okay to block.
-                    return Err(
+                    Err(
                         "can call blocking only when running on the multi-threaded runtime",
-                    );
+                    )
                 }
             }
             (context::EnterRuntime::NotEntered, true) => {

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -576,13 +576,13 @@ fn notify_locked(waiters: &mut WaitList, state: &AtomicUsize, curr: usize) -> Op
             EMPTY | NOTIFIED => {
                 let res = state.compare_exchange(curr, set_state(curr, NOTIFIED), SeqCst, SeqCst);
 
-                match res {
-                    Ok(_) => return None,
+                return match res {
+                    Ok(_) => None,
                     Err(actual) => {
                         let actual_state = get_state(actual);
                         assert!(actual_state == EMPTY || actual_state == NOTIFIED);
                         state.store(set_state(actual, NOTIFIED), SeqCst);
-                        return None;
+                        None
                     }
                 }
             }

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -309,11 +309,11 @@ impl<T: 'static> JoinSet<T> {
         let mut entry = match self.inner.pop_notified(cx.waker()) {
             Some(entry) => entry,
             None => {
-                if self.is_empty() {
-                    return Poll::Ready(None);
+                return if self.is_empty() {
+                    Poll::Ready(None)
                 } else {
                     // The waker was set by `pop_notified`.
-                    return Poll::Pending;
+                    Poll::Pending
                 }
             }
         };
@@ -369,11 +369,11 @@ impl<T: 'static> JoinSet<T> {
         let mut entry = match self.inner.pop_notified(cx.waker()) {
             Some(entry) => entry,
             None => {
-                if self.is_empty() {
-                    return Poll::Ready(None);
+                return if self.is_empty() {
+                    Poll::Ready(None)
                 } else {
                     // The waker was set by `pop_notified`.
-                    return Poll::Pending;
+                    Poll::Pending
                 }
             }
         };


### PR DESCRIPTION
## Motivation

I just saw this possible modification with my IDE. I thought that way it's better follow Rust convention. But feel free to not merge it if you think the contrary.
