### PR TITLE
Fix futures_io::AsyncSeek implementaion for Compat

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -24,9 +24,9 @@ default = []
 full = ["codec", "compat", "io-util", "time", "net", "rt"]
 
 net = ["tokio/net"]
-compat = ["futures-io",]
+compat = ["futures-io"]
 codec = ["tracing"]
-time = ["tokio/time","slab"]
+time = ["tokio/time", "slab"]
 io = []
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
@@ -42,7 +42,9 @@ futures-io = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", optional = true }
 pin-project-lite = "0.2.0"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
-tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
+tracing = { version = "0.1.25", default-features = false, features = [
+    "std",
+], optional = true }
 
 [target.'cfg(tokio_unstable)'.dependencies]
 hashbrown = { version = "0.12.0", optional = true }
@@ -56,6 +58,7 @@ async-stream = "0.3.0"
 futures = "0.3.0"
 futures-test = "0.3.5"
 parking_lot = "0.12.0"
+tempfile = "3.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -24,9 +24,9 @@ default = []
 full = ["codec", "compat", "io-util", "time", "net", "rt"]
 
 net = ["tokio/net"]
-compat = ["futures-io"]
+compat = ["futures-io",]
 codec = ["tracing"]
-time = ["tokio/time", "slab"]
+time = ["tokio/time","slab"]
 io = []
 io-util = ["io", "tokio/rt", "tokio/io-util"]
 rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
@@ -34,7 +34,7 @@ rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.22.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.28.0", path = "../tokio", features = ["sync"] }
 bytes = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
@@ -42,9 +42,7 @@ futures-io = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", optional = true }
 pin-project-lite = "0.2.7"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
-tracing = { version = "0.1.25", default-features = false, features = [
-    "std",
-], optional = true }
+tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
 
 [target.'cfg(tokio_unstable)'.dependencies]
 hashbrown = { version = "0.12.0", optional = true }

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -226,18 +226,15 @@ impl<T: tokio::io::AsyncSeek> futures_io::AsyncSeek for Compat<T> {
         cx: &mut Context<'_>,
         pos: io::SeekFrom,
     ) -> Poll<io::Result<u64>> {
-        match self.as_mut().project().inner.poll_complete(cx) {
-            Poll::Ready(_) => {
-                if self.seek_pos != Some(pos) {
-                    self.as_mut().project().inner.start_seek(pos)?;
-                    *self.as_mut().project().seek_pos = Some(pos);
-                }
-                let res = ready!(self.as_mut().project().inner.poll_complete(cx));
-                *self.as_mut().project().seek_pos = None;
-                Poll::Ready(res.map(|p| p as u64))
-            }
-            Poll::Pending => Poll::Pending,
+        if self.seek_pos != Some(pos) {
+            // Ensure previous seeks have finished before starting a new one
+            ready!(self.as_mut().project().inner.poll_complete(cx))?;
+            self.as_mut().project().inner.start_seek(pos)?;
+            *self.as_mut().project().seek_pos = Some(pos);
         }
+        let res = ready!(self.as_mut().project().inner.poll_complete(cx));
+        *self.as_mut().project().seek_pos = None;
+        Poll::Ready(res.map(|p| p as u64))
     }
 }
 

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -1,4 +1,5 @@
-#![cfg(all(feature = "compat", not(tokio_wasi)))] // WASI does not support all fs operations
+#![cfg(all(feature = "compat"))]
+#![cfg(not(target_os = "wasi"))] // WASI does not support all fs operations
 #![warn(rust_2018_idioms)]
 
 use futures_io::SeekFrom;
@@ -29,7 +30,7 @@ async fn compat_file_seek() -> futures_util::io::Result<()> {
 
     file.flush().await?;
 
-    // Verify we still have 8 elements
+    // Verify we still have 8 elements.
     assert_eq!(file.seek(SeekFrom::End(0)).await?, 8);
     // Seek back to the start of the file to read and verify contents.
     file.seek(SeekFrom::Start(0)).await?;

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "compat")]
+#![cfg(all(feature = "compat", not(tokio_wasi)))] // WASI does not support all fs operations
 #![warn(rust_2018_idioms)]
 
 use futures_io::SeekFrom;

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -24,10 +24,10 @@ async fn compat_file_seek() -> futures_util::io::Result<()> {
     assert_eq!(file.stream_position().await?, 8);
 
     // Modify elements at position 2.
-    assert_eq!(file.seek(SeekFrom::Start(2)).await.unwrap(), 2);
-    file.write_all(&[8, 9]).await.unwrap();
+    assert_eq!(file.seek(SeekFrom::Start(2)).await?, 2);
+    file.write_all(&[8, 9]).await?;
 
-    file.flush().await.unwrap();
+    file.flush().await?;
 
     // Verify we still have 8 elements
     assert_eq!(file.seek(SeekFrom::End(0)).await?, 8);

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -1,44 +1,42 @@
 #![cfg(feature = "compat")]
 #![warn(rust_2018_idioms)]
 
-use futures_util::io;
-
-async fn tokio_stream_position() -> io::Result<()> {
-    use tokio::fs::File;
-    use tokio::io::{AsyncSeekExt, AsyncWriteExt};
-    let path = "../target/tokio-seek.test";
-
-    let mut file = File::create(path).await?;
-    let buffer = [0u8; 16];
-    file.write_all(&buffer).await?;
-
-    let pos = file.stream_position().await?;
-    println!("tokio got pos {}", pos);
-
-    Ok(())
-}
-
-async fn compat_stream_position() -> io::Result<()> {
-    use futures::io::{AsyncSeekExt, AsyncWriteExt};
-    use tokio::fs::File;
-    use tokio_util::compat::TokioAsyncWriteCompatExt;
-    let path = "../target/compat-seek.test";
-
-    let mut file = File::create(path).await?.compat_write();
-    let buffer = [0u8; 16];
-    file.write_all(&buffer).await?;
-
-    // Error: other file operation is pending,
-    // call poll_complete before start_seek
-    let pos = file.stream_position().await?;
-    println!("futures got pos {}", pos);
-
-    Ok(())
-}
+use futures_io::SeekFrom;
+use futures_util::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tempfile::NamedTempFile;
+use tokio::fs::OpenOptions;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
 
 #[tokio::test]
-async fn combined() -> io::Result<()> {
-    tokio_stream_position().await?;
-    compat_stream_position().await?;
+async fn compat_file_seek() -> futures_util::io::Result<()> {
+    let temp_file = NamedTempFile::new()?;
+    let mut file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(temp_file)
+        .await?
+        .compat_write();
+
+    file.write_all(&[0, 1, 2, 3, 4, 5]).await?;
+    file.write_all(&[6, 7]).await?;
+
+    assert_eq!(file.stream_position().await?, 8);
+
+    // Modify elements at position 2.
+    assert_eq!(file.seek(SeekFrom::Start(2)).await.unwrap(), 2);
+    file.write_all(&[8, 9]).await.unwrap();
+
+    file.flush().await.unwrap();
+
+    // Verify we still have 8 elements
+    assert_eq!(file.seek(SeekFrom::End(0)).await?, 8);
+    // Seek back to the start of the file to read and verify contents.
+    file.seek(SeekFrom::Start(0)).await?;
+
+    let mut buf = Vec::new();
+    let num_bytes = file.read_to_end(&mut buf).await?;
+    assert_eq!(&buf[..num_bytes], &[0, 1, 8, 9, 4, 5, 6, 7]);
+
     Ok(())
 }

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "compat")]
+#![warn(rust_2018_idioms)]
+
+use futures_util::io;
+
+async fn tokio_stream_position() -> io::Result<()> {
+    use tokio::fs::File;
+    use tokio::io::{AsyncSeekExt, AsyncWriteExt};
+    let path = "../target/tokio-seek.test";
+
+    let mut file = File::create(path).await?;
+    let buffer = [0u8; 16];
+    file.write_all(&buffer).await?;
+
+    let pos = file.stream_position().await?;
+    println!("tokio got pos {}", pos);
+
+    Ok(())
+}
+
+async fn compat_stream_position() -> io::Result<()> {
+    use futures::io::{AsyncSeekExt, AsyncWriteExt};
+    use tokio::fs::File;
+    use tokio_util::compat::TokioAsyncWriteCompatExt;
+    let path = "../target/compat-seek.test";
+
+    let mut file = File::create(path).await?.compat_write();
+    let buffer = [0u8; 16];
+    file.write_all(&buffer).await?;
+
+    // Error: other file operation is pending,
+    // call poll_complete before start_seek
+    let pos = file.stream_position().await?;
+    println!("futures got pos {}", pos);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn combined() -> io::Result<()> {
+    tokio_stream_position().await?;
+    compat_stream_position().await?;
+    Ok(())
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Aims to address #5764.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Waiting for a seek operation to complete by calling `poll_complete` before calling `start_seek`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
