### PR TITLE
Added partial reexport of bytes crate

### DIFF
--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -55,10 +55,7 @@ pub mod sync;
 
 pub mod either;
 
-/// A partial reexport of the bytes crate.
-pub mod bytes {
-    pub use bytes::{Buf, BufMut, Bytes, BytesMut};
-}
+pub use bytes;
 
 #[cfg(any(feature = "io", feature = "codec"))]
 mod util {

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -55,6 +55,11 @@ pub mod sync;
 
 pub mod either;
 
+/// A partial reexport of the bytes crate.
+pub mod bytes {
+    pub use bytes::{ Bytes, BytesMut, Buf, BufMut };
+}
+
 #[cfg(any(feature = "io", feature = "codec"))]
 mod util {
     use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -57,7 +57,7 @@ pub mod either;
 
 /// A partial reexport of the bytes crate.
 pub mod bytes {
-    pub use bytes::{Bytes, BytesMut, Buf, BufMut};
+    pub use bytes::{Buf, BufMut, Bytes, BytesMut};
 }
 
 #[cfg(any(feature = "io", feature = "codec"))]

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -57,7 +57,7 @@ pub mod either;
 
 /// A partial reexport of the bytes crate.
 pub mod bytes {
-    pub use bytes::{ Bytes, BytesMut, Buf, BufMut };
+    pub use bytes::{Bytes, BytesMut, Buf, BufMut};
 }
 
 #[cfg(any(feature = "io", feature = "codec"))]


### PR DESCRIPTION
BytesMut is exposed in:
codec/encoder.rs, codec/decoder.rs and udp/frame.rs,
 
BufMut is exposed in:
io/read_buf.rs, lib.rs

Buf is exposed in:
lib.rs

It would be helpful to reexport Bytes for CopyToBytes in io/copy_to_byes.rs due to its implementations 

This pr will reexport bytes::{ Bytes, BytesMut, Buf, BufMut } in a submodule at the crate base also named bytes.

resolves #5719 