### PR TITLE
Fix stacked borrows issue in `IdleNotifiedSet`

### DIFF
--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -460,3 +460,22 @@ unsafe impl<T> linked_list::Link for ListEntry<T> {
         ListEntry::addr_of_pointers(target)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::runtime::Builder;
+    use crate::task::JoinSet;
+
+    // A test that runs under miri.
+    //
+    // https://github.com/tokio-rs/tokio/pull/5693
+    #[test]
+    fn join_set_test() {
+        let rt = Builder::new_current_thread().build().unwrap();
+
+        let mut set = JoinSet::new();
+        set.spawn_on(futures::future::ready(()), rt.handle());
+
+        rt.block_on(set.join_next()).unwrap().unwrap();
+    }
+}

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -421,7 +421,7 @@ impl<T: 'static> Wake for ListEntry<T> {
             // We move ourself to the notified list.
             let me = unsafe {
                 // Safety: We just checked that we are in this particular list.
-                lock.idle.remove(NonNull::from(&**me)).unwrap()
+                lock.idle.remove(ListEntry::as_raw(me)).unwrap()
             };
             lock.notified.push_front(me);
 


### PR DESCRIPTION
This PR avoids a raw pointer → reference → raw pointer conversion because it violates stacked borrows.

When I wrote this code originally, I didn't think this was an issue because it is used with `LinkedList::remove`, which shouldn't leave any raw pointers derived from the reference anywhere. However, the return value of `remove` gets is provenance from the pointer passed to `remove`, so when `me` is inserted in the other linked list, that raw pointer is derived from the reference.

Note that the code is valid under tree borrows since the reference points at something containing an `UnsafeCell`. Therefore, this issue should not lead to miscompilations.

Refs: https://github.com/tokio-rs/tokio/issues/3399#issuecomment-1546419558
Cc @udoprog 