### PR TITLE
stream: add StreamExt::timeout_repeating

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -57,7 +57,7 @@ use try_next::TryNext;
 
 cfg_time! {
     pub(crate) mod timeout;
-    use timeout::Timeout;
+    use timeout::{Timeout, TimeoutMode};
     use tokio::time::Duration;
     mod throttle;
     use throttle::{throttle, Throttle};
@@ -924,7 +924,9 @@ pub trait StreamExt: Stream {
     /// If the wrapped stream yields a value before the deadline is reached, the
     /// value is returned. Otherwise, an error is returned. The caller may decide
     /// to continue consuming the stream and will eventually get the next source
-    /// stream value once it becomes available.
+    /// stream value once it becomes available. See
+    /// [`timeout_repeating`](StreamExt::timeout_repeating) for an alternative
+    /// where the timeouts will repeat.
     ///
     /// # Notes
     ///
@@ -988,7 +990,86 @@ pub trait StreamExt: Stream {
     where
         Self: Sized,
     {
-        Timeout::new(self, duration)
+        Timeout::new(self, duration, TimeoutMode::Once)
+    }
+
+    /// Applies a per-item timeout to the passed stream.
+    ///
+    /// `timeout_repeating()` takes a `Duration` that represents the maximum amount of
+    /// time each element of the stream has to complete before timing out.
+    ///
+    /// If the wrapped stream yields a value before the deadline is reached, the
+    /// value is returned. Otherwise, an error is returned. The caller may decide
+    /// to continue consuming the stream and will eventually get the next source
+    /// stream value once it becomes available. Unlike `timeout()`, if no value
+    /// becomes available before the deadline is reached, additional errors are
+    /// returned at the specified interval.  See [`timeout`](StreamExt::timeout)
+    /// for an alternative where the timeouts do not repeat.
+    ///
+    /// # Notes
+    ///
+    /// This function consumes the stream passed into it and returns a
+    /// wrapped version of it.
+    ///
+    /// Polling the returned stream will continue to poll the inner stream even
+    /// if one or more items time out.
+    ///
+    /// # Examples
+    ///
+    /// Suppose we have a stream `int_stream` that yields 3 numbers (1, 2, 3):
+    ///
+    /// ```
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
+    /// use std::time::Duration;
+    /// # let int_stream = stream::iter(1..=3);
+    ///
+    /// let int_stream = int_stream.timeout_repeating(Duration::from_secs(1));
+    /// tokio::pin!(int_stream);
+    ///
+    /// // When no items time out, we get the 3 elements in succession:
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(2)));
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(3)));
+    /// assert_eq!(int_stream.try_next().await, Ok(None));
+    ///
+    /// // If the second item times out, we get an error and continue polling the stream:
+    /// # let mut int_stream = stream::iter(vec![Ok(1), Err(()), Ok(2), Ok(3)]);
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
+    /// assert!(int_stream.try_next().await.is_err());
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(2)));
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(3)));
+    /// assert_eq!(int_stream.try_next().await, Ok(None));
+    ///
+    /// // If we want to stop consuming the source stream the first time an
+    /// // element times out, we can use the `take_while` operator:
+    /// # let int_stream = stream::iter(vec![Ok(1), Err(()), Ok(2), Ok(3)]);
+    /// let mut int_stream = int_stream.take_while(Result::is_ok);
+    ///
+    /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
+    /// assert_eq!(int_stream.try_next().await, Ok(None));
+    ///
+    /// // Timeout errors will be continuously produced at the specified
+    /// // interval until the wrapped stream yields a value.
+    /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(23)));
+    /// let timeout_stream = interval_stream.timeout_repeating(Duration::from_millis(9));
+    /// tokio::pin!(timeout_stream);
+    ///
+    /// // Multiple timeouts will be received between values in the source stream.
+    /// assert!(timeout_stream.try_next().await.is_ok());
+    /// assert!(timeout_stream.try_next().await.is_err());
+    /// assert!(timeout_stream.try_next().await.is_err());
+    /// assert!(timeout_stream.try_next().await.is_ok());
+    /// # }
+    /// ```
+    #[cfg(all(feature = "time"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    fn timeout_repeating(self, duration: Duration) -> Timeout<Self>
+    where
+        Self: Sized,
+    {
+        Timeout::new(self, duration, TimeoutMode::Repeating)
     }
 
     /// Slows down a stream by enforcing a delay between items.

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -941,7 +941,7 @@ pub trait StreamExt: Stream {
     /// Suppose we have a stream `int_stream` that yields 3 numbers (1, 2, 3):
     ///
     /// ```
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
     /// # async fn main() {
     /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
     /// use std::time::Duration;
@@ -1019,7 +1019,7 @@ pub trait StreamExt: Stream {
     /// Suppose we have a stream `int_stream` that yields 3 numbers (1, 2, 3):
     ///
     /// ```
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
     /// # async fn main() {
     /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
     /// use std::time::Duration;
@@ -1052,8 +1052,8 @@ pub trait StreamExt: Stream {
     ///
     /// // Timeout errors will be continuously produced at the specified
     /// // interval until the wrapped stream yields a value.
-    /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(100)));
-    /// let timeout_stream = interval_stream.timeout_repeating(Duration::from_millis(10));
+    /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(23)));
+    /// let timeout_stream = interval_stream.timeout_repeating(Duration::from_millis(9));
     /// tokio::pin!(timeout_stream);
     ///
     /// // Multiple timeouts will be received between values in the source stream.
@@ -1061,16 +1061,7 @@ pub trait StreamExt: Stream {
     /// assert!(timeout_stream.try_next().await.is_err(), "expected one timeout");
     /// assert!(timeout_stream.try_next().await.is_err(), "expected a second timeout");
     /// // Will eventually receive another value from the source stream...
-    /// # let mut count = 0;
-    /// loop {
-    ///   if timeout_stream.try_next().await.is_ok() {
-    ///     break;
-    ///   }
-    /// # count += 1;
-    /// # if count > 20 {
-    /// #   panic!("did not receive another event from the wrapped stream")
-    /// # }
-    /// }
+    /// assert!(timeout_stream.try_next().await.is_ok(), "expected non-timeout");
     /// # }
     /// ```
     #[cfg(all(feature = "time"))]

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -57,7 +57,9 @@ use try_next::TryNext;
 
 cfg_time! {
     pub(crate) mod timeout;
-    use timeout::{Timeout, TimeoutMode};
+    pub(crate) mod timeout_repeating;
+    use timeout::Timeout;
+    use timeout_repeating::TimeoutRepeating;
     use tokio::time::Duration;
     mod throttle;
     use throttle::{throttle, Throttle};
@@ -990,7 +992,7 @@ pub trait StreamExt: Stream {
     where
         Self: Sized,
     {
-        Timeout::new(self, duration, TimeoutMode::Once)
+        Timeout::new(self, duration)
     }
 
     /// Applies a per-item timeout to the passed stream.
@@ -1066,11 +1068,11 @@ pub trait StreamExt: Stream {
     /// ```
     #[cfg(all(feature = "time"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
-    fn timeout_repeating(self, duration: Duration) -> Timeout<Self>
+    fn timeout_repeating(self, duration: Duration) -> TimeoutRepeating<Self>
     where
         Self: Sized,
     {
-        Timeout::new(self, duration, TimeoutMode::Repeating)
+        TimeoutRepeating::new(self, duration)
     }
 
     /// Slows down a stream by enforcing a delay between items.

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -941,7 +941,7 @@ pub trait StreamExt: Stream {
     /// ```
     /// # #[tokio::main]
     /// # async fn main() {
-    /// use tokio_stream::{self as stream, StreamExt};
+    /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
     /// use std::time::Duration;
     /// # let int_stream = stream::iter(1..=3);
     ///
@@ -969,6 +969,17 @@ pub trait StreamExt: Stream {
     ///
     /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
     /// assert_eq!(int_stream.try_next().await, Ok(None));
+    ///
+    /// // Once a timeout error is received, no further events will be received
+    /// // unless the wrapped stream yields a value (timeouts do not repeat).
+    /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(23)));
+    /// let timeout_stream = interval_stream.timeout(Duration::from_millis(9));
+    /// tokio::pin!(timeout_stream);
+    ///
+    /// // Only one timeout will be received between values in the source stream.
+    /// assert!(timeout_stream.try_next().await.is_ok());
+    /// assert!(timeout_stream.try_next().await.is_err());
+    /// assert!(timeout_stream.try_next().await.is_ok());
     /// # }
     /// ```
     #[cfg(all(feature = "time"))]

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -943,9 +943,9 @@ pub trait StreamExt: Stream {
     /// Suppose we have a stream `int_stream` that yields 3 numbers (1, 2, 3):
     ///
     /// ```
-    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
+    /// # #[tokio::main]
     /// # async fn main() {
-    /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
+    /// use tokio_stream::{self as stream, StreamExt};
     /// use std::time::Duration;
     /// # let int_stream = stream::iter(1..=3);
     ///
@@ -973,9 +973,17 @@ pub trait StreamExt: Stream {
     ///
     /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
     /// assert_eq!(int_stream.try_next().await, Ok(None));
+    /// # }
+    /// ```
     ///
-    /// // Once a timeout error is received, no further events will be received
-    /// // unless the wrapped stream yields a value (timeouts do not repeat).
+    /// Once a timeout error is received, no further events will be received
+    /// unless the wrapped stream yields a value (timeouts do not repeat).
+    ///
+    /// ```
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
+    /// # async fn main() {
+    /// use tokio_stream::{StreamExt, wrappers::IntervalStream};
+    /// use std::time::Duration;
     /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(100)));
     /// let timeout_stream = interval_stream.timeout(Duration::from_millis(10));
     /// tokio::pin!(timeout_stream);
@@ -1022,9 +1030,9 @@ pub trait StreamExt: Stream {
     /// Suppose we have a stream `int_stream` that yields 3 numbers (1, 2, 3):
     ///
     /// ```
-    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
+    /// # #[tokio::main]
     /// # async fn main() {
-    /// use tokio_stream::{self as stream, StreamExt, wrappers::IntervalStream};
+    /// use tokio_stream::{self as stream, StreamExt};
     /// use std::time::Duration;
     /// # let int_stream = stream::iter(1..=3);
     ///
@@ -1052,9 +1060,17 @@ pub trait StreamExt: Stream {
     ///
     /// assert_eq!(int_stream.try_next().await, Ok(Some(1)));
     /// assert_eq!(int_stream.try_next().await, Ok(None));
+    /// # }
+    /// ```
     ///
-    /// // Timeout errors will be continuously produced at the specified
-    /// // interval until the wrapped stream yields a value.
+    /// Timeout errors will be continuously produced at the specified interval
+    /// until the wrapped stream yields a value.
+    ///
+    /// ```
+    /// # #[tokio::main(flavor = "current_thread", start_paused = true)]
+    /// # async fn main() {
+    /// use tokio_stream::{StreamExt, wrappers::IntervalStream};
+    /// use std::time::Duration;
     /// let interval_stream = IntervalStream::new(tokio::time::interval(Duration::from_millis(23)));
     /// let timeout_stream = interval_stream.timeout_repeating(tokio::time::interval(Duration::from_millis(9)));
     /// tokio::pin!(timeout_stream);

--- a/tokio-stream/src/stream_ext/timeout.rs
+++ b/tokio-stream/src/stream_ext/timeout.rs
@@ -9,15 +9,6 @@ use pin_project_lite::pin_project;
 use std::fmt;
 use std::time::Duration;
 
-/// Behavior of timeouts.
-#[derive(Debug)]
-pub(super) enum TimeoutMode {
-    /// A timeout will only fire once.
-    Once,
-    /// A timeout will fire repeatedly.
-    Repeating,
-}
-
 pin_project! {
     /// Stream returned by the [`timeout`](super::StreamExt::timeout) method.
     #[must_use = "streams do nothing unless polled"]
@@ -29,16 +20,15 @@ pin_project! {
         deadline: Sleep,
         duration: Duration,
         poll_deadline: bool,
-        timeout_mode: TimeoutMode,
     }
 }
 
-/// Error returned by `Timeout`.
+/// Error returned by `Timeout` and `TimeoutRepeating`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct Elapsed(());
 
 impl<S: Stream> Timeout<S> {
-    pub(super) fn new(stream: S, duration: Duration, timeout_mode: TimeoutMode) -> Self {
+    pub(super) fn new(stream: S, duration: Duration) -> Self {
         let next = Instant::now() + duration;
         let deadline = tokio::time::sleep_until(next);
 
@@ -47,7 +37,6 @@ impl<S: Stream> Timeout<S> {
             deadline,
             duration,
             poll_deadline: true,
-            timeout_mode,
         }
     }
 }
@@ -56,7 +45,7 @@ impl<S: Stream> Stream for Timeout<S> {
     type Item = Result<S::Item, Elapsed>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut me = self.project();
+        let me = self.project();
 
         match me.stream.poll_next(cx) {
             Poll::Ready(v) => {
@@ -70,46 +59,28 @@ impl<S: Stream> Stream for Timeout<S> {
             Poll::Pending => {}
         };
 
-        match me.timeout_mode {
-            TimeoutMode::Once => {
-                if *me.poll_deadline {
-                    ready!(me.deadline.poll(cx));
-                    *me.poll_deadline = false;
-                    return Poll::Ready(Some(Err(Elapsed::new())));
-                }
-
-                Poll::Pending
-            }
-            TimeoutMode::Repeating => {
-                ready!(me.deadline.as_mut().poll(cx));
-                let next = Instant::now() + *me.duration;
-                me.deadline.reset(next);
-                Poll::Ready(Some(Err(Elapsed::new())))
-            }
+        if *me.poll_deadline {
+            ready!(me.deadline.poll(cx));
+            *me.poll_deadline = false;
+            return Poll::Ready(Some(Err(Elapsed::new())));
         }
+
+        Poll::Pending
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.stream.size_hint();
 
-        match self.timeout_mode {
-            TimeoutMode::Once => {
-                // The timeout stream may insert an error before and after each message
-                // from the underlying stream, but no more than one error between each
-                // message. Hence the upper bound is computed as 2x+1.
+        // The timeout stream may insert an error before and after each message
+        // from the underlying stream, but no more than one error between each
+        // message. Hence the upper bound is computed as 2x+1.
 
-                // Using a helper function to enable use of question mark operator.
-                fn twice_plus_one(value: Option<usize>) -> Option<usize> {
-                    value?.checked_mul(2)?.checked_add(1)
-                }
-
-                (lower, twice_plus_one(upper))
-            }
-            TimeoutMode::Repeating => {
-                // The timeout stream may insert an error an infinite number of times.
-                (lower, None)
-            }
+        // Using a helper function to enable use of question mark operator.
+        fn twice_plus_one(value: Option<usize>) -> Option<usize> {
+            value?.checked_mul(2)?.checked_add(1)
         }
+
+        (lower, twice_plus_one(upper))
     }
 }
 

--- a/tokio-stream/src/stream_ext/timeout_repeating.rs
+++ b/tokio-stream/src/stream_ext/timeout_repeating.rs
@@ -1,11 +1,10 @@
 use crate::stream_ext::Fuse;
 use crate::{Elapsed, Stream};
-use tokio::time::{self, Interval, MissedTickBehavior};
+use tokio::time::Interval;
 
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use pin_project_lite::pin_project;
-use std::time::Duration;
 
 pin_project! {
     /// Stream returned by the [`timeout_repeating`](super::StreamExt::timeout_repeating) method.
@@ -20,12 +19,7 @@ pin_project! {
 }
 
 impl<S: Stream> TimeoutRepeating<S> {
-    pub(super) fn new(stream: S, duration: Duration) -> Self {
-        let mut interval = time::interval(duration);
-        // Use Delay behavior so timeouts are always emitted at least
-        // `duration` apart.
-        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
-
+    pub(super) fn new(stream: S, interval: Interval) -> Self {
         TimeoutRepeating {
             stream: Fuse::new(stream),
             interval,

--- a/tokio-stream/src/stream_ext/timeout_repeating.rs
+++ b/tokio-stream/src/stream_ext/timeout_repeating.rs
@@ -1,0 +1,66 @@
+use crate::stream_ext::Fuse;
+use crate::{Elapsed, Stream};
+use tokio::time::{Instant, Sleep};
+
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use pin_project_lite::pin_project;
+use std::time::Duration;
+
+pin_project! {
+    /// Stream returned by the [`timeout_repeating`](super::StreamExt::timeout_repeating) method.
+    #[must_use = "streams do nothing unless polled"]
+    #[derive(Debug)]
+    pub struct TimeoutRepeating<S> {
+        #[pin]
+        stream: Fuse<S>,
+        #[pin]
+        deadline: Sleep,
+        duration: Duration,
+    }
+}
+
+impl<S: Stream> TimeoutRepeating<S> {
+    pub(super) fn new(stream: S, duration: Duration) -> Self {
+        let next = Instant::now() + duration;
+        let deadline = tokio::time::sleep_until(next);
+
+        TimeoutRepeating {
+            stream: Fuse::new(stream),
+            deadline,
+            duration,
+        }
+    }
+}
+
+impl<S: Stream> Stream for TimeoutRepeating<S> {
+    type Item = Result<S::Item, Elapsed>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut me = self.project();
+
+        match me.stream.poll_next(cx) {
+            Poll::Ready(v) => {
+                if v.is_some() {
+                    let next = Instant::now() + *me.duration;
+                    me.deadline.reset(next);
+                }
+                return Poll::Ready(v.map(Ok));
+            }
+            Poll::Pending => {}
+        };
+
+        ready!(me.deadline.as_mut().poll(cx));
+        let next = Instant::now() + *me.duration;
+        me.deadline.reset(next);
+        Poll::Ready(Some(Err(Elapsed::new())))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, _) = self.stream.size_hint();
+
+        // The timeout stream may insert an error an infinite number of times.
+        (lower, None)
+    }
+}


### PR DESCRIPTION
## Motivation

The behavior of `StreamExt::timeout` is it only fires the timeout once (per value produced from the wrapped stream) and while this behavior is documented it is easy to overlook and assume that timeouts are generated repeatedly. I had made use of `timeout` in a project assuming that timeouts did repeat and it led to a subtle bug. It is useful for my use case for timeouts to fire repeatedly, so this change adds that in `timeout_repeating` as an alternative to `timeout`. For example, one might want to log a message at a fixed interval while no messages are being produced from a stream.

## Solution

The non-repeating timeout behavior of `timeout` was not tested or demonstrated by the doc test, so first this was added.

A new `enum TimeoutMode` has been added to describe the two possible behaviors. `stream_ext::Timeout` was modified with a new `timeout_mode: TimeoutMode` field to share an implementation between the two behaviors.