### PR TITLE
Use a dynamic buffer in the `AsyncReadExt`'s `read_exact` example

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -292,7 +292,8 @@ cfg_io_util! {
         /// #[tokio::main]
         /// async fn main() -> io::Result<()> {
         ///     let mut f = File::open("foo.txt").await?;
-        ///     let mut buffer = [0; 10];
+        ///     let len = 10;
+        ///     let mut buffer = vec![0; len];
         ///
         ///     // read exactly 10 bytes
         ///     f.read_exact(&mut buffer).await?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

See [this SO question](https://stackoverflow.com/questions/68979882/readread-exact-does-not-fill-buffer).
In most cases when `read_exact` is used the user doesn't know beforehand how many bytes are gonna be read. This leads to code like `Vec::with_capacity(len)` when really what the user wants is `vec![0; len]` (the former has a length of zero so it succeeds with `Ok(0)`).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Change the example to use the `vec!` macro instead of a fixed-sized array. This will make adding a warning obsolete.