### PR TITLE
doc: Update Clippy version in contrib guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,8 +131,12 @@ cargo check --all-features
 cargo test --all-features
 ```
 
-Clippy must be run using the MSRV, so Tokio can avoid having to `#[allow]` new
-lints whose fixes would be incompatible with the current MSRV:
+Clippy respects the `rust-version` field in `Cargo.toml` (as of 1.64.0), so
+it is OK to use a newer version of the toolchain than the current MSRV.
+However, it's usually best to use the same toolchain version for Clippy that
+is used in CI (defined by `env.rust_clippy` in [ci.yml][ci.yml]):
+
+[ci.yml]: .github/workflows/ci.yml
 
 <!--
 When updating this, also update:
@@ -146,7 +150,7 @@ When updating this, also update:
 -->
 
 ```
-cargo +1.49.0 clippy --all --tests --all-features
+cargo +1.65.0 clippy --all --tests --all-features
 ```
 
 When building documentation normally, the markers that list the features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,10 +131,9 @@ cargo check --all-features
 cargo test --all-features
 ```
 
-Clippy respects the `rust-version` field in `Cargo.toml` (as of 1.64.0), so
-it is OK to use a newer version of the toolchain than the current MSRV.
-However, it's usually best to use the same toolchain version for Clippy that
-is used in CI (defined by `env.rust_clippy` in [ci.yml][ci.yml]):
+Ideally, you should use the same version of clippy as the one used in CI
+(defined by `env.rust_clippy` in [ci.yml][ci.yml]), because newer versions
+might have new lints:
 
 [ci.yml]: .github/workflows/ci.yml
 

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -449,6 +449,7 @@ macro_rules! select {
         use $crate::macros::support::Pin;
         use $crate::macros::support::Poll::{Ready, Pending};
 
+        #[doc(hidden)]
         const BRANCHES: u32 = $crate::count!( $($count)* );
 
         let mut disabled: __tokio_select_util::Mask = Default::default();


### PR DESCRIPTION
## Motivation

In CI, we are using a newer version of Clippy than what is stated in the
contributions guide.

Additionally, it is no longer necessary to use Clippy from the MSRV. As
of Clippy 1.64, the `rust-version` field in Cargo.toml is respected.

## Solution

The text and the command have been updated to reflect the current state
of CI and best practices.
