### PR TITLE
time: fix typo

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -28,8 +28,8 @@ use std::task::{self, Poll};
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
-/// If the provided future completes immediatelly, then the future returned from
-/// this function is guaranteed to complete immediatelly with an [`Ok`] variant
+/// If the provided future completes immediately, then the future returned from
+/// this function is guaranteed to complete immediately with an [`Ok`] variant
 /// no matter the provided duration.
 ///
 /// [`Ok`]: std::result::Result::Ok
@@ -105,8 +105,8 @@ where
 /// This function returns a future whose return type is [`Result`]`<T,`[`Elapsed`]`>`, where `T` is the
 /// return type of the provided future.
 ///
-/// If the provided future completes immediatelly, then the future returned from
-/// this function is guaranteed to complete immediatelly with an [`Ok`] variant
+/// If the provided future completes immediately, then the future returned from
+/// this function is guaranteed to complete immediately with an [`Ok`] variant
 /// no matter the provided deadline.
 ///
 /// [`Ok`]: std::result::Result::Ok


### PR DESCRIPTION
**This commit**
- Replace instances of "immediatelly" with "immediately".