### PR TITLE
chore: prepare tokio-util v0.7.6

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.6 (February 10, 2023)
+
+This release fixes a compilation failure in 0.7.5 when it is used together with
+Tokio version 1.21 and unstable features are enabled. ([#5445])
+
+[#5445]: https://github.com/tokio-rs/tokio/pull/5445
+
 # 0.7.5 (February 9, 2023)
 
 This release fixes an accidental breaking change where `UnwindSafe` was

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.5"
+version = "0.7.6"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.7.6 (February 10, 2023)

This release fixes a compilation failure in 0.7.5 when it is used together with Tokio version 1.21 and unstable features are enabled. ([#5445])

[#5445]: https://github.com/tokio-rs/tokio/pull/5445
