### PR TITLE
time: document immediate completion guarantee for timeouts

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -28,9 +28,9 @@ use std::task::{self, Poll};
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
-/// If the provided future completes immediatelly, then future returned from this
-/// function is guaranteed to complete immediatelly with an [`Ok`] variant no
-/// matter the provided duration.
+/// If the provided future completes immediatelly, then the future returned from
+/// this function is guaranteed to complete immediatelly with an [`Ok`] variant
+/// no matter the provided duration.
 ///
 /// [`Ok`]: std::result::Result::Ok
 /// [`Result`]: std::result::Result
@@ -105,9 +105,9 @@ where
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
-/// If the provided future completes immediatelly, then future returned from this
-/// function is guaranteed to complete immediatelly with an [`Ok`] variant no
-/// matter the provided deadline.
+/// If the provided future completes immediatelly, then the future returned from
+/// this function is guaranteed to complete immediatelly with an [`Ok`] variant
+/// no matter the provided deadline.
 ///
 /// [`Ok`]: std::result::Result::Ok
 /// [`Result`]: std::result::Result

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -28,6 +28,11 @@ use std::task::{self, Poll};
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
+/// If the provided future completes immediatelly, then future returned from this
+/// function is guaranteed to complete immediatelly with an [`Ok`] variant no
+/// matter the provided duration.
+///
+/// [`Ok`]: std::result::Result::Ok
 /// [`Result`]: std::result::Result
 /// [`Elapsed`]: crate::time::error::Elapsed
 ///
@@ -100,6 +105,11 @@ where
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
+/// If the provided future completes immediatelly, then future returned from this
+/// function is guaranteed to complete immediatelly with an [`Ok`] variant no
+/// matter the provided deadline.
+///
+/// [`Ok`]: std::result::Result::Ok
 /// [`Result`]: std::result::Result
 /// [`Elapsed`]: crate::time::error::Elapsed
 ///


### PR DESCRIPTION
Add documentation to `tokio::time::{timeout, timeout_at}`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #5495

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add to documentation the guarantee that future returned from `tokio::time::{timeout, timeout_at}` will complete immediatelly with `Ok` value if provided future completes immediatelly.
