### PR TITLE
fix: better spans in #[tokio::main] output

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,19 +1,19 @@
 error[E0308]: mismatched types
- --> tests/fail/macros_type_mismatch.rs:5:5
+ --> $DIR/macros_type_mismatch.rs:5:5
   |
 5 |     Ok(())
   |     ^^^^^^- help: consider using a semicolon here: `;`
   |     |
-  |     expected `()`, found `Result<(), _>`
+  |     expected `()`, found enum `Result`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
 
 error[E0308]: mismatched types
- --> tests/fail/macros_type_mismatch.rs:8:1
+ --> $DIR/macros_type_mismatch.rs:8:1
   |
 8 | #[tokio::main]
-  | ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
+  | ^^^^^^^^^^^^^^ expected `()`, found enum `Result`
 9 | async fn missing_return_type() {
   |                                - help: a return type might be missing here: `-> _`
   |
@@ -22,10 +22,10 @@ error[E0308]: mismatched types
   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:14:31
+  --> $DIR/macros_type_mismatch.rs:14:31
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
-   |          ---------------      ^^^^^^^^^^^^^^ expected `Result<(), ()>`, found `()`
+   |          ---------------      ^^^^^^^^^^^^^^ expected enum `Result`, found `()`
    |          |
    |          implicitly returns `()` as its body has no tail or `return` expression
 ...
@@ -36,7 +36,7 @@ error[E0308]: mismatched types
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:29:1
+  --> $DIR/macros_type_mismatch.rs:29:1
    |
 29 | #[tokio::main]
    | ^^^^^^^^^^^^^^ expected `()`, found integer

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,47 +1,46 @@
 error[E0308]: mismatched types
- --> $DIR/macros_type_mismatch.rs:5:5
+ --> tests/fail/macros_type_mismatch.rs:5:5
   |
-4 | async fn missing_semicolon_or_return_type() {
-  |                                             - help: a return type might be missing here: `-> _`
 5 |     Ok(())
-  |     ^^^^^^ expected `()`, found enum `Result`
+  |     ^^^^^^- help: consider using a semicolon here: `;`
+  |     |
+  |     expected `()`, found `Result<(), _>`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:10:5
-   |
-9  | async fn missing_return_type() {
-   |                                - help: a return type might be missing here: `-> _`
-10 |     return Ok(());
-   |     ^^^^^^^^^^^^^^ expected `()`, found enum `Result`
-   |
-   = note: expected unit type `()`
-                   found enum `Result<(), _>`
+ --> tests/fail/macros_type_mismatch.rs:8:1
+  |
+8 | #[tokio::main]
+  | ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
+9 | async fn missing_return_type() {
+  |                                - help: a return type might be missing here: `-> _`
+  |
+  = note: expected unit type `()`
+                  found enum `Result<(), _>`
+  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:23:5
+  --> tests/fail/macros_type_mismatch.rs:14:31
    |
 14 | async fn extra_semicolon() -> Result<(), ()> {
-   |                               -------------- expected `Result<(), ()>` because of return type
+   |          ---------------      ^^^^^^^^^^^^^^ expected `Result<(), ()>`, found `()`
+   |          |
+   |          implicitly returns `()` as its body has no tail or `return` expression
 ...
 23 |     Ok(());
-   |     ^^^^^^^ expected enum `Result`, found `()`
+   |           - help: remove this semicolon to return this value
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try adding an expression at the end of the block
-   |
-23 ~     Ok(());;
-24 +     Ok(())
-   |
 
 error[E0308]: mismatched types
-  --> $DIR/macros_type_mismatch.rs:32:5
+  --> tests/fail/macros_type_mismatch.rs:29:1
    |
+29 | #[tokio::main]
+   | ^^^^^^^^^^^^^^ expected `()`, found integer
 30 | async fn issue_4635() {
    |                       - help: try adding a return type: `-> i32`
-31 |     return 1;
-32 |     ;
-   |     ^ expected `()`, found integer
+   |
+   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -376,7 +376,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     let body = &input.block;
     let brace_token = input.block.brace_token;
     let body_ident = quote! { body };
-    let block_expr = quote_spanned! {last_stmt_end_span=>
+    let block_expr = quote_spanned! {Span::call_site()=>
         #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
         {
             return #rt

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -406,8 +406,11 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     let body = if is_test {
         quote_spanned! {last_stmt_end_span=>
             let body = async {
-                let body_cast: #output_type = #body;
-                body_cast
+                #[allow(unreachable_code)]
+                {
+                    let body_cast: #output_type = #body;
+                    body_cast
+                }
             };
             #crate_path::pin!(body);
             let body: ::std::pin::Pin<&mut dyn ::std::future::Future<Output = #output_type>> = body;

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -328,7 +328,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     input.sig.asyncness = None;
 
     // If type mismatch occurs, the current rustc points to the last statement.
-    let (last_stmt_start_span, _last_stmt_end_span) = {
+    let (last_stmt_start_span, last_stmt_end_span) = {
         let mut last_stmt = input
             .block
             .stmts
@@ -375,7 +375,9 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
 
     let body = &input.block;
     let brace_token = input.block.brace_token;
-    let body_ident = quote! { body };
+    let body_ident = quote_spanned! {last_stmt_end_span=>
+        body
+    };
     let block_expr = quote_spanned! {Span::call_site()=>
         #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
         {

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -408,8 +408,8 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
             let body = async {
                 #[allow(unreachable_code)]
                 {
-                    let body_cast: #output_type = #body;
-                    body_cast
+                    let _body_cast: #output_type = #body;
+                    _body_cast
                 }
             };
             #crate_path::pin!(body);
@@ -421,8 +421,8 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
             {
                 #[allow(unreachable_code)]
                 {
-                    let body_cast: #output_type = #body;
-                    body_cast
+                    let _body_cast: #output_type = #body;
+                    _body_cast
                 }
             };
         }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -328,7 +328,7 @@ fn parse_knobs(mut input: syn::ItemFn, is_test: bool, config: FinalConfig) -> To
     input.sig.asyncness = None;
 
     // If type mismatch occurs, the current rustc points to the last statement.
-    let (last_stmt_start_span, last_stmt_end_span) = {
+    let (last_stmt_start_span, _last_stmt_end_span) = {
         let mut last_stmt = input
             .block
             .stmts


### PR DESCRIPTION
Fix #5518.

## Motivation

The `#[tokio::main]` macro in its current state produces output that degrades IDE functionality — code generated by the proc macro is annotated with spans that point back to the end of the (user-provided) contents of `async fn main`, resulting in IDE plugins (correctly) treating the last binding in `main` as a call to a Tokio function.

As an example, if one adds a typo to the generated code, the error produced on `master` points to user code: 
```
error[E0599]: no method named `enable_al` found for struct `tokio::runtime::Builder` in the current scope
 --> src/main.rs:5:13
  |
5 |     variable;
  |             ^ help: there is a method with a similar name: `enable_all`
```

## Solution

We replace the span attached to the Tokio-generated code with one that points to the invocation site of the `#[tokio::main]` macro itself:

```
error[E0599]: no method named `enable_al` found for struct `tokio::runtime::Builder` in the current scope
 --> src/main.rs:1:1
  |
1 | #[tokio::main]
  | ^^^^^^^^^^^^^^ help: there is a method with a similar name: `enable_all`
```