### PR TITLE
Add ci step to check tokio-stream/fuzz compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,6 +698,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
-      - name: Check tokio/
+      - name: Check /tokio/
         run: cargo fuzz check --all-features
         working-directory: tokio
+      - name: Check /tokio-stream/
+        run: cargo fuzz check --all-features
+        working-directory: tokio-stream


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Solves the `/tokio-stream/` piece of #5601 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Similar to the `/tokio/` check, adds step in CI to run `cargo fuzz check` on `/tokio-stream/` dir

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Closes:  #5601