### PR TITLE
sync::broadcast: reduce memory usage by calling drop earlier

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -815,7 +815,10 @@ impl<T> Sender<T> {
 fn new_receiver<T>(shared: Arc<Shared<T>>) -> Receiver<T> {
     let mut tail = shared.tail.lock();
 
-    if tail.rx_cnt == MAX_RECEIVERS {
+    if tail.rx_cnt == 0 {
+        // Go back to drop values earlier, potentially consuming less memory
+        tail.pos = 0;
+    } else if tail.rx_cnt == MAX_RECEIVERS {
         panic!("max receivers");
     }
 


### PR DESCRIPTION
When there are no `Receiver`s listening, you can roll back to the start of the buffer so you call `Drop` on values earlier
