### PR TITLE
WIP make loom work in tokio-util

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -52,3 +52,23 @@ jobs:
           LOOM_MAX_PREEMPTIONS: ${{ matrix.max_preemptions }}
           LOOM_MAX_BRANCHES: 10000
           SCOPE: ${{ matrix.scope }}
+  loom-util:
+    name: loom on tokio-util
+    # base_ref is null when it's not a pull request
+    if: github.repository_owner == 'tokio-rs' && (contains(github.event.pull_request.labels.*.name, 'R-loom') || (github.base_ref == null))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: ${{ env.rust_stable }}
+      - uses: Swatinem/rust-cache@v2
+      - name: loom tokio-util
+        run: cargo test --lib --release --features full -- --nocapture $SCOPE
+        working-directory: tokio-util
+        env:
+          RUSTFLAGS: --cfg loom --cfg tokio_unstable -Dwarnings -C debug-assertions
+          LOOM_MAX_PREEMPTIONS: ${{ matrix.max_preemptions }}
+          LOOM_MAX_BRANCHES: 10000
+          SCOPE: ${{ matrix.scope }}

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -58,6 +58,9 @@ futures-test = "0.3.5"
 parking_lot = "0.12.0"
 tempfile = "3.1.0"
 
+[target.'cfg(loom)'.dev-dependencies]
+loom = { version = "0.5.2", features = ["futures", "checkpoint"] }
+
 [package.metadata.docs.rs]
 all-features = true
 # enable unstable features in the documentation

--- a/tokio-util/src/either.rs
+++ b/tokio-util/src/either.rs
@@ -164,7 +164,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(loom)))]
 mod tests {
     use super::*;
     use tokio::io::{repeat, AsyncReadExt, Repeat};

--- a/tokio-util/src/loom.rs
+++ b/tokio-util/src/loom.rs
@@ -1,1 +1,5 @@
+#[cfg(not(loom))]
 pub(crate) use std::sync;
+
+#[cfg(loom)]
+pub(crate) use loom::sync;

--- a/tokio-util/src/sync/cancellation_token/tree_node.rs
+++ b/tokio-util/src/sync/cancellation_token/tree_node.rs
@@ -298,12 +298,15 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
     if locked_node.is_cancelled {
         return;
     }
+    println!("a");
 
     // One by one, adopt grandchildren and then cancel and detach the child
     while let Some(child) = locked_node.children.pop() {
+        println!("b1");
         // This can't deadlock because the mutex we are already
         // holding is the parent of child.
         let mut locked_child = child.inner.lock().unwrap();
+        println!("b2");
 
         // Detach the child from node
         // No need to modify node.children, as the child already got removed with `.pop`
@@ -356,10 +359,12 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
         // Now the child is cancelled and detached and all its children are adopted.
         // Just continue until all (including adopted) children are cancelled and detached.
     }
+    println!("c");
 
     // Cancel the node itself.
     locked_node.is_cancelled = true;
     locked_node.children = Vec::new();
     drop(locked_node);
     node.waker.notify_waiters();
+    println!("d");
 }

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -13,3 +13,6 @@ pub use poll_semaphore::PollSemaphore;
 
 mod reusable_box;
 pub use reusable_box::ReusableBoxFuture;
+
+#[cfg(loom)]
+mod tests;

--- a/tokio-util/src/sync/tests/loom_cancellation_token.rs
+++ b/tokio-util/src/sync/tests/loom_cancellation_token.rs
@@ -48,6 +48,7 @@ fn cancel_token_owned() {
 #[test]
 fn cancel_with_child() {
     loom::model(|| {
+        println!("FOO");
         let token = CancellationToken::new();
         let token1 = token.clone();
         let token2 = token.clone();
@@ -153,20 +154,27 @@ fn drop_and_cancel_token() {
 #[test]
 fn cancel_parent_and_child() {
     loom::model(|| {
+        println!("FOO");
         let token1 = CancellationToken::new();
         let token2 = token1.clone();
         let child_token = token1.child_token();
 
         let th1 = thread::spawn(move || {
+            println!("drop parent");
             drop(token1);
+            println!("drop parent done");
         });
 
         let th2 = thread::spawn(move || {
+            println!("cancel parent");
             token2.cancel();
+            println!("cancel parent done");
         });
 
         let th3 = thread::spawn(move || {
+            println!("cancel child");
             child_token.cancel();
+            println!("cancel child done");
         });
 
         assert_ok!(th1.join());

--- a/tokio-util/src/sync/tests/mod.rs
+++ b/tokio-util/src/sync/tests/mod.rs
@@ -1,1 +1,1 @@
-
+mod loom_cancellation_token;


### PR DESCRIPTION
We're not actually running the loom tests in tokio-util. I made some progress towards fixing that, but I got stuck. I will look more later.

```
FOO
drop parent
drop parent done
cancel child
a
c
d
cancel child done
cancel parent
a
b1
thread 'sync::tests::loom_cancellation_token::cancel_parent_and_child' panicked at 'deadlock; threads = [(Id(0), Blocked(Location(None))), (Id(1), Terminated), (Id(2), Blocked(Location(None))), (Id(3), Blocked(Location(None)))]', /home/aliceryhl/.cargo/registry/src/github.com-1ecc6299db9ec823/loom-0.5.6/src/rt/execution.rs:215:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/std/src/panicking.rs:579:5
   1: core::panicking::panic_fmt
             at /rustc/84c898d65adf2f39a5a98507f1fe0ce10a2b8dbc/library/core/src/panicking.rs:64:14
   2: loom::rt::execution::Execution::schedule
   3: scoped_tls::ScopedKey<T>::with
   4: loom::rt::object::Ref<T>::branch_acquire
   5: loom::rt::mutex::Mutex::acquire_lock
   6: loom::sync::mutex::Mutex<T>::lock
   7: tokio_util::sync::cancellation_token::CancellationToken::cancel
   8: core::ops::function::FnOnce::call_once{{vtable.shim}}
   9: generator::stack::StackBox<F>::call_once
  10: generator::gen_impl::gen_init
```