### PR TITLE
chore: upgrade remaining 2018 edition crates to 2021 edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,8 +495,8 @@ jobs:
       - name: "rustfmt --check"
         # Workaround for rust-lang/cargo#7732
         run: |
-          if ! rustfmt --check --edition 2018 $(git ls-files '*.rs'); then
-            printf "Please run \`rustfmt --edition 2018 \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
+          if ! rustfmt --check --edition 2021 $(git ls-files '*.rs'); then
+            printf "Please run \`rustfmt --edition 2021 \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
             exit 1
           fi
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,10 +173,10 @@ command below instead:
 
 ```
 # Mac or Linux
-rustfmt --check --edition 2018 $(git ls-files '*.rs')
+rustfmt --check --edition 2021 $(git ls-files '*.rs')
 
 # Powershell
-Get-ChildItem . -Filter "*.rs" -Recurse | foreach { rustfmt --check --edition 2018 $_.FullName }
+Get-ChildItem . -Filter "*.rs" -Recurse | foreach { rustfmt --check --edition 2021 $_.FullName }
 ```
 The `--check` argument prints the things that need to be fixed. If you remove
 it, `rustfmt` will update your files locally instead.
@@ -230,7 +230,7 @@ integration tests in the crate and follow the style.
 
 Some of our crates include a set of fuzz tests, this will be marked by a
 directory `fuzz`. It is a good idea to run fuzz tests after each change.
-To get started with fuzz testing you'll need to install 
+To get started with fuzz testing you'll need to install
 [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
 
 `cargo install cargo-fuzz`

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -2,7 +2,7 @@
 name = "benches"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [features]
 test-util = ["tokio/test-util"]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -2,7 +2,7 @@
 name = "examples"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead, and delete the **path**.

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -18,7 +18,7 @@ use futures::SinkExt;
 use http::{header::HeaderValue, Request, Response, StatusCode};
 #[macro_use]
 extern crate serde_derive;
-use std::{convert::TryFrom, env, error::Error, fmt, io};
+use std::{env, error::Error, fmt, io};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Decoder, Encoder, Framed};

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stress-test"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests-build"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [features]

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tests-integration"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
-edition = "2018"
+edition = "2021"
 publish = false
 
 [[bin]]

--- a/tests-integration/tests/process_stdio.rs
+++ b/tests-integration/tests/process_stdio.rs
@@ -7,7 +7,6 @@ use tokio::process::{Child, Command};
 use tokio_test::assert_ok;
 
 use futures::future::{self, FutureExt};
-use std::convert::TryInto;
 use std::env;
 use std::io;
 use std::process::{ExitStatus, Stdio};

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -5,7 +5,7 @@ name = "tokio-macros"
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.x.y" git tag.
 version = "2.1.0"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"

--- a/tokio-stream/fuzz/Cargo.toml
+++ b/tokio-stream/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokio-stream-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/tokio/fuzz/Cargo.toml
+++ b/tokio/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokio-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/tokio-rs/tokio/pull/5559 and https://github.com/tokio-rs/tokio/pull/5571 have updated some crates to 2021 edition, but there are still some left.

This upgrades all remaining 2018 edition crates to 2021 edition.