### PR TITLE
Fix FreeBSD ci

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'tokio-.*')
 auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
-  image_family: freebsd-12-4
+  image_family: freebsd-13-1
 env:
   RUST_STABLE: stable
   RUST_NIGHTLY: nightly-2022-10-25

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -31,7 +31,7 @@ task:
     RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
     RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
   setup_script:
-    - pkg install -y bash curl
+    - pkg install -y bash
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal --default-toolchain $RUST_NIGHTLY
     - . $HOME/.cargo/env
@@ -45,7 +45,7 @@ task:
 task:
   name: FreeBSD 32-bit
   setup_script:
-    - pkg install -y bash curl
+    - pkg install -y bash
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,7 @@ env:
 task:
   name: FreeBSD 64-bit
   setup_script:
-    - pkg install -y bash curl
+    - pkg install -y bash
     - curl https://sh.rustup.rs -sSf --output rustup.sh
     - sh rustup.sh -y --profile minimal --default-toolchain $RUST_STABLE
     - . $HOME/.cargo/env


### PR DESCRIPTION
CI is failing:
```
pkg install -y bash curl
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Updating database digests format: . done
The following 2 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
	bash: 5.2.15

Installed packages to be UPGRADED:
	curl: 7.85.0 -> 7.88.1

Number of packages to be installed: 1
Number of packages to be upgraded: 1

The process will require 9 MiB more space.
3 MiB to be downloaded.
[1/2] Fetching curl-7.88.1.pkg: .......... done
[2/2] Fetching bash-5.2.15.pkg: .......... done
Checking integrity... done (0 conflicting)
[1/2] Upgrading curl from 7.85.0 to 7.88.1...
[1/2] Extracting curl-7.88.1: .......... done
[2/2] Installing bash-5.2.15...
[2/2] Extracting bash-5.2.15: .......... done
curl https://sh.rustup.rs -sSf --output rustup.sh
ld-elf.so.1: /usr/local/lib/libcurl.so.4: Undefined symbol "nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation"
```