### PR TITLE
net: fix named pipes server configuration builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
       - features
       - minrust
       - fmt
-      - clippy
       - docs
       - valgrind
       - loom-compile
@@ -340,22 +339,6 @@ jobs:
             printf "Please run \`rustfmt --edition 2018 \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
             exit 1
           fi
-
-  clippy:
-    name: clippy
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install Rust ${{ env.rust_clippy }}
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ env.rust_clippy }}
-          override: true
-          components: clippy
-      - uses: Swatinem/rust-cache@v1
-      # Run clippy
-      - name: "clippy --all"
-        run: cargo clippy --all --tests --all-features
 
   docs:
     name: docs

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.3", features = ["full"] }
+tokio = { version = "1.18.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.18.4 (January 3, 2022)
+
+### Fixed
+
+- net: fix Windows named pipe server builder to maintain option when toggling
+  pipe mode ([#5336]).
+
+[#5336]: https://github.com/tokio-rs/tokio/pull/5336
+
 # 1.18.3 (September 27, 2022)
 
 This release removes the dependency on the `once_cell` crate to restore the MSRV

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.0.x" git tag.
-version = "1.18.3"
+version = "1.18.4"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.18.3", features = ["full"] }
+tokio = { version = "1.18.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -1681,11 +1681,10 @@ impl ServerOptions {
     ///
     /// [`dwPipeMode`]: https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-createnamedpipea
     pub fn pipe_mode(&mut self, pipe_mode: PipeMode) -> &mut Self {
-        self.pipe_mode = match pipe_mode {
-            PipeMode::Byte => winbase::PIPE_TYPE_BYTE,
-            PipeMode::Message => winbase::PIPE_TYPE_MESSAGE,
-        };
-
+        let is_msg = matches!(pipe_mode, PipeMode::Message);
+        // Pipe mode is implemented as a bit flag 0x4. Set is message and unset
+        // is byte.
+        bool_flag!(self.pipe_mode, is_msg, winbase::PIPE_TYPE_MESSAGE);
         self
     }
 
@@ -2411,4 +2410,49 @@ unsafe fn named_pipe_info(handle: RawHandle) -> io::Result<PipeInfo> {
         in_buffer_size,
         max_instances,
     })
+}
+
+#[cfg(test)]
+mod test {
+    use self::winbase::{PIPE_REJECT_REMOTE_CLIENTS, PIPE_TYPE_BYTE, PIPE_TYPE_MESSAGE};
+    use super::*;
+
+    #[test]
+    fn opts_default_pipe_mode() {
+        let opts = ServerOptions::new();
+        assert_eq!(opts.pipe_mode, PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS);
+    }
+
+    #[test]
+    fn opts_unset_reject_remote() {
+        let mut opts = ServerOptions::new();
+        opts.reject_remote_clients(false);
+        assert_eq!(opts.pipe_mode & PIPE_REJECT_REMOTE_CLIENTS, 0);
+    }
+
+    #[test]
+    fn opts_set_pipe_mode_maintains_reject_remote_clients() {
+        let mut opts = ServerOptions::new();
+        opts.pipe_mode(PipeMode::Byte);
+        assert_eq!(opts.pipe_mode, PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS);
+
+        opts.reject_remote_clients(false);
+        opts.pipe_mode(PipeMode::Byte);
+        assert_eq!(opts.pipe_mode, PIPE_TYPE_BYTE);
+
+        opts.reject_remote_clients(true);
+        opts.pipe_mode(PipeMode::Byte);
+        assert_eq!(opts.pipe_mode, PIPE_TYPE_BYTE | PIPE_REJECT_REMOTE_CLIENTS);
+
+        opts.reject_remote_clients(false);
+        opts.pipe_mode(PipeMode::Message);
+        assert_eq!(opts.pipe_mode, PIPE_TYPE_MESSAGE);
+
+        opts.reject_remote_clients(true);
+        opts.pipe_mode(PipeMode::Message);
+        assert_eq!(
+            opts.pipe_mode,
+            PIPE_TYPE_MESSAGE | PIPE_REJECT_REMOTE_CLIENTS
+        );
+    }
 }


### PR DESCRIPTION
The `pipe_mode` function would erase any previously set configuration option specified using the pipe_mode fit field. This patch fixes the builder to maintain the bit field when changing the pipe mode.