### PR TITLE
sync: don't leak tracing spans in mutex guards

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -8,7 +8,7 @@ use std::cell::UnsafeCell;
 use std::error::Error;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
-use std::{fmt, marker, mem, ptr};
+use std::{fmt, marker, mem};
 
 /// An asynchronous `Mutex`-like type.
 ///
@@ -737,7 +737,7 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
         // original. In the end, we have not duplicated or forgotten any values.
         MutexGuardInner {
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: unsafe { ptr::read(&me.resource_span) },
+            resource_span: unsafe { std::ptr::read(&me.resource_span) },
             lock: me.lock,
         }
     }
@@ -976,9 +976,7 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
         let me = mem::ManuallyDrop::new(self);
         // SAFETY: This duplicates the values in every field of the mutex guard,
         // then forgets the originals, so in the end no value is duplicated.
-        MappedMutexGuardInner {
-            s: me.s,
-        }
+        MappedMutexGuardInner { s: me.s }
     }
 
     /// Makes a new [`MappedMutexGuard`] for a component of the locked data.

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -381,6 +381,7 @@ impl<T: ?Sized> Mutex<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -558,6 +559,7 @@ impl<T: ?Sized> Mutex<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -192,6 +192,7 @@ pub struct MappedMutexGuard<'a, T: ?Sized> {
 
 /// A helper type used when taking apart a `MutexGuard` without running its
 /// Drop implementation.
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct MutexGuardInner<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,
@@ -200,6 +201,7 @@ struct MutexGuardInner<'a, T: ?Sized> {
 
 /// A helper type used when taking apart a `MappedMutexGuard` without running
 /// its Drop implementation.
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct MappedMutexGuardInner<'a, T: ?Sized> {
     s: &'a semaphore::Semaphore,
     data: *mut T,

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -447,6 +447,7 @@ impl<T: ?Sized> RwLock<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -594,6 +595,7 @@ impl<T: ?Sized> RwLock<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -787,6 +789,7 @@ impl<T: ?Sized> RwLock<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -921,6 +924,7 @@ impl<T: ?Sized> RwLock<T> {
             false,
         );
 
+        #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -422,23 +422,32 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     pub async fn read(&self) -> RwLockReadGuard<'_, T> {
+        let acquire_fut = async {
+            self.s.acquire(1).await.unwrap_or_else(|_| {
+                // The semaphore was closed. but, we never explicitly close it, and we have a
+                // handle to it through the Arc, which means that this can never happen.
+                unreachable!()
+            });
+
+            RwLockReadGuard {
+                s: &self.s,
+                data: self.c.get(),
+                marker: PhantomData,
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: self.resource_span.clone(),
+            }
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let inner = trace::async_op(
-            || self.s.acquire(1),
+        let acquire_fut = trace::async_op(
+            move || acquire_fut,
             self.resource_span.clone(),
             "RwLock::read",
             "poll",
             false,
         );
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let inner = self.s.acquire(1);
-
-        inner.await.unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            unreachable!()
-        });
+        let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
@@ -449,13 +458,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        RwLockReadGuard {
-            s: &self.s,
-            data: self.c.get(),
-            marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: self.resource_span.clone(),
-        }
+        guard
     }
 
     /// Blockingly locks this `RwLock` with shared read access.
@@ -564,25 +567,37 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     pub async fn read_owned(self: Arc<Self>) -> OwnedRwLockReadGuard<T> {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let inner = trace::async_op(
-            || self.s.acquire(1),
-            self.resource_span.clone(),
+        let resource_span = self.resource_span.clone();
+
+        let acquire_fut = async {
+            self.s.acquire(1).await.unwrap_or_else(|_| {
+                // The semaphore was closed. but, we never explicitly close it, and we have a
+                // handle to it through the Arc, which means that this can never happen.
+                unreachable!()
+            });
+
+            OwnedRwLockReadGuard {
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: self.resource_span.clone(),
+                data: self.c.get(),
+                lock: self,
+                _p: PhantomData,
+            }
+        };
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let acquire_fut = trace::async_op(
+            move || acquire_fut,
+            resource_span,
             "RwLock::read_owned",
             "poll",
             false,
         );
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let inner = self.s.acquire(1);
-
-        inner.await.unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            unreachable!()
-        });
+        let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        self.resource_span.in_scope(|| {
+        guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
             current_readers = 1,
@@ -590,16 +605,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-
-        OwnedRwLockReadGuard {
-            data: self.c.get(),
-            lock: self,
-            _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        }
+        guard
     }
 
     /// Attempts to acquire this `RwLock` with shared read access.
@@ -641,6 +647,14 @@ impl<T: ?Sized> RwLock<T> {
             Err(TryAcquireError::Closed) => unreachable!(),
         }
 
+        let guard = RwLockReadGuard {
+            s: &self.s,
+            data: self.c.get(),
+            marker: marker::PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: self.resource_span.clone(),
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -650,13 +664,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        Ok(RwLockReadGuard {
-            s: &self.s,
-            data: self.c.get(),
-            marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: self.resource_span.clone(),
-        })
+        Ok(guard)
     }
 
     /// Attempts to acquire this `RwLock` with shared read access.
@@ -704,8 +712,16 @@ impl<T: ?Sized> RwLock<T> {
             Err(TryAcquireError::Closed) => unreachable!(),
         }
 
+        let guard = OwnedRwLockReadGuard {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: self.resource_span.clone(),
+            data: self.c.get(),
+            lock: self,
+            _p: PhantomData,
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        self.resource_span.in_scope(|| {
+        guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
             current_readers = 1,
@@ -713,16 +729,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-
-        Ok(OwnedRwLockReadGuard {
-            data: self.c.get(),
-            lock: self,
-            _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        })
+        Ok(guard)
     }
 
     /// Locks this `RwLock` with exclusive write access, causing the current
@@ -754,23 +761,33 @@ impl<T: ?Sized> RwLock<T> {
     ///}
     /// ```
     pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
+        let acquire_fut = async {
+            self.s.acquire(self.mr).await.unwrap_or_else(|_| {
+                // The semaphore was closed. but, we never explicitly close it, and we have a
+                // handle to it through the Arc, which means that this can never happen.
+                unreachable!()
+            });
+
+            RwLockWriteGuard {
+                permits_acquired: self.mr,
+                s: &self.s,
+                data: self.c.get(),
+                marker: marker::PhantomData,
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: self.resource_span.clone(),
+            }
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let inner = trace::async_op(
-            || self.s.acquire(self.mr),
+        let acquire_fut = trace::async_op(
+            move || acquire_fut,
             self.resource_span.clone(),
             "RwLock::write",
             "poll",
             false,
         );
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let inner = self.s.acquire(self.mr);
-
-        inner.await.unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            unreachable!()
-        });
+        let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
@@ -781,14 +798,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        RwLockWriteGuard {
-            permits_acquired: self.mr,
-            s: &self.s,
-            data: self.c.get(),
-            marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: self.resource_span.clone(),
-        }
+        guard
     }
 
     /// Blockingly locks this `RwLock` with exclusive write access.
@@ -883,25 +893,38 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     pub async fn write_owned(self: Arc<Self>) -> OwnedRwLockWriteGuard<T> {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let inner = trace::async_op(
-            || self.s.acquire(self.mr),
-            self.resource_span.clone(),
+        let resource_span = self.resource_span.clone();
+
+        let acquire_fut = async {
+            self.s.acquire(self.mr).await.unwrap_or_else(|_| {
+                // The semaphore was closed. but, we never explicitly close it, and we have a
+                // handle to it through the Arc, which means that this can never happen.
+                unreachable!()
+            });
+
+            OwnedRwLockWriteGuard {
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: self.resource_span.clone(),
+                permits_acquired: self.mr,
+                data: self.c.get(),
+                lock: self,
+                _p: PhantomData,
+            }
+        };
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let acquire_fut = trace::async_op(
+            move || acquire_fut,
+            resource_span,
             "RwLock::write_owned",
             "poll",
             false,
         );
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let inner = self.s.acquire(self.mr);
-
-        inner.await.unwrap_or_else(|_| {
-            // The semaphore was closed. but, we never explicitly close it, and we have a
-            // handle to it through the Arc, which means that this can never happen.
-            unreachable!()
-        });
+        let guard = acquire_fut.await;
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        self.resource_span.in_scope(|| {
+        guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
             write_locked = true,
@@ -909,17 +932,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-
-        OwnedRwLockWriteGuard {
-            permits_acquired: self.mr,
-            data: self.c.get(),
-            lock: self,
-            _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        }
+        guard
     }
 
     /// Attempts to acquire this `RwLock` with exclusive write access.
@@ -952,6 +965,15 @@ impl<T: ?Sized> RwLock<T> {
             Err(TryAcquireError::Closed) => unreachable!(),
         }
 
+        let guard = RwLockWriteGuard {
+            permits_acquired: self.mr,
+            s: &self.s,
+            data: self.c.get(),
+            marker: marker::PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: self.resource_span.clone(),
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -961,14 +983,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        Ok(RwLockWriteGuard {
-            permits_acquired: self.mr,
-            s: &self.s,
-            data: self.c.get(),
-            marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span: self.resource_span.clone(),
-        })
+        Ok(guard)
     }
 
     /// Attempts to acquire this `RwLock` with exclusive write access.
@@ -1008,8 +1023,17 @@ impl<T: ?Sized> RwLock<T> {
             Err(TryAcquireError::Closed) => unreachable!(),
         }
 
+        let guard = OwnedRwLockWriteGuard {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: self.resource_span.clone(),
+            permits_acquired: self.mr,
+            data: self.c.get(),
+            lock: self,
+            _p: PhantomData,
+        };
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
-        self.resource_span.in_scope(|| {
+        guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
             write_locked = true,
@@ -1017,17 +1041,7 @@ impl<T: ?Sized> RwLock<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-
-        Ok(OwnedRwLockWriteGuard {
-            permits_acquired: self.mr,
-            data: self.c.get(),
-            lock: self,
-            _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        })
+        Ok(guard)
     }
 
     /// Returns a mutable reference to the underlying data.

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -5,7 +5,6 @@ use crate::util::trace;
 use std::cell::UnsafeCell;
 use std::marker;
 use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
 use std::sync::Arc;
 
 pub(crate) mod owned_read_guard;
@@ -596,7 +595,7 @@ impl<T: ?Sized> RwLock<T> {
 
         OwnedRwLockReadGuard {
             data: self.c.get(),
-            lock: ManuallyDrop::new(self),
+            lock: self,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             resource_span,
@@ -719,7 +718,7 @@ impl<T: ?Sized> RwLock<T> {
 
         Ok(OwnedRwLockReadGuard {
             data: self.c.get(),
-            lock: ManuallyDrop::new(self),
+            lock: self,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             resource_span,
@@ -916,7 +915,7 @@ impl<T: ?Sized> RwLock<T> {
         OwnedRwLockWriteGuard {
             permits_acquired: self.mr,
             data: self.c.get(),
-            lock: ManuallyDrop::new(self),
+            lock: self,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             resource_span,
@@ -1024,7 +1023,7 @@ impl<T: ?Sized> RwLock<T> {
         Ok(OwnedRwLockWriteGuard {
             permits_acquired: self.mr,
             data: self.c.get(),
-            lock: ManuallyDrop::new(self),
+            lock: self,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             resource_span,

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -1,10 +1,7 @@
 use crate::sync::rwlock::RwLock;
-use std::fmt;
 use std::marker::PhantomData;
-use std::mem;
-use std::mem::ManuallyDrop;
-use std::ops;
 use std::sync::Arc;
+use std::{fmt, mem, ops, ptr};
 
 /// Owned RAII structure used to release the shared read access of a lock when
 /// dropped.
@@ -16,15 +13,37 @@ use std::sync::Arc;
 /// [`RwLock`]: struct@crate::sync::RwLock
 #[clippy::has_significant_drop]
 pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
-    // ManuallyDrop allows us to destructure into this field without running the destructor.
-    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) lock: Arc<RwLock<T>>,
     pub(super) data: *const U,
     pub(super) _p: PhantomData<T>,
 }
 
+struct Inner<T: ?Sized, U: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    lock: Arc<RwLock<T>>,
+    data: *const U,
+}
+
 impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
+    fn skip_drop(self) -> Inner<T, U> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        unsafe {
+            Inner {
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: ptr::read(&me.resource_span),
+                lock: ptr::read(&me.lock),
+                data: me.data,
+            }
+        }
+    }
+
     /// Makes a new `OwnedRwLockReadGuard` for a component of the locked data.
     /// This operation cannot fail as the `OwnedRwLockReadGuard` passed in
     /// already locked the data.
@@ -58,18 +77,14 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
         F: FnOnce(&U) -> &V,
     {
         let data = f(&*this) as *const V;
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         OwnedRwLockReadGuard {
-            lock: ManuallyDrop::new(lock),
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -112,18 +127,14 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
             Some(data) => data as *const V,
             None => return Err(this),
         };
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         Ok(OwnedRwLockReadGuard {
-            lock: ManuallyDrop::new(lock),
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 }
@@ -157,7 +168,6 @@ where
 impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockReadGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(1);
-        unsafe { ManuallyDrop::drop(&mut self.lock) };
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -22,6 +22,7 @@ pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
     pub(super) _p: PhantomData<T>,
 }
 
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<T: ?Sized, U: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,
@@ -72,7 +73,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
     /// # }
     /// ```
     #[inline]
-    pub fn map<F, V: ?Sized>(mut this: Self, f: F) -> OwnedRwLockReadGuard<T, V>
+    pub fn map<F, V: ?Sized>(this: Self, f: F) -> OwnedRwLockReadGuard<T, V>
     where
         F: FnOnce(&U) -> &V,
     {
@@ -119,7 +120,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
     /// # }
     /// ```
     #[inline]
-    pub fn try_map<F, V: ?Sized>(mut this: Self, f: F) -> Result<OwnedRwLockReadGuard<T, V>, Self>
+    pub fn try_map<F, V: ?Sized>(this: Self, f: F) -> Result<OwnedRwLockReadGuard<T, V>, Self>
     where
         F: FnOnce(&U) -> Option<&V>,
     {

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -1,11 +1,9 @@
 use crate::sync::rwlock::owned_read_guard::OwnedRwLockReadGuard;
 use crate::sync::rwlock::owned_write_guard_mapped::OwnedRwLockMappedWriteGuard;
 use crate::sync::rwlock::RwLock;
-use std::fmt;
 use std::marker::PhantomData;
-use std::mem::{self, ManuallyDrop};
-use std::ops;
 use std::sync::Arc;
+use std::{fmt, mem, ops, ptr};
 
 /// Owned RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -17,16 +15,40 @@ use std::sync::Arc;
 /// [`RwLock`]: struct@crate::sync::RwLock
 #[clippy::has_significant_drop]
 pub struct OwnedRwLockWriteGuard<T: ?Sized> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
-    // ManuallyDrop allows us to destructure into this field without running the destructor.
-    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) lock: Arc<RwLock<T>>,
     pub(super) data: *mut T,
     pub(super) _p: PhantomData<T>,
 }
 
+struct Inner<T: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    permits_acquired: u32,
+    lock: Arc<RwLock<T>>,
+    data: *const T,
+}
+
 impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
+    fn skip_drop(self) -> Inner<T> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        unsafe {
+            Inner {
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: ptr::read(&me.resource_span),
+                permits_acquired: me.permits_acquired,
+                lock: ptr::read(&me.lock),
+                data: me.data,
+            }
+        }
+    }
+
     /// Makes a new [`OwnedRwLockMappedWriteGuard`] for a component of the locked
     /// data.
     ///
@@ -65,20 +87,15 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         F: FnOnce(&mut T) -> &mut U,
     {
         let data = f(&mut *this) as *mut U;
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         OwnedRwLockMappedWriteGuard {
-            permits_acquired,
-            lock: ManuallyDrop::new(lock),
+            permits_acquired: this.permits_acquired,
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -129,21 +146,15 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             Some(data) => data as *mut U,
             None => return Err(this),
         };
-        let permits_acquired = this.permits_acquired;
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         Ok(OwnedRwLockMappedWriteGuard {
-            permits_acquired,
-            lock: ManuallyDrop::new(lock),
+            permits_acquired: this.permits_acquired,
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 
@@ -193,12 +204,19 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
     /// # }
     /// ```
     pub fn downgrade(mut self) -> OwnedRwLockReadGuard<T> {
-        let lock = unsafe { ManuallyDrop::take(&mut self.lock) };
-        let data = self.data;
-        let to_release = (self.permits_acquired - 1) as usize;
+        let this = self.skip_drop();
+        let guard = OwnedRwLockReadGuard {
+            lock: this.lock,
+            data: this.data,
+            _p: PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: this.resource_span,
+        };
 
         // Release all but one of the permits held by the write guard
-        lock.s.release(to_release);
+        let to_release = (this.permits_acquired - 1) as usize;
+        this.lock.s.release(to_release);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -217,18 +235,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(self);
-
-        OwnedRwLockReadGuard {
-            lock: ManuallyDrop::new(lock),
-            data,
-            _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        }
+        guard
     }
 }
 
@@ -267,6 +274,7 @@ where
 impl<T: ?Sized> Drop for OwnedRwLockWriteGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(self.permits_acquired as usize);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -275,6 +283,5 @@ impl<T: ?Sized> Drop for OwnedRwLockWriteGuard<T> {
             write_locked.op = "override",
             )
         });
-        unsafe { ManuallyDrop::drop(&mut self.lock) };
     }
 }

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -1,9 +1,7 @@
 use crate::sync::rwlock::RwLock;
-use std::fmt;
 use std::marker::PhantomData;
-use std::mem::{self, ManuallyDrop};
-use std::ops;
 use std::sync::Arc;
+use std::{fmt, mem, ops, ptr};
 
 /// Owned RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -16,16 +14,40 @@ use std::sync::Arc;
 /// [`OwnedRwLockWriteGuard`]: struct@crate::sync::OwnedRwLockWriteGuard
 #[clippy::has_significant_drop]
 pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
-    // ManuallyDrop allows us to destructure into this field without running the destructor.
-    pub(super) lock: ManuallyDrop<Arc<RwLock<T>>>,
+    pub(super) lock: Arc<RwLock<T>>,
     pub(super) data: *mut U,
     pub(super) _p: PhantomData<T>,
 }
 
+struct Inner<T: ?Sized, U: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    permits_acquired: u32,
+    lock: Arc<RwLock<T>>,
+    data: *const U,
+}
+
 impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
+    fn skip_drop(self) -> Inner<T, U> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        unsafe {
+            Inner {
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                resource_span: ptr::read(&me.resource_span),
+                permits_acquired: me.permits_acquired,
+                lock: ptr::read(&me.lock),
+                data: me.data,
+            }
+        }
+    }
+
     /// Makes a new `OwnedRwLockMappedWriteGuard` for a component of the locked
     /// data.
     ///
@@ -64,20 +86,15 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
         F: FnOnce(&mut U) -> &mut V,
     {
         let data = f(&mut *this) as *mut V;
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         OwnedRwLockMappedWriteGuard {
-            permits_acquired,
-            lock: ManuallyDrop::new(lock),
+            permits_acquired: this.permits_acquired,
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -126,20 +143,15 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
             Some(data) => data as *mut V,
             None => return Err(this),
         };
-        let lock = unsafe { ManuallyDrop::take(&mut this.lock) };
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         Ok(OwnedRwLockMappedWriteGuard {
-            permits_acquired,
-            lock: ManuallyDrop::new(lock),
+            permits_acquired: this.permits_acquired,
+            lock: this.lock,
             data,
             _p: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 }
@@ -179,6 +191,7 @@ where
 impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockMappedWriteGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(self.permits_acquired as usize);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -187,6 +200,5 @@ impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockMappedWriteGuard<T, U> {
             write_locked.op = "override",
             )
         });
-        unsafe { ManuallyDrop::drop(&mut self.lock) };
     }
 }

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -24,6 +24,7 @@ pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
     pub(super) _p: PhantomData<T>,
 }
 
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<T: ?Sized, U: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -22,6 +22,7 @@ pub struct RwLockReadGuard<'a, T: ?Sized> {
     pub(super) marker: PhantomData<&'a T>,
 }
 
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -1,8 +1,6 @@
 use crate::sync::batch_semaphore::Semaphore;
-use std::fmt;
-use std::marker;
-use std::mem;
-use std::ops;
+use std::marker::PhantomData;
+use std::{fmt, mem, ops};
 
 /// RAII structure used to release the shared read access of a lock when
 /// dropped.
@@ -15,14 +13,35 @@ use std::ops;
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
 pub struct RwLockReadGuard<'a, T: ?Sized> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
     pub(super) s: &'a Semaphore,
     pub(super) data: *const T,
-    pub(super) marker: marker::PhantomData<&'a T>,
+    pub(super) marker: PhantomData<&'a T>,
+}
+
+struct Inner<'a, T: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    s: &'a Semaphore,
+    data: *const T,
 }
 
 impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
+    fn skip_drop(self) -> Inner<'a, T> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        Inner {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: unsafe { std::ptr::read(&me.resource_span) },
+            s: me.s,
+            data: me.data,
+        }
+    }
+
     /// Makes a new `RwLockReadGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `RwLockReadGuard` passed in already
@@ -62,18 +81,14 @@ impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
         F: FnOnce(&T) -> &U,
     {
         let data = f(&*this) as *const U;
-        let s = this.s;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         RwLockReadGuard {
-            s,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -121,18 +136,14 @@ impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
             Some(data) => data as *const U,
             None => return Err(this),
         };
-        let s = this.s;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         Ok(RwLockReadGuard {
-            s,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 }

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -1,10 +1,8 @@
 use crate::sync::batch_semaphore::Semaphore;
 use crate::sync::rwlock::read_guard::RwLockReadGuard;
 use crate::sync::rwlock::write_guard_mapped::RwLockMappedWriteGuard;
-use std::fmt;
-use std::marker;
-use std::mem;
-use std::ops;
+use std::marker::PhantomData;
+use std::{fmt, mem, ops};
 
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -17,15 +15,38 @@ use std::ops;
 #[clippy::has_significant_drop]
 #[must_use = "if unused the RwLock will immediately unlock"]
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) s: &'a Semaphore,
     pub(super) data: *mut T,
-    pub(super) marker: marker::PhantomData<&'a mut T>,
+    pub(super) marker: PhantomData<&'a mut T>,
+}
+
+struct Inner<'a, T: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    permits_acquired: u32,
+    s: &'a Semaphore,
+    data: *mut T,
 }
 
 impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
+    fn skip_drop(self) -> Inner<'a, T> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        Inner {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: unsafe { std::ptr::read(&me.resource_span) },
+            permits_acquired: me.permits_acquired,
+            s: me.s,
+            data: me.data,
+        }
+    }
+
     /// Makes a new [`RwLockMappedWriteGuard`] for a component of the locked data.
     ///
     /// This operation cannot fail as the `RwLockWriteGuard` passed in already
@@ -68,19 +89,15 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         F: FnOnce(&mut T) -> &mut U,
     {
         let data = f(&mut *this) as *mut U;
-        let s = this.s;
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
+
         RwLockMappedWriteGuard {
-            permits_acquired,
-            s,
+            permits_acquired: this.permits_acquired,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -135,19 +152,15 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             Some(data) => data as *mut U,
             None => return Err(this),
         };
-        let s = this.s;
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
+
         Ok(RwLockMappedWriteGuard {
-            permits_acquired,
-            s,
+            permits_acquired: this.permits_acquired,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 
@@ -199,10 +212,19 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
     ///
     /// [`RwLock`]: struct@crate::sync::RwLock
     pub fn downgrade(self) -> RwLockReadGuard<'a, T> {
-        let RwLockWriteGuard { s, data, .. } = self;
-        let to_release = (self.permits_acquired - 1) as usize;
+        let this = self.skip_drop();
+        let guard = RwLockReadGuard {
+            s: this.s,
+            data: this.data,
+            marker: PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: this.resource_span,
+        };
+
         // Release all but one of the permits held by the write guard
-        s.release(to_release);
+        let to_release = (self.permits_acquired - 1) as usize;
+        this.s.release(to_release);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         self.resource_span.in_scope(|| {
             tracing::trace!(
@@ -221,18 +243,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = self.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(self);
-
-        RwLockReadGuard {
-            s,
-            data,
-            marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
-        }
+        guard
     }
 }
 

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -1,8 +1,6 @@
 use crate::sync::batch_semaphore::Semaphore;
-use std::fmt;
-use std::marker;
-use std::mem;
-use std::ops;
+use std::marker::PhantomData;
+use std::{fmt, mem, ops};
 
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
@@ -15,15 +13,38 @@ use std::ops;
 /// [`RwLockWriteGuard`]: struct@crate::sync::RwLockWriteGuard
 #[clippy::has_significant_drop]
 pub struct RwLockMappedWriteGuard<'a, T: ?Sized> {
+    // When changing the fields in this struct, make sure to update the
+    // `skip_drop` method.
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) s: &'a Semaphore,
     pub(super) data: *mut T,
-    pub(super) marker: marker::PhantomData<&'a mut T>,
+    pub(super) marker: PhantomData<&'a mut T>,
+}
+
+struct Inner<'a, T: ?Sized> {
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    resource_span: tracing::Span,
+    permits_acquired: u32,
+    s: &'a Semaphore,
+    data: *mut T,
 }
 
 impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
+    fn skip_drop(self) -> Inner<'a, T> {
+        let me = mem::ManuallyDrop::new(self);
+        // SAFETY: This duplicates the values in every field of the guard, then
+        // forgets the originals, so in the end no value is duplicated.
+        Inner {
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: unsafe { std::ptr::read(&me.resource_span) },
+            permits_acquired: me.permits_acquired,
+            s: me.s,
+            data: me.data,
+        }
+    }
+
     /// Makes a new `RwLockMappedWriteGuard` for a component of the locked data.
     ///
     /// This operation cannot fail as the `RwLockMappedWriteGuard` passed in already
@@ -65,20 +86,15 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
         F: FnOnce(&mut T) -> &mut U,
     {
         let data = f(&mut *this) as *mut U;
-        let s = this.s;
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         RwLockMappedWriteGuard {
-            permits_acquired,
-            s,
+            permits_acquired: this.permits_acquired,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         }
     }
 
@@ -132,20 +148,15 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
             Some(data) => data as *mut U,
             None => return Err(this),
         };
-        let s = this.s;
-        let permits_acquired = this.permits_acquired;
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let resource_span = this.resource_span.clone();
-        // NB: Forget to avoid drop impl from being called.
-        mem::forget(this);
+        let this = this.skip_drop();
 
         Ok(RwLockMappedWriteGuard {
-            permits_acquired,
-            s,
+            permits_acquired: this.permits_acquired,
+            s: this.s,
             data,
-            marker: marker::PhantomData,
+            marker: PhantomData,
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            resource_span,
+            resource_span: this.resource_span,
         })
     }
 }

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -23,6 +23,7 @@ pub struct RwLockMappedWriteGuard<'a, T: ?Sized> {
     pub(super) marker: PhantomData<&'a mut T>,
 }
 
+#[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<'a, T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,


### PR DESCRIPTION
Currently, `MappedMutexGuard::map` can leak a tracing span, which can lead to a memory leak. This PR fixes that.

I'd also like to add a tracing span to the other guards and add a mapped owned guard, but that can happen in a follow-up PR.