### PR TITLE
Constify `{Mutex, Notify, OnceCell, RwLock, Semaphore}::new`

### DIFF
--- a/tokio/src/loom/std/atomic_u64_static_const_new.rs
+++ b/tokio/src/loom/std/atomic_u64_static_const_new.rs
@@ -6,7 +6,7 @@ pub(crate) type StaticAtomicU64 = AtomicU64;
 impl AtomicU64 {
     pub(crate) const fn new(val: u64) -> Self {
         Self {
-            inner: Mutex::const_new(val),
+            inner: Mutex::new(val),
         }
     }
 }

--- a/tokio/src/loom/std/mutex.rs
+++ b/tokio/src/loom/std/mutex.rs
@@ -8,12 +8,7 @@ pub(crate) struct Mutex<T: ?Sized>(sync::Mutex<T>);
 #[allow(dead_code)]
 impl<T> Mutex<T> {
     #[inline]
-    pub(crate) fn new(t: T) -> Mutex<T> {
-        Mutex(sync::Mutex::new(t))
-    }
-
-    #[inline]
-    pub(crate) const fn const_new(t: T) -> Mutex<T> {
+    pub(crate) const fn new(t: T) -> Mutex<T> {
         Mutex(sync::Mutex::new(t))
     }
 

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -47,14 +47,7 @@ pub(crate) struct RwLockWriteGuard<'a, T: ?Sized>(
 
 impl<T> Mutex<T> {
     #[inline]
-    pub(crate) fn new(t: T) -> Mutex<T> {
-        Mutex(PhantomData, parking_lot::Mutex::new(t))
-    }
-
-    #[inline]
-    #[cfg(all(feature = "parking_lot", not(all(loom, test))))]
-    #[cfg_attr(docsrs, doc(cfg(all(feature = "parking_lot",))))]
-    pub(crate) const fn const_new(t: T) -> Mutex<T> {
+    pub(crate) const fn new(t: T) -> Mutex<T> {
         Mutex(PhantomData, parking_lot::const_mutex(t))
     }
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -556,6 +556,18 @@ macro_rules! cfg_not_has_const_mutex_new {
     }
 }
 
+macro_rules! cfg_const_if_has_const_mutex_new {
+    ($(#[$attr:meta])* $vis:vis const fn $fn_name:ident $( $rest : tt )*) => {
+        #[cfg(not(all(loom, test)))]
+        $(#[$attr])*
+        $vis const fn $fn_name $( $rest )*
+
+        #[cfg(all(loom, test))]
+        $(#[$attr])*
+        $vis fn $fn_name $( $rest )*
+    }
+}
+
 macro_rules! cfg_not_wasi {
     ($($item:item)*) => {
         $(

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -43,20 +43,11 @@ pub(crate) struct OrphanQueueImpl<T> {
 }
 
 impl<T> OrphanQueueImpl<T> {
-    cfg_not_has_const_mutex_new! {
-        pub(crate) fn new() -> Self {
+    cfg_const_if_has_const_mutex_new! {
+        pub(crate) const fn new() -> Self {
             Self {
                 sigchild: Mutex::new(None),
                 queue: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    cfg_has_const_mutex_new! {
-        pub(crate) const fn new() -> Self {
-            Self {
-                sigchild: Mutex::const_new(None),
-                queue: Mutex::const_new(Vec::new()),
             }
         }
     }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -418,19 +418,21 @@ fn atomic_inc_num_notify_waiters_calls(data: &AtomicUsize) {
 }
 
 impl Notify {
-    /// Create a new `Notify`, initialized without a permit.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tokio::sync::Notify;
-    ///
-    /// let notify = Notify::new();
-    /// ```
-    pub fn new() -> Notify {
-        Notify {
-            state: AtomicUsize::new(0),
-            waiters: Mutex::new(LinkedList::new()),
+    cfg_const_if_has_const_mutex_new! {
+        /// Create a new `Notify`, initialized without a permit.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::sync::Notify;
+        ///
+        /// let notify = Notify::new();
+        /// ```
+        pub const fn new() -> Notify {
+            Notify {
+                state: AtomicUsize::new(0),
+                waiters: Mutex::new(LinkedList::new()),
+            }
         }
     }
 
@@ -445,10 +447,7 @@ impl Notify {
     /// ```
     #[cfg(not(all(loom, test)))]
     pub const fn const_new() -> Notify {
-        Notify {
-            state: AtomicUsize::new(0),
-            waiters: Mutex::const_new(LinkedList::new()),
-        }
+        Self::new()
     }
 
     /// Wait for a notification.

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -123,12 +123,14 @@ impl<T> From<T> for OnceCell<T> {
 }
 
 impl<T> OnceCell<T> {
-    /// Creates a new empty `OnceCell` instance.
-    pub fn new() -> Self {
-        OnceCell {
-            value_set: AtomicBool::new(false),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
-            semaphore: Semaphore::new(1),
+    cfg_const_if_has_const_mutex_new! {
+        /// Creates a new empty `OnceCell` instance.
+        pub const fn new() -> Self {
+            OnceCell {
+                value_set: AtomicBool::new(false),
+                value: UnsafeCell::new(MaybeUninit::uninit()),
+                semaphore: Semaphore::new(1),
+            }
         }
     }
 
@@ -175,11 +177,7 @@ impl<T> OnceCell<T> {
     /// ```
     #[cfg(not(all(loom, test)))]
     pub const fn const_new() -> Self {
-        OnceCell {
-            value_set: AtomicBool::new(false),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
-            semaphore: Semaphore::const_new(1),
-        }
+        Self::new()
     }
 
     /// Returns `true` if the `OnceCell` currently contains a value, and `false`


### PR DESCRIPTION
## Motivation

With MSRV bumped to 1.63, we can now make `{Mutex, Notify, OnceCell, RwLock, Semaphore}::new` available in const context.

## Solution

Removed the tracing log in these functions and makes these function usable in const context when `cfg(not(all(loom, test)))`.