### PR TITLE
sync: make `notify_waiters` calls atomic

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -539,7 +539,7 @@ impl Notify {
         // The number of calls does not matter for the guarding waiter.
         let guard = UnsafeCell::new(Waiter::new(0));
         // Safety: the pointer is not null. Additionally, we have made sure
-        // that `guard` will not but moved until the guarded list is dropped.
+        // that `guard` will not be moved until the guarded list is dropped.
         let mut guarded_list =
             unsafe { decoupled_list.into_guarded(NonNull::new_unchecked(guard.get())) };
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -296,7 +296,7 @@ impl<'a> NotifyWaitersList<'a> {
 impl Drop for NotifyWaitersList<'_> {
     fn drop(&mut self) {
         // If the list is not empty, we unlink all waiters from it.
-        // We do call wakers to avoid double panic.
+        // We do not wake the waiters to avoid double panics.
         if !self.is_empty {
             let _lock_guard = self.notify.waiters.lock();
             while let Some(mut waiter) = self.list.pop_back() {

--- a/tokio/src/sync/tests/loom_notify.rs
+++ b/tokio/src/sync/tests/loom_notify.rs
@@ -47,110 +47,6 @@ fn notify_waiters() {
     });
 }
 
-fn notify_waiters_poll_consistency_variant(poll_setting: [bool; 2]) {
-    let notify = Arc::new(Notify::new());
-    let mut notified = [
-        tokio_test::task::spawn(notify.notified()),
-        tokio_test::task::spawn(notify.notified()),
-    ];
-    for i in 0..2 {
-        if poll_setting[i] {
-            assert_pending!(notified[i].poll());
-        }
-    }
-
-    let tx = notify.clone();
-    let th = thread::spawn(move || {
-        tx.notify_waiters();
-    });
-
-    let res1 = notified[0].poll();
-    let res2 = notified[1].poll();
-
-    // If res1 is ready, then res2 must also be ready.
-    assert!(res1.is_pending() || res2.is_ready());
-
-    th.join().unwrap();
-}
-
-#[test]
-fn notify_waiters_poll_consistency() {
-    // We test different scenarios where pending futures had or had not
-    // been polled before the call to `notify_waiters`.
-    loom::model(|| notify_waiters_poll_consistency_variant([false, false]));
-    loom::model(|| notify_waiters_poll_consistency_variant([true, false]));
-    loom::model(|| notify_waiters_poll_consistency_variant([false, true]));
-    loom::model(|| notify_waiters_poll_consistency_variant([true, true]));
-}
-
-fn notify_waiters_poll_consistency_wake_up_batches_variant(order: [usize; 2]) {
-    let notify = Arc::new(Notify::new());
-
-    let mut futs = (0..WAKE_LIST_SIZE + 1)
-        .map(|_| tokio_test::task::spawn(notify.notified()))
-        .collect::<Vec<_>>();
-
-    assert_pending!(futs[order[0]].poll());
-    for i in 2..futs.len() {
-        assert_pending!(futs[i].poll());
-    }
-    assert_pending!(futs[order[1]].poll());
-
-    let tx = notify.clone();
-    let th = thread::spawn(move || {
-        tx.notify_waiters();
-    });
-
-    let res1 = futs[0].poll();
-    let res2 = futs[1].poll();
-
-    // If res1 is ready, then res2 must also be ready.
-    assert!(res1.is_pending() || res2.is_ready());
-
-    th.join().unwrap();
-}
-
-#[test]
-fn notify_waiters_poll_consistency_wake_up_batches() {
-    // We test polling two futures in different batches in various orders.
-    loom::model(|| notify_waiters_poll_consistency_wake_up_batches_variant([0, 1]));
-    loom::model(|| notify_waiters_poll_consistency_wake_up_batches_variant([1, 0]));
-}
-
-fn notify_waiters_is_atomic_variant(wait_for_index: usize) {
-    let notify = Arc::new(Notify::new());
-
-    let mut futs = (0..WAKE_LIST_SIZE + 1)
-        .map(|_| tokio_test::task::spawn(notify.notified()))
-        .collect::<Vec<_>>();
-
-    for fut in &mut futs {
-        assert_pending!(fut.poll());
-    }
-
-    let tx = notify.clone();
-    let th = thread::spawn(move || {
-        tx.notify_waiters();
-    });
-
-    block_on(async {
-        futs.remove(wait_for_index).await;
-        let mut new_fut = tokio_test::task::spawn(notify.notified());
-        assert_pending!(new_fut.poll());
-        notify.notify_one();
-        assert_ready!(new_fut.poll());
-    });
-
-    th.join().unwrap();
-}
-
-#[test]
-fn notify_waiters_is_atomic() {
-    // We test polling two futures in different batches in various orders.
-    loom::model(|| notify_waiters_is_atomic_variant(0));
-    loom::model(|| notify_waiters_is_atomic_variant(32));
-}
-
 #[test]
 fn notify_waiters_and_one() {
     loom::model(|| {
@@ -248,8 +144,140 @@ fn notify_drop() {
     });
 }
 
+/// Polls two `Notified` futures and checks if poll results are
+/// consistent with each other. If one of the futures was notifed
+/// by the `notify_waiters` call, then the other one must be notified
+/// as well.
 #[test]
-fn notify_waiters_sequential() {
+fn notify_waiters_poll_consistency() {
+    fn notify_waiters_poll_consistency_variant(poll_setting: [bool; 2]) {
+        let notify = Arc::new(Notify::new());
+        let mut notified = [
+            tokio_test::task::spawn(notify.notified()),
+            tokio_test::task::spawn(notify.notified()),
+        ];
+        for i in 0..2 {
+            if poll_setting[i] {
+                assert_pending!(notified[i].poll());
+            }
+        }
+
+        let tx = notify.clone();
+        let th = thread::spawn(move || {
+            tx.notify_waiters();
+        });
+
+        let res1 = notified[0].poll();
+        let res2 = notified[1].poll();
+
+        // If res1 is ready, then res2 must also be ready.
+        assert!(res1.is_pending() || res2.is_ready());
+
+        th.join().unwrap();
+    }
+
+    // We test different scenarios in which pending futures had or had not
+    // been polled before the call to `notify_waiters`.
+    loom::model(|| notify_waiters_poll_consistency_variant([false, false]));
+    loom::model(|| notify_waiters_poll_consistency_variant([true, false]));
+    loom::model(|| notify_waiters_poll_consistency_variant([false, true]));
+    loom::model(|| notify_waiters_poll_consistency_variant([true, true]));
+}
+
+/// Polls two `Notified` futures and checks if poll results are
+/// consistent with each other. If one of the futures was notifed
+/// by the `notify_waiters` call, then the other one must be notified
+/// as well.
+///
+/// Here we also add other `Notified` futures in between to force the
+/// two tested futures to end up in different chunks.
+#[test]
+fn notify_waiters_poll_consistency_many() {
+    fn notify_waiters_poll_consistency_many_variant(order: [usize; 2]) {
+        let notify = Arc::new(Notify::new());
+
+        let mut futs = (0..WAKE_LIST_SIZE + 1)
+            .map(|_| tokio_test::task::spawn(notify.notified()))
+            .collect::<Vec<_>>();
+
+        assert_pending!(futs[order[0]].poll());
+        for i in 2..futs.len() {
+            assert_pending!(futs[i].poll());
+        }
+        assert_pending!(futs[order[1]].poll());
+
+        let tx = notify.clone();
+        let th = thread::spawn(move || {
+            tx.notify_waiters();
+        });
+
+        let res1 = futs[0].poll();
+        let res2 = futs[1].poll();
+
+        // If res1 is ready, then res2 must also be ready.
+        assert!(res1.is_pending() || res2.is_ready());
+
+        th.join().unwrap();
+    }
+
+    // We test different scenarios in which futures are polled in different order.
+    loom::model(|| notify_waiters_poll_consistency_many_variant([0, 1]));
+    loom::model(|| notify_waiters_poll_consistency_many_variant([1, 0]));
+}
+
+/// Checks if a call to `notify_waiters` is observed as atomic when combined with
+/// concurrent calls to `notify_one`.
+#[test]
+fn notify_waiters_is_atomic() {
+    fn notify_waiters_is_atomic_variant(tested_fut_index: usize) {
+        let notify = Arc::new(Notify::new());
+
+        let mut futs = (0..WAKE_LIST_SIZE + 1)
+            .map(|_| tokio_test::task::spawn(notify.notified()))
+            .collect::<Vec<_>>();
+
+        for fut in &mut futs {
+            assert_pending!(fut.poll());
+        }
+
+        let tx = notify.clone();
+        let th = thread::spawn(move || {
+            tx.notify_waiters();
+        });
+
+        block_on(async {
+            // If awaiting one of the futures completes, then we should be
+            // able to assume that all pending futures are notified. Therefore
+            // a notification from a subsequent `notify_one` call should not
+            // be consumed by an old future.
+            futs.remove(tested_fut_index).await;
+
+            let mut new_fut = tokio_test::task::spawn(notify.notified());
+            assert_pending!(new_fut.poll());
+
+            notify.notify_one();
+
+            // `new_fut` must consume the notification from `notify_one`.
+            assert_ready!(new_fut.poll());
+        });
+
+        th.join().unwrap();
+    }
+
+    // We test different scenarios in which the tested future is at the beginning
+    // or at the end of the waiters queue used by `Notify`.
+    loom::model(|| notify_waiters_is_atomic_variant(0));
+    loom::model(|| notify_waiters_is_atomic_variant(32));
+}
+
+/// Checks if a single call to `notify_waiters` does not get through two `Notified`
+/// futures created and awaited sequentially like this:
+/// ```ignore
+/// notify.notified().await;
+/// notify.notified().await;
+/// ```
+#[test]
+fn notify_waiters_sequential_notified_await() {
     use crate::sync::oneshot;
 
     loom::model(|| {

--- a/tokio/src/sync/tests/loom_notify.rs
+++ b/tokio/src/sync/tests/loom_notify.rs
@@ -144,10 +144,9 @@ fn notify_drop() {
     });
 }
 
-/// Polls two `Notified` futures and checks if poll results are
-/// consistent with each other. If one of the futures was notifed
-/// by the `notify_waiters` call, then the other one must be notified
-/// as well.
+/// Polls two `Notified` futures and checks if poll results are consistent
+/// with each other. If the first future is notified by a `notify_waiters`
+/// call, then the second one must be notified as well.
 #[test]
 fn notify_waiters_poll_consistency() {
     fn notify_waiters_poll_consistency_variant(poll_setting: [bool; 2]) {
@@ -184,13 +183,12 @@ fn notify_waiters_poll_consistency() {
     loom::model(|| notify_waiters_poll_consistency_variant([true, true]));
 }
 
-/// Polls two `Notified` futures and checks if poll results are
-/// consistent with each other. If one of the futures was notifed
-/// by the `notify_waiters` call, then the other one must be notified
-/// as well.
+/// Polls two `Notified` futures and checks if poll results are consistent
+/// with each other. If the first future is notified by a `notify_waiters`
+/// call, then the second one must be notified as well.
 ///
-/// Here we also add other `Notified` futures in between to force the
-/// two tested futures to end up in different chunks.
+/// Here we also add other `Notified` futures in between to force the two
+/// tested futures to end up in different chunks.
 #[test]
 fn notify_waiters_poll_consistency_many() {
     fn notify_waiters_poll_consistency_many_variant(order: [usize; 2]) {
@@ -225,8 +223,8 @@ fn notify_waiters_poll_consistency_many() {
     loom::model(|| notify_waiters_poll_consistency_many_variant([1, 0]));
 }
 
-/// Checks if a call to `notify_waiters` is observed as atomic when combined with
-/// concurrent calls to `notify_one`.
+/// Checks if a call to `notify_waiters` is observed as atomic when combined
+/// with a concurrent call to `notify_one`.
 #[test]
 fn notify_waiters_is_atomic() {
     fn notify_waiters_is_atomic_variant(tested_fut_index: usize) {

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -47,6 +47,44 @@ fn notify_clones_waker_before_lock() {
 }
 
 #[test]
+fn notify_waiters_handles_panicking_waker() {
+    use futures::task::ArcWake;
+
+    let notify = Arc::new(Notify::new());
+
+    struct PanickingWaker(Arc<Notify>);
+
+    impl ArcWake for PanickingWaker {
+        fn wake_by_ref(_arc_self: &Arc<Self>) {
+            panic!("waker panicked");
+        }
+    }
+
+    let bad_fut = notify.notified();
+    pin!(bad_fut);
+
+    let waker = futures::task::waker(Arc::new(PanickingWaker(notify.clone())));
+    let mut cx = Context::from_waker(&waker);
+    let _ = bad_fut.poll(&mut cx);
+
+    let mut futs = Vec::new();
+    for _ in 0..32 {
+        let mut fut = tokio_test::task::spawn(notify.notified());
+        assert!(fut.poll().is_pending());
+        futs.push(fut);
+    }
+
+    assert!(std::panic::catch_unwind(|| {
+        notify.notify_waiters();
+    })
+    .is_err());
+
+    for mut fut in futs {
+        assert!(fut.poll().is_ready());
+    }
+}
+
+#[test]
 fn notify_simple() {
     let notify = Notify::new();
 

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -46,6 +46,7 @@ fn notify_clones_waker_before_lock() {
     let _ = future.poll(&mut cx);
 }
 
+#[cfg(panic = "unwind")]
 #[test]
 fn notify_waiters_handles_panicking_waker() {
     use futures::task::ArcWake;

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -290,6 +290,56 @@ cfg_io_readiness! {
     }
 }
 
+// ===== impl Iter =====
+
+feature! {
+    #![any(
+        feature = "process",
+        feature = "sync",
+        feature = "rt",
+        feature = "signal",
+    )]
+
+    /// Iterates over list elements without consuming them.
+    pub(crate) struct Iter<'a, T: Link> {
+        curr: Option<NonNull<T::Target>>,
+        _list: &'a LinkedList<T, T::Target>,
+    }
+
+    impl<T: Link> LinkedList<T, T::Target> {
+        fn iter(&self) -> Iter<'_, T> {
+            let curr = self.head;
+            Iter {
+                curr,
+                _list: self,
+            }
+        }
+    }
+
+    impl<'a, T: Link> IntoIterator for &'a LinkedList<T, T::Target> {
+        type Item = NonNull<T::Target>;
+        type IntoIter = Iter<'a, T>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter()
+        }
+    }
+
+    impl<'a, T: Link> Iterator for Iter<'a, T> {
+        type Item = NonNull<T::Target>;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            if let Some(curr) = self.curr {
+                // safety: the pointer references data contained by the list
+                self.curr = unsafe { T::pointers(curr).as_ref() }.get_next();
+                Some(curr)
+            } else {
+                None
+            }
+        }
+    }
+}
+
 // ===== impl Pointers =====
 
 impl<T> Pointers<T> {
@@ -450,6 +500,35 @@ pub(crate) mod tests {
         assert_eq!([5, 7, 31].to_vec(), items);
 
         assert!(list.is_empty());
+    }
+
+    #[test]
+    fn iter() {
+        let a = entry(5);
+        let b = entry(7);
+        let c = entry(31);
+
+        let mut list = LinkedList::<&Entry, <&Entry as Link>::Target>::new();
+        list.push_front(a.as_ref());
+        list.push_front(b.as_ref());
+        list.push_front(c.as_ref());
+
+        let mut iter = list.iter();
+        assert_eq!(
+            Some(31),
+            iter.next().map(|entry| unsafe { entry.as_ref().val })
+        );
+        assert_eq!(
+            Some(7),
+            iter.next().map(|entry| unsafe { entry.as_ref().val })
+        );
+        assert_eq!(
+            Some(5),
+            iter.next().map(|entry| unsafe { entry.as_ref().val })
+        );
+        assert_eq!(None, iter.next());
+
+        assert!(!list.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`tokio::sync::Notify` has an internal waiters queue locked behind a mutex. `Notify::notify_waiters` is a function to notify all waiters from this queue. It first acquires the lock, then removes waiters from the queue and wakes them up. However, the whole process is done in batches of 32 waiters to avoid deadlocks. The function has to release the lock before waking up a batch and re-acquire it before proceeding to the next one. In this short timespan, another thread can acquire the lock and modify the queue or the internal state. This leads to the following issues:
1. **Spurious wake-ups**. This is an issue reported in #5396. A single `notify_waiters` call can notify multiple futures which are created and awaited sequentially. For example, both futures from the following code can complete:
 ```rust
 notify.notified().await;
 notify.notified().await;
 ```
2. **Inconsistency in results from `poll`**. One could expect that sequentially polled futures will yield results consistent with each other. If one pending future returns `Ready`, then other futures which were pending should also be ready. As an example, let's say that we have two pending `Notified` futures: `fut1` and `fut2`. If we call `notify_waiters` in parallel with the following, the assertion can fail:
```rust
let res1 = fut1.poll();
let res2 = fut2.poll();
assert!(res1.is_pending() || res2.is_ready()); // if res1 is ready, then res2 must also be ready
```
3. **Lost notifications from subsequent `notify_one` calls**. It is possible that calling `notify_one` after awaiting a future notified by `notify_waiters` will result in the notification being lost. As an example, let's say that we have a pending `notify.notified()` future `fut`. If we call `notify_waiters` in parallel with the following code, it can hang forever:
```rust
fut.await;
notify.notify_one();
notify.notified().await; // this should consume the notification from `notify_one`.
```

For more context, see the discussion in #5404 or in the related [Discord thread](https://discord.com/channels/500028886025895936/1075130573447770293).

Closes: #5396

## Solution

The idea is to move all waiters to a secondary list, which is created in each call to `notify_waiters`. This list will be unavailable to modify from `notify_one` and other parts of the code, so the waiters contained in it will not consume other notifications, and it will be impossible to insert new waiters into it. This approach eliminates all presented issues.

The tricky part is how to allow waiters contained by a secondary list to remove themselves from it. It is possible to drop a waiter still contained by a secondary list, and in such case it should be able to unlink itself from the neighboring nodes from the list. To solve it, this PR adds a new variant of a linked list, which allows removing a node from it without knowing the list head's memory address. This is done by adding a special “guard” node, which makes the list circular.

To solve the issue with inconsistency in results from `poll`, this PR also adds some additional logic to `poll_notified`. A polled future has to know whether it is already included by a secondary list in `notify_waiters` and is staged to be notified. In such case it also has to remove itself from the list. To determine if it is contained by a secondary list, a future uses the counter of `notify_waiters` calls. If the current value of this counter is different from the value recorded by a future at the time, when it was being added to the queue, then there is an ongoing `notify_waiters` call. In such case the future removes itself from the secondary list.
