### PR TITLE
Make macro_rules `(try_)join!` always available

### DIFF
--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -53,7 +53,6 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! join {
     (@ {
         // One `_` for each branch in the `join!` macro. This is not used once

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -30,13 +30,13 @@ pub(crate) mod scoped_tls;
 cfg_macros! {
     #[macro_use]
     mod select;
-
-    #[macro_use]
-    mod join;
-
-    #[macro_use]
-    mod try_join;
 }
+
+#[macro_use]
+mod join;
+
+#[macro_use]
+mod try_join;
 
 // Includes re-exports needed to implement macros
 #[doc(hidden)]

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -99,7 +99,6 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
 macro_rules! try_join {
     (@ {
         // One `_` for each branch in the `try_join!` macro. This is not used once


### PR DESCRIPTION
## Motivation

It does not use anything from `tokio-macros`, thus gating it behind feature `macros` does not make sense.

It forces users who have to use `tokio::{try_join, join}` to enable feature `macros` and pull in crate tokio-macros, which is unnecessary.

## Solution

Make `tokio::{try_join, join}` always available regardless of whether feature `macros` is enabled.