### PR TITLE
time: clean up redundant check in Wheel::poll()

### DIFF
--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -149,13 +149,12 @@ impl Wheel {
             }
 
             match self.next_expiration() {
-                Some(ref expiration) if expiration.deadline > now => return None,
-                Some(ref expiration) => {
+                Some(ref expiration) if expiration.deadline <= now => {
                     self.process_expiration(expiration);
 
                     self.set_elapsed(expiration.deadline);
                 }
-                None => {
+                _ => {
                     // in this case the poll did not indicate an expiration
                     // _and_ we were not able to find a next expiration in
                     // the current list of timers.  advance to the poll's

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -148,16 +148,7 @@ impl Wheel {
                 return Some(handle);
             }
 
-            // under what circumstances is poll.expiration Some vs. None?
-            let expiration = self.next_expiration().and_then(|expiration| {
-                if expiration.deadline > now {
-                    None
-                } else {
-                    Some(expiration)
-                }
-            });
-
-            match expiration {
+            match self.next_expiration() {
                 Some(ref expiration) if expiration.deadline > now => return None,
                 Some(ref expiration) => {
                     self.process_expiration(expiration);


### PR DESCRIPTION
The condition checked in the and_then() call is the same as is checked in the match below, so we can clean it up by just matching on next_expiration() directly.
