### PR TITLE
[feature] Add check for  LinesCodec when input contains '\n'

### DIFF
--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -190,6 +190,9 @@ where
 
     fn encode(&mut self, line: T, buf: &mut BytesMut) -> Result<(), LinesCodecError> {
         let line = line.as_ref();
+        if line.contains('\n') {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, "The input contains line separator.").into());
+        }
         buf.reserve(line.len() + 1);
         buf.put(line.as_bytes());
         buf.put_u8(b'\n');

--- a/tokio-util/tests/codecs.rs
+++ b/tokio-util/tests/codecs.rs
@@ -236,6 +236,8 @@ fn lines_encoder() {
 
     codec.encode("line 2", &mut buf).unwrap();
     assert_eq!("line 1\nline 2\n", buf);
+
+    assert!(codec.encode("abc\n", &mut buf).is_err())
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

we should check weather input contains '\n'. For example, if we encode "abc\n", we get "abc\n\n".
But when we decode, we get "abc"