### PR TITLE
Tokio test mock wait

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -310,6 +310,8 @@ impl Inner {
 
                         if now < until {
                             break;
+                        } else {
+                            self.waiting = None;
                         }
                     } else {
                         self.waiting = Some(Instant::now() + *dur);

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 
 use std::io;
-use std::time::{Duration, Instant};
+use tokio::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_test::io::Builder;
 
@@ -86,10 +86,9 @@ async fn mock_panics_write_data_left() {
     Builder::new().write(b"write").build();
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn wait() {
-    // 200ms should be enough to ensure no other factors are causing the delay
-    const FIRST_WAIT: Duration = Duration::from_millis(200);
+    const FIRST_WAIT: Duration = Duration::from_secs(1);
 
     let mut mock = Builder::new()
         .wait(FIRST_WAIT)
@@ -117,11 +116,10 @@ async fn wait() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn multiple_wait() {
-    // 200ms should be enough to ensure no other factors are causing the delay
-    const FIRST_WAIT: Duration = Duration::from_millis(200);
-    const SECOND_WAIT: Duration = Duration::from_millis(200);
+    const FIRST_WAIT: Duration = Duration::from_secs(1);
+    const SECOND_WAIT: Duration = Duration::from_secs(1);
 
     let mut mock = Builder::new()
         .wait(FIRST_WAIT)

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -1,8 +1,8 @@
 #![warn(rust_2018_idioms)]
 
 use std::io;
-use tokio::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::{Duration, Instant};
 use tokio_test::io::Builder;
 
 #[tokio::test]

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -1,9 +1,7 @@
 #![warn(rust_2018_idioms)]
 
-use std::{
-    io,
-    time::{Duration, Instant},
-};
+use std::io;
+use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_test::io::Builder;
 


### PR DESCRIPTION
Clear `waiting` after completion of the current wait allowing subsequent waits to be registered instead of being discarded.

## Motivation

The `Mock` in `tokio-test::io` won't work properly with multiple `Action::Wait()` actions.

Example using `Builder::wait()` 
```rust
    let mut mock = Builder::new()
        .wait(Duration::from_secs(10))
        .read(b"hello ")
        .wait(Duration::from_secs(10))
        .read(b"world!")
        .build();

    let mut buf = [0; 256];

    let start = Instant::now();

    let n = mock.read(&mut buf).await.expect("read 1");
    let n = mock.read(&mut buf).await.expect("read 2");

    // `start.elapsed()` will be something around 10s instead of the expected 20s
```

The first commit in this PR includes two tests regarding the `wait` issue, one of which `multiple_wait` is equivalent to the example above and fails without the fix introduced in the second commit of this PR

## Solution

The `waiting` option on `Inner` was set on the first `Action::Wait()` but never cleared, causing subsequent `Action::Wait()` to be discarded because the value of `waiting` was already in the past.

The fix clears `self.waiting` when the wait has finished