### PR TITLE
Condition unwinding tests on `cfg(panic = "unwind")`

### DIFF
--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -291,6 +291,7 @@ fn capacity_too_big() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 #[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn panic_in_clone() {
     use std::panic::{self, AssertUnwindSafe};

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -213,6 +213,7 @@ fn reopened_after_subscribe() {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 #[cfg(not(tokio_wasm))] // wasm currently doesn't support unwinding
 fn send_modify_panic() {
     let (tx, mut rx) = watch::channel("one");


### PR DESCRIPTION
These tests rely on unwinding and will fail if built with panic-abort.

## Motivation

The Rust toolchain for Android is built with panic-abort and these tests will fail without these changes.

## Solution

Add a `cfg` annotation that only enables these tests if `panic = "unwind"`.
