### PR TITLE
Resolve a semantic conflict between #5608 and #5628.

### DIFF
--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -342,6 +342,15 @@ cfg_io_readiness! {
 }
 
 cfg_taskdump! {
+    impl<T: Link> CountedLinkedList<T, T::Target> {
+        pub(crate) fn for_each<F>(&mut self, f: F)
+        where
+            F: FnMut(&T::Handle),
+        {
+            self.list.for_each(f)
+        }
+    }
+
     impl<T: Link> LinkedList<T, T::Target> {
         pub(crate) fn for_each<F>(&mut self, mut f: F)
         where


### PR DESCRIPTION
This PR resolves a semantic conflict between #5608 and #5628. Both PRs modified `tokio/src/runtime/task/list.rs`:
- #5628 changed the field type of `OwnedTasks::inner`
- #5608 added `OwnedTasks::for_each` (that forwards to a `for_each` on `OwnedTasks::inner`)
 
Because these changes did not occur close together, they did not pose a merge conflict for either PR; rather, [a semantic conflict](https://bors.tech/essay/2017/02/02/pitch/).

This PR fixes the semantic conflict, but does not fix that CI allows such conflicts to occur. To resolve that, this repo would need to adopt something like [bors](https://bors.tech/).

Further discussion: https://discord.com/channels/500028886025895936/500336346770964480/1100809662208675982
