### PR TITLE
net: Add recv_buf for UdpSocket and UnixDatagram

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -982,7 +982,7 @@ impl UdpSocket {
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
 
                 let n = (*self.io).recv(dst)?;
-                
+
                 // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
                 // buffer.
                 unsafe {

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -825,7 +825,7 @@ impl UdpSocket {
     /// address to which it is connected. On success, returns the number of
     /// bytes read.
     ///
-    /// The function must be called with valid byte array buf of sufficient size
+    /// This method must be called with valid byte array buf of sufficient size
     /// to hold the message bytes. If a message is too long to fit in the
     /// supplied buffer, excess bytes may be discarded.
     ///
@@ -881,11 +881,11 @@ impl UdpSocket {
         /// Tries to receive data from the stream into the provided buffer, advancing the
         /// buffer's internal cursor, returning how many bytes were read.
         ///
-        /// The function must be called with valid byte array buf of sufficient size
+        /// This method must be called with valid byte array buf of sufficient size
         /// to hold the message bytes. If a message is too long to fit in the
         /// supplied buffer, excess bytes may be discarded.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
         /// returned. This function is usually paired with `readable()`.
@@ -933,10 +933,10 @@ impl UdpSocket {
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
 
-                // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
-                // buffer.
                 let n = (*self.io).recv(dst)?;
 
+                // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
+                // buffer.
                 unsafe {
                     buf.advance_mut(n);
                 }
@@ -949,11 +949,11 @@ impl UdpSocket {
         /// to which it is connected, advancing the buffer's internal cursor,
         /// returning how many bytes were read.
         ///
-        /// The function must be called with valid byte array buf of sufficient size
+        /// This method must be called with valid byte array buf of sufficient size
         /// to hold the message bytes. If a message is too long to fit in the
         /// supplied buffer, excess bytes may be discarded.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Examples
         ///
@@ -981,10 +981,10 @@ impl UdpSocket {
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
 
+                let n = (*self.io).recv(dst)?;
+                
                 // Safety: We trust `UdpSocket::recv` to have filled up `n` bytes in the
                 // buffer.
-                let n = (*self.io).recv(dst)?;
-
                 unsafe {
                     buf.advance_mut(n);
                 }
@@ -996,11 +996,11 @@ impl UdpSocket {
         /// Tries to receive a single datagram message on the socket. On success,
         /// returns the number of bytes read and the origin.
         ///
-        /// The function must be called with valid byte array buf of sufficient size
+        /// This method must be called with valid byte array buf of sufficient size
         /// to hold the message bytes. If a message is too long to fit in the
         /// supplied buffer, excess bytes may be discarded.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// When there is no pending data, `Err(io::ErrorKind::WouldBlock)` is
         /// returned. This function is usually paired with `readable()`.
@@ -1056,10 +1056,10 @@ impl UdpSocket {
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
 
-                // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
-                // buffer.
                 let (n, addr) = (*self.io).recv_from(dst)?;
 
+                // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
+                // buffer.
                 unsafe {
                     buf.advance_mut(n);
                 }
@@ -1071,11 +1071,11 @@ impl UdpSocket {
         /// Receives a single datagram message on the socket, advancing the
         /// buffer's internal cursor, returning how many bytes were read and the origin.
         ///
-        /// The function must be called with valid byte array buf of sufficient size
+        /// This method must be called with valid byte array buf of sufficient size
         /// to hold the message bytes. If a message is too long to fit in the
         /// supplied buffer, excess bytes may be discarded.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Notes
         /// Note that the socket address **cannot** be implicitly trusted, because it is relatively
@@ -1112,10 +1112,10 @@ impl UdpSocket {
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
 
-                // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
-                // buffer.
                 let (n, addr) = (*self.io).recv_from(dst)?;
 
+                // Safety: We trust `UdpSocket::recv_from` to have filled up `n` bytes in the
+                // buffer.
                 unsafe {
                     buf.advance_mut(n);
                 }
@@ -1360,7 +1360,7 @@ impl UdpSocket {
     /// Tries to receive a single datagram message on the socket. On success,
     /// returns the number of bytes read and the origin.
     ///
-    /// The function must be called with valid byte array buf of sufficient size
+    /// This method must be called with valid byte array buf of sufficient size
     /// to hold the message bytes. If a message is too long to fit in the
     /// supplied buffer, excess bytes may be discarded.
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -807,6 +807,8 @@ impl UnixDatagram {
     cfg_io_util! {
         /// Tries to receive data from the socket without waiting.
         ///
+        /// No byte array buf initialization is required.
+        ///
         /// # Examples
         ///
         /// ```no_run
@@ -866,8 +868,63 @@ impl UnixDatagram {
             Ok((n, SocketAddr(addr)))
         }
 
+        /// Receives from the socket, advances the
+        /// buffer's internal cursor and returns how many bytes were read and the origin.
+        ///
+        /// No byte array buf initialization is required.
+        ///
+        /// # Examples
+        /// ```
+        /// # use std::error::Error;
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        /// use tokio::net::UnixDatagram;
+        /// use tempfile::tempdir;
+        ///
+        /// // We use a temporary directory so that the socket
+        /// // files left by the bound sockets will get cleaned up.
+        /// let tmp = tempdir()?;
+        ///
+        /// // Bind each socket to a filesystem path
+        /// let tx_path = tmp.path().join("tx");
+        /// let tx = UnixDatagram::bind(&tx_path)?;
+        /// let rx_path = tmp.path().join("rx");
+        /// let rx = UnixDatagram::bind(&rx_path)?;
+        ///
+        /// let bytes = b"hello world";
+        /// tx.send_to(bytes, &rx_path).await?;
+        ///
+        /// let mut buf = Vec::with_capacity(24);
+        /// let (size, addr) = rx.recv_buf_from(&mut buf).await?;
+        ///
+        /// let dgram = &buf[..size];
+        /// assert_eq!(dgram, bytes);
+        /// assert_eq!(addr.as_pathname().unwrap(), &tx_path);
+        ///
+        /// # Ok(())
+        /// # }
+        /// ```
+        pub async fn recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
+            self.io.registration().async_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UnixDatagram::recv_from` to have filled up `n` bytes in the
+                // buffer.
+                let (n, addr) = (*self.io).recv_from(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+                Ok((n,SocketAddr(addr)))
+            }).await
+        }
+
         /// Tries to read data from the stream into the provided buffer, advancing the
         /// buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// No byte array buf initialization is required.
         ///
         /// # Examples
         ///
@@ -925,6 +982,52 @@ impl UnixDatagram {
 
                 Ok(n)
             })
+        }
+
+        /// Receives data from the socket from the address to which it is connected,
+        /// advancing the buffer's internal cursor, returning how many bytes were read.
+        ///
+        /// No byte array buf initialization is required.
+        ///
+        /// # Examples
+        /// ```
+        /// # use std::error::Error;
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        /// use tokio::net::UnixDatagram;
+        ///
+        /// // Create the pair of sockets
+        /// let (sock1, sock2) = UnixDatagram::pair()?;
+        ///
+        /// // Since the sockets are paired, the paired send/recv
+        /// // functions can be used
+        /// let bytes = b"hello world";
+        /// sock1.send(bytes).await?;
+        ///
+        /// let mut buff = Vec::with_capacity(24);
+        /// let size = sock2.recv_buf(&mut buff).await?;
+        ///
+        /// let dgram = &buff[..size];
+        /// assert_eq!(dgram, bytes);
+        ///
+        /// # Ok(())
+        /// # }
+        /// ```
+        pub async fn recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
+            self.io.registration().async_io(Interest::READABLE, || {
+                let dst = buf.chunk_mut();
+                let dst =
+                    unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
+
+                // Safety: We trust `UnixDatagram::recv_from` to have filled up `n` bytes in the
+                // buffer.
+                let n = (*self.io).recv(dst)?;
+
+                unsafe {
+                    buf.advance_mut(n);
+                }
+                Ok(n)
+            }).await
         }
     }
 

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -807,7 +807,7 @@ impl UnixDatagram {
     cfg_io_util! {
         /// Tries to receive data from the socket without waiting.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Examples
         ///
@@ -871,7 +871,7 @@ impl UnixDatagram {
         /// Receives from the socket, advances the
         /// buffer's internal cursor and returns how many bytes were read and the origin.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Examples
         /// ```
@@ -924,7 +924,7 @@ impl UnixDatagram {
         /// Tries to read data from the stream into the provided buffer, advancing the
         /// buffer's internal cursor, returning how many bytes were read.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Examples
         ///
@@ -987,7 +987,7 @@ impl UnixDatagram {
         /// Receives data from the socket from the address to which it is connected,
         /// advancing the buffer's internal cursor, returning how many bytes were read.
         ///
-        /// No byte array buf initialization is required.
+        /// This method can be used even if `buf` is uninitialized.
         ///
         /// # Examples
         /// ```

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -525,6 +525,23 @@ async fn try_recv_buf() {
 }
 
 #[tokio::test]
+async fn recv_buf() -> std::io::Result<()> {
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    let receiver = UdpSocket::bind("127.0.0.1:0").await?;
+
+    sender.connect(receiver.local_addr()?).await?;
+    receiver.connect(sender.local_addr()?).await?;
+
+    sender.send(MSG).await?;
+    let mut recv_buf = Vec::with_capacity(32);
+    let len = receiver.recv_buf(&mut recv_buf).await?;
+
+    assert_eq!(len, MSG_LEN);
+    assert_eq!(&recv_buf[..len], MSG);
+    Ok(())
+}
+
+#[tokio::test]
 async fn try_recv_buf_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -565,6 +582,23 @@ async fn try_recv_buf_from() {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn recv_buf_from() -> std::io::Result<()> {
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    let receiver = UdpSocket::bind("127.0.0.1:0").await?;
+
+    sender.connect(receiver.local_addr()?).await?;
+
+    sender.send(MSG).await?;
+    let mut recv_buf = Vec::with_capacity(32);
+    let (len, caddr) = receiver.recv_buf_from(&mut recv_buf).await?;
+
+    assert_eq!(len, MSG_LEN);
+    assert_eq!(&recv_buf[..len], MSG);
+    assert_eq!(caddr, sender.local_addr()?);
+    Ok(())
 }
 
 #[tokio::test]

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -277,6 +277,28 @@ async fn try_recv_buf_from() -> std::io::Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn recv_buf_from() -> std::io::Result<()> {
+    let tmp = tempfile::tempdir()?;
+
+    // Bind each socket to a filesystem path
+    let tx_path = tmp.path().join("tx");
+    let tx = UnixDatagram::bind(&tx_path)?;
+    let rx_path = tmp.path().join("rx");
+    let rx = UnixDatagram::bind(&rx_path)?;
+
+    let bytes = b"hello world";
+    tx.send_to(bytes, &rx_path).await?;
+
+    let mut buf = Vec::with_capacity(24);
+    let (size, addr) = rx.recv_buf_from(&mut buf).await?;
+
+    let dgram = &buf[..size];
+    assert_eq!(dgram, bytes);
+    assert_eq!(addr.as_pathname().unwrap(), &tx_path);
+    Ok(())
+}
+
 // Even though we use sync non-blocking io we still need a reactor.
 #[tokio::test]
 async fn try_recv_buf_never_block() -> io::Result<()> {
@@ -322,6 +344,24 @@ async fn try_recv_buf_never_block() -> io::Result<()> {
         _ => unreachable!("unexpected error {:?}", err),
     }
 
+    Ok(())
+}
+
+#[tokio::test]
+async fn recv_buf() -> std::io::Result<()> {
+    // Create the pair of sockets
+    let (sock1, sock2) = UnixDatagram::pair()?;
+
+    // Since the sockets are paired, the paired send/recv
+    // functions can be used
+    let bytes = b"hello world";
+    sock1.send(bytes).await?;
+
+    let mut buff = Vec::with_capacity(24);
+    let size = sock2.recv_buf(&mut buff).await?;
+
+    let dgram = &buff[..size];
+    assert_eq!(dgram, bytes);
     Ok(())
 }
 


### PR DESCRIPTION
## Motivation

Closes  #5563.

In order to supplies buffer with `length=0` to receive data on `UdpSocket` and `UnixDatagram`, `try_recv_buf_from` and `try_recv_buf` should be used.
Unfortunately, they require additional care compared to `standard recv` variants.

## Solution
Two new methods `recv_buf` and `recv_buf_from` have been added to `UdpSocket` and `UnixDatagram`.
These provide the same ergonomic of `recv` and `recv_from`, without the constraint `buf.length > 0`.

