### PR TITLE
Hide constant in select! macro for docs

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -449,6 +449,7 @@ macro_rules! select {
         use $crate::macros::support::Pin;
         use $crate::macros::support::Poll::{Ready, Pending};
 
+        #[doc(hidden)]
         const BRANCHES: u32 = $crate::count!( $($count)* );
 
         let mut disabled: __tokio_select_util::Mask = Default::default();


### PR DESCRIPTION
Using a nighly rustdoc the internal `BRANCHES` constant may leak into private documentation.
For background see https://github.com/serde-rs/serde/pull/2426.

Using the example from `select!` ([src](https://github.com/tokio-rs/tokio/blob/3b45e8614d45a44ebe6edf7b7939805f692f90ec/tokio/src/macros/select.rs#L151-L169)) and using `RUSTDOCFLAGS="--enable-index-page -Zunstable-options" cargo +nightly doc --no-deps --document-private-items` show the problem:
- Before the change:
![image](https://user-images.githubusercontent.com/85930053/231444184-1eced8e3-d2a5-4af1-bdf5-d75a987705f7.png)
- After the change:
![image](https://user-images.githubusercontent.com/85930053/231444688-9f5622c7-b9a4-4c15-8264-867ed14aeec5.png)

Of course there may be other such instances, I haven't exhaustively searched for them.