### PR TITLE
add token bucket example to Semaphore

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -152,10 +152,9 @@ use std::sync::Arc;
 ///     }
 ///
 ///     async fn close(self) {
+///         self.sem.close();
 ///         self.jh.abort();
 ///         let _ = self.jh.await;
-///
-///         self.sem.close();
 ///     }
 /// }
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -135,9 +135,8 @@ use std::sync::Arc;
 /// }
 ///
 /// impl TokenBucket {
-///     fn new(duration: Duration) -> Self {
-///         let rate = (1.0 / duration.as_secs_f32()) as usize;
-///         let sem = Arc::new(Semaphore::new(rate));
+///     fn new(duration: Duration, capacity: usize) -> Self {
+///         let sem = Arc::new(Semaphore::new(capacity));
 ///
 ///         // refills the tokens at the end of each interval
 ///         let jh = tokio::spawn({
@@ -149,7 +148,7 @@ use std::sync::Arc;
 ///                 loop {
 ///                     interval.tick().await;
 ///
-///                     if sem.available_permits() < rate {
+///                     if sem.available_permits() < capacity {
 ///                         sem.add_permits(1);
 ///                     }
 ///                 }
@@ -172,9 +171,9 @@ use std::sync::Arc;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let ops = 1.0; // operation per second
-///     let update_interval = 1.0 / ops;
-///     let bucket = TokenBucket::new(Duration::from_secs_f32(update_interval));
+///     let capacity = 5; // operation per second
+///     let update_interval = Duration::from_secs_f32(1.0 / capacity as f32);
+///     let bucket = TokenBucket::new(update_interval, capacity);
 ///
 ///     for _ in 0..5 {
 ///         bucket.acquire().await.unwrap();

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -94,7 +94,7 @@ use std::sync::Arc;
 /// Unlike the example that limits how many requests can be handled at the same time, we do not add
 /// tokens back when we finish handling a request. Instead, tokens are added only by a timer task.
 ///
-/// Note that this implementation is suboptimal / when the duration is small, because it consumes a
+/// Note that this implementation is suboptimal when the duration is small, because it consumes a
 /// lot of cpu constantly looping and sleeping.
 ///
 /// [token bucket]: https://en.wikipedia.org/wiki/Token_bucket

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -139,7 +139,7 @@ use std::sync::Arc;
 ///                     interval.tick().await;
 ///
 ///                     let cap = rate - sem.available_permits();
-///                     sem.add_permits(std::cmp::min(cap, 1));
+///                     sem.add_permits(cap.min(1));
 ///                 }
 ///             }
 ///         });

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -138,8 +138,9 @@ use std::sync::Arc;
 ///                 loop {
 ///                     interval.tick().await;
 ///
-///                     let cap = rate - sem.available_permits();
-///                     sem.add_permits(cap.min(1));
+///                     if sem.available_permits() < rate {
+///                         sem.add_permits(1);
+///                     }
 ///                 }
 ///             }
 ///         });

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -108,11 +108,22 @@ use std::sync::Arc;
 /// operations should occur. Exceeding this rate can result in suboptimal
 /// performance or even errors.
 ///
-/// The provided example uses a `TokenBucket`, implemented using a semaphore, that
-/// limits operations to a specific rate although token buckets allow short bursts that are faster
-/// than the allowed rate. The token bucket will be refilled after each interval. When the rate is exceeded,
-/// the `acquire` method will await until a token is available. Note that this implementation is suboptimal
-/// when the rate is large, because it consumes a lot of cpu constantly looping and sleeping.
+/// This example implements rate limiting using a [token bucket]. A token bucket is a form of rate
+/// limiting that doesn't kick in immediately, to allow for short bursts of incoming requests that
+/// arrive at the same time.
+///
+/// With a token bucket, each incoming request consumes a token, and the tokens are refilled at a
+/// certain rate that defines the rate limit. When a burst of requests arrives, tokens are
+/// immediately given out until the bucket is empty. Once the bucket is empty, requests will have to
+/// wait for new tokens to be added.
+///
+/// Unlike the example that limits how many requests can be handled at the same time, we do not add
+/// tokens back when we finish handling a request. Instead, tokens are added only by a timer task.
+///
+/// Note that this implementation is suboptimal / when the duration is small, because it consumes a
+/// lot of cpu constantly looping and sleeping.
+///
+/// [token bucket]: https://en.wikipedia.org/wiki/Token_bucket
 /// ```
 /// use std::sync::Arc;
 /// use tokio::sync::{AcquireError, Semaphore};


### PR DESCRIPTION
Implements the token bucket example as listed in #5933.