### PR TITLE
Reduce LLVM code generation

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -53,9 +53,7 @@ impl Handle {
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
-        if let Some(notified) = notified {
-            me.schedule_task(notified, false);
-        }
+        me.schedule_option_task_without_yield(notified);
 
         handle
     }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1024,6 +1024,12 @@ impl Handle {
         })
     }
 
+    pub(super) fn schedule_option_task_without_yield(&self, task: Option<Notified>) {
+        if let Some(task) = task {
+            self.schedule_task(task, false);
+        }
+    }
+
     fn schedule_local(&self, core: &mut Core, task: Notified, is_yield: bool) {
         core.stats.inc_local_schedule_count();
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -215,8 +215,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         fn new_header(
             state: State,
             vtable: &'static Vtable,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            tracing_id: Option<tracing::Id>,
+            #[cfg(all(tokio_unstable, feature = "tracing"))] tracing_id: Option<tracing::Id>,
         ) -> Header {
             Header {
                 state,

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -221,7 +221,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
             Header {
                 state,
                 queue_next: UnsafeCell::new(None),
-                vtable,,
+                vtable,
                 owner_id: UnsafeCell::new(0),
                 #[cfg(all(tokio_unstable, feature = "tracing"))]
                 tracing_id,

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -244,8 +244,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                 assert_eq!(trailer_addr, trailer_ptr.as_ptr() as usize);
 
                 let scheduler_addr = scheduler as *const S as usize;
-                let scheduler_ptr =
-                    unsafe { Header::get_scheduler::<S>(NonNull::from(header)) };
+                let scheduler_ptr = unsafe { Header::get_scheduler::<S>(NonNull::from(header)) };
                 assert_eq!(scheduler_addr, scheduler_ptr.as_ptr() as usize);
 
                 let id_addr = task_id as *const Id as usize;
@@ -253,7 +252,12 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                 assert_eq!(id_addr, id_ptr.as_ptr() as usize);
             }
             unsafe {
-                check(&result.header, &result.trailer, &result.core.scheduler, &result.core.task_id);
+                check(
+                    &result.header,
+                    &result.trailer,
+                    &result.core.scheduler,
+                    &result.core.task_id,
+                );
             }
         }
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -207,8 +207,6 @@ pub(super) enum Stage<T: Future> {
     Consumed,
 }
 
-
-
 impl<T: Future, S: Schedule> Cell<T, S> {
     /// Allocates a new task cell, containing the header, trailer, and core
     /// structures.

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -453,15 +453,14 @@ fn cancel_task<T: Future, S: Schedule>(core: &Core<T, S>) {
         core.drop_future_or_output();
     }));
 
-    core.store_output(panic_result_to_join_error(core.task_id, res));
+    core.store_output(Err(panic_result_to_join_error(core.task_id, res)));
 }
 
-fn panic_result_to_join_error(task_id: Id, res: Result<(), Box<dyn Any + Send + 'static>>) {
-    let err = match res {
+fn panic_result_to_join_error(task_id: Id,res: Result<(), Box<dyn Any + Send + 'static>>) -> JoinError {
+    match res {
         Ok(()) => JoinError::cancelled(task_id),
         Err(panic) => JoinError::panic(task_id, panic),
-    };
-    Err(err)
+    }
 }
 
 /// Polls the future. If the future completes, the output is written to the

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -456,7 +456,10 @@ fn cancel_task<T: Future, S: Schedule>(core: &Core<T, S>) {
     core.store_output(Err(panic_result_to_join_error(core.task_id, res)));
 }
 
-fn panic_result_to_join_error(task_id: Id,res: Result<(), Box<dyn Any + Send + 'static>>) -> JoinError {
+fn panic_result_to_join_error(
+    task_id: Id,
+    res: Result<(), Box<dyn Any + Send + 'static>>,
+) -> JoinError {
     match res {
         Ok(()) => JoinError::cancelled(task_id),
         Err(panic) => JoinError::panic(task_id, panic),

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -213,7 +213,7 @@ where
                 }
 
                 let transition_res = self.state().transition_to_idle();
-                if let &TransitionToIdle::Cancelled = &transition_res {
+                if let TransitionToIdle::Cancelled = transition_res {
                     // The transition to idle failed because the task was
                     // cancelled during the poll.
                     cancel_task(self.core());

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -96,7 +96,14 @@ impl<S: 'static> OwnedTasks<S> {
         T::Output: Send + 'static,
     {
         let (task, notified, join) = super::new_task(task, scheduler, id);
+        let notified = unsafe {
+            self.bind_inner(task, notified)
+        };
+        (join, notified)
+    }
 
+    /// The part of `bind` that's the same for every type of future.
+    unsafe fn bind_inner(&self, task: Task<S>, notified: Notified<S>) -> Option<Notified<S>> {
         unsafe {
             // safety: We just created the task, so we have exclusive access
             // to the field.
@@ -108,7 +115,7 @@ impl<S: 'static> OwnedTasks<S> {
             drop(lock);
             drop(notified);
             task.shutdown();
-            (join, None)
+            None
         } else {
             lock.list.push_front(task);
             (join, Some(notified))

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -118,7 +118,7 @@ impl<S: 'static> OwnedTasks<S> {
             None
         } else {
             lock.list.push_front(task);
-            (join, Some(notified))
+            Some(notified)
         }
     }
 

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -96,9 +96,7 @@ impl<S: 'static> OwnedTasks<S> {
         T::Output: Send + 'static,
     {
         let (task, notified, join) = super::new_task(task, scheduler, id);
-        let notified = unsafe {
-            self.bind_inner(task, notified)
-        };
+        let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }
 

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -101,7 +101,10 @@ impl<S: 'static> OwnedTasks<S> {
     }
 
     /// The part of `bind` that's the same for every type of future.
-    unsafe fn bind_inner(&self, task: Task<S>, notified: Notified<S>) -> Option<Notified<S>> {
+    unsafe fn bind_inner(&self, task: Task<S>, notified: Notified<S>) -> Option<Notified<S>>
+    where
+        S: Schedule,
+    {
         unsafe {
             // safety: We just created the task, so we have exclusive access
             // to the field.

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -11,18 +11,22 @@ cfg_trace! {
         #[inline]
         #[track_caller]
         pub(crate) fn task<F>(task: F, kind: &'static str, name: Option<&str>, id: u64) -> Instrumented<F> {
+            #[track_caller]
+            fn get_span(kind: &'static str, name: Option<&str>, id: u64) -> tracing::Span {
+                let location = std::panic::Location::caller();
+                tracing::trace_span!(
+                    target: "tokio::task",
+                    "runtime.spawn",
+                    %kind,
+                    task.name = %name.unwrap_or_default(),
+                    task.id = id,
+                    loc.file = location.file(),
+                    loc.line = location.line(),
+                    loc.col = location.column(),
+                )
+            }
             use tracing::instrument::Instrument;
-            let location = std::panic::Location::caller();
-            let span = tracing::trace_span!(
-                target: "tokio::task",
-                "runtime.spawn",
-                %kind,
-                task.name = %name.unwrap_or_default(),
-                task.id = id,
-                loc.file = location.file(),
-                loc.line = location.line(),
-                loc.col = location.column(),
-            );
+            let span = get_span(kind, name, id);
             task.instrument(span)
         }
 


### PR DESCRIPTION
This reduces the amount of LLVM code generated, which is helpful for compilation speed.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

A big portion of LLVM code generation for Lemmy server is caused by a few Tokio functions: [cargo llvm-lines output](https://github.com/LemmyNet/lemmy/files/12010680/lineslib-lto.zip)

It would be helpful to reduce this because it contributes to Lemmy's extremely slow compilation.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Split parts of functions into separate functions without unneeded generic parameters: https://nnethercote.github.io/perf-book/compile-times.html#llvm-ir
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
