### PR TITLE
tokio-util: add AsyncRead/AsyncWrite passthrough for inspect

### DIFF
--- a/tokio-util/src/io/inspect.rs
+++ b/tokio-util/src/io/inspect.rs
@@ -52,7 +52,7 @@ impl<R: AsyncRead, F: FnMut(&[u8])> AsyncRead for InspectReader<R, F> {
     }
 }
 
-impl<R: AsyncRead + AsyncWrite, F: FnMut(&[u8])> AsyncWrite for InspectReader<R, F> {
+impl<R: AsyncWrite, F> AsyncWrite for InspectReader<R, F> {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -157,7 +157,7 @@ impl<W: AsyncWrite, F: FnMut(&[u8])> AsyncWrite for InspectWriter<W, F> {
     }
 }
 
-impl<W: AsyncRead + AsyncWrite, F: FnMut(&[u8])> AsyncRead for InspectWriter<W, F> {
+impl<W: AsyncRead, F> AsyncRead for InspectWriter<W, F> {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/tokio-util/src/io/inspect.rs
+++ b/tokio-util/src/io/inspect.rs
@@ -74,6 +74,18 @@ impl<R: AsyncWrite, F> AsyncWrite for InspectReader<R, F> {
     ) -> Poll<std::result::Result<(), std::io::Error>> {
         self.project().reader.poll_shutdown(cx)
     }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize>> {
+        self.project().reader.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.reader.is_write_vectored()
+    }
 }
 
 pin_project! {

--- a/tokio-util/src/io/inspect.rs
+++ b/tokio-util/src/io/inspect.rs
@@ -52,6 +52,30 @@ impl<R: AsyncRead, F: FnMut(&[u8])> AsyncRead for InspectReader<R, F> {
     }
 }
 
+impl<R: AsyncRead + AsyncWrite, F: FnMut(&[u8])> AsyncWrite for InspectReader<R, F> {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<std::result::Result<usize, std::io::Error>> {
+        self.project().reader.poll_write(cx, buf)
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        self.project().reader.poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<std::result::Result<(), std::io::Error>> {
+        self.project().reader.poll_shutdown(cx)
+    }
+}
+
 pin_project! {
     /// An adapter that lets you inspect the data that's being written.
     ///
@@ -130,5 +154,15 @@ impl<W: AsyncWrite, F: FnMut(&[u8])> AsyncWrite for InspectWriter<W, F> {
 
     fn is_write_vectored(&self) -> bool {
         self.writer.is_write_vectored()
+    }
+}
+
+impl<W: AsyncRead + AsyncWrite, F: FnMut(&[u8])> AsyncRead for InspectWriter<W, F> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<std::io::Result<()>> {
+        self.project().writer.poll_read(cx, buf)
     }
 }


### PR DESCRIPTION
This commit allows you to use `InspectReader` and `InspectWriter` on types that implement both AsyncRead + AsyncWriter without losing those trait implementations.

## Motivation

While implementing clients for tcp interfaces it can be helpful to inspect the bytes sent / received through a `tokio::io::TcpStream`.  The existing InspectReader / InspectWriter structs are a good start, but using them causes the stream to lose its AsyncWrite / AsyncRead trait impls. 

## Solution

By adding implementations for `AsyncRead` to `InspectWriter` and `AsyncWrite` to `InspectReader` it is now possible to inspect bytes sent through a `TcpStream` (or any other `T: AsyncRead+AsyncWrite`) and still pass that stream onto another subsystem that expects a `T: AsyncRead+AsyncWrite`.

For example:
```rust
use tokio::io::TcpStream;
use tokio_util::io::{InspectReader, InspectWriter};

#[tokio::main]
async fn main() {
    let stream = TcpStream::connect("127.0.0.1:8080").await.unwrap();
    let stream = InspectReader::new(stream, |buf: &[u8]| ... );
    let stream = InspectWriter::new(stream, |buf: &[u8]| ...);
        
    SomeClient::new(stream).run();
}
```
