### PR TITLE
sync: useful Debug impl for RwLock 

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -85,7 +85,6 @@ const MAX_READS: u32 = 10;
 /// [`RwLockWriteGuard`]: struct@RwLockWriteGuard
 /// [`Send`]: trait@std::marker::Send
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
-#[derive(Debug)]
 pub struct RwLock<T: ?Sized> {
     #[cfg(all(tokio_unstable, feature = "tracing"))]
     resource_span: tracing::Span,
@@ -1093,5 +1092,19 @@ where
 {
     fn default() -> Self {
         Self::new(T::default())
+    }
+}
+
+impl<T: ?Sized> std::fmt::Debug for RwLock<T>
+where
+    T: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("RwLock");
+        match self.try_read() {
+            Ok(inner) => d.field("data", &&*inner),
+            Err(_) => d.field("data", &format_args!("<locked>")),
+        };
+        d.finish()
     }
 }


### PR DESCRIPTION
## Motivation

Currently the `std::fmt::Debug` impl for `tokio::sync::RwLock` is just what `#[derive(Debug)]` provides and looks like

```
RwLock { mr: 536870911, s: Semaphore { permits: 536870911 }, c: UnsafeCell { .. } }
```

which isn't very useful. Instead we can show the data *if* no thread currently holds the write lock. This matches what is done in `std::sync::RwLock` and in `tokio::sync::Mutex`.

## Solution

The updated code is basically a 1 to 1 mapping from the tokio [Mutex implementation](https://docs.rs/tokio/latest/src/tokio/sync/mutex.rs.html#787-799). 
