### PR TITLE
Add a check-redox job in GH Action ci.yml workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -624,7 +624,7 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
           target: x86_64-unknown-redox
       - name: check tokio on redox
-        run: cargo check --target x86_64-unknown-redox
+        run: cargo check --target x86_64-unknown-redox --all-features
         working-directory: tokio
 
   wasm32-unknown-unknown:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -613,7 +613,7 @@ jobs:
         working-directory: tokio
 
   check-redox:
-    name: check that tokio compiles on redox-os target (pending addition to CI testing)
+    name: build tokio for redox-os
     needs: basics
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
       - check-readme
       - test-hyper
       - x86_64-fortanix-unknown-sgx
+      - check-redox
       - wasm32-unknown-unknown
       - wasm32-wasi
       - check-external-types
@@ -609,6 +610,21 @@ jobs:
       # NOTE: Currently the only test we can run is to build tokio with rt and sync features.
       - name: build tokio
         run: cargo build --target x86_64-fortanix-unknown-sgx --features rt,sync
+        working-directory: tokio
+
+  check-redox:
+    name: check that tokio compiles on redox-os target (pending addition to CI testing)
+    needs: basics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.rust_nightly }}
+          target: x86_64-unknown-redox
+      - name: check tokio on redox
+        run: cargo check --target x86_64-unknown-redox
         working-directory: tokio
 
   wasm32-unknown-unknown:


### PR DESCRIPTION
This PR adds a `cargo check` job for redox-os, to ensure tokio continues to compile correctly for that target, as discussed with @Darksonn in this comment thread https://github.com/tokio-rs/tokio/pull/5790#issuecomment-1589772978

## Motivation
Have tokio support redox-os as a target and avoid changes breaking it.

## Solution
Pending solving some issues and providing a CI solution on redox-os to the tokio project, so that build can be done, and tests to run and pass - this interim step add a compile check to ensure that tokio will compile for that target.

Redox-os project will work on build and test run and create new PRs in the future to add them to tokio CI.

Thanks for your collaboration and support of redox-os