### PR TITLE
net: improve `from_std` docs

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -206,7 +206,7 @@ impl TcpListener {
     ///
     /// The caller is responsible for ensuring that the listener is in
     /// non-blocking mode. Otherwise all I/O operations on the listener
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -195,14 +195,21 @@ impl TcpListener {
     /// Creates new `TcpListener` from a `std::net::TcpListener`.
     ///
     /// This function is intended to be used to wrap a TCP listener from the
-    /// standard library in the Tokio equivalent. The conversion assumes nothing
-    /// about the underlying listener; it is left up to the user to set it in
-    /// non-blocking mode.
+    /// standard library in the Tokio equivalent.
     ///
     /// This API is typically paired with the `socket2` crate and the `Socket`
     /// type to build up and customize a listener before it's shipped off to the
     /// backing event loop. This allows configuration of options like
     /// `SO_REUSEPORT`, binding to multiple addresses, etc.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the listener is in
+    /// non-blocking mode. Otherwise all I/O operations on the listener
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking
     ///
     /// # Examples
     ///

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -674,7 +674,7 @@ impl TcpSocket {
     ///
     /// The caller is responsible for ensuring that the socket is in
     /// non-blocking mode. Otherwise all I/O operations on the socket
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -666,6 +666,7 @@ impl TcpSocket {
     /// socket must not have been connected prior to calling this function. This
     /// function is typically used together with crates such as [`socket2`] to
     /// configure socket options that are not available on `TcpSocket`.
+    /// It is left up to the user to set the socket in non-blocking mode.
     ///
     /// [`std::net::TcpStream`]: struct@std::net::TcpStream
     /// [`socket2`]: https://docs.rs/socket2/
@@ -678,8 +679,8 @@ impl TcpSocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> std::io::Result<()> {
-    ///
     ///     let socket2_socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
+    ///     socket2_socket.set_nonblocking(true)?;
     ///
     ///     let socket = TcpSocket::from_std_stream(socket2_socket.into());
     ///

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -666,10 +666,18 @@ impl TcpSocket {
     /// socket must not have been connected prior to calling this function. This
     /// function is typically used together with crates such as [`socket2`] to
     /// configure socket options that are not available on `TcpSocket`.
-    /// It is left up to the user to set the socket in non-blocking mode.
     ///
     /// [`std::net::TcpStream`]: struct@std::net::TcpStream
     /// [`socket2`]: https://docs.rs/socket2/
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode. Otherwise all I/O operations on the socket
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking
     ///
     /// # Examples
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -171,7 +171,7 @@ impl TcpStream {
     ///
     /// The caller is responsible for ensuring that the stream is in
     /// non-blocking mode. Otherwise all I/O operations on the stream
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -165,9 +165,16 @@ impl TcpStream {
     /// Creates new `TcpStream` from a `std::net::TcpStream`.
     ///
     /// This function is intended to be used to wrap a TCP stream from the
-    /// standard library in the Tokio equivalent. The conversion assumes nothing
-    /// about the underlying stream; it is left up to the user to set it in
-    /// non-blocking mode.
+    /// standard library in the Tokio equivalent.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the stream is in
+    /// non-blocking mode. Otherwise all I/O operations on the stream
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking
     ///
     /// # Examples
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -179,13 +179,20 @@ impl UdpSocket {
     /// Creates new `UdpSocket` from a previously bound `std::net::UdpSocket`.
     ///
     /// This function is intended to be used to wrap a UDP socket from the
-    /// standard library in the Tokio equivalent. The conversion assumes nothing
-    /// about the underlying socket; it is left up to the user to set it in
-    /// non-blocking mode.
+    /// standard library in the Tokio equivalent.
     ///
     /// This can be used in conjunction with socket2's `Socket` interface to
     /// configure a socket before it's handed off, such as setting options like
     /// `reuse_address` or binding to multiple addresses.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socket is in
+    /// non-blocking mode. Otherwise all I/O operations on the socket
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///
     /// # Panics
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -189,7 +189,7 @@ impl UdpSocket {
     ///
     /// The caller is responsible for ensuring that the socket is in
     /// non-blocking mode. Otherwise all I/O operations on the socket
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -426,9 +426,16 @@ impl UnixDatagram {
     /// Creates new `UnixDatagram` from a `std::os::unix::net::UnixDatagram`.
     ///
     /// This function is intended to be used to wrap a UnixDatagram from the
-    /// standard library in the Tokio equivalent. The conversion assumes
-    /// nothing about the underlying datagram; it is left up to the user to set
-    /// it in non-blocking mode.
+    /// standard library in the Tokio equivalent.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the socker is in
+    /// non-blocking mode. Otherwise all I/O operations on the socket
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///
     /// # Panics
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -477,21 +477,19 @@ impl UnixDatagram {
     /// Turns a [`tokio::net::UnixDatagram`] into a [`std::os::unix::net::UnixDatagram`].
     ///
     /// The returned [`std::os::unix::net::UnixDatagram`] will have nonblocking
-    /// mode set as `true`.  Use [`set_nonblocking`] to change the blocking mode
+    /// mode set as `true`. Use [`set_nonblocking`] to change the blocking mode
     /// if needed.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use std::error::Error;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     let tokio_socket = tokio::net::UnixDatagram::bind("127.0.0.1:0")?;
-    ///     let std_socket = tokio_socket.into_std()?;
-    ///     std_socket.set_nonblocking(false)?;
-    ///     Ok(())
-    /// }
+    /// # use std::error::Error;
+    /// # async fn dox() -> Result<(), Box<dyn Error>> {
+    /// let tokio_socket = tokio::net::UnixDatagram::bind("/path/to/the/socket")?;
+    /// let std_socket = tokio_socket.into_std()?;
+    /// std_socket.set_nonblocking(false)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`tokio::net::UnixDatagram`]: UnixDatagram

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -432,7 +432,7 @@ impl UnixDatagram {
     ///
     /// The caller is responsible for ensuring that the socker is in
     /// non-blocking mode. Otherwise all I/O operations on the socket
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -79,7 +79,7 @@ impl UnixListener {
     ///
     /// The caller is responsible for ensuring that the listener is in
     /// non-blocking mode. Otherwise all I/O operations on the listener
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -73,9 +73,16 @@ impl UnixListener {
     /// Creates new `UnixListener` from a `std::os::unix::net::UnixListener `.
     ///
     /// This function is intended to be used to wrap a UnixListener from the
-    /// standard library in the Tokio equivalent. The conversion assumes
-    /// nothing about the underlying listener; it is left up to the user to set
-    /// it in non-blocking mode.
+    /// standard library in the Tokio equivalent.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the listener is in
+    /// non-blocking mode. Otherwise all I/O operations on the listener
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking
     ///
     /// # Panics
     ///

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -84,6 +84,21 @@ impl UnixListener {
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixListener;
+    /// use std::os::unix::net::UnixListener as StdUnixListener;
+    /// # use std::error::Error;
+    ///
+    /// # async fn dox() -> Result<(), Box<dyn Error>> {
+    /// let std_listener = StdUnixListener::bind("/path/to/the/socket")?;
+    /// std_listener.set_nonblocking(true)?;
+    /// let listener = UnixListener::from_std(std_listener)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Panics
     ///
     /// This function panics if it is not called from within a runtime with
@@ -102,20 +117,18 @@ impl UnixListener {
     /// Turns a [`tokio::net::UnixListener`] into a [`std::os::unix::net::UnixListener`].
     ///
     /// The returned [`std::os::unix::net::UnixListener`] will have nonblocking mode
-    /// set as `true`.  Use [`set_nonblocking`] to change the blocking mode if needed.
+    /// set as `true`. Use [`set_nonblocking`] to change the blocking mode if needed.
     ///
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use std::error::Error;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     let tokio_listener = tokio::net::UnixListener::bind("127.0.0.1:0")?;
-    ///     let std_listener = tokio_listener.into_std()?;
-    ///     std_listener.set_nonblocking(false)?;
-    ///     Ok(())
-    /// }
+    /// # use std::error::Error;
+    /// # async fn dox() -> Result<(), Box<dyn Error>> {
+    /// let tokio_listener = tokio::net::UnixListener::bind("/path/to/the/socket")?;
+    /// let std_listener = tokio_listener.into_std()?;
+    /// std_listener.set_nonblocking(false)?;
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`tokio::net::UnixListener`]: UnixListener

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -720,6 +720,21 @@ impl UnixStream {
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::UnixStream;
+    /// use std::os::unix::net::UnixStream as StdUnixStream;
+    /// # use std::error::Error;
+    ///
+    /// # async fn dox() -> Result<(), Box<dyn Error>> {
+    /// let std_stream = StdUnixStream::connect("/path/to/the/socket")?;
+    /// std_stream.set_nonblocking(true)?;
+    /// let stream = UnixStream::from_std(std_stream)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
     /// # Panics
     ///
     /// This function panics if it is not called from within a runtime with

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -715,7 +715,7 @@ impl UnixStream {
     ///
     /// The caller is responsible for ensuring that the stream is in
     /// non-blocking mode. Otherwise all I/O operations on the stream
-    /// will block the thread, what can cause unexpected behavior.
+    /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -709,9 +709,16 @@ impl UnixStream {
     /// Creates new `UnixStream` from a `std::os::unix::net::UnixStream`.
     ///
     /// This function is intended to be used to wrap a UnixStream from the
-    /// standard library in the Tokio equivalent. The conversion assumes
-    /// nothing about the underlying stream; it is left up to the user to set
-    /// it in non-blocking mode.
+    /// standard library in the Tokio equivalent.
+    ///
+    /// # Notes
+    ///
+    /// The caller is responsible for ensuring that the stream is in
+    /// non-blocking mode. Otherwise all I/O operations on the stream
+    /// will block the thread, what can cause unexpected behavior.
+    /// Non-blocking mode can be set using [`set_nonblocking`].
+    ///
+    /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///
     /// # Panics
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Unlike documentation for other methods performing conversion from std types, docs for the `TcpSocket::from_std_stream` method do not warn about setting the socket in non-blocking mode.
The attached example also doesn't set the socket in non-blocking mode.

## Solution

This change adds a suitable comment in the docs and sets the socket in non-blocking mode in the example.
