### PR TITLE
ci: fix spurious CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
       - uses: Swatinem/rust-cache@v2
       - name: asan
-        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --tests -- --test-threads 1
+        run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --tests -- --test-threads 1 --nocapture
         env:
           RUSTFLAGS: -Z sanitizer=address
           # Ignore `trybuild` errors as they are irrelevant and flaky on nightly


### PR DESCRIPTION
PR #5720 introduced runtime self-tuning. It included a test that attempts to verify self-tuning logic. The test is heavily reliant on timing details. This patch tries to make the test more reliable by not assuming tuning will converge within a set amount of time.