### PR TITLE
Remove unused code from fuzz_steam_map.rs

### DIFF
--- a/tokio-stream/fuzz/fuzz_targets/fuzz_stream_map.rs
+++ b/tokio-stream/fuzz/fuzz_targets/fuzz_stream_map.rs
@@ -3,17 +3,8 @@
 use libfuzzer_sys::fuzz_target;
 use std::pin::Pin;
 
-use tokio_stream::{self as stream, pending, Stream, StreamExt, StreamMap};
-use tokio_test::{assert_ok, assert_pending, assert_ready, task};
-
-macro_rules! assert_ready_some {
-    ($($t:tt)*) => {
-        match assert_ready!($($t)*) {
-            Some(v) => v,
-            None => panic!("expected `Some`, got `None`"),
-        }
-    };
-}
+use tokio_stream::{self as stream, Stream, StreamMap};
+use tokio_test::{assert_pending, assert_ready, task};
 
 macro_rules! assert_ready_none {
     ($($t:tt)*) => {


### PR DESCRIPTION
This fixes compilation warnings for `tokio-stream/fuzz`

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This is the prereq before the next step of adding a compilation check step in CI to address https://github.com/tokio-rs/tokio/issues/5601

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Removes unused code in order for the warnings to go away.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
