### PR TITLE
deps!: bump `socket2` (to `0.5.3`) and MSRV (to `1.63`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   # - tokio-util/Cargo.toml
   # - tokio-test/Cargo.toml
   # - tokio-stream/Cargo.toml
-  rust_min: 1.56.0
+  rust_min: 1.63.0
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -187,12 +187,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.56.0.
+released at least six months ago. The current MSRV is 1.63.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.27 to now - Rust 1.56
+ * 1.30 to now - Rust 1.63
+ * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46
  * 1.0 to 1.14 - Rust 1.45

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-stream"
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.14"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-test"
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.2"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-util"
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.8"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio"
 # - Create "v1.x.y" git tag.
 version = "1.29.1"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -108,7 +108,7 @@ num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dependencies]
-socket2 = { version = "0.4.9", optional = true, features = [ "all" ] }
+socket2 = { version = "0.5.3", optional = true, features = [ "all" ] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
@@ -147,7 +147,7 @@ mockall = "0.11.1"
 async-stream = "0.3"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "wasm64")))'.dev-dependencies]
-socket2 = "0.4.9"
+socket2 = "0.5.3"
 tempfile = "3.1.0"
 
 [target.'cfg(not(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown")))'.dev-dependencies]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -187,12 +187,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.56.0.
+released at least six months ago. The current MSRV is 1.63.0.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.27 to now - Rust 1.56
+ * 1.30 to now - Rust 1.63
+ * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46
  * 1.0 to 1.14 - Rust 1.45

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -457,7 +457,7 @@ impl TcpSocket {
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
     ///
     /// [`set_tos`]: Self::set_tos
-    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    // https://docs.rs/socket2/0.5.3/src/socket2/socket.rs.html#1464
     #[cfg(not(any(
         target_os = "fuchsia",
         target_os = "redox",
@@ -484,7 +484,7 @@ impl TcpSocket {
     ///
     /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
-    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    // https://docs.rs/socket2/0.5.3/src/socket2/socket.rs.html#1446
     #[cfg(not(any(
         target_os = "fuchsia",
         target_os = "redox",

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1855,7 +1855,7 @@ impl UdpSocket {
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
     ///
     /// [`set_tos`]: Self::set_tos
-    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    // https://docs.rs/socket2/0.5.3/src/socket2/socket.rs.html#1464
     #[cfg(not(any(
         target_os = "fuchsia",
         target_os = "redox",
@@ -1882,7 +1882,7 @@ impl UdpSocket {
     ///
     /// **NOTE:** On Windows, `IP_TOS` is only supported on [Windows 8+ or
     /// Windows Server 2012+.](https://docs.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options)
-    // https://docs.rs/socket2/0.4.2/src/socket2/socket.rs.html#1178
+    // https://docs.rs/socket2/0.5.3/src/socket2/socket.rs.html#1446
     #[cfg(not(any(
         target_os = "fuchsia",
         target_os = "redox",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Due to MSRV restrictions, the `tokio` crate depends on an old version of the `socket2` crate that depends on the `winapi` crate. This is unfortunate because nowadays, we should prefer the officially maintained `windows-sys` crate for Windows API bindings.

Note that this problem is not only an issue of updating dependencies to the latest version. By keeping the old version of `socket2` around, we are forcing consumers of the `tokio` crate to download and compile two redundant crates in the dependency tree: `winapi` and `windows-sys`. With the latter being officially supported, it is about time we prune `winapi` from the dependency tree.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR bumps `socket2` to version `0.5`, which is the final piece in the dependency tree that still previously relied on `winapi`. See the [changelog](https://github.com/rust-lang/socket2/blob/baa8f2b27de11cfd582f9f0f891a5c421d3b200e/CHANGELOG.md) for more details. All references in the documentation and manifest files have been updated accordingly.

Note that this has already been attempted in #5603. However, due to MSRV constraints, the author promptly closed the PR. A few months later, it should now be safe to bump the MSRV to `1.63`, which also happens to be the MSRV for `socket2`. Since `1.63` was released [eleven months ago](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html) as of writing, we are well beyond the six-month eligibility requirement of the MSRV policy. :tada:

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
