### PR TITLE
chore: prepare Tokio v1.30.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.30.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,45 @@
+# 1.30.0 (August 6, 2023)
+
+### Fixed
+- sync: fix import style for `std::error::Error` (#5818)
+- util: fix broken intra-doc link (#5849)
+- process: fix `raw_arg` not showing up in docs (#5865)
+- ci: fix clippy warnings (#5891)
+- runtime: fix flaky test `wake_while_rt_is_dropping` (#5905)
+- rt(alt): fix a number of concurrency bugs (#5907)
+
+### Changed
+
+- ci: reenable semver check (#5845)
+- Speedup CI (#5691)
+- tokio: reduce LLVM code generation (#5859)
+- runtime: use `Arc::increment_strong_count` instead of `mem::forget` (#5872)
+- rt: use optional non-zero value for task `owner_id` (#5876)
+- poll: Do not clear readiness on short read/writes. (#5881)
+- sync: make `const_new` methods always available (#5885)
+- sync: avoid false sharing in mpsc channel (#5829)  
+### Added
+
+- sync: add `broadcast::Sender::new` (#5824)
+- net: implement `UCred` for espidf (#5868)
+- rt(alt): track which workers are idle. (#5886)
+- fs: add `File::options()` (#5869)
+- rt: add runtime ID (#5864)
+- test: fetch actions from mock handle before write (#5814)
+- rt: initial implementation of new threaded runtime (#5823)
+- time: implement extra reset variants for `Interval` (#5878)
+- rt: pop at least one task from inject queue (#5908)
+
+### Removed
+
+- tokio: removed unused `tokio_*` cfgs (#5890)
+
+### Documented
+
+- sync: mention lagging in docs for `broadcast::send` (#5820)
+- runtime: expand on sharing runtime docs (#5858)
+- io: use vec in example for `AsyncReadExt::read_exact` (#5863)
+- time: mark `Sleep` as `!Unpin` in docs (#5916)
 # 1.29.1 (June 29, 2023)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 tokio: bump MSRV to 1.63 ([#5887])
 
-### Fixed
-- runtime: fix flaky test `wake_while_rt_is_dropping` ([#5905])
-
 ### Changed
 
 - tokio: reduce LLVM code generation ([#5859])
@@ -23,7 +20,7 @@ tokio: bump MSRV to 1.63 ([#5887])
 ### Removed
 
 - tokio: removed unused `tokio_*` cfgs ([#5890])
-- remove build script to speed up compilation ([#5890])
+- remove build script to speed up compilation ([#5887])
 
 ### Documented
 
@@ -38,7 +35,6 @@ tokio: bump MSRV to 1.63 ([#5887])
 - rt: initial implementation of new threaded runtime ([#5823])
 
 [#5887]: https://github.com/tokio-rs/tokio/pull/5887
-[#5905]: https://github.com/tokio-rs/tokio/pull/5905
 [#5859]: https://github.com/tokio-rs/tokio/pull/5859
 [#5859]: https://github.com/tokio-rs/tokio/pull/5881
 [#5885]: https://github.com/tokio-rs/tokio/pull/5885

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -3,18 +3,11 @@
 tokio: bump MSRV to 1.63 (#5887)
 
 ### Fixed
-- sync: fix import style for `std::error::Error` (#5818)
-- util: fix broken intra-doc link (#5849)
-- process: fix `raw_arg` not showing up in docs (#5865)
-- ci: fix clippy warnings (#5891)
 - runtime: fix flaky test `wake_while_rt_is_dropping` (#5905)
 
 ### Changed
 
-- Speedup CI (#5691)
 - tokio: reduce LLVM code generation (#5859)
-- runtime: use `Arc::increment_strong_count` instead of `mem::forget` (#5872)
-- rt: use optional non-zero value for task `owner_id` (#5876)
 - poll: Do not clear readiness on short read/writes. (#5881)
 - sync: make `const_new` methods always available (#5885)
 - sync: avoid false sharing in mpsc channel (#5829)  
@@ -23,9 +16,6 @@ tokio: bump MSRV to 1.63 (#5887)
 - sync: add `broadcast::Sender::new` (#5824)
 - net: implement `UCred` for espidf (#5868)
 - fs: add `File::options()` (#5869)
-- rt: add runtime ID (#5864)
-- test: fetch actions from mock handle before write (#5814)
-- rt: initial implementation of new threaded runtime (#5823)
 - time: implement extra reset variants for `Interval` (#5878)
 - rt: pop at least one task from inject queue (#5908)
 
@@ -40,10 +30,13 @@ tokio: bump MSRV to 1.63 (#5887)
 - runtime: expand on sharing runtime docs (#5858)
 - io: use vec in example for `AsyncReadExt::read_exact` (#5863)
 - time: mark `Sleep` as `!Unpin` in docs (#5916)
+- process: fix `raw_arg` not showing up in docs (#5865)
 
 ### Unstable
 - rt(alt): fix a number of concurrency bugs (#5907)
 - rt(alt): track which workers are idle. (#5886)
+- rt: add runtime ID (#5864)
+- rt: initial implementation of new threaded runtime (#5823)
 
 # 1.29.1 (June 29, 2023)
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.30.0 (August 6, 2023)
+# 1.30.0 (August 9, 2023)
 
 This release bumps the MSRV of Tokio to 1.63. ([#5887])
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -16,6 +16,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 - net: implement `UCred` for espidf ([#5868])
 - fs: add `File::options()` ([#5869])
 - time: implement extra reset variants for `Interval` ([#5878])
+- process: add {ChildStd*}::into_owned_{fd, handle} ([#5899])
 
 ### Removed
 
@@ -50,6 +51,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 [#5885]: https://github.com/tokio-rs/tokio/pull/5885
 [#5887]: https://github.com/tokio-rs/tokio/pull/5887
 [#5890]: https://github.com/tokio-rs/tokio/pull/5890
+[#5899]: https://github.com/tokio-rs/tokio/pull/5899
 [#5908]: https://github.com/tokio-rs/tokio/pull/5908
 [#5916]: https://github.com/tokio-rs/tokio/pull/5916
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 1.30.0 (August 6, 2023)
 
-tokio: bump MSRV to 1.63 ([#5887])
+This release bumps the MSRV of Tokio to 1.63. ([#5887])
 
 ### Changed
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -33,8 +33,6 @@ tokio: bump MSRV to 1.63 (#5887)
 - process: fix `raw_arg` not showing up in docs (#5865)
 
 ### Unstable
-- rt(alt): fix a number of concurrency bugs (#5907)
-- rt(alt): track which workers are idle. (#5886)
 - rt: add runtime ID (#5864)
 - rt: initial implementation of new threaded runtime (#5823)
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,16 +1,16 @@
 # 1.30.0 (August 6, 2023)
 
+tokio: bump MSRV to 1.63 (#5887)
+
 ### Fixed
 - sync: fix import style for `std::error::Error` (#5818)
 - util: fix broken intra-doc link (#5849)
 - process: fix `raw_arg` not showing up in docs (#5865)
 - ci: fix clippy warnings (#5891)
 - runtime: fix flaky test `wake_while_rt_is_dropping` (#5905)
-- rt(alt): fix a number of concurrency bugs (#5907)
 
 ### Changed
 
-- ci: reenable semver check (#5845)
 - Speedup CI (#5691)
 - tokio: reduce LLVM code generation (#5859)
 - runtime: use `Arc::increment_strong_count` instead of `mem::forget` (#5872)
@@ -22,7 +22,6 @@
 
 - sync: add `broadcast::Sender::new` (#5824)
 - net: implement `UCred` for espidf (#5868)
-- rt(alt): track which workers are idle. (#5886)
 - fs: add `File::options()` (#5869)
 - rt: add runtime ID (#5864)
 - test: fetch actions from mock handle before write (#5814)
@@ -33,6 +32,7 @@
 ### Removed
 
 - tokio: removed unused `tokio_*` cfgs (#5890)
+- the entire build.rs is removed so compiling Tokio should be faster
 
 ### Documented
 
@@ -40,6 +40,11 @@
 - runtime: expand on sharing runtime docs (#5858)
 - io: use vec in example for `AsyncReadExt::read_exact` (#5863)
 - time: mark `Sleep` as `!Unpin` in docs (#5916)
+
+### Unstable
+- rt(alt): fix a number of concurrency bugs (#5907)
+- rt(alt): track which workers are idle. (#5886)
+
 # 1.29.1 (June 29, 2023)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,40 +1,61 @@
 # 1.30.0 (August 6, 2023)
 
-tokio: bump MSRV to 1.63 (#5887)
+tokio: bump MSRV to 1.63 ([#5887])
 
 ### Fixed
-- runtime: fix flaky test `wake_while_rt_is_dropping` (#5905)
+- runtime: fix flaky test `wake_while_rt_is_dropping` ([#5905])
 
 ### Changed
 
-- tokio: reduce LLVM code generation (#5859)
-- poll: Do not clear readiness on short read/writes. (#5881)
-- sync: make `const_new` methods always available (#5885)
-- sync: avoid false sharing in mpsc channel (#5829)  
+- tokio: reduce LLVM code generation ([#5859])
+- io: support `--cfg mio_unsupported_force_poll_poll` flag ([#5881])
+- sync: make `const_new` methods always available ([#5885])
+- sync: avoid false sharing in mpsc channel ([#5829])
+- rt: pop at least one task from inject queue ([#5908])
+
 ### Added
 
-- sync: add `broadcast::Sender::new` (#5824)
-- net: implement `UCred` for espidf (#5868)
-- fs: add `File::options()` (#5869)
-- time: implement extra reset variants for `Interval` (#5878)
-- rt: pop at least one task from inject queue (#5908)
+- sync: add `broadcast::Sender::new` ([#5824])
+- net: implement `UCred` for espidf ([#5868])
+- fs: add `File::options()` ([#5869])
+- time: implement extra reset variants for `Interval` ([#5878])
 
 ### Removed
 
-- tokio: removed unused `tokio_*` cfgs (#5890)
-- the entire build.rs is removed so compiling Tokio should be faster
+- tokio: removed unused `tokio_*` cfgs ([#5890])
+- remove build script to speed up compilation ([#5890])
 
 ### Documented
 
-- sync: mention lagging in docs for `broadcast::send` (#5820)
-- runtime: expand on sharing runtime docs (#5858)
-- io: use vec in example for `AsyncReadExt::read_exact` (#5863)
-- time: mark `Sleep` as `!Unpin` in docs (#5916)
-- process: fix `raw_arg` not showing up in docs (#5865)
+- sync: mention lagging in docs for `broadcast::send` ([#5820])
+- runtime: expand on sharing runtime docs ([#5858])
+- io: use vec in example for `AsyncReadExt::read_exact` ([#5863])
+- time: mark `Sleep` as `!Unpin` in docs ([#5916])
+- process: fix `raw_arg` not showing up in docs ([#5865])
 
 ### Unstable
-- rt: add runtime ID (#5864)
-- rt: initial implementation of new threaded runtime (#5823)
+- rt: add runtime ID ([#5864])
+- rt: initial implementation of new threaded runtime ([#5823])
+
+[#5887]: https://github.com/tokio-rs/tokio/pull/5887
+[#5905]: https://github.com/tokio-rs/tokio/pull/5905
+[#5859]: https://github.com/tokio-rs/tokio/pull/5859
+[#5859]: https://github.com/tokio-rs/tokio/pull/5881
+[#5885]: https://github.com/tokio-rs/tokio/pull/5885
+[#5829]: https://github.com/tokio-rs/tokio/pull/5829
+[#5908]: https://github.com/tokio-rs/tokio/pull/5908
+[#5824]: https://github.com/tokio-rs/tokio/pull/5824
+[#5868]: https://github.com/tokio-rs/tokio/pull/5868
+[#5869]: https://github.com/tokio-rs/tokio/pull/5869
+[#5878]: https://github.com/tokio-rs/tokio/pull/5878
+[#5890]: https://github.com/tokio-rs/tokio/pull/5890
+[#5820]: https://github.com/tokio-rs/tokio/pull/5820
+[#5858]: https://github.com/tokio-rs/tokio/pull/5858
+[#5863]: https://github.com/tokio-rs/tokio/pull/5863
+[#5916]: https://github.com/tokio-rs/tokio/pull/5916
+[#5865]: https://github.com/tokio-rs/tokio/pull/5865
+[#5864]: https://github.com/tokio-rs/tokio/pull/5864
+[#5823]: https://github.com/tokio-rs/tokio/pull/5823
 
 # 1.29.1 (June 29, 2023)
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -46,7 +46,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 [#5868]: https://github.com/tokio-rs/tokio/pull/5868
 [#5869]: https://github.com/tokio-rs/tokio/pull/5869
 [#5878]: https://github.com/tokio-rs/tokio/pull/5878
-[#5885]: https://github.com/tokio-rs/tokio/pull/5881
+[#5881]: https://github.com/tokio-rs/tokio/pull/5881
 [#5885]: https://github.com/tokio-rs/tokio/pull/5885
 [#5887]: https://github.com/tokio-rs/tokio/pull/5887
 [#5890]: https://github.com/tokio-rs/tokio/pull/5890

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -34,24 +34,23 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 - rt: add runtime ID ([#5864])
 - rt: initial implementation of new threaded runtime ([#5823])
 
-[#5887]: https://github.com/tokio-rs/tokio/pull/5887
-[#5859]: https://github.com/tokio-rs/tokio/pull/5859
-[#5859]: https://github.com/tokio-rs/tokio/pull/5881
-[#5885]: https://github.com/tokio-rs/tokio/pull/5885
-[#5829]: https://github.com/tokio-rs/tokio/pull/5829
-[#5908]: https://github.com/tokio-rs/tokio/pull/5908
+[#5820]: https://github.com/tokio-rs/tokio/pull/5820
+[#5823]: https://github.com/tokio-rs/tokio/pull/5823
 [#5824]: https://github.com/tokio-rs/tokio/pull/5824
+[#5829]: https://github.com/tokio-rs/tokio/pull/5829
+[#5858]: https://github.com/tokio-rs/tokio/pull/5858
+[#5859]: https://github.com/tokio-rs/tokio/pull/5859
+[#5863]: https://github.com/tokio-rs/tokio/pull/5863
+[#5864]: https://github.com/tokio-rs/tokio/pull/5864
+[#5865]: https://github.com/tokio-rs/tokio/pull/5865
 [#5868]: https://github.com/tokio-rs/tokio/pull/5868
 [#5869]: https://github.com/tokio-rs/tokio/pull/5869
 [#5878]: https://github.com/tokio-rs/tokio/pull/5878
+[#5885]: https://github.com/tokio-rs/tokio/pull/5885
+[#5887]: https://github.com/tokio-rs/tokio/pull/5887
 [#5890]: https://github.com/tokio-rs/tokio/pull/5890
-[#5820]: https://github.com/tokio-rs/tokio/pull/5820
-[#5858]: https://github.com/tokio-rs/tokio/pull/5858
-[#5863]: https://github.com/tokio-rs/tokio/pull/5863
+[#5908]: https://github.com/tokio-rs/tokio/pull/5908
 [#5916]: https://github.com/tokio-rs/tokio/pull/5916
-[#5865]: https://github.com/tokio-rs/tokio/pull/5865
-[#5864]: https://github.com/tokio-rs/tokio/pull/5864
-[#5823]: https://github.com/tokio-rs/tokio/pull/5823
 
 # 1.29.1 (June 29, 2023)
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -16,7 +16,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 - net: implement `UCred` for espidf ([#5868])
 - fs: add `File::options()` ([#5869])
 - time: implement extra reset variants for `Interval` ([#5878])
-- process: add {ChildStd*}::into_owned_{fd, handle} ([#5899])
+- process: add `{ChildStd*}::into_owned_{fd, handle}` ([#5899])
 
 ### Removed
 
@@ -32,6 +32,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 - process: fix `raw_arg` not showing up in docs ([#5865])
 
 ### Unstable
+
 - rt: add runtime ID ([#5864])
 - rt: initial implementation of new threaded runtime ([#5823])
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -46,6 +46,7 @@ This release bumps the MSRV of Tokio to 1.63. ([#5887])
 [#5868]: https://github.com/tokio-rs/tokio/pull/5868
 [#5869]: https://github.com/tokio-rs/tokio/pull/5869
 [#5878]: https://github.com/tokio-rs/tokio/pull/5878
+[#5885]: https://github.com/tokio-rs/tokio/pull/5881
 [#5885]: https://github.com/tokio-rs/tokio/pull/5885
 [#5887]: https://github.com/tokio-rs/tokio/pull/5887
 [#5890]: https://github.com/tokio-rs/tokio/pull/5890

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.29.1"
+version = "1.30.0"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.29.1", features = ["full"] }
+tokio = { version = "1.30.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
As requested by @Darksonn in #5887

First time doing this for this project so please let me know if if I need to correct something. I went through all of the commits after the v1.29.1 release on June 29 and tried to sort them into the CHANGELOG buckets that made sense but may have misplaced some.

# 1.30.0 (August 9, 2023)

This release bumps the MSRV of Tokio to 1.63. ([#5887])

### Changed

- tokio: reduce LLVM code generation ([#5859])
- io: support `--cfg mio_unsupported_force_poll_poll` flag ([#5881])
- sync: make `const_new` methods always available ([#5885])
- sync: avoid false sharing in mpsc channel ([#5829])
- rt: pop at least one task from inject queue ([#5908])

### Added

- sync: add `broadcast::Sender::new` ([#5824])
- net: implement `UCred` for espidf ([#5868])
- fs: add `File::options()` ([#5869])
- time: implement extra reset variants for `Interval` ([#5878])
- process: add `{ChildStd*}::into_owned_{fd, handle}` ([#5899])

### Removed

- tokio: removed unused `tokio_*` cfgs ([#5890])
- remove build script to speed up compilation ([#5887])

### Documented

- sync: mention lagging in docs for `broadcast::send` ([#5820])
- runtime: expand on sharing runtime docs ([#5858])
- io: use vec in example for `AsyncReadExt::read_exact` ([#5863])
- time: mark `Sleep` as `!Unpin` in docs ([#5916])
- process: fix `raw_arg` not showing up in docs ([#5865])

### Unstable

- rt: add runtime ID ([#5864])
- rt: initial implementation of new threaded runtime ([#5823])

[#5820]: https://github.com/tokio-rs/tokio/pull/5820
[#5823]: https://github.com/tokio-rs/tokio/pull/5823
[#5824]: https://github.com/tokio-rs/tokio/pull/5824
[#5829]: https://github.com/tokio-rs/tokio/pull/5829
[#5858]: https://github.com/tokio-rs/tokio/pull/5858
[#5859]: https://github.com/tokio-rs/tokio/pull/5859
[#5863]: https://github.com/tokio-rs/tokio/pull/5863
[#5864]: https://github.com/tokio-rs/tokio/pull/5864
[#5865]: https://github.com/tokio-rs/tokio/pull/5865
[#5868]: https://github.com/tokio-rs/tokio/pull/5868
[#5869]: https://github.com/tokio-rs/tokio/pull/5869
[#5878]: https://github.com/tokio-rs/tokio/pull/5878
[#5881]: https://github.com/tokio-rs/tokio/pull/5881
[#5885]: https://github.com/tokio-rs/tokio/pull/5885
[#5887]: https://github.com/tokio-rs/tokio/pull/5887
[#5890]: https://github.com/tokio-rs/tokio/pull/5890
[#5899]: https://github.com/tokio-rs/tokio/pull/5899
[#5908]: https://github.com/tokio-rs/tokio/pull/5908
[#5916]: https://github.com/tokio-rs/tokio/pull/5916