### PR TITLE
rt: add runtime Id

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -381,11 +381,12 @@ impl Handle {
         /// [unstable]: crate#unstable-features
         /// [`Id`]: struct@crate::runtime::Id
         pub fn id(&self) -> runtime::Id {
-            match &self.inner {
-                scheduler::Handle::CurrentThread(handle) => handle.runtime_id,
+            let owned_id = match &self.inner {
+                scheduler::Handle::CurrentThread(handle) => handle.owned_id(),
                 #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
-                scheduler::Handle::MultiThread(handle) => handle.runtime_id,
-            }
+                scheduler::Handle::MultiThread(handle) => handle.owned_id(),
+            };
+            runtime::Id::from_u64(owned_id)
         }
     }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -1,3 +1,5 @@
+#[cfg(tokio_unstable)]
+use crate::runtime;
 use crate::runtime::{context, scheduler, RuntimeFlavor};
 
 /// Handle to the runtime.
@@ -355,6 +357,35 @@ impl Handle {
             scheduler::Handle::CurrentThread(_) => RuntimeFlavor::CurrentThread,
             #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
             scheduler::Handle::MultiThread(_) => RuntimeFlavor::MultiThread,
+        }
+    }
+
+    cfg_unstable! {
+        /// Returns the [`Id`] of the current `Runtime`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Handle;
+        ///
+        /// #[tokio::main(flavor = "current_thread")]
+        /// async fn main() {
+        ///   println!("Current runtime id: {}", Handle::current().id());
+        /// }
+        /// ```
+        ///
+        /// **Note**: This is an [unstable API][unstable]. The public API of this type
+        /// may break in 1.x releases. See [the documentation on unstable
+        /// features][unstable] for details.
+        ///
+        /// [unstable]: crate#unstable-features
+        /// [`Id`]: struct@crate::runtime::Id
+        pub fn id(&self) -> runtime::Id {
+            match &self.inner {
+                scheduler::Handle::CurrentThread(handle) => handle.runtime_id,
+                #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
+                scheduler::Handle::MultiThread(handle) => handle.runtime_id,
+            }
         }
     }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -386,7 +386,7 @@ impl Handle {
                 #[cfg(all(feature = "rt-multi-thread", not(tokio_wasi)))]
                 scheduler::Handle::MultiThread(handle) => handle.owned_id(),
             };
-            runtime::Id::from_u64(owned_id)
+            owned_id.into()
         }
     }
 }

--- a/tokio/src/runtime/id.rs
+++ b/tokio/src/runtime/id.rs
@@ -6,7 +6,7 @@ use std::fmt;
 /// # Notes
 ///
 /// - Runtime IDs are unique relative to other *currently running* runtimes.
-///   When a task completes, the same ID may be used for another task.
+///   When a runtime completes, the same ID may be used for another runtime.
 /// - Runtime IDs are *not* sequential, and do not indicate the order in which
 ///   runtimes are started or any other data.
 /// - The runtime ID of the currently running task can be obtained from the
@@ -32,18 +32,14 @@ use std::fmt;
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct Id(u64);
 
-impl fmt::Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
+impl Id {
+    pub(crate) fn from_u64(val: u64) -> Self {
+        Id(val)
     }
 }
 
-impl Id {
-    pub(crate) fn next() -> Self {
-        use crate::loom::sync::atomic::{Ordering::Relaxed, StaticAtomicU64};
-
-        static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
-
-        Self(NEXT_ID.fetch_add(1, Relaxed))
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
     }
 }

--- a/tokio/src/runtime/id.rs
+++ b/tokio/src/runtime/id.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::num::NonZeroU64;
 
 /// An opaque ID that uniquely identifies a runtime relative to all other currently
 /// running runtimes.
@@ -30,11 +31,11 @@ use std::fmt;
 /// [unstable]: crate#unstable-features
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-pub struct Id(u64);
+pub struct Id(NonZeroU64);
 
-impl Id {
-    pub(crate) fn from_u64(val: u64) -> Self {
-        Id(val)
+impl From<NonZeroU64> for Id {
+    fn from(value: NonZeroU64) -> Self {
+        Id(value)
     }
 }
 

--- a/tokio/src/runtime/id.rs
+++ b/tokio/src/runtime/id.rs
@@ -1,0 +1,49 @@
+use std::fmt;
+
+/// An opaque ID that uniquely identifies a runtime relative to all other currently
+/// running runtimes.
+///
+/// # Notes
+///
+/// - Runtime IDs are unique relative to other *currently running* runtimes.
+///   When a task completes, the same ID may be used for another task.
+/// - Runtime IDs are *not* sequential, and do not indicate the order in which
+///   runtimes are started or any other data.
+/// - The runtime ID of the currently running task can be obtained from the
+///   Handle.
+///
+/// # Examples
+///
+/// ```
+/// use tokio::runtime::Handle;
+///
+/// #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+/// async fn main() {
+///   println!("Current runtime id: {}", Handle::current().id());
+/// }
+/// ```
+///
+/// **Note**: This is an [unstable API][unstable]. The public API of this type
+/// may break in 1.x releases. See [the documentation on unstable
+/// features][unstable] for details.
+///
+/// [unstable]: crate#unstable-features
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
+pub struct Id(u64);
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Id {
+    pub(crate) fn next() -> Self {
+        use crate::loom::sync::atomic::{Ordering::Relaxed, StaticAtomicU64};
+
+        static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
+
+        Self(NEXT_ID.fetch_add(1, Relaxed))
+    }
+}

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -226,6 +226,10 @@ cfg_rt! {
     mod builder;
     pub use self::builder::Builder;
     cfg_unstable! {
+        mod id;
+        #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+        pub use id::Id;
+
         pub use self::builder::UnhandledPanic;
         pub use crate::util::rand::RngSeed;
     }

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -1,8 +1,6 @@
 use crate::future::poll_fn;
 use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Arc;
-#[cfg(tokio_unstable)]
-use crate::runtime;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
@@ -43,9 +41,6 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
-
-    #[cfg(tokio_unstable)]
-    pub(crate) runtime_id: runtime::Id,
 }
 
 /// Data required for executing the scheduler. The struct is passed around to
@@ -146,8 +141,6 @@ impl CurrentThread {
             driver: driver_handle,
             blocking_spawner,
             seed_generator,
-            #[cfg(tokio_unstable)]
-            runtime_id: runtime::Id::next(),
         });
 
         let core = AtomicCell::new(Some(Box::new(Core {
@@ -545,6 +538,12 @@ cfg_metrics! {
         pub(crate) fn active_tasks_count(&self) -> usize {
             self.shared.owned.active_tasks_count()
         }
+    }
+}
+
+impl Handle {
+    pub(crate) fn owned_id(&self) -> u64 {
+        self.shared.owned.id
     }
 }
 

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -1,6 +1,8 @@
 use crate::future::poll_fn;
 use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Arc;
+#[cfg(tokio_unstable)]
+use crate::runtime;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
@@ -41,6 +43,9 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
+
+    #[cfg(tokio_unstable)]
+    pub(crate) runtime_id: runtime::Id,
 }
 
 /// Data required for executing the scheduler. The struct is passed around to
@@ -141,6 +146,8 @@ impl CurrentThread {
             driver: driver_handle,
             blocking_spawner,
             seed_generator,
+            #[cfg(tokio_unstable)]
+            runtime_id: runtime::Id::next(),
         });
 
         let core = AtomicCell::new(Some(Box::new(Core {

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -541,9 +541,11 @@ cfg_metrics! {
     }
 }
 
-impl Handle {
-    pub(crate) fn owned_id(&self) -> u64 {
-        self.shared.owned.id
+cfg_unstable! {
+    impl Handle {
+        pub(crate) fn owned_id(&self) -> u64 {
+            self.shared.owned.id
+        }
     }
 }
 

--- a/tokio/src/runtime/scheduler/current_thread.rs
+++ b/tokio/src/runtime/scheduler/current_thread.rs
@@ -542,8 +542,10 @@ cfg_metrics! {
 }
 
 cfg_unstable! {
+    use std::num::NonZeroU64;
+
     impl Handle {
-        pub(crate) fn owned_id(&self) -> u64 {
+        pub(crate) fn owned_id(&self) -> NonZeroU64 {
             self.shared.owned.id
         }
     }

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -60,8 +60,10 @@ impl Handle {
 }
 
 cfg_unstable! {
+    use std::num::NonZeroU64;
+
     impl Handle {
-        pub(crate) fn owned_id(&self) -> u64 {
+        pub(crate) fn owned_id(&self) -> NonZeroU64 {
             self.shared.owned.id
         }
     }

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -1,5 +1,7 @@
 use crate::future::Future;
 use crate::loom::sync::Arc;
+#[cfg(tokio_unstable)]
+use crate::runtime;
 use crate::runtime::scheduler::multi_thread::worker;
 use crate::runtime::{
     blocking, driver,
@@ -30,6 +32,9 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
+
+    #[cfg(tokio_unstable)]
+    pub(crate) runtime_id: runtime::Id,
 }
 
 impl Handle {

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -59,9 +59,13 @@ impl Handle {
 
         handle
     }
+}
 
-    pub(crate) fn owned_id(&self) -> u64 {
-        self.shared.owned.id
+cfg_unstable! {
+    impl Handle {
+        pub(crate) fn owned_id(&self) -> u64 {
+            self.shared.owned.id
+        }
     }
 }
 

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -1,7 +1,5 @@
 use crate::future::Future;
 use crate::loom::sync::Arc;
-#[cfg(tokio_unstable)]
-use crate::runtime;
 use crate::runtime::scheduler::multi_thread::worker;
 use crate::runtime::{
     blocking, driver,
@@ -32,9 +30,6 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
-
-    #[cfg(tokio_unstable)]
-    pub(crate) runtime_id: runtime::Id,
 }
 
 impl Handle {
@@ -63,6 +58,10 @@ impl Handle {
         }
 
         handle
+    }
+
+    pub(crate) fn owned_id(&self) -> u64 {
+        self.shared.owned.id
     }
 }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -158,7 +158,7 @@ pub(crate) struct Shared {
     idle: Idle,
 
     /// Collection of all active tasks spawned onto this executor.
-    pub(super) owned: OwnedTasks<Arc<Handle>>,
+    pub(crate) owned: OwnedTasks<Arc<Handle>>,
 
     /// Data synchronized by the scheduler mutex
     pub(super) synced: Mutex<Synced>,
@@ -302,8 +302,6 @@ pub(super) fn create(
         driver: driver_handle,
         blocking_spawner,
         seed_generator,
-        #[cfg(tokio_unstable)]
-        runtime_id: runtime::Id::next(),
     });
 
     let mut launch = Launch(vec![]);

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -302,6 +302,8 @@ pub(super) fn create(
         driver: driver_handle,
         blocking_spawner,
         seed_generator,
+        #[cfg(tokio_unstable)]
+        runtime_id: runtime::Id::next(),
     });
 
     let mut launch = Launch(vec![]);

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -55,7 +55,7 @@ cfg_not_has_atomic_u64! {
 
 pub(crate) struct OwnedTasks<S: 'static> {
     inner: Mutex<CountedOwnedTasksInner<S>>,
-    id: u64,
+    pub(crate) id: u64,
 }
 struct CountedOwnedTasksInner<S: 'static> {
     list: CountedLinkedList<Task<S>, <Task<S> as Link>::Target>,
@@ -63,7 +63,7 @@ struct CountedOwnedTasksInner<S: 'static> {
 }
 pub(crate) struct LocalOwnedTasks<S: 'static> {
     inner: UnsafeCell<OwnedTasksInner<S>>,
-    id: u64,
+    pub(crate) id: u64,
     _not_send_or_sync: PhantomData<*const ()>,
 }
 struct OwnedTasksInner<S: 'static> {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -809,7 +809,7 @@ cfg_unstable! {
         /// [unstable]: crate#unstable-features
         /// [`Id`]: struct@crate::runtime::Id
         pub fn id(&self) -> runtime::Id {
-            runtime::Id::from_u64(self.context.shared.local_state.owned.id)
+            self.context.shared.local_state.owned.id.into()
         }
     }
 }

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -1,6 +1,8 @@
 //! Runs `!Send` futures on the current thread.
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::{Arc, Mutex};
+#[cfg(tokio_unstable)]
+use crate::runtime;
 use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, Task};
 use crate::runtime::{context, ThreadId};
 use crate::sync::AtomicWaker;
@@ -784,6 +786,30 @@ cfg_unstable! {
                 .expect("Unhandled Panic behavior modified after starting LocalSet")
                 .unhandled_panic = behavior;
             self
+        }
+
+        /// Returns the [`Id`] of the current `LocalSet` runtime.
+        ///
+        /// # Examples
+        ///
+        /// ```rust
+        /// use tokio::task;
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///     let local_set = task::LocalSet::new();
+        ///     println!("Local set id: {}", local_set.id());
+        /// }
+        /// ```
+        ///
+        /// **Note**: This is an [unstable API][unstable]. The public API of this type
+        /// may break in 1.x releases. See [the documentation on unstable
+        /// features][unstable] for details.
+        ///
+        /// [unstable]: crate#unstable-features
+        /// [`Id`]: struct@crate::runtime::Id
+        pub fn id(&self) -> runtime::Id {
+            runtime::Id::from_u64(self.context.shared.local_state.owned.id)
         }
     }
 }

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -60,6 +60,29 @@ fn interleave_then_enter() {
     let _enter = rt3.enter();
 }
 
+#[cfg(tokio_unstable)]
+mod unstable {
+    use super::*;
+
+    #[test]
+    fn runtime_id_is_same() {
+        let rt = rt();
+
+        let handle1 = rt.handle();
+        let handle2 = rt.handle();
+
+        assert_eq!(handle1.id(), handle2.id());
+    }
+
+    #[test]
+    fn runtime_ids_different() {
+        let rt1 = rt();
+        let rt2 = rt();
+
+        assert_ne!(rt1.handle().id(), rt2.handle().id());
+    }
+}
+
 fn rt() -> Runtime {
     tokio::runtime::Builder::new_current_thread()
         .build()

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -762,4 +762,22 @@ mod unstable {
             .unwrap();
         })
     }
+
+    #[test]
+    fn runtime_id_is_same() {
+        let rt = rt();
+
+        let handle1 = rt.handle();
+        let handle2 = rt.handle();
+
+        assert_eq!(handle1.id(), handle2.id());
+    }
+
+    #[test]
+    fn runtime_ids_different() {
+        let rt1 = rt();
+        let rt2 = rt();
+
+        assert_ne!(rt1.handle().id(), rt2.handle().id());
+    }
 }


### PR DESCRIPTION
## Motivation

There are a number of cases in which being able to identify a runtime is
useful.

When instrumenting an application, this is particularly true. For
example, we would like to be able to add traces for runtimes so that
tasks can be differentiated (#5792). It would also allow a way to
differentiate runtimes which are have their tasks dumped.

Outside of instrumentation, it may be useful to check whether 2 runtime
handles are pointing to the same runtime.

## Solution

This change adds an opaque `runtime::Id` struct which serves this
purpose, initially behind the `tokio_unstable` cfg flag. 

The inner value of the ID is taken from the `OwnedTasks` or
`LocalOwnedTasks` struct which every runtime and local set already
has. This will mean that any use of the ID will align with the task
dump feature.

The Id is added within the scope of working towards closing #5545.
