### PR TITLE
remove double store of deadline, saving 128 bytes

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -298,9 +298,11 @@ pub(crate) struct TimerEntry {
     /// This is manipulated only under the inner mutex. TODO: Can we use loom
     /// cells for this?
     inner: StdUnsafeCell<TimerShared>,
-    /// Initial deadline for the timer. This is used to register on the first
+    /// Deadline for the timer. This is used to register on the first
     /// poll, as we can't register prior to being pinned.
-    initial_deadline: Option<Instant>,
+    deadline: Instant,
+    /// Whether the deadline has been registered.
+    registered: bool,
     /// Ensure the type is !Unpin
     _m: std::marker::PhantomPinned,
 }
@@ -504,7 +506,8 @@ impl TimerEntry {
         Self {
             driver,
             inner: StdUnsafeCell::new(TimerShared::new()),
-            initial_deadline: Some(deadline),
+            deadline,
+            registered: false,
             _m: std::marker::PhantomPinned,
         }
     }
@@ -513,8 +516,12 @@ impl TimerEntry {
         unsafe { &*self.inner.get() }
     }
 
+    pub(crate) fn deadline(&self) -> Instant {
+        self.deadline
+    }
+
     pub(crate) fn is_elapsed(&self) -> bool {
-        !self.inner().state.might_be_registered() && self.initial_deadline.is_none()
+        !self.inner().state.might_be_registered() && self.registered
     }
 
     /// Cancels and deregisters the timer. This operation is irreversible.
@@ -545,7 +552,8 @@ impl TimerEntry {
     }
 
     pub(crate) fn reset(mut self: Pin<&mut Self>, new_time: Instant) {
-        unsafe { self.as_mut().get_unchecked_mut() }.initial_deadline = None;
+        unsafe { self.as_mut().get_unchecked_mut() }.deadline = new_time;
+        unsafe { self.as_mut().get_unchecked_mut() }.registered = true;
 
         let tick = self.driver().time_source().deadline_to_tick(new_time);
 
@@ -567,7 +575,8 @@ impl TimerEntry {
             panic!("{}", crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
         }
 
-        if let Some(deadline) = self.initial_deadline {
+        if !self.registered {
+            let deadline = self.deadline;
             self.as_mut().reset(deadline);
         }
 

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -235,7 +235,6 @@ pin_project! {
 cfg_trace! {
     #[derive(Debug)]
     struct Inner {
-        deadline: Instant,
         ctx: trace::AsyncOpTracingCtx,
     }
 }
@@ -243,7 +242,6 @@ cfg_trace! {
 cfg_not_trace! {
     #[derive(Debug)]
     struct Inner {
-        deadline: Instant,
     }
 }
 
@@ -296,11 +294,11 @@ impl Sleep {
                 resource_span,
             };
 
-            Inner { deadline, ctx }
+            Inner { ctx }
         };
 
         #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let inner = Inner { deadline };
+        let inner = Inner {};
 
         Sleep { inner, entry }
     }
@@ -311,7 +309,7 @@ impl Sleep {
 
     /// Returns the instant at which the future will complete.
     pub fn deadline(&self) -> Instant {
-        self.inner.deadline
+        self.entry.deadline()
     }
 
     /// Returns `true` if `Sleep` has elapsed.
@@ -357,7 +355,6 @@ impl Sleep {
     fn reset_inner(self: Pin<&mut Self>, deadline: Instant) {
         let mut me = self.project();
         me.entry.as_mut().reset(deadline);
-        (me.inner).deadline = deadline;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Due to cache-aligned padding, `Sleep` is quite large.

Sleep totals 640 bytes, a majority of it is padding caused by `CachePadded` alignment.

<details>
<summary>Breakdown of cache usage</summary>

Breakdown of the size and padding made with help by @Nilstrieb using `-Zprint-type-sizes`

```
print-type-size type: `tokio::time::Sleep`: 640 bytes, alignment: 128 bytes
print-type-size     field `.entry`: 512 bytes
print-type-size     field `.inner`: 16 bytes
print-type-size     end padding: 112 bytes

print-type-size type: `tokio::runtime::time::entry::TimerEntry`: 512 bytes, alignment: 128 bytes
print-type-size     field `.driver`: 0 bytes
print-type-size     field `._m`: 0 bytes
print-type-size     field `.inner`: 384 bytes
print-type-size     field `.initial_deadline`: 16 bytes
print-type-size     end padding: 112 bytes

print-type-size type: `tokio::runtime::time::entry::TimerShared`: 384 bytes, alignment: 128 bytes
print-type-size     field `.driver_state`: 128 bytes
print-type-size     field `.state`: 256 bytes
print-type-size     field `._p`: 0 bytes

print-type-size type: `tokio::runtime::time::entry::StateCell`: 256 bytes, alignment: 128 bytes
print-type-size     field `.waker`: 128 bytes
print-type-size     field `.state`: 8 bytes
print-type-size     field `.result`: 1 bytes
print-type-size     end padding: 119 bytes
```

* `CachePadded<StateCell::waker>` has 104 bytes of padding.
* `StateCell` has 119 bytes of padding.
* `CachePadded<TimerShared::driver_state>` has 96 bytes of padding.
* `TimerEntry` has 112 bytes of padding.
* `Sleep` has 112 bytes of padding.

Total padding: 543 bytes.

This means in theory, Sleep should occupy no more than 128 bytes. In practice, I know this is more complicated, as the `CachePadded` decorators exist for a reason.

</details>

## Solution

A simple fix is to utilise the initial_deadline field in the `TimerEntry` type, sharing it with `Sleep`. This cuts down on the outer layer of sleep needing 128 extra bytes.

Refs: #5348