### PR TITLE
Use ::core qualified imports instead of ::std inside tokio::test macro

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -402,7 +402,7 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
         quote! {
             let body = async #body;
             #crate_path::pin!(body);
-            let body: ::std::pin::Pin<&mut dyn ::std::future::Future<Output = #output_type>> = body;
+            let body: ::core::pin::Pin<&mut dyn ::core::future::Future<Output = #output_type>> = body;
         }
     } else {
         quote! {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
At work, we have a crate in our monorepo which is `#![no_std]` for build size reasons. However, we use `tokio` to test that its async functionality is functional in CI for simplicity and leave the other executor for the "real" usage of the library.

In a recent `tokio` update, we started to see this error when compiling its tests:
```
error[E0433]: failed to resolve: could not find `std` in the list of imported crates
   --> crypto/crate-name/src/lib.rs:556:5
    |
556 |     #[tokio::test]
    |     ^^^^^^^^^^^^^^ could not find `std` in the list of imported crates
    |
    = note: this error originates in the attribute macro `tokio::test` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I was not immediately able to find which commit caused this, but you can observe the cause here:
https://github.com/tokio-rs/tokio/blob/fd7d0ad5e57e968cd45a3dba75250ea272e32e10/tokio-macros/src/entry.rs#L402-L406

<details>

<summary>You can reproduce the issue with this project: </summary>

```toml
[package]
name = "reproducer"
version = "0.1.0"
edition = "2021"

[dev-dependencies]
tokio = { version = "1", features = ["rt", "macros"] }
```

```rust
#![no_std]

async fn future_to_test() -> i32 {
    1
}

#[cfg(test)]
mod tests {
    use super::*;

    #[tokio::test]
    async fn test_future() {
        assert_eq!(future_to_test().await, 1);
    }
}
```

</details>


## Solution

Given that that `std::future` and `std::pin` are re-exports of their `core` equivalents, I propose to qualify these imports inside the `tokio::test` macro with `::core` instead of `::std` for better compatibility. AFAIK this should not have any negative impacts for other users.

By making this change, a `#![no_std]` crate can continue to smoothly use `tokio` as a dev-dependency without any workarounds needed in the rest of the crate.
