### PR TITLE
sync: reduce contention in `Notify`

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -42,6 +42,10 @@ name = "rt_multi_threaded"
 path = "rt_multi_threaded.rs"
 harness = false
 
+[[bench]]
+name = "sync_notify"
+path = "sync_notify.rs"
+harness = false
 
 [[bench]]
 name = "sync_rwlock"
@@ -67,3 +71,4 @@ harness = false
 name = "copy"
 path = "copy.rs"
 harness = false
+

--- a/benches/sync_notify.rs
+++ b/benches/sync_notify.rs
@@ -1,0 +1,90 @@
+use bencher::Bencher;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(6)
+        .build()
+        .unwrap()
+}
+
+fn notify_waiters<const N_WAITERS: usize>(b: &mut Bencher) {
+    let rt = rt();
+    let notify = Arc::new(Notify::new());
+    let counter = Arc::new(AtomicUsize::new(0));
+    for _ in 0..N_WAITERS {
+        rt.spawn({
+            let notify = notify.clone();
+            let counter = counter.clone();
+            async move {
+                loop {
+                    notify.notified().await;
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+    }
+
+    const N_ITERS: usize = 500;
+    b.iter(|| {
+        counter.store(0, Ordering::Relaxed);
+        loop {
+            notify.notify_waiters();
+            if counter.load(Ordering::Relaxed) >= N_ITERS {
+                break;
+            }
+        }
+    });
+}
+
+fn notify_one<const N_WAITERS: usize>(b: &mut Bencher) {
+    let rt = rt();
+    let notify = Arc::new(Notify::new());
+    let counter = Arc::new(AtomicUsize::new(0));
+    for _ in 0..N_WAITERS {
+        rt.spawn({
+            let notify = notify.clone();
+            let counter = counter.clone();
+            async move {
+                loop {
+                    notify.notified().await;
+                    counter.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        });
+    }
+
+    const N_ITERS: usize = 500;
+    b.iter(|| {
+        counter.store(0, Ordering::Relaxed);
+        loop {
+            notify.notify_one();
+            if counter.load(Ordering::Relaxed) >= N_ITERS {
+                break;
+            }
+        }
+    });
+}
+
+bencher::benchmark_group!(
+    notify_waiters_simple,
+    notify_waiters::<10>,
+    notify_waiters::<50>,
+    notify_waiters::<100>,
+    notify_waiters::<200>,
+    notify_waiters::<500>
+);
+
+bencher::benchmark_group!(
+    notify_one_simple,
+    notify_one::<10>,
+    notify_one::<50>,
+    notify_one::<100>,
+    notify_one::<200>,
+    notify_one::<500>
+);
+
+bencher::benchmark_main!(notify_waiters_simple, notify_one_simple);

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1108,8 +1108,7 @@ impl Drop for Notified<'_> {
             let mut notify_state = notify.state.load(SeqCst);
 
             // We hold the lock, so this field is not concurrently accessed by
-            // `notify_*` functions. We will unlink the waiter and drop it shortly,
-            // so we can use relaxed ordering.
+            // `notify_*` functions and we can use the relaxed ordering.
             let notification = waiter.notification.load(Relaxed);
 
             // remove the entry from the list (if not already removed)

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -218,15 +218,15 @@ struct Waiter {
     /// Intrusive linked-list pointers.
     pointers: linked_list::Pointers<Waiter>,
 
-    /// Waiting task's waker. This field is either protected by
-    /// the `waiters` lock in `Notify` or exclusively owned by
-    /// the enclosing `Waiter`, depending on the value of `notification`.
+    /// Waiting task's waker. Depending on the value of `notification`,
+    /// this field is either protected by the `waiters` lock in
+    /// `Notify`, or it is exclusively owned by the enclosing `Waiter`.
     waker: UnsafeCell<Option<Waker>>,
 
-    /// Notification for this waiter. If it is `None`, then `waker` is
-    /// protected by the `waiters` lock. If it is `Some`, the waker is
-    /// exclusively owned by the enclosing `Waiter` and can be
-    /// accessed without locking.
+    /// Notification for this waiter.
+    /// * if it's `None`, then `waker` is protected by the `waiters` lock.
+    /// * if it's `Some`, then `waker` is exclusively owned by the
+    ///   enclosing `Waiter` and can be accessed without locking.
     notification: AtomicNotification,
 
     /// Should not be `Unpin`.
@@ -263,7 +263,7 @@ const NOTIFICATION_ALL: usize = 2;
 
 /// Notification for a `Waiter`.
 /// This struct is equivalent to `Option<Notification>`, but uses
-/// `AtomicUsize` for atomic operations.
+/// `AtomicUsize` inside for atomic operations.
 #[derive(Debug)]
 struct AtomicNotification(AtomicUsize);
 
@@ -287,9 +287,10 @@ impl AtomicNotification {
         }
     }
 
-    /// Clears the notification. This method is used by a `Notified`
-    /// future to consume the notification. It uses relaxed ordering
-    /// and should be only used once this variable is no longer shared.
+    /// Clears the notification.
+    /// This method is used by a `Notified` future to consume the
+    /// notification. It uses relaxed ordering and should be only
+    /// used once the atomic notification is no longer shared.
     fn clear(&self) {
         self.0.store(NOTIFICATION_NONE, Relaxed);
     }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -940,7 +940,7 @@ impl Notified<'_> {
                 drop(waiters);
                 drop(old_waker);
 
-                return Poll::Pending;
+                Poll::Pending
             }
             Waiting => {
                 if waiter.notification.load(Acquire) != NOTIFICATION_NONE {
@@ -1006,7 +1006,7 @@ impl Notified<'_> {
                     drop(old_waker);
 
                     *state = Done;
-                    return Poll::Ready(());
+                    Poll::Ready(())
                 } else {
                     // Safety: we hold the lock, so we can modify the waker.
                     unsafe {
@@ -1027,12 +1027,10 @@ impl Notified<'_> {
                     drop(waiters);
                     drop(old_waker);
 
-                    return Poll::Pending;
+                    Poll::Pending
                 }
             }
-            Done => {
-                return Poll::Ready(());
-            }
+            Done => Poll::Ready(()),
         }
     }
 }


### PR DESCRIPTION
This PR replaces the notification field used by waiters in `Notify` with an atomic variable to reduce lock contention when multiple pending `Notified` futures are completing.

## Motivation

The typical lifecycle of a `Notified` future looks like this:
1. It gets polled for the first time, and it is inserted into the waiting list.
2. It receives a notification from a `notify_one` or `notify_waiters` call and is removed from the waiting list.
3. The notifying function calls `wake()` on the future's waker.
4. The future gets polled again by the executor, consumes the notification and returns `Ready`.

Currently, step 4 requires acquiring the lock to read the notification field and the lock is released immediately after. Using an atomic variable here should significantly reduce lock contention, especially when multiple futures get notified at once by a `notify_waiters` call.

## Benchmarks

Simple benchmarks on my machine (Linux 6.1.11, 4-core x86_64 developer laptop) show improved performance by 15-35%.
<details>
<summary>Click to expand results</summary>

master (`c894069`)
```
test notify_one<10>      ... bench:     128,130 ns/iter (+/- 18,168)
test notify_one<50>      ... bench:     226,002 ns/iter (+/- 20,095)
test notify_one<100>     ... bench:     199,244 ns/iter (+/- 18,873)
test notify_one<200>     ... bench:     210,647 ns/iter (+/- 28,222)
test notify_one<500>     ... bench:     218,932 ns/iter (+/- 29,464)

test notify_waiters<10>  ... bench:     289,161 ns/iter (+/- 25,546)
test notify_waiters<50>  ... bench:     248,969 ns/iter (+/- 47,217)
test notify_waiters<100> ... bench:     246,124 ns/iter (+/- 51,925)
test notify_waiters<200> ... bench:     250,637 ns/iter (+/- 44,959)
test notify_waiters<500> ... bench:     245,787 ns/iter (+/- 62,522)
```

with atomic notification:
```
test notify_one<10>      ... bench:     112,035 ns/iter (+/- 18,930)
test notify_one<50>      ... bench:     153,866 ns/iter (+/- 21,207)
test notify_one<100>     ... bench:     150,171 ns/iter (+/- 36,634)
test notify_one<200>     ... bench:     154,960 ns/iter (+/- 12,386)
test notify_one<500>     ... bench:     152,904 ns/iter (+/- 17,885)

test notify_waiters<10>  ... bench:     210,752 ns/iter (+/- 23,719)
test notify_waiters<50>  ... bench:     161,876 ns/iter (+/- 7,037)
test notify_waiters<100> ... bench:     157,448 ns/iter (+/- 25,909)
test notify_waiters<200> ... bench:     167,677 ns/iter (+/- 22,640)
test notify_waiters<500> ... bench:     290,953 ns/iter (+/- 39,285)
```

</details>

With many contending waiters (>500) benchmarks show degraded performance, but I did some profiling and the bottleneck seems to be somewhere in the scheduler.
