### PR TITLE
docs: fix typo in doc comment

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -209,7 +209,7 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 
 /// Marks async function to be executed by selected runtime. This macro helps set up a `Runtime`
 /// without requiring the user to use [Runtime](../tokio/runtime/struct.Runtime.html) or
-/// [Builder](../tokio/runtime/struct.builder.html) directly.
+/// [Builder](../tokio/runtime/struct.Builder.html) directly.
 ///
 /// ## Function arguments:
 ///


### PR DESCRIPTION
## Motivation

fix a broken link on the [docs.rs](https://docs.rs/tokio-macros/2.1.0/tokio_macros/attr.main_rt.html) page.

## Solution

fix the typo in the link
