### PR TITLE
chore: update nix to 0.26

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -122,7 +122,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.42" }
-nix = { version = "0.24", default-features = false, features = ["fs", "socket"] }
+nix = { version = "0.26", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.42.0"


### PR DESCRIPTION
This updates nix (dev-dependency) to 0.26.