### PR TITLE
chore: prepare tokio-test v0.4.3

### DIFF
--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.4.3 (August 23, 2023)
+
+- deps: fix minimum required version of `async-stream` ([#5347])
+- deps: fix minimum required version of `tokio-stream` ([#4376])
+- docs: improve `tokio_test::task` docs ([#5132])
+- io: fetch actions from mock handle before write ([#5814])
+- io: fix wait operation on mock ([#5554])
+
+[#4376]: https://github.com/tokio-rs/tokio/pull/4376
+[#5132]: https://github.com/tokio-rs/tokio/pull/5132
+[#5347]: https://github.com/tokio-rs/tokio/pull/5347
+[#5554]: https://github.com/tokio-rs/tokio/pull/5554
+[#5814]: https://github.com/tokio-rs/tokio/pull/5814
+
 # 0.4.2 (May 14, 2021)
 
 - test: add `assert_elapsed!` macro ([#3728])

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-test"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-test-0.4.x" git tag.
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 rust-version = "1.56"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.4.3 (August 23, 2023)

- deps: fix minimum required version of `async-stream` ([#5347])
- deps: fix minimum required version of `tokio-stream` ([#4376])
- docs: improve `tokio_test::task` docs ([#5132])
- io: fetch actions from mock handle before write ([#5814])
- io: fix wait operation on mock ([#5554])

[#4376]: https://github.com/tokio-rs/tokio/pull/4376
[#5132]: https://github.com/tokio-rs/tokio/pull/5132
[#5347]: https://github.com/tokio-rs/tokio/pull/5347
[#5554]: https://github.com/tokio-rs/tokio/pull/5554
[#5814]: https://github.com/tokio-rs/tokio/pull/5814