### PR TITLE
rt: make drop timeout configurable

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 pub(crate) struct BlockingPool {
     spawner: Spawner,
     shutdown_rx: shutdown::Receiver,
+    drop_timeout: Option<Duration>,
 }
 
 #[derive(Clone)]
@@ -232,6 +233,7 @@ impl BlockingPool {
                 }),
             },
             shutdown_rx,
+            drop_timeout: builder.drop_timeout.clone(),
         }
     }
 
@@ -275,7 +277,7 @@ impl BlockingPool {
 
 impl Drop for BlockingPool {
     fn drop(&mut self) {
-        self.shutdown(None);
+        self.shutdown(self.drop_timeout);
     }
 }
 

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -233,7 +233,7 @@ impl BlockingPool {
                 }),
             },
             shutdown_rx,
-            drop_timeout: builder.drop_timeout.clone(),
+            drop_timeout: builder.drop_timeout,
         }
     }
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1110,6 +1110,7 @@ impl fmt::Debug for Builder {
                 &"<dyn Fn() -> String + Send + Sync + 'static>",
             )
             .field("thread_stack_size", &self.thread_stack_size)
+            .field("drop_timeout", &self.drop_timeout)
             .field("after_start", &self.after_start.as_ref().map(|_| "..."))
             .field("before_stop", &self.before_stop.as_ref().map(|_| "..."))
             .field("before_park", &self.before_park.as_ref().map(|_| "..."))

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -461,16 +461,17 @@ impl Builder {
         self
     }
 
-    /// Sets the drop timeout.
+    /// Sets the maximal time dropping a [`Runtime`] will wait for pending threads.
     ///
-    /// This is intended to limit the time it could take to wait for threads that
-    /// are still stuck in [`spawn_blocking`].
+    /// This is intended to prevent threads that are stuck [`spawn_blocking`]
+    /// from blocking the program indefinitely.
     ///
     /// Important: After the timeout, the runtime stops waiting for those threads.
     /// It does **not** cancel those threads. This means it is no longer guaranteed
-    /// that all resources of this pool are properly released.
+    /// that when the Runtime object is gone, all resources of the Runtime are
+    /// properly released yet.
     ///
-    /// For that reason, this option is primarily intended for runtimes that are
+    /// For that reason, this option is primarily intended for Runtimes that are
     /// dropped right before the end of the program.
     ///
     /// # Examples


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The current behaviour of the `Runtime` object is to wait for all `spawn_blocking` tasks before `Runtime::drop()` returns.

There are legitimate situations where this behavior is undesired, such as at the end of the program where it might be an active decision of the programmer not to wait for stale threads to increase shutdown reliability, but it is hard-coded in the `Runtime`'s `drop` implementation and cannot be changed.

There **is** the possibility of calling `Runtime::shutdown_background` to avoid this behavior, but this isn't always reliable, for example when panicking:

```rust
use std::{thread, time::Duration};
use tokio::{sync::oneshot, task};

fn main() {
    let runtime = tokio::runtime::Builder::new_current_thread()
        .enable_all()
        .build()
        .unwrap();

    runtime.block_on(async move {
        let (tx, rx) = oneshot::channel();
        task::spawn_blocking(move || {
            tx.send(()).unwrap();
            thread::sleep(Duration::from_secs(10));
        });
        rx.await.unwrap();

        panic!();
    });

    // This is never reached because `panic` will unwind
    // out of `block_on` and drop `runtime` directly
    runtime.shutdown_background();
}
```

## Solution

Introducing the builder option `Builder::drop_timeout(Duration)` which can set the timeout used in the `Runtime::drop()` function:

```rust
use std::thread;
use std::time::{Duration, Instant};
use tokio::{sync::oneshot, task};

fn main() {
    let runtime = tokio::runtime::Builder::new_current_thread()
        .enable_all()
        .drop_timeout(Duration::from_nanos(0))
        .build()
        .unwrap();

    runtime.block_on(async move {
        let (tx, rx) = oneshot::channel();
        task::spawn_blocking(move || {
            tx.send(()).unwrap();
            thread::sleep(Duration::from_secs(10));
        });
        rx.await.unwrap();

        panic!();
    });

    let now = Instant::now();
    drop(runtime);
    assert!(now.elapsed().as_secs() < 1);
}
```

Refs: #5340