### PR TITLE
chore: prepare tokio-macros v2.1.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.1.0 (April 25th, 2023)
+
+- macros: fix typo in `#[tokio::test]` docs ([#5636])
+- macros: make entrypoints more efficient ([#5621])
+
+[#5621]: https://github.com/tokio-rs/tokio/pull/5621
+[#5636]: https://github.com/tokio-rs/tokio/pull/5636
+
 # 2.0.0 (March 24th, 2023)
 
 This major release updates the dependency on the syn crate to 2.0.0, and

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.x.y" git tag.
-version = "2.0.0"
+version = "2.1.0"
 edition = "2018"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -97,7 +97,7 @@ stats = []
 autocfg = "1.1"
 
 [dependencies]
-tokio-macros = { version = "~2.0.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.1.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.0"
 


### PR DESCRIPTION
# 2.1.0 (April 25th, 2023)

- macros: fix typo in `#[tokio::test]` docs ([#5636])
- macros: make entrypoints more efficient ([#5621])

[#5621]: https://github.com/tokio-rs/tokio/pull/5621
[#5636]: https://github.com/tokio-rs/tokio/pull/5636