### PR TITLE
wait for in-flight ops before cloning `File`

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -399,6 +399,7 @@ impl File {
     /// # }
     /// ```
     pub async fn try_clone(&self) -> io::Result<File> {
+        self.inner.lock().await.complete_inflight().await;
         let std = self.std.clone();
         let std_file = asyncify(move || std.try_clone()).await?;
         Ok(File::from_std(std_file))


### PR DESCRIPTION
If there is an ongoing operation on a file, wait for that to complete before performing the clone in `File::try_clone`. This avoids a race between the ongoing operation and any subsequent operations performed on the clone.

Fixes: #5759

## Motivation

#5759 shows a situation where a file is written to with `write_all`, and once that completes (Poll::Ready), cloned with `try_clone`. The file contents are then read back from the clone. In unlucky situations, this read produces an empty result because the read occurs before the write has completed.

## Solution

Like most methods on File, the `try_clone` function should wait until any previous asynchronously-completing operations on the file are complete before actually cloning the file.

## No Tests?

The failure fixed by this PR appears _very_ difficult to test:
 * It is a race condition, and one which almost always succeeds (that is, the write almost always completes before the read).
 * It's not well-defined what an operating system will do if a file is duplicated while a `write(2)` syscall is in progress. Reproducing the race requires that the read happen _before_ the invocation of `write(2)`. In practice, this bug reproduces best on a very busy system, such as in CI, where the worker thread that calls `wait(2)` is not scheduled immediately.
 * Tests run with a mocked `spawn_blocking` which does not exhibit this bug.
 * If I was able to produce a test case where the closure passed to `spawn_blocking` was blocked from executing, then when the fix was applied the test would block indefinitely.

I'm open to suggestions as to how to test this, but perhaps the fix is simple enough to accept without them?