### PR TITLE
WIP: add some missing `tokio::fs` function tests - DRAFT WIP

### DIFF
--- a/tokio/src/fs/canonicalize.rs
+++ b/tokio/src/fs/canonicalize.rs
@@ -46,7 +46,6 @@ use std::path::{Path, PathBuf};
 /// }
 /// ```
 pub async fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
-    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::canonicalize(path)).await
 }

--- a/tokio/src/fs/canonicalize.rs
+++ b/tokio/src/fs/canonicalize.rs
@@ -46,6 +46,7 @@ use std::path::{Path, PathBuf};
 /// }
 /// ```
 pub async fn canonicalize(path: impl AsRef<Path>) -> io::Result<PathBuf> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::canonicalize(path)).await
 }

--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -130,6 +130,7 @@ feature! {
         /// builder.mode(0o775);
         /// ```
         pub fn mode(&mut self, mode: u32) -> &mut Self {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.mode = Some(mode);
             self
         }

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -399,6 +399,7 @@ impl File {
     /// # }
     /// ```
     pub async fn try_clone(&self) -> io::Result<File> {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         let std = self.std.clone();
         let std_file = asyncify(move || std.try_clone()).await?;
         Ok(File::from_std(std_file))
@@ -423,6 +424,7 @@ impl File {
     /// # }
     /// ```
     pub async fn into_std(mut self) -> StdFile {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.inner.get_mut().complete_inflight().await;
         Arc::try_unwrap(self.std).expect("Arc::try_unwrap failed")
     }
@@ -448,6 +450,7 @@ impl File {
     /// # }
     /// ```
     pub fn try_into_std(mut self) -> Result<StdFile, Self> {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         match Arc::try_unwrap(self.std) {
             Ok(file) => Ok(file),
             Err(std_file_arc) => {
@@ -706,12 +709,14 @@ impl AsyncWrite for File {
 
 impl From<StdFile> for File {
     fn from(std: StdFile) -> Self {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         Self::from_std(std)
     }
 }
 
 impl fmt::Debug for File {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         fmt.debug_struct("tokio::fs::File")
             .field("std", &self.std)
             .finish()
@@ -728,6 +733,7 @@ impl std::os::unix::io::AsRawFd for File {
 #[cfg(unix)]
 impl std::os::unix::io::FromRawFd for File {
     unsafe fn from_raw_fd(fd: std::os::unix::io::RawFd) -> Self {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         StdFile::from_raw_fd(fd).into()
     }
 }

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -96,6 +96,7 @@ impl OpenOptions {
     /// let future = options.read(true).open("foo.txt");
     /// ```
     pub fn new() -> OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         OpenOptions(StdOpenOptions::new())
     }
 
@@ -125,6 +126,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn read(&mut self, read: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.read(read);
         self
     }
@@ -155,6 +157,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn write(&mut self, write: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.write(write);
         self
     }
@@ -214,6 +217,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn append(&mut self, append: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.append(append);
         self
     }
@@ -247,6 +251,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn truncate(&mut self, truncate: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.truncate(truncate);
         self
     }
@@ -283,6 +288,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn create(&mut self, create: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.create(create);
         self
     }
@@ -326,6 +332,7 @@ impl OpenOptions {
     /// }
     /// ```
     pub fn create_new(&mut self, create_new: bool) -> &mut OpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.0.create_new(create_new);
         self
     }
@@ -383,6 +390,7 @@ impl OpenOptions {
     /// [`Other`]: std::io::ErrorKind::Other
     /// [`PermissionDenied`]: std::io::ErrorKind::PermissionDenied
     pub async fn open(&self, path: impl AsRef<Path>) -> io::Result<File> {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         let path = path.as_ref().to_owned();
         let opts = self.0.clone();
 
@@ -392,6 +400,7 @@ impl OpenOptions {
 
     /// Returns a mutable reference to the underlying `std::fs::OpenOptions`
     pub(super) fn as_inner_mut(&mut self) -> &mut StdOpenOptions {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         &mut self.0
     }
 }
@@ -426,6 +435,7 @@ feature! {
         /// }
         /// ```
         pub fn mode(&mut self, mode: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().mode(mode);
             self
         }
@@ -458,6 +468,7 @@ feature! {
         /// }
         /// ```
         pub fn custom_flags(&mut self, flags: i32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().custom_flags(flags);
             self
         }
@@ -494,6 +505,7 @@ feature! {
         ///
         /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
         pub fn access_mode(&mut self, access: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().access_mode(access);
             self
         }
@@ -527,6 +539,7 @@ feature! {
         ///
         /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
         pub fn share_mode(&mut self, share: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().share_mode(share);
             self
         }
@@ -559,6 +572,7 @@ feature! {
         /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
         /// [`CreateFile2`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
         pub fn custom_flags(&mut self, flags: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().custom_flags(flags);
             self
         }
@@ -598,6 +612,7 @@ feature! {
         /// [`CreateFile`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea
         /// [`CreateFile2`]: https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfile2
         pub fn attributes(&mut self, attributes: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().attributes(attributes);
             self
         }
@@ -646,6 +661,7 @@ feature! {
         /// [Impersonation Levels]:
         ///     https://docs.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-security_impersonation_level
         pub fn security_qos_flags(&mut self, flags: u32) -> &mut OpenOptions {
+            assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
             self.as_inner_mut().security_qos_flags(flags);
             self
         }

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -238,6 +238,7 @@ impl DirEntry {
     ///
     /// The exact text, of course, depends on what files you have in `.`.
     pub fn path(&self) -> PathBuf {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         self.std.path()
     }
 
@@ -293,6 +294,7 @@ impl DirEntry {
     /// # }
     /// ```
     pub async fn metadata(&self) -> io::Result<Metadata> {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
         let std = self.std.clone();
         asyncify(move || std.metadata()).await
     }
@@ -328,6 +330,8 @@ impl DirEntry {
     /// # }
     /// ```
     pub async fn file_type(&self) -> io::Result<FileType> {
+        assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
+
         #[cfg(not(any(
             target_os = "solaris",
             target_os = "illumos",

--- a/tokio/src/fs/remove_dir_all.rs
+++ b/tokio/src/fs/remove_dir_all.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 ///
 /// [std]: fn@std::fs::remove_dir_all
 pub async fn remove_dir_all(path: impl AsRef<Path>) -> io::Result<()> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_dir_all(path)).await
 }

--- a/tokio/src/fs/remove_file.rs
+++ b/tokio/src/fs/remove_file.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 ///
 /// [std]: std::fs::remove_file
 pub async fn remove_file(path: impl AsRef<Path>) -> io::Result<()> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let path = path.as_ref().to_owned();
     asyncify(move || std::fs::remove_file(path)).await
 }

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 ///
 /// This is an async version of [`std::fs::rename`](std::fs::rename)
 pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<()> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let from = from.as_ref().to_owned();
     let to = to.as_ref().to_owned();
 

--- a/tokio/src/fs/symlink_dir.rs
+++ b/tokio/src/fs/symlink_dir.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 ///
 /// [std]: std::os::windows::fs::symlink_dir
 pub async fn symlink_dir(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/src/fs/symlink_file.rs
+++ b/tokio/src/fs/symlink_file.rs
@@ -12,6 +12,7 @@ use std::path::Path;
 ///
 /// [std]: std::os::windows::fs::symlink_file
 pub async fn symlink_file(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+    assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
     let src = src.as_ref().to_owned();
     let dst = dst.as_ref().to_owned();
 

--- a/tokio/tests/fs_canonicalize_dir.rs
+++ b/tokio/tests/fs_canonicalize_dir.rs
@@ -1,0 +1,31 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support directory operations
+
+use tokio::fs;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn canonicalize_root_dir_unix() {
+    assert_eq!(
+        fs::canonicalize("/.")
+            .await
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "/"
+    );
+}
+
+#[tokio::test]
+#[cfg(windows)]
+async fn canonicalize_root_dir_windows() {
+    // 2-step let bindings due to Rust memory semantics
+    let dir_path = fs::canonicalize("C:\\.\\")
+        .await
+        .unwrap();
+
+    let dir_name = dir_path.to_str().unwrap();
+
+    assert!(dir_name.starts_with("\\\\"));
+    assert!(dir_name.ends_with("C:\\"));
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I tried experimenting with `no-panic` (long story) and discovered that a number of the functions in `tokio/src/fs` are not really tested. I was able to stick `panic!()` calls into over 30 of these functions without causing any test failures.

I hope to improve the test coverage as discussed further below.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I started by injecting lines of code like this into `tokio/src/fs` to help keep track of what is and is not tested:

```rs
assert!(std::env::var("XXX_KEEP_UNTESTED_XXX").is_ok());
```

to cause the untested `tokio::fs` functions to panic without triggering any build issues.

I have been able to add most of the missing test coverage in my own workspace. I am starting this PR with test coverage of `tokio::fs::canonicalize()` and will push more of my changes once we have a green build.

TODO:

- [ ] finish the missing test coverage for `tokio::fs`
- [ ] remove the tested `tokio::fs` functions from `tokio/tests/async_send_sync.rs`, unless there is still reason to keep them there
- [ ] ensure that all injected panicking code is removed

Future work ideas time permitting _beyond this PR_:

- improve test coverage in some other places such as `tokio::io`, `tokio::net`, etc.
- explore & propose alternative ideas for code coverage - I already found `cargo-llvm-cov` with permissive licensing and design to work with faster nexte.st for testing
- look into mutation testing