### PR TITLE
Enrich StreamReader and SinkWriter

### DIFF
--- a/tokio-util/src/io/copy_to_bytes.rs
+++ b/tokio-util/src/io/copy_to_bytes.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+use futures_core::stream::Stream;
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use std::pin::Pin;
@@ -64,5 +65,12 @@ where
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_close(cx)
+    }
+}
+
+impl<S: Stream> Stream for CopyToBytes<S> {
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
     }
 }

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -1,6 +1,7 @@
 use futures_core::ready;
 use futures_sink::Sink;
 
+use futures_core::stream::Stream;
 use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
@@ -113,5 +114,12 @@ where
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         self.project().inner.poll_close(cx).map_err(Into::into)
+    }
+}
+
+impl<S: Stream> Stream for SinkWriter<S> {
+    type Item = S::Item;
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.project().inner.poll_next(cx)
     }
 }

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -6,7 +6,7 @@ use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::AsyncWrite;
+use tokio::io::{AsyncRead, AsyncWrite};
 
 pin_project! {
     /// Convert a [`Sink`] of byte chunks into an [`AsyncWrite`].
@@ -121,5 +121,15 @@ impl<S: Stream> Stream for SinkWriter<S> {
     type Item = S::Item;
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.project().inner.poll_next(cx)
+    }
+}
+
+impl<S: AsyncRead> AsyncRead for SinkWriter<S> {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.project().inner.poll_read(cx, buf)
     }
 }


### PR DESCRIPTION
Implementing feature suggested in issue #5745

Basically what was done is:
- implement Sink for StreamReader<Sink>
- implement Stream for SinkWriterStream>
- implement AsyncRead for SinkWriter<AsyncRead>
- implement Stream for CopyToBytes<Stream>

The implementation is pretty straightforward since the actual work is all demanded to the underlying object, so I thought that introducing new tests would not be really helpful.
