### PR TITLE
SyncIOBridge: Add `into_inner`

### DIFF
--- a/tokio-util/src/io/sync_bridge.rs
+++ b/tokio-util/src/io/sync_bridge.rs
@@ -140,4 +140,9 @@ impl<T: Unpin> SyncIoBridge<T> {
     pub fn new_with_handle(src: T, rt: tokio::runtime::Handle) -> Self {
         Self { src, rt }
     }
+
+    /// Consume this bridge, returning the underlying stream.
+    pub fn into_inner(self) -> T {
+        self.src
+    }
 }

--- a/tokio-util/tests/io_sync_bridge.rs
+++ b/tokio-util/tests/io_sync_bridge.rs
@@ -44,6 +44,18 @@ async fn test_async_write_to_sync() -> Result<(), Box<dyn Error>> {
 }
 
 #[tokio::test]
+async fn test_into_inner() -> Result<(), Box<dyn Error>> {
+    let mut buf = Vec::new();
+    SyncIoBridge::new(tokio::io::empty())
+        .into_inner()
+        .read_to_end(&mut buf)
+        .await
+        .unwrap();
+    assert_eq!(buf.len(), 0);
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_shutdown() -> Result<(), Box<dyn Error>> {
     let (s1, mut s2) = tokio::io::duplex(1024);
     let (_rh, wh) = tokio::io::split(s1);


### PR DESCRIPTION
This keeps us in sync with other I/O wrapper types (e.g. `BufWriter`).

I was working on this change
https://github.com/ostreedev/ostree-rs-ext/pull/527/commits/13455cce4923ac0c3237d3983c2d4044842fb139 and it would have been helpful to be able to call this API so I can return the input stream back to the caller in order to extend its lifetime.
