### PR TITLE
runtime: `Scoped` should not be `Sync`

### DIFF
--- a/tokio/src/runtime/context/scoped.rs
+++ b/tokio/src/runtime/context/scoped.rs
@@ -6,8 +6,6 @@ pub(super) struct Scoped<T> {
     pub(super) inner: Cell<*const T>,
 }
 
-unsafe impl<T: Sync> Sync for Scoped<T> {}
-
 impl<T> Scoped<T> {
     pub(super) const fn new() -> Scoped<T> {
         Scoped {

--- a/tokio/src/runtime/context/scoped.rs
+++ b/tokio/src/runtime/context/scoped.rs
@@ -6,7 +6,7 @@ pub(super) struct Scoped<T> {
     pub(super) inner: Cell<*const T>,
 }
 
-unsafe impl<T> Sync for Scoped<T> {}
+unsafe impl<T: Sync> Sync for Scoped<T> {}
 
 impl<T> Scoped<T> {
     pub(super) const fn new() -> Scoped<T> {
@@ -52,7 +52,7 @@ impl<T> Scoped<T> {
         if val.is_null() {
             f(None)
         } else {
-            unsafe { f(Some(&*(val as *const T))) }
+            unsafe { f(Some(&*val)) }
         }
     }
 }


### PR DESCRIPTION
If the `Scoped` type is `Sync`, then you can call `set` from two threads in parallel. Since it accesses `inner` without synchronization, this is a data race.

This is a soundness issue for the `Scoped` type, but since this is an internal API and we don't use it incorrectly anywhere, there is no harm done. 