### PR TITLE
Merge 1.28.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.28.0", features = ["full"] }
+tokio = { version = "1.28.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.28.1 (May 10th, 2023)
+
+This release fixes a mistake in the build script that makes `AsFd`
+implementations unavailable on Rust 1.63. ([#5677])
+
+[#5677]: https://github.com/tokio-rs/tokio/pull/5677
+
 # 1.28.0 (April 25th, 2023)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.28.0"
+version = "1.28.1"
 edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.28.0", features = ["full"] }
+tokio = { version = "1.28.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -19,13 +19,14 @@ const CONST_MUTEX_NEW_PROBE: &str = r#"
 
 const AS_FD_PROBE: &str = r#"
 {
-    #![allow(unused_imports)]
-
+    #[allow(unused_imports)]
     #[cfg(unix)]
     use std::os::unix::prelude::AsFd as _;
+    #[allow(unused_imports)]
     #[cfg(windows)]
     use std::os::windows::prelude::AsSocket as _;
-    #[cfg(target = "wasm32-wasi")]
+    #[allow(unused_imports)]
+    #[cfg(target_os = "wasi")]
     use std::os::wasi::prelude::AsFd as _;
 }
 "#;


### PR DESCRIPTION
Merge tokio-1.28.x into master.

Refs: #5679

This commit sets up the history in the following way:
```text
*   89b73f39bfcd Merge 'tokio-1.28.x' into 'master' (#5680)
|\  
| * a26fc9c9f956 (tokio-1.28.x) chore: prepare Tokio v1.28.1 (#5679)
| * f2d033e4541d build: fix warnings in AS_FD_PROBE (#5677)
* | 7fe88ce4addf fuzz: remove unused code from `fuzz_steam_map.rs` (#5675)
* | c999699f5ed1 sync: remove 'static bound from `PollSender` (#5665)
* | 7430865d655d taskdump: instrument `JoinHandle` and `tokio::fs` (#5676)
* | 56239a9035a5 macros: fix typo in doc comment (#5671)
* | 1b4106a1ce7e net: add nodelay methods on TcpSocket (#5672)
* | 3abe877bf7de ci: check that `tokio/fuzz` compiles (#5670)
* | 61b68a8abc7e sync: implement more traits for channel errors (#5666)
* | 52bc6b6f2d77 fs: reduce blocking ops in `fs::read_dir` (#5653)
* | f478ff4a249b tokio: add `CountedLinkedList::for_each` (#5660)
* | 660eac71f0ac taskdump: implement task dumps for current-thread runtime (#5608)
* | 1d785fd66fce metrics: add metric for number of tasks (#5628)
* | 6a8f6f5a90a1 net: add uds doc alias for unix sockets (#5659)
* | 398dfda56d3e chore: prepare tokio-stream v0.1.14 (#5658)
* | 9bdc475539d1 stream: fix minimum Tokio dependency (#5657)
* | b5a5ddb4cfbe (tag: tokio-stream-0.1.13) chore: prepare tokio-stream v0.1.13 (#5652)
* | 74c6e6c68333 (tag: tokio-util-0.7.8) chore: prepare tokio-util v0.7.8 (#5651)
|/  
* f21d59609964 (tag: tokio-1.28.0) chore: prepare Tokio v1.28.0 (#5650)
```

**This branch must be merged from the command line! Do not use the GitHub UI!**