### PR TITLE
bugfix: Remove erroneous wake call in SinkWriter

### DIFF
--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -101,10 +101,10 @@ where
         let mut this = self.project();
 
         ready!(this.inner.as_mut().poll_ready(cx).map_err(Into::into))?;
-        Poll::Ready(match this.inner.as_mut().start_send(buf) {
-            Ok(()) => Ok(buf.len()),
-            Err(e) => Err(e.into()),
-        })
+        match this.inner.as_mut().start_send(buf) {
+            Ok(()) => Poll::Ready(Ok(buf.len())),
+            Err(e) => Poll::Ready(Err(e.into())),
+        }
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {


### PR DESCRIPTION
Per review comment https://github.com/tokio-rs/tokio/pull/5070#discussion_r997835198:
> Adding a wake call here will be a busy loop that consumes 100% CPU
> waiting for it to become ready. We shouldn't do that.

Furthermore, according to https://docs.rs/futures-sink/latest/futures_sink/trait.Sink.html#tymethod.poll_ready, poll_ready will make sure that the current task is notified.

Discussion: https://discord.com/channels/500028886025895936/500336346770964480/1072534504981418024
