### PR TITLE
Semaphore example using an Arc<Semaphore> for semaphore passing

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -260,6 +260,7 @@ impl Runtime {
     ///     println!("now running on a worker thread");
     /// });
     /// # }
+    /// ```
     #[track_caller]
     pub fn spawn_blocking<F, R>(&self, func: F) -> JoinHandle<R>
     where

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -76,33 +76,34 @@ use std::sync::Arc;
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
 ///     loop {
+///         // Acquire permit before accepting, else the connection will wait without purpose
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///
 ///         tokio::spawn(async move {
-///                 let mut buf = [0; 1024];
+///              let mut buf = [0; 1024];
 ///
-///                 // In a loop, read data from the socket and write the data back.
-///                 loop {
-///                     let n = match socket.read(&mut buf).await {
-///                         // socket closed
-///                         Ok(n) if n == 0 => break,
-///                         Ok(n) => n,
-///                         Err(e) => {
-///                             eprintln!("failed to read from socket; err = {:?}", e);
-///                             break;
-///                         }
-///                     };
+///              // In a loop, read data from the socket and write the data back.
+///              loop {
+///                  let n = match socket.read(&mut buf).await {
+///                      // socket closed
+///                      Ok(n) if n == 0 => break,
+///                      Ok(n) => n,
+///                      Err(e) => {
+///                          eprintln!("failed to read from socket; err = {:?}", e);
+///                          break;
+///                      }
+///                  };
 ///
-///                     // Write the data back
-///                     if let Err(e) = socket.write_all(&buf[0..n]).await {
-///                         eprintln!("failed to write to socket; err = {:?}", e);
-///                         break;
-///                     }
-///                 }
+///                  // Write the data back
+///                  if let Err(e) = socket.write_all(&buf[0..n]).await {
+///                      eprintln!("failed to write to socket; err = {:?}", e);
+///                      break;
+///                  }
+///              }
 ///
-///                 // Drop the permit, so more tasks can be created
-///                 drop(permit);
+///              // Drop the permit, so more tasks can be created
+///              drop(permit);
 ///         });
 ///     }
 /// }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -101,7 +101,7 @@ use std::sync::Arc;
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
 ///     loop {
-///         // Acquire permit before accepting, to avoid needlessly taking up a (finite) file descriptor
+///         // Acquire permit before accepting the next socket.
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -93,7 +93,7 @@ use std::sync::Arc;
 /// ```no_run
 /// use std::sync::Arc;
 /// use tokio::sync::Semaphore;
-/// use tokio::net::{TcpListener, TcpStream};
+/// use tokio::net::TcpListener;
 ///
 /// #[tokio::main]
 /// async fn main() -> std::io::Result<()> {

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -96,7 +96,7 @@ use std::sync::Arc;
 /// use tokio::net::{TcpListener, TcpStream};
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// async fn main() -> std::io::Result<()> {
 ///     let semaphore = Arc::new(Semaphore::new(3));
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -66,23 +66,31 @@ use std::sync::Arc;
 /// `Arc`s have been dropped.
 ///
 /// ```
+/// use std::sync::Arc;
+/// use tokio::sync::Semaphore;
+///
 /// #[tokio::main]
 /// async fn main() {
 ///     let semaphore = Arc::new(Semaphore::new(3));
 ///     let mut join_handles = Vec::new();
 ///
 ///     for _ in 0..5 {
-///         let permit = semaphore.clone().acquire_owned().await.unwrap();
+///         let semaphore_clone = semaphore.clone();
 ///         join_handles.push(tokio::spawn(async move {
-///             // perform task...
-///             // explicitly own `permit` in the task
-///             drop(permit);
+///             perform_task(semaphore_clone).await;
 ///         }));
 ///     }
 ///
 ///     for handle in join_handles {
 ///         handle.await.unwrap();
 ///     }
+/// }
+///
+/// async fn perform_task(semaphore: Arc<Semaphore>) {
+///     let permit = semaphore.acquire_owned().await.unwrap();
+///     // perform task...
+///     // explicitly own `permit` in the task
+///     drop(permit);
 /// }
 /// ```
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -75,7 +75,7 @@ use std::sync::Arc;
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
 ///     loop {
-///         // Acquire permit before accepting, else the connection will wait without purpose
+///         // Acquire permit before accepting, to avoid needlessly taking up a (finite) file descriptor
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -71,21 +71,21 @@ use std::sync::Arc;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///    let semaphore = Arc::new(Semaphore::new(3));
-///    let mut join_handles = Vec::new();
+///     let semaphore = Arc::new(Semaphore::new(3));
+///     let mut join_handles = Vec::new();
 ///
-///    for _ in 0..5 {
-///        let permit = semaphore.clone().acquire_owned().await.unwrap();
-///        join_handles.push(tokio::spawn(async move {
-///            // perform task...
-///            // explicitly own `permit` in the task
-///            drop(permit);
-///        }));
-///    }
+///     for _ in 0..5 {
+///         let permit = semaphore.clone().acquire_owned().await.unwrap();
+///         join_handles.push(tokio::spawn(async move {
+///             // perform task...
+///             // explicitly own `permit` in the task
+///             drop(permit);
+///         }));
+///     }
 ///
-///    for handle in join_handles {
-///        handle.await.unwrap();
-///    }
+///     for handle in join_handles {
+///         handle.await.unwrap();
+///     }
 /// }
 /// ```
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -88,10 +88,7 @@ use std::sync::Arc;
 /// memory usage, CPU time, etc.). Once acquired, a new task is spawned; and once
 /// finished, the permit is dropped inside of the task to allow others to spawn.
 /// Permits must be acquired via [`Semaphore::acquire_owned`] to be
-/// movable across the task boundary. Contrastingly, if the semaphore were a global,
-/// as in the file-limiting example, only ['Semaphore::acquire'] would be necessary.
-/// This is because a `Permit<'static>` would be returned, which is movable across
-/// task boundaries, since the semaphore lives forever.
+/// movable across the task boundary. (Since our semaphore is not a global variable — if it was, then `acquire` would be enough.)
 ///
 /// ```no_run
 /// use std::sync::Arc;

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -120,7 +120,7 @@ use std::sync::Arc;
 /// }
 ///
 /// # async fn handle_connection(socket: &mut TcpStream) {
-/// #   todo!()
+/// #   // Do work
 /// # }
 /// ```
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -87,7 +87,7 @@ use std::sync::Arc;
 /// this semaphore, in order to limit usage of system resources (like file descriptors,
 /// memory usage, CPU time, etc.). Once acquired, a new task is spawned; and once
 /// finished, the permit is dropped inside of the task to allow others to spawn.
-/// Permits must be acquired via [`Semaphore::acquire_owned`], in order to be
+/// Permits must be acquired via [`Semaphore::acquire_owned`] to be
 /// movable across the task boundary. Contrastingly, if the semaphore were a global,
 /// as in the file-limiting example, only ['Semaphore::acquire'] would be necessary.
 /// This is because a `Permit<'static>` would be returned, which is movable across

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -64,21 +64,18 @@ use std::sync::Arc;
 /// of our tasks to it, the `Semaphore` will continue to exist in a static-like context, until all
 /// `Arc`s have been dropped.
 ///
-/// In this example, a `for` loop is used for the outer loop to pass tests. In practice, this would be
-/// a bare `loop`.
-/// ```
+/// ```no_run
 /// use std::sync::Arc;
 /// use tokio::sync::Semaphore;
 /// use tokio::net::TcpListener;
 /// use tokio::io::{AsyncReadExt, AsyncWriteExt};
 ///
 /// #[tokio::main]
-/// async fn main() {
+/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ///     let semaphore = Arc::new(Semaphore::new(3));
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
-///     // Replace the for loop, with a bare loop
-///     for _ in 0..5 {
+///     loop {
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -80,9 +80,11 @@ use std::sync::Arc;
 ///         let (mut socket, _) = listener.accept().await?;
 ///
 ///         tokio::spawn(async move {
-///             // Do work, and drop socket after
+///             // Do work using the socket.
 ///             handle_connection(&mut socket).await;
-///             // Explicitly drop the permit, so more tasks can be created
+///             // Drop socket while the permit is still live.
+///             drop(socket);
+///             // Drop the permit, so more tasks can be created.
 ///             drop(permit);
 ///         });
 ///     }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -118,7 +118,6 @@ use std::sync::Arc;
 ///         });
 ///     }
 /// }
-///
 /// # async fn handle_connection(socket: &mut TcpStream) {
 /// #   // Do work
 /// # }

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -76,9 +76,9 @@ use std::sync::Arc;
 /// }
 /// ```
 ///
-/// Limit number of incoming requests being handled at the same time.
+/// Limit the number of incoming requests being handled at the same time.
 ///
-/// Similar to limiting the number of simultaneous opened files, network handles
+/// Similar to limiting the number of simultaneously opened files, network handles
 /// are a limited resource. Allowing an unbounded amount of requests to be processed
 /// could result in a denial-of-service, among many other issues.
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -71,26 +71,21 @@ use std::sync::Arc;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let semaphore = Arc::new(Semaphore::new(3));
-///     let mut join_handles = Vec::new();
+///    let semaphore = Arc::new(Semaphore::new(3));
+///    let mut join_handles = Vec::new();
 ///
-///     for _ in 0..5 {
-///         let semaphore_clone = semaphore.clone();
-///         join_handles.push(tokio::spawn(async move {
-///             perform_task(semaphore_clone).await;
-///         }));
-///     }
+///    for _ in 0..5 {
+///        let permit = semaphore.clone().acquire_owned().await.unwrap();
+///        join_handles.push(tokio::spawn(async move {
+///            // perform task...
+///            // explicitly own `permit` in the task
+///            drop(permit);
+///        }));
+///    }
 ///
-///     for handle in join_handles {
-///         handle.await.unwrap();
-///     }
-/// }
-///
-/// async fn perform_task(semaphore: Arc<Semaphore>) {
-///     let permit = semaphore.acquire_owned().await.unwrap();
-///     // perform task...
-///     // explicitly own `permit` in the task
-///     drop(permit);
+///    for handle in join_handles {
+///        handle.await.unwrap();
+///    }
 /// }
 /// ```
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -83,12 +83,12 @@ use std::sync::Arc;
 /// could result in a denial-of-service, among many other issues.
 ///
 /// This example uses an `Arc<Semaphore>` instead of a global variable.
-/// Before we spawn a new task to process a request, we must acquire a permit from
-/// this semaphore, in order to limit usage of system resources (like file descriptors,
-/// memory usage, CPU time, etc.). Once acquired, a new task is spawned; and once
-/// finished, the permit is dropped inside of the task to allow others to spawn.
-/// Permits must be acquired via [`Semaphore::acquire_owned`] to be
-/// movable across the task boundary. (Since our semaphore is not a global variable — if it was, then `acquire` would be enough.)
+/// To limit the number of requests that can be processed at the time,
+/// we acquire a permit for each task before spawning it. Once acquired,
+/// a new task is spawned; and once finished, the permit is dropped inside
+/// of the task to allow others to spawn. Permits must be acquired via
+/// [`Semaphore::acquire_owned`] to be movable across the task boundary.
+/// (Since our semaphore is not a global variable — if it was, then `acquire` would be enough.)
 ///
 /// ```no_run
 /// use std::sync::Arc;

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -118,7 +118,7 @@ use std::sync::Arc;
 ///         });
 ///     }
 /// }
-/// # async fn handle_connection(socket: &mut TcpStream) {
+/// # async fn handle_connection(_socket: &mut tokio::net::TcpStream) {
 /// #   // Do work
 /// # }
 /// ```

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -47,8 +47,7 @@ use std::sync::Arc;
 /// }
 /// ```
 ///
-/// Limit number of incoming requests being handled at the same time, using a task-safe semaphore
-/// via [`Semaphore::acquire_owned`].
+/// Limit number of incoming requests being handled at the same time.
 ///
 /// Similar to limiting the numer of simultaneous opened files, network handles are a limited resource.
 /// Allowing an unbounded amount of requests to be processed could result in a denial-of-service,

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -102,6 +102,9 @@ use std::sync::Arc;
 ///
 ///     loop {
 ///         // Acquire permit before accepting the next socket.
+///         //
+///         // We use `acquire_owned` so that we can move `permit` into
+///         // other tasks.
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -82,7 +82,7 @@ use std::sync::Arc;
 /// are a limited resource. Allowing an unbounded amount of requests to be processed
 /// could result in a denial-of-service, among many other issues.
 ///
-/// However, in contrast to the file example, this example uses an `Arc<Semaphore>`.
+/// This example uses an `Arc<Semaphore>` instead of a global variable.
 /// Before we spawn a new task to process a request, we must acquire a permit from
 /// this semaphore, in order to limit usage of system resources (like file descriptors,
 /// memory usage, CPU time, etc.). Once acquired, a new task is spawned; and once

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -64,6 +64,8 @@ use std::sync::Arc;
 /// of our tasks to it, the `Semaphore` will continue to exist in a static-like context, until all
 /// `Arc`s have been dropped.
 ///
+/// In this example, a `for` loop is used for the outer loop to pass tests. In practice, this would be
+/// a bare `loop`.
 /// ```
 /// use std::sync::Arc;
 /// use tokio::sync::Semaphore;
@@ -71,11 +73,12 @@ use std::sync::Arc;
 /// use tokio::io::{AsyncReadExt, AsyncWriteExt};
 ///
 /// #[tokio::main]
-/// async fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// async fn main() {
 ///     let semaphore = Arc::new(Semaphore::new(3));
 ///     let listener = TcpListener::bind("127.0.0.1:8080").await?;
 ///
-///     loop {
+///     // Replace the for loop, with a bare loop
+///     for _ in 0..5 {
 ///         let permit = semaphore.clone().acquire_owned().await.unwrap();
 ///         let (mut socket, _) = listener.accept().await?;
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

A simple example of limiting request processing using a task-safe semaphore and demonstrating `acquire_owned` for: https://github.com/tokio-rs/tokio/issues/5933