### PR TITLE
tokio-util: time: add `DelayQueue::peek`

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -877,12 +877,9 @@ impl<T> DelayQueue<T> {
     /// Gets the [`Key`] that [`poll_expired`] will pull out of the queue next, without
     /// pulling it out or waiting for the deadline to expire.
     ///
-    /// If entries are already expired at insertion, they are returned in order of
-    /// insertion, not by how far in the past their deadline would have expired.
-    ///
-    /// The next expiring key is only recalculated when the queue is polled, therefore
-    /// this method will potentially return already expired keys if the queue is not
-    /// polled regularly.
+    /// Entries that have already expired may be returned in any order, but it is
+    /// guaranteed that this method returns them in the same order as when items
+    /// are popped from the `DelayQueue`.
     ///
     /// # Examples
     ///

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -909,9 +909,7 @@ impl<T> DelayQueue<T> {
     pub fn peek(&self) -> Option<Key> {
         use self::wheel::Stack;
 
-        self.expired
-            .peek()
-            .or_else(|| self.wheel.peek())
+        self.expired.peek().or_else(|| self.wheel.peek())
     }
 
     /// Returns the next time to poll as determined by the wheel

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -876,8 +876,6 @@ impl<T> DelayQueue<T> {
 
     /// Gets the [`Key`] that will expire next.
     ///
-    /// This will not consider keys that are already marked as expired by the queue,
-    /// such as entries that are inserted when their deadline has already been reached.
     /// The next expiring key is only recalculated when the queue is polled, therefore
     /// this method will potentially return already expired keys if the queue is not
     /// polled regularly.
@@ -904,7 +902,11 @@ impl<T> DelayQueue<T> {
     ///
     /// [`Key`]: struct@Key
     pub fn next_expiring(&self) -> Option<Key> {
-        self.wheel.next_expiring_entry()
+        use self::wheel::Stack;
+
+        self.expired
+            .peek()
+            .or_else(|| self.wheel.next_expiring_entry())
     }
 
     /// Returns the next time to poll as determined by the wheel

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -874,6 +874,33 @@ impl<T> DelayQueue<T> {
         self.slab.compact();
     }
 
+    /// Gets the [`Key`] that will expire next.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage
+    ///
+    /// ```rust
+    /// use tokio_util::time::DelayQueue;
+    /// use std::time::Duration;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let mut delay_queue = DelayQueue::new();
+    ///
+    /// let key1 = delay_queue.insert("foo", Duration::from_secs(10));
+    /// let key2 = delay_queue.insert("bar", Duration::from_secs(5));
+    /// let key3 = delay_queue.insert("baz", Duration::from_secs(15));
+    ///
+    /// assert_eq!(delay_queue.next_expiring().unwrap(), key2);
+    /// # }
+    /// ```
+    ///
+    /// [`Key`]: struct@Key
+    pub fn next_expiring(&self) -> Option<Key> {
+        self.wheel.next_expiring_entry()
+    }
+
     /// Returns the next time to poll as determined by the wheel
     fn next_deadline(&mut self) -> Option<Instant> {
         self.wheel
@@ -1164,6 +1191,10 @@ impl<T> wheel::Stack for Stack<T> {
         } else {
             None
         }
+    }
+
+    fn peek(&self) -> Option<Self::Owned> {
+        self.head
     }
 
     #[track_caller]

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -876,6 +876,12 @@ impl<T> DelayQueue<T> {
 
     /// Gets the [`Key`] that will expire next.
     ///
+    /// This will not consider keys that are already marked as expired by the queue,
+    /// such as entries that are inserted when their deadline has already been reached.
+    /// The next expiring key is only recalculated when the queue is polled, therefore
+    /// this method will potentially return already expired keys if the queue is not
+    /// polled regularly.
+    ///
     /// # Examples
     ///
     /// Basic usage

--- a/tokio-util/src/time/wheel/level.rs
+++ b/tokio-util/src/time/wheel/level.rs
@@ -206,6 +206,10 @@ impl<T: Stack> Level<T> {
 
         ret
     }
+
+    pub(crate) fn peek_entry_slot(&self, slot: usize) -> Option<T::Owned> {
+        self.slot[slot].peek()
+    }
 }
 
 impl<T> fmt::Debug for Level<T> {

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -139,6 +139,12 @@ where
         self.next_expiration().map(|expiration| expiration.deadline)
     }
 
+    /// Next key that will expire
+    pub(crate) fn next_expiring_entry(&self) -> Option<T::Owned> {
+        self.next_expiration()
+            .and_then(|expiration| self.peek_entry(&expiration))
+    }
+
     /// Advances the timer up to the instant represented by `now`.
     pub(crate) fn poll(&mut self, now: u64, store: &mut T::Store) -> Option<T::Owned> {
         loop {
@@ -242,6 +248,10 @@ where
 
     fn pop_entry(&mut self, expiration: &Expiration, store: &mut T::Store) -> Option<T::Owned> {
         self.levels[expiration.level].pop_entry_slot(expiration.slot, store)
+    }
+
+    fn peek_entry(&self, expiration: &Expiration) -> Option<T::Owned> {
+        self.levels[expiration.level].peek_entry_slot(expiration.slot)
     }
 
     fn level_for(&self, when: u64) -> usize {

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -140,7 +140,7 @@ where
     }
 
     /// Next key that will expire
-    pub(crate) fn next_expiring_entry(&self) -> Option<T::Owned> {
+    pub(crate) fn peek(&self) -> Option<T::Owned> {
         self.next_expiration()
             .and_then(|expiration| self.peek_entry(&expiration))
     }

--- a/tokio-util/src/time/wheel/stack.rs
+++ b/tokio-util/src/time/wheel/stack.rs
@@ -22,6 +22,9 @@ pub(crate) trait Stack: Default {
     /// Pop an item from the stack
     fn pop(&mut self, store: &mut Self::Store) -> Option<Self::Owned>;
 
+    /// Peek into the stack.
+    fn peek(&self) -> Option<Self::Owned>;
+
     fn remove(&mut self, item: &Self::Borrowed, store: &mut Self::Store);
 
     fn when(item: &Self::Borrowed, store: &Self::Store) -> u64;

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -823,6 +823,44 @@ async fn remove_after_compact_poll() {
     assert!(panic.is_err());
 }
 
+#[tokio::test(start_paused = true)]
+async fn next_expiring() {
+    let mut queue = task::spawn(DelayQueue::new());
+
+    let now = Instant::now();
+
+    let key = queue.insert_at("foo", now + ms(5));
+    let key2 = queue.insert_at("bar", now + ms(1));
+    let key3 = queue.insert_at("baz", now + ms(10));
+
+    assert_eq!(queue.next_expiring(), Some(key2));
+
+    sleep(ms(6)).await;
+
+    assert_eq!(queue.next_expiring(), Some(key2));
+
+    let entry = assert_ready_some!(poll!(queue));
+    assert_eq!(entry.get_ref(), &"bar");
+
+    assert_eq!(queue.next_expiring(), Some(key));
+
+    let entry = assert_ready_some!(poll!(queue));
+    assert_eq!(entry.get_ref(), &"foo");
+
+    assert_eq!(queue.next_expiring(), Some(key3));
+
+    assert_pending!(poll!(queue));
+
+    sleep(ms(5)).await;
+
+    assert_eq!(queue.next_expiring(), Some(key3));
+
+    let entry = assert_ready_some!(poll!(queue));
+    assert_eq!(entry.get_ref(), &"baz");
+
+    assert!(queue.next_expiring().is_none());
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -861,6 +861,26 @@ async fn next_expiring() {
     assert!(queue.next_expiring().is_none());
 }
 
+#[tokio::test(start_paused = true)]
+async fn next_expiring_expired_in_order() {
+    let mut queue = task::spawn(DelayQueue::new());
+
+    let now = Instant::now();
+
+    let key1 = queue.insert_at("foo", now - ms(5));
+    let key2 = queue.insert_at("bar", now);
+    let key3 = queue.insert_at("baz", now - ms(10));
+
+    for (key, value) in [(key3, "baz"), (key2, "bar"), (key1, "foo")].into_iter() {
+        assert_eq!(queue.next_expiring(), Some(key));
+
+        let entry = assert_ready_some!(poll!(queue));
+        assert_eq!(entry.get_ref(), &value);
+    }
+
+    assert!(queue.next_expiring().is_none());
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -830,7 +830,7 @@ async fn next_expiring() {
     let now = Instant::now();
 
     let key = queue.insert_at("foo", now + ms(5));
-    let key2 = queue.insert_at("bar", now + ms(1));
+    let key2 = queue.insert_at("bar", now);
     let key3 = queue.insert_at("baz", now + ms(10));
 
     assert_eq!(queue.next_expiring(), Some(key2));


### PR DESCRIPTION
## Motivation

My goal is to implement an expiring LRU cache that uses a `DashMap` + `DelayQueue` with an optional maximum capacity. On capacity overflow, I want to remove the item that would've been next to expire. I described this issue in #5279.

## Solution

Adding `DelayQueue::peek` allows for getting the `Key` that will expire next. In my usecase, a `DelayQueue<K>` + `DashMap<K, V>` is used, so after removing the next expiring key from the queue, it can also be used to remove it from the map because `K` is now known. I made an implementation that showcases this [here](https://github.com/Gelbpunkt/http-proxy/blob/delay-queue/src/expiring_lru.rs).

This implementation is based on `pop_entry_slot` and uses `peek` methods instead which don't touch the contents of the stack and levels.