### PR TITLE
Make Contributing guide more newbie friendly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,9 @@ There are two ways to write tests: [integration tests](https://doc.rust-lang.org
 Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. They are passed to the compiler using RUSTFLAGS and RUSTDOC_FLAGS environment variables. One of the most prevalent ones is the cfg option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
 
 For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
-`% RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features=full --test rt_metrics`
+```
+$ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features=full --test rt_metrics`
+```
 
 #### Integration tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -672,7 +672,7 @@ When releasing a new version of a crate, follow these steps:
    entry for that release version into your editor and close the window.
 
 [keep-a-changelog]: https://github.com/olivierlacan/keep-a-changelog/blob/master/CHANGELOG.md
-[unit-tests]: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html
+[unit-tests]: https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html
 [integration-tests]: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html
 [documentation-tests]: https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html
 [conditional-compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ include one or more tests to ensure that Tokio does not regress in the future.
 There are two ways to write tests: [integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) and [documentation tests](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html)
 (Tokio avoids [unit tests](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) as much as possible).
 
-Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. They are passed to the compiler using RUSTFLAGS and RUSTDOC_FLAGS environment variables. One of the most prevalent ones is the cfg option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
+Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. They are passed to the compiler using RUSTFLAGS and RUSTDOCFLAGS environment variables. One of the most prevalent ones is the cfg option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
 
 For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,8 +197,13 @@ If the change being proposed alters code (as opposed to only documentation for
 example), it is either adding new functionality to Tokio or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Tokio does not regress in the future.
-There are two ways to write tests: integration tests and documentation tests
-(Tokio avoids unit tests as much as possible).
+There are two ways to write tests: [integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) and [documentation tests](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html)
+(Tokio avoids [unit tests](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) as much as possible).
+
+Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. They are passed to the compiler using RUSTFLAGS and RUSTDOC_FLAGS environment variables. One of the most prevalent ones is the cfg option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
+
+For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
+`% RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features=full --test rt_metrics`
 
 #### Integration tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ include one or more tests to ensure that Tokio does not regress in the future.
 There are two ways to write tests: [integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) and [documentation tests](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html)
 (Tokio avoids [unit tests](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) as much as possible).
 
-Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. They are passed to the compiler using RUSTFLAGS and RUSTDOCFLAGS environment variables. One of the most prevalent ones is the cfg option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
+Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. Code marked with such attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment variables. One of the most prevalent flags passed in these variables is the `--cfg` option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
 
 For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,11 +197,11 @@ If the change being proposed alters code (as opposed to only documentation for
 example), it is either adding new functionality to Tokio or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Tokio does not regress in the future.
-There are two ways to write tests: [integration tests](integration-tests)
-and [documentation tests](documentation-tests).
-(Tokio avoids [unit tests](unit-tests) as much as possible).
+There are two ways to write tests: [integration tests][integration-tests]
+and [documentation tests][documentation-tests].
+(Tokio avoids [unit tests][unit-tests] as much as possible).
 
-Tokio uses [conditional compilation attributes](conditional-compilation)
+Tokio uses [conditional compilation attributes][conditional-compilation]
 throughout the codebase, to modify rustc's behavior. Code marked with such
 attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment
 variables. One of the most prevalent flags passed in these variables is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,12 +197,19 @@ If the change being proposed alters code (as opposed to only documentation for
 example), it is either adding new functionality to Tokio or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Tokio does not regress in the future.
-There are two ways to write tests: [integration tests](https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html) and [documentation tests](https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html)
-(Tokio avoids [unit tests](https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html) as much as possible).
+There are two ways to write tests: [integration tests](integration-tests) and
+[documentation tests](documentation-tests).
+(Tokio avoids [unit tests](unit-tests) as much as possible).
 
-Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/reference/conditional-compilation.html) throughout the codebase, to modify rustc's behavior. Code marked with such attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment variables. One of the most prevalent flags passed in these variables is the `--cfg` option. To run tests in a particular file, check first what options #![cfg] declaration defines for that file.
+Tokio uses [conditional compilation attributes](conditional-compilation)
+throughout the codebase, to modify rustc's behavior. Code marked with such
+attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment
+variables. One of the most prevalent flags passed in these variables is
+the `--cfg` option. To run tests in a particular file, check first what options
+#![cfg] declaration defines for that file.
 
-For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
+For instance, to run a test marked with the 'tokio_unstable' cfg option, you
+must pass this flag to the compiler when running the test.
 ```
 $ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --all-features --test rt_metrics
 ```
@@ -665,3 +672,7 @@ When releasing a new version of a crate, follow these steps:
    entry for that release version into your editor and close the window.
 
 [keep-a-changelog]: https://github.com/olivierlacan/keep-a-changelog/blob/master/CHANGELOG.md
+[unit-tests]: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html
+[integration-tests]: https://doc.rust-lang.org/rust-by-example/testing/integration_testing.html
+[documentation-tests]: https://doc.rust-lang.org/rust-by-example/testing/doc_testing.html
+[conditional-compilation]: https://doc.rust-lang.org/reference/conditional-compilation.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ Tokio uses [conditional compilation attributes](https://doc.rust-lang.org/refere
 
 For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to the compiler when running the test.
 ```
-$ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features=full --test rt_metrics`
+$ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --all-features --test rt_metrics
 ```
 
 #### Integration tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,19 +197,19 @@ If the change being proposed alters code (as opposed to only documentation for
 example), it is either adding new functionality to Tokio or it is fixing
 existing, broken functionality. In both of these cases, the pull request should
 include one or more tests to ensure that Tokio does not regress in the future.
-There are two ways to write tests: [integration tests](integration-tests) and
-[documentation tests](documentation-tests).
+There are two ways to write tests: [integration tests](integration-tests)
+and [documentation tests](documentation-tests).
 (Tokio avoids [unit tests](unit-tests) as much as possible).
 
 Tokio uses [conditional compilation attributes](conditional-compilation)
 throughout the codebase, to modify rustc's behavior. Code marked with such
 attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment
 variables. One of the most prevalent flags passed in these variables is
-the `--cfg` option. To run tests in a particular file, check first what options
-#![cfg] declaration defines for that file.
+the `--cfg` option. To run tests in a particular file, check first what
+options #![cfg] declaration defines for that file.
 
-For instance, to run a test marked with the 'tokio_unstable' cfg option, you
-must pass this flag to the compiler when running the test.
+For instance, to run a test marked with the 'tokio_unstable' cfg option,
+you must pass this flag to the compiler when running the test.
 ```
 $ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --all-features --test rt_metrics
 ```


### PR DESCRIPTION
## Motivation

One of the first things a new contributor will want to do, is to execute the tests for the project. We can make tokio more accessible to newbies, by making running tests as simple as possible. 

## Solution

This PR amends the existing Contributing guide, by adding links to fundamental testing concepts in Rust, and information about conditional compilation attributes and how to use them to run tests with cargo.