### PR TITLE
Stabilise Command::raw_arg

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -398,17 +398,11 @@ impl Command {
         self
     }
 
-    cfg_unstable_windows! {
+    cfg_windows! {
         /// Append literal text to the command line without any quoting or escaping.
         ///
         /// This is useful for passing arguments to `cmd.exe /c`, which doesn't follow
         /// `CommandLineToArgvW` escaping rules.
-        ///
-        /// **Note**: This is an [unstable API][unstable] but will be stabilised once
-        /// tokio's MSRV is sufficiently new. See [the documentation on
-        /// unstable features][unstable] for details about using unstable features.
-        ///
-        /// [unstable]: crate#unstable-features
         pub fn raw_arg<S: AsRef<OsStr>>(&mut self, text_to_append_as_is: S) -> &mut Command {
             self.std.raw_arg(text_to_append_as_is);
             self


### PR DESCRIPTION
Stabilise `Command::raw_arg`. Fixes #5929
