### PR TITLE
rt: augment ready check after on_park for awoken

### DIFF
--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -298,9 +298,9 @@ impl Context {
             core = c;
         }
 
-        // This check will fail if `before_park` spawns a task for us to run
+        // This check will fail if `before_park` spawns a task or has awoken a task for us to run
         // instead of parking the thread
-        if core.tasks.is_empty() {
+        if core.tasks.is_empty() && ! handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed) {
             // Park until the thread is signaled
             core.metrics.about_to_park();
             core.metrics.submit(&handle.shared.worker_metrics);

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -290,7 +290,10 @@ impl Context {
     fn park(&self, mut core: Box<Core>, handle: &Handle) -> Box<Core> {
         let mut driver = core.driver.take().expect("driver missing");
 
-        let before = handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed);
+        let before = handle
+            .shared
+            .woken
+            .load(std::sync::atomic::Ordering::Relaxed);
         if let Some(f) = &handle.shared.config.before_park {
             // Incorrect lint, the closures are actually different types so `f`
             // cannot be passed as an argument to `enter`.
@@ -299,9 +302,15 @@ impl Context {
             core = c;
         }
 
-        // This check will succeed and we will park if `before_park` didn't spawn any task and
-        // didn't add to an empty set of awoken tasks.
-        if core.tasks.is_empty() && (before || ! handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed)) {
+        // This check will succeed and we will park if `before_park` didn't spawn any
+        // task and didn't add to an empty set of awoken tasks.
+        if core.tasks.is_empty()
+            && (before
+                || !handle
+                    .shared
+                    .woken
+                    .load(std::sync::atomic::Ordering::Relaxed))
+        {
             // Park until the thread is signaled
             core.metrics.about_to_park();
             core.metrics.submit(&handle.shared.worker_metrics);

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -290,6 +290,7 @@ impl Context {
     fn park(&self, mut core: Box<Core>, handle: &Handle) -> Box<Core> {
         let mut driver = core.driver.take().expect("driver missing");
 
+        let before = handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed);
         if let Some(f) = &handle.shared.config.before_park {
             // Incorrect lint, the closures are actually different types so `f`
             // cannot be passed as an argument to `enter`.
@@ -298,9 +299,9 @@ impl Context {
             core = c;
         }
 
-        // This check will fail if `before_park` spawns a task or has awoken a task for us to run
-        // instead of parking the thread
-        if core.tasks.is_empty() && ! handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed) {
+        // This check will succeed and we will park if `before_park` didn't spawn any task and
+        // didn't add to an empty set of awoken tasks.
+        if core.tasks.is_empty() && (before || ! handle.shared.woken.load(std::sync::atomic::Ordering::Relaxed)) {
             // Park until the thread is signaled
             core.metrics.about_to_park();
             core.metrics.submit(&handle.shared.worker_metrics);


### PR DESCRIPTION
There had been a check for new tasks being spawned by the `on_park` callback to potentially avoid parking the thread. This adds a check for existing tasks having been awoken by the same callback.

This is for current_thread only.

## Motivation

When `tokio-uring`'s current thread is about to park, it submits work to the io_uring device and optionally can check if work has been completed - when io_uring work has been completed, the io_uring completion queue is read and tasks that had been blocked on io_uring operation futures are awoken. The current tip does not actually check for work being done because this problem in the `on_park` check meant the thread was going to be parked anyway so benchmarks didn't show much improvement. But when both the change proposed in this PR is made and the callback is modified to check for work having been done, performance tests show a marked improvement in throughput. Being able to avoid the parking of the thread when there is work to do saves many steps in actually getting to that work.

## Solution

Add one more check before actually parking the thread. One test, already there, was for whether any new tasks had been created by the `on_park` callback. Now another test checks whether any tasks have been awoken. Either is enough to avoid parking the thread. The scheduler gets back to scheduling ready tasks.
