### PR TITLE
stream: bump version of async-stream

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -19,7 +19,7 @@ categories = ["asynchronous", "testing"]
 [dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
 tokio-stream = { version = "0.1.1", path = "../tokio-stream" }
-async-stream = "0.3"
+async-stream = "0.3.3"
 
 bytes = "1.0.0"
 futures-core = "0.3.0"


### PR DESCRIPTION
The `tokio-test` crate depends on `async-stream v0.3.0` that incorrectly specifies its dependencies.

## How to reproduce
Firstly, create an empty project with the next dev deps:
```toml
[dev-dependencies]
tokio-test = "0.4.2"
```

Secondly, fetch minimal versions of deps (`cargo +nightly update -Zminimal-versions`).

Now it fails to compile (`cargo test`):
```
error[E0277]: the trait bound `TokenStream2: From<proc_macro2::TokenTree>` is not satisfied
  --> /home/.cargo/registry/src/github.com-1ecc6299db9ec823/async-stream-impl-0.3.0/src/lib.rs:17:36
   |
17 |     let input = TokenStream2::from(TokenTree::Group(Group::new(Delimiter::Brace, input)));
   |                 ------------------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `From<proc_macro2::TokenTree>` is not implemented for `TokenStream2`
   |                 |
   |                 required by a bound introduced by this call
   |
   = help: the trait `From<proc_macro::TokenStream>` is implemented for `TokenStream2`
```

It occurs because `async-stream v0.3.0` wrongly specifies `proc-macro2 = "1"` but uses conversion added in `v1.0.2`.

The latest `async-stream` doesn't use this conversion, so there is no error.