### PR TITLE
sync: improve docs for watch channels

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -383,7 +383,7 @@
 //!                         sleep.set(time::sleep_until(op_start + conf.timeout));
 //!                     }
 //!                     _ = rx.changed() => {
-//!                         conf = rx.borrow().clone();
+//!                         conf = rx.borrow_and_update().clone();
 //!
 //!                         // The configuration has been updated. Update the
 //!                         // `sleep` using the new `timeout` value.

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -26,18 +26,18 @@
 //! The [`Receiver`] half provides an asynchronous [`changed`] method. This
 //! method is ready when a new, *unseen* value is sent via the [`Sender`] half.
 //!
-//! * The [`changed`] method returns `Ok(())` on receiving a new value, or
-//!   `Err(_)` if the [`Sender`] has been closed.
-//! * On completion, the [`changed`] method marks the new value as *seen*. If
-//!   [`Receiver::changed()`] is called again, it will not return immediately
-//!   unless a subsequent value is sent.
+//! * [`Receiver::changed()`] returns `Ok(())` on receiving a new value, or
+//!   `Err(_)` if the [`Sender`] has been dropped.
+//! * If the latest value is *unseen* when calling [`changed`], then [`changed`]
+//!   will return immediately. If the latest message is *seen*, then it will
+//!   sleep until either a new message is sent via the [`Sender`] half, or the
+//!   [`Sender`] is dropped.
+//! * On completion, the [`changed`] method marks the new value as *seen*.
 //! * At creation, the initial value is considered *seen*. In other words,
-//!   [`Receiver::changed()`] will not return until a subsequent value is sent
-//!   via the [`Sender`] half.
+//!   [`Receiver::changed()`] will not return until a subsequent value is sent.
 //! * New [`Receiver`] instances can be created with [`Sender::subscribe()`].
 //!   The current value at the time the [`Receiver`] is created is considered
-//!   *seen*. [`Receiver::changed()`] will not return until a subsequent value
-//!   is sent.
+//!   *seen*.
 //!
 //! # Examples
 //!

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -17,8 +17,9 @@
 //! To access the **latest** value stored in the channel and mark it as *seen*,
 //! use [`Receiver::borrow_and_update()`].
 //!
-//! To access the latest value but **not** mark it as seen, use
-//! [`Receiver::borrow()`].
+//! To access the latest value **without** changing its state to *seen*, use
+//! [`Receiver::borrow()`]. (If the value has already been marked *seen*,
+//! [`Receiver::borrow()`] is equivalent to [`Receiver::borrow_and_update()`].)
 //!
 //! ## Change notifications
 //!
@@ -31,12 +32,12 @@
 //!   [`Receiver::changed()`] is called again, it will not return immediately
 //!   unless a subsequent value is sent.
 //! * At creation, the initial value is considered *seen*. In other words,
-//!   [`Receiver::changed()`] will not return immediately until a subsequent
-//!   value is sent via the [`Sender`] half.
+//!   [`Receiver::changed()`] will not return until a subsequent value is sent
+//!   via the [`Sender`] half.
 //! * New [`Receiver`] instances can be created with [`Sender::subscribe()`].
 //!   The current value at the time the [`Receiver`] is created is considered
-//!   *seen*. [`Receiver::changed()`] will only return after subsequent values
-//!   are sent.
+//!   *seen*. [`Receiver::changed()`] will not return until a subsequent value
+//!   is sent.
 //!
 //! # Examples
 //!

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -21,6 +21,9 @@
 //! [`Receiver::borrow()`]. (If the value has already been marked *seen*,
 //! [`Receiver::borrow()`] is equivalent to [`Receiver::borrow_and_update()`].)
 //!
+//! For more information on when to use these methods, see
+//! [here](#borrow_and_update-versus-borrow).
+//!
 //! ## Change notifications
 //!
 //! The [`Receiver`] half provides an asynchronous [`changed`] method. This
@@ -514,7 +517,11 @@ impl<T> Receiver<T> {
     /// ```
     /// </details>
     ///
+    /// For more information on when to use this method versus
+    /// [`borrow_and_update`], see [here](self#borrow_and_update-versus-borrow).
+    ///
     /// [`changed`]: Receiver::changed
+    /// [`borrow_and_update`]: Receiver::borrow_and_update
     ///
     /// # Examples
     ///
@@ -566,7 +573,11 @@ impl<T> Receiver<T> {
     /// ```
     /// </details>
     ///
+    /// For more information on when to use this method versus [`borrow`], see
+    /// [here](self#borrow_and_update-versus-borrow).
+    ///
     /// [`changed`]: Receiver::changed
+    /// [`borrow`]: Receiver::borrow
     pub fn borrow_and_update(&mut self) -> Ref<'_, T> {
         let inner = self.shared.value.read().unwrap();
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -28,14 +28,14 @@
 //! * The [`changed`] method returns `Ok(())` on receiving a new value, or
 //!   `Err(_)` if the [`Sender`] has been closed.
 //! * On completion, the [`changed`] method marks the new value as *seen*. If
-//!   [`Receiver::changed()`] is called again, it will not be ready unless a
-//!   subsequent value is sent.
+//!   [`Receiver::changed()`] is called again, it will not return immediately
+//!   unless a subsequent value is sent.
 //! * At creation, the initial value is considered *seen*. In other words,
-//!   [`Receiver::changed()`] will not be ready until a subsequent value is sent
-//!   via the [`Sender`] half.
+//!   [`Receiver::changed()`] will not return immediately until a subsequent
+//!   value is sent via the [`Sender`] half.
 //! * New [`Receiver`] instances can be created with [`Sender::subscribe()`].
 //!   The current value at the time the [`Receiver`] is created is considered
-//!   *seen*. [`Receiver::changed()`] will only be ready after subsequent values
+//!   *seen*. [`Receiver::changed()`] will only return after subsequent values
 //!   are sent.
 //!
 //! # Examples


### PR DESCRIPTION
## Motivation

I found the watch docs as written to be somewhat confusing.

* It wasn't clear to me whether values are marked seen or not at creation/subscribe time.
* The example also confused me a bit, suggesting a while loop when a do-while loop is generally more correct.
* I noticed a potential race with `borrow` that is no longer an issue with `borrow_and_update`.

## Solution

Update the documentation for the watch module to try and make all this clearer.