### PR TITLE
rt: batch pop from injection queue when idle

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -24,13 +24,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scope:
-          - --skip loom_pool
-          - loom_pool::group_a
-          - loom_pool::group_b
-          - loom_pool::group_c
-          - loom_pool::group_d
-          - time::driver
+        include:
+          - scope: --skip loom_pool
+            max_preemptions: 2
+          - scope: loom_pool::group_a
+            max_preemptions: 1
+          - scope: loom_pool::group_b
+            max_preemptions: 2
+          - scope: loom_pool::group_c
+            max_preemptions: 1
+          - scope: loom_pool::group_d
+            max_preemptions: 1
+          - scope: time::driver
+            max_preemptions: 2
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}
@@ -43,6 +49,6 @@ jobs:
         working-directory: tokio
         env:
           RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings
-          LOOM_MAX_PREEMPTIONS: 2
+          LOOM_MAX_PREEMPTIONS: ${{ matrix.max_preemptions }}
           LOOM_MAX_BRANCHES: 10000
           SCOPE: ${{ matrix.scope }}

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -111,8 +111,8 @@ impl<T> Local<T> {
     }
 
     /// How many tasks can be pushed into the queue
-    pub(crate) fn capacity(&self) -> usize {
-        self.inner.capacity()
+    pub(crate) fn remaining_slots(&self) -> usize {
+        self.inner.remaining_slots()
     }
 
     pub(crate) fn max_capacity(&self) -> usize {
@@ -569,7 +569,7 @@ impl<T> Drop for Local<T> {
 }
 
 impl<T> Inner<T> {
-    fn capacity(&self) -> usize {
+    fn remaining_slots(&self) -> usize {
         let (steal, _) = unpack(self.head.load(Acquire));
         let tail = self.tail.load(Acquire);
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -634,11 +634,15 @@ impl Core {
 
             let n = cmp::min(n, self.run_queue.max_capacity() / 2);
 
-            worker.inject().pop_n(n, |task| {
-                if self.run_queue.push_back(task).is_err() {
-                    panic!("[internal Tokio bug] pushing to local queue failed.");
-                }
-            })
+            let mut tasks = worker.inject().pop_n(n);
+
+            // Pop the first task to return immedietly
+            let ret = tasks.next();
+
+            // Push the rest of the on the run queue
+            self.run_queue.push_back(tasks);
+
+            ret
         }
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -68,6 +68,7 @@ use crate::util::atomic_cell::AtomicCell;
 use crate::util::rand::{FastRand, RngSeedGenerator};
 
 use std::cell::RefCell;
+use std::cmp;
 use std::time::Duration;
 
 /// A scheduler worker
@@ -509,8 +510,11 @@ impl Context {
                 } else {
                     // Not enough budget left to run the LIFO task, push it to
                     // the back of the queue and return.
-                    core.run_queue
-                        .push_back(task, self.worker.inject(), &mut core.metrics);
+                    core.run_queue.push_back_or_overflow(
+                        task,
+                        self.worker.inject(),
+                        &mut core.metrics,
+                    );
                     return Ok(core);
                 }
             }
@@ -612,7 +616,29 @@ impl Core {
         if self.tick % worker.handle.shared.config.global_queue_interval == 0 {
             worker.inject().pop().or_else(|| self.next_local_task())
         } else {
-            self.next_local_task().or_else(|| worker.inject().pop())
+            let maybe_task = self.next_local_task();
+
+            if maybe_task.is_some() {
+                return maybe_task;
+            }
+
+            let cap = self.run_queue.capacity();
+
+            // The worker is currently idle, pull a batch of work from the
+            // injection queue. We don't want to pull *all* the work so other
+            // workers can also get some.
+            let n = cmp::min(
+                worker.inject().len() / worker.handle.shared.remotes.len() + 1,
+                cap,
+            );
+
+            let n = cmp::min(n, self.run_queue.max_capacity() / 2);
+
+            worker.inject().pop_n(n, |task| {
+                if self.run_queue.push_back(task).is_err() {
+                    panic!("[internal Tokio bug] pushing to local queue failed.");
+                }
+            })
         }
     }
 
@@ -808,7 +834,7 @@ impl Handle {
         // flexibility and the task may go to the front of the queue.
         let should_notify = if is_yield || self.shared.config.disable_lifo_slot {
             core.run_queue
-                .push_back(task, &self.shared.inject, &mut core.metrics);
+                .push_back_or_overflow(task, &self.shared.inject, &mut core.metrics);
             true
         } else {
             // Push to the LIFO slot
@@ -817,7 +843,7 @@ impl Handle {
 
             if let Some(prev) = prev {
                 core.run_queue
-                    .push_back(prev, &self.shared.inject, &mut core.metrics);
+                    .push_back_or_overflow(prev, &self.shared.inject, &mut core.metrics);
             }
 
             core.lifo_slot = Some(task);

--- a/tokio/src/runtime/task/inject.rs
+++ b/tokio/src/runtime/task/inject.rs
@@ -131,14 +131,14 @@ impl<T: 'static> Inject<T> {
         // Lock the queue
         let p = self.pointers.lock();
 
-        let n = cmp::min(n, unsafe { self.len.unsync_load() });
-
-        // Decrement the count.
-        //
         // safety: All updates to the len atomic are guarded by the mutex. As
         // such, a non-atomic load followed by a store is safe.
-        self.len
-            .store(unsafe { self.len.unsync_load() } - n, Release);
+        let len = unsafe { self.len.unsync_load() };
+
+        let n = cmp::min(n, len);
+
+        // Decrement the count.
+        self.len.store(len - n, Release);
 
         Pop {
             len: n,

--- a/tokio/src/runtime/task/inject.rs
+++ b/tokio/src/runtime/task/inject.rs
@@ -261,7 +261,7 @@ impl<'a, T: 'static> ExactSizeIterator for Pop<'a, T> {
 
 impl<'a, T: 'static> Drop for Pop<'a, T> {
     fn drop(&mut self) {
-        while let Some(_) = self.next() {}
+        for _ in self.by_ref() {}
     }
 }
 

--- a/tokio/src/runtime/tests/inject.rs
+++ b/tokio/src/runtime/tests/inject.rs
@@ -1,0 +1,38 @@
+use crate::runtime::task::{Inject};
+
+#[test]
+fn push_and_pop() {
+    let inject = Inject::new();
+
+    for _ in 0..10 {
+        let (task, _) = super::unowned(async { });
+        inject.push(task);
+    }
+
+    for _ in 0..10 {
+        assert!(inject.pop().is_some());
+    }
+
+    assert!(inject.pop().is_none());
+}
+
+#[test]
+fn push_batch_and_pop() {
+    let inject = Inject::new();
+    
+    inject.push_batch((0..10).map(|_| super::unowned(async {}).0));
+
+    assert_eq!(5, inject.pop_n(5).collect::<Vec<_>>().len());
+    assert_eq!(5, inject.pop_n(5).collect::<Vec<_>>().len());
+    assert_eq!(0, inject.pop_n(5).collect::<Vec<_>>().len());
+}
+
+#[test]
+fn pop_n_drains_on_drop() {
+    let inject = Inject::new();
+    
+    inject.push_batch((0..10).map(|_| super::unowned(async {}).0));
+    let _ = inject.pop_n(10);
+
+    assert_eq!(inject.len(), 0);
+}

--- a/tokio/src/runtime/tests/inject.rs
+++ b/tokio/src/runtime/tests/inject.rs
@@ -1,11 +1,11 @@
-use crate::runtime::task::{Inject};
+use crate::runtime::task::Inject;
 
 #[test]
 fn push_and_pop() {
     let inject = Inject::new();
 
     for _ in 0..10 {
-        let (task, _) = super::unowned(async { });
+        let (task, _) = super::unowned(async {});
         inject.push(task);
     }
 
@@ -19,7 +19,7 @@ fn push_and_pop() {
 #[test]
 fn push_batch_and_pop() {
     let inject = Inject::new();
-    
+
     inject.push_batch((0..10).map(|_| super::unowned(async {}).0));
 
     assert_eq!(5, inject.pop_n(5).collect::<Vec<_>>().len());
@@ -30,7 +30,7 @@ fn push_batch_and_pop() {
 #[test]
 fn pop_n_drains_on_drop() {
     let inject = Inject::new();
-    
+
     inject.push_batch((0..10).map(|_| super::unowned(async {}).0));
     let _ = inject.pop_n(10);
 

--- a/tokio/src/runtime/tests/inject.rs
+++ b/tokio/src/runtime/tests/inject.rs
@@ -22,9 +22,9 @@ fn push_batch_and_pop() {
 
     inject.push_batch((0..10).map(|_| super::unowned(async {}).0));
 
-    assert_eq!(5, inject.pop_n(5).collect::<Vec<_>>().len());
-    assert_eq!(5, inject.pop_n(5).collect::<Vec<_>>().len());
-    assert_eq!(0, inject.pop_n(5).collect::<Vec<_>>().len());
+    assert_eq!(5, inject.pop_n(5).count());
+    assert_eq!(5, inject.pop_n(5).count());
+    assert_eq!(0, inject.pop_n(5).count());
 }
 
 #[test]

--- a/tokio/src/runtime/tests/loom_queue.rs
+++ b/tokio/src/runtime/tests/loom_queue.rs
@@ -39,7 +39,7 @@ fn basic() {
         for _ in 0..2 {
             for _ in 0..2 {
                 let (task, _) = super::unowned(async {});
-                local.push_back(task, &inject, &mut metrics);
+                local.push_back_or_overflow(task, &inject, &mut metrics);
             }
 
             if local.pop().is_some() {
@@ -48,7 +48,7 @@ fn basic() {
 
             // Push another task
             let (task, _) = super::unowned(async {});
-            local.push_back(task, &inject, &mut metrics);
+            local.push_back_or_overflow(task, &inject, &mut metrics);
 
             while local.pop().is_some() {
                 n += 1;
@@ -92,7 +92,7 @@ fn steal_overflow() {
 
         // push a task, pop a task
         let (task, _) = super::unowned(async {});
-        local.push_back(task, &inject, &mut metrics);
+        local.push_back_or_overflow(task, &inject, &mut metrics);
 
         if local.pop().is_some() {
             n += 1;
@@ -100,7 +100,7 @@ fn steal_overflow() {
 
         for _ in 0..6 {
             let (task, _) = super::unowned(async {});
-            local.push_back(task, &inject, &mut metrics);
+            local.push_back_or_overflow(task, &inject, &mut metrics);
         }
 
         n += th.join().unwrap();
@@ -146,7 +146,7 @@ fn multi_stealer() {
         // Push work
         for _ in 0..NUM_TASKS {
             let (task, _) = super::unowned(async {});
-            local.push_back(task, &inject, &mut metrics);
+            local.push_back_or_overflow(task, &inject, &mut metrics);
         }
 
         let th1 = {
@@ -184,10 +184,10 @@ fn chained_steal() {
         // Load up some tasks
         for _ in 0..4 {
             let (task, _) = super::unowned(async {});
-            l1.push_back(task, &inject, &mut metrics);
+            l1.push_back_or_overflow(task, &inject, &mut metrics);
 
             let (task, _) = super::unowned(async {});
-            l2.push_back(task, &inject, &mut metrics);
+            l2.push_back_or_overflow(task, &inject, &mut metrics);
         }
 
         // Spawn a task to steal from **our** queue

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -63,6 +63,7 @@ cfg_loom! {
 }
 
 cfg_not_loom! {
+    mod inject;
     mod queue;
 
     #[cfg(not(miri))]

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -34,7 +34,7 @@ fn fits_256() {
 
     for _ in 0..256 {
         let (task, _) = super::unowned(async {});
-        local.push_back(task, &inject, &mut metrics);
+        local.push_back_or_overflow(task, &inject, &mut metrics);
     }
 
     cfg_metrics! {
@@ -54,7 +54,7 @@ fn overflow() {
 
     for _ in 0..257 {
         let (task, _) = super::unowned(async {});
-        local.push_back(task, &inject, &mut metrics);
+        local.push_back_or_overflow(task, &inject, &mut metrics);
     }
 
     cfg_metrics! {
@@ -84,7 +84,7 @@ fn steal_batch() {
 
     for _ in 0..4 {
         let (task, _) = super::unowned(async {});
-        local1.push_back(task, &inject, &mut metrics);
+        local1.push_back_or_overflow(task, &inject, &mut metrics);
     }
 
     assert!(steal1.steal_into(&mut local2, &mut metrics).is_some());
@@ -157,7 +157,7 @@ fn stress1() {
         for _ in 0..NUM_LOCAL {
             for _ in 0..NUM_PUSH {
                 let (task, _) = super::unowned(async {});
-                local.push_back(task, &inject, &mut metrics);
+                local.push_back_or_overflow(task, &inject, &mut metrics);
             }
 
             for _ in 0..NUM_POP {
@@ -215,7 +215,7 @@ fn stress2() {
 
         for i in 0..NUM_TASKS {
             let (task, _) = super::unowned(async {});
-            local.push_back(task, &inject, &mut metrics);
+            local.push_back_or_overflow(task, &inject, &mut metrics);
 
             if i % 128 == 0 && local.pop().is_some() {
                 num_pop += 1;

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -518,7 +518,7 @@ fn injection_queue_depth() {
     for _ in 0..10 {
         rt.spawn(async {
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-         });
+        });
     }
 
     thread::spawn(move || {

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -514,6 +514,13 @@ fn injection_queue_depth() {
     rt.spawn(async move { rx1.recv().unwrap() });
     rt.spawn(async move { rx2.recv().unwrap() });
 
+    // Spawn some more to make sure there are items
+    for _ in 0..10 {
+        rt.spawn(async {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+         });
+    }
+
     thread::spawn(move || {
         handle.spawn(async {});
     })
@@ -522,7 +529,7 @@ fn injection_queue_depth() {
 
     let n = metrics.injection_queue_depth();
     assert!(1 <= n, "{}", n);
-    assert!(3 >= n, "{}", n);
+    assert!(15 >= n, "{}", n);
 
     tx1.send(()).unwrap();
     tx2.send(()).unwrap();


### PR DESCRIPTION
In the multi-threaded scheduler, when no tasks are on the local queue, a worker will attempt to pull tasks from the injection queue. Previously, the worker would only attempt to poll one task from the injection queue and then continue trying to find work from other sources. This can result in the injection queue backing up when many tasks are scheduled outside the runtime.

This patch updates the worker to try to poll more than one task from the injection queue when it has no more local work. Note that we also don't want a single worker to poll **all** tasks on the injection queue, as that would result in work becoming unbalanced.

## Benchmarks:

I added some new benchmarks. All benchmark results are the same except for `spawn_many_remote_busy`

**Before:**

test spawn_many_remote_busy ... bench:  10,140,229 ns/iter (+/- 1,142,091)

**After:**

test spawn_many_remote_busy ... bench:   8,143,800 ns/iter (+/- 426,671)

