### PR TITLE
Add cooperative UCred impl for espidf and other process-less OSes

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -54,6 +54,9 @@ pub(crate) use self::impl_solaris::get_peer_cred;
 #[cfg(target_os = "aix")]
 pub(crate) use self::impl_aix::get_peer_cred;
 
+#[cfg(target_os = "espidf")]
+pub(crate) use self::impl_noproc::get_peer_cred;
+
 #[cfg(any(
     target_os = "linux",
     target_os = "redox",
@@ -289,5 +292,19 @@ pub(crate) mod impl_aix {
                 Err(io::Error::last_os_error())
             }
         }
+    }
+}
+
+#[cfg(target_os = "espidf")]
+pub(crate) mod impl_noproc {
+    use crate::net::unix::UnixStream;
+    use std::io;
+
+    pub(crate) fn get_peer_cred(_sock: &UnixStream) -> io::Result<super::UCred> {
+        Ok(super::UCred {
+            uid: 0,
+            gid: 0,
+            pid: None,
+        })
     }
 }


### PR DESCRIPTION
## Motivation

espidf fails to compile due to missing get_peer_cred APIs.  Since there are no processes (it runs FreeRTOS), we can just
pretend everything runs as root.

## Solution

Dummy implementation keeps existing code happy and isn't technically wrong since it would show all UNIX domain sockets as being owned by the same user.
