### PR TITLE
ci: speed up multi-threaded runtime loom tests.

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -28,13 +28,13 @@ jobs:
           - scope: --skip loom_pool
             max_preemptions: 2
           - scope: loom_pool::group_a
-            max_preemptions: 1
+            max_preemptions: 2
           - scope: loom_pool::group_b
             max_preemptions: 2
           - scope: loom_pool::group_c
-            max_preemptions: 1
+            max_preemptions: 2
           - scope: loom_pool::group_d
-            max_preemptions: 1
+            max_preemptions: 2
           - scope: time::driver
             max_preemptions: 2
     steps:

--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -4,7 +4,6 @@
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::{Arc, Condvar, Mutex};
-use crate::loom::thread;
 use crate::runtime::driver::{self, Driver};
 use crate::util::TryLock;
 
@@ -104,18 +103,14 @@ impl Unparker {
 impl Inner {
     /// Parks the current thread for at most `dur`.
     fn park(&self, handle: &driver::Handle) {
-        for _ in 0..3 {
-            // If we were previously notified then we consume this notification and
-            // return quickly.
-            if self
-                .state
-                .compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst)
-                .is_ok()
-            {
-                return;
-            }
-
-            thread::yield_now();
+        // If we were previously notified then we consume this notification and
+        // return quickly.
+        if self
+            .state
+            .compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst)
+            .is_ok()
+        {
+            return;
         }
 
         if let Some(mut driver) = self.shared.driver.try_lock() {

--- a/tokio/src/runtime/tests/loom_pool.rs
+++ b/tokio/src/runtime/tests/loom_pool.rs
@@ -349,6 +349,7 @@ mod group_d {
 fn mk_pool(num_threads: usize) -> Runtime {
     runtime::Builder::new_multi_thread()
         .worker_threads(num_threads)
+        .event_interval(2)
         .build()
         .unwrap()
 }


### PR DESCRIPTION
Increase max preemption back to 2 while running the tests in under 90 minutes.