### PR TITLE
io: add `Ready::ERROR` and report error readiness

### DIFF
--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -211,13 +211,13 @@ impl Interest {
             mio_add(&mut mio, mio::Interest::READABLE);
         }
 
-        // we should now always have a valid mio interest: either an tokio interest with a
-        // corresponding mio interest was used, or - if only the error interest was specified -
-        // we've picked a default interest.
-        match mio {
-            Some(inner) => inner,
-            None => unreachable!("no mio interest is specified"),
-        }
+        // the default `mio::Interest::READABLE` should never be used in practice. Either
+        //
+        // - at least one tokio interest with a mio counterpart was used
+        // - only the error tokio interest was specified
+        //
+        // in both cases, `mio` is Some already
+        mio.unwrap_or(mio::Interest::READABLE)
     }
 
     pub(crate) fn mask(self) -> Ready {

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -254,7 +254,7 @@ impl Ready {
             ready |= Ready::READ_CLOSED;
         }
 
-        // error readiness is reported regardless of interest
+        // an event with the error readiness matches any interest
         ready |= Ready::ERROR;
 
         ready

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -254,8 +254,9 @@ impl Ready {
             ready |= Ready::READ_CLOSED;
         }
 
-        // an event with the error readiness matches any interest
-        ready |= Ready::ERROR;
+        if interest.is_error() {
+            ready |= Ready::ERROR;
+        }
 
         ready
     }

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -11,6 +11,7 @@ const READ_CLOSED: usize = 0b0_0100;
 const WRITE_CLOSED: usize = 0b0_1000;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const PRIORITY: usize = 0b1_0000;
+const ERROR: usize = 0b10_0000;
 
 /// Describes the readiness state of an I/O resources.
 ///
@@ -40,13 +41,17 @@ impl Ready {
     #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub const PRIORITY: Ready = Ready(PRIORITY);
 
+    /// Returns a `Ready` representing error readiness.
+    pub const ERROR: Ready = Ready(ERROR);
+
     /// Returns a `Ready` representing readiness for all operations.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED | PRIORITY);
+    pub const ALL: Ready =
+        Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED | ERROR | PRIORITY);
 
     /// Returns a `Ready` representing readiness for all operations.
     #[cfg(not(any(target_os = "linux", target_os = "android")))]
-    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED);
+    pub const ALL: Ready = Ready(READABLE | WRITABLE | READ_CLOSED | WRITE_CLOSED | ERROR);
 
     // Must remain crate-private to avoid adding a public dependency on Mio.
     pub(crate) fn from_mio(event: &mio::event::Event) -> Ready {
@@ -77,6 +82,10 @@ impl Ready {
 
         if event.is_write_closed() {
             ready |= Ready::WRITE_CLOSED;
+        }
+
+        if event.is_error() {
+            ready |= Ready::ERROR;
         }
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -182,6 +191,21 @@ impl Ready {
         self.contains(Ready::PRIORITY)
     }
 
+    /// Returns `true` if the value includes error `readiness`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::io::Ready;
+    ///
+    /// assert!(!Ready::EMPTY.is_error());
+    /// assert!(!Ready::WRITABLE.is_error());
+    /// assert!(Ready::ERROR.is_error());
+    /// ```
+    pub fn is_error(self) -> bool {
+        self.contains(Ready::ERROR)
+    }
+
     /// Returns true if `self` is a superset of `other`.
     ///
     /// `other` may represent more than one readiness operations, in which case
@@ -229,6 +253,9 @@ impl Ready {
             ready |= Ready::PRIORITY;
             ready |= Ready::READ_CLOSED;
         }
+
+        // error readiness is reported regardless of interest
+        ready |= Ready::ERROR;
 
         ready
     }
@@ -283,7 +310,8 @@ impl fmt::Debug for Ready {
         fmt.field("is_readable", &self.is_readable())
             .field("is_writable", &self.is_writable())
             .field("is_read_closed", &self.is_read_closed())
-            .field("is_write_closed", &self.is_write_closed());
+            .field("is_write_closed", &self.is_write_closed())
+            .field("is_error", &self.is_error());
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         fmt.field("is_priority", &self.is_priority());

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -707,6 +707,11 @@ async fn await_error_readiness_timestamping() {
 
     let fd = AsyncFd::new(socket).unwrap();
 
+    tokio::select! {
+        _ = fd.ready(Interest::ERROR) => panic!(),
+        _ = tokio::time::sleep(Duration::from_millis(10)) => {}
+    }
+
     let buf = b"hello there";
     fd.get_ref().send(buf).unwrap();
 

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -711,7 +711,7 @@ async fn await_error_readiness_timestamping() {
     fd.get_ref().send(buf).unwrap();
 
     // the send timestamp should now be in the error queue
-    let guard = fd.ready(Interest::READABLE).await.unwrap();
+    let guard = fd.ready(Interest::ERROR).await.unwrap();
     assert_eq!(guard.ready(), Ready::ERROR);
 }
 
@@ -799,7 +799,6 @@ async fn await_error_readiness_invalid_address() {
 
     let fd = AsyncFd::new(socket).unwrap();
 
-    let guard = fd.ready(Interest::READABLE).await.unwrap();
-
+    let guard = fd.ready(Interest::ERROR).await.unwrap();
     assert_eq!(guard.ready(), Ready::ERROR);
 }

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -685,3 +685,121 @@ async fn clear_ready_matching_clears_ready_mut() {
     guard.clear_ready_matching(Ready::WRITABLE);
     assert_eq!(guard.ready(), Ready::EMPTY);
 }
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn await_error_readiness_timestamping() {
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    use tokio::io::{Interest, Ready};
+
+    let address_a = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let address_b = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+
+    let socket = std::net::UdpSocket::bind(address_a).unwrap();
+
+    socket.set_nonblocking(true).unwrap();
+
+    // configure send timestamps
+    configure_timestamping_socket(&socket).unwrap();
+
+    socket.connect(address_b).unwrap();
+
+    let fd = AsyncFd::new(socket).unwrap();
+
+    let buf = b"hello there";
+    fd.get_ref().send(buf).unwrap();
+
+    // the send timestamp should now be in the error queue
+    let guard = fd.ready(Interest::READABLE).await.unwrap();
+    assert_eq!(guard.ready(), Ready::ERROR);
+}
+
+#[cfg(target_os = "linux")]
+fn configure_timestamping_socket(udp_socket: &std::net::UdpSocket) -> std::io::Result<libc::c_int> {
+    // enable software timestamping, and specifically software send timestamping
+    let options = libc::SOF_TIMESTAMPING_SOFTWARE | libc::SOF_TIMESTAMPING_TX_SOFTWARE;
+
+    let res = unsafe {
+        libc::setsockopt(
+            udp_socket.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_TIMESTAMP,
+            &options as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&options) as libc::socklen_t,
+        )
+    };
+
+    if res == -1 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(res)
+    }
+}
+
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn await_error_readiness_invalid_address() {
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::io::{Interest, Ready};
+
+    let socket_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+    let socket = std::net::UdpSocket::bind(socket_addr).unwrap();
+    let socket_fd = socket.as_raw_fd();
+
+    // Enable IP_RECVERR option to receive error messages
+    // https://man7.org/linux/man-pages/man7/ip.7.html has some extra information
+    let recv_err: libc::c_int = 1;
+    unsafe {
+        let res = libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::SOL_IP,
+            libc::IP_RECVERR,
+            &recv_err as *const _ as *const libc::c_void,
+            std::mem::size_of_val(&recv_err) as libc::socklen_t,
+        );
+        if res == -1 {
+            panic!("{:?}", std::io::Error::last_os_error());
+        }
+    }
+
+    // Spawn a separate thread for sending messages
+    tokio::spawn(async move {
+        // Set the destination address. This address is invalid in this context. the OS will notice
+        // that nobody is listening on port 1234. Normally this is ignored (UDP is "fire and forget"),
+        // but because IP_RECVERR is enabled, the error will actually be reported to the sending socket
+        let mut dest_addr =
+            unsafe { std::mem::MaybeUninit::<libc::sockaddr_in>::zeroed().assume_init() };
+        dest_addr.sin_family = libc::AF_INET as _;
+        dest_addr.sin_port = 1234u16.to_be(); // Destination port
+
+        // Prepare the message data
+        let message = "Hello, Socket!";
+
+        // Prepare the message structure for sendmsg
+        let mut iov = libc::iovec {
+            iov_base: message.as_ptr() as *mut libc::c_void,
+            iov_len: message.len(),
+        };
+
+        // Prepare the destination address for the sendmsg call
+        let dest_sockaddr: *const libc::sockaddr = &dest_addr as *const _ as *const libc::sockaddr;
+        let dest_addrlen: libc::socklen_t = std::mem::size_of_val(&dest_addr) as libc::socklen_t;
+
+        let mut msg: libc::msghdr = unsafe { std::mem::MaybeUninit::zeroed().assume_init() };
+        msg.msg_name = dest_sockaddr as *mut libc::c_void;
+        msg.msg_namelen = dest_addrlen;
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+
+        if unsafe { libc::sendmsg(socket_fd, &msg, 0) } == -1 {
+            Err(std::io::Error::last_os_error()).unwrap()
+        }
+    });
+
+    let fd = AsyncFd::new(socket).unwrap();
+
+    let guard = fd.ready(Interest::READABLE).await.unwrap();
+
+    assert_eq!(guard.ready(), Ready::ERROR);
+}


### PR DESCRIPTION
## Motivation

fixes #5716

The motivation is to await messages arriving in a UdpSocket's error queue. The error queue is a mechanism to asynchronously process errors on a socket. By separating them from the normal queue, error information does not interfere with standard IO, but at the same time better error messages can be given than just a single integer as the result of send/receive.

This potentially has many use cases. My particular one is awaiting when a send timestamp is available.

## Solution

The solution is to provide `Ready::ERROR`. This is already supported in `mio`, but so far was not exposed in tokio. In combination with `AsyncFd::ready` with some arbitrary interest, this can be used to await error readiness.

One potentially controversial change is that error readiness is reported regardless of interest. That is in practice how error readiness works on operating systems: errors are always reported, no matter what the configured interest is.

```rust
            // error readiness is reported regardless of interest
            ready |= Ready::ERROR;
```

### Testing

Send timestamping, my primary use case, only works on linux. I've provided a test for it, but it is only compiled/executed on linux.

I've also included a test that sends a UDP packet to a local socket where nobody is listening. Normally this send operation would just succeed, but by setting the `IP_RECVERR` socket option, the sending socket is notified via the error queue that there is nobody listening on the other side. Turns out this test also only works on linux.

I'm not sure what to do about other operating systems. because we're just re-exposing mio functionality here maybe it's fine to just have the linux tests on CI?

