### PR TITLE
fs: update cfg attr in `fs::read_dir`

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -139,7 +139,9 @@ impl ReadDir {
                     target_os = "solaris",
                     target_os = "illumos",
                     target_os = "haiku",
-                    target_os = "vxworks"
+                    target_os = "vxworks",
+                    target_os = "nto",
+                    target_os = "vita",
                 )))]
                 file_type: std.file_type().ok(),
                 std: Arc::new(std),
@@ -200,7 +202,9 @@ pub struct DirEntry {
         target_os = "solaris",
         target_os = "illumos",
         target_os = "haiku",
-        target_os = "vxworks"
+        target_os = "vxworks",
+        target_os = "nto",
+        target_os = "vita",
     )))]
     file_type: Option<FileType>,
     std: Arc<std::fs::DirEntry>,
@@ -331,7 +335,9 @@ impl DirEntry {
             target_os = "solaris",
             target_os = "illumos",
             target_os = "haiku",
-            target_os = "vxworks"
+            target_os = "vxworks",
+            target_os = "nto",
+            target_os = "vita",
         )))]
         if let Some(file_type) = self.file_type {
             return Ok(file_type);


### PR DESCRIPTION
This change updates the cfg attribute to prevent unnecessary file metadata fetching on new targets.

The current `DirEntry::file_type` implementation returns a pre-parsed value from `fs::read_dir` for most targets. Some Unix operating systems are excluded because of the overhead of fetching metadata to get the file type. However, as the Rust compiler has been updated, new targets have been added and an update is needed. The cfg attribute is taken from [the std implementation](https://github.com/rust-lang/rust/blob/3c9e0705ba0c1c845fe7cdbd0bdf4a914f49cc8e/library/std/src/sys/unix/fs.rs#L862-L869).

Related Issue: #5804