### PR TITLE
chore: enable cargo v2 resolver to prevent dev-deps from enabling log feature of mio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
           # in order to run doctests for unstable features, we must also pass
           # the unstable cfg to RustDoc
           RUSTDOCFLAGS: --cfg tokio_unstable
-    
+
   test-unstable-taskdump:
     name: test tokio full --unstable --taskdump
     needs: basics
@@ -399,10 +399,10 @@ jobs:
           RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64
       # https://github.com/tokio-rs/tokio/pull/5356
       # https://github.com/tokio-rs/tokio/issues/5373
-      - run: cargo hack build -p tokio --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+      - run: cargo hack build -p tokio --feature-powerset --depth 2 --keep-going
         env:
           RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64 --cfg tokio_no_const_mutex_new
-      - run: cargo hack build -p tokio --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+      - run: cargo hack build -p tokio --feature-powerset --depth 2 --keep-going
         env:
           RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_atomic_u64
 
@@ -421,15 +421,15 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
       - name: check --feature-powerset
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+        run: cargo hack check --all --feature-powerset --depth 2 --keep-going
       # Try with unstable feature flags
       - name: check --feature-powerset --unstable
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+        run: cargo hack check --all --feature-powerset --depth 2 --keep-going
         env:
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings
       # Try with unstable and taskdump feature flags
       - name: check --feature-powerset --unstable --taskdump
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+        run: cargo hack check --all --feature-powerset --depth 2 --keep-going
         env:
           RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
   "tokio",
   "tokio-macros",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -132,7 +132,7 @@ nix = { version = "0.26", default-features = false, features = ["fs", "socket"] 
 version = "0.48"
 optional = true
 
-[target.'cfg(docsrs)'.dependencies.windows-sys]
+[target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.48"
 features = [
     "Win32_Foundation",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Currently building with MSRV from the workspace root fails with the following error ([ci log](https://github.com/tokio-rs/tokio/actions/runs/5233633822/jobs/9449234197)):

```console
$ cargo +1.56 check --workspace --all-features
error: package `log v0.4.19` cannot be built because it requires rustc 1.60.0 or newer, while the currently active rustc version is 1.56.1
```

This is because the development dependency (mio-aio) enables mio's log feature (requires Rust 1.60 since log [0.4.19](https://github.com/rust-lang/log/releases/tag/0.4.19) released a few hours ago), and it is propagated to the normal dependencies by the cargo v1 resolver's [feature unification](https://doc.rust-lang.org/stable/cargo/reference/features.html#feature-unification).

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Enable cargo v2 resolver to prevent dev-deps from enabling log feature of mio.