### PR TITLE
sync: implement 'Clone' for watch::Sender

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -525,7 +525,8 @@ impl<T> Receiver<T> {
     /// method sleeps until a new message is sent by the [`Sender`] connected to
     /// this `Receiver`, or until the [`Sender`] is dropped.
     ///
-    /// This method returns an error if and only if the [`Sender`] is dropped.
+    /// This method returns an error if there is no new value in the channel that
+    /// has not yet been marked seen and all [`Sender`]s are dropped.
     ///
     /// # Cancel safety
     ///


### PR DESCRIPTION
Here I'm implement Clone for watch::Sender, which makes it mpsc

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

### TODO

- [ ] Update docs to make it clear it's mpmc

## Motivation

See https://github.com/tokio-rs/tokio/issues/4809

## Solution

I've implemented one of the suggestions in the issue, which is to keep track of the number of Senders separate from the version.

Open questions: are there other methods that need to be added? E.g. 'upgrading' a receiver to a sender or getting the number of current Senders