### PR TITLE
Add `JoinSet::spawn_blocking`

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -247,6 +247,21 @@ impl<T: 'static> JoinSet<T> {
         self.insert(crate::runtime::spawn_blocking(f))
     }
 
+    /// Spawn the blocking code on the blocking threadpool of the
+    /// provided runtime and store it in this `JoinSet`, returning an
+    /// [`AbortHandle`] that can be used to remotely cancel the task.
+    ///
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    #[track_caller]
+    pub fn spawn_blocking_on<F>(&mut self, f: F, handle: &Handle) -> AbortHandle
+    where
+        F: FnOnce() -> T,
+        F: Send + 'static,
+        T: Send,
+    {
+        self.insert(handle.spawn_blocking(f))
+    }
+
     fn insert(&mut self, jh: JoinHandle<T>) -> AbortHandle {
         let abort = jh.abort_handle();
         let mut entry = self.inner.insert_idle(jh);

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -201,6 +201,52 @@ impl<T: 'static> JoinSet<T> {
         self.insert(local_set.spawn_local(task))
     }
 
+    /// Spawn the blocking code on the blocking threadpool and store
+    /// it in this `JoinSet`, returning an [`AbortHandle`] that can be
+    /// used to remotely cancel the task.
+    ///
+    /// # Examples
+    ///
+    /// Spawn multiple blocking tasks and wait for them.
+    ///
+    /// ```
+    /// use tokio::task::JoinSet;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let mut set = JoinSet::new();
+    ///
+    ///     for i in 0..10 {
+    ///         set.spawn_blocking(move || { i });
+    ///     }
+    ///
+    ///     let mut seen = [false; 10];
+    ///     while let Some(res) = set.join_next().await {
+    ///         let idx = res.unwrap();
+    ///         seen[idx] = true;
+    ///     }
+    ///
+    ///     for i in 0..10 {
+    ///         assert!(seen[i]);
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// This method panics if called outside of a Tokio runtime.
+    ///
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    #[track_caller]
+    pub fn spawn_blocking<F>(&mut self, f: F) -> AbortHandle
+    where
+        F: FnOnce() -> T,
+        F: Send + 'static,
+        T: Send,
+    {
+        self.insert(crate::runtime::spawn_blocking(f))
+    }
+
     fn insert(&mut self, jh: JoinHandle<T>) -> AbortHandle {
         let abort = jh.abort_handle();
         let mut entry = self.inner.insert_idle(jh);


### PR DESCRIPTION
## Motivation

I recently wrote some code that boiled down to spawning a blocking task inside of an async task, which has undesired indentation and `unwrap`ping:

```rust
joinset.spawn(async move {
    tokio::task::spawn_blocking(move || {
        // blocking work
    })
        .await
        .unwrap(/* Panic occurred; re-raising */)
});
```

## Solution

This is better expressed as spawning the blocking task directly on the `JoinSet`. The above code can now be written as:

```rust
joinset.spawn_blocking(move || {
    // blocking work
});
```
