### PR TITLE
feat: low-level probes

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -107,6 +107,7 @@ memchr = { version = "2.2", optional = true }
 mio = { version = "0.8.4", optional = true }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
+probe = { version = "0.3", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
 socket2 = { version = "0.4.4", optional = true, features = [ "all" ] }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -480,6 +480,9 @@ pub mod net;
 
 mod loom;
 
+#[cfg(feature = "probe")]
+mod probes;
+
 cfg_process! {
     pub mod process;
 }

--- a/tokio/src/probes.rs
+++ b/tokio/src/probes.rs
@@ -1,0 +1,44 @@
+//! Low-level probes for tools like [perf].
+//!
+//! [perf]: https://perf.wiki.kernel.org/index.php/Main_Page
+use crate::runtime::task::Id;
+use probe::probe;
+
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+// IMPORTANT: Never inline probes because this confuses `perf probe`!
+// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+/// Begin to poll a task.
+#[inline(never)]
+pub(crate) fn task_poll_begin(id: Id) {
+    let id = id.as_u64() as isize;
+    probe!(tokio, task_poll_begin, id);
+}
+
+/// Finished to poll a task.
+#[inline(never)]
+pub(crate) fn task_poll_end(id: Id, is_ready: bool, panicked: bool) {
+    let id = id.as_u64() as isize;
+    let is_ready = is_ready as isize;
+    let panicked = panicked as isize;
+    probe!(tokio, task_poll_end, id, is_ready, panicked);
+}
+
+/// Ended a task, so it will never be polled again.
+#[inline(never)]
+pub(crate) fn task_finish(id: Id) {
+    let id = id.as_u64() as isize;
+    probe!(tokio, task_finish, id);
+}
+
+/// Start blocking task.
+#[inline(never)]
+pub(crate) fn task_blocking_begin() {
+    probe!(tokio, task_blocking_begin);
+}
+
+/// Finish blocking task.
+#[inline(never)]
+pub(crate) fn task_blocking_end() {
+    probe!(tokio, task_blocking_end);
+}

--- a/tokio/src/probes.rs
+++ b/tokio/src/probes.rs
@@ -10,6 +10,7 @@ use probe::probe;
 
 /// Begin to poll a task.
 #[inline(never)]
+#[allow(unused_variables)] // probe!() doesn't use variables on non-supported targets
 pub(crate) fn task_poll_begin(id: Id) {
     let id = id.as_u64() as isize;
     probe!(tokio, task_poll_begin, id);
@@ -17,6 +18,7 @@ pub(crate) fn task_poll_begin(id: Id) {
 
 /// Finished to poll a task.
 #[inline(never)]
+#[allow(unused_variables)] // probe!() doesn't use variables on non-supported targets
 pub(crate) fn task_poll_end(id: Id, is_ready: bool, panicked: bool) {
     let id = id.as_u64() as isize;
     let is_ready = is_ready as isize;
@@ -26,6 +28,7 @@ pub(crate) fn task_poll_end(id: Id, is_ready: bool, panicked: bool) {
 
 /// Ended a task, so it will never be polled again.
 #[inline(never)]
+#[allow(unused_variables)] // probe!() doesn't use variables on non-supported targets
 pub(crate) fn task_finish(id: Id) {
     let id = id.as_u64() as isize;
     probe!(tokio, task_finish, id);
@@ -33,12 +36,14 @@ pub(crate) fn task_finish(id: Id) {
 
 /// Start blocking task.
 #[inline(never)]
+#[allow(unused_variables)] // probe!() doesn't use variables on non-supported targets
 pub(crate) fn task_blocking_begin() {
     probe!(tokio, task_blocking_begin);
 }
 
 /// Finish blocking task.
 #[inline(never)]
+#[allow(unused_variables)] // probe!() doesn't use variables on non-supported targets
 pub(crate) fn task_blocking_end() {
     probe!(tokio, task_blocking_end);
 }

--- a/tokio/src/runtime/blocking/task.rs
+++ b/tokio/src/runtime/blocking/task.rs
@@ -39,6 +39,15 @@ where
         // we want it to start without any budgeting.
         crate::runtime::coop::stop();
 
-        Poll::Ready(func())
+        #[cfg(feature = "probe")]
+        crate::probes::task_blocking_begin();
+
+        let res = Poll::Ready(func());
+
+        #[cfg(feature = "probe")]
+        crate::probes::task_blocking_end();
+
+        #[allow(clippy::let_and_return)]
+        res
     }
 }


### PR DESCRIPTION
I'm opening this mostly to see if there's interest in such a feature. If there's a agreement, we can bikeshed the probe names and potential documentation that should come with them.

## Motivation
Linux [perf] is a very powerful tool to understand the performance of an app. While it knows about threads, the tokio tasks are completely opaque to it and hence you'll have a hard time reading the `perf script` output.

## Solution
Add [SystemTap SDT] probes for task polling. See https://github.com/crepererum/tokio2chrome for an example on how to use the probes. This system can later be extended by dtrace probes, which are supported by MacOS and Co.

[perf]: https://perf.wiki.kernel.org/index.php/Main_Page
[SystemTap SDT]: https://sourceware.org/systemtap/wiki/AddingUserSpaceProbingToApps