### PR TITLE
Add ci step to check /tokio/ fuzzing compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -685,3 +685,19 @@ jobs:
           cargo install cargo-check-external-types --locked --version 0.1.6
           cargo check-external-types --all-features --config external-types.toml
         working-directory: tokio
+
+  check-fuzzing:
+    name: check-fuzzing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.rust_nightly }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-fuzz
+        run: cargo install cargo-fuzz
+      - name: Check tokio/
+        run: cargo fuzz check --all-features
+        working-directory: tokio


### PR DESCRIPTION
Adds `check-fuzzing` CI steps to install `cargo-fuzz` and check if `fuzz_targets` under `/tokio/` compile

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Solves the `/tokio/` piece of https://github.com/tokio-rs/tokio/issues/5601

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds the following CI steps:
* Install `rust_nightly` - need over `rust_stable` for `cargo-fuzz` see [here](https://github.com/rust-fuzz/cargo-fuzz/blob/main/README.md?plain=1#L14)
* Install `cargo-fuzz`
* Run `cargo fuzz check` on `/tokio/` dir

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
