### PR TITLE
net: fix test compilation failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,8 @@ jobs:
 
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
+      - name: Cargo tree
+        run: cargo tree -p tokio --target wasm32-wasi --features full
 
       - name: WASI test tokio full
         run: cargo test -p tokio --target wasm32-wasi --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,8 +582,6 @@ jobs:
 
       - name: Install cargo-wasi
         run: cargo install cargo-wasi
-      - name: Cargo tree
-        run: cargo tree -p tokio --target wasm32-wasi --features full
 
       - name: WASI test tokio full
         run: cargo test -p tokio --target wasm32-wasi --features full

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -143,11 +143,11 @@ tokio-test = { version = "0.4.0", path = "../tokio-test" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 futures = { version = "0.3.0", features = ["async-await"] }
 mockall = "0.11.1"
-tempfile = "3.1.0"
 async-stream = "0.3"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dev-dependencies]
 socket2 = "0.4"
+tempfile = "3.1.0"
 
 [target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dev-dependencies]
 rand = "0.8.0"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -136,7 +136,8 @@ features = [
 ]
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]
-version = "0.3.6"
+version = "0.4.0"
+features = ["std"]
 
 [dev-dependencies]
 tokio-test = { version = "0.4.0", path = "../tokio-test" }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -137,7 +137,6 @@ features = [
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]
 version = "0.4.0"
-features = ["std"]
 
 [dev-dependencies]
 tokio-test = { version = "0.4.0", path = "../tokio-test" }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -136,7 +136,7 @@ features = [
 ]
 
 [target.'cfg(windows)'.dev-dependencies.ntapi]
-version = "0.4.0"
+version = "0.3.6"
 
 [dev-dependencies]
 tokio-test = { version = "0.4.0", path = "../tokio-test" }

--- a/tokio/tests/net_named_pipe.rs
+++ b/tokio/tests/net_named_pipe.rs
@@ -417,7 +417,7 @@ fn num_instances(pipe_name: impl AsRef<str>) -> io::Result<u32> {
 
     let status = unsafe {
         ntioapi::NtQueryDirectoryFile(
-            root.as_raw_handle(),
+            root.as_raw_handle().cast(),
             std::ptr::null_mut(),
             None,
             std::ptr::null_mut(),


### PR DESCRIPTION
This fixes a compile failure in our test suite where there is a mismatch between two versions of the c_void type.