### PR TITLE
Update stream, util, test to 2021 edition

### DIFF
--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-stream"
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.12"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -568,7 +568,7 @@ where
     }
 }
 
-impl<K, V> std::iter::FromIterator<(K, V)> for StreamMap<K, V>
+impl<K, V> FromIterator<(K, V)> for StreamMap<K, V>
 where
     K: Hash + Eq,
 {

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-test"
 # - Update CHANGELOG.md.
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.2"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-util"
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.7"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I want to close #5560, so tokio-stream, tokio-util, and tokio-test can be updated to the 2021 edition.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
1. I grepped for traits that are already included in the Prelude (TryInto, TryFrom and FromIterator) and removed shortened paths. There weren't any imports that had those traits. 
2. I ran `cargo fix --edition` on the mentioned crates. I did see a disjoint capture change in the closure here: https://github.com/tokio-rs/tokio/blob/b489acb46cb7e932808a1e9c8a4655089375d53c/tokio-util/src/sync/reusable_box.rs#L65 but I changed it back since it seems fine (I'm not entirely sure though). Other than that, I didn't see any more changes.

I'm not sure if there are more things to do. I would be happy to work on them.

Closes #5560