### PR TITLE
Create UdpSocket method that exposes `async_io`

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1329,7 +1329,7 @@ impl UdpSocket {
     /// flag is cleared and the socket readiness is awaited again. This loop
     /// repeated until the closure returns an `Ok` or an error that doesn't
     /// have the `WouldBlock` value.
-    /// 
+    ///
     /// The closure should only return a `WouldBlock` error if it has performed
     /// an IO operation on the socket that failed due to the socket not being
     /// ready. Returning a `WouldBlock` error in any other situation will

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1319,6 +1319,48 @@ impl UdpSocket {
             .try_io(interest, || self.io.try_io(f))
     }
 
+    /// Reads or writes from the socket using a user-provided IO operation.
+    ///
+    /// The readiness of the socket is awaited and when the socket is ready,
+    /// the provided closure is called. The closure should attempt to perform
+    /// IO operation on the socket by manually calling the appropriate syscall.
+    /// If the operation fails because the socket is not actually ready,
+    /// then the closure should return a `WouldBlock` error, the readiness
+    /// flag is cleared and the socket readiness is awaited again. This loop
+    /// repeated until the closure returns an `Ok` or an error that doesn't
+    /// have the `WouldBlock` value.
+    /// 
+    /// The closure should only return a `WouldBlock` error if it has performed
+    /// an IO operation on the socket that failed due to the socket not being
+    /// ready. Returning a `WouldBlock` error in any other situation will
+    /// incorrectly clear the readiness flag, which can cause the socket to
+    /// behave incorrectly.
+    ///
+    /// The closure should not perform the IO operation using any of the methods
+    /// defined on the Tokio `UdpSocket` type, as this will mess with the
+    /// readiness flag and can cause the socket to behave incorrectly.
+    ///
+    /// This method is not intended to be used with combined interests.
+    /// The closure should perform only one type of IO operation, so it should not
+    /// require more than one ready state. This method may panic or sleep forever
+    /// if it is called with a combined interest.
+    ///
+    /// Usually, [`readable()`], [`writable()`] or [`ready()`] is used with this function.
+    ///
+    /// [`readable()`]: UdpSocket::readable()
+    /// [`writable()`]: UdpSocket::writable()
+    /// [`ready()`]: UdpSocket::ready()
+    pub async fn async_io<R>(
+        &self,
+        interest: Interest,
+        mut f: impl FnMut() -> io::Result<R>,
+    ) -> io::Result<R> {
+        self.io
+            .registration()
+            .async_io(interest, || self.io.try_io(&mut f))
+            .await
+    }
+
     /// Receives data from the socket, without removing it from the input queue.
     /// On success, returns the number of bytes read and the address from whence
     /// the data came.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

We're building a PTP library and need to be able to read timestamp information from received UDP packet. This is not possible with Tokio's APIs directly of course, so we have to make the specific syscall ourselves.

We're making our PTP stack async, so receiving a packet has to be async as well.

All async udp functions that need to send or receive use the private internal `async_io` function from the `Registration`. This isn't available to use from the outside while the polling version of this API is public (named `try_io`).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I made a new method just like the existing `try_io` that allows access to the inner API.
With this we can plug in our own syscall that can read the socket together with the options so a timestamp is returned.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
