### PR TITLE
Fix ThreadId implementation on targets without atomicu64

### DIFF
--- a/tokio/src/loom/std/atomic_u64_static_once_cell.rs
+++ b/tokio/src/loom/std/atomic_u64_static_once_cell.rs
@@ -23,11 +23,32 @@ impl StaticAtomicU64 {
         }
     }
 
+    pub(crate) fn load(&self, order: Ordering) -> u64 {
+        *self.inner().lock()
+    }
+
     pub(crate) fn fetch_add(&self, val: u64, order: Ordering) -> u64 {
         let mut lock = self.inner().lock();
         let prev = *lock;
         *lock = prev + val;
         prev
+    }
+
+    pub(crate) fn compare_exchange_weak(
+        &self,
+        current: u64,
+        new: u64,
+        _success: Ordering,
+        _failure: Ordering,
+    ) -> Result<u64, u64> {
+        let mut lock = self.inner().lock();
+
+        if *lock == current {
+            *lock = new;
+            Ok(current)
+        } else {
+            Err(*lock)
+        }
     }
 
     fn inner(&self) -> &Mutex<u64> {


### PR DESCRIPTION
The new ThreadId code from #5329 in tokio 1.24.0 assumes that `StaticAtomicU64` has `load` and `compare_exchange_weak` methods, which was not always the case. This was causing the following build failure:

```console
error[E0599]: no method named `load` found for struct `StaticAtomicU64` in the current scope
  --> tokio-1.24.0/src/runtime/thread_id.rs:12:32
   |
12 |         let mut last = NEXT_ID.load(Relaxed);
   |                                ^^^^ method not found in `StaticAtomicU64`
   |
  ::: tokio-1.24.0/src/loom/std/atomic_u64_static_once_cell.rs:5:1
   |
5  | pub(crate) struct StaticAtomicU64 {
   | --------------------------------- method `load` not found for this

error[E0599]: no method named `compare_exchange_weak` found for struct `StaticAtomicU64` in the current scope
  --> tokio-1.24.0/src/runtime/thread_id.rs:19:27
   |
19 |             match NEXT_ID.compare_exchange_weak(last, id, Relaxed, Relaxed) {
   |                           ^^^^^^^^^^^^^^^^^^^^^ method not found in `StaticAtomicU64`
   |
  ::: tokio-1.24.0/src/loom/std/atomic_u64_static_once_cell.rs:5:1
   |
5  | pub(crate) struct StaticAtomicU64 {
   | --------------------------------- method `compare_exchange_weak` not found for this
```