### PR TITLE
Revert "macros: fix diagnostics of last statement"

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -354,10 +354,10 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
         },
     };
     if let Some(v) = config.worker_threads {
-        rt = quote_spanned! {last_stmt_start_span=> #rt.worker_threads(#v) };
+        rt = quote! { #rt.worker_threads(#v) };
     }
     if let Some(v) = config.start_paused {
-        rt = quote_spanned! {last_stmt_start_span=> #rt.start_paused(#v) };
+        rt = quote! { #rt.start_paused(#v) };
     }
 
     let header = if is_test {


### PR DESCRIPTION
Reverts tokio-rs/tokio#5762

It's a non-impactful change, but I'm reverting it because it's titled as if the problem is fixed.
