### PR TITLE
chore: prepare Tokio v1.24.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.24.0", features = ["full"] }
+tokio = { version = "1.24.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.24.1 (January 6, 2022)
+
+This release fixes a compilation failure when using ([#5356])
+```
+RUSTFLAGS='--cfg tokio_no_atomic_u64 --cfg tokio_no_const_mutex_new'
+```
+
+[#5356]: https://github.com/tokio-rs/tokio/pull/5356
+
 # 1.24.0 (January 5, 2022)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,9 +1,6 @@
 # 1.24.1 (January 6, 2022)
 
-This release fixes a compilation failure when using ([#5356])
-```
-RUSTFLAGS='--cfg tokio_no_atomic_u64 --cfg tokio_no_const_mutex_new'
-```
+This release fixes a compilation failure on targets without `AtomicU64` when using rustc older than 1.63. ([#5356])
 
 [#5356]: https://github.com/tokio-rs/tokio/pull/5356
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.24.0"
+version = "1.24.1"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.24.0", features = ["full"] }
+tokio = { version = "1.24.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.24.1 (January 6, 2022)

This release fixes a compilation failure on targets without `AtomicU64` when using rustc older than 1.63. ([#5356])

[#5356]: https://github.com/tokio-rs/tokio/pull/5356