### PR TITLE
Fix fuzz warnings

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -658,5 +658,6 @@ cfg_macros! {
 #[cfg(test)]
 fn is_unpin<T: Unpin>() {}
 
+/// fuzz test (fuzz_linked_list)
 #[cfg(fuzzing)]
 pub mod fuzz;

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -507,7 +507,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    // #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_clean {
         ($e:ident) => {{
             assert!($e.pointers.get_next().is_none());
@@ -515,7 +515,7 @@ pub(crate) mod tests {
         }};
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    // #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_ptr_eq {
         ($a:expr, $b:expr) => {{
             // Deal with mapping a Pin<&mut T> -> Option<NonNull<T>>

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -507,7 +507,7 @@ pub(crate) mod tests {
         }
     }
 
-    // #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_clean {
         ($e:ident) => {{
             assert!($e.pointers.get_next().is_none());
@@ -515,7 +515,7 @@ pub(crate) mod tests {
         }};
     }
 
-    // #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_ptr_eq {
         ($a:expr, $b:expr) => {{
             // Deal with mapping a Pin<&mut T> -> Option<NonNull<T>>

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -507,7 +507,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    #[cfg(test)]
     macro_rules! assert_clean {
         ($e:ident) => {{
             assert!($e.pointers.get_next().is_none());
@@ -515,7 +515,7 @@ pub(crate) mod tests {
         }};
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
+    #[cfg(test)]
     macro_rules! assert_ptr_eq {
         ($a:expr, $b:expr) => {{
             // Deal with mapping a Pin<&mut T> -> Option<NonNull<T>>

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -507,6 +507,7 @@ pub(crate) mod tests {
         }
     }
 
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that. 
     macro_rules! assert_clean {
         ($e:ident) => {{
             assert!($e.pointers.get_next().is_none());
@@ -514,6 +515,7 @@ pub(crate) mod tests {
         }};
     }
 
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that. 
     macro_rules! assert_ptr_eq {
         ($a:expr, $b:expr) => {{
             // Deal with mapping a Pin<&mut T> -> Option<NonNull<T>>
@@ -717,6 +719,7 @@ pub(crate) mod tests {
         }
     }
 
+    /// This is a fuzz test. You run it by entering `cargo fuzz run fuzz_linked_list` in CLI in `/tokio/` module.
     #[cfg(fuzzing)]
     pub fn fuzz_linked_list(ops: &[u8]) {
         enum Op {

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -507,7 +507,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that. 
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_clean {
         ($e:ident) => {{
             assert!($e.pointers.get_next().is_none());
@@ -515,7 +515,7 @@ pub(crate) mod tests {
         }};
     }
 
-    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that. 
+    #[allow(unused_macros)] // This macro is used inside unsafe block but clippy doesn't see that.
     macro_rules! assert_ptr_eq {
         ($a:expr, $b:expr) => {{
             // Deal with mapping a Pin<&mut T> -> Option<NonNull<T>>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->
Fix the warnings you get when you run `cargo fuzz run fuzz_linked_list` in `/tokio/` directory
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
preparation for solving https://github.com/tokio-rs/tokio/issues/5601

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
I added documentation to solve `missing_docs` lint (I think that's what the lint was called). I also added `#[allow(unused_macros)]` to a couple of macros that were used inside unsafe block (clippy apparently can't see inside unsafe blocks).