### PR TITLE
Revert "macros: hide internal constant in select! macro (#5617)"

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -449,7 +449,6 @@ macro_rules! select {
         use $crate::macros::support::Pin;
         use $crate::macros::support::Poll::{Ready, Pending};
 
-        #[doc(hidden)]
         const BRANCHES: u32 = $crate::count!( $($count)* );
 
         let mut disabled: __tokio_select_util::Mask = Default::default();


### PR DESCRIPTION
This reverts commit cf9a03c107ea523480e03234aff422905abaf8d7.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The underlying rustdoc bug has been fixed in https://github.com/rust-lang/rust/pull/110450.
