### PR TITLE
macros: spawn task for entry future and block on it

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -4,7 +4,7 @@ error: the `async` keyword is missing from the function declaration
 6 | fn main_is_not_async() {}
   | ^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `spawn`, `crate`
  --> $DIR/macros_invalid_input.rs:8:15
   |
 8 | #[tokio::main(foo)]
@@ -22,13 +22,13 @@ error: the `async` keyword is missing from the function declaration
 15 | fn test_is_not_async() {}
    | ^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `spawn`, `crate`
   --> $DIR/macros_invalid_input.rs:17:15
    |
 17 | #[tokio::test(foo)]
    |               ^^^
 
-error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`
+error: Unknown attribute foo is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `spawn`, `crate`
   --> $DIR/macros_invalid_input.rs:20:15
    |
 20 | #[tokio::test(foo = 123)]

--- a/tests-build/tests/fail/macros_spawn_no_send.rs
+++ b/tests-build/tests/fail/macros_spawn_no_send.rs
@@ -1,0 +1,19 @@
+use std::rc::Rc;
+
+use tests_build::tokio;
+
+async fn send_f() {}
+
+#[tokio::test(spawn = true)]
+async fn no_send_test() {
+    let _value = Rc::new(0);
+    send_f().await;
+}
+
+#[tokio::main(spawn = true)]
+async fn no_send_main() {
+    let _value = Rc::new(0);
+    send_f().await;
+}
+
+fn main() {}

--- a/tests-build/tests/fail/macros_spawn_no_send.stderr
+++ b/tests-build/tests/fail/macros_spawn_no_send.stderr
@@ -1,0 +1,24 @@
+error: future cannot be sent between threads safely
+  --> tests/fail/macros_spawn_no_send.rs:13:1
+   |
+13 | #[tokio::main(spawn = true)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ future created by async block is not `Send`
+   |
+   = help: within `[async block@$DIR/tests/fail/macros_spawn_no_send.rs:13:1: 13:29]`, the trait `Send` is not implemented for `Rc<i32>`
+note: future is not `Send` as this value is used across an await
+  --> tests/fail/macros_spawn_no_send.rs:16:14
+   |
+15 |     let _value = Rc::new(0);
+   |         ------ has type `Rc<i32>` which is not `Send`
+16 |     send_f().await;
+   |              ^^^^^ await occurs here, with `_value` maybe used later
+17 | }
+   | - `_value` is later dropped here
+note: required by a bound in `Runtime::spawn`
+  --> $WORKSPACE/tokio/src/runtime/runtime.rs
+   |
+   |     pub fn spawn<F>(&self, future: F) -> JoinHandle<F::Output>
+   |            ----- required by a bound in this associated function
+   |     where
+   |         F: Future + Send + 'static,
+   |                     ^^^^ required by this bound in `Runtime::spawn`

--- a/tests-build/tests/macros.rs
+++ b/tests-build/tests/macros.rs
@@ -15,6 +15,9 @@ fn compile_fail_full() {
     t.compile_fail("tests/fail/macros_invalid_input.rs");
 
     #[cfg(feature = "full")]
+    t.compile_fail("tests/fail/macros_spawn_no_send.rs");
+
+    #[cfg(feature = "full")]
     t.compile_fail("tests/fail/macros_dead_code.rs");
 
     #[cfg(feature = "full")]

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -175,6 +175,32 @@ use proc_macro::TokenStream;
 ///
 /// Note that `start_paused` requires the `test-util` feature to be enabled.
 ///
+/// ### Spawn and join entry future
+///
+/// ```no_run
+/// #[tokio::main(spawn = true)]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+///
+/// Equivalent code not using `#[tokio::main]`
+///
+/// ```no_run
+/// fn main() {
+///     let runtime = tokio::runtime::Builder::new_multi_thread()
+///         .enable_all()
+///         .build()
+///         .unwrap();
+///     let handle = runtime.spawn(async {
+///         println!("Hello world");
+///     });
+///     runtime.block_on(async move {
+///         handle.await.unwrap()
+///     });
+/// }
+/// ```
+///
 /// ### Rename package
 ///
 /// ```rust
@@ -237,6 +263,32 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 ///         .block_on(async {
 ///             println!("Hello world");
 ///         })
+/// }
+/// ```
+///
+/// ### Spawn and join entry future
+///
+/// ```no_run
+/// #[tokio::main(flavor = "current_thread", spawn = true)]
+/// async fn main() {
+///     println!("Hello world");
+/// }
+/// ```
+///
+/// Equivalent code not using `#[tokio::main]`
+///
+/// ```no_run
+/// fn main() {
+///     let runtime = tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .build()
+///         .unwrap();
+///     let handle = runtime.spawn(async {
+///         println!("Hello world");
+///     });
+///     runtime.block_on(async move {
+///         handle.await.unwrap()
+///     });
 /// }
 /// ```
 ///
@@ -413,6 +465,33 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ```
 ///
 /// Note that `start_paused` requires the `test-util` feature to be enabled.
+///
+/// ### Spawn and join entry future
+///
+/// ```no_run
+/// #[tokio::test(spawn = true)]
+/// async fn my_test() {
+///     assert!(true);
+/// }
+/// ```
+///
+/// Equivalent code not using `#[tokio::test]`
+///
+/// ```no_run
+/// #[test]
+/// fn my_test() {
+///     let runtime = tokio::runtime::Builder::new_current_thread()
+///         .enable_all()
+///         .build()
+///         .unwrap();
+///     let handle = runtime.spawn(async {
+///         assert!(true);
+///     });
+///     runtime.block_on(async move {
+///         handle.await.unwrap()
+///     });
+/// }
+/// ```
 ///
 /// ### Rename package
 ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
`#[tokio::main]` and `#[tokio::test]` require only `Future` for entry future. In contrast `tokio::spawn` demands also `Send`. The divergence is subtle, people may not be aware of it in single task tests until they spawn `!Send` future in real code.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
This pr introduce `spawn = true` to fill the gap. So people can enforce `Send` for entry futures on demand.

## Aggressive suggestions
I wonder whether this should be the default for tests, but apparent it is not realistic for project with large dependents.

I was bit once by this in earlier stage of rust road. I was trying to build a `!Sync`, `Send` and `Clone` struct so I can batch asynchronous futures without contentions from possible parallel tasks. [It fits my mental model.](https://github.com/kezhuw/bookkeeper-client-rust/blob/76f2fc88384966b1e367f3dc6f3538938214d214/README.md#send-sync-and-await) All went good including tests. But it bombed in real application. It hurts.

Almost all futures we are programming are `Send`. `spawn = false` is enough for exceptions which are probably fragile((#4588).

## Build failure
I was not able to pass the test using [`cargo test --features full`](https://github.com/tokio-rs/tokio/blob/37bb47c4a2aff8913e536767645772f15650e6cd/tests-build/README.md). So a pull request to gain test output. Here is a piece of what I get.

```
error[E0432]: unresolved import `tests_build::tokio`
 --> $DIR/macros_type_mismatch.rs:1:5
  |
1 | use tests_build::tokio;
  |     ^^^^^^^^^^^^^^^^^^ no `tokio` in the root
```