### PR TITLE
io: increase `MAX_BUF` from `16384` to `2MiB`

### DIFF
--- a/tokio/src/fs/file/tests.rs
+++ b/tokio/src/fs/file/tests.rs
@@ -231,12 +231,12 @@ fn flush_while_idle() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn read_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = 16 * 1024;
+    let chunk_a = crate::io::blocking::MAX_BUF;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;
 
-    assert_eq!(chunk_d / 1024, 64);
+    assert_eq!(chunk_d / 1024 / 1024, 8);
 
     let mut data = vec![];
     for i in 0..(chunk_d - 1) {
@@ -303,12 +303,12 @@ fn read_with_buffer_larger_than_max() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn write_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = 16 * 1024;
+    let chunk_a = crate::io::blocking::MAX_BUF;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;
 
-    assert_eq!(chunk_d / 1024, 64);
+    assert_eq!(chunk_d / 1024 / 1024, 8);
 
     let mut data = vec![];
     for i in 0..(chunk_d - 1) {

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -26,7 +26,7 @@ pub(crate) struct Buf {
     pos: usize,
 }
 
-pub(crate) const MAX_BUF: usize = 16 * 1024;
+pub(crate) const MAX_BUF: usize = 2 * 1024 * 1024;
 
 #[derive(Debug)]
 enum State<T> {

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -108,13 +108,12 @@ where
 #[cfg(test)]
 #[cfg(not(loom))]
 mod tests {
+    use crate::io::blocking::MAX_BUF;
     use crate::io::AsyncWriteExt;
     use std::io;
     use std::pin::Pin;
     use std::task::Context;
     use std::task::Poll;
-
-    const MAX_BUF: usize = 16 * 1024;
 
     struct TextMockWriter;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

While working on [Spacedrive](https://github.com/spacedriveapp/spacedrive/), we were noticing some oddities during file reading in regards to encryption and decryption.

We use a stream reader where 1MiB of the source file is read, encrypted, written and this repeats until the end. We arguably need to use `read` for this, as opposed to `read_exact`, as we need to know the exact amount of bytes read *and* guarantee that if the full 1MiB isn't read, the buffer still contains valid data.

I noticed some oddities while calling `read`, and that it was only reading 16KB at a time. This would have been fine, but this results in 64 `read` calls until the 1MiB buffer is populated.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The 64 read calls to populate a 1MiB buffer turned out to be extremely slow. By increasing the buffer size to 2MiB, we were able to bring encryption time down from 24~ seconds to 8.7~ seconds.

I have done some testing regarding the 2MiB value. 1MiB seemed to be a little too low, and gave us a time-to-encrypt of 15~ seconds. 4MiB gave us 8.7~ seconds also, but 2MiB should be cheaper and more universal.

This value could likely be configurable somewhere, but I'm not too sure how the API would work there.

On another note, 2MiB may be too large for some platforms and I'm not too sure if this is allocated on the stack or heap. In the event it's stack allocated, we may be better off increasing the default to 32/64KB and allowing it to be configurable.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
