### PR TITLE
Accept path as crate rename as well

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -36,13 +36,10 @@ async fn test_worker_threads_not_int() {}
 async fn test_worker_threads_and_current_thread() {}
 
 #[tokio::test(crate = 456)]
-async fn test_crate_not_ident_int() {}
+async fn test_crate_not_path_int() {}
 
 #[tokio::test(crate = "456")]
-async fn test_crate_not_ident_invalid() {}
-
-#[tokio::test(crate = "abc::edf")]
-async fn test_crate_not_ident_path() {}
+async fn test_crate_not_path_invalid() {}
 
 #[tokio::test]
 #[test]

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -64,34 +64,28 @@ error: The `worker_threads` option requires the `multi_thread` runtime flavor. U
 35 | #[tokio::test(flavor = "current_thread", worker_threads = 4)]
    |                                                           ^
 
-error: Failed to parse value of `crate` as ident.
+error: Failed to parse value of `crate` as path.
   --> $DIR/macros_invalid_input.rs:38:23
    |
 38 | #[tokio::test(crate = 456)]
    |                       ^^^
 
-error: Failed to parse value of `crate` as ident: "456"
+error: Failed to parse value of `crate` as path: "456"
   --> $DIR/macros_invalid_input.rs:41:23
    |
 41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
-error: Failed to parse value of `crate` as ident: "abc::edf"
-  --> $DIR/macros_invalid_input.rs:44:23
-   |
-44 | #[tokio::test(crate = "abc::edf")]
-   |                       ^^^^^^^^^^
-
 error: second test attribute is supplied
-  --> $DIR/macros_invalid_input.rs:48:1
+  --> $DIR/macros_invalid_input.rs:45:1
    |
-48 | #[test]
+45 | #[test]
    | ^^^^^^^
 
 error: duplicated attribute
-  --> $DIR/macros_invalid_input.rs:48:1
+  --> $DIR/macros_invalid_input.rs:45:1
    |
-48 | #[test]
+45 | #[test]
    | ^^^^^^^
    |
 note: the lint level is defined here

--- a/tokio/tests/macros_rename_test.rs
+++ b/tokio/tests/macros_rename_test.rs
@@ -5,6 +5,10 @@ use std as tokio;
 
 use ::tokio as tokio1;
 
+mod test {
+    pub use ::tokio;
+}
+
 async fn compute() -> usize {
     let join = tokio1::spawn(async { 1 });
     join.await.unwrap()
@@ -22,5 +26,10 @@ fn crate_rename_main() {
 
 #[tokio1::test(crate = "tokio1")]
 async fn crate_rename_test() {
+    assert_eq!(1, compute().await);
+}
+
+#[test::tokio::test(crate = "test::tokio")]
+async fn crate_path_test() {
     assert_eq!(1, compute().await);
 }


### PR DESCRIPTION
## Motivation

Currently Tokio supports renaming the crate inside the macro with the `crate` attribute. I was playing around with a personal library that simplifies some stuff around multiple macros, including the Tokio macro.
To implement this with macro hygiene in mind I was re-exporting Tokio, but turns out Tokio only accepts idents, not full paths.

## Solution

The solution was quite simple, just let Tokio accept paths, by using `syn::Path`, instead of only accepting an ident. There should be no functional change, as idents can also be parsed as paths.
