### PR TITLE
ci: update Cirrus CI config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-4-release-amd64
+  image_family: freebsd-12-4
 env:
   RUST_STABLE: stable
   RUST_NIGHTLY: nightly-2022-10-25

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,5 @@
+only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'tokio-.*')
+auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
   image_family: freebsd-12-4
 env:
@@ -11,7 +13,6 @@ env:
 # the system's binaries, so the environment shouldn't matter.
 task:
   name: FreeBSD 64-bit
-  auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh
@@ -26,7 +27,6 @@ task:
 
 task:
   name: FreeBSD docs
-  auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
   env:
     RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
     RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
@@ -44,7 +44,6 @@ task:
 
 task:
   name: FreeBSD 32-bit
-  auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
   setup_script:
     - pkg install -y bash curl
     - curl https://sh.rustup.rs -sSf --output rustup.sh


### PR DESCRIPTION
- [Use image_family for FreeBSD image in Cirrus CI](https://github.com/tokio-rs/tokio/commit/f9f7035e36d188d9c59369cf118b8c9d5d28cb55) -- simplify config 
- [Do not trigger Cirrus CI on branches other than master and tokio-.*](https://github.com/tokio-rs/tokio/commit/16a8b19883d6725e18bffa79036c84097cf8f8da) -- adopt a similar behavior as GitHub workflows