### PR TITLE
chore: update windows-sys to 0.45

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45"
 
 [[example]]
 name = "chat"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -125,11 +125,11 @@ libc = { version = "0.2.42" }
 nix = { version = "0.24", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45"
 optional = true
 
 [target.'cfg(docsrs)'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45"
 features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",


### PR DESCRIPTION
We may want to wait for the windows-sys update in the dependencies before merging.

- mio: https://github.com/tokio-rs/mio/pull/1644
- parking_lot_core: https://github.com/Amanieu/parking_lot/pull/368