### PR TITLE
Reexported bytes::BytesMut

### DIFF
--- a/tokio-util/src/codec/mod.rs
+++ b/tokio-util/src/codec/mod.rs
@@ -288,3 +288,5 @@ pub use self::lines_codec::{LinesCodec, LinesCodecError};
 
 mod any_delimiter_codec;
 pub use self::any_delimiter_codec::{AnyDelimiterCodec, AnyDelimiterCodecError};
+
+pub use bytes::BytesMut;


### PR DESCRIPTION
reexports bytes::BytesMut in codec module

resolves #5719 