### PR TITLE
time: fix repeatedly_reset_entry_inserted_as_expired test

### DIFF
--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -257,6 +257,10 @@ async fn reset_twice() {
 #[tokio::test]
 async fn repeatedly_reset_entry_inserted_as_expired() {
     time::pause();
+
+    // Instants before the start of the test seem to break in wasm.
+    time::sleep(ms(1000)).await;
+
     let mut queue = task::spawn(DelayQueue::new());
     let now = Instant::now();
 

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -560,6 +560,10 @@ async fn reset_later_after_slot_starts() {
 #[tokio::test]
 async fn reset_inserted_expired() {
     time::pause();
+
+    // Instants before the start of the test seem to break in wasm.
+    time::sleep(ms(1000)).await;
+
     let mut queue = task::spawn(DelayQueue::new());
     let now = Instant::now();
 


### PR DESCRIPTION
There's a new CI failure on master.

<details>
  <summary>CI Output</summary>
  
```
     Running tests/time_delay_queue.rs (target/wasm32-wasi/debug/deps/time_delay_queue-f0c21ef322a44873.wasm)

running 30 tests
test compact_change_deadline ... ok
test compact_expire_empty ... ok
test compact_remove_empty ... ok
test compact_remove_remapped_keys ... ok
test delay_queue_poll_expired_when_empty ... ok
test expire_first_key_when_reset_to_expire_earlier ... ok
test expire_second_key_when_reset_to_expire_earlier ... ok
test expires_before_last_insert ... ok
test insert_after_ready_poll ... ok
test insert_before_first_after_poll ... ok
test insert_in_past_after_poll_fires_immediately ... ok
test insert_in_past_fires_immediately ... ok
test multi_delay_at_start ... ok
test multi_immediate_delays ... ok
test multi_reset ... ok
test remove_after_compact ... ignored, FIXME: Does not seem to work with WASI
test remove_after_compact_poll ... ignored, FIXME: Does not seem to work with WASI
test remove_at_timer_wheel_threshold ... ok
test remove_entry ... ok
test remove_expired_item ... ok
Error: failed to run main module `/home/runner/work/tokio/tokio/target/wasm32-wasi/debug/deps/time_delay_queue-f0c21ef322a44873.wasm`

Caused by:
    0: failed to invoke command default
    1: error while executing at wasm backtrace:
           0: 0x14360f - <unknown>!__rust_start_panic
           1: 0x142f1d - <unknown>!rust_panic
           2: 0x142ee4 - <unknown>!std::panicking::rust_panic_with_hook::hd6f3df478dab5dc5
           3: 0x1419aa - <unknown>!std::panicking::begin_panic_handler::{{closure}}::h7be61ca999d17a10
           4: 0x1418d4 - <unknown>!std::sys_common::backtrace::__rust_end_short_backtrace::h1c7217a99e6903e8
           5: 0x142552 - <unknown>!rust_begin_unwind
           6: 0x149a0d - <unknown>!core::panicking::panic_fmt::h86214d64a55c1d57
           7: 0x15016d - <unknown>!core::panicking::panic_display::h58fb45e5567db9b3
           8: 0x14fd1d - <unknown>!core::panicking::panic_str::hef6f4fea2c6da56a
           9: 0x14fceb - <unknown>!core::option::expect_failed::he9c7eebda4091106
          10: 0x140db4 - <unknown>!<std::time::Instant as core::ops::arith::Sub<core::time::Duration>>::sub::h9d1ea7149970c4f4
          11: 0xb656b - <unknown>!<tokio::time::instant::Instant as core::ops::arith::Sub<core::time::Duration>>::sub::h8709be5f2824f4d8
          12: 0x1423c - <unknown>!time_delay_queue::repeatedly_reset_entry_inserted_as_expired::{{closure}}::h5113477f19ab55d3
          13: 0x3e836 - <unknown>!<core::pin::Pin<P> as core::future::future::Future>::poll::h4fa8cd4e55f21ac9
          14: 0x3e8ce - <unknown>!<core::pin::Pin<P> as core::future::future::Future>::poll::h642aec97e6dd8367
          15: 0x3c5c7 - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::{{closure}}::h1e04fe847e0eed21
          16: 0x3b926 - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::{{closure}}::hda5894a20edb5dea
          17: 0x3b74d - <unknown>!tokio::runtime::scheduler::current_thread::Context::enter::h0551c0eeeb75cb0b
          18: 0x3bfd4 - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::block_on::{{closure}}::h04e2d857a61424cc
          19: 0x3ad99 - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::enter::{{closure}}::hefeb9ef4b490f0b0
          20: 0x3aceb - <unknown>!tokio::macros::scoped_tls::ScopedKey<T>::set::h768b6b08d5c1ff74
          21: 0x3bd7c - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::enter::h3549fc9053a672ee
          22: 0x3b4a4 - <unknown>!tokio::runtime::scheduler::current_thread::CoreGuard::block_on::h29331f6bd3fa002f
          23: 0x3b0df - <unknown>!tokio::runtime::scheduler::current_thread::CurrentThread::block_on::h252f5d42c4325f40
          24: 0x3aeb2 - <unknown>!tokio::runtime::runtime::Runtime::block_on::hd567519e6c4ccdf2
          25: 0x14000 - <unknown>!time_delay_queue::repeatedly_reset_entry_inserted_as_expired::h2e8d9e0d39e801f8
          26: 0x13e64 - <unknown>!time_delay_queue::repeatedly_reset_entry_inserted_as_expired::{{closure}}::hba3d5e0e60e4e59f
          27: 0x40eae - <unknown>!core::ops::function::FnOnce::call_once::h21770440c4a77129
          28: 0x78844 - <unknown>!test::__rust_begin_short_backtrace::h2f7251cabac8cc17
          29: 0x78824 - <unknown>!core::ops::function::FnOnce::call_once{{vtable.shim}}::h98ae03618d6ef851
          30: 0xa0133 - <unknown>!test::run_test::run_test_inner::hcac225d7d620b63b
          31: 0x8b209 - <unknown>!test::run_test::h2db965a4129a3fb3
          32: 0x871c7 - <unknown>!test::console::run_tests_console::h58c4d5717b25d8bf
          33: 0x9f467 - <unknown>!test::test_main::hc2411b2d7bc2431a
          34: 0x9f6b3 - <unknown>!test::test_main_static::hd744aa7211882b13
          35: 0x2c72f - <unknown>!time_delay_queue::main::h41b7fb16cef306a9
          36: 0x4107d - <unknown>!core::ops::function::FnOnce::call_once::h3c9e1736a43e028c
          37: 0x6f4ba - <unknown>!std::sys_common::backtrace::__rust_begin_short_backtrace::h47e6361a0d37dfca
          38: 0x3a287 - <unknown>!std::rt::lang_start::{{closure}}::h20bb17588a43137f
          39: 0x13a6bf - <unknown>!std::rt::lang_start_internal::h83cbd77d07ad3a3a
          40: 0x3a224 - <unknown>!std::rt::lang_start::h6ec71f408c08c5b2
          41: 0x2c753 - <unknown>!__main_void
          42: 0x1bfa - <unknown>!_start
       note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information
    2: wasm trap: wasm `unreachable` instruction executed

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: wasmtime::trap::from_runtime_box
   2: wasmtime::func::Func::call_impl
   3: wasmtime::linker::Linker<T>::module::{{closure}}::{{closure}}
   4: wasmtime::func::Func::invoke
   5: wasmtime::func::Caller<T>::with
   6: wasmtime::trampoline::func::stub_fn
   7: <unknown>
   8: <unknown>
   9: wasmtime_setjmp
  10: wasmtime_runtime::traphandlers::<impl wasmtime_runtime::traphandlers::call_thread_state::CallThreadState>::with
  11: wasmtime_runtime::traphandlers::catch_traps
  12: wasmtime::func::Func::call_impl
  13: wasmtime_cli::commands::run::RunCommand::invoke_func
  14: wasmtime_cli::commands::run::RunCommand::load_main_module
  15: wasmtime_cli::commands::run::RunCommand::execute
  16: wasmtime::main
  17: std::sys_common::backtrace::__rust_begin_short_backtrace
  18: std::rt::lang_start::{{closure}}
  19: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/core/src/ops/function.rs:287:13
  20: std::panicking::try::do_call
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panicking.rs:483:40
  21: std::panicking::try
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panicking.rs:447:19
  22: std::panic::catch_unwind
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panic.rs:140:14
  23: std::rt::lang_start_internal::{{closure}}
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/rt.rs:148:48
  24: std::panicking::try::do_call
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panicking.rs:483:40
  25: std::panicking::try
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panicking.rs:447:19
  26: std::panic::catch_unwind
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/panic.rs:140:14
  27: std::rt::lang_start_internal
             at /rustc/001a77fac33f6560ff361ff38f661ff5f1c6bf85/library/std/src/rt.rs:148:20
  28: main
  29: <unknown>
  30: __libc_start_main
  31: <unknown>
error: test failed, to rerun pass `-p tokio-util --test time_delay_queue`
```
</details>

This PR is an attempt to fix it.