### PR TITLE
Implement Borrow/BorrowMut for MutexGuard

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -4,6 +4,7 @@ use crate::sync::batch_semaphore as semaphore;
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;
 
+use std::borrow::{Borrow, BorrowMut};
 use std::cell::UnsafeCell;
 use std::error::Error;
 use std::marker::PhantomData;
@@ -947,6 +948,18 @@ impl<T: ?Sized> Drop for MutexGuard<'_, T> {
                 locked = false,
             );
         });
+    }
+}
+
+impl<T: ?Sized> Borrow<T> for MutexGuard<'_, T> {
+    fn borrow(&self) -> &T {
+        self
+    }
+}
+
+impl<T: ?Sized> BorrowMut<T> for MutexGuard<'_, T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        self
     }
 }
 


### PR DESCRIPTION
Useful when you are working with abstract types.

```rust
type FooLocked<'guard> = Foo<MutexGuard<'guard, Something>>; // ERROR! `MutexGuard: !Borrow` 
type FooOwned<'any> = Foo< Something>;
type FooRef<'any> = Foo<&'any Something>;

struct Foo<T: Borrow<Something>> {
  foo: T
}
```

`MutexGuard` already implements `Deref` but different from `Borrow`, it does not have a blanket `impl Borrow for T` (https://doc.rust-lang.org/std/borrow/trait.Borrow.html#impl-Borrow%3CT%3E-for-T) making the `FooOwned` variant impracticable.