### PR TITLE
chore: list 1.32.x as LTS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,16 +218,17 @@ releases are:
 
  * `1.20.x` - LTS release until September 2023. (MSRV 1.49)
  * `1.25.x` - LTS release until March 2024. (MSRV 1.49)
+ * `1.32.x` - LTS release until September 2024 (MSRV 1.63)
 
 Each LTS release will continue to receive backported fixes for at least a year.
 If you wish to use a fixed minor release in your project, we recommend that you
 use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.18.x` patch release, you
+example, to specify that you wish to use the newest `1.25.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.18", features = [...] }
+tokio = { version = "~1.25", features = [...] }
 ```
 
 ### Previous LTS releases

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -218,16 +218,17 @@ releases are:
 
  * `1.20.x` - LTS release until September 2023. (MSRV 1.49)
  * `1.25.x` - LTS release until March 2024. (MSRV 1.49)
+ * `1.32.x` - LTS release until September 2024 (MSRV 1.63)
 
 Each LTS release will continue to receive backported fixes for at least a year.
 If you wish to use a fixed minor release in your project, we recommend that you
 use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.18.x` patch release, you
+example, to specify that you wish to use the newest `1.25.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.18", features = [...] }
+tokio = { version = "~1.25", features = [...] }
 ```
 
 ### Previous LTS releases


### PR DESCRIPTION
List that 1.32.x will be supported until September 2024. The 1.20.x LTS
which is supported until September 2023 has been left, to be removed in
October.