### PR TITLE
Add `RwLockWriteGuard::{downgrade_map, try_downgrade_map}`.

### DIFF
--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -125,7 +125,8 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
     /// # async fn main() {
     /// let lock = Arc::new(RwLock::new(Foo(1)));
     ///
-    /// let mapped = OwnedRwLockWriteGuard::downgrade_map(Arc::clone(&lock).write_owned().await, |f| &f.0);
+    /// let guard = Arc::clone(&lock).write_owned().await;
+    /// let mapped = OwnedRwLockWriteGuard::downgrade_map(guard, |f| &f.0);
     /// let foo = lock.read_owned().await;
     /// assert_eq!(foo.0, *mapped);
     /// # }
@@ -258,7 +259,8 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
     /// # async fn main() {
     /// let lock = Arc::new(RwLock::new(Foo(1)));
     ///
-    /// let guard = OwnedRwLockWriteGuard::try_downgrade_map(Arc::clone(&lock).write_owned().await, |f| Some(&f.0)).expect("should not fail");
+    /// let guard = Arc::clone(&lock).write_owned().await;
+    /// let guard = OwnedRwLockWriteGuard::try_downgrade_map(guard, |f| Some(&f.0)).expect("should not fail");
     /// let foo = lock.read_owned().await;
     /// assert_eq!(foo.0, *guard);
     /// # }

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -100,7 +100,77 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         }
     }
 
-    /// Attempts to make  a new [`OwnedRwLockMappedWriteGuard`] for a component
+    /// Makes a new [`OwnedRwLockReadGuard`] for a component of the locked data.
+    ///
+    /// This operation cannot fail as the `OwnedRwLockWriteGuard` passed in already
+    /// locked the data.
+    ///
+    /// This is an associated function that needs to be used as
+    /// `OwnedRwLockWriteGuard::downgrade_map(..)`. A method would interfere with methods of
+    /// the same name on the contents of the locked data.
+    ///
+    /// Inside of `f`, you retain exclusive access to the data, despite only being given a `&T`. Handing out a
+    /// `&mut T` would result in unsoundness, as you could use interior mutability.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// let mapped = OwnedRwLockWriteGuard::downgrade_map(Arc::clone(&lock).write_owned().await, |f| &f.0);
+    /// let foo = lock.read_owned().await;
+    /// assert_eq!(foo.0, *mapped);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn downgrade_map<F, U: ?Sized>(this: Self, f: F) -> OwnedRwLockReadGuard<T, U>
+    where
+        F: FnOnce(&T) -> &U,
+    {
+        let data = f(&*this) as *const U;
+        let this = this.skip_drop();
+        let guard = OwnedRwLockReadGuard {
+            lock: this.lock,
+            data,
+            _p: PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: this.resource_span,
+        };
+
+        // Release all but one of the permits held by the write guard
+        let to_release = (this.permits_acquired - 1) as usize;
+        guard.lock.s.release(to_release);
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        guard.resource_span.in_scope(|| {
+            tracing::trace!(
+            target: "runtime::resource::state_update",
+            write_locked = false,
+            write_locked.op = "override",
+            )
+        });
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        guard.resource_span.in_scope(|| {
+            tracing::trace!(
+            target: "runtime::resource::state_update",
+            current_readers = 1,
+            current_readers.op = "add",
+            )
+        });
+
+        guard
+    }
+
+    /// Attempts to make a new [`OwnedRwLockMappedWriteGuard`] for a component
     /// of the locked data. The original guard is returned if the closure
     /// returns `None`.
     ///
@@ -157,6 +227,86 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             resource_span: this.resource_span,
         })
+    }
+
+    /// Attempts to make a new [`OwnedRwLockReadGuard`] for a component of
+    /// the locked data. The original guard is returned if the closure returns
+    /// `None`.
+    ///
+    /// This operation cannot fail as the `OwnedRwLockWriteGuard` passed in already
+    /// locked the data.
+    ///
+    /// This is an associated function that needs to be
+    /// used as `OwnedRwLockWriteGuard::try_downgrade_map(...)`. A method would interfere with
+    /// methods of the same name on the contents of the locked data.
+    ///
+    /// Inside of `f`, you retain exclusive access to the data, despite only being given a `&T`. Handing out a
+    /// `&mut T` would result in unsoundness, as you could use interior mutability.
+    ///
+    /// If this function returns `Err(...)`, the lock is never unlocked nor downgraded.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// let guard = OwnedRwLockWriteGuard::try_downgrade_map(Arc::clone(&lock).write_owned().await, |f| Some(&f.0)).expect("should not fail");
+    /// let foo = lock.read_owned().await;
+    /// assert_eq!(foo.0, *guard);
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_downgrade_map<F, U: ?Sized>(
+        this: Self,
+        f: F,
+    ) -> Result<OwnedRwLockReadGuard<T, U>, Self>
+    where
+        F: FnOnce(&T) -> Option<&U>,
+    {
+        let data = match f(&*this) {
+            Some(data) => data as *const U,
+            None => return Err(this),
+        };
+        let this = this.skip_drop();
+        let guard = OwnedRwLockReadGuard {
+            lock: this.lock,
+            data,
+            _p: PhantomData,
+            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            resource_span: this.resource_span,
+        };
+
+        // Release all but one of the permits held by the write guard
+        let to_release = (this.permits_acquired - 1) as usize;
+        guard.lock.s.release(to_release);
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        guard.resource_span.in_scope(|| {
+            tracing::trace!(
+            target: "runtime::resource::state_update",
+            write_locked = false,
+            write_locked.op = "override",
+            )
+        });
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        guard.resource_span.in_scope(|| {
+            tracing::trace!(
+            target: "runtime::resource::state_update",
+            current_readers = 1,
+            current_readers.op = "add",
+            )
+        });
+
+        Ok(guard)
     }
 
     /// Converts this `OwnedRwLockWriteGuard` into an

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -160,6 +160,9 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
             resource_span: this.resource_span,
         })
     }
+
+    // Note: No `downgrade`, `downgrade_map` nor `try_downgrade_map` because they would be unsound, as we're already
+    //       potentially been mapped with internal mutability.
 }
 
 impl<T: ?Sized> ops::Deref for RwLockMappedWriteGuard<'_, T> {


### PR DESCRIPTION
Adds `RwLockWriteGuard::{downgrade_map, try_downgrade_map}`.

## Motivation

These functions allow the following code to work:

```rust
impl T {
    fn try_get(&self) -> Option<&U> { ... }
}

pub async fn foo(lock: RwLock<T>) -> RwLockReadGuard<U> {
    // Check with a read lock
    if let Ok(value) = RwLockReadGuard::try_map(lock.read().await, |value| value.try_get()) {
        return value;
    }

    // Else "upgrade" and check if it was changed in the meantime
    let guard = lock.write().await;
    if let Ok(value) = RwLockWriteGuard::try_downgrade_map(guard, |value| value.try_get()) {
        return value;
    }

    // Use `guard` mutably
    // ...
}
```

The code uses a double-checked lock on a `RwLock` to do some action, and then returns a mapped read guard to the inner data.

With the current suite of functions, we can't easily perform the second check efficiently. We need to not unlock the rwlock, which means we'd need to first call `try_get` to check if it's available, then perform a downgrade and map it with `try_get().unwrap()` to get the value again. This involves calling `try_get` twice, which isn't desirable.

These function are `Fn(&T) -> &U`, so I don't believe there are any soundness issues (I made a [stack overflow question](https://stackoverflow.com/questions/75631336) to check if it was sound, and someone suggested that if it was, this could be a good API to add, so I made this PR).

## Solution

We simply add the functions on `RwLockWriteGuard`. `RwLockMappedWriteGuard` can't have them, due to unsoundness, but a non-mapped `RwLockWriteGuard` is fine.
