### PR TITLE
CI: Always assume minor release in semver check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,7 @@ jobs:
       - name: Check semver compatibility
         run: |
           cargo semver-checks check-release \
+              --release-type minor \
               --exclude benches \
               --exclude examples \
               --exclude stress-test \


### PR DESCRIPTION
As discussed in #5437.