### PR TITLE
tokio: fix warnings in AS_FD_PROBE

### DIFF
--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -19,13 +19,14 @@ const CONST_MUTEX_NEW_PROBE: &str = r#"
 
 const AS_FD_PROBE: &str = r#"
 {
-    #![allow(unused_imports)]
-
+    #[allow(unused_imports)]
     #[cfg(unix)]
     use std::os::unix::prelude::AsFd as _;
+    #[allow(unused_imports)]
     #[cfg(windows)]
     use std::os::windows::prelude::AsSocket as _;
-    #[cfg(target = "wasm32-wasi")]
+    #[allow(unused_imports)]
+    #[cfg(target_os = "wasi")]
     use std::os::wasi::prelude::AsFd as _;
 }
 "#;


### PR DESCRIPTION
## Motivation

The `AsFd` implementations did not actually appear when building with rustc 1.63. The previous state of the probe generated a warning which resulted in `tokio_no_as_fd` being generated:

```
[tokio 1.28.0] error[E0658]: attributes on expressions are experimental
[tokio 1.28.0]  --> <anon>:3:5
[tokio 1.28.0]   |
[tokio 1.28.0] 3 |     #![allow(unused_imports)]
[tokio 1.28.0]   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
[tokio 1.28.0]   |
[tokio 1.28.0]   = note: see issue #15701 <https://github.com/rust-lang/rust/issues/15701> for more information
[tokio 1.28.0] 
[tokio 1.28.0] error: aborting due to previous error
[tokio 1.28.0] 
[tokio 1.28.0] For more information about this error, try `rustc --explain E0658`.
[tokio 1.28.0] cargo:rustc-cfg=tokio_no_as_fd
```

## Solution

Instead, add the `allow` to each import separately.

Tested this locally with rust 1.63 and it seemed to have the desired effect.