### PR TITLE
docs: added trailing backticks

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -260,6 +260,7 @@ impl Runtime {
     ///     println!("now running on a worker thread");
     /// });
     /// # }
+    /// ```
     #[track_caller]
     pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
     where


### PR DESCRIPTION
## Motivation

To get syntax highlights in code docs

Currently:

<img width="596" alt="Screenshot 2023-08-18 at 12 47 30 AM" src="https://github.com/Ghamza-Jd/tokio/assets/26389705/536ce345-c215-4207-9411-9f46dfbc04d7">

After adding backticks:

<img width="630" alt="Screenshot 2023-08-18 at 12 49 14 AM" src="https://github.com/Ghamza-Jd/tokio/assets/26389705/74748787-23c2-422e-8514-6915abd66a38">
