### PR TITLE
chore: prepare tokio-util v0.7.7

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.7.7 (February 12, 2023)
+
+This release reverts the removal of the `Encoder` bound on the `FramedParts`
+constructor from [#5280] since it turned out to be a breaking change. ([#5450])
+
+[#5450]: https://github.com/tokio-rs/tokio/pull/5450
+
 # 0.7.6 (February 10, 2023)
 
 This release fixes a compilation failure in 0.7.5 when it is used together with

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.6"
+version = "0.7.7"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.7.7 (February 12, 2023)

This release reverts the removal of the `Encoder` bound on the `FramedParts` constructor from [#5280] since it turned out to be a breaking change. ([#5450])

[#5280]: https://github.com/tokio-rs/tokio/pull/5280
[#5450]: https://github.com/tokio-rs/tokio/pull/5450