### PR TITLE
Add redox-os to conditional compilation #[cfg] for ucred usage alongside other linux-like OS

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -121,11 +121,11 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 backtrace = { version = "0.3.58" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.42", optional = true }
+libc = { version = "0.2.145", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-libc = { version = "0.2.42" }
+libc = { version = "0.2.145" }
 nix = { version = "0.26", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -31,7 +31,7 @@ impl UCred {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "redox", target_os = "android", target_os = "openbsd"))]
 pub(crate) use self::impl_linux::get_peer_cred;
 
 #[cfg(any(target_os = "netbsd"))]
@@ -49,7 +49,7 @@ pub(crate) use self::impl_solaris::get_peer_cred;
 #[cfg(target_os = "aix")]
 pub(crate) use self::impl_aix::get_peer_cred;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "openbsd"))]
+#[cfg(any(target_os = "linux", target_os = "redox", target_os = "android", target_os = "openbsd"))]
 pub(crate) mod impl_linux {
     use crate::net::unix::{self, UnixStream};
 
@@ -58,7 +58,7 @@ pub(crate) mod impl_linux {
 
     #[cfg(target_os = "openbsd")]
     use libc::sockpeercred as ucred;
-    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg(any(target_os = "linux", target_os = "redox", target_os = "android"))]
     use libc::ucred;
 
     pub(crate) fn get_peer_cred(sock: &UnixStream) -> io::Result<super::UCred> {

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -31,7 +31,12 @@ impl UCred {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "redox", target_os = "android", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "redox",
+    target_os = "android",
+    target_os = "openbsd"
+))]
 pub(crate) use self::impl_linux::get_peer_cred;
 
 #[cfg(any(target_os = "netbsd"))]
@@ -49,7 +54,12 @@ pub(crate) use self::impl_solaris::get_peer_cred;
 #[cfg(target_os = "aix")]
 pub(crate) use self::impl_aix::get_peer_cred;
 
-#[cfg(any(target_os = "linux", target_os = "redox", target_os = "android", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "redox",
+    target_os = "android",
+    target_os = "openbsd"
+))]
 pub(crate) mod impl_linux {
     use crate::net::unix::{self, UnixStream};
 


### PR DESCRIPTION
I recently got an MR merged into rust libc to add the ucred struct for redox-os.
That was what was missing in order to allow tokio to compile for redox-os.
That change was recently released as part of libc version 0.2.245.

This PR adds the redox-os to the conditional compile directives for the linux-like OSs, so that it can use ucred and compile without any tokio code changes.

This will unblock much useage (and fork and patch maintenance) in redox development for tokio, and allow it to be used much more widely.

It's still WIP as I work on an issue on my end, but wanted to get it here sooner rather than later - hope that is OK.