### PR TITLE
Hide `Unpin`'s documentation for `Sleep`

### DIFF
--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -37,7 +37,7 @@ signal = ["tokio/signal"]
 
 [dependencies]
 futures-core = { version = "0.3.0" }
-pin-project-lite = "0.2.7"
+pin-project-lite = "0.2.11"
 tokio = { version = "1.15.0", path = "../tokio", features = ["sync"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", optional = true }
 

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -40,7 +40,7 @@ futures-core = "0.3.0"
 futures-sink = "0.3.0"
 futures-io = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", optional = true }
-pin-project-lite = "0.2.7"
+pin-project-lite = "0.2.11"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -96,7 +96,7 @@ stats = []
 [dependencies]
 tokio-macros = { version = "~2.1.0", path = "../tokio-macros", optional = true }
 
-pin-project-lite = "0.2.7"
+pin-project-lite = "0.2.11"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -220,6 +220,7 @@ pin_project! {
     /// [`select!`]: ../macro.select.html
     /// [`tokio::pin!`]: ../macro.pin.html
     // Alias for old name in 0.2
+    #[project(!Unpin)]
     #[cfg_attr(docsrs, doc(alias = "Delay"))]
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #5901 

Hides the documentation for the `Unpin` implementation for `Sleep`.

Not as nice as marking it as `!Unpin`, but at least is less confusing.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Bump the `pin-project-lite` version to the `2.9.11`, which added support to `#[project(!Unpin)]`, in https://github.com/taiki-e/pin-project-lite/pull/76.

## Doc view

Not as nice as showing `!Unpin`, but at least it is less confusing.

![image](https://github.com/tokio-rs/tokio/assets/27595790/265b410e-cdfb-4d59-ab29-91aff109fd29)
