### PR TITLE
Use `Arc::increment_strong_count` instead of `mem::forget`

### DIFF
--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -63,7 +63,7 @@ cfg_loom! {
 
     // Make sure debug assertions are enabled
     #[cfg(not(debug_assertions))]
-    compiler_error!("these tests require debug assertions to be enabled");
+    compile_error!("these tests require debug assertions to be enabled");
 }
 
 cfg_not_loom! {

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -1,6 +1,5 @@
 use crate::sync::Notify;
 use std::future::Future;
-use std::mem::ManuallyDrop;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
 
@@ -12,16 +11,16 @@ fn notify_clones_waker_before_lock() {
     const VTABLE: &RawWakerVTable = &RawWakerVTable::new(clone_w, wake, wake_by_ref, drop_w);
 
     unsafe fn clone_w(data: *const ()) -> RawWaker {
-        let arc = ManuallyDrop::new(Arc::<Notify>::from_raw(data as *const Notify));
+        let ptr = data as *const Notify;
+        Arc::<Notify>::increment_strong_count(ptr);
         // Or some other arbitrary code that shouldn't be executed while the
         // Notify wait list is locked.
-        arc.notify_one();
-        let _arc_clone: ManuallyDrop<_> = arc.clone();
+        (*ptr).notify_one();
         RawWaker::new(data, VTABLE)
     }
 
     unsafe fn drop_w(data: *const ()) {
-        let _ = Arc::<Notify>::from_raw(data as *const Notify);
+        drop(Arc::<Notify>::from_raw(data as *const Notify));
     }
 
     unsafe fn wake(_data: *const ()) {

--- a/tokio/src/util/wake.rs
+++ b/tokio/src/util/wake.rs
@@ -50,16 +50,8 @@ fn waker_vtable<W: Wake>() -> &'static RawWakerVTable {
     )
 }
 
-unsafe fn inc_ref_count<T: Wake>(data: *const ()) {
-    // Retain Arc, but don't touch refcount by wrapping in ManuallyDrop
-    let arc = ManuallyDrop::new(Arc::<T>::from_raw(data as *const T));
-
-    // Now increase refcount, but don't drop new refcount either
-    let _arc_clone: ManuallyDrop<_> = arc.clone();
-}
-
 unsafe fn clone_arc_raw<T: Wake>(data: *const ()) -> RawWaker {
-    inc_ref_count::<T>(data);
+    Arc::<T>::increment_strong_count(data as *const T);
     RawWaker::new(data, waker_vtable::<T>())
 }
 


### PR DESCRIPTION
The `Arc::increment_strong_count` method was stabilized in Rust 1.51, and our MSRV is now new enough to use it.