### PR TITLE
Remove no-longer-necessary cargo-semver-checks flags.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,13 +245,7 @@ jobs:
           tool: cargo-semver-checks
       - name: Check semver compatibility
         run: |
-          cargo semver-checks check-release \
-              --release-type minor \
-              --exclude benches \
-              --exclude examples \
-              --exclude stress-test \
-              --exclude tests-build \
-              --exclude tests-integration
+          cargo semver-checks check-release --release-type minor
 
   cross-check:
     name: cross-check


### PR DESCRIPTION
## Motivation

The `--exclude` flags for `cargo-semver-checks` here were previously only needed due to a bug in the `cargo-semver-checks` CLI logic.

The correct behavior (available as of v0.18.3) for `cargo-semver-checks` is to ignore `publish = false` crates when scanning a workspace, *unless* those crates are specifically selected for checking.

All the crates being excluded here are `publish = false`. That makes them excluded by default, so all `--exclude` flags are no-ops.

## Solution

Remove the unnecessary `--exclude` flags.
