### PR TITLE
use criterion

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,7 +9,7 @@ test-util = ["tokio/test-util"]
 
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
-bencher = "0.1.5"
+criterion = "0.5.1"
 rand = "0.8"
 rand_chacha = "0.3"
 

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -6,7 +6,7 @@ use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tokio_util::codec::{BytesCodec, FramedRead /*FramedWrite*/};
 
-use bencher::{benchmark_group, benchmark_main, Bencher};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 use std::fs::File as StdFile;
 use std::io::Read as StdRead;
@@ -23,81 +23,90 @@ const BLOCK_COUNT: usize = 1_000;
 const BUFFER_SIZE: usize = 4096;
 const DEV_ZERO: &str = "/dev/zero";
 
-fn async_read_codec(b: &mut Bencher) {
+fn async_read_codec(c: &mut Criterion) {
     let rt = rt();
 
-    b.iter(|| {
-        let task = || async {
-            let file = File::open(DEV_ZERO).await.unwrap();
-            let mut input_stream = FramedRead::with_capacity(file, BytesCodec::new(), BUFFER_SIZE);
+    c.bench_function("async_read_codec", |b| {
+        b.iter(|| {
+            let task = || async {
+                let file = File::open(DEV_ZERO).await.unwrap();
+                let mut input_stream =
+                    FramedRead::with_capacity(file, BytesCodec::new(), BUFFER_SIZE);
 
-            for _i in 0..BLOCK_COUNT {
-                let _bytes = input_stream.next().await.unwrap();
-            }
-        };
-
-        rt.block_on(task());
-    });
-}
-
-fn async_read_buf(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        let task = || async {
-            let mut file = File::open(DEV_ZERO).await.unwrap();
-            let mut buffer = [0u8; BUFFER_SIZE];
-
-            for _i in 0..BLOCK_COUNT {
-                let count = file.read(&mut buffer).await.unwrap();
-                if count == 0 {
-                    break;
+                for _i in 0..BLOCK_COUNT {
+                    let _bytes = input_stream.next().await.unwrap();
                 }
-            }
-        };
+            };
 
-        rt.block_on(task());
+            rt.block_on(task());
+        })
     });
 }
 
-fn async_read_std_file(b: &mut Bencher) {
+fn async_read_buf(c: &mut Criterion) {
     let rt = rt();
 
-    let task = || async {
-        let mut file = tokio::task::block_in_place(|| Box::pin(StdFile::open(DEV_ZERO).unwrap()));
+    c.bench_function("async_read_buf", |b| {
+        b.iter(|| {
+            let task = || async {
+                let mut file = File::open(DEV_ZERO).await.unwrap();
+                let mut buffer = [0u8; BUFFER_SIZE];
 
-        for _i in 0..BLOCK_COUNT {
+                for _i in 0..BLOCK_COUNT {
+                    let count = file.read(&mut buffer).await.unwrap();
+                    if count == 0 {
+                        break;
+                    }
+                }
+            };
+
+            rt.block_on(task());
+        });
+    });
+}
+
+fn async_read_std_file(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("async_read_std_file", |b| {
+        b.iter(|| {
+            let task = || async {
+                let mut file =
+                    tokio::task::block_in_place(|| Box::pin(StdFile::open(DEV_ZERO).unwrap()));
+
+                for _i in 0..BLOCK_COUNT {
+                    let mut buffer = [0u8; BUFFER_SIZE];
+                    let mut file_ref = file.as_mut();
+
+                    tokio::task::block_in_place(move || {
+                        file_ref.read_exact(&mut buffer).unwrap();
+                    });
+                }
+            };
+
+            rt.block_on(task());
+        });
+    });
+}
+
+fn sync_read(c: &mut Criterion) {
+    c.bench_function("sync_read", |b| {
+        b.iter(|| {
+            let mut file = StdFile::open(DEV_ZERO).unwrap();
             let mut buffer = [0u8; BUFFER_SIZE];
-            let mut file_ref = file.as_mut();
 
-            tokio::task::block_in_place(move || {
-                file_ref.read_exact(&mut buffer).unwrap();
-            });
-        }
-    };
-
-    b.iter(|| {
-        rt.block_on(task());
+            for _i in 0..BLOCK_COUNT {
+                file.read_exact(&mut buffer).unwrap();
+            }
+        })
     });
 }
 
-fn sync_read(b: &mut Bencher) {
-    b.iter(|| {
-        let mut file = StdFile::open(DEV_ZERO).unwrap();
-        let mut buffer = [0u8; BUFFER_SIZE];
-
-        for _i in 0..BLOCK_COUNT {
-            file.read_exact(&mut buffer).unwrap();
-        }
-    });
-}
-
-benchmark_group!(
+criterion_group!(
     file,
     async_read_std_file,
     async_read_buf,
     async_read_codec,
     sync_read
 );
-
-benchmark_main!(file);
+criterion_main!(file);

--- a/benches/rt_multi_threaded.rs
+++ b/benches/rt_multi_threaded.rs
@@ -5,63 +5,68 @@
 use tokio::runtime::{self, Runtime};
 use tokio::sync::oneshot;
 
-use bencher::{benchmark_group, benchmark_main, Bencher};
 use std::sync::atomic::Ordering::Relaxed;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{mpsc, Arc};
 use std::time::{Duration, Instant};
 
+use criterion::{criterion_group, criterion_main, Criterion};
+
 const NUM_WORKERS: usize = 4;
 const NUM_SPAWN: usize = 10_000;
 const STALL_DUR: Duration = Duration::from_micros(10);
 
-fn spawn_many_local(b: &mut Bencher) {
+fn spawn_many_local(c: &mut Criterion) {
     let rt = rt();
 
     let (tx, rx) = mpsc::sync_channel(1000);
     let rem = Arc::new(AtomicUsize::new(0));
 
-    b.iter(|| {
-        rem.store(NUM_SPAWN, Relaxed);
+    c.bench_function("spawn_many_local", |b| {
+        b.iter(|| {
+            rem.store(NUM_SPAWN, Relaxed);
 
-        rt.block_on(async {
-            for _ in 0..NUM_SPAWN {
-                let tx = tx.clone();
-                let rem = rem.clone();
+            rt.block_on(async {
+                for _ in 0..NUM_SPAWN {
+                    let tx = tx.clone();
+                    let rem = rem.clone();
 
-                tokio::spawn(async move {
-                    if 1 == rem.fetch_sub(1, Relaxed) {
-                        tx.send(()).unwrap();
-                    }
-                });
-            }
+                    tokio::spawn(async move {
+                        if 1 == rem.fetch_sub(1, Relaxed) {
+                            tx.send(()).unwrap();
+                        }
+                    });
+                }
 
-            let _ = rx.recv().unwrap();
-        });
+                let _ = rx.recv().unwrap();
+            });
+        })
     });
 }
 
-fn spawn_many_remote_idle(b: &mut Bencher) {
+fn spawn_many_remote_idle(c: &mut Criterion) {
     let rt = rt();
 
     let mut handles = Vec::with_capacity(NUM_SPAWN);
 
-    b.iter(|| {
-        for _ in 0..NUM_SPAWN {
-            handles.push(rt.spawn(async {}));
-        }
-
-        rt.block_on(async {
-            for handle in handles.drain(..) {
-                handle.await.unwrap();
+    c.bench_function("spawn_many_remote_idle", |b| {
+        b.iter(|| {
+            for _ in 0..NUM_SPAWN {
+                handles.push(rt.spawn(async {}));
             }
-        });
+
+            rt.block_on(async {
+                for handle in handles.drain(..) {
+                    handle.await.unwrap();
+                }
+            });
+        })
     });
 }
 
 // The runtime is busy with tasks that consume CPU time and yield. Yielding is a
 // lower notification priority than spawning / regular notification.
-fn spawn_many_remote_busy1(b: &mut Bencher) {
+fn spawn_many_remote_busy1(c: &mut Criterion) {
     let rt = rt();
     let rt_handle = rt.handle();
     let mut handles = Vec::with_capacity(NUM_SPAWN);
@@ -78,16 +83,18 @@ fn spawn_many_remote_busy1(b: &mut Bencher) {
         });
     }
 
-    b.iter(|| {
-        for _ in 0..NUM_SPAWN {
-            handles.push(rt_handle.spawn(async {}));
-        }
-
-        rt.block_on(async {
-            for handle in handles.drain(..) {
-                handle.await.unwrap();
+    c.bench_function("spawn_many_remote_busy1", |b| {
+        b.iter(|| {
+            for _ in 0..NUM_SPAWN {
+                handles.push(rt_handle.spawn(async {}));
             }
-        });
+
+            rt.block_on(async {
+                for handle in handles.drain(..) {
+                    handle.await.unwrap();
+                }
+            });
+        })
     });
 
     flag.store(false, Relaxed);
@@ -95,7 +102,7 @@ fn spawn_many_remote_busy1(b: &mut Bencher) {
 
 // The runtime is busy with tasks that consume CPU time and spawn new high-CPU
 // tasks. Spawning goes via a higher notification priority than yielding.
-fn spawn_many_remote_busy2(b: &mut Bencher) {
+fn spawn_many_remote_busy2(c: &mut Criterion) {
     const NUM_SPAWN: usize = 1_000;
 
     let rt = rt();
@@ -119,49 +126,52 @@ fn spawn_many_remote_busy2(b: &mut Bencher) {
         });
     }
 
-    b.iter(|| {
-        for _ in 0..NUM_SPAWN {
-            handles.push(rt_handle.spawn(async {}));
-        }
-
-        rt.block_on(async {
-            for handle in handles.drain(..) {
-                handle.await.unwrap();
+    c.bench_function("spawn_many_remote_busy2", |b| {
+        b.iter(|| {
+            for _ in 0..NUM_SPAWN {
+                handles.push(rt_handle.spawn(async {}));
             }
-        });
+
+            rt.block_on(async {
+                for handle in handles.drain(..) {
+                    handle.await.unwrap();
+                }
+            });
+        })
     });
 
     flag.store(false, Relaxed);
 }
 
-fn yield_many(b: &mut Bencher) {
+fn yield_many(c: &mut Criterion) {
     const NUM_YIELD: usize = 1_000;
     const TASKS: usize = 200;
 
-    let rt = rt();
+    c.bench_function("yield_many", |b| {
+        let rt = rt();
+        let (tx, rx) = mpsc::sync_channel(TASKS);
 
-    let (tx, rx) = mpsc::sync_channel(TASKS);
+        b.iter(move || {
+            for _ in 0..TASKS {
+                let tx = tx.clone();
 
-    b.iter(move || {
-        for _ in 0..TASKS {
-            let tx = tx.clone();
+                rt.spawn(async move {
+                    for _ in 0..NUM_YIELD {
+                        tokio::task::yield_now().await;
+                    }
 
-            rt.spawn(async move {
-                for _ in 0..NUM_YIELD {
-                    tokio::task::yield_now().await;
-                }
+                    tx.send(()).unwrap();
+                });
+            }
 
-                tx.send(()).unwrap();
-            });
-        }
-
-        for _ in 0..TASKS {
-            let _ = rx.recv().unwrap();
-        }
+            for _ in 0..TASKS {
+                let _ = rx.recv().unwrap();
+            }
+        })
     });
 }
 
-fn ping_pong(b: &mut Bencher) {
+fn ping_pong(c: &mut Criterion) {
     const NUM_PINGS: usize = 1_000;
 
     let rt = rt();
@@ -169,45 +179,45 @@ fn ping_pong(b: &mut Bencher) {
     let (done_tx, done_rx) = mpsc::sync_channel(1000);
     let rem = Arc::new(AtomicUsize::new(0));
 
-    b.iter(|| {
-        let done_tx = done_tx.clone();
-        let rem = rem.clone();
-        rem.store(NUM_PINGS, Relaxed);
+    c.bench_function("ping_pong", |b| {
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(NUM_PINGS, Relaxed);
 
-        rt.block_on(async {
-            tokio::spawn(async move {
-                for _ in 0..NUM_PINGS {
-                    let rem = rem.clone();
-                    let done_tx = done_tx.clone();
-
-                    tokio::spawn(async move {
-                        let (tx1, rx1) = oneshot::channel();
-                        let (tx2, rx2) = oneshot::channel();
+            rt.block_on(async {
+                tokio::spawn(async move {
+                    for _ in 0..NUM_PINGS {
+                        let rem = rem.clone();
+                        let done_tx = done_tx.clone();
 
                         tokio::spawn(async move {
-                            rx1.await.unwrap();
-                            tx2.send(()).unwrap();
+                            let (tx1, rx1) = oneshot::channel();
+                            let (tx2, rx2) = oneshot::channel();
+
+                            tokio::spawn(async move {
+                                rx1.await.unwrap();
+                                tx2.send(()).unwrap();
+                            });
+
+                            tx1.send(()).unwrap();
+                            rx2.await.unwrap();
+
+                            if 1 == rem.fetch_sub(1, Relaxed) {
+                                done_tx.send(()).unwrap();
+                            }
                         });
+                    }
+                });
 
-                        tx1.send(()).unwrap();
-                        rx2.await.unwrap();
-
-                        if 1 == rem.fetch_sub(1, Relaxed) {
-                            done_tx.send(()).unwrap();
-                        }
-                    });
-                }
+                done_rx.recv().unwrap();
             });
-
-            done_rx.recv().unwrap();
-        });
+        })
     });
 }
 
-fn chained_spawn(b: &mut Bencher) {
+fn chained_spawn(c: &mut Criterion) {
     const ITER: usize = 1_000;
-
-    let rt = rt();
 
     fn iter(done_tx: mpsc::SyncSender<()>, n: usize) {
         if n == 0 {
@@ -219,18 +229,21 @@ fn chained_spawn(b: &mut Bencher) {
         }
     }
 
-    let (done_tx, done_rx) = mpsc::sync_channel(1000);
+    c.bench_function("chained_spawn", |b| {
+        let rt = rt();
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
 
-    b.iter(move || {
-        let done_tx = done_tx.clone();
+        b.iter(move || {
+            let done_tx = done_tx.clone();
 
-        rt.block_on(async {
-            tokio::spawn(async move {
-                iter(done_tx, ITER);
+            rt.block_on(async {
+                tokio::spawn(async move {
+                    iter(done_tx, ITER);
+                });
+
+                done_rx.recv().unwrap();
             });
-
-            done_rx.recv().unwrap();
-        });
+        })
     });
 }
 
@@ -249,7 +262,7 @@ fn stall() {
     }
 }
 
-benchmark_group!(
+criterion_group!(
     scheduler,
     spawn_many_local,
     spawn_many_remote_idle,
@@ -260,4 +273,4 @@ benchmark_group!(
     chained_spawn,
 );
 
-benchmark_main!(scheduler);
+criterion_main!(scheduler);

--- a/benches/signal.rs
+++ b/benches/signal.rs
@@ -1,7 +1,7 @@
 //! Benchmark the delay in propagating OS signals to any listeners.
 #![cfg(unix)]
 
-use bencher::{benchmark_group, benchmark_main, Bencher};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -41,7 +41,7 @@ pub fn send_signal(signal: libc::c_int) {
     }
 }
 
-fn many_signals(bench: &mut Bencher) {
+fn many_signals(c: &mut Criterion) {
     let num_signals = 10;
     let (tx, mut rx) = mpsc::channel(num_signals);
 
@@ -75,21 +75,23 @@ fn many_signals(bench: &mut Bencher) {
     // tasks have been polled at least once
     rt.block_on(Spinner::new());
 
-    bench.iter(|| {
-        rt.block_on(async {
-            send_signal(libc::SIGCHLD);
-            for _ in 0..num_signals {
-                rx.recv().await.expect("channel closed");
-            }
+    c.bench_function("many_signals", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                send_signal(libc::SIGCHLD);
+                for _ in 0..num_signals {
+                    rx.recv().await.expect("channel closed");
+                }
 
-            send_signal(libc::SIGIO);
-            for _ in 0..num_signals {
-                rx.recv().await.expect("channel closed");
-            }
-        });
+                send_signal(libc::SIGIO);
+                for _ in 0..num_signals {
+                    rx.recv().await.expect("channel closed");
+                }
+            });
+        })
     });
 }
 
-benchmark_group!(signal_group, many_signals,);
+criterion_group!(signal_group, many_signals,);
 
-benchmark_main!(signal_group);
+criterion_main!(signal_group);

--- a/benches/signal.rs
+++ b/benches/signal.rs
@@ -92,6 +92,6 @@ fn many_signals(c: &mut Criterion) {
     });
 }
 
-criterion_group!(signal_group, many_signals,);
+criterion_group!(signal_group, many_signals);
 
 criterion_main!(signal_group);

--- a/benches/spawn.rs
+++ b/benches/spawn.rs
@@ -2,10 +2,7 @@
 //! This essentially measure the time to enqueue a task in the local and remote
 //! case.
 
-#[macro_use]
-extern crate bencher;
-
-use bencher::{black_box, Bencher};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 async fn work() -> usize {
     let val = 1 + 1;
@@ -13,67 +10,77 @@ async fn work() -> usize {
     black_box(val)
 }
 
-fn basic_scheduler_spawn(bench: &mut Bencher) {
+fn basic_scheduler_spawn(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
-    bench.iter(|| {
-        runtime.block_on(async {
-            let h = tokio::spawn(work());
-            assert_eq!(h.await.unwrap(), 2);
-        });
+
+    c.bench_function("basic_scheduler_spawn", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let h = tokio::spawn(work());
+                assert_eq!(h.await.unwrap(), 2);
+            });
+        })
     });
 }
 
-fn basic_scheduler_spawn10(bench: &mut Bencher) {
+fn basic_scheduler_spawn10(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
-    bench.iter(|| {
-        runtime.block_on(async {
-            let mut handles = Vec::with_capacity(10);
-            for _ in 0..10 {
-                handles.push(tokio::spawn(work()));
-            }
-            for handle in handles {
-                assert_eq!(handle.await.unwrap(), 2);
-            }
-        });
+
+    c.bench_function("basic_scheduler_spawn10", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut handles = Vec::with_capacity(10);
+                for _ in 0..10 {
+                    handles.push(tokio::spawn(work()));
+                }
+                for handle in handles {
+                    assert_eq!(handle.await.unwrap(), 2);
+                }
+            });
+        })
     });
 }
 
-fn threaded_scheduler_spawn(bench: &mut Bencher) {
+fn threaded_scheduler_spawn(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
         .build()
         .unwrap();
-    bench.iter(|| {
-        runtime.block_on(async {
-            let h = tokio::spawn(work());
-            assert_eq!(h.await.unwrap(), 2);
-        });
+    c.bench_function("threaded_scheduler_spawn", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let h = tokio::spawn(work());
+                assert_eq!(h.await.unwrap(), 2);
+            });
+        })
     });
 }
 
-fn threaded_scheduler_spawn10(bench: &mut Bencher) {
+fn threaded_scheduler_spawn10(c: &mut Criterion) {
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
         .build()
         .unwrap();
-    bench.iter(|| {
-        runtime.block_on(async {
-            let mut handles = Vec::with_capacity(10);
-            for _ in 0..10 {
-                handles.push(tokio::spawn(work()));
-            }
-            for handle in handles {
-                assert_eq!(handle.await.unwrap(), 2);
-            }
-        });
+    c.bench_function("threaded_scheduler_spawn10", |b| {
+        b.iter(|| {
+            runtime.block_on(async {
+                let mut handles = Vec::with_capacity(10);
+                for _ in 0..10 {
+                    handles.push(tokio::spawn(work()));
+                }
+                for handle in handles {
+                    assert_eq!(handle.await.unwrap(), 2);
+                }
+            });
+        })
     });
 }
 
-bencher::benchmark_group!(
+criterion_group!(
     spawn,
     basic_scheduler_spawn,
     basic_scheduler_spawn10,
@@ -81,4 +88,4 @@ bencher::benchmark_group!(
     threaded_scheduler_spawn10,
 );
 
-bencher::benchmark_main!(spawn);
+criterion_main!(spawn);

--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -1,5 +1,6 @@
-use bencher::{black_box, Bencher};
 use tokio::sync::mpsc;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 type Medium = [usize; 64];
 type Large = [Medium; 64];
@@ -11,163 +12,183 @@ fn rt() -> tokio::runtime::Runtime {
         .unwrap()
 }
 
-fn create_1_medium(b: &mut Bencher) {
-    b.iter(|| {
-        black_box(&mpsc::channel::<Medium>(1));
-    });
-}
-
-fn create_100_medium(b: &mut Bencher) {
-    b.iter(|| {
-        black_box(&mpsc::channel::<Medium>(100));
-    });
-}
-
-fn create_100_000_medium(b: &mut Bencher) {
-    b.iter(|| {
-        black_box(&mpsc::channel::<Medium>(100_000));
-    });
-}
-
-fn send_medium(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        let (tx, mut rx) = mpsc::channel::<Medium>(1000);
-
-        let _ = rt.block_on(tx.send([0; 64]));
-
-        rt.block_on(rx.recv()).unwrap();
-    });
-}
-
-fn send_large(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        let (tx, mut rx) = mpsc::channel::<Large>(1000);
-
-        let _ = rt.block_on(tx.send([[0; 64]; 64]));
-
-        rt.block_on(rx.recv()).unwrap();
-    });
-}
-
-fn contention_bounded(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        rt.block_on(async move {
-            let (tx, mut rx) = mpsc::channel::<usize>(1_000_000);
-
-            for _ in 0..5 {
-                let tx = tx.clone();
-                tokio::spawn(async move {
-                    for i in 0..1000 {
-                        tx.send(i).await.unwrap();
-                    }
-                });
-            }
-
-            for _ in 0..1_000 * 5 {
-                let _ = rx.recv().await;
-            }
+fn create_1_medium(c: &mut Criterion) {
+    c.bench_function("create_1_medium", |b| {
+        b.iter(|| {
+            black_box(&mpsc::channel::<Medium>(1));
         })
     });
 }
 
-fn contention_bounded_full(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        rt.block_on(async move {
-            let (tx, mut rx) = mpsc::channel::<usize>(100);
-
-            for _ in 0..5 {
-                let tx = tx.clone();
-                tokio::spawn(async move {
-                    for i in 0..1000 {
-                        tx.send(i).await.unwrap();
-                    }
-                });
-            }
-
-            for _ in 0..1_000 * 5 {
-                let _ = rx.recv().await;
-            }
+fn create_100_medium(c: &mut Criterion) {
+    c.bench_function("create_100_medium", |b| {
+        b.iter(|| {
+            black_box(&mpsc::channel::<Medium>(100));
         })
     });
 }
 
-fn contention_unbounded(b: &mut Bencher) {
-    let rt = rt();
-
-    b.iter(|| {
-        rt.block_on(async move {
-            let (tx, mut rx) = mpsc::unbounded_channel::<usize>();
-
-            for _ in 0..5 {
-                let tx = tx.clone();
-                tokio::spawn(async move {
-                    for i in 0..1000 {
-                        tx.send(i).unwrap();
-                    }
-                });
-            }
-
-            for _ in 0..1_000 * 5 {
-                let _ = rx.recv().await;
-            }
+fn create_100_000_medium(c: &mut Criterion) {
+    c.bench_function("create_100_000_medium", |b| {
+        b.iter(|| {
+            black_box(&mpsc::channel::<Medium>(100_000));
         })
     });
 }
 
-fn uncontented_bounded(b: &mut Bencher) {
+fn send_medium(c: &mut Criterion) {
     let rt = rt();
 
-    b.iter(|| {
-        rt.block_on(async move {
-            let (tx, mut rx) = mpsc::channel::<usize>(1_000_000);
+    c.bench_function("send_medium", |b| {
+        b.iter(|| {
+            let (tx, mut rx) = mpsc::channel::<Medium>(1000);
 
-            for i in 0..5000 {
-                tx.send(i).await.unwrap();
-            }
+            let _ = rt.block_on(tx.send([0; 64]));
 
-            for _ in 0..5_000 {
-                let _ = rx.recv().await;
-            }
+            rt.block_on(rx.recv()).unwrap();
         })
     });
 }
 
-fn uncontented_unbounded(b: &mut Bencher) {
+fn send_large(c: &mut Criterion) {
     let rt = rt();
 
-    b.iter(|| {
-        rt.block_on(async move {
-            let (tx, mut rx) = mpsc::unbounded_channel::<usize>();
+    c.bench_function("send_large", |b| {
+        b.iter(|| {
+            let (tx, mut rx) = mpsc::channel::<Large>(1000);
 
-            for i in 0..5000 {
-                tx.send(i).unwrap();
-            }
+            let _ = rt.block_on(tx.send([[0; 64]; 64]));
 
-            for _ in 0..5_000 {
-                let _ = rx.recv().await;
-            }
+            rt.block_on(rx.recv()).unwrap();
         })
     });
 }
 
-bencher::benchmark_group!(
+fn contention_bounded(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("contention_bounded", |b| {
+        b.iter(|| {
+            rt.block_on(async move {
+                let (tx, mut rx) = mpsc::channel::<usize>(1_000_000);
+
+                for _ in 0..5 {
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        for i in 0..1000 {
+                            tx.send(i).await.unwrap();
+                        }
+                    });
+                }
+
+                for _ in 0..1_000 * 5 {
+                    let _ = rx.recv().await;
+                }
+            })
+        })
+    });
+}
+
+fn contention_bounded_full(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("contention_bounded_full", |b| {
+        b.iter(|| {
+            rt.block_on(async move {
+                let (tx, mut rx) = mpsc::channel::<usize>(100);
+
+                for _ in 0..5 {
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        for i in 0..1000 {
+                            tx.send(i).await.unwrap();
+                        }
+                    });
+                }
+
+                for _ in 0..1_000 * 5 {
+                    let _ = rx.recv().await;
+                }
+            })
+        })
+    });
+}
+
+fn contention_unbounded(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("contention_unbounded", |b| {
+        b.iter(|| {
+            rt.block_on(async move {
+                let (tx, mut rx) = mpsc::unbounded_channel::<usize>();
+
+                for _ in 0..5 {
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        for i in 0..1000 {
+                            tx.send(i).unwrap();
+                        }
+                    });
+                }
+
+                for _ in 0..1_000 * 5 {
+                    let _ = rx.recv().await;
+                }
+            })
+        })
+    });
+}
+
+fn uncontented_bounded(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("uncontented_bounded", |b| {
+        b.iter(|| {
+            rt.block_on(async move {
+                let (tx, mut rx) = mpsc::channel::<usize>(1_000_000);
+
+                for i in 0..5000 {
+                    tx.send(i).await.unwrap();
+                }
+
+                for _ in 0..5_000 {
+                    let _ = rx.recv().await;
+                }
+            })
+        })
+    });
+}
+
+fn uncontented_unbounded(c: &mut Criterion) {
+    let rt = rt();
+
+    c.bench_function("uncontented_unbounded", |b| {
+        b.iter(|| {
+            rt.block_on(async move {
+                let (tx, mut rx) = mpsc::unbounded_channel::<usize>();
+
+                for i in 0..5000 {
+                    tx.send(i).unwrap();
+                }
+
+                for _ in 0..5_000 {
+                    let _ = rx.recv().await;
+                }
+            })
+        })
+    });
+}
+
+criterion_group!(
     create,
     create_1_medium,
     create_100_medium,
     create_100_000_medium
 );
 
-bencher::benchmark_group!(send, send_medium, send_large);
+criterion_group!(send, send_medium, send_large);
 
-bencher::benchmark_group!(
+criterion_group!(
     contention,
     contention_bounded,
     contention_bounded_full,
@@ -176,4 +197,4 @@ bencher::benchmark_group!(
     uncontented_unbounded
 );
 
-bencher::benchmark_main!(create, send, contention);
+criterion_main!(create, send, contention);

--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -163,7 +163,7 @@ fn uncontented_unbounded(g: &mut BenchmarkGroup<WallTime>) {
     });
 }
 
-fn group_create_medium(c: &mut Criterion) {
+fn bench_create_medium(c: &mut Criterion) {
     let mut group = c.benchmark_group("create_medium");
     create_medium::<1>(&mut group);
     create_medium::<100>(&mut group);
@@ -171,14 +171,14 @@ fn group_create_medium(c: &mut Criterion) {
     group.finish();
 }
 
-fn group_send(c: &mut Criterion) {
+fn bench_send(c: &mut Criterion) {
     let mut group = c.benchmark_group("send");
-    send_data::<Medium, 1000>(&mut group, "Medium");
-    send_data::<Large, 1000>(&mut group, "Medium");
+    send_data::<Medium, 1000>(&mut group, "medium");
+    send_data::<Large, 1000>(&mut group, "large");
     group.finish();
 }
 
-fn group_contention(c: &mut Criterion) {
+fn bench_contention(c: &mut Criterion) {
     let mut group = c.benchmark_group("contention");
     contention_bounded(&mut group);
     contention_bounded_full(&mut group);
@@ -186,16 +186,16 @@ fn group_contention(c: &mut Criterion) {
     group.finish();
 }
 
-fn group_uncontented(c: &mut Criterion) {
+fn bench_uncontented(c: &mut Criterion) {
     let mut group = c.benchmark_group("uncontented");
     uncontented_bounded(&mut group);
     uncontented_unbounded(&mut group);
     group.finish();
 }
 
-criterion_group!(create, group_create_medium);
-criterion_group!(send, group_send);
-criterion_group!(contention, group_contention);
-criterion_group!(uncontented, group_uncontented);
+criterion_group!(create, bench_create_medium);
+criterion_group!(send, bench_send);
+criterion_group!(contention, bench_contention);
+criterion_group!(uncontented, bench_uncontented);
 
 criterion_main!(create, send, contention, uncontented);

--- a/benches/sync_mpsc_oneshot.rs
+++ b/benches/sync_mpsc_oneshot.rs
@@ -1,27 +1,28 @@
-use bencher::{benchmark_group, benchmark_main, Bencher};
 use tokio::{
     runtime::Runtime,
     sync::{mpsc, oneshot},
 };
 
-fn request_reply_current_thread(b: &mut Bencher) {
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn request_reply_current_thread(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
 
-    request_reply(b, rt);
+    request_reply(c, rt);
 }
 
-fn request_reply_multi_threaded(b: &mut Bencher) {
+fn request_reply_multi_threaded(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(1)
         .build()
         .unwrap();
 
-    request_reply(b, rt);
+    request_reply(c, rt);
 }
 
-fn request_reply(b: &mut Bencher, rt: Runtime) {
+fn request_reply(b: &mut Criterion, rt: Runtime) {
     let tx = rt.block_on(async move {
         let (tx, mut rx) = mpsc::channel::<oneshot::Sender<()>>(10);
         tokio::spawn(async move {
@@ -32,22 +33,24 @@ fn request_reply(b: &mut Bencher, rt: Runtime) {
         tx
     });
 
-    b.iter(|| {
-        let task_tx = tx.clone();
-        rt.block_on(async move {
-            for _ in 0..1_000 {
-                let (o_tx, o_rx) = oneshot::channel();
-                task_tx.send(o_tx).await.unwrap();
-                let _ = o_rx.await;
-            }
+    b.bench_function("request_reply", |b| {
+        b.iter(|| {
+            let task_tx = tx.clone();
+            rt.block_on(async move {
+                for _ in 0..1_000 {
+                    let (o_tx, o_rx) = oneshot::channel();
+                    task_tx.send(o_tx).await.unwrap();
+                    let _ = o_rx.await;
+                }
+            })
         })
     });
 }
 
-benchmark_group!(
+criterion_group!(
     sync_mpsc_oneshot_group,
     request_reply_current_thread,
     request_reply_multi_threaded,
 );
 
-benchmark_main!(sync_mpsc_oneshot_group);
+criterion_main!(sync_mpsc_oneshot_group);

--- a/benches/sync_notify.rs
+++ b/benches/sync_notify.rs
@@ -75,7 +75,7 @@ fn notify_one<const N_WAITERS: usize>(g: &mut BenchmarkGroup<WallTime>) {
     });
 }
 
-fn group_notify_one(c: &mut Criterion) {
+fn bench_notify_one(c: &mut Criterion) {
     let mut group = c.benchmark_group("notify_one");
     notify_one::<10>(&mut group);
     notify_one::<50>(&mut group);
@@ -85,7 +85,7 @@ fn group_notify_one(c: &mut Criterion) {
     group.finish();
 }
 
-fn group_notify_waiters(c: &mut Criterion) {
+fn bench_notify_waiters(c: &mut Criterion) {
     let mut group = c.benchmark_group("notify_waiters");
     notify_waiters::<10>(&mut group);
     notify_waiters::<50>(&mut group);
@@ -97,8 +97,8 @@ fn group_notify_waiters(c: &mut Criterion) {
 
 criterion_group!(
     notify_waiters_simple,
-    group_notify_one,
-    group_notify_waiters
+    bench_notify_one,
+    bench_notify_waiters
 );
 
 criterion_main!(notify_waiters_simple);

--- a/benches/sync_rwlock.rs
+++ b/benches/sync_rwlock.rs
@@ -142,14 +142,14 @@ fn read_concurrent_contended(g: &mut BenchmarkGroup<WallTime>) {
     });
 }
 
-fn group_contention(c: &mut Criterion) {
+fn bench_contention(c: &mut Criterion) {
     let mut group = c.benchmark_group("contention");
     read_concurrent_contended(&mut group);
     read_concurrent_contended_multi(&mut group);
     group.finish();
 }
 
-fn group_uncontented(c: &mut Criterion) {
+fn bench_uncontented(c: &mut Criterion) {
     let mut group = c.benchmark_group("uncontented");
     read_uncontended(&mut group);
     read_concurrent_uncontended(&mut group);
@@ -157,7 +157,7 @@ fn group_uncontented(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(contention, group_contention);
-criterion_group!(uncontented, group_uncontented);
+criterion_group!(contention, bench_contention);
+criterion_group!(uncontented, bench_uncontented);
 
 criterion_main!(contention, uncontented);

--- a/benches/sync_semaphore.rs
+++ b/benches/sync_semaphore.rs
@@ -1,21 +1,24 @@
-use bencher::Bencher;
 use std::sync::Arc;
 use tokio::{sync::Semaphore, task};
 
-fn uncontended(b: &mut Bencher) {
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn uncontended(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(6)
         .build()
         .unwrap();
 
     let s = Arc::new(Semaphore::new(10));
-    b.iter(|| {
-        let s = s.clone();
-        rt.block_on(async move {
-            for _ in 0..6 {
-                let permit = s.acquire().await;
-                drop(permit);
-            }
+    c.bench_function("uncontended", |b| {
+        b.iter(|| {
+            let s = s.clone();
+            rt.block_on(async move {
+                for _ in 0..6 {
+                    let permit = s.acquire().await;
+                    drop(permit);
+                }
+            })
         })
     });
 }
@@ -25,95 +28,103 @@ async fn task(s: Arc<Semaphore>) {
     drop(permit);
 }
 
-fn uncontended_concurrent_multi(b: &mut Bencher) {
+fn uncontended_concurrent_multi(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(6)
         .build()
         .unwrap();
 
     let s = Arc::new(Semaphore::new(10));
-    b.iter(|| {
-        let s = s.clone();
-        rt.block_on(async move {
-            let j = tokio::try_join! {
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone()))
-            };
-            j.unwrap();
+    c.bench_function("uncontended_concurrent_multi", |b| {
+        b.iter(|| {
+            let s = s.clone();
+            rt.block_on(async move {
+                let j = tokio::try_join! {
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone()))
+                };
+                j.unwrap();
+            })
         })
     });
 }
 
-fn uncontended_concurrent_single(b: &mut Bencher) {
+fn uncontended_concurrent_single(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
 
     let s = Arc::new(Semaphore::new(10));
-    b.iter(|| {
-        let s = s.clone();
-        rt.block_on(async move {
-            tokio::join! {
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone())
-            };
+    c.bench_function("uncontended_concurrent_single", |b| {
+        b.iter(|| {
+            let s = s.clone();
+            rt.block_on(async move {
+                tokio::join! {
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone())
+                };
+            })
         })
     });
 }
 
-fn contended_concurrent_multi(b: &mut Bencher) {
+fn contended_concurrent_multi(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(6)
         .build()
         .unwrap();
 
     let s = Arc::new(Semaphore::new(5));
-    b.iter(|| {
-        let s = s.clone();
-        rt.block_on(async move {
-            let j = tokio::try_join! {
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone())),
-                task::spawn(task(s.clone()))
-            };
-            j.unwrap();
+    c.bench_function("contended_concurrent_multi", |b| {
+        b.iter(|| {
+            let s = s.clone();
+            rt.block_on(async move {
+                let j = tokio::try_join! {
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone())),
+                    task::spawn(task(s.clone()))
+                };
+                j.unwrap();
+            })
         })
     });
 }
 
-fn contended_concurrent_single(b: &mut Bencher) {
+fn contended_concurrent_single(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
 
     let s = Arc::new(Semaphore::new(5));
-    b.iter(|| {
-        let s = s.clone();
-        rt.block_on(async move {
-            tokio::join! {
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone()),
-                task(s.clone())
-            };
+    c.bench_function("contended_concurrent_single", |b| {
+        b.iter(|| {
+            let s = s.clone();
+            rt.block_on(async move {
+                tokio::join! {
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone()),
+                    task(s.clone())
+                };
+            })
         })
     });
 }
 
-bencher::benchmark_group!(
+criterion_group!(
     sync_semaphore,
     uncontended,
     uncontended_concurrent_multi,
@@ -122,4 +133,4 @@ bencher::benchmark_group!(
     contended_concurrent_single
 );
 
-bencher::benchmark_main!(sync_semaphore);
+criterion_main!(sync_semaphore);

--- a/benches/time_now.rs
+++ b/benches/time_now.rs
@@ -19,6 +19,6 @@ fn time_now_current_thread(c: &mut Criterion) {
     });
 }
 
-criterion_group!(time_now, time_now_current_thread,);
+criterion_group!(time_now, time_now_current_thread);
 
 criterion_main!(time_now);

--- a/benches/time_now.rs
+++ b/benches/time_now.rs
@@ -2,24 +2,23 @@
 //! This essentially measure the time to enqueue a task in the local and remote
 //! case.
 
-#[macro_use]
-extern crate bencher;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-use bencher::{black_box, Bencher};
-
-fn time_now_current_thread(bench: &mut Bencher) {
+fn time_now_current_thread(c: &mut Criterion) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_time()
         .build()
         .unwrap();
 
-    bench.iter(|| {
-        rt.block_on(async {
-            black_box(tokio::time::Instant::now());
+    c.bench_function("time_now_current_thread", |b| {
+        b.iter(|| {
+            rt.block_on(async {
+                black_box(tokio::time::Instant::now());
+            })
         })
-    })
+    });
 }
 
-bencher::benchmark_group!(time_now, time_now_current_thread,);
+criterion_group!(time_now, time_now_current_thread,);
 
-bencher::benchmark_main!(time_now);
+criterion_main!(time_now);


### PR DESCRIPTION
Replaces `bencher` with `criterion`.

Resolves #5979.