### PR TITLE
io: fix safety of `LinkedList` drain_filter API

### DIFF
--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -307,7 +307,7 @@ cfg_io_driver_impl! {
     impl<T: Link> LinkedList<T, T::Target> {
         pub(crate) fn drain_filter<F>(&mut self, filter: F) -> DrainFilter<'_, T, F>
         where
-            F: FnMut(&mut T::Target) -> bool,
+            F: FnMut(&T::Target) -> bool,
         {
             let curr = self.head;
             DrainFilter {
@@ -321,7 +321,7 @@ cfg_io_driver_impl! {
     impl<'a, T, F> Iterator for DrainFilter<'a, T, F>
     where
         T: Link,
-        F: FnMut(&mut T::Target) -> bool,
+        F: FnMut(&T::Target) -> bool,
     {
         type Item = T::Handle;
 


### PR DESCRIPTION
The `drain_filter` method on the internal `LinkedList` type passes a `&mut` reference to the node type. However, the `LinkedList` is intended to be used with nodes that are shared in other ways. For example, `task::Header` is accessible concurrently from multiple threads.

Currently, the only usage of `drain_filter` is in a case where `&mut` access is safe, so this change is to help prevent future bugs and tighten up the safety of internal utilities.