### PR TITLE
ci: Make semver check non-mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
       - test-unstable
       - miri
       - asan
-      - semver
       - cross-check
       - cross-test
       - no-atomic-u64


### PR DESCRIPTION
As discussed in #5437.

Making it mandatory is incompatible with our current workflow of merging PR's first and then increasing the version number.
It would require increasing the version number on every API change, directly in the PR.

With changing it to non-mandatory, our workflow would be:
- When an API change happens, the semver check will fail
- The increase-version-number PR later will make it succeed again

How we will deal with it in the future is open for discussion. cargo-semver-checks is also in the process of releasing a new github action, so we should wait until then to discuss our possibilities.