### PR TITLE
Add implementations of AsFd/AsHandle/AsSocket

### DIFF
--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -43,6 +43,7 @@ fn main() {
     let mut enable_addr_of = false;
     let mut enable_target_has_atomic = false;
     let mut enable_const_mutex_new = false;
+    let mut enable_as_fd = false;
     let mut target_needs_atomic_u64_fallback = false;
 
     match AutoCfg::new() {
@@ -106,6 +107,7 @@ fn main() {
             // The `Mutex::new` method was made const in 1.63.
             if ac.probe_rustc_version(1, 64) {
                 enable_const_mutex_new = true;
+                enable_as_fd = true;
             } else if ac.probe_rustc_version(1, 63) {
                 // This compiler claims to be 1.63, but there are some nightly
                 // compilers that claim to be 1.63 without supporting the
@@ -115,6 +117,7 @@ fn main() {
                 // The oldest nightly that supports the feature is 2022-06-20.
                 if ac.probe_expression(CONST_MUTEX_NEW_PROBE) {
                     enable_const_mutex_new = true;
+                    enable_as_fd = true;
                 }
             }
         }
@@ -160,6 +163,14 @@ fn main() {
         //
         // RUSTFLAGS="--cfg tokio_no_const_mutex_new"
         autocfg::emit("tokio_no_const_mutex_new")
+    }
+
+    if !enable_as_fd {
+        // To disable this feature on compilers that support it, you can
+        // explicitly pass this flag with the following environment variable:
+        //
+        // RUSTFLAGS="--cfg tokio_no_as_fd"
+        autocfg::emit("tokio_no_as_fd");
     }
 
     if target_needs_atomic_u64_fallback {

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -725,6 +725,13 @@ impl std::os::unix::io::AsRawFd for File {
     }
 }
 
+#[cfg(all(unix, not(tokio_no_as_fd)))]
+impl std::os::fd::AsFd for File {
+    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        unsafe { std::os::fd::BorrowedFd::borrow_raw(std::os::unix::io::AsRawFd::as_raw_fd(self)) }
+    }
+}
+
 #[cfg(unix)]
 impl std::os::unix::io::FromRawFd for File {
     unsafe fn from_raw_fd(fd: std::os::unix::io::RawFd) -> Self {
@@ -736,6 +743,17 @@ impl std::os::unix::io::FromRawFd for File {
 impl std::os::windows::io::AsRawHandle for File {
     fn as_raw_handle(&self) -> std::os::windows::io::RawHandle {
         self.std.as_raw_handle()
+    }
+}
+
+#[cfg(all(windows, not(tokio_no_as_fd)))]
+impl std::os::windows::io::AsHandle {
+    fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
+        unsafe {
+            std::os::windows::io::BorrowedHandle::borrow_raw(
+                std::os::windows::io::AsRawHandle::as_raw_handle(self),
+            )
+        }
     }
 }
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -726,9 +726,11 @@ impl std::os::unix::io::AsRawFd for File {
 }
 
 #[cfg(all(unix, not(tokio_no_as_fd)))]
-impl std::os::fd::AsFd for File {
-    fn as_fd(&self) -> std::os::fd::BorrowedFd<'_> {
-        unsafe { std::os::fd::BorrowedFd::borrow_raw(std::os::unix::io::AsRawFd::as_raw_fd(self)) }
+impl std::os::unix::io::AsFd for File {
+    fn as_fd(&self) -> std::os::unix::io::BorrowedFd<'_> {
+        unsafe {
+            std::os::unix::io::BorrowedFd::borrow_raw(std::os::unix::io::AsRawFd::as_raw_fd(self))
+        }
     }
 }
 
@@ -747,7 +749,7 @@ impl std::os::windows::io::AsRawHandle for File {
 }
 
 #[cfg(all(windows, not(tokio_no_as_fd)))]
-impl std::os::windows::io::AsHandle {
+impl std::os::windows::io::AsHandle for File {
     fn as_handle(&self) -> std::os::windows::io::BorrowedHandle<'_> {
         unsafe {
             std::os::windows::io::BorrowedHandle::borrow_raw(

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -407,6 +407,13 @@ mod sys {
             self.io.as_raw_fd()
         }
     }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for TcpListener {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+        }
+    }
 }
 
 cfg_unstable! {
@@ -420,6 +427,13 @@ cfg_unstable! {
                 self.io.as_raw_fd()
             }
         }
+
+        #[cfg(not(tokio_no_as_fd))]
+        impl AsFd for TcpListener {
+            fn as_fd(&self) -> BorrowedFd<'_> {
+                unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+            }
+        }
     }
 }
 
@@ -431,6 +445,13 @@ mod sys {
     impl AsRawSocket for TcpListener {
         fn as_raw_socket(&self) -> RawSocket {
             self.io.as_raw_socket()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsSocket for UdpSocket {
+        fn as_socket(&self) -> BorrowedSocket<'_> {
+            unsafe { BorrowedSocket::borrow_raw(self.as_raw_socket()) }
         }
     }
 }

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -449,7 +449,7 @@ mod sys {
     }
 
     #[cfg(not(tokio_no_as_fd))]
-    impl AsSocket for UdpSocket {
+    impl AsSocket for TcpListener {
         fn as_socket(&self) -> BorrowedSocket<'_> {
             unsafe { BorrowedSocket::borrow_raw(self.as_raw_socket()) }
         }

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -4,10 +4,14 @@ use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 
+#[cfg(all(unix, not(tokio_no_as_fd)))]
+use std::os::fd::{AsFd, BorrowedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, FromRawSocket, IntoRawSocket, RawSocket};
+#[cfg(all(windows, not(tokio_no_as_fd)))]
+use std::os::windows::io::{AsSocket, BorrowedSocket};
 use std::time::Duration;
 
 cfg_net! {
@@ -737,6 +741,13 @@ impl AsRawFd for TcpSocket {
     }
 }
 
+#[cfg(all(unix, not(tokio_no_as_fd)))]
+impl AsFd for TcpSocket {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+    }
+}
+
 #[cfg(unix)]
 impl FromRawFd for TcpSocket {
     /// Converts a `RawFd` to a `TcpSocket`.
@@ -769,6 +780,13 @@ impl IntoRawSocket for TcpSocket {
 impl AsRawSocket for TcpSocket {
     fn as_raw_socket(&self) -> RawSocket {
         self.inner.as_raw_socket()
+    }
+}
+
+#[cfg(all(windows, not(tokio_no_as_fd)))]
+impl AsSocket for TcpSocket {
+    fn as_socket(&self) -> BorrowedSocket<'_> {
+        unsafe { BorrowedSocket::borrow_raw(self.as_raw_socket()) }
     }
 }
 

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -5,7 +5,7 @@ use std::io;
 use std::net::SocketAddr;
 
 #[cfg(all(unix, not(tokio_no_as_fd)))]
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 #[cfg(windows)]

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1342,6 +1342,13 @@ mod sys {
             self.io.as_raw_fd()
         }
     }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for TcpStream {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+        }
+    }
 }
 
 #[cfg(windows)]
@@ -1354,6 +1361,13 @@ mod sys {
             self.io.as_raw_socket()
         }
     }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsSocket for TcpStream {
+        fn as_socket(&self) -> BorrowedSocket<'_> {
+            unsafe { BorrowedSocket::borrow_raw(self.as_raw_socket()) }
+        }
+    }
 }
 
 #[cfg(all(tokio_unstable, tokio_wasi))]
@@ -1364,6 +1378,13 @@ mod sys {
     impl AsRawFd for TcpStream {
         fn as_raw_fd(&self) -> RawFd {
             self.io.as_raw_fd()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for TcpStream {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
         }
     }
 }

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1691,7 +1691,7 @@ impl fmt::Debug for UdpSocket {
     }
 }
 
-#[cfg(all(unix))]
+#[cfg(unix)]
 mod sys {
     use super::UdpSocket;
     use std::os::unix::prelude::*;
@@ -1699,6 +1699,13 @@ mod sys {
     impl AsRawFd for UdpSocket {
         fn as_raw_fd(&self) -> RawFd {
             self.io.as_raw_fd()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for UdpSocket {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
         }
     }
 }
@@ -1711,6 +1718,13 @@ mod sys {
     impl AsRawSocket for UdpSocket {
         fn as_raw_socket(&self) -> RawSocket {
             self.io.as_raw_socket()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsSocket for UdpSocket {
+        fn as_socket(&self) -> BorrowedSocket<'_> {
+            unsafe { BorrowedSocket::borrow_raw(self.as_raw_socket()) }
         }
     }
 }

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::io;
 use std::net::Shutdown;
 #[cfg(not(tokio_no_as_fd))]
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -5,6 +5,8 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 use std::net::Shutdown;
+#[cfg(not(tokio_no_as_fd))]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
@@ -1434,5 +1436,12 @@ impl fmt::Debug for UnixDatagram {
 impl AsRawFd for UnixDatagram {
     fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
+    }
+}
+
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for UnixDatagram {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -4,6 +4,8 @@ use crate::net::unix::{SocketAddr, UnixStream};
 use std::convert::TryFrom;
 use std::fmt;
 use std::io;
+#[cfg(not(tokio_no_as_fd))]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
@@ -206,5 +208,12 @@ impl fmt::Debug for UnixListener {
 impl AsRawFd for UnixListener {
     fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
+    }
+}
+
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for UnixListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -5,7 +5,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io;
 #[cfg(not(tokio_no_as_fd))]
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;

--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -6,9 +6,9 @@ use crate::io::{AsyncRead, AsyncWrite, PollEvented, ReadBuf, Ready};
 use mio::unix::pipe as mio_pipe;
 use std::fs::File;
 use std::io::{self, Read, Write};
-#[cfg(not(tokio_no_as_fd))]
-use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
+#[cfg(not(tokio_no_as_fd))]
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
 use std::pin::Pin;

--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -6,6 +6,8 @@ use crate::io::{AsyncRead, AsyncWrite, PollEvented, ReadBuf, Ready};
 use mio::unix::pipe as mio_pipe;
 use std::fs::File;
 use std::io::{self, Read, Write};
+#[cfg(not(tokio_no_as_fd))]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::fs::{FileTypeExt, OpenOptionsExt};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::path::Path;
@@ -662,6 +664,13 @@ impl AsRawFd for Sender {
     }
 }
 
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for Sender {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+    }
+}
+
 /// Reading end of a Unix pipe.
 ///
 /// It can be constructed from a FIFO file with [`OpenOptions::open_receiver`].
@@ -1158,6 +1167,13 @@ impl AsyncRead for Receiver {
 impl AsRawFd for Receiver {
     fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
+    }
+}
+
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for Receiver {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }
 

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -10,7 +10,7 @@ use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
 #[cfg(not(tokio_no_as_fd))]
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -9,6 +9,8 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
+#[cfg(not(tokio_no_as_fd))]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
@@ -998,5 +1000,12 @@ impl fmt::Debug for UnixStream {
 impl AsRawFd for UnixStream {
     fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()
+    }
+}
+
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for UnixStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1491,7 +1491,7 @@ mod sys {
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStdin {
         fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
         }
     }
 
@@ -1504,7 +1504,7 @@ mod sys {
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStdout {
         fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
         }
     }
 
@@ -1517,7 +1517,7 @@ mod sys {
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStderr {
         fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
         }
     }
 }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1429,7 +1429,7 @@ impl TryInto<Stdio> for ChildStderr {
 #[cfg(unix)]
 mod sys {
     #[cfg(not(tokio_no_as_fd))]
-    use std::os::fd::{AsFd, BorrowedFd};
+    use std::os::unix::io::{AsFd, BorrowedFd};
     use std::os::unix::io::{AsRawFd, RawFd};
 
     use super::{ChildStderr, ChildStdin, ChildStdout};
@@ -1490,7 +1490,7 @@ mod sys {
 
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStdin {
-        fn as_fd(&self) -> BorrowedHandle<'_> {
+        fn as_handle(&self) -> BorrowedHandle<'_> {
             unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
         }
     }
@@ -1503,7 +1503,7 @@ mod sys {
 
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStdout {
-        fn as_fd(&self) -> BorrowedHandle<'_> {
+        fn as_handle(&self) -> BorrowedHandle<'_> {
             unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
         }
     }
@@ -1516,7 +1516,7 @@ mod sys {
 
     #[cfg(not(tokio_no_as_fd))]
     impl AsHandle for ChildStderr {
-        fn as_fd(&self) -> BorrowedHandle<'_> {
+        fn as_handle(&self) -> BorrowedHandle<'_> {
             unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
         }
     }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1428,6 +1428,8 @@ impl TryInto<Stdio> for ChildStderr {
 
 #[cfg(unix)]
 mod sys {
+    #[cfg(not(tokio_no_as_fd))]
+    use std::os::fd::{AsFd, BorrowedFd};
     use std::os::unix::io::{AsRawFd, RawFd};
 
     use super::{ChildStderr, ChildStdin, ChildStdout};
@@ -1438,9 +1440,23 @@ mod sys {
         }
     }
 
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for ChildStdin {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+        }
+    }
+
     impl AsRawFd for ChildStdout {
         fn as_raw_fd(&self) -> RawFd {
             self.inner.as_raw_fd()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for ChildStdout {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
         }
     }
 
@@ -1449,10 +1465,19 @@ mod sys {
             self.inner.as_raw_fd()
         }
     }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsFd for ChildStderr {
+        fn as_fd(&self) -> BorrowedFd<'_> {
+            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+        }
+    }
 }
 
 #[cfg(windows)]
 mod sys {
+    #[cfg(not(tokio_no_as_fd))]
+    use std::os::windows::io::{AsHandle, BorrowedHandle};
     use std::os::windows::io::{AsRawHandle, RawHandle};
 
     use super::{ChildStderr, ChildStdin, ChildStdout};
@@ -1463,15 +1488,36 @@ mod sys {
         }
     }
 
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsHandle for ChildStdin {
+        fn as_fd(&self) -> BorrowedHandle<'_> {
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
+        }
+    }
+
     impl AsRawHandle for ChildStdout {
         fn as_raw_handle(&self) -> RawHandle {
             self.inner.as_raw_handle()
         }
     }
 
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsHandle for ChildStdout {
+        fn as_fd(&self) -> BorrowedHandle<'_> {
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
+        }
+    }
+
     impl AsRawHandle for ChildStderr {
         fn as_raw_handle(&self) -> RawHandle {
             self.inner.as_raw_handle()
+        }
+    }
+
+    #[cfg(not(tokio_no_as_fd))]
+    impl AsHandle for ChildStderr {
+        fn as_fd(&self) -> BorrowedHandle<'_> {
+            unsafe { BorrowedHandle::borrow_raw(self.as_raw_fd()) }
         }
     }
 }

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -40,7 +40,7 @@ use std::fs::File;
 use std::future::Future;
 use std::io;
 #[cfg(not(tokio_no_as_fd))]
-use std::os::fd::{AsFd, BorrowedFd};
+use std::os::unix::io::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::pin::Pin;
 use std::process::{Child as StdChild, ExitStatus, Stdio};

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -39,6 +39,8 @@ use std::fmt;
 use std::fs::File;
 use std::future::Future;
 use std::io;
+#[cfg(not(tokio_no_as_fd))]
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
 use std::pin::Pin;
 use std::process::{Child as StdChild, ExitStatus, Stdio};
@@ -194,6 +196,13 @@ impl AsRawFd for Pipe {
     }
 }
 
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for Pipe {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+    }
+}
+
 pub(crate) fn convert_to_stdio(io: ChildStdio) -> io::Result<Stdio> {
     let mut fd = io.inner.into_inner()?.fd;
 
@@ -243,6 +252,13 @@ impl fmt::Debug for ChildStdio {
 impl AsRawFd for ChildStdio {
     fn as_raw_fd(&self) -> RawFd {
         self.inner.as_raw_fd()
+    }
+}
+
+#[cfg(not(tokio_no_as_fd))]
+impl AsFd for ChildStdio {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
     }
 }
 


### PR DESCRIPTION
The new release of socket2 works with these traits rather than the old `AsRaw*` ones.