### PR TITLE
time: Do not overflow to signal value

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -72,6 +72,10 @@ type TimerResult = Result<(), crate::time::error::Error>;
 const STATE_DEREGISTERED: u64 = u64::MAX;
 const STATE_PENDING_FIRE: u64 = STATE_DEREGISTERED - 1;
 const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
+/// The largest safe integer to use for ticks.
+///
+/// This value should be updated if any other signal values are added above.
+pub(super) const MAX_SAFE_MILLIS_DURATION: u64 = u64::MAX - 2;
 
 /// This structure holds the current shared state of the timer - its scheduled
 /// time (if registered), or otherwise the result of the timer completing, as
@@ -126,7 +130,7 @@ impl StateCell {
     fn when(&self) -> Option<u64> {
         let cur_state = self.state.load(Ordering::Relaxed);
 
-        if cur_state == u64::MAX {
+        if cur_state == STATE_DEREGISTERED {
             None
         } else {
             Some(cur_state)

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -8,7 +8,7 @@
 
 mod entry;
 pub(crate) use entry::TimerEntry;
-use entry::{EntryList, TimerHandle, TimerShared};
+use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION};
 
 mod handle;
 pub(crate) use self::handle::Handle;

--- a/tokio/src/runtime/time/source.rs
+++ b/tokio/src/runtime/time/source.rs
@@ -1,3 +1,4 @@
+use super::MAX_SAFE_MILLIS_DURATION;
 use crate::time::{Clock, Duration, Instant};
 
 /// A structure which handles conversion from Instants to u64 timestamps.
@@ -25,7 +26,7 @@ impl TimeSource {
             .unwrap_or_else(|| Duration::from_secs(0));
         let ms = dur.as_millis();
 
-        ms.try_into().unwrap_or(u64::MAX)
+        ms.try_into().unwrap_or(MAX_SAFE_MILLIS_DURATION)
     }
 
     pub(crate) fn tick_to_duration(&self, t: u64) -> Duration {

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -274,6 +274,7 @@ async fn issue_5183() {
     let big = std::time::Duration::from_secs(u64::MAX / 10);
     // This is a workaround since awaiting sleep(big) will never finish.
     tokio::select! {
+    biased;
         _ = tokio::time::sleep(big) => {}
         _ = tokio::time::sleep(std::time::Duration::from_nanos(1)) => {}
     }

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -268,6 +268,18 @@ async fn exactly_max() {
 }
 
 #[tokio::test]
+async fn issue_5183() {
+    time::pause();
+
+    let big = std::time::Duration::from_secs(u64::MAX / 10);
+    // This is a workaround since awaiting sleep(big) will never finish.
+    tokio::select! {
+        _ = tokio::time::sleep(big) => {}
+        _ = tokio::time::sleep(std::time::Duration::from_nanos(1)) => {}
+    }
+}
+
+#[tokio::test]
 async fn no_out_of_bounds_close_to_max() {
     time::pause();
     time::sleep(ms(MAX_DURATION - 1)).await;

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -273,8 +273,9 @@ async fn issue_5183() {
 
     let big = std::time::Duration::from_secs(u64::MAX / 10);
     // This is a workaround since awaiting sleep(big) will never finish.
+    #[rustfmt::skip]
     tokio::select! {
-    biased;
+	biased;
         _ = tokio::time::sleep(big) => {}
         _ = tokio::time::sleep(std::time::Duration::from_nanos(1)) => {}
     }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

As described in #5183, Tokio will panic if you sleep far, but not too far into the future.
This can cause issues and crashes in some cases where you don't expect it which is the main motivation for solving it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The issue is that the time value will overflow and then get set to `u64::MAX`, `u64::MAX` is also used as the signal value for the state `STATE_DEREGISTERED` which will cause the [`when`] function to think that the time already have fired and thus been deregistered.

If the program is run in debug mode it will fail a bit earlier because of a [`debug_assert`]

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Issue with this PR

This PR will currently never complete CI since the test I have added fails to ever complete. I am not sure how that should be resolved so I have opened this PR to discuss it as well. Should it be commented out or can it be made to work instead.

[`when`]: https://github.com/tokio-rs/tokio/blob/93bde0870fd706afbca795b94ce6e46d1f878edb/tokio/src/runtime/time/entry.rs#LL125C2-L134C1
[`debug_assert`]: https://github.com/tokio-rs/tokio/blob/master/tokio/src/runtime/time/entry.rs#L239