### PR TITLE
Implement task dumps for current-thread runtime.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,10 +186,10 @@ jobs:
         run: cargo test --all-features
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
           # in order to run doctests for unstable features, we must also pass
           # the unstable cfg to RustDoc
-          RUSTDOCFLAGS: --cfg tokio_unstable
+          RUSTDOCFLAGS: --cfg tokio_unstable --cfg tokio_taskdump
 
   miri:
     name: miri
@@ -269,7 +269,7 @@ jobs:
         uses: taiki-e/install-action@cross
       - run: cross check --workspace --all-features --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   cross-test:
     name: cross-test
@@ -297,14 +297,14 @@ jobs:
       # First run with all features (including parking_lot)
       - run: cross test -p tokio --all-features --target ${{ matrix.target }} --tests
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_ipv6 ${{ matrix.rustflags }}
       # Now run without parking_lot
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
       # The `tokio_no_parking_lot` cfg is here to ensure the `sed` above does not silently break.
       - run: cross test -p tokio --features full,test-util --target ${{ matrix.target }} --tests
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 --cfg tokio_no_parking_lot ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_ipv6 --cfg tokio_no_parking_lot ${{ matrix.rustflags }}
 
   # See https://github.com/tokio-rs/tokio/issues/5187
   no-atomic-u64:
@@ -325,15 +325,15 @@ jobs:
           target: i686-unknown-linux-gnu
       - run: cargo test -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --all-features
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_atomic_u64
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64
       # https://github.com/tokio-rs/tokio/pull/5356
       # https://github.com/tokio-rs/tokio/issues/5373
       - run: cargo hack build -p tokio --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_atomic_u64 --cfg tokio_no_const_mutex_new
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64 --cfg tokio_no_const_mutex_new
       - run: cargo hack build -p tokio --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_atomic_u64
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64
 
   features:
     name: features
@@ -354,7 +354,7 @@ jobs:
       - name: check --feature-powerset --unstable
         run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   minrust:
     name: minrust
@@ -406,7 +406,7 @@ jobs:
           cargo hack check --all-features --ignore-private
       - name: "check --all-features --unstable -Z minimal-versions"
         env:
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
         run: |
           # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
           # from determining minimal versions based on dev-dependencies.
@@ -463,8 +463,8 @@ jobs:
       - name: "doc --lib --all-features"
         run: cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
-          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable --cfg tokio_taskdump
+          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   loom-compile:
     name: build loom tests
@@ -480,7 +480,7 @@ jobs:
         run: cargo test --no-run --lib --features full
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   check-readme:
     name: Check README
@@ -587,19 +587,19 @@ jobs:
         run: cargo test -p tokio --target wasm32-wasi --features full
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
       - name: WASI test tokio-util full
         run: cargo test -p tokio-util --target wasm32-wasi --features full
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
       - name: WASI test tokio-stream
         run: cargo test -p tokio-stream --target wasm32-wasi --features time,net,io-util,sync
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
       - name: test tests-integration --features wasi-rt
         # TODO: this should become: `cargo hack wasi test --each-feature`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,11 +186,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - windows-latest
-          - ubuntu-latest
+        include:
+          - os: windows-latest
+          - os: ubuntu-latest
             rustflags: --cfg tokio_taskdump
-          - macos-latest
+          - os: macos-latest
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
@@ -530,9 +530,7 @@ jobs:
       matrix:
         os:
           - windows-latest
-            rustflags: --cfg tokio_taskdump
           - ubuntu-latest
-            rustflags: --cfg tokio_taskdump
           - macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,6 +404,11 @@ jobs:
       - name: check --feature-powerset --unstable
         run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
         env:
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
+      # Try with unstable and taskdump feature flags
+      - name: check --feature-powerset --unstable --taskdump
+        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+        env:
           RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   minrust:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,6 @@ jobs:
         include:
           - os: windows-latest
           - os: ubuntu-latest
-            rustflags: --cfg tokio_taskdump
           - os: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -203,10 +202,35 @@ jobs:
         run: cargo test --all-features
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg tokio_unstable ${{ matrix.rustflags }} -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
           # in order to run doctests for unstable features, we must also pass
           # the unstable cfg to RustDoc
-          RUSTDOCFLAGS: --cfg tokio_unstable ${{ matrix.rustflags }}
+          RUSTDOCFLAGS: --cfg tokio_unstable
+    
+  test-unstable-taskdump:
+    name: test tokio full --unstable --taskdump
+    needs: basics
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: ${{ env.rust_stable }}
+      - uses: Swatinem/rust-cache@v2
+      # Run `tokio` with "unstable" and "taskdump" cfg flags.
+      - name: test tokio full --cfg unstable --cfg taskdump
+        run: cargo test --all-features
+        working-directory: tokio
+        env:
+          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          # in order to run doctests for unstable features, we must also pass
+          # the unstable cfg to RustDoc
+          RUSTDOCFLAGS: --cfg tokio_unstable --cfg tokio_taskdump
 
   miri:
     name: miri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
         os:
           - windows-latest
           - ubuntu-latest
+            rustflags: --cfg tokio_taskdump
           - macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -186,10 +187,10 @@ jobs:
         run: cargo test --all-features
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable ${{ matrix.rustflags }} -Dwarnings
           # in order to run doctests for unstable features, we must also pass
           # the unstable cfg to RustDoc
-          RUSTDOCFLAGS: --cfg tokio_unstable --cfg tokio_taskdump
+          RUSTDOCFLAGS: --cfg tokio_unstable ${{ matrix.rustflags }}
 
   miri:
     name: miri
@@ -278,9 +279,11 @@ jobs:
       matrix:
         include:
           - target: i686-unknown-linux-gnu
+            rustflags: --cfg tokio_taskdump
           - target: arm-unknown-linux-gnueabihf
           - target: armv7-unknown-linux-gnueabihf
           - target: aarch64-unknown-linux-gnu
+            rustflags: --cfg tokio_taskdump
 
           # Run a platform without AtomicU64 and no const Mutex::new
           - target: arm-unknown-linux-gnueabihf
@@ -501,7 +504,9 @@ jobs:
       matrix:
         os:
           - windows-latest
+            rustflags: --cfg tokio_taskdump
           - ubuntu-latest
+            rustflags: --cfg tokio_taskdump
           - macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -587,19 +592,19 @@ jobs:
         run: cargo test -p tokio --target wasm32-wasi --features full
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
       - name: WASI test tokio-util full
         run: cargo test -p tokio-util --target wasm32-wasi --features full
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
       - name: WASI test tokio-stream
         run: cargo test -p tokio-stream --target wasm32-wasi --features time,net,io-util,sync
         env:
           CARGO_TARGET_WASM32_WASI_RUNNER: "wasmtime run --"
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
       - name: test tests-integration --features wasi-rt
         # TODO: this should become: `cargo hack wasi test --each-feature`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         uses: taiki-e/install-action@cross
       - run: cross check --workspace --all-features --target ${{ matrix.target }}
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
   cross-test:
     name: cross-test
@@ -297,14 +297,14 @@ jobs:
       # First run with all features (including parking_lot)
       - run: cross test -p tokio --all-features --target ${{ matrix.target }} --tests
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_ipv6 ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 ${{ matrix.rustflags }}
       # Now run without parking_lot
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
       # The `tokio_no_parking_lot` cfg is here to ensure the `sed` above does not silently break.
       - run: cross test -p tokio --features full,test-util --target ${{ matrix.target }} --tests
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_ipv6 --cfg tokio_no_parking_lot ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_ipv6 --cfg tokio_no_parking_lot ${{ matrix.rustflags }}
 
   # See https://github.com/tokio-rs/tokio/issues/5187
   no-atomic-u64:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -508,7 +508,7 @@ jobs:
         run: cargo test --no-run --lib --features full
         working-directory: tokio
         env:
-          RUSTFLAGS: --cfg loom --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
 
   check-readme:
     name: Check README

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead, and delete the **path**.
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing", "taskdump"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
@@ -90,3 +90,7 @@ path = "named-pipe-ready.rs"
 [[example]]
 name = "named-pipe-multi-client"
 path = "named-pipe-multi-client.rs"
+
+[[example]]
+name = "dump"
+path = "dump.rs"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead, and delete the **path**.
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing", "taskdump"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,6 +1,10 @@
 //! This example demonstrates tokio's experimental taskdumping functionality.
 
-#[cfg(all(tokio_unstable, target_os = "linux"))]
+#[cfg(all(
+    tokio_unstable,
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     use std::hint::black_box;
@@ -34,7 +38,11 @@ async fn main() {
     }
 }
 
-#[cfg(not(all(tokio_unstable, target_os = "linux")))]
+#[cfg(not(all(
+    tokio_unstable,
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+)))]
 fn main() {
     println!("task dumps are not available")
 }

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,25 +1,25 @@
 //! This example demonstrates tokio's experimental taskdumping functionality.
 
-use std::hint::black_box;
-
-#[inline(never)]
-async fn a() {
-    black_box(b()).await
-}
-
-#[inline(never)]
-async fn b() {
-    black_box(c()).await
-}
-
-#[inline(never)]
-async fn c() {
-    black_box(tokio::task::yield_now()).await
-}
-
 #[cfg(all(tokio_unstable, target_os = "linux"))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
+    use std::hint::black_box;
+
+    #[inline(never)]
+    async fn a() {
+        black_box(b()).await
+    }
+
+    #[inline(never)]
+    async fn b() {
+        black_box(c()).await
+    }
+
+    #[inline(never)]
+    async fn c() {
+        black_box(tokio::task::yield_now()).await
+    }
+
     tokio::spawn(a());
     tokio::spawn(b());
     tokio::spawn(c());

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -4,7 +4,7 @@
     tokio_unstable,
     tokio_taskdump,
     target_os = "linux",
-    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
@@ -43,7 +43,7 @@ async fn main() {
     tokio_unstable,
     tokio_taskdump,
     target_os = "linux",
-    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 )))]
 fn main() {
     println!("task dumps are not available")

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,0 +1,34 @@
+//! This example demonstrates tokio's experimental taskdumping functionality.
+
+use std::hint::black_box;
+
+#[inline(never)]
+async fn a() {
+    black_box(b()).await
+}
+
+#[inline(never)]
+async fn b() {
+    black_box(c()).await
+}
+
+#[inline(never)]
+async fn c() {
+    black_box(tokio::task::yield_now()).await
+}
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    tokio::spawn(a());
+    tokio::spawn(b());
+    tokio::spawn(c());
+
+    let handle = tokio::runtime::Handle::current();
+    let dump = handle.dump();
+
+    for (i, task) in dump.tasks().iter().enumerate() {
+        let trace = task.trace();
+        println!("task {i} trace:");
+        println!("{trace}");
+    }
+}

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,3 +1,5 @@
+#![cfg(tokio_unstable)]
+
 //! This example demonstrates tokio's experimental taskdumping functionality.
 
 use std::hint::black_box;

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -2,6 +2,7 @@
 
 #[cfg(all(
     tokio_unstable,
+    tokio_taskdump,
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
 ))]
@@ -40,6 +41,7 @@ async fn main() {
 
 #[cfg(not(all(
     tokio_unstable,
+    tokio_taskdump,
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
 )))]

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,5 +1,3 @@
-#![cfg(tokio_unstable)]
-
 //! This example demonstrates tokio's experimental taskdumping functionality.
 
 use std::hint::black_box;
@@ -19,6 +17,7 @@ async fn c() {
     black_box(tokio::task::yield_now()).await
 }
 
+#[cfg(all(tokio_unstable, target_os = "linux"))]
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     tokio::spawn(a());
@@ -33,4 +32,9 @@ async fn main() {
         println!("task {i} trace:");
         println!("{trace}");
     }
+}
+
+#[cfg(not(all(tokio_unstable, target_os = "linux")))]
+fn main() {
+    println!("task dumps are not available")
 }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -85,6 +85,7 @@ signal = [
   "windows-sys/Win32_System_Console",
 ]
 sync = []
+taskdump = ["backtrace"]
 test-util = ["rt", "sync", "time"]
 time = []
 
@@ -114,6 +115,7 @@ socket2 = { version = "0.4.9", optional = true, features = [ "all" ] }
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_unstable)'.dependencies]
 tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true } # Not in full
+backtrace = { version = "0.3.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -85,7 +85,7 @@ signal = [
   "windows-sys/Win32_System_Console",
 ]
 sync = []
-taskdump = ["backtrace"]
+taskdump = ["rt", "backtrace"]
 test-util = ["rt", "sync", "time"]
 time = []
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -85,7 +85,6 @@ signal = [
   "windows-sys/Win32_System_Console",
 ]
 sync = []
-taskdump = ["rt", "backtrace"]
 test-util = ["rt", "sync", "time"]
 time = []
 
@@ -115,7 +114,11 @@ socket2 = { version = "0.4.9", optional = true, features = [ "all" ] }
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_unstable)'.dependencies]
 tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true } # Not in full
-backtrace = { version = "0.3.58", optional = true }
+
+# Currently unstable. The API exposed by these features may be broken at any time.
+# Requires `--cfg tokio_unstable` to enable.
+[target.'cfg(tokio_taskdump)'.dependencies]
+backtrace = { version = "0.3.58" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -115,7 +115,7 @@ socket2 = { version = "0.4.9", optional = true, features = [ "all" ] }
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_unstable)'.dependencies]
 tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true } # Not in full
-backtrace = { version = "0.3.0", optional = true }
+backtrace = { version = "0.3.58", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.42", optional = true }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -495,12 +495,12 @@ compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
     tokio_taskdump,
     not(all(
         target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))
 ))]
 compile_error!(
     "The `tokio_taskdump` feature is only currently supported on \
-linux, on `aarch64`, `i686` and `x86_64`."
+linux, on `aarch64`, `x86` and `x86_64`."
 );
 
 // Includes re-exports used by macros.

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -489,13 +489,13 @@ compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.
 
 #[cfg(all(
     not(tokio_unstable),
-    feature = "taskdump",
+    tokio_taskdump,
 ))]
-compile_error!("The `taskdump` feature requires `--cfg tokio_unstable`.");
+compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 
 #[cfg(all(
     tokio_unstable,
-    feature = "taskdump",
+    tokio_taskdump,
     not(all(
         target_os = "linux",
         any(
@@ -505,8 +505,8 @@ compile_error!("The `taskdump` feature requires `--cfg tokio_unstable`.");
         )
     ))
 ))]
-compile_error!("The `taskdump` feature is only currently supported on linux, \
-on `aarch64`, `i686` and `x86_64`.");
+compile_error!("The `tokio_taskdump` feature is only currently supported on \
+linux, on `aarch64`, `i686` and `x86_64`.");
 
 // Includes re-exports used by macros.
 //

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -487,6 +487,27 @@ compile_error!("Tokio's build script has incorrectly detected wasm.");
 ))]
 compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
 
+#[cfg(all(
+    not(tokio_unstable),
+    feature = "taskdump",
+))]
+compile_error!("The `taskdump` feature requires `--cfg tokio_unstable`.");
+
+#[cfg(all(
+    tokio_unstable,
+    feature = "taskdump",
+    not(all(
+        target_os = "linux",
+        any(
+            target_arch = "aarch64",
+            target_arch = "i686",
+            target_arch = "x86_64"
+        )
+    ))
+))]
+compile_error!("The `taskdump` feature is only currently supported on linux, \
+on `aarch64`, `i686` and `x86_64`.");
+
 // Includes re-exports used by macros.
 //
 // This module is not intended to be part of the public API. In general, any

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -487,10 +487,7 @@ compile_error!("Tokio's build script has incorrectly detected wasm.");
 ))]
 compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
 
-#[cfg(all(
-    not(tokio_unstable),
-    tokio_taskdump,
-))]
+#[cfg(all(not(tokio_unstable), tokio_taskdump))]
 compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 
 #[cfg(all(
@@ -498,15 +495,13 @@ compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
     tokio_taskdump,
     not(all(
         target_os = "linux",
-        any(
-            target_arch = "aarch64",
-            target_arch = "i686",
-            target_arch = "x86_64"
-        )
+        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))
 ))]
-compile_error!("The `tokio_taskdump` feature is only currently supported on \
-linux, on `aarch64`, `i686` and `x86_64`.");
+compile_error!(
+    "The `tokio_taskdump` feature is only currently supported on \
+linux, on `aarch64`, `i686` and `x86_64`."
+);
 
 // Includes re-exports used by macros.
 //

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -490,9 +490,6 @@ compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.
 #[cfg(all(not(tokio_unstable), tokio_taskdump))]
 compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 
-#[cfg(all(not(feature = "rt"), tokio_taskdump))]
-compile_error!("The `tokio_taskdump` feature requires the `rt` feature.");
-
 #[cfg(all(
     tokio_taskdump,
     not(all(

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -490,10 +490,11 @@ compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.
 #[cfg(all(not(tokio_unstable), tokio_taskdump))]
 compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 
+#[cfg(all(not(feature = "rt"), tokio_taskdump))]
+compile_error!("The `tokio_taskdump` feature requires the `rt` feature.");
+
 #[cfg(all(
-    tokio_unstable,
     tokio_taskdump,
-    feature = "rt",
     not(all(
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -493,6 +493,7 @@ compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 #[cfg(all(
     tokio_unstable,
     tokio_taskdump,
+    feature = "rt",
     not(all(
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -376,8 +376,26 @@ macro_rules! cfg_not_rt_multi_thread {
 macro_rules! cfg_taskdump {
     ($($item:item)*) => {
         $(
-            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
-            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))))]
+            #[cfg(all(
+                tokio_unstable,
+                feature = "taskdump",
+                target_os = "linux",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "i686",
+                    target_arch = "x86_64"
+                )
+            ))]
+            #[cfg_attr(docsrs, doc(cfg(all(
+                tokio_unstable,
+                feature = "taskdump",
+                target_os = "linux",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "i686",
+                    target_arch = "x86_64"
+                )
+            ))))]
             $item
         )*
     };

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -373,6 +373,16 @@ macro_rules! cfg_not_rt_multi_thread {
     }
 }
 
+macro_rules! cfg_taskdump {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(tokio_unstable, feature = "taskdump"))]
+            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "taskdump"))))]
+            $item
+        )*
+    };
+}
+
 macro_rules! cfg_test_util {
     ($($item:item)*) => {
         $(

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -378,7 +378,7 @@ macro_rules! cfg_taskdump {
         $(
             #[cfg(all(
                 tokio_unstable,
-                feature = "taskdump",
+                tokio_taskdump,
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
@@ -388,7 +388,7 @@ macro_rules! cfg_taskdump {
             ))]
             #[cfg_attr(docsrs, doc(cfg(all(
                 tokio_unstable,
-                feature = "taskdump",
+                tokio_taskdump,
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -376,8 +376,8 @@ macro_rules! cfg_not_rt_multi_thread {
 macro_rules! cfg_taskdump {
     ($($item:item)*) => {
         $(
-            #[cfg(all(tokio_unstable, feature = "taskdump"))]
-            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "taskdump"))))]
+            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))))]
             $item
         )*
     };

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -379,6 +379,7 @@ macro_rules! cfg_taskdump {
             #[cfg(all(
                 tokio_unstable,
                 tokio_taskdump,
+                feature = "rt",
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
@@ -389,6 +390,7 @@ macro_rules! cfg_taskdump {
             #[cfg_attr(docsrs, doc(cfg(all(
                 tokio_unstable,
                 tokio_taskdump,
+                feature = "rt",
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -382,7 +382,7 @@ macro_rules! cfg_taskdump {
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
-                    target_arch = "i686",
+                    target_arch = "x86",
                     target_arch = "x86_64"
                 )
             ))]
@@ -392,7 +392,7 @@ macro_rules! cfg_taskdump {
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
-                    target_arch = "i686",
+                    target_arch = "x86",
                     target_arch = "x86_64"
                 )
             ))))]

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -50,7 +50,12 @@ struct Context {
     /// the sheduler
     budget: Cell<coop::Budget>,
 
-    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    ))]
     trace: trace::Context,
 }
 
@@ -83,7 +88,16 @@ tokio_thread_local! {
 
             budget: Cell::new(coop::Budget::unconstrained()),
 
-            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+            #[cfg(all(
+                tokio_unstable,
+                feature = "taskdump",
+                target_os = "linux",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "i686",
+                    target_arch = "x86_64"
+                )
+            ))]
             trace: trace::Context::new(),
         }
     }

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -12,10 +12,10 @@ cfg_rt! {
     use std::cell::RefCell;
     use std::marker::PhantomData;
     use std::time::Duration;
-}
 
-cfg_taskdump! {
-    use crate::runtime::task::trace;
+    cfg_taskdump! {
+        use crate::runtime::task::trace;
+    }
 }
 
 struct Context {
@@ -53,6 +53,7 @@ struct Context {
     #[cfg(all(
         tokio_unstable,
         tokio_taskdump,
+        feature = "rt",
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
@@ -91,6 +92,7 @@ tokio_thread_local! {
             #[cfg(all(
                 tokio_unstable,
                 tokio_taskdump,
+                feature = "rt",
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
@@ -402,13 +404,13 @@ cfg_rt! {
             matches!(self, EnterRuntime::Entered { .. })
         }
     }
-}
 
-cfg_taskdump! {
-    /// SAFETY: Callers of this function must ensure that trace frames always
-    /// form a valid linked list.
-    pub(crate) unsafe fn with_trace<R>(f: impl FnOnce(&trace::Context) -> R) -> R {
-        CONTEXT.with(|c| f(&c.trace))
+    cfg_taskdump! {
+        /// SAFETY: Callers of this function must ensure that trace frames always
+        /// form a valid linked list.
+        pub(crate) unsafe fn with_trace<R>(f: impl FnOnce(&trace::Context) -> R) -> R {
+            CONTEXT.with(|c| f(&c.trace))
+        }
     }
 }
 

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -54,7 +54,7 @@ struct Context {
         tokio_unstable,
         tokio_taskdump,
         target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
     trace: trace::Context,
 }
@@ -94,7 +94,7 @@ tokio_thread_local! {
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",
-                    target_arch = "i686",
+                    target_arch = "x86",
                     target_arch = "x86_64"
                 )
             ))]

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -50,7 +50,7 @@ struct Context {
     /// the sheduler
     budget: Cell<coop::Budget>,
 
-    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
     trace: trace::Context,
 }
 
@@ -83,7 +83,7 @@ tokio_thread_local! {
 
             budget: Cell::new(coop::Budget::unconstrained()),
 
-            #[cfg(all(tokio_unstable, feature = "taskdump"))]
+            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
             trace: trace::Context::new(),
         }
     }

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -52,7 +52,7 @@ struct Context {
 
     #[cfg(all(
         tokio_unstable,
-        feature = "taskdump",
+        tokio_taskdump,
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))]
@@ -90,7 +90,7 @@ tokio_thread_local! {
 
             #[cfg(all(
                 tokio_unstable,
-                feature = "taskdump",
+                tokio_taskdump,
                 target_os = "linux",
                 any(
                     target_arch = "aarch64",

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -4,21 +4,18 @@ use std::fmt;
 
 /// A snapshot of a runtime's state.
 #[derive(Debug)]
-
 pub struct Dump {
     tasks: Tasks,
 }
 
 /// Snapshots of tasks.
 #[derive(Debug)]
-
 pub struct Tasks {
     tasks: Vec<Task>,
 }
 
 /// A snapshot of a task.
 #[derive(Debug)]
-
 pub struct Task {
     trace: Trace,
 }

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -1,0 +1,69 @@
+//! Snapshots of runtime state.
+
+use std::fmt;
+
+/// A snapshot of a runtime's state.
+#[derive(Debug)]
+
+pub struct Dump {
+    tasks: Tasks,
+}
+
+/// Snapshots of tasks.
+#[derive(Debug)]
+
+pub struct Tasks {
+    tasks: Vec<Task>,
+}
+
+/// A snapshot of a task.
+#[derive(Debug)]
+
+pub struct Task {
+    trace: Trace,
+}
+
+/// An execution trace of a task's last poll.
+#[derive(Debug)]
+pub struct Trace {
+    inner: super::task::trace::Trace,
+}
+
+impl Dump {
+    pub(crate) fn new(tasks: Vec<Task>) -> Self {
+        Self {
+            tasks: Tasks { tasks },
+        }
+    }
+
+    /// Tasks in this snapshot.
+    pub fn tasks(&self) -> &Tasks {
+        &self.tasks
+    }
+}
+
+impl Tasks {
+    /// Iterate over tasks.
+    pub fn iter(&self) -> impl Iterator<Item = &Task> {
+        self.tasks.iter()
+    }
+}
+
+impl Task {
+    pub(crate) fn new(trace: super::task::trace::Trace) -> Self {
+        Self {
+            trace: Trace { inner: trace },
+        }
+    }
+
+    /// A trace of this task's state.
+    pub fn trace(&self) -> &Trace {
+        &self.trace
+    }
+}
+
+impl fmt::Display for Trace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -255,6 +255,7 @@ impl Handle {
         #[cfg(all(
             tokio_unstable,
             tokio_taskdump,
+            feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]
@@ -285,6 +286,7 @@ impl Handle {
         #[cfg(all(
             tokio_unstable,
             tokio_taskdump,
+            feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -274,7 +274,7 @@ impl Handle {
         F::Output: Send + 'static,
     {
         let id = crate::runtime::task::Id::next();
-        #[cfg(all(tokio_unstable, feature = "taskdump"))]
+        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
         let future = super::task::trace::Trace::root(future);
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(future, "task", _name, id.as_u64());

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -256,7 +256,7 @@ impl Handle {
             tokio_unstable,
             tokio_taskdump,
             target_os = "linux",
-            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+            any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]
         let future = super::task::trace::Trace::root(future);
 
@@ -286,7 +286,7 @@ impl Handle {
             tokio_unstable,
             tokio_taskdump,
             target_os = "linux",
-            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+            any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]
         let future = super::task::trace::Trace::root(future);
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -254,7 +254,7 @@ impl Handle {
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         #[cfg(all(
             tokio_unstable,
-            feature = "taskdump",
+            tokio_taskdump,
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
         ))]
@@ -284,7 +284,7 @@ impl Handle {
         let id = crate::runtime::task::Id::next();
         #[cfg(all(
             tokio_unstable,
-            feature = "taskdump",
+            tokio_taskdump,
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
         ))]

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -252,6 +252,9 @@ impl Handle {
     /// [`tokio::time`]: crate::time
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        let future = super::task::trace::Trace::root(future);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future =
             crate::util::trace::task(future, "block_on", None, super::task::Id::next().as_u64());

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -252,7 +252,12 @@ impl Handle {
     /// [`tokio::time`]: crate::time
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        #[cfg(all(
+            tokio_unstable,
+            feature = "taskdump",
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        ))]
         let future = super::task::trace::Trace::root(future);
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -277,7 +282,12 @@ impl Handle {
         F::Output: Send + 'static,
     {
         let id = crate::runtime::task::Id::next();
-        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        #[cfg(all(
+            tokio_unstable,
+            feature = "taskdump",
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        ))]
         let future = super::task::trace::Trace::root(future);
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(future, "task", _name, id.as_u64());

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -233,6 +233,11 @@ cfg_rt! {
     mod defer;
     pub(crate) use defer::Defer;
 
+    cfg_taskdump! {
+        pub mod dump;
+        pub use dump::Dump;
+    }
+
     mod handle;
     pub use handle::{EnterGuard, Handle, TryCurrentError};
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -292,7 +292,7 @@ impl Runtime {
             tokio_unstable,
             tokio_taskdump,
             target_os = "linux",
-            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+            any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]
         let future = super::task::trace::Trace::root(future);
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -290,7 +290,7 @@ impl Runtime {
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         #[cfg(all(
             tokio_unstable,
-            feature = "taskdump",
+            tokio_taskdump,
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
         ))]

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -288,6 +288,9 @@ impl Runtime {
     /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
+        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        let future = super::task::trace::Trace::root(future);
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(
             future,

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -291,6 +291,7 @@ impl Runtime {
         #[cfg(all(
             tokio_unstable,
             tokio_taskdump,
+            feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
         ))]

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -288,7 +288,12 @@ impl Runtime {
     /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        #[cfg(all(
+            tokio_unstable,
+            feature = "taskdump",
+            target_os = "linux",
+            any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        ))]
         let future = super::task::trace::Trace::root(future);
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -387,9 +387,17 @@ impl Handle {
         // todo: how to make this work outside of a runtime context?
         CURRENT.with(|maybe_context| {
             // drain the local queue
-            let Some(context) = maybe_context else { return };
+            let context = if let Some(context) = maybe_context {
+                context
+            } else {
+                return
+            };
             let mut maybe_core = context.core.borrow_mut();
-            let Some(core) = maybe_core.as_mut() else { return };
+            let core = if let Some(core) = maybe_core.as_mut() {
+                core
+            } else {
+                return
+            };
             let local = &mut core.tasks;
             let _ = local.drain(..);
 

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -378,7 +378,12 @@ impl Handle {
     }
 
     /// Capture a snapshot of this runtime's state.
-    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    ))]
     pub(crate) fn dump(&self) -> crate::runtime::Dump {
         use crate::runtime::dump;
         use task::trace::trace_current_thread;

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -382,7 +382,7 @@ impl Handle {
         tokio_unstable,
         tokio_taskdump,
         target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
     pub(crate) fn dump(&self) -> crate::runtime::Dump {
         use crate::runtime::dump;

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -380,7 +380,7 @@ impl Handle {
     /// Capture a snapshot of this runtime's state.
     #[cfg(all(
         tokio_unstable,
-        feature = "taskdump",
+        tokio_taskdump,
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -378,7 +378,7 @@ impl Handle {
     }
 
     /// Capture a snapshot of this runtime's state.
-    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
     pub(crate) fn dump(&self) -> crate::runtime::Dump {
         use crate::runtime::dump;
         use task::trace::trace_current_thread;

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -377,6 +377,46 @@ impl Handle {
         handle
     }
 
+    /// Capture a snapshot of this runtime's state.
+    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    pub(crate) fn dump(&self) -> crate::runtime::Dump {
+        use crate::runtime::{dump, task::trace::Trace};
+
+        let mut snapshots = vec![];
+
+        // todo: how to make this work outside of a runtime context?
+        CURRENT.with(|maybe_context| {
+            // drain the local queue
+            let Some(context) = maybe_context else { return };
+            let mut maybe_core = context.core.borrow_mut();
+            let Some(core) = maybe_core.as_mut() else { return };
+            let local = &mut core.tasks;
+            let _ = local.drain(..);
+
+            // drain the injection queue
+            if let Some(injection) = self.shared.queue.lock().as_mut() {
+                let _ = injection.drain(..);
+            }
+
+            // notify each task
+            let mut tasks = vec![];
+            self.shared.owned.for_each(|task| {
+                // set the notified bit
+                let _ = task.as_raw().state().transition_to_notified_for_tracing();
+                // store the raw tasks into a vec
+                tasks.push(task.as_raw());
+            });
+
+            // trace each task
+            for task in tasks {
+                let ((), trace) = Trace::capture(|| task.poll());
+                snapshots.push(dump::Task::new(trace));
+            }
+        });
+
+        dump::Dump::new(snapshots)
+    }
+
     fn pop(&self) -> Option<task::Notified<Arc<Handle>>> {
         match self.shared.queue.lock().as_mut() {
             Some(queue) => queue.pop_front(),

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -172,6 +172,18 @@ impl<S: 'static> OwnedTasks<S> {
     }
 }
 
+cfg_taskdump! {
+    impl<S: 'static> OwnedTasks<S> {
+        /// Locks the tasks, and calls `f` on an iterator over them.
+        pub(crate) fn for_each<F>(&self, f: F)
+        where
+            F: FnMut(&Task<S>)
+        {
+            self.inner.lock().list.for_each(f)
+        }
+    }
+}
+
 impl<S: 'static> LocalOwnedTasks<S> {
     pub(crate) fn new() -> Self {
         Self {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -207,6 +207,10 @@ use self::state::State;
 
 mod waker;
 
+cfg_taskdump! {
+    pub(crate) mod trace;
+}
+
 use crate::future::Future;
 use crate::util::linked_list;
 
@@ -338,6 +342,11 @@ impl<S: 'static> Task<S> {
             raw: RawTask::from_raw(ptr),
             _p: PhantomData,
         }
+    }
+
+    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    pub(crate) fn as_raw(&self) -> RawTask {
+        self.raw
     }
 
     fn header(&self) -> &Header {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -344,7 +344,12 @@ impl<S: 'static> Task<S> {
         }
     }
 
-    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    ))]
     pub(crate) fn as_raw(&self) -> RawTask {
         self.raw
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -350,7 +350,7 @@ impl<S: 'static> Task<S> {
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))]
-    pub(crate) fn as_raw(&self) -> RawTask {
+    pub(super) fn as_raw(&self) -> RawTask {
         self.raw
     }
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -344,7 +344,7 @@ impl<S: 'static> Task<S> {
         }
     }
 
-    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
     pub(crate) fn as_raw(&self) -> RawTask {
         self.raw
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -348,7 +348,7 @@ impl<S: 'static> Task<S> {
         tokio_unstable,
         tokio_taskdump,
         target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
     pub(super) fn as_raw(&self) -> RawTask {
         self.raw

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -346,7 +346,7 @@ impl<S: 'static> Task<S> {
 
     #[cfg(all(
         tokio_unstable,
-        feature = "taskdump",
+        tokio_taskdump,
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -347,6 +347,7 @@ impl<S: 'static> Task<S> {
     #[cfg(all(
         tokio_unstable,
         tokio_taskdump,
+        feature = "rt",
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -190,7 +190,7 @@ impl RawTask {
     }
 
     /// Returns a reference to the task's state.
-    pub(crate) fn state(&self) -> &State {
+    pub(super) fn state(&self) -> &State {
         &self.header().state
     }
 

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -6,7 +6,7 @@ use std::ptr::NonNull;
 use std::task::{Poll, Waker};
 
 /// Raw task handle
-pub(super) struct RawTask {
+pub(crate) struct RawTask {
     ptr: NonNull<Header>,
 }
 
@@ -190,12 +190,12 @@ impl RawTask {
     }
 
     /// Returns a reference to the task's state.
-    pub(super) fn state(&self) -> &State {
+    pub(crate) fn state(&self) -> &State {
         &self.header().state
     }
 
     /// Safety: mutual exclusion is required to call this function.
-    pub(super) fn poll(self) {
+    pub(crate) fn poll(self) {
         let vtable = self.header().vtable;
         unsafe { (vtable.poll)(self.ptr) }
     }

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -6,7 +6,7 @@ use std::ptr::NonNull;
 use std::task::{Poll, Waker};
 
 /// Raw task handle
-pub(crate) struct RawTask {
+pub(in crate::runtime) struct RawTask {
     ptr: NonNull<Header>,
 }
 

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -275,7 +275,7 @@ impl State {
         tokio_unstable,
         tokio_taskdump,
         target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
     pub(super) fn transition_to_notified_for_tracing(&self) {
         self.fetch_update_action(|mut snapshot| {

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -273,7 +273,7 @@ impl State {
     /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref count.
     #[cfg(all(
         tokio_unstable,
-        feature = "taskdump",
+        tokio_taskdump,
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -271,7 +271,7 @@ impl State {
     }
 
     /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref count.
-    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
     pub(super) fn transition_to_notified_for_tracing(&self) {
         self.fetch_update_action(|mut snapshot| {
             snapshot.set_notified();

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use std::usize;
 
-pub(crate) struct State {
+pub(super) struct State {
     val: AtomicUsize,
 }
 

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -271,7 +271,12 @@ impl State {
     }
 
     /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref count.
-    #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    ))]
     pub(super) fn transition_to_notified_for_tracing(&self) {
         self.fetch_update_action(|mut snapshot| {
             snapshot.set_notified();

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -272,7 +272,7 @@ impl State {
 
     /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref count.
     #[cfg(all(tokio_unstable, feature = "taskdump"))]
-    pub(crate) fn transition_to_notified_for_tracing(&self) {
+    pub(super) fn transition_to_notified_for_tracing(&self) {
         self.fetch_update_action(|mut snapshot| {
             snapshot.set_notified();
             snapshot.ref_inc();

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -274,6 +274,7 @@ impl State {
     #[cfg(all(
         tokio_unstable,
         tokio_taskdump,
+        feature = "rt",
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -1,0 +1,215 @@
+use backtrace::BacktraceFrame;
+use std::future::Future;
+use std::{
+    cell::Cell,
+    ffi::c_void,
+    fmt,
+    pin::Pin,
+    ptr::{self, NonNull},
+    task::{self, Poll},
+};
+
+mod symbol;
+mod tree;
+
+use symbol::Symbol;
+use tree::Tree;
+
+type Backtrace = Vec<BacktraceFrame>;
+type SymbolTrace = Vec<Symbol>;
+
+/// The ambiant backtracing context.
+pub(crate) struct Context {
+    /// The address of [`Trace::root`] establishes an upper unwinding bound on
+    /// the backtraces in `Trace`.
+    active_frame: Cell<Option<NonNull<Frame>>>,
+    /// The place to stash backtraces.
+    collector: Cell<Option<Trace>>,
+}
+
+/// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
+struct Frame {
+    /// The location associated with this frame.
+    inner_addr: *const c_void,
+
+    /// The parent frame, if any.
+    parent: Option<NonNull<Frame>>,
+}
+
+/// An tree execution trace.
+///
+/// Traces are captured with [`Trace::capture`], rooted with [`Trace::root`]
+/// and leaved with [`Trace::leaf`].
+#[derive(Clone, Debug)]
+pub(crate) struct Trace {
+    // The linear backtraces that comprise this trace. These linear traces can
+    // be re-knitted into a tree.
+    backtraces: Vec<Backtrace>,
+}
+
+pin_project_lite::pin_project! {
+    #[derive(Debug, Clone)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub(crate) struct Root<T> {
+        #[pin]
+        future: T,
+    }
+}
+
+impl Context {
+    pub(crate) const fn new() -> Self {
+        Context {
+            active_frame: Cell::new(None),
+            collector: Cell::new(None),
+        }
+    }
+
+    /// SAFETY: Callers of this function must ensure that trace frames always
+    /// form a valid linked list.
+    unsafe fn with_current<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Self) -> R,
+    {
+        crate::runtime::context::with_trace(f)
+    }
+
+    unsafe fn with_current_frame<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Cell<Option<NonNull<Frame>>>) -> R,
+    {
+        Self::with_current(|context| f(&context.active_frame))
+    }
+
+    fn with_current_collector<F, R>(f: F) -> R
+    where
+        F: FnOnce(&Cell<Option<Trace>>) -> R,
+    {
+        unsafe { Self::with_current(|context| f(&context.collector)) }
+    }
+}
+
+impl Trace {
+    /// Invokes `f`, returning both its result and the collection of backtraces
+    /// captured at each sub-invocation of [`Trace::leaf`].
+    #[inline(never)]
+    pub(crate) fn capture<F, R>(f: F) -> (R, Trace)
+    where
+        F: FnOnce() -> R,
+    {
+        let collector = Trace { backtraces: vec![] };
+
+        let previous = Context::with_current_collector(|current| current.replace(Some(collector)));
+
+        let result = f();
+
+        let collector =
+            Context::with_current_collector(|current| current.replace(previous)).unwrap();
+
+        (result, collector)
+    }
+
+    /// The root of a trace.
+    #[inline(never)]
+    pub(crate) fn root<F>(future: F) -> Root<F> {
+        Root { future }
+    }
+
+    /// If this is a sub-invocation of [`Trace::capture`], capture a backtrace.
+    ///
+    /// The captured backtrace will be returned by [`Trace::capture`].
+    ///
+    /// Invoking this function does nothing when it is not a sub-invocation
+    /// [`Trace::capture`].
+    // This function is marked `#[inline(never)]` to ensure that it gets a distinct `Frame` in the
+    // backtrace, below which frames should not be included in the backtrace (since they reflect the
+    // internal implementation details of this crate).
+    #[inline(never)]
+    pub(crate) fn leaf() {
+        // Safety: We don't manipulate the current context's active frame.
+        unsafe {
+            Context::with_current(|context_cell| {
+                if let Some(mut collector) = context_cell.collector.take() {
+                    let mut frames = vec![];
+                    let mut above_leaf = false;
+
+                    if let Some(active_frame) = context_cell.active_frame.get() {
+                        let active_frame = active_frame.as_ref();
+
+                        backtrace::trace(|frame| {
+                            let below_root =
+                                !ptr::eq(frame.symbol_address(), active_frame.inner_addr);
+
+                            // only capture frames above `Trace::leaf` and below
+                            // `Trace::root`.
+                            if above_leaf && below_root {
+                                frames.push(frame.to_owned().into());
+                            }
+
+                            if ptr::eq(frame.symbol_address(), Self::leaf as *const _) {
+                                above_leaf = true;
+                            }
+
+                            // only continue unwinding if we're below `Trace::root`
+                            below_root
+                        });
+                    }
+                    collector.backtraces.push(frames);
+                    context_cell.collector.set(Some(collector));
+                }
+            });
+        }
+    }
+}
+
+impl fmt::Display for Trace {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Tree::from_trace(self.clone()).fmt(f)
+    }
+}
+
+fn defer<F: FnOnce() -> R, R>(f: F) -> impl Drop {
+    use std::mem::ManuallyDrop;
+
+    struct Defer<F: FnOnce() -> R, R>(ManuallyDrop<F>);
+
+    impl<F: FnOnce() -> R, R> Drop for Defer<F, R> {
+        #[inline(always)]
+        fn drop(&mut self) {
+            unsafe {
+                ManuallyDrop::take(&mut self.0)();
+            }
+        }
+    }
+
+    Defer(ManuallyDrop::new(f))
+}
+
+impl<T: Future> Future for Root<T> {
+    type Output = T::Output;
+
+    #[inline(never)]
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: The context's current frame is restored to its original state
+        // before `frame` is dropped.
+        unsafe {
+            let mut frame = Frame {
+                inner_addr: Self::poll as *const c_void,
+                parent: None,
+            };
+
+            Context::with_current_frame(|current| {
+                frame.parent = current.take();
+                current.set(Some(NonNull::from(&frame)));
+            });
+
+            let _restore = defer(|| {
+                Context::with_current_frame(|current| {
+                    current.set(frame.parent);
+                });
+            });
+
+            let this = self.project();
+            this.future.poll(cx)
+        }
+    }
+}

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -231,7 +231,7 @@ pub(in crate::runtime) fn trace_current_thread(
     let mut tasks = vec![];
     owned.for_each(|task| {
         // set the notified bit
-        let _ = task.as_raw().state().transition_to_notified_for_tracing();
+        task.as_raw().state().transition_to_notified_for_tracing();
         // store the raw tasks into a vec
         tasks.push(task.as_raw());
     });

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -223,9 +223,9 @@ pub(in crate::runtime) fn trace_current_thread(
     local: &mut VecDeque<Notified<Arc<current_thread::Handle>>>,
     injection: &mut VecDeque<Notified<Arc<current_thread::Handle>>>,
 ) -> Vec<Trace> {
-    // drain the local and injection queues
-    let _ = local.drain(..);
-    let _ = injection.drain(..);
+    // clear the local and injection queues
+    local.clear();
+    injection.clear();
 
     // notify each task
     let mut tasks = vec![];

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -1,16 +1,14 @@
 use crate::loom::sync::Arc;
 use crate::runtime::scheduler::current_thread;
 use backtrace::BacktraceFrame;
+use std::cell::Cell;
 use std::collections::VecDeque;
+use std::ffi::c_void;
+use std::fmt;
 use std::future::Future;
-use std::{
-    cell::Cell,
-    ffi::c_void,
-    fmt,
-    pin::Pin,
-    ptr::{self, NonNull},
-    task::{self, Poll},
-};
+use std::pin::Pin;
+use std::ptr::{self, NonNull};
+use std::task::{self, Poll};
 
 mod symbol;
 mod tree;

--- a/tokio/src/runtime/task/trace/symbol.rs
+++ b/tokio/src/runtime/task/trace/symbol.rs
@@ -1,0 +1,94 @@
+use backtrace::BacktraceSymbol;
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ptr,
+};
+
+/// A symbol in a backtrace.
+///
+/// This wrapper type serves two purposes. The first is that it provides a
+/// representation of a symbol that can be inserted into hashmaps and hashsets;
+/// the [`backtrace`] crate does not define [`Hash`], [`PartialEq`], or [`Eq`]
+/// on [`BacktraceSymbol`], and recommends that users define their own wrapper
+/// which implements these traits.
+///
+/// Second, this wrapper includes a `parent_hash` field that uniquely
+/// identifies this symbol's position in its trace. Otherwise, e.g., our code
+/// would not be able to distinguish between recursive calls of a function at
+/// different depths.
+#[derive(Clone)]
+pub(super) struct Symbol {
+    pub(super) symbol: BacktraceSymbol,
+    pub(super) parent_hash: u64,
+}
+
+impl Hash for Symbol {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        if let Some(name) = self.symbol.name() {
+            name.as_bytes().hash(state);
+        }
+
+        if let Some(addr) = self.symbol.addr() {
+            ptr::hash(addr, state);
+        }
+
+        self.symbol.filename().hash(state);
+        self.symbol.lineno().hash(state);
+        self.symbol.colno().hash(state);
+        self.parent_hash.hash(state);
+    }
+}
+
+impl PartialEq for Symbol {
+    fn eq(&self, other: &Self) -> bool {
+        (self.parent_hash == other.parent_hash)
+            && match (self.symbol.name(), other.symbol.name()) {
+                (None, None) => true,
+                (Some(lhs_name), Some(rhs_name)) => lhs_name.as_bytes() == rhs_name.as_bytes(),
+                _ => false,
+            }
+            && match (self.symbol.addr(), other.symbol.addr()) {
+                (None, None) => true,
+                (Some(lhs_addr), Some(rhs_addr)) => ptr::eq(lhs_addr, rhs_addr),
+                _ => false,
+            }
+            && (self.symbol.filename() == other.symbol.filename())
+            && (self.symbol.lineno() == other.symbol.lineno())
+            && (self.symbol.colno() == other.symbol.colno())
+    }
+}
+
+impl Eq for Symbol {}
+
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(name) = self.symbol.name() {
+            let name = name.to_string();
+            let name = if let Some((name, _)) = name.rsplit_once("::") {
+                name
+            } else {
+                &name
+            };
+            fmt::Display::fmt(&name, f)?;
+        }
+
+        if let Some(filename) = self.symbol.filename() {
+            f.write_str(" at ")?;
+            filename.to_string_lossy().fmt(f)?;
+            if let Some(lineno) = self.symbol.lineno() {
+                f.write_str(":")?;
+                fmt::Display::fmt(&lineno, f)?;
+                if let Some(colno) = self.symbol.colno() {
+                    f.write_str(":")?;
+                    fmt::Display::fmt(&colno, f)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/tokio/src/runtime/task/trace/symbol.rs
+++ b/tokio/src/runtime/task/trace/symbol.rs
@@ -1,9 +1,7 @@
 use backtrace::BacktraceSymbol;
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    ptr,
-};
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::ptr;
 
 /// A symbol in a backtrace.
 ///

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::DefaultHasher, HashMap as Map, HashSet as Set};
+use std::collections::{hash_map::DefaultHasher, HashMap, HashSet};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
@@ -12,17 +12,17 @@ pub(super) struct Tree {
     /// The roots of the trees.
     ///
     /// There should only be one root, but the code is robust to multiple roots.
-    roots: Set<Symbol>,
+    roots: HashSet<Symbol>,
 
     /// The adjacency list of symbols in the execution tree(s).
-    edges: Map<Symbol, Set<Symbol>>,
+    edges: HashMap<Symbol, HashSet<Symbol>>,
 }
 
 impl Tree {
     /// Constructs a [`Tree`] from [`Trace`]
     pub(super) fn from_trace(trace: Trace) -> Self {
-        let mut roots: Set<Symbol> = Set::default();
-        let mut edges: Map<Symbol, Set<Symbol>> = Map::default();
+        let mut roots: HashSet<Symbol> = HashSet::default();
+        let mut edges: HashMap<Symbol, HashSet<Symbol>> = HashMap::default();
 
         for trace in trace.backtraces {
             let trace = to_symboltrace(trace);

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -1,8 +1,6 @@
-use std::{
-    collections::{hash_map::DefaultHasher, HashMap as Map, HashSet as Set},
-    fmt,
-    hash::{Hash, Hasher},
-};
+use std::collections::{hash_map::DefaultHasher, HashMap as Map, HashSet as Set};
+use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use super::{Backtrace, Symbol, SymbolTrace, Trace};
 

--- a/tokio/src/runtime/task/trace/tree.rs
+++ b/tokio/src/runtime/task/trace/tree.rs
@@ -1,0 +1,128 @@
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap as Map, HashSet as Set},
+    fmt,
+    hash::{Hash, Hasher},
+};
+
+use super::{Backtrace, Symbol, SymbolTrace, Trace};
+
+/// An adjacency list representation of an execution tree.
+///
+/// This tree provides a convenient intermediate representation for formatting
+/// [`Trace`] as a tree.
+pub(super) struct Tree {
+    /// The roots of the trees.
+    ///
+    /// There should only be one root, but the code is robust to multiple roots.
+    roots: Set<Symbol>,
+
+    /// The adjacency list of symbols in the execution tree(s).
+    edges: Map<Symbol, Set<Symbol>>,
+}
+
+impl Tree {
+    /// Constructs a [`Tree`] from [`Trace`]
+    pub(super) fn from_trace(trace: Trace) -> Self {
+        let mut roots: Set<Symbol> = Set::default();
+        let mut edges: Map<Symbol, Set<Symbol>> = Map::default();
+
+        for trace in trace.backtraces {
+            let trace = to_symboltrace(trace);
+
+            if let Some(first) = trace.first() {
+                roots.insert(first.to_owned());
+            }
+
+            let mut trace = trace.into_iter().peekable();
+            while let Some(frame) = trace.next() {
+                let subframes = edges.entry(frame).or_default();
+                if let Some(subframe) = trace.peek() {
+                    subframes.insert(subframe.clone());
+                }
+            }
+        }
+
+        Tree { roots, edges }
+    }
+
+    /// Produces the sub-symbols of a given symbol.
+    fn consequences(&self, frame: &Symbol) -> Option<impl ExactSizeIterator<Item = &Symbol>> {
+        Some(self.edges.get(frame)?.iter())
+    }
+
+    /// Format this [`Tree`] as a textual tree.
+    fn display<W: fmt::Write>(
+        &self,
+        f: &mut W,
+        root: &Symbol,
+        is_last: bool,
+        prefix: &str,
+    ) -> fmt::Result {
+        let root_fmt = format!("{}", root);
+
+        let current;
+        let next;
+
+        if is_last {
+            current = format!("{prefix}└╼\u{a0}{root_fmt}");
+            next = format!("{}\u{a0}\u{a0}\u{a0}", prefix);
+        } else {
+            current = format!("{prefix}├╼\u{a0}{root_fmt}");
+            next = format!("{}│\u{a0}\u{a0}", prefix);
+        }
+
+        write!(f, "{}", {
+            let mut current = current.chars();
+            current.next().unwrap();
+            current.next().unwrap();
+            &current.as_str()
+        })?;
+
+        if let Some(consequences) = self.consequences(root) {
+            let len = consequences.len();
+            for (i, consequence) in consequences.enumerate() {
+                let is_last = i == len - 1;
+                writeln!(f)?;
+                self.display(f, consequence, is_last, &next)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for Tree {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for root in &self.roots {
+            self.display(f, root, true, " ")?;
+        }
+        Ok(())
+    }
+}
+
+/// Resolve a sequence of [`backtrace::BacktraceFrame`]s into a sequence of
+/// [`Symbol`]s.
+fn to_symboltrace(backtrace: Backtrace) -> SymbolTrace {
+    // Resolve the backtrace frames to symbols.
+    let backtrace: Backtrace = {
+        let mut backtrace = backtrace::Backtrace::from(backtrace);
+        backtrace.resolve();
+        backtrace.into()
+    };
+
+    // Accumulate the symbols in descending order into `symboltrace`.
+    let mut symboltrace: SymbolTrace = vec![];
+    let mut state = DefaultHasher::new();
+    for frame in backtrace.into_iter().rev() {
+        for symbol in frame.symbols().iter().rev() {
+            let symbol = Symbol {
+                symbol: symbol.clone(),
+                parent_hash: state.finish(),
+            };
+            symbol.hash(&mut state);
+            symboltrace.push(symbol);
+        }
+    }
+
+    symboltrace
+}

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -182,6 +182,7 @@ cfg_rt! {
         #[cfg(all(
             tokio_unstable,
             tokio_taskdump,
+            feature = "rt",
             target_os = "linux",
             any(
                 target_arch = "aarch64",

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -179,6 +179,8 @@ cfg_rt! {
         T::Output: Send + 'static,
     {
         use crate::runtime::task;
+        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        let future = task::trace::Trace::root(future);
         let id = task::Id::next();
         let task = crate::util::trace::task(future, "task", name, id.as_u64());
         let handle = Handle::current();

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -181,7 +181,7 @@ cfg_rt! {
         use crate::runtime::task;
         #[cfg(all(
             tokio_unstable,
-            feature = "taskdump",
+            tokio_taskdump,
             target_os = "linux",
             any(
                 target_arch = "aarch64",

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -179,7 +179,16 @@ cfg_rt! {
         T::Output: Send + 'static,
     {
         use crate::runtime::task;
-        #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+        #[cfg(all(
+            tokio_unstable,
+            feature = "taskdump",
+            target_os = "linux",
+            any(
+                target_arch = "aarch64",
+                target_arch = "i686",
+                target_arch = "x86_64"
+            )
+        ))]
         let future = task::trace::Trace::root(future);
         let id = task::Id::next();
         let task = crate::util::trace::task(future, "task", name, id.as_u64());

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -185,7 +185,7 @@ cfg_rt! {
             target_os = "linux",
             any(
                 target_arch = "aarch64",
-                target_arch = "i686",
+                target_arch = "x86",
                 target_arch = "x86_64"
             )
         ))]

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -50,7 +50,7 @@ pub async fn yield_now() {
                 tokio_unstable,
                 tokio_taskdump,
                 target_os = "linux",
-                any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+                any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
             ))]
             crate::runtime::task::trace::Trace::leaf();
 

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -49,6 +49,7 @@ pub async fn yield_now() {
             #[cfg(all(
                 tokio_unstable,
                 tokio_taskdump,
+                feature = "rt",
                 target_os = "linux",
                 any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
             ))]

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -46,6 +46,9 @@ pub async fn yield_now() {
         type Output = ();
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            #[cfg(all(tokio_unstable, feature = "taskdump"))]
+            crate::runtime::task::trace::Trace::leaf();
+
             if self.yielded {
                 return Poll::Ready(());
             }

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -48,7 +48,7 @@ pub async fn yield_now() {
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
             #[cfg(all(
                 tokio_unstable,
-                feature = "taskdump",
+                tokio_taskdump,
                 target_os = "linux",
                 any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
             ))]

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -46,7 +46,7 @@ pub async fn yield_now() {
         type Output = ();
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-            #[cfg(all(tokio_unstable, feature = "taskdump"))]
+            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
             crate::runtime::task::trace::Trace::leaf();
 
             if self.yielded {

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -46,7 +46,12 @@ pub async fn yield_now() {
         type Output = ();
 
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-            #[cfg(all(tokio_unstable, feature = "taskdump", target_os = "linux"))]
+            #[cfg(all(
+                tokio_unstable,
+                feature = "taskdump",
+                target_os = "linux",
+                any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+            ))]
             crate::runtime::task::trace::Trace::leaf();
 
             if self.yielded {

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -294,6 +294,32 @@ cfg_io_readiness! {
     }
 }
 
+cfg_taskdump! {
+    impl<T: Link> LinkedList<T, T::Target> {
+        pub(crate) fn for_each<F>(&mut self, mut f: F)
+        where
+            F: FnMut(&T::Handle),
+        {
+            let mut addr = 0;
+            if let Some(first) = self.pop_back() {
+                addr = T::as_raw(&first).as_ptr() as usize;
+                f(&first);
+                self.push_front(first);
+            }
+
+            while let Some(handle) = self.pop_back() {
+                if addr == T::as_raw(&handle).as_ptr() as usize {
+                    self.push_front(handle);
+                    break;
+                } else {
+                    f(&handle);
+                    self.push_front(handle);
+                }
+            }
+        }
+    }
+}
+
 // ===== impl GuardedLinkedList =====
 
 feature! {

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -10,7 +10,7 @@ cfg_trace! {
 
         #[inline]
         #[track_caller]
-        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>, id: u64) -> Instrumented<crate::runtime::task::trace::Root<F>> {
+        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>, id: u64) -> Instrumented<F> {
             use tracing::instrument::Instrument;
             let location = std::panic::Location::caller();
             let span = tracing::trace_span!(
@@ -23,7 +23,6 @@ cfg_trace! {
                 loc.line = location.line(),
                 loc.col = location.column(),
             );
-            let task = crate::runtime::task::trace::Trace::root(task);
             task.instrument(span)
         }
 

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -10,7 +10,7 @@ cfg_trace! {
 
         #[inline]
         #[track_caller]
-        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>, id: u64) -> Instrumented<F> {
+        pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>, id: u64) -> Instrumented<crate::runtime::task::trace::Root<F>> {
             use tracing::instrument::Instrument;
             let location = std::panic::Location::caller();
             let span = tracing::trace_span!(
@@ -23,6 +23,7 @@ cfg_trace! {
                 loc.line = location.line(),
                 loc.col = location.column(),
             );
+            let task = crate::runtime::task::trace::Trace::root(task);
             task.instrument(span)
         }
 

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -1,0 +1,48 @@
+use std::hint::black_box;
+use tokio::runtime;
+
+#[inline(never)]
+async fn a() {
+    black_box(b()).await
+}
+
+#[inline(never)]
+async fn b() {
+    black_box(c()).await
+}
+
+#[inline(never)]
+async fn c() {
+    black_box(tokio::task::yield_now()).await
+}
+
+#[test]
+fn test() {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.spawn(a());
+
+    let handle = rt.handle();
+
+    assert_eq!(handle.dump().tasks().iter().count(), 0);
+
+    let dump = rt.block_on(async {
+        handle.spawn(a());
+        handle.dump()
+    });
+
+    let tasks: Vec<_> = dump.tasks().iter().collect();
+
+    assert_eq!(tasks.len(), 2);
+
+    for task in tasks {
+        let trace = task.trace().to_string();
+        assert!(trace.contains("dump::a"));
+        assert!(trace.contains("dump::b"));
+        assert!(trace.contains("dump::c"));
+        assert!(trace.contains("tokio::task::yield_now"));
+    }
+}

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -1,4 +1,9 @@
-#![cfg(all(feature = "taskdump", tokio_unstable, target_os = "linux"))]
+#![cfg(all(
+    tokio_unstable,
+    feature = "taskdump",
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+))]
 
 use std::hint::black_box;
 use tokio::runtime;

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "taskdump", tokio_unstable))]
+
 use std::hint::black_box;
 use tokio::runtime;
 

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -42,9 +42,9 @@ fn test() {
 
     for task in tasks {
         let trace = task.trace().to_string();
-        assert!(trace.contains("dump::a"));
-        assert!(trace.contains("dump::b"));
-        assert!(trace.contains("dump::c"));
+        assert!(trace.contains("dump_current_thread::a"));
+        assert!(trace.contains("dump_current_thread::b"));
+        assert!(trace.contains("dump_current_thread::c"));
         assert!(trace.contains("tokio::task::yield_now"));
     }
 }

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "taskdump", tokio_unstable))]
+#![cfg(all(feature = "taskdump", tokio_unstable, target_os = "linux"))]
 
 use std::hint::black_box;
 use tokio::runtime;

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -1,6 +1,6 @@
 #![cfg(all(
     tokio_unstable,
-    feature = "taskdump",
+    tokio_taskdump,
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
 ))]

--- a/tokio/tests/dump_current_thread.rs
+++ b/tokio/tests/dump_current_thread.rs
@@ -2,7 +2,7 @@
     tokio_unstable,
     tokio_taskdump,
     target_os = "linux",
-    any(target_arch = "aarch64", target_arch = "i686", target_arch = "x86_64")
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]
 
 use std::hint::black_box;


### PR DESCRIPTION
## Motivation
In Java, *thread dumps* are an invaluable tool for debugging a stuck application in production. When a user requests a threaddump from a JVM, they receive text including the following information about each thread managed by the JVM:
- The thread name.
- The thread ID.
- The thread's priority.
- The thread's execution status: e.g., `RUNNABLE`, `WAITING`, or `BLOCKED`.
  This information is useful for debugging deadlocks.
- The thread's call stack.

Thread dumps provide a starting point for debugging deadlocks. A programmer can thread dump a deadlocked program, identify the `BLOCKED` threads, and inspect their call stacks to identify the resources they are blocked on.

This PR is a first step towards bringing an analogous functionality to tokio: "task dumps". A task dump is a comprehensive snapshot of the state of a Tokio application. This proposal will allow tokio services to briefly pause their work, reflect upon their internal runtime state, and comprehensively report that state to their operator.

## Solution
This PR implements a task dump mechanism for the current-thread runtime, that provides execution traces of each task. Execution traces are produced by instrumenting tokio's leaves to conditionally capture backtraces, which are then coalesced into a tree for each task.

For example, executing this program:
```rust
use std::hint::black_box;

#[inline(never)]
async fn a() {
    black_box(b()).await
}

#[inline(never)]
async fn b() {
    black_box(c()).await
}

#[inline(never)]
async fn c() {
    black_box(tokio::task::yield_now()).await
}

#[tokio::main(flavor = "current_thread")]
async fn main() {
    tokio::spawn(a());
    tokio::spawn(b());
    tokio::spawn(c());

    let handle = tokio::runtime::Handle::current();
    let dump = handle.dump();

    for (i, task) in dump.tasks().iter().enumerate() {
        let trace = task.trace();
        println!("task {i} trace:");
        println!("{trace}");
    }
}
```
Will produce an output like:
```
task 0 trace:
╼ dump::a::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:7:19
  └╼ dump::b::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:12:19
     └╼ dump::c::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:17:40
        └╼ tokio::task::yield_now::yield_now::{{closure}} at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:72:32
           └╼ <tokio::task::yield_now::yield_now::{{closure}}::YieldNow as core::future::future::Future>::poll at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:50:13
task 1 trace:
╼ dump::b::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:12:19
  └╼ dump::c::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:17:40
     └╼ tokio::task::yield_now::yield_now::{{closure}} at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:72:32
        └╼ <tokio::task::yield_now::yield_now::{{closure}}::YieldNow as core::future::future::Future>::poll at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:50:13
task 2 trace:
╼ dump::c::{{closure}} at /home/ubuntu/projects/tokio/examples/dump.rs:17:40
  └╼ tokio::task::yield_now::yield_now::{{closure}} at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:72:32
     └╼ <tokio::task::yield_now::yield_now::{{closure}}::YieldNow as core::future::future::Future>::poll at /home/ubuntu/projects/tokio/tokio/src/task/yield_now.rs:50:13
```

## Limitations
- Dumps of multi-thread runtimes are `unimplemented!()`
- Dumps of current-thread runtimes must be captured from within an active runtime context.
- Dumps do not yet provide important metadata, like spawn location or task name.
- Dumps do not yet include tasks in [`LocalSet`](https://docs.rs/tokio/1.27.0/tokio/task/struct.LocalSet.html)s or [`FuturesUnordered`](https://docs.rs/futures/latest/futures/stream/struct.FuturesUnordered.html).
- Execution traces cannot yet be decorated with extra information, like function arguments.

These limitations will be addressed in future PRs.

**NOTE:** The initial state of this PR *only* instruments `yield_now`. I will similarly instrument other leaf futures after this PR passes initial review.

## Related Reading
- https://github.com/tokio-rs/tokio/issues/5457
  This PR addresses this feature proposal.
- [***📄 Tack Trace Mechanisms***](https://hackmd.io/@jswrenn/SkldX98Ci)
  This document contrasts several potential approaches to tracing future state. This PR implements "📦 Backtrace the Leaves".