### PR TITLE
ci: drop MIPS targets from cross-check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,9 +411,7 @@ jobs:
         target:
           - powerpc-unknown-linux-gnu
           - powerpc64-unknown-linux-gnu
-          - mips-unknown-linux-gnu
           - arm-linux-androideabi
-          - mipsel-unknown-linux-musl
     steps:
       - uses: actions/checkout@v3
       - name: Install Rust ${{ env.rust_stable }}


### PR DESCRIPTION
Currently, Tokio runs cross-compilation checks for the `mips-unknown-linux-gnu` and `mipsel-unknown-linux-musl` target triples. However, Rust has recently demoted these targets from Tier 2 support to Tier 3 (see rust-lang/compiler-team#648). Therefore, MIPS toolchains may not always be available, even in stable releases. This is currently [breaking our CI builds][1], as Rust 1.72.0 does not contain a standard library for `mips-unknown-linux-gnu`.

This branch removes these builds from the cross-compilation check's build matrix. Tokio may still build successfully for MIPS targets, but we can't easily guarantee support when the stable Rust release train may or may not be able to build for MIPS targets.

[1]: https://github.com/tokio-rs/tokio/actions/runs/5970263562/job/16197657405?pr=5947#step:3:80