### PR TITLE
Use the cargo-semver-checks GitHub Action for semver-checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,17 +254,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust ${{ env.rust_stable }}
-        uses: dtolnay/rust-toolchain@master
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
-          toolchain: ${{ env.rust_stable }}
-      - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-semver-checks
-      - name: Check semver compatibility
-        run: |
-          cargo semver-checks check-release --release-type minor
+          rust-toolchain: ${{ env.rust_stable }}
+          release-type: minor
 
   cross-check:
     name: cross-check


### PR DESCRIPTION
## Motivation

Will provide a substantial performance improvement:
- cargo-semver-checks v0.20 is orders of magnitude faster at checking large crates — 2354x faster on `aws-sdk-ec2`
- the GitHub Action caches baseline rustdoc JSON files which is worth another ~2x speedup.

As discussed here: https://github.com/tokio-rs/tokio/pull/5437#issuecomment-1520366922

## Solution

Switch to using the `cargo-semver-checks` GitHub Action which handles all of the above correctly and automatically. It also automatically downloads a prebuilt binary for the latest release of `cargo-semver-checks` so it should essentially run on autopilot from here on.
