### PR TITLE
mpsc and watch errors (SendError<T>...) without bond T:Debug

### DIFF
--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -122,7 +122,7 @@ cfg_time! {
         /// dropped.
         Closed(T),
     }
-    
+
     impl<T> fmt::Debug for SendTimeoutError<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match *self {
@@ -144,6 +144,6 @@ cfg_time! {
             )
         }
     }
-    
+
     impl<T> Error for SendTimeoutError<T> {}
 }

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -4,8 +4,14 @@ use std::error::Error;
 use std::fmt;
 
 /// Error returned by the `Sender`.
-#[derive(Debug)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub struct SendError<T>(pub T);
+
+impl<T> fmt::Debug for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendError").finish_non_exhaustive()
+    }
+}
 
 impl<T> fmt::Display for SendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -13,13 +19,13 @@ impl<T> fmt::Display for SendError<T> {
     }
 }
 
-impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+impl<T> std::error::Error for SendError<T> {}
 
 // ===== TrySendError =====
 
 /// This enumeration is the list of the possible error outcomes for the
 /// [try_send](super::Sender::try_send) method.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(PartialEq, Eq, Clone, Copy)]
 pub enum TrySendError<T> {
     /// The data could not be sent on the channel because the channel is
     /// currently full and sending would require blocking.
@@ -30,7 +36,14 @@ pub enum TrySendError<T> {
     Closed(T),
 }
 
-impl<T: fmt::Debug> Error for TrySendError<T> {}
+impl<T> fmt::Debug for TrySendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            TrySendError::Full(..) => "Full(..)".fmt(f),
+            TrySendError::Closed(..) => "Closed(..)".fmt(f),
+        }
+    }
+}
 
 impl<T> fmt::Display for TrySendError<T> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -44,6 +57,8 @@ impl<T> fmt::Display for TrySendError<T> {
         )
     }
 }
+
+impl<T> Error for TrySendError<T> {}
 
 impl<T> From<SendError<T>> for TrySendError<T> {
     fn from(src: SendError<T>) -> TrySendError<T> {
@@ -96,7 +111,7 @@ impl Error for RecvError {}
 cfg_time! {
     // ===== SendTimeoutError =====
 
-    #[derive(Debug, Eq, PartialEq)]
+    #[derive(PartialEq, Eq, Clone, Copy)]
     /// Error returned by [`Sender::send_timeout`](super::Sender::send_timeout)].
     pub enum SendTimeoutError<T> {
         /// The data could not be sent on the channel because the channel is
@@ -107,8 +122,15 @@ cfg_time! {
         /// dropped.
         Closed(T),
     }
-
-    impl<T: fmt::Debug> Error for SendTimeoutError<T> {}
+    
+    impl<T> fmt::Debug for SendTimeoutError<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match *self {
+                SendTimeoutError::Timeout(..) => "Timeout(..)".fmt(f),
+                SendTimeoutError::Closed(..) => "Closed(..)".fmt(f),
+            }
+        }
+    }
 
     impl<T> fmt::Display for SendTimeoutError<T> {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -122,4 +144,6 @@ cfg_time! {
             )
         }
     }
+    
+    impl<T> Error for SendTimeoutError<T> {}
 }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -208,18 +208,24 @@ pub mod error {
     use std::fmt;
 
     /// Error produced when sending a value fails.
-    #[derive(Debug)]
+    #[derive(PartialEq, Eq, Clone, Copy)]
     pub struct SendError<T>(pub T);
 
     // ===== impl SendError =====
-
-    impl<T: fmt::Debug> fmt::Display for SendError<T> {
+    
+    impl<T> fmt::Debug for SendError<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("SendError").finish_non_exhaustive()
+        }
+    }
+    
+    impl<T> fmt::Display for SendError<T> {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(fmt, "channel closed")
         }
     }
 
-    impl<T: fmt::Debug> std::error::Error for SendError<T> {}
+    impl<T> std::error::Error for SendError<T> {}
 
     /// Error produced when receiving a change notification.
     #[derive(Debug, Clone)]

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -212,13 +212,13 @@ pub mod error {
     pub struct SendError<T>(pub T);
 
     // ===== impl SendError =====
-    
+
     impl<T> fmt::Debug for SendError<T> {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.debug_struct("SendError").finish_non_exhaustive()
         }
     }
-    
+
     impl<T> fmt::Display for SendError<T> {
         fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(fmt, "channel closed")


### PR DESCRIPTION
Closes #5664

Hi @Darksonn,

I did it, I looked at [std::sync::mpsc::SendError](https://doc.rust-lang.org/std/sync/mpsc/struct.SendError.html#) and [std::sync::mpsc::TrySendError](https://doc.rust-lang.org/std/sync/mpsc/enum.TrySendError.html#) implementations as a based to my commits.

I looked over all the Tokio's channel and found (in addition to the `mpsc`) a similar issue with the `watch` channel so I fixed it too.

There is one difference with the `std` code that I didn't do because it's adding a bond `Send` on `T` for the `Error` trait impl on their error and I don't see why it is required... (See in `std::sync::mpsc` [impl<T: Send> Error for SendError<T>](https://doc.rust-lang.org/std/sync/mpsc/struct.SendError.html#impl-Error-for-SendError%3CT%3E) and [impl<T: Send> Error for TrySendError<T>](https://doc.rust-lang.org/std/sync/mpsc/enum.TrySendError.html#impl-Error-for-TrySendError%3CT%3E))

Do you think we need to impose `T: Send` for the `Error` impl ?

I ran the test on the whole repo on my machine and all the tests passed (and some where ignored).