### PR TITLE
process: Impl `{ChildStd*}::into_owned_{fd, handle}`

### DIFF
--- a/tokio/src/doc/os.rs
+++ b/tokio/src/doc/os.rs
@@ -11,6 +11,9 @@ pub mod windows {
         /// See [std::os::windows::io::RawHandle](https://doc.rust-lang.org/std/os/windows/io/type.RawHandle.html)
         pub type RawHandle = crate::doc::NotDefinedHere;
 
+        /// See [std::os::windows::io::OwnedHandle](https://doc.rust-lang.org/std/os/windows/io/struct.OwnedHandle.html)
+        pub type OwnedHandle = crate::doc::NotDefinedHere;
+
         /// See [std::os::windows::io::AsRawHandle](https://doc.rust-lang.org/std/os/windows/io/trait.AsRawHandle.html)
         pub trait AsRawHandle {
             /// See [std::os::windows::io::AsRawHandle::as_raw_handle](https://doc.rust-lang.org/std/os/windows/io/trait.AsRawHandle.html#tymethod.as_raw_handle)

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1484,7 +1484,7 @@ mod sys {
     impl_traits!(ChildStderr);
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, docsrs))]
 #[cfg_attr(docsrs, doc(cfg(windows)))]
 mod windows {
     use super::*;

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -259,7 +259,7 @@ use std::os::unix::process::CommandExt;
 use std::os::windows::process::CommandExt;
 
 cfg_windows! {
-    use crate::os::windows::io::{AsRawHandle, RawHandle, AsHandle, BorrowedHandle};
+    use crate::os::windows::io::{AsRawHandle, RawHandle};
 }
 
 /// This structure mimics the API of [`std::process::Command`] found in the standard library, but
@@ -1447,84 +1447,75 @@ impl TryInto<Stdio> for ChildStderr {
 }
 
 #[cfg(unix)]
+#[cfg_attr(docsrs, doc(cfg(unix)))]
 mod sys {
-    use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
+    use std::{
+        io,
+        os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd},
+    };
 
     use super::{ChildStderr, ChildStdin, ChildStdout};
 
-    impl AsRawFd for ChildStdin {
-        fn as_raw_fd(&self) -> RawFd {
-            self.inner.as_raw_fd()
-        }
+    macro_rules! impl_traits {
+        ($type:ty) => {
+            impl $type {
+                /// Convert into [`OwnedFd`].
+                pub fn into_owned_fd(self) -> io::Result<OwnedFd> {
+                    self.inner.into_owned_fd()
+                }
+            }
+
+            impl AsRawFd for $type {
+                fn as_raw_fd(&self) -> RawFd {
+                    self.inner.as_raw_fd()
+                }
+            }
+
+            impl AsFd for $type {
+                fn as_fd(&self) -> BorrowedFd<'_> {
+                    unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
+                }
+            }
+        };
     }
 
-    impl AsFd for ChildStdin {
-        fn as_fd(&self) -> BorrowedFd<'_> {
-            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
-        }
-    }
-
-    impl AsRawFd for ChildStdout {
-        fn as_raw_fd(&self) -> RawFd {
-            self.inner.as_raw_fd()
-        }
-    }
-
-    impl AsFd for ChildStdout {
-        fn as_fd(&self) -> BorrowedFd<'_> {
-            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
-        }
-    }
-
-    impl AsRawFd for ChildStderr {
-        fn as_raw_fd(&self) -> RawFd {
-            self.inner.as_raw_fd()
-        }
-    }
-
-    impl AsFd for ChildStderr {
-        fn as_fd(&self) -> BorrowedFd<'_> {
-            unsafe { BorrowedFd::borrow_raw(self.as_raw_fd()) }
-        }
-    }
+    impl_traits!(ChildStdin);
+    impl_traits!(ChildStdout);
+    impl_traits!(ChildStderr);
 }
 
-cfg_windows! {
-    impl AsRawHandle for ChildStdin {
-        fn as_raw_handle(&self) -> RawHandle {
-            self.inner.as_raw_handle()
-        }
+#[cfg(windows)]
+#[cfg_attr(docsrs, doc(cfg(windows)))]
+mod windows {
+    use super::*;
+    use crate::os::windows::io::{AsHandle, BorrowedHandle, OwnedHandle};
+
+    macro_rules! impl_traits {
+        ($type:ty) => {
+            impl $type {
+                /// Convert into [`OwnedHandle`].
+                pub fn into_owned_handle(self) -> io::Result<OwnedHandle> {
+                    self.inner.into_owned_handle()
+                }
+            }
+
+            impl AsRawHandle for $type {
+                fn as_raw_handle(&self) -> RawHandle {
+                    self.inner.as_raw_handle()
+                }
+            }
+
+            impl AsHandle for $type {
+                fn as_handle(&self) -> BorrowedHandle<'_> {
+                    unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+                }
+            }
+        };
     }
 
-    impl AsHandle for ChildStdin {
-        fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
-        }
-    }
-
-    impl AsRawHandle for ChildStdout {
-        fn as_raw_handle(&self) -> RawHandle {
-            self.inner.as_raw_handle()
-        }
-    }
-
-    impl AsHandle for ChildStdout {
-        fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
-        }
-    }
-
-    impl AsRawHandle for ChildStderr {
-        fn as_raw_handle(&self) -> RawHandle {
-            self.inner.as_raw_handle()
-        }
-    }
-
-    impl AsHandle for ChildStderr {
-        fn as_handle(&self) -> BorrowedHandle<'_> {
-            unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
-        }
-    }
+    impl_traits!(ChildStdin);
+    impl_traits!(ChildStdout);
+    impl_traits!(ChildStderr);
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1488,8 +1488,9 @@ mod sys {
 #[cfg_attr(docsrs, doc(cfg(windows)))]
 mod windows {
     use super::*;
-    use crate::os::windows::io::{AsHandle, BorrowedHandle, OwnedHandle};
+    use crate::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, OwnedHandle, RawHandle};
 
+    #[cfg(not(docsrs))]
     macro_rules! impl_traits {
         ($type:ty) => {
             impl $type {
@@ -1508,6 +1509,30 @@ mod windows {
             impl AsHandle for $type {
                 fn as_handle(&self) -> BorrowedHandle<'_> {
                     unsafe { BorrowedHandle::borrow_raw(self.as_raw_handle()) }
+                }
+            }
+        };
+    }
+
+    #[cfg(docsrs)]
+    macro_rules! impl_traits {
+        ($type:ty) => {
+            impl $type {
+                /// Convert into [`OwnedHandle`].
+                pub fn into_owned_handle(self) -> io::Result<OwnedHandle> {
+                    todo!("For doc generation only")
+                }
+            }
+
+            impl AsRawHandle for $type {
+                fn as_raw_handle(&self) -> RawHandle {
+                    todo!("For doc generation only")
+                }
+            }
+
+            impl AsHandle for $type {
+                fn as_handle(&self) -> BorrowedHandle<'_> {
+                    todo!("For doc generation only")
                 }
             }
         };


### PR DESCRIPTION
Fixed #4403 and fixed #5333

## Motivation

`tokio::process::ChildStd*` does not implement `IntoRawFd`/`IntoRawHandle` or any similar method to obtain an owned fd/handle of the child stdin/stdout/stderr.

It makes sense since converting it to a raw fd/handle is fallible operation.

## Solution

Implement `into_owned_fd` and `into_owned_handle` for these `ChildStd*`, which returns `io::Result<Owned*>` since it is fallible.

I chose to return `OwnedFd`/`OwnedHandle` instead of `RawFd`/`RawHandle` since the msrv has just bumped to 1.63 so we can now use these types and it is much more ergonomic than returning raw ones.