### PR TITLE
codec: add borrow framed to allow temporary codec replacement 

### DIFF
--- a/tokio-util/src/codec/decoder.rs
+++ b/tokio-util/src/codec/decoder.rs
@@ -182,3 +182,13 @@ pub trait Decoder {
         Framed::new(io, self)
     }
 }
+
+impl<T: Decoder> Decoder for &mut T {
+    type Item = T::Item;
+
+    type Error = T::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        (**self).decode(src)
+    }
+}

--- a/tokio-util/src/codec/encoder.rs
+++ b/tokio-util/src/codec/encoder.rs
@@ -23,3 +23,11 @@ pub trait Encoder<Item> {
     /// [`FramedWrite`]: crate::codec::FramedWrite
     fn encode(&mut self, item: Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
 }
+
+impl<I, T: Encoder<I>> Encoder<I> for &mut T {
+    type Error = T::Error;
+
+    fn encode(&mut self, item: I, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        (**self).encode(item, dst)
+    }
+}

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -115,6 +115,26 @@ impl BorrowMut<WriteFrame> for RWFrames {
         &mut self.write
     }
 }
+impl Borrow<ReadFrame> for &mut RWFrames {
+    fn borrow(&self) -> &ReadFrame {
+        &self.read
+    }
+}
+impl BorrowMut<ReadFrame> for &mut RWFrames {
+    fn borrow_mut(&mut self) -> &mut ReadFrame {
+        &mut self.read
+    }
+}
+impl Borrow<WriteFrame> for &mut RWFrames {
+    fn borrow(&self) -> &WriteFrame {
+        &self.write
+    }
+}
+impl BorrowMut<WriteFrame> for &mut RWFrames {
+    fn borrow_mut(&mut self) -> &mut WriteFrame {
+        &mut self.write
+    }
+}
 impl<T, U, R> Stream for FramedImpl<T, U, R>
 where
     T: AsyncRead,

--- a/tokio-util/tests/framed_write.rs
+++ b/tokio-util/tests/framed_write.rs
@@ -116,7 +116,8 @@ fn borrow_framed_write() {
         assert!(assert_ready!(pin!(framed).poll_ready(cx)).is_ok());
         assert!(pin!(framed).start_send(0x04).is_ok());
 
-        let mut borrow_framed = framed.with_encoder(|_| U64Encoder);
+        let mut new_codec = U64Encoder;
+        let mut borrow_framed = framed.with_encoder(|_| &mut new_codec);
         assert!(assert_ready!(pin!(borrow_framed).poll_ready(cx)).is_ok());
         assert!(pin!(borrow_framed).start_send(0x08).is_ok());
 


### PR DESCRIPTION
## Motivation
Provide a more convenient way of temporarily replacing the codec used by the Framed struct without taking ownership of it.
Currently, the only way to replace the codec in Framed is by using the map_codec method, which consumes the Framed instance and returns a new one with the updated codec. This can be inconvenient if you want to temporarily use a different codec and then switch back to the original one, as you would need to store the original Framed instance somewhere and use map_codec to replace it every time.

## Solution
Create a borrowed reference to a Framed instance and use it to construct a new BorrowFramed instance with a different codec through the new added `with_codec` function. This way, you can use the BorrowFramed instance instead of the original Framed one for as long as you need, and then discard it without affecting the original instance.
