### PR TITLE
docs: specify the line ending of LinesCodec

### DIFF
--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -6,7 +6,7 @@ use std::{cmp, fmt, io, str, usize};
 
 /// A simple [`Decoder`] and [`Encoder`] implementation that splits up data into lines.
 ///
-/// Character `\n` is the line ending.
+/// This uses the `\n` character as the line ending on all platforms.
 ///
 /// [`Decoder`]: crate::codec::Decoder
 /// [`Encoder`]: crate::codec::Encoder

--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -6,6 +6,8 @@ use std::{cmp, fmt, io, str, usize};
 
 /// A simple [`Decoder`] and [`Encoder`] implementation that splits up data into lines.
 ///
+/// Character `\n` is the line ending.
+///
 /// [`Decoder`]: crate::codec::Decoder
 /// [`Encoder`]: crate::codec::Encoder
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]


### PR DESCRIPTION
It is to specify the line ending of `LinesCodec` is `\n`.