### PR TITLE
fs: fix `File::from_raw_fd` test

### DIFF
--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -184,7 +184,7 @@ async fn unix_fd_is_valid() {
 #[tokio::test]
 #[cfg(unix)]
 async fn read_file_from_unix_fd() {
-    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
+    use std::os::unix::io::{FromRawFd, IntoRawFd};
 
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();
@@ -192,6 +192,7 @@ async fn read_file_from_unix_fd() {
     let file1 = File::open(tempfile.path()).await.unwrap();
     let raw_fd = file1.into_std().await.into_raw_fd();
     assert!(raw_fd > 0);
+
     let mut file2 = unsafe { File::from_raw_fd(raw_fd) };
 
     let mut buf = [0; 1024];

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -190,10 +190,8 @@ async fn read_file_from_unix_fd() {
     tempfile.write_all(HELLO).unwrap();
 
     let file1 = File::open(tempfile.path()).await.unwrap();
-    let raw_fd = file1.as_raw_fd();
-    assert!(raw_fd > 0);
-
     let raw_fd = file1.into_std().await.into_raw_fd();
+    assert!(raw_fd > 0);
     let mut file2 = unsafe { File::from_raw_fd(raw_fd) };
 
     let mut buf = [0; 1024];

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -193,7 +193,9 @@ async fn read_file_from_unix_fd() {
     let file1 = File::open(tempfile.path()).await.unwrap();
     let raw_fd = file1.as_raw_fd();
     assert!(raw_fd > 0);
-    std::mem::forget(file1);
+
+    // We will reuse the raw file descriptor.
+    std::mem::forget(file1.into_std().await);
 
     let mut file2 = unsafe { File::from_raw_fd(raw_fd) };
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -193,6 +193,7 @@ async fn read_file_from_unix_fd() {
     let file1 = File::open(tempfile.path()).await.unwrap();
     let raw_fd = file1.as_raw_fd();
     assert!(raw_fd > 0);
+    std::mem::forget(file1);
 
     let mut file2 = unsafe { File::from_raw_fd(raw_fd) };
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -184,8 +184,7 @@ async fn unix_fd_is_valid() {
 #[tokio::test]
 #[cfg(unix)]
 async fn read_file_from_unix_fd() {
-    use std::os::unix::io::AsRawFd;
-    use std::os::unix::io::FromRawFd;
+    use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd};
 
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();
@@ -194,9 +193,7 @@ async fn read_file_from_unix_fd() {
     let raw_fd = file1.as_raw_fd();
     assert!(raw_fd > 0);
 
-    // We will reuse the raw file descriptor.
-    std::mem::forget(file1.into_std().await);
-
+    let raw_fd = file1.into_std().await.into_raw_fd();
     let mut file2 = unsafe { File::from_raw_fd(raw_fd) };
 
     let mut buf = [0; 1024];


### PR DESCRIPTION
One of the `tokio::fs` tests began to spuriously fail in the CI after #5493 was merged. I believe it comes from dropping `File` with the same fd twice. This PR should fix this.

cc @brodybits