### PR TITLE
fs: always try to get file type in `fs::read_dir`

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -135,12 +135,6 @@ impl ReadDir {
             let success = ret.is_ok();
 
             buf.push_back(ret.map(|std| DirEntry {
-                #[cfg(not(any(
-                    target_os = "solaris",
-                    target_os = "illumos",
-                    target_os = "haiku",
-                    target_os = "vxworks"
-                )))]
                 file_type: std.file_type().ok(),
                 std: Arc::new(std),
             }));
@@ -196,12 +190,6 @@ feature! {
 /// path or possibly other metadata through per-platform extension traits.
 #[derive(Debug)]
 pub struct DirEntry {
-    #[cfg(not(any(
-        target_os = "solaris",
-        target_os = "illumos",
-        target_os = "haiku",
-        target_os = "vxworks"
-    )))]
     file_type: Option<FileType>,
     std: Arc<std::fs::DirEntry>,
 }
@@ -327,12 +315,6 @@ impl DirEntry {
     /// # }
     /// ```
     pub async fn file_type(&self) -> io::Result<FileType> {
-        #[cfg(not(any(
-            target_os = "solaris",
-            target_os = "illumos",
-            target_os = "haiku",
-            target_os = "vxworks"
-        )))]
         if let Some(file_type) = self.file_type {
             return Ok(file_type);
         }


### PR DESCRIPTION
The current implementation of `fs::read_dir` pre-stores the file type, except for a few operating systems that are known to require an extra call to get the file type. The cfg attributes we use to check such operating systems comes from [the std implementation](
https://github.com/rust-lang/rust/blob/3c9e0705ba0c1c845fe7cdbd0bdf4a914f49cc8e/library/std/src/sys/unix/fs.rs#L862-L869), but this was recently updated and no longer matches.

I think I'd rather just delete those cfg attributes, because when we read a directory, we also read the file type, except in very few cases.
