### PR TITLE
chore: Update Cargo.toml to refer to latest tokio

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead, and delete the **path**.
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing"] }
+tokio = { version = "1", path = "../tokio", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -27,7 +27,7 @@ quote = "1"
 syn = { version = "1.0.56", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
+tokio = { version = "1", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -28,7 +28,7 @@ signal = ["tokio/signal"]
 [dependencies]
 futures-core = { version = "0.3.0" }
 pin-project-lite = "0.2.0"
-tokio = { version = "1.8.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.25.0", path = "../tokio", features = ["sync"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", optional = true }
 
 [dev-dependencies]

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -17,7 +17,7 @@ Testing utilities for Tokio- and futures-based code
 categories = ["asynchronous", "testing"]
 
 [dependencies]
-tokio = { version = "1.2.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
+tokio = { version = "1.25.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
 tokio-stream = { version = "0.1.1", path = "../tokio-stream" }
 async-stream = "0.3.3"
 

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.21.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.25.0", path = "../tokio", features = ["sync"] }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"


### PR DESCRIPTION
## Motivation

`path = ..` are dropped when publishing, and the `version = ..` is used.
Those `version` should refer to the latest tokio.

## Solution

- Use "1" in `dev-dependencies`, however it would be reasonable to remove the `version` altogether here.
- Use latest version in `dependencies`.
