### PR TITLE
Cancellation token docs

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -97,7 +97,8 @@ impl core::fmt::Debug for CancellationToken {
 }
 
 impl Clone for CancellationToken {
-    /// Creates a clone of the `CancellationToken` which will get cancelled whenever the current token gets cancelled, and vice versa.
+    /// Creates a clone of the `CancellationToken` which will get cancelled
+    /// whenever the current token gets cancelled, and vice versa.
     fn clone(&self) -> Self {
         tree_node::increase_handle_refcount(&self.inner);
         CancellationToken {
@@ -127,7 +128,8 @@ impl CancellationToken {
     }
 
     /// Creates a `CancellationToken` which will get cancelled whenever the
-    /// current token gets cancelled. Unlike a cloned `CancellationToken`, cancelling a child token does not cancel the parent token.
+    /// current token gets cancelled. Unlike a cloned `CancellationToken`,
+    /// cancelling a child token does not cancel the parent token.
     ///
     /// If the current token is already cancelled, the child token will get
     /// returned in cancelled state.


### PR DESCRIPTION
This clarifies the difference between `clone()` and `child_token()` on `CancellationToken`.