### PR TITLE
Mark `MutexGuard` with `#[clippy::has_significant_drop]`

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -164,6 +164,7 @@ pub struct MutexGuard<'a, T: ?Sized> {
 /// point `lock` will succeed yet again.
 ///
 /// [`Arc`]: std::sync::Arc
+#[clippy::has_significant_drop]
 pub struct OwnedMutexGuard<T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,
@@ -175,6 +176,7 @@ pub struct OwnedMutexGuard<T: ?Sized> {
 /// This can be used to hold a subfield of the protected data.
 ///
 /// [`MutexGuard::map`]: method@MutexGuard::map
+#[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct MappedMutexGuard<'a, T: ?Sized> {
     s: &'a semaphore::Semaphore,

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -141,6 +141,7 @@ pub struct Mutex<T: ?Sized> {
 ///
 /// The lock is automatically released whenever the guard is dropped, at which
 /// point `lock` will succeed yet again.
+#[clippy::has_significant_drop]
 #[must_use = "if unused the Mutex will immediately unlock"]
 pub struct MutexGuard<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 ///
 /// [`read_owned`]: method@crate::sync::RwLock::read_owned
 /// [`RwLock`]: struct@crate::sync::RwLock
+#[clippy::has_significant_drop]
 pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 ///
 /// [`write_owned`]: method@crate::sync::RwLock::write_owned
 /// [`RwLock`]: struct@crate::sync::RwLock
+#[clippy::has_significant_drop]
 pub struct OwnedRwLockWriteGuard<T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 ///
 /// [mapping]: method@crate::sync::OwnedRwLockWriteGuard::map
 /// [`OwnedRwLockWriteGuard`]: struct@crate::sync::OwnedRwLockWriteGuard
+#[clippy::has_significant_drop]
 pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -12,6 +12,7 @@ use std::ops;
 ///
 /// [`read`]: method@crate::sync::RwLock::read
 /// [`RwLock`]: struct@crate::sync::RwLock
+#[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
 pub struct RwLockReadGuard<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -14,6 +14,7 @@ use std::ops;
 ///
 /// [`write`]: method@crate::sync::RwLock::write
 /// [`RwLock`]: struct@crate::sync::RwLock
+#[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -13,6 +13,7 @@ use std::ops;
 ///
 /// [mapping]: method@crate::sync::RwLockWriteGuard::map
 /// [`RwLockWriteGuard`]: struct@crate::sync::RwLockWriteGuard
+#[clippy::has_significant_drop]
 pub struct RwLockMappedWriteGuard<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -89,6 +89,7 @@ pub struct Semaphore {
 ///
 /// [`acquire`]: crate::sync::Semaphore::acquire()
 #[must_use]
+#[clippy::has_significant_drop]
 #[derive(Debug)]
 pub struct SemaphorePermit<'a> {
     sem: &'a Semaphore,
@@ -101,6 +102,7 @@ pub struct SemaphorePermit<'a> {
 ///
 /// [`acquire_owned`]: crate::sync::Semaphore::acquire_owned()
 #[must_use]
+#[clippy::has_significant_drop]
 #[derive(Debug)]
 pub struct OwnedSemaphorePermit {
     sem: Arc<Semaphore>,


### PR DESCRIPTION
`#[clippy::has_significant_drop]` tells that a structure should be considered when evaluating some lints. Examples of such behavior are the existent `clippy::significant_drop_in_scrutinee` and the soon-to-be-finished https://github.com/rust-lang/rust-clippy/issues/9399.

