### PR TITLE
macros: define cancellation safety

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -133,7 +133,10 @@
 ///
 /// Cancellation safety can be defined in the following way: If you have a
 /// future that has not yet completed, then it must be a no-op to drop that
-/// future and recreate it.
+/// future and recreate it. This definition is motivated by the situation where
+/// a `select!` is used in a loop. Without this guarantee, you would lose your
+/// progress when another branch completes and you restart the `select!` by
+/// going around the loop.
 ///
 /// Be aware that cancelling something that is not cancellation safe is not
 /// necessarily wrong. For example, if you are cancelling a task because the

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -130,7 +130,7 @@
 /// cancelled, that always happens at an `.await`. If your function behaves
 /// correctly even if it is restarted while waiting at an `.await`, then it is
 /// cancellation safe.
-/// 
+///
 /// Cancellation safety can be defined in the following way: If you have a
 /// future that has not yet completed, then it must be a no-op to drop that
 /// future and recreate it.

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -130,6 +130,10 @@
 /// cancelled, that always happens at an `.await`. If your function behaves
 /// correctly even if it is restarted while waiting at an `.await`, then it is
 /// cancellation safe.
+/// 
+/// Cancellation safety can be defined in the following way: If you have a
+/// future that has not yet completed, then it must be a no-op to drop that
+/// future and recreate it.
 ///
 /// Be aware that cancelling something that is not cancellation safe is not
 /// necessarily wrong. For example, if you are cancelling a task because the


### PR DESCRIPTION
This adds a precise definition of cancellation safety to the docs of `select!`.

cc @yoshuawuyts