### PR TITLE
tokio-util: enable non-`'static` `PollSender`

### DIFF
--- a/tokio-util/src/sync/mpsc.rs
+++ b/tokio-util/src/sync/mpsc.rs
@@ -65,10 +65,12 @@ async fn make_acquire_future<T>(
 }
 
 #[derive(Debug)]
-// TODO: This should be replace with a type_alias_impl_trait to eliminate `'static` and all the transmutes 
+// TODO: This should be replace with a type_alias_impl_trait to eliminate `'static` and all the transmutes
 struct PollSenderFuture<T>(ReusableBoxFuture<'static, Result<OwnedPermit<T>, PollSendError<T>>>);
 
-impl<T> From<ReusableBoxFuture<'static, Result<OwnedPermit<T>, PollSendError<T>>>> for PollSenderFuture<T> {
+impl<T> From<ReusableBoxFuture<'static, Result<OwnedPermit<T>, PollSendError<T>>>>
+    for PollSenderFuture<T>
+{
     fn from(v: ReusableBoxFuture<'static, Result<OwnedPermit<T>, PollSendError<T>>>) -> Self {
         Self(v)
     }
@@ -76,7 +78,9 @@ impl<T> From<ReusableBoxFuture<'static, Result<OwnedPermit<T>, PollSendError<T>>
 
 impl<T: Send> From<Option<Sender<T>>> for PollSenderFuture<T> {
     fn from(data: Option<Sender<T>>) -> Self {
-        let v = ReusableBoxFuture::<'_, Result<OwnedPermit<T>, PollSendError<T>>>::new(make_acquire_future(data));
+        let v = ReusableBoxFuture::<'_, Result<OwnedPermit<T>, PollSendError<T>>>::new(
+            make_acquire_future(data),
+        );
         // This is safe because we're just transmuting the `'static` bound on the Box<dyn> to get around storage issue
         unsafe { mem::transmute(v) }
     }
@@ -84,7 +88,9 @@ impl<T: Send> From<Option<Sender<T>>> for PollSenderFuture<T> {
 
 impl<T: Send> PollSenderFuture<T> {
     fn get<'a>(&mut self) -> &mut ReusableBoxFuture<'a, Result<OwnedPermit<T>, PollSendError<T>>>
-    where T: 'a {
+    where
+        T: 'a,
+    {
         // This is safe because we're just untransmuting the `'static` bound on the Box<dyn> to get around storage issue
         unsafe { mem::transmute(&mut self.0) }
     }

--- a/tokio-util/src/sync/mpsc.rs
+++ b/tokio-util/src/sync/mpsc.rs
@@ -64,7 +64,7 @@ async fn make_acquire_future<T>(
     }
 }
 
-impl<'a, T: Send+'a> PollSender<'a, T> {
+impl<'a, T: Send + 'a> PollSender<'a, T> {
     /// Creates a new `PollSender`.
     pub fn new(sender: Sender<T>) -> Self {
         Self {

--- a/tokio-util/tests/mpsc.rs
+++ b/tokio-util/tests/mpsc.rs
@@ -29,7 +29,7 @@ async fn simple() {
 
 #[tokio::test]
 async fn simple_ref() {
-    let v = [1, 2, 3i32];
+    let v = vec![1, 2, 3i32];
 
     let (send, mut recv) = channel(3);
     let mut send = PollSender::new(send);
@@ -46,9 +46,7 @@ async fn simple_ref() {
     assert_eq!(*recv.recv().await.unwrap(), 1);
     assert!(reserve.is_woken());
     assert_ready_ok!(reserve.poll());
-
     drop(recv);
-
     send.send_item(&42).unwrap();
 }
 

--- a/tokio-util/tests/mpsc.rs
+++ b/tokio-util/tests/mpsc.rs
@@ -27,7 +27,6 @@ async fn simple() {
     send.send_item(42).unwrap();
 }
 
-
 #[tokio::test]
 async fn simple_ref() {
     let v = [1, 2, 3i32];
@@ -52,7 +51,6 @@ async fn simple_ref() {
 
     send.send_item(&42).unwrap();
 }
-
 
 #[tokio::test]
 async fn repeated_poll_reserve() {

--- a/tokio-util/tests/mpsc.rs
+++ b/tokio-util/tests/mpsc.rs
@@ -27,6 +27,33 @@ async fn simple() {
     send.send_item(42).unwrap();
 }
 
+
+#[tokio::test]
+async fn simple_ref() {
+    let v = [1, 2, 3i32];
+
+    let (send, mut recv) = channel(3);
+    let mut send = PollSender::new(send);
+
+    for vi in v.iter() {
+        let mut reserve = spawn(poll_fn(|cx| send.poll_reserve(cx)));
+        assert_ready_ok!(reserve.poll());
+        send.send_item(vi).unwrap();
+    }
+
+    let mut reserve = spawn(poll_fn(|cx| send.poll_reserve(cx)));
+    assert_pending!(reserve.poll());
+
+    assert_eq!(*recv.recv().await.unwrap(), 1);
+    assert!(reserve.is_woken());
+    assert_ready_ok!(reserve.poll());
+
+    drop(recv);
+
+    send.send_item(&42).unwrap();
+}
+
+
 #[tokio::test]
 async fn repeated_poll_reserve() {
     let (send, mut recv) = channel::<i32>(1);


### PR DESCRIPTION
## Motivation

Currently, `PollSender` is limited to sending `'static` types, which limits its usefulness when sending non-`static`ally borrowed things to and from scoped tasks (e.g. `async-scoped`).

## Solution

Remove the `'static` restriction by introducing a lifetime parameter.