### PR TITLE
rt: use internal ThreadId implementation

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -237,6 +237,9 @@ cfg_rt! {
     mod runtime;
     pub use runtime::{Runtime, RuntimeFlavor};
 
+    mod thread_id;
+    pub(crate) use thread_id::ThreadId;
+
     cfg_metrics! {
         mod metrics;
         pub use metrics::RuntimeMetrics;

--- a/tokio/src/runtime/thread_id.rs
+++ b/tokio/src/runtime/thread_id.rs
@@ -1,0 +1,31 @@
+use std::num::NonZeroU64;
+
+#[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]
+pub(crate) struct ThreadId(NonZeroU64);
+
+impl ThreadId {
+    pub(crate) fn next() -> Self {
+        use crate::loom::sync::atomic::{Ordering::Relaxed, StaticAtomicU64};
+
+        static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(0);
+
+        let mut last = NEXT_ID.load(Relaxed);
+        loop {
+            let id = match last.checked_add(1) {
+                Some(id) => id,
+                None => exhausted(),
+            };
+
+            match NEXT_ID.compare_exchange_weak(last, id, Relaxed, Relaxed) {
+                Ok(_) => return ThreadId(NonZeroU64::new(id).unwrap()),
+                Err(id) => last = id,
+            }
+        }
+    }
+}
+
+#[cold]
+#[allow(dead_code)]
+fn exhausted() -> ! {
+    panic!("failed to generate unique thread ID: bitspace exhausted")
+}

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -141,7 +141,7 @@ fn worker_noop_count() {
         time::sleep(Duration::from_millis(1)).await;
     });
     drop(rt);
-    assert!(2 <= metrics.worker_noop_count(0));
+    assert!(0 < metrics.worker_noop_count(0));
 
     let rt = threaded();
     let metrics = rt.metrics();
@@ -149,8 +149,8 @@ fn worker_noop_count() {
         time::sleep(Duration::from_millis(1)).await;
     });
     drop(rt);
-    assert!(1 <= metrics.worker_noop_count(0));
-    assert!(1 <= metrics.worker_noop_count(1));
+    assert!(0 < metrics.worker_noop_count(0));
+    assert!(0 < metrics.worker_noop_count(1));
 }
 
 #[test]


### PR DESCRIPTION
The version provided by `std` has limitations, including no way to try to get a thread ID without panicking.

Replaces #5184