### PR TITLE
Semaphore example for limiting access to a file

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -76,7 +76,7 @@ use std::sync::Arc;
 /// Limit access to a file:
 /// ```
 /// use std::io::{Result, Write};
-/// use std::fs::File;
+/// use tokio::fs::File;
 ///
 /// static PERMITS: Semaphore = Semaphore::const_new(100);
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -73,7 +73,19 @@ use std::sync::Arc;
 /// }
 /// ```
 ///
-/// Limit access to a file:
+/// Limit the number of simultaneously opened files in your program.
+///
+/// Most operating systems have limits on the number of open file
+/// handles. Even in systems without explicit limits, resource constraints
+/// implicitly set an upper bound on the number of open files. If your
+/// program attempts to open a large number of files and exceeds this
+/// limit, it will result in an error.
+///
+/// This example uses a Semaphore with 100 permits. By acquiring a permit from
+/// the Semaphore before accessing a file, you ensure that your program opens
+/// no more than 100 files at a time. When trying to open the 101st
+/// file, the program will wait until a permit becomes available before
+/// proceeding to open another file.
 /// ```
 /// use std::io::Result;
 /// use tokio::fs::File;
@@ -86,7 +98,7 @@ use std::sync::Arc;
 ///     let _permit = PERMITS.acquire().await.unwrap();
 ///     let mut buffer = File::create("example.txt").await?;
 ///     buffer.write_all(message).await?;
-///     Ok(())
+///     Ok(()) // Permit goes out of scope here, and is available again for acquisition
 /// }
 /// ```
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -75,15 +75,17 @@ use std::sync::Arc;
 ///
 /// Limit access to a file:
 /// ```
-/// use std::io::{Result, Write};
+/// use std::io::Result;
 /// use tokio::fs::File;
+/// use tokio::sync::Semaphore;
+/// use tokio::io::AsyncWriteExt;
 ///
 /// static PERMITS: Semaphore = Semaphore::const_new(100);
 ///
 /// async fn write_to_file(message: &[u8]) -> Result<()> {
 ///     let _permit = PERMITS.acquire().await.unwrap();
-///     let mut buffer = File::create("example.txt")?;
-///     buffer.write_all(message)?;
+///     let mut buffer = File::create("example.txt").await?;
+///     buffer.write_all(message).await?;
 ///     Ok(())
 /// }
 /// ```

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -73,6 +73,21 @@ use std::sync::Arc;
 /// }
 /// ```
 ///
+/// Limit access to a file:
+/// ```
+/// use std::io::{Result, Write};
+/// use std::fs::File;
+///
+/// static PERMITS: Semaphore = Semaphore::const_new(100);
+///
+/// async fn write_to_file(message: &[u8]) -> Result<()> {
+///     let _permit = PERMITS.acquire().await.unwrap();
+///     let mut buffer = File::create("example.txt")?;
+///     buffer.write_all(message)?;
+///     Ok(())
+/// }
+/// ```
+///
 /// [`PollSemaphore`]: https://docs.rs/tokio-util/latest/tokio_util/sync/struct.PollSemaphore.html
 /// [`Semaphore::acquire_owned`]: crate::sync::Semaphore::acquire_owned
 #[derive(Debug)]


### PR DESCRIPTION
To improve Semaphore examples, as called for in Issue #5933, here is a simple example for limiting access to a File resource.