### PR TITLE
[WIP]feat: add lockless split trait

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,7 +87,6 @@ signal = [
 sync = []
 test-util = ["rt", "sync", "time"]
 time = []
-gat = []
 
 # Technically, removing this is a breaking change even though it only ever did
 # anything with the unstable flag on. It is probably safe to get rid of it after

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,6 +87,7 @@ signal = [
 sync = []
 test-util = ["rt", "sync", "time"]
 time = []
+gat = []
 
 # Technically, removing this is a breaking change even though it only ever did
 # anything with the unstable flag on. It is probably safe to get rid of it after

--- a/tokio/src/io/lockless_split.rs
+++ b/tokio/src/io/lockless_split.rs
@@ -26,7 +26,7 @@ cfg_net_or_io_util! {
     unsafe impl<T: Send + Sync + Shutdown> Send for LocklessOwnedWriteHalf<T> {}
 
     /// Inner split trait
-    pub trait LocklessSplitableOwned {
+    pub trait LocklessSplitable {
         /// Owned Read Split
         type OwnedReadHalf;
         /// Owned Write Split
@@ -35,32 +35,6 @@ cfg_net_or_io_util! {
         /// Split into owned parts
         fn into_split(self) -> (Self::OwnedReadHalf, Self::OwnedWriteHalf);
     }
-
-    impl<T> LocklessSplitableOwned for T
-    where
-        T: LocklessSplit + Shutdown,
-    {
-        type OwnedReadHalf = LocklessOwnedReadHalf<T>;
-
-        type OwnedWriteHalf = LocklessOwnedWriteHalf<T>;
-
-        fn into_split(self) -> (Self::OwnedReadHalf, Self::OwnedWriteHalf) {
-            let shared = Arc::new(UnsafeCell::new(self));
-            (
-                LocklessOwnedReadHalf(shared.clone()),
-                LocklessOwnedWriteHalf(shared),
-            )
-        }
-    }
-}
-
-cfg_net_or_io_util_or_gat! {
-    /// Borrowed Write Half Part
-    #[derive(Debug)]
-    pub struct LocklessWriteHalf<'cx, T>(pub &'cx T);
-    /// Borrowed Read Half Part
-    #[derive(Debug)]
-    pub struct LocklessReadHalf<'cx, T>(pub &'cx T);
 
     /// The object with has this `LocklessSplit` trait can be safely split
     /// to read/write object in both form of `Owned` or `Borrowed`.
@@ -78,80 +52,23 @@ cfg_net_or_io_util_or_gat! {
         fn shutdown(&mut self) {}
     }
 
-    /// Inner split trait
-    pub trait LocklessSplitableBorrowed {
-        /// Borrowed Read Split
-        type Read<'a>
-        where
-            Self: 'a;
-        /// Borrowed Write Split
-        type Write<'a>
-        where
-            Self: 'a;
-
-        /// Split into borrowed parts
-        fn split(&mut self) -> (Self::Read<'_>, Self::Write<'_>);
-    }
-
-    impl<T> LocklessSplitableBorrowed for T
+    impl<T> LocklessSplitable for T
     where
         T: LocklessSplit + Shutdown,
     {
-        type Read<'a> = LocklessReadHalf<'a, T> where Self: 'a;
+        type OwnedReadHalf = LocklessOwnedReadHalf<T>;
 
-        type Write<'a> = LocklessWriteHalf<'a, T> where Self: 'a;
+        type OwnedWriteHalf = LocklessOwnedWriteHalf<T>;
 
-        fn split(&mut self) -> (Self::Read<'_>, Self::Write<'_>) {
-            (LocklessReadHalf(&*self), LocklessWriteHalf(&*self))
+        fn into_split(self) -> (Self::OwnedReadHalf, Self::OwnedWriteHalf) {
+            let shared = Arc::new(UnsafeCell::new(self));
+            (
+                LocklessOwnedReadHalf(shared.clone()),
+                LocklessOwnedWriteHalf(shared),
+            )
         }
     }
 
-    #[allow(clippy::cast_ref_to_mut)]
-    impl<'a, T> AsyncRead for LocklessReadHalf<'a, T>
-    where
-        T: AsyncRead,
-    {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<io::Result<()>> {
-            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
-            let stream = unsafe { Pin::new_unchecked(stream) };
-            stream.poll_read(cx, buf)
-        }
-    }
-
-    #[allow(clippy::cast_ref_to_mut)]
-    impl<'a, T> AsyncWrite for LocklessWriteHalf<'a, T>
-    where
-        T: AsyncWrite,
-    {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<Result<usize, io::Error>> {
-            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
-            let stream = unsafe { Pin::new_unchecked(stream) };
-            stream.poll_write(cx, buf)
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
-            let stream = unsafe { Pin::new_unchecked(stream) };
-            stream.poll_flush(cx)
-        }
-
-        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
-            let stream = unsafe { Pin::new_unchecked(stream) };
-            stream.poll_shutdown(cx)
-        }
-    }
-}
-
-cfg_net_or_io_util! {
     impl<T> AsyncRead for LocklessOwnedReadHalf<T>
     where
         T: AsyncRead,

--- a/tokio/src/io/lockless_split.rs
+++ b/tokio/src/io/lockless_split.rs
@@ -1,0 +1,261 @@
+use std::{
+    cell::UnsafeCell,
+    error::Error,
+    fmt::{self, Debug},
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use super::{AsyncRead, AsyncWrite, ReadBuf};
+
+cfg_net_or_io_util! {
+    /// Owned Read Half Part
+    #[derive(Debug)]
+    pub struct LocklessOwnedReadHalf<T>(pub Arc<UnsafeCell<T>>);
+    /// Owned Write Half Part
+    #[derive(Debug)]
+    pub struct LocklessOwnedWriteHalf<T>(pub Arc<UnsafeCell<T>>)
+    where
+        T: Shutdown;
+
+    unsafe impl<T: Send + Sync> Sync for LocklessOwnedReadHalf<T> {}
+    unsafe impl<T: Send + Sync> Send for LocklessOwnedReadHalf<T> {}
+    unsafe impl<T: Send + Sync + Shutdown> Sync for LocklessOwnedWriteHalf<T> {}
+    unsafe impl<T: Send + Sync + Shutdown> Send for LocklessOwnedWriteHalf<T> {}
+
+    /// Inner split trait
+    pub trait LocklessSplitableOwned {
+        /// Owned Read Split
+        type OwnedReadHalf;
+        /// Owned Write Split
+        type OwnedWriteHalf;
+
+        /// Split into owned parts
+        fn into_split(self) -> (Self::OwnedReadHalf, Self::OwnedWriteHalf);
+    }
+
+    impl<T> LocklessSplitableOwned for T
+    where
+        T: LocklessSplit + Shutdown,
+    {
+        type OwnedReadHalf = LocklessOwnedReadHalf<T>;
+
+        type OwnedWriteHalf = LocklessOwnedWriteHalf<T>;
+
+        fn into_split(self) -> (Self::OwnedReadHalf, Self::OwnedWriteHalf) {
+            let shared = Arc::new(UnsafeCell::new(self));
+            (
+                LocklessOwnedReadHalf(shared.clone()),
+                LocklessOwnedWriteHalf(shared),
+            )
+        }
+    }
+}
+
+cfg_net_or_io_util_or_gat! {
+    /// Borrowed Write Half Part
+    #[derive(Debug)]
+    pub struct LocklessWriteHalf<'cx, T>(pub &'cx T);
+    /// Borrowed Read Half Part
+    #[derive(Debug)]
+    pub struct LocklessReadHalf<'cx, T>(pub &'cx T);
+
+    /// The object with has this `LocklessSplit` trait can be safely split
+    /// to read/write object in both form of `Owned` or `Borrowed`.
+    ///
+    /// # Safety
+    ///
+    /// Users should ensure the read
+    /// operations are indenpendent from the write ones, the methods
+    /// from `AsyncRead` and `AsyncWrite` can execute concurrently.
+    pub unsafe trait LocklessSplit {}
+
+    /// Shutdown trait used for drop OwnedWriteHalf
+    pub trait Shutdown {
+        /// shutdown write
+        fn shutdown(&mut self) {}
+    }
+
+    /// Inner split trait
+    pub trait LocklessSplitableBorrowed {
+        /// Borrowed Read Split
+        type Read<'a>
+        where
+            Self: 'a;
+        /// Borrowed Write Split
+        type Write<'a>
+        where
+            Self: 'a;
+
+        /// Split into borrowed parts
+        fn split(&mut self) -> (Self::Read<'_>, Self::Write<'_>);
+    }
+
+    impl<T> LocklessSplitableBorrowed for T
+    where
+        T: LocklessSplit + Shutdown,
+    {
+        type Read<'a> = LocklessReadHalf<'a, T> where Self: 'a;
+
+        type Write<'a> = LocklessWriteHalf<'a, T> where Self: 'a;
+
+        fn split(&mut self) -> (Self::Read<'_>, Self::Write<'_>) {
+            (LocklessReadHalf(&*self), LocklessWriteHalf(&*self))
+        }
+    }
+
+    #[allow(clippy::cast_ref_to_mut)]
+    impl<'a, T> AsyncRead for LocklessReadHalf<'a, T>
+    where
+        T: AsyncRead,
+    {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_read(cx, buf)
+        }
+    }
+
+    #[allow(clippy::cast_ref_to_mut)]
+    impl<'a, T> AsyncWrite for LocklessWriteHalf<'a, T>
+    where
+        T: AsyncWrite,
+    {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            let stream = unsafe { &mut *(self.0 as *const T as *mut T) };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_shutdown(cx)
+        }
+    }
+}
+
+cfg_net_or_io_util! {
+    impl<T> AsyncRead for LocklessOwnedReadHalf<T>
+    where
+        T: AsyncRead,
+    {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let stream = unsafe { &mut *self.0.get() };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_read(cx, buf)
+        }
+    }
+
+    impl<T> AsyncWrite for LocklessOwnedWriteHalf<T>
+    where
+        T: AsyncWrite + Shutdown,
+    {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            let stream = unsafe { &mut *self.0.get() };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            let stream = unsafe { &mut *self.0.get() };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_flush(cx)
+        }
+
+        fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            let stream = unsafe { &mut *self.0.get() };
+            let stream = unsafe { Pin::new_unchecked(stream) };
+            stream.poll_shutdown(cx)
+        }
+    }
+
+    pub(crate) fn reunite<T: Shutdown>(
+        read: LocklessOwnedReadHalf<T>,
+        write: LocklessOwnedWriteHalf<T>,
+    ) -> Result<T, ReuniteError<T>> where T: Debug {
+        if Arc::ptr_eq(&read.0, &write.0) {
+            // we cannot execute drop for OwnedWriteHalf.
+            unsafe {
+                let _inner: Arc<UnsafeCell<T>> = std::mem::transmute(write);
+            }
+            Ok(Arc::try_unwrap(read.0)
+                .expect("try_unwrap failed in reunite")
+                .into_inner())
+        } else {
+            Err(ReuniteError(read, write))
+        }
+    }
+
+    impl<T> LocklessOwnedReadHalf<T>
+    where
+        T: Shutdown + Debug,
+    {
+        /// reunite write half
+        #[inline]
+        pub fn reunite(self, other: LocklessOwnedWriteHalf<T>) -> Result<T, ReuniteError<T>> {
+            reunite(self, other)
+        }
+    }
+
+    impl<T> LocklessOwnedWriteHalf<T>
+    where
+        T: Shutdown + Debug,
+    {
+        /// reunite read half
+        #[inline]
+        pub fn reunite(self, other: LocklessOwnedReadHalf<T>) -> Result<T, ReuniteError<T>> {
+            reunite(other, self)
+        }
+    }
+
+    impl<T> Drop for LocklessOwnedWriteHalf<T>
+    where
+        T: Shutdown,
+    {
+        fn drop(&mut self) {
+            let stream = unsafe { &mut *self.0.get() };
+            stream.shutdown();
+        }
+    }
+
+    /// Error indicating that two halves were not from the same socket, and thus
+    /// could not be reunited.
+    #[derive(Debug)]
+    pub struct ReuniteError<T: Shutdown>(pub LocklessOwnedReadHalf<T>, pub LocklessOwnedWriteHalf<T>);
+
+    impl<T> fmt::Display for ReuniteError<T>
+    where
+        T: Shutdown,
+    {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "tried to reunite halves")
+        }
+    }
+
+    impl<T> Error for ReuniteError<T> where T: Shutdown + Debug {}
+}

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -256,6 +256,15 @@ cfg_io_std! {
     pub use stdout::{stdout, Stdout};
 }
 
+cfg_net_or_io_util_or_gat! {
+    mod lockless_split;
+    pub use lockless_split::{LocklessSplitableBorrowed, LocklessReadHalf, LocklessWriteHalf};
+}
+
+cfg_net_or_io_util! {
+    pub use lockless_split::{Shutdown, LocklessSplitableOwned, LocklessSplit, LocklessOwnedReadHalf, LocklessOwnedWriteHalf};
+}
+
 cfg_io_util! {
     mod split;
     pub use split::{split, ReadHalf, WriteHalf};

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -256,13 +256,9 @@ cfg_io_std! {
     pub use stdout::{stdout, Stdout};
 }
 
-cfg_net_or_io_util_or_gat! {
-    mod lockless_split;
-    pub use lockless_split::{LocklessSplitableBorrowed, LocklessReadHalf, LocklessWriteHalf};
-}
-
 cfg_net_or_io_util! {
-    pub use lockless_split::{Shutdown, LocklessSplitableOwned, LocklessSplit, LocklessOwnedReadHalf, LocklessOwnedWriteHalf};
+    mod lockless_split;
+    pub use lockless_split::{Shutdown, LocklessSplitable, LocklessSplit, LocklessOwnedReadHalf, LocklessOwnedWriteHalf};
 }
 
 cfg_io_util! {

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -216,6 +216,26 @@ macro_rules! cfg_net_or_process {
     }
 }
 
+macro_rules! cfg_net_or_io_util {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(feature = "net", feature = "io-util"))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", feature = "io-util"))))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_net_or_io_util_or_gat {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(feature = "net", feature = "io-util", feature = "gat"))]
+            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", feature = "io-util", feature = "gat"))))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_net {
     ($($item:item)*) => {
         $(

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -226,16 +226,6 @@ macro_rules! cfg_net_or_io_util {
     }
 }
 
-macro_rules! cfg_net_or_io_util_or_gat {
-    ($($item:item)*) => {
-        $(
-            #[cfg(any(feature = "net", feature = "io-util", feature = "gat"))]
-            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", feature = "io-util", feature = "gat"))))]
-            $item
-        )*
-    }
-}
-
 macro_rules! cfg_net {
     ($($item:item)*) => {
         $(

--- a/tokio/src/net/tcp/lockless_split.rs
+++ b/tokio/src/net/tcp/lockless_split.rs
@@ -1,0 +1,11 @@
+use crate::io::{LocklessSplit, Shutdown};
+
+use super::TcpStream;
+
+unsafe impl LocklessSplit for TcpStream {}
+
+impl Shutdown for TcpStream {
+    fn shutdown(&mut self) {
+        let _ = self.shutdown_std(std::net::Shutdown::Write);
+    }
+}

--- a/tokio/src/net/tcp/mod.rs
+++ b/tokio/src/net/tcp/mod.rs
@@ -12,5 +12,7 @@ pub use split::{ReadHalf, WriteHalf};
 mod split_owned;
 pub use split_owned::{OwnedReadHalf, OwnedWriteHalf, ReuniteError};
 
+mod lockless_split;
+
 pub(crate) mod stream;
 pub(crate) use stream::TcpStream;

--- a/tokio/src/net/unix/lockless_split.rs
+++ b/tokio/src/net/unix/lockless_split.rs
@@ -1,0 +1,11 @@
+use crate::io::{LocklessSplit, Shutdown};
+
+use super::UnixStream;
+
+unsafe impl LocklessSplit for UnixStream {}
+
+impl Shutdown for UnixStream {
+    fn shutdown(&mut self) {
+        let _ = self.shutdown_std(std::net::Shutdown::Write);
+    }
+}

--- a/tokio/src/net/unix/mod.rs
+++ b/tokio/src/net/unix/mod.rs
@@ -13,6 +13,8 @@ pub use split::{ReadHalf, WriteHalf};
 mod split_owned;
 pub use split_owned::{OwnedReadHalf, OwnedWriteHalf, ReuniteError};
 
+mod lockless_split;
+
 mod socketaddr;
 pub use socketaddr::SocketAddr;
 

--- a/tokio/tests/io_lockless_split.rs
+++ b/tokio/tests/io_lockless_split.rs
@@ -3,10 +3,8 @@
 
 use tokio::io::{
     AsyncRead, AsyncWrite, LocklessOwnedReadHalf, LocklessOwnedWriteHalf, LocklessSplit,
-    LocklessSplitableOwned, ReadBuf, Shutdown,
+    LocklessSplitable, ReadBuf, Shutdown,
 };
-#[cfg(gat)]
-use tokio::io::{LocklessReadHalf, LocklessWriteHalf};
 
 use std::io;
 use std::pin::Pin;
@@ -52,10 +50,6 @@ impl Shutdown for RW {}
 fn is_send_and_sync() {
     fn assert_bound<T: Send + Sync>() {}
 
-    #[cfg(gat)]
-    assert_bound::<LocklessReadHalf<'_, RW>>();
-    #[cfg(gat)]
-    assert_bound::<LocklessWriteHalf<'_, RW>>();
     assert_bound::<LocklessOwnedReadHalf<RW>>();
     assert_bound::<LocklessOwnedWriteHalf<RW>>();
 }

--- a/tokio/tests/io_lockless_split.rs
+++ b/tokio/tests/io_lockless_split.rs
@@ -1,0 +1,83 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(tokio_wasi)))] // Wasi does not support panic recovery
+
+use tokio::io::{
+    AsyncRead, AsyncWrite, LocklessOwnedReadHalf, LocklessOwnedWriteHalf, LocklessSplit,
+    LocklessSplitableOwned, ReadBuf, Shutdown,
+};
+#[cfg(gat)]
+use tokio::io::{LocklessReadHalf, LocklessWriteHalf};
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+#[derive(Debug)]
+struct RW;
+
+impl AsyncRead for RW {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        buf.put_slice(&[b'z']);
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for RW {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Poll::Ready(Ok(1))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+unsafe impl LocklessSplit for RW {}
+
+impl Shutdown for RW {}
+
+#[test]
+fn is_send_and_sync() {
+    fn assert_bound<T: Send + Sync>() {}
+
+    #[cfg(gat)]
+    assert_bound::<LocklessReadHalf<'_, RW>>();
+    #[cfg(gat)]
+    assert_bound::<LocklessWriteHalf<'_, RW>>();
+    assert_bound::<LocklessOwnedReadHalf<RW>>();
+    assert_bound::<LocklessOwnedWriteHalf<RW>>();
+}
+
+#[test]
+fn unsplit_ok() {
+    let (r, w) = RW.into_split();
+    assert!(r.reunite(w).is_ok());
+}
+
+#[test]
+#[should_panic]
+fn unsplit_err1() {
+    let (r, _) = RW.into_split();
+    let (_, w) = RW.into_split();
+    let _ = r.reunite(w).unwrap();
+}
+
+#[test]
+#[should_panic]
+fn unsplit_err2() {
+    let (_, w) = RW.into_split();
+    let (r, _) = RW.into_split();
+    let _ = r.reunite(w).unwrap();
+}


### PR DESCRIPTION
## Motivation

Hey, the [split](https://github.com/tokio-rs/tokio/blob/d44b1ca9c8fdf6392d7b5b625bef49d141de79f1/tokio/src/io/split.rs#LL34C15-L34C15) method provides a general way of splitting Stream implements `AsyncRead`, `AsyncWrite` to `ReadHalf` and `WriteHalf`. But this way adds a [lock](https://github.com/tokio-rs/tokio/blob/d44b1ca9c8fdf6392d7b5b625bef49d141de79f1/tokio/src/io/split.rs#L54), it will affect read-write irrelevant Stream and greatly reduce the performance. 

## Solution

I add a new marker trait `LocklessSplit` to mark read-write irrelevant Stream. Then I add a `LocklessSplitable` trait with a default implementation for it. e.g., rust-tls can provide read-write irrelevant TlsStream. I refered [monoio](https://github.com/bytedance/monoio/blob/4498424d3df7c137b0c239c3ecccadd3b5dd3481/monoio/src/io/util/split.rs)'s trait design.
