### PR TITLE
util/io: add `SyncReadToAsyncRead`

### DIFF
--- a/tokio-util/src/io/mod.rs
+++ b/tokio-util/src/io/mod.rs
@@ -19,7 +19,9 @@ mod stream_reader;
 
 cfg_io_util! {
     mod sync_bridge;
+    mod sync_read_to_async_read;
     pub use self::sync_bridge::SyncIoBridge;
+    pub use self::sync_read_to_async_read::SyncReadIntoAsyncRead;
 }
 
 pub use self::copy_to_bytes::CopyToBytes;

--- a/tokio-util/src/io/sync_read_to_async_read.rs
+++ b/tokio-util/src/io/sync_read_to_async_read.rs
@@ -1,0 +1,132 @@
+use bytes::buf::Take;
+use bytes::Buf;
+use core::task::Poll::Ready;
+use futures_core::{ready, Future};
+use std::io;
+use std::io::Read;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use tokio::io::AsyncRead;
+use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+
+#[derive(Debug)]
+enum State<Buf: bytes::Buf + bytes::BufMut> {
+    Idle(Option<Buf>),
+    Busy(JoinHandle<(io::Result<usize>, Take<Buf>)>),
+}
+
+use State::{Busy, Idle};
+
+/// Use a [`SyncReadIntoAsyncRead`] to asynchronously read from a
+/// synchronous API.
+#[derive(Debug)]
+pub struct SyncReadIntoAsyncRead<R: Read + Send, Buf: bytes::Buf + bytes::BufMut> {
+    state: Mutex<State<Buf>>,
+    reader: Arc<Mutex<R>>,
+    rt: Handle,
+}
+
+impl<R: Read + Send, Buf: bytes::Buf + bytes::BufMut> SyncReadIntoAsyncRead<R, Buf> {
+    /// This must be called from within a Tokio runtime context, or else it will panic.
+    #[track_caller]
+    pub fn new(rt: Handle, reader: R) -> Self {
+        Self {
+            rt,
+            state: State::Idle(None).into(),
+            reader: Arc::new(reader.into()),
+        }
+    }
+
+    /// This must be called from within a Tokio runtime context, or else it will panic.
+    pub fn new_with_reader(readable: R) -> Self {
+        Self::new(Handle::current(), readable)
+    }
+}
+
+pub(crate) const MAX_BUF: usize = 2 * 1024 * 1024;
+/// Repeats operations that are interrupted.
+macro_rules! uninterruptibly {
+    ($e:expr) => {{
+        loop {
+            match $e {
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
+                res => break res,
+            }
+        }
+    }};
+}
+
+impl<
+        R: Read + Send + 'static + std::marker::Unpin,
+        Buf: bytes::Buf + bytes::BufMut + Send + Default + std::marker::Unpin + 'static,
+    > AsyncRead for SyncReadIntoAsyncRead<R, Buf>
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        dst: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let me = self.get_mut();
+        // Do we need this mutex?
+        let state = me.state.get_mut();
+
+        loop {
+            match state {
+                Idle(ref mut buf_cell) => {
+                    let mut buf = buf_cell.take().unwrap_or_default();
+
+                    if buf.has_remaining() {
+                        buf.copy_to_slice(dst.initialized_mut());
+                        *buf_cell = Some(buf);
+                        return Ready(Ok(()));
+                    }
+
+                    let target_length = std::cmp::min(dst.remaining(), MAX_BUF);
+                    let mut new_buf = vec![0; target_length];
+
+                    let reader = me.reader.clone();
+                    *state = Busy(me.rt.spawn_blocking(move || {
+                        let result = uninterruptibly!(reader.blocking_lock().read(&mut new_buf));
+
+                        buf.put_slice(&new_buf);
+
+                        if let Ok(n) = result {
+                            (result, buf.take(n))
+                        } else {
+                            (result, buf.take(0))
+                        }
+                    }));
+                }
+                Busy(ref mut rx) => {
+                    let (result, mut buf) = ready!(Pin::new(rx).poll(cx))?;
+
+                    match result {
+                        Ok(_) => {
+                            let remaining = buf.remaining();
+                            let mut adjusted_dst = dst.take(remaining);
+                            buf.copy_to_slice(adjusted_dst.initialize_unfilled());
+                            dst.advance(remaining);
+                            *state = Idle(None);
+                            return Ready(Ok(()));
+                        }
+                        Err(e) => {
+                            *state = Idle(None);
+                            return Ready(Err(e));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<R: Read + Send, Buf: bytes::Buf + bytes::BufMut> From<R> for SyncReadIntoAsyncRead<R, Buf> {
+    /// This must be called from within a Tokio runtime context, or else it will panic.
+    fn from(value: R) -> Self {
+        Self::new_with_reader(value)
+    }
+}

--- a/tokio-util/tests/io_sync_read_to_async_read.rs
+++ b/tokio-util/tests/io_sync_read_to_async_read.rs
@@ -1,0 +1,22 @@
+#![warn(rust_2018_idioms)]
+use tokio::io::AsyncReadExt;
+use tokio_util::io::SyncReadIntoAsyncRead;
+
+#[tokio::test]
+async fn test_sync_read_to_async_read() -> std::io::Result<()> {
+    let buffer = std::io::Cursor::new(bytes::Bytes::from_static(&[0, 1, 2, 3, 4, 5, 6, 7]));
+    let sync_reader = std::io::BufReader::new(buffer);
+    let mut async_reader =
+        SyncReadIntoAsyncRead::<_, bytes::BytesMut>::new_with_reader(sync_reader);
+
+    let mut buf = [0; 5];
+    async_reader.read_exact(&mut buf).await?;
+    assert_eq!(buf, [0, 1, 2, 3, 4]);
+
+    assert_eq!(async_reader.read(&mut buf).await?, 3);
+    assert_eq!(&buf[..3], [5, 6, 7]);
+
+    assert_eq!(async_reader.read(&mut buf).await?, 0);
+
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`SyncIoBridge` was added to go from async to sync, this is the symmetrical data structure to go from sync to async.

It is very helpful when you have a sync-only API and you want to mix it with async APIs by unifying everything to async until keyword generics / async traits (not the macro) becomes a thing.

## Solution

It's ugly, probably not good at all in terms of performance characteristics or semantics, but it's sometimes useful to have to prototype, check things and play around.

Inspired by https://docs.rs/tokio-sync-read-stream/latest/tokio_sync_read_stream/ which is abandoned AFAIK.

The idea is just to watch for updates in the IO thread of Tokio, queue them into some sort of multi-thread write-only buffer (this can be improved I believe with a more "specific" data structure for this usecase) with some sort of artificial buffer size.

It drops data whenever there's a panic in the `Reader::read` or reading the value when it's queued for some reason, it will also drop data if the received data is too big compared to the current buffer's size.

It should probably support some form of drop counters for diagnosing issues.

I'm uncertain if this change is desired at all or should take this form, I am interested into all sorts of feedback. :)