### PR TITLE
chore: prepare tokio-macros v2.0.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 2.0.0 (March 24th, 2023)
+
+This major release updates the dependency on the syn crate to 2.0.0, and
+increases the MSRV to 1.56.
+
+As part of this release, we are adopting a policy of incrementing the
+tokio-macros major version more often. This reduces the chance of issues where
+people are confused about the same version of Tokio not behaving in the same
+way, if you happen to be using two different versions of tokio-macros.
+
+- macros: update `syn` ([#5572])
+- macros: accept path as crate rename ([#5557])
+
+[#5572]: https://github.com/tokio-rs/tokio/pull/5572
+[#5557]: https://github.com/tokio-rs/tokio/pull/5557
+
 # 1.8.2 (November 30th, 2022)
 
 - fix a regression introduced in 1.8.1 ([#5244])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.x.y" git tag.
-version = "1.8.2"
+version = "2.0.0"
 edition = "2018"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 2.0.0 (March 24th, 2023)

This major release updates the dependency on the syn crate to 2.0.0, and increases the MSRV to 1.56.

As part of this release, we are adopting a policy of incrementing the tokio-macros major version more often. This reduces the chance of issues where people are confused about the same version of Tokio not behaving in the same way, if you happen to be using two different versions of tokio-macros.

- macros: update `syn` ([#5572])
- macros: accept path as crate rename ([#5557])

[#5572]: https://github.com/tokio-rs/tokio/pull/5572
[#5557]: https://github.com/tokio-rs/tokio/pull/5557