### PR TITLE
poll: Do not clear readiness on short read/writes.

### DIFF
--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -165,7 +165,9 @@ feature! {
                 match self.io.as_ref().unwrap().read(b) {
                     Ok(n) => {
                         // if we read a partially full buffer, this is sufficient on unix to show
-                        // that the socket buffer has been drained
+                        // that the socket buffer has been drained.  Unfortunately this assumption
+                        // fails for level-triggered selectors (like on Windows or poll even for
+                        // UNIX): https://github.com/tokio-rs/tokio/issues/5866
                         if n > 0 && (!cfg!(windows) && !cfg!(mio_unsupported_force_poll_poll) && n < len) {
                             self.registration.clear_readiness(evt);
                         }
@@ -196,7 +198,9 @@ feature! {
                 match self.io.as_ref().unwrap().write(buf) {
                     Ok(n) => {
                         // if we write only part of our buffer, this is sufficient on unix to show
-                        // that the socket buffer is full
+                        // that the socket buffer is full.  Unfortunately this assumption
+                        // fails for level-triggered selectors (like on Windows or poll even for
+                        // UNIX): https://github.com/tokio-rs/tokio/issues/5866
                         if n > 0 && (!cfg!(windows) && !cfg!(mio_unsupported_force_poll_poll) && n < buf.len()) {
                             self.registration.clear_readiness(evt);
                         }

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -166,7 +166,7 @@ feature! {
                     Ok(n) => {
                         // if we read a partially full buffer, this is sufficient on unix to show
                         // that the socket buffer has been drained
-                        if n > 0 && (!cfg!(windows) && n < len) {
+                        if n > 0 && (!cfg!(windows) && !cfg!(mio_unsupported_force_poll_poll) && n < len) {
                             self.registration.clear_readiness(evt);
                         }
 
@@ -197,7 +197,7 @@ feature! {
                     Ok(n) => {
                         // if we write only part of our buffer, this is sufficient on unix to show
                         // that the socket buffer is full
-                        if n > 0 && (!cfg!(windows) && n < buf.len()) {
+                        if n > 0 && (!cfg!(windows) && !cfg!(mio_unsupported_force_poll_poll) && n < buf.len()) {
                             self.registration.clear_readiness(evt);
                         }
 


### PR DESCRIPTION
## Motivation

The new mio_unsupported_force_poll_poll behaviour works the same as Windows (using level-triggered APIs to mimic edge-triggered ones) and it depends on intercepting an EAGAIN result to start polling the fd again.  Without this change, short reads don't reregister with the poll Selector and it causes the socket to stall in a read async call forever.

## Solution

Per #5866, going with the simplest solution of just adding another `cfg!` check alongside the Windows one.
