### PR TITLE
stream: add "full" feature flag

### DIFF
--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -18,6 +18,16 @@ categories = ["asynchronous"]
 
 [features]
 default = ["time"]
+
+full = [
+    "time",
+    "net",
+    "io-util",
+    "fs",
+    "sync",
+    "signal"
+]
+
 time = ["tokio/time"]
 net = ["tokio/net"]
 io-util = ["tokio/io-util"]


### PR DESCRIPTION
Add "full" feature flag, that enables all other features. This is analog to tokio's "full" feature flag.

## Motivation

I often use tokio's "full" feature flag during early development and for hobby projects. That way I don't have to manage 
features early on and can just use everything and changing to specific features once a project is further developed.

I'd like to be able to do the same with tokio-stream. 

I was thinking about creating an issue for this first, but I decided that creating a PR is not that much slower so here it is.