### PR TITLE
fs: Add `File::options()` assoc function to mimic std

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -195,9 +195,9 @@ impl File {
         Ok(File::from_std(std_file))
     }
 
-    /// Returns a new OpenOptions object.
+    /// Returns a new [`OpenOptions`] object.
     ///
-    /// This function returns a new OpenOptions object that you can use to
+    /// This function returns a new `OpenOptions` object that you can use to
     /// open or create a file with specific options if `open()` or `create()`
     /// are not appropriate.
     ///

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -3,7 +3,7 @@
 //! [`File`]: File
 
 use self::State::*;
-use crate::fs::asyncify;
+use crate::fs::{asyncify, OpenOptions};
 use crate::io::blocking::Buf;
 use crate::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 use crate::sync::Mutex;
@@ -124,8 +124,6 @@ impl File {
     ///
     /// See [`OpenOptions`] for more details.
     ///
-    /// [`OpenOptions`]: super::OpenOptions
-    ///
     /// # Errors
     ///
     /// This function will return an error if called from outside of the Tokio
@@ -167,8 +165,6 @@ impl File {
     ///
     /// See [`OpenOptions`] for more details.
     ///
-    /// [`OpenOptions`]: super::OpenOptions
-    ///
     /// # Errors
     ///
     /// Results in an error if called from outside of the Tokio runtime or if
@@ -197,6 +193,37 @@ impl File {
         let path = path.as_ref().to_owned();
         let std_file = asyncify(move || StdFile::create(path)).await?;
         Ok(File::from_std(std_file))
+    }
+
+    /// Returns a new OpenOptions object.
+    ///
+    /// This function returns a new OpenOptions object that you can use to
+    /// open or create a file with specific options if `open()` or `create()`
+    /// are not appropriate.
+    ///
+    /// It is equivalent to `OpenOptions::new()`, but allows you to write more
+    /// readable code. Instead of
+    /// `OpenOptions::new().append(true).open("example.log")`,
+    /// you can write `File::options().append(true).open("example.log")`. This
+    /// also avoids the need to import `OpenOptions`.
+    ///
+    /// See the [`OpenOptions::new`] function for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::File;
+    /// use tokio::io::AsyncWriteExt;
+    ///
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let mut f = File::options().append(true).open("example.log").await?;
+    /// f.write_all(b"new line").await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn options() -> OpenOptions {
+        OpenOptions::new()
     }
 
     /// Converts a [`std::fs::File`][std] to a [`tokio::fs::File`][file].

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -217,7 +217,7 @@ impl File {
     ///
     /// # async fn dox() -> std::io::Result<()> {
     /// let mut f = File::options().append(true).open("example.log").await?;
-    /// f.write_all(b"new line").await?;
+    /// f.write_all(b"new line\n").await?;
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
I've found myself `std::fs::Files::options()` function really convenient and I accidentally typed it in tokio project. Hey, it would be an easy PR chance, right?

Code is copied from std with minor modifications, including docs explaining its motivation.