### PR TITLE
task: make `JoinHandle::abort_handle` public

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -184,26 +184,26 @@ impl<T> JoinHandle<T> {
     ///
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
-    /// #  tokio::time::pause();
-    ///    let mut handles = Vec::new();
+    /// # tokio::time::pause();
+    /// let mut handles = Vec::new();
     ///
-    ///    handles.push(tokio::spawn(async {
-    ///       time::sleep(time::Duration::from_secs(10)).await;
-    ///       true
-    ///    }));
+    /// handles.push(tokio::spawn(async {
+    ///    time::sleep(time::Duration::from_secs(10)).await;
+    ///    true
+    /// }));
     ///
-    ///    handles.push(tokio::spawn(async {
-    ///       time::sleep(time::Duration::from_secs(10)).await;
-    ///       false
-    ///    }));
+    /// handles.push(tokio::spawn(async {
+    ///    time::sleep(time::Duration::from_secs(10)).await;
+    ///    false
+    /// }));
     ///
-    ///    for handle in &handles {
-    ///        handle.abort();
-    ///    }
+    /// for handle in &handles {
+    ///     handle.abort();
+    /// }
     ///
-    ///    for handle in handles {
-    ///        assert!(handle.await.unwrap_err().is_cancelled());
-    ///    }
+    /// for handle in handles {
+    ///     assert!(handle.await.unwrap_err().is_cancelled());
+    /// }
     /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
@@ -264,27 +264,27 @@ impl<T> JoinHandle<T> {
     /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     /// #  time::pause();
-    ///    let mut handles = Vec::new();
+    /// let mut handles = Vec::new();
     ///
-    ///    handles.push(tokio::spawn(async {
-    ///       time::sleep(time::Duration::from_secs(10)).await;
-    ///       true
-    ///    }));
+    /// handles.push(tokio::spawn(async {
+    ///    time::sleep(time::Duration::from_secs(10)).await;
+    ///    true
+    /// }));
     ///
-    ///    handles.push(tokio::spawn(async {
-    ///       time::sleep(time::Duration::from_secs(10)).await;
-    ///       false
-    ///    }));
+    /// handles.push(tokio::spawn(async {
+    ///    time::sleep(time::Duration::from_secs(10)).await;
+    ///    false
+    /// }));
     ///
-    ///    let abort_handles: Vec<task::AbortHandle> = handles.iter().map(|h| h.abort_handle()).collect();
+    /// let abort_handles: Vec<task::AbortHandle> = handles.iter().map(|h| h.abort_handle()).collect();
     ///
-    ///    for handle in abort_handles {
-    ///        handle.abort();
-    ///    }
+    /// for handle in abort_handles {
+    ///     handle.abort();
+    /// }
     ///
-    ///    for handle in handles {
-    ///        assert!(handle.await.unwrap_err().is_cancelled());
-    ///    }
+    /// for handle in handles {
+    ///     assert!(handle.await.unwrap_err().is_cancelled());
+    /// }
     /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -184,6 +184,7 @@ impl<T> JoinHandle<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
+    /// #  tokio::time::pause();
     ///    let mut handles = Vec::new();
     ///
     ///    handles.push(tokio::spawn(async {
@@ -262,6 +263,7 @@ impl<T> JoinHandle<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
+    /// #  tokio::time::pause();
     ///    let mut handles = Vec::new();
     ///
     ///    handles.push(tokio::spawn(async {

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -182,8 +182,8 @@ impl<T> JoinHandle<T> {
     /// ```rust
     /// use tokio::time;
     ///
-    /// #[tokio::main]
-    /// async fn main() {
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() {
     /// #  tokio::time::pause();
     ///    let mut handles = Vec::new();
     ///
@@ -204,7 +204,7 @@ impl<T> JoinHandle<T> {
     ///    for handle in handles {
     ///        assert!(handle.await.unwrap_err().is_cancelled());
     ///    }
-    /// }
+    /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
     pub fn abort(&self) {
@@ -261,9 +261,9 @@ impl<T> JoinHandle<T> {
     /// ```rust
     /// use tokio::{time, task};
     ///
-    /// #[tokio::main]
-    /// async fn main() {
-    /// #  tokio::time::pause();
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() {
+    /// #  time::pause();
     ///    let mut handles = Vec::new();
     ///
     ///    handles.push(tokio::spawn(async {
@@ -285,7 +285,7 @@ impl<T> JoinHandle<T> {
     ///    for handle in handles {
     ///        assert!(handle.await.unwrap_err().is_cancelled());
     ///    }
-    /// }
+    /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
     pub fn abort_handle(&self) -> super::AbortHandle {

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -182,9 +182,8 @@ impl<T> JoinHandle<T> {
     /// ```rust
     /// use tokio::time;
     ///
-    /// # #[tokio::main(flavor = "current_thread")]
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
     /// # async fn main() {
-    /// # tokio::time::pause();
     /// let mut handles = Vec::new();
     ///
     /// handles.push(tokio::spawn(async {
@@ -221,9 +220,8 @@ impl<T> JoinHandle<T> {
     /// ```rust
     /// use tokio::time;
     ///
-    /// # #[tokio::main(flavor = "current_thread")]
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
     /// # async fn main() {
-    /// # time::pause();
     /// let handle1 = tokio::spawn(async {
     ///     // do some stuff here
     /// });
@@ -261,9 +259,8 @@ impl<T> JoinHandle<T> {
     /// ```rust
     /// use tokio::{time, task};
     ///
-    /// # #[tokio::main(flavor = "current_thread")]
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
     /// # async fn main() {
-    /// #  time::pause();
     /// let mut handles = Vec::new();
     ///
     /// handles.push(tokio::spawn(async {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The `AbortHandle` API is currently only exposed through `JoinSet`. This makes custom, user-defined implementations of `JoinSet`-like wrappers impossible.

## Solution

As mentioned in #4530, the `abort_handle` method is simply made public.
