### PR TITLE
process: add `raw_arg` method to `Command`

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -404,7 +404,7 @@ impl Command {
     ///
     /// This is useful for passing arguments to `cmd.exe /c`, which doesn't follow
     /// `CommandLineToArgvW` escaping rules.
-    /// 
+    ///
     /// **Note**: This is an [unstable API][unstable] but will be stabilised once
     /// tokio's MSRV is sufficiently new. See [the documentation on
     /// unstable features][unstable] for details about using unstable features.
@@ -1111,7 +1111,7 @@ impl Child {
             }
         }
     }
-    
+
     /// Attempts to force the child to exit, but does not wait for the request
     /// to take effect.
     ///

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -400,15 +400,20 @@ impl Command {
         self
     }
 
-    cfg_windows! {
-        /// Append literal text to the command line without any quoting or escaping.
-        ///
-        /// This is useful for passing arguments to `cmd.exe /c`, which doesn't follow
-        /// `CommandLineToArgvW` escaping rules.
-        pub fn raw_arg<S: AsRef<OsStr>>(&mut self, text_to_append_as_is: S) -> &mut Command {
-            self.std.raw_arg(text_to_append_as_is);
-            self
-        }
+    /// Append literal text to the command line without any quoting or escaping.
+    ///
+    /// This is useful for passing arguments to `cmd.exe /c`, which doesn't follow
+    /// `CommandLineToArgvW` escaping rules.
+    /// 
+    /// **Note**: This is an [unstable API][unstable] but will be stabilised once
+    /// tokio's MSRV is sufficiently new. See [the documentation on
+    /// unstable features][unstable] for details about using unstable features.
+    #[cfg(windows)]
+    #[cfg(tokio_unstable)]
+    #[cfg_attr(docsrs, doc(cfg(all(windows, tokio_unstable))))]
+    pub fn raw_arg<S: AsRef<OsStr>>(&mut self, text_to_append_as_is: S) -> &mut Command {
+        self.std.raw_arg(text_to_append_as_is);
+        self
     }
 
     /// Inserts or updates an environment variable mapping.
@@ -1096,7 +1101,9 @@ impl Child {
         }
     }
 
-    cfg_windows! {
+    #[cfg(windows)]
+    #[cfg(tokio_unstable)]
+    #[cfg_attr(docsrs, doc(cfg(all(windows, tokio_unstable))))]
         /// Extracts the raw handle of the process associated with this child while
         /// it is still running. Returns `None` if the child has exited.
         pub fn raw_handle(&self) -> Option<RawHandle> {
@@ -1105,7 +1112,7 @@ impl Child {
                 FusedChild::Done(_) => None,
             }
         }
-    }
+
 
     /// Attempts to force the child to exit, but does not wait for the request
     /// to take effect.

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -400,6 +400,17 @@ impl Command {
         self
     }
 
+    cfg_windows! {
+        /// Append literal text to the command line without any quoting or escaping.
+        ///
+        /// This is useful for passing arguments to `cmd.exe /c`, which doesn't follow
+        /// `CommandLineToArgvW` escaping rules.
+        pub fn raw_arg<S: AsRef<OsStr>>(&mut self, text_to_append_as_is: S) -> &mut Command {
+            self.std.raw_arg(text_to_append_as_is);
+            self
+        }
+    }
+
     /// Inserts or updates an environment variable mapping.
     ///
     /// Note that environment variable names are case-insensitive (but case-preserving) on Windows,

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1101,9 +1101,7 @@ impl Child {
         }
     }
 
-    #[cfg(windows)]
-    #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(all(windows, tokio_unstable))))]
+    cfg_windows! {
         /// Extracts the raw handle of the process associated with this child while
         /// it is still running. Returns `None` if the child has exited.
         pub fn raw_handle(&self) -> Option<RawHandle> {
@@ -1112,8 +1110,8 @@ impl Child {
                 FusedChild::Done(_) => None,
             }
         }
-
-
+    }
+    
     /// Attempts to force the child to exit, but does not wait for the request
     /// to take effect.
     ///


### PR DESCRIPTION
Adds the `raw_arg` method to `tokio::process::Command`
