### PR TITLE
add `Lazy` cell to `tokio::sync`

### DIFF
--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -474,19 +474,19 @@ impl<T: fmt::Debug, Fut, F> fmt::Debug for Lazy<T, Fut, F> {
     }
 }
 
-unsafe impl<T: Send, F: Send, Fut: Send> Send for Lazy<T, F, Fut> {}
+unsafe impl<T: Send, Fut: Send, F: Send> Send for Lazy<T, Fut, F> {}
 
 // We never create a `&F` from a `&Lazy<T, F>` so it is fine
 // to not require a `Sync` bound on `F`.
 // Need `T: Send + Sync` for `Sync` as the thread that intitializes
 // the cell could be different from the one that destroys it.
-unsafe impl<T: Send + Sync, F: Send, Fut: Send> Sync for Lazy<T, F, Fut> {}
+unsafe impl<T: Send + Sync, Fut: Send, F: Send> Sync for Lazy<T, Fut, F> {}
 
-impl<T: UnwindSafe, F: UnwindSafe, Fut: UnwindSafe> UnwindSafe for Lazy<T, F, Fut> {}
-impl<T: UnwindSafe + RefUnwindSafe, F: UnwindSafe, Fut: UnwindSafe> RefUnwindSafe
+impl<T: UnwindSafe, Fut: UnwindSafe, F: UnwindSafe> UnwindSafe for Lazy<T, Fut, F> {}
+impl<T: UnwindSafe + RefUnwindSafe, Fut: UnwindSafe, F: UnwindSafe> RefUnwindSafe
     for Lazy<T, F, Fut>
 {
 }
 
 // F is not structurally pinned
-impl<T: Unpin, F, Fut: Unpin> Unpin for Lazy<T, F, Fut> {}
+impl<T: Unpin, Fut: Unpin, F> Unpin for Lazy<T, Fut, F> {}

--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -1,10 +1,12 @@
 use super::Semaphore;
 use crate::loom::cell::UnsafeCell;
+use std::fmt;
 use std::future::Future;
+use std::mem::ManuallyDrop;
 use std::ops::Drop;
+use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{fmt, mem::ManuallyDrop};
 
 /// The inner data of a `Lazy`.
 /// Is `function` when not yet initialized,
@@ -325,3 +327,6 @@ unsafe impl<T: Send, F: Send> Send for Lazy<T, F> {}
 // We never create a `&F` from a `&Lazy<T, F>` so it is fine
 // to not require a `Sync` bound on `F`
 unsafe impl<T: Sync, F: Send> Sync for Lazy<T, F> {}
+
+impl<T: UnwindSafe, F: UnwindSafe> UnwindSafe for Lazy<T, F> {}
+impl<T: UnwindSafe + RefUnwindSafe, F: UnwindSafe> RefUnwindSafe for Lazy<T, F> {}

--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -325,8 +325,10 @@ impl<T: fmt::Debug, F> fmt::Debug for Lazy<T, F> {
 unsafe impl<T: Send, F: Send> Send for Lazy<T, F> {}
 
 // We never create a `&F` from a `&Lazy<T, F>` so it is fine
-// to not require a `Sync` bound on `F`
-unsafe impl<T: Sync, F: Send> Sync for Lazy<T, F> {}
+// to not require a `Sync` bound on `F`.
+// Need `T: Send + Sync` for `Sync` as the thread that intitializes
+// the cell could be different from the one that destroys it.
+unsafe impl<T: Send + Sync, F: Send> Sync for Lazy<T, F> {}
 
 impl<T: UnwindSafe, F: UnwindSafe> UnwindSafe for Lazy<T, F> {}
 impl<T: UnwindSafe + RefUnwindSafe, F: UnwindSafe> RefUnwindSafe for Lazy<T, F> {}

--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -127,7 +127,10 @@ impl<T, F> Lazy<T, F> {
     ///
     /// The `Lazy` must be initialized.
     unsafe fn get_unchecked_mut(&mut self) -> Option<&mut T> {
-        unsafe { self.value.with_mut(|v| (&mut *v).value.as_mut()) }
+        #[allow(clippy::needless_borrow)]
+        unsafe {
+            self.value.with_mut(|v| (&mut *v).value.as_mut())
+        }
     }
 
     /// Gets a reference to the result of this lazy value if it was initialized,

--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -1,0 +1,324 @@
+use super::Semaphore;
+use crate::loom::cell::UnsafeCell;
+use std::future::Future;
+use std::ops::Drop;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{fmt, mem::ManuallyDrop};
+
+/// The inner data of a `Lazy`.
+/// Is `function` when not yet initialized,
+/// `value` with `Some` when initialized,
+/// and `value` with `None` when poisoned.
+union LazyData<T, F> {
+    value: ManuallyDrop<Option<T>>,
+    function: ManuallyDrop<F>,
+}
+
+/// A value that is initialized on the first access.
+/// The initialization procedure is allowed to be asycnhronous,
+/// so access to the value requires an `await`.
+///
+/// # Example
+///
+/// ```
+/// use tokio::sync::Lazy;
+///
+/// async fn some_computation() -> u32 {
+///     1 + 1
+/// }
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let lazy : Lazy<u32> = Lazy::const_new(|| Box::pin(async { some_computation().await }));
+///
+///     let result = tokio::spawn(async move {
+///         *lazy.force().await
+///     }).await.unwrap();
+///
+///     assert_eq!(result, 2);
+/// }
+/// ```
+pub struct Lazy<T, F = fn() -> Pin<Box<dyn Future<Output = T> + Send>>> {
+    value_set: AtomicBool,
+    value: UnsafeCell<LazyData<T, F>>,
+    semaphore: Semaphore,
+}
+
+impl<T, F> Lazy<T, F> {
+    /// Creates a new empty `Lazy` instance with the given initializing
+    /// async function.
+    #[must_use]
+    #[inline]
+    pub fn new(init: F) -> Lazy<T, F> {
+        Lazy {
+            value_set: AtomicBool::new(false),
+            value: UnsafeCell::new(LazyData {
+                function: ManuallyDrop::new(init),
+            }),
+            semaphore: Semaphore::new(1),
+        }
+    }
+
+    /// Creates a new `Lazy` instance with the given initializing
+    /// async function.
+    ///
+    /// Equivalent to `Lazy::new`, except that it can be used in static
+    /// variables.
+    /// /// # Example
+    ///
+    /// ```
+    /// use tokio::sync::Lazy;
+    ///
+    /// async fn some_computation() -> u32 {
+    ///     1 + 1
+    /// }
+    ///
+    /// static LAZY : Lazy<u32> = Lazy::const_new(|| Box::pin(async { some_computation().await }));
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let result = tokio::spawn(async {
+    ///         *LAZY.force().await
+    ///     }).await.unwrap();
+    ///
+    ///     assert_eq!(result, 2);
+    /// }
+    /// ```
+    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "parking_lot")))]
+    #[must_use]
+    #[inline]
+    pub const fn const_new(init: F) -> Lazy<T, F> {
+        Lazy {
+            value_set: AtomicBool::new(false),
+            value: UnsafeCell::new(LazyData {
+                function: ManuallyDrop::new(init),
+            }),
+            semaphore: Semaphore::const_new(1),
+        }
+    }
+
+    /// Returns `true` if this `Lazy` has been initialized, and `false` otherwise.
+    fn initialized(&self) -> bool {
+        self.value_set.load(Ordering::Acquire)
+    }
+
+    /// Returns `true` if this `Lazy` has been initialized, and `false` otherwise.
+    /// Because it takes a mutable reference, it doesn't require an atomic operation.
+    fn initialized_mut(&mut self) -> bool {
+        *self.value_set.get_mut()
+    }
+
+    /// Returns a reference to the value,
+    /// or `None` if it has been poisoned.
+    ///
+    /// # Safety
+    ///
+    /// The `Lazy` must be initialized.
+    unsafe fn get_unchecked(&self) -> Option<&T> {
+        unsafe { self.value.with(|v| (*v).value.as_ref()) }
+    }
+
+    /// Returns a mutable reference to the value,
+    /// or `None` if it has been poisoned.
+    ///
+    /// # Safety
+    ///
+    /// The `Lazy` must be initialized.
+    unsafe fn get_unchecked_mut(&mut self) -> Option<&mut T> {
+        unsafe { self.value.with_mut(|v| (&mut *v).value.as_mut()) }
+    }
+
+    /// Gets a reference to the result of this lazy value if it was initialized,
+    /// otherwise returns `None`.
+    #[must_use]
+    #[inline]
+    pub fn get(&self) -> Option<&T> {
+        if self.initialized() {
+            // SAFETY: we just checked that the `Lazy` is initialized
+            unsafe { self.get_unchecked() }
+        } else {
+            None
+        }
+    }
+
+    /// Gets a mutable reference to the result of this lazy value if it was initialized,
+    /// otherwise returns `None`.
+    #[must_use]
+    #[inline]
+    pub fn get_mut(&mut self) -> Option<&mut T> {
+        if self.initialized_mut() {
+            // SAFETY: we just checked that the `Lazy` is initialized
+            unsafe { self.get_unchecked_mut() }
+        } else {
+            None
+        }
+    }
+
+    /// Consumes this Lazy returning the stored value.
+    /// Returns Ok(value) if Lazy is initialized and Err(f) otherwise.
+    ///
+    /// # Panics
+    ///
+    /// If this `Lazy` is poisoned because the initialization function panicked,
+    /// calls to this function will panic.
+
+    pub fn into_value(self) -> Result<T, F> {
+        // Prevent double-drop
+        let mut me = ManuallyDrop::new(self);
+
+        if me.initialized_mut() {
+            // SAFETY: we just checked that the `Lazy` is initialized.
+            let maybe_val = unsafe { me.value.with_mut(|v| ManuallyDrop::take(&mut (*v).value)) };
+            Ok(maybe_val.unwrap_or_else(|| panic!("Lazy instance has previously been poisoned")))
+        } else {
+            // SAFETY: we just checked that the `Lazy` is uninitialized.
+            // We own the `Lazy`, so there are no outstading references
+            // and it is not in the process of initialization.
+            Err(unsafe {
+                me.value
+                    .with_mut(|v| ManuallyDrop::take(&mut (*v).function))
+            })
+        }
+    }
+}
+
+impl<T, F, Fut> Lazy<T, F>
+where
+    F: FnOnce() -> Fut,
+    Fut: Future<Output = T>,
+{
+    /// Initializes the `Lazy`, if it has not yet been.
+    /// Once this has returned, `LazyData` is guaranteed to be in the `value` state.
+    #[cold]
+    async fn initialize(&self) {
+        // Here we try to acquire the semaphore permit. Holding the permit
+        // will allow us to set the value of the Lazy, and prevents
+        // other tasks from initializing the Lazy while we are holding
+        // it.
+        match self.semaphore.acquire().await {
+            Ok(permit) => {
+                debug_assert!(!self.initialized());
+
+                // No matter what happens, nobody will ever get another try
+                // at initializing the Lazy.
+                permit.forget();
+
+                // SAFETY: This lazy is uninitialized, so it still stores the initializing function.
+                let f = unsafe {
+                    self.value
+                        .with_mut(|v| ManuallyDrop::take(&mut (*v).function))
+                };
+
+                // If the function panics, we have to set the `Lazy` to poisoned.
+                // So all the initialization work happens on the `Drop` of this struct.
+                struct InitializeOnDrop<'a, T, F> {
+                    lazy: &'a Lazy<T, F>,
+                    value: ManuallyDrop<Option<T>>,
+                }
+
+                impl<'a, T, F> Drop for InitializeOnDrop<'a, T, F> {
+                    fn drop(&mut self) {
+                        // Write the new value to the `Lazy`.
+                        // SAFETY: we hold the only semaphore permit.
+                        // We are inside `drop`, so nobody will access our fields after us.
+                        unsafe {
+                            self.lazy.value.with_mut(|v| {
+                                (*v).value = ManuallyDrop::new(ManuallyDrop::take(&mut self.value))
+                            });
+                        }
+                        // FIXME this can be unsychronized when we have a mutable borrow of the `Lazy`
+                        self.lazy.value_set.store(true, Ordering::Release);
+                        self.lazy.semaphore.close();
+                    }
+                }
+
+                // Arm the initialize-on-drop-mechanism.
+                let mut initialize_on_drop = InitializeOnDrop {
+                    lazy: self,
+                    value: ManuallyDrop::new(None),
+                };
+
+                // Run the initializing function to get the new value.
+                // If this panics, `initialize_on_drop` is dropped with
+                // `value = None` and poisions the `Lazy`.
+                // Otherwise, it is dropped with the new value and initializes
+                // the `Lazy` with it.
+                initialize_on_drop.value = ManuallyDrop::new(Some(f().await));
+
+                drop(initialize_on_drop)
+            }
+            Err(_) => {
+                debug_assert!(self.initialized());
+            }
+        }
+    }
+
+    /// Forces the evaluation of this lazy value and returns a reference to the result.
+    ///
+    /// # Panics
+    ///
+    /// If the initialization function panics, the `Lazy` is poisoned
+    /// and all subsequent calls to this function will panic.
+    #[inline]
+    pub async fn force(&self) -> &T {
+        if !self.initialized() {
+            self.initialize().await;
+        }
+        // SAFETY: we just initialized the `Lazy`
+        (unsafe { self.get_unchecked() })
+            .unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+    }
+
+    /// Forces the evaluation of this lazy value and returns a mutable reference to the result.
+    ///
+    /// # Panics
+    ///
+    /// If the initialization function panics, the `Lazy` is poisoned
+    /// and all subsequent calls to this function will panic.
+    #[inline]
+    pub async fn force_mut(&mut self) -> &mut T {
+        if !self.initialized_mut() {
+            self.initialize().await;
+        }
+        // SAFETY: we just initialized the `Lazy`
+        (unsafe { self.get_unchecked_mut() })
+            .unwrap_or_else(|| panic!("Lazy instance has previously been poisoned"))
+    }
+}
+
+impl<T, F> Drop for Lazy<T, F> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.initialized_mut() {
+            // SAFETY: we just checked for the `Lazy` being initialized.
+            // We are inside `drop`, so nobody will access our fields after us.
+            unsafe { self.value.with_mut(|v| ManuallyDrop::drop(&mut (*v).value)) };
+        } else {
+            // SAFETY: we just check for the `Lazy` being uninitialized.
+            // We hold an `&mut` to this `Lazy`, so nobody else is in the process of initializing it.
+            // We are inside `drop`, so nobody will access our fields after us.
+            unsafe {
+                self.value
+                    .with_mut(|v| ManuallyDrop::drop(&mut (*v).function))
+            };
+        }
+    }
+}
+
+impl<T: fmt::Debug, F> fmt::Debug for Lazy<T, F> {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.get() {
+            Some(v) => f.debug_tuple("Lazy").field(v).finish(),
+            None => f.write_str("Lazy(Uninit)"),
+        }
+    }
+}
+
+unsafe impl<T: Send, F: Send> Send for Lazy<T, F> {}
+
+// We never create a `&F` from a `&Lazy<T, F>` so it is fine
+// to not require a `Sync` bound on `F`
+unsafe impl<T: Sync, F: Send> Sync for Lazy<T, F> {}

--- a/tokio/src/sync/lazy.rs
+++ b/tokio/src/sync/lazy.rs
@@ -478,7 +478,7 @@ unsafe impl<T: Send, Fut: Send, F: Send> Send for Lazy<T, Fut, F> {}
 
 // We never create a `&F` from a `&Lazy<T, F>` so it is fine
 // to not require a `Sync` bound on `F`.
-// Need `T: Send + Sync` for `Sync` as the thread that intitializes
+// Need `T: Send + Sync` for `Sync` as the thread that initializes
 // the cell could be different from the one that destroys it.
 unsafe impl<T: Send + Sync, Fut: Send, F: Send> Sync for Lazy<T, Fut, F> {}
 

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -434,6 +434,10 @@
 //!   holds a number of permits, which tasks may request in order to enter a
 //!   critical section. Semaphores are useful for implementing limiting or
 //!   bounding of any kind.
+//!
+//! * [`OnceCell`](OnceCell) A value that can be initialized only once.
+//!  
+//! * [`Lazy`](Lazy) A value that is lazily initialized on first access.
 
 cfg_sync! {
     /// Named future types.
@@ -476,6 +480,9 @@ cfg_sync! {
 
     mod once_cell;
     pub use self::once_cell::{OnceCell, SetError};
+
+    mod lazy;
+    pub use self::lazy::Lazy;
 
     pub mod watch;
 }

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -331,6 +331,15 @@ mod windows_signal {
 assert_value!(tokio::sync::AcquireError: Send & Sync & Unpin);
 assert_value!(tokio::sync::Barrier: Send & Sync & Unpin);
 assert_value!(tokio::sync::BarrierWaitResult: Send & Sync & Unpin);
+assert_value!(tokio::sync::Lazy<NN,NN>: !Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<NN,YN>: !Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<NN,YY>: !Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YN,NN>: !Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YN,YN>: Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YN,YY>: Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YY,NN>: !Send & !Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YY,YN>: Send & Sync & Unpin);
+assert_value!(tokio::sync::Lazy<YY,YY>: Send & Sync & Unpin);
 assert_value!(tokio::sync::MappedMutexGuard<'_, NN>: !Send & !Sync & Unpin);
 assert_value!(tokio::sync::MappedMutexGuard<'_, YN>: Send & !Sync & Unpin);
 assert_value!(tokio::sync::MappedMutexGuard<'_, YY>: Send & Sync & Unpin);

--- a/tokio/tests/sync_lazy.rs
+++ b/tokio/tests/sync_lazy.rs
@@ -2,9 +2,8 @@
 #![cfg(all(feature = "full", feature = "parking_lot"))]
 
 use core::panic;
-use futures::poll;
+use futures::{pin_mut, poll};
 use std::ops::Drop;
-use std::pin::pin;
 use std::sync::atomic::{AtomicU32, Ordering};
 use tokio::runtime;
 use tokio::sync::Lazy;
@@ -77,7 +76,8 @@ fn force_cancel() {
 
     rt.block_on(async {
         let handle1 = rt.spawn(async {
-            let fut = pin!(LAZY.force());
+            let fut = LAZY.force();
+            pin_mut!(fut);
             let _ = poll!(fut);
         });
         let handle2 = rt.spawn(async {

--- a/tokio/tests/sync_lazy.rs
+++ b/tokio/tests/sync_lazy.rs
@@ -1,0 +1,172 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", feature = "parking_lot"))]
+
+use core::panic;
+use std::ops::Drop;
+use std::sync::atomic::{AtomicU32, Ordering};
+use tokio::runtime;
+use tokio::sync::Lazy;
+use tokio::time;
+
+use std::time::Duration;
+
+#[test]
+fn drop_lazy() {
+    let rt = runtime::Builder::new_current_thread().build().unwrap();
+
+    static NUM_DROPS: AtomicU32 = AtomicU32::new(0);
+
+    rt.block_on(async {
+        struct Foo {}
+
+        let fooer = Foo {};
+
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                NUM_DROPS.fetch_add(1, Ordering::Release);
+            }
+        }
+
+        {
+            let lazy = Lazy::new(|| Box::pin(async { fooer }));
+            lazy.force().await;
+        }
+        assert!(NUM_DROPS.load(Ordering::Acquire) == 1);
+    });
+}
+
+#[test]
+fn drop_into_value() {
+    let rt = runtime::Builder::new_current_thread().build().unwrap();
+
+    static NUM_DROPS: AtomicU32 = AtomicU32::new(0);
+
+    rt.block_on(async {
+        struct Foo {}
+
+        let fooer = Foo {};
+
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                NUM_DROPS.fetch_add(1, Ordering::Release);
+            }
+        }
+
+        let lazy = Lazy::new(|| Box::pin(async { fooer }));
+        lazy.force().await;
+
+        let fooer = lazy
+            .into_value()
+            .unwrap_or_else(|_| panic!("lazy should be initialized"));
+        let count = NUM_DROPS.load(Ordering::Acquire);
+        assert!(count == 0);
+        drop(fooer);
+        let count = NUM_DROPS.load(Ordering::Acquire);
+        assert!(count == 1);
+    });
+}
+
+#[test]
+fn drop_into_value_err() {
+    let rt = runtime::Builder::new_current_thread().build().unwrap();
+
+    static NUM_DROPS: AtomicU32 = AtomicU32::new(0);
+
+    rt.block_on(async {
+        #[derive(Debug)]
+        struct Foo {}
+
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                NUM_DROPS.fetch_add(1, Ordering::Release);
+            }
+        }
+
+        let fooer = Foo {};
+
+        let lazy: Lazy<Foo, _> = Lazy::new(|| fooer);
+
+        let get_a_fooer = lazy.into_value().unwrap_err();
+        let count = NUM_DROPS.load(Ordering::Acquire);
+        assert!(count == 0);
+        drop(get_a_fooer);
+        let count = NUM_DROPS.load(Ordering::Acquire);
+        assert!(count == 1);
+    });
+}
+
+#[test]
+fn force() {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()
+        .unwrap();
+
+    static LAZY: Lazy<u32> = Lazy::const_new(|| Box::pin(async { 5 }));
+
+    rt.block_on(async {
+        let handle1 = rt.spawn(async { *LAZY.force().await });
+        let handle2 = rt.spawn(async {
+            time::sleep(Duration::from_millis(1)).await;
+            *LAZY.force().await
+        });
+
+        time::advance(Duration::from_millis(1)).await;
+        time::resume();
+
+        let result1 = handle1.await.unwrap();
+        let result2 = handle2.await.unwrap();
+
+        assert_eq!(result1, 5);
+        assert_eq!(result2, 5);
+    });
+}
+
+#[test]
+#[cfg_attr(not(panic = "unwind"), should_panic)]
+fn force_panic() {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_time()
+        .start_paused(true)
+        .build()
+        .unwrap();
+
+    static LAZY: Lazy<u32> = Lazy::const_new(|| Box::pin(async { panic!() }));
+
+    rt.block_on(async {
+        let handle1 = rt.spawn(async { *LAZY.force().await });
+        let handle2 = rt.spawn(async {
+            time::sleep(Duration::from_millis(1)).await;
+            *LAZY.force().await
+        });
+
+        time::advance(Duration::from_millis(1)).await;
+        time::resume();
+
+        handle1.await.unwrap_err();
+        handle2.await.unwrap_err();
+
+        assert_eq!(LAZY.get(), None);
+    });
+}
+
+#[test]
+fn force_and_get() {
+    let rt = runtime::Builder::new_current_thread().build().unwrap();
+
+    static LAZY: Lazy<u32> = Lazy::const_new(|| Box::pin(async { 5 }));
+
+    rt.block_on(async {
+        let _ = rt.spawn(async { LAZY.force().await }).await;
+        let value = *LAZY.get().unwrap();
+        assert_eq!(value, 5);
+    });
+}
+
+#[test]
+fn get_uninit() {
+    static LAZY: Lazy<u32> = Lazy::const_new(|| Box::pin(async { panic!() }));
+    let uninit = LAZY.get();
+    assert!(uninit.is_none());
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Often, you need to initialize some global state once, early on program startup. The sync `Lazy` solves that problem for sync code, this does so for async code.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Adds a new `Lazy` type to `tokio::sync`, analogous to `once_cell::sync::lazy` or `std::sync::LazyLock`. Unlike those types, this `Lazy` takes an async closure instead of a sync one.

Because of this, the tokio `Lazy` can't implement `Deref` or `DerefMut`, which makes its API much less ergonomic. However, `#![feature(impl_trait_in_assoc_type)]` will likely be stabilized relatively soon. That will allow implementing `IntoFuture` for `&Lazy` and `&mut Lazy`, which will close much of the ergonomic gap.

One wart with this API is the default type parameter `F = fn() -> Pin<Box<dyn Future<Output = T> + Send>>`. The sync `Lazy` deals with this as well, but it's even worse for async as the future type also needs to be nameable. Hopefully `#![feature(type_alias_impl_trait)]` will help with this someday.