### PR TITLE
fix empty `join!` and `try_join!`

### DIFF
--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -158,7 +158,9 @@ macro_rules! join {
 
     // ===== Entry point =====
 
-    ( $($e:expr),* $(,)?) => {
+    ( $($e:expr),+ $(,)?) => {
         $crate::join!(@{ () (0) } $($e,)*)
     };
+
+    () => { async {}.await }
 }

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -210,7 +210,9 @@ macro_rules! try_join {
 
     // ===== Entry point =====
 
-    ( $($e:expr),* $(,)?) => {
+    ( $($e:expr),+ $(,)?) => {
         $crate::try_join!(@{ () (0) } $($e,)*)
     };
+
+    () => { async { Ok(()) }.await }
 }

--- a/tokio/tests/macros_join.rs
+++ b/tokio/tests/macros_join.rs
@@ -153,3 +153,9 @@ async fn a_different_future_is_polled_first_every_time_poll_fn_is_polled() {
         *poll_order.lock().unwrap()
     );
 }
+
+#[tokio::test]
+#[allow(clippy::unit_cmp)]
+async fn empty_join() {
+    assert_eq!(tokio::join!(), ());
+}

--- a/tokio/tests/macros_try_join.rs
+++ b/tokio/tests/macros_try_join.rs
@@ -183,3 +183,8 @@ async fn a_different_future_is_polled_first_every_time_poll_fn_is_polled() {
         *poll_order.lock().unwrap()
     );
 }
+
+#[tokio::test]
+async fn empty_try_join() {
+    assert_eq!(tokio::try_join!() as Result<_, ()>, Ok(()));
+}


### PR DESCRIPTION
This fixes #5502, i. e. `join!()` and `try_join!()` emitting `loop {}`. It does so in two ways:
1. The current macro implemention entry points are changed to not accept empty invocations
2. New entry points for empty invocations are added