### PR TITLE
Allow getting the `Semaphore` from a `OwnedSemaphorePermit`.

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -678,8 +678,8 @@ impl OwnedSemaphorePermit {
     }
 
     /// Returns the [`Semaphore`] from which this permit was acquired.
-    pub fn semaphore(&self) -> Arc<Semaphore> {
-        self.sem.clone()
+    pub fn semaphore(&self) -> &Arc<Semaphore> {
+        &self.sem
     }
 }
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -676,6 +676,11 @@ impl OwnedSemaphorePermit {
         self.permits += other.permits;
         other.permits = 0;
     }
+
+    /// Returns the [`Semaphore`] from which this permit was acquired.
+    pub fn semaphore(&self) -> Arc<Semaphore> {
+        self.sem.clone()
+    }
 }
 
 impl Drop for SemaphorePermit<'_> {


### PR DESCRIPTION
The `OwnedSemaphorePermit` tracks the `Semaphore` from which it was acquired, but does not allow users to access it.

With this change I don't have to store both, saving some space.