### PR TITLE
ci: skip miri tests when running loom

### DIFF
--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -461,7 +461,7 @@ unsafe impl<T> linked_list::Link for ListEntry<T> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod tests {
     use crate::runtime::Builder;
     use crate::task::JoinSet;


### PR DESCRIPTION
Disables a recently added miri test when running loom tests.
