### PR TITLE
tokio: remove ref of scheduler in owned task

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,6 +12,8 @@ tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 bencher = "0.1.5"
 rand = "0.8"
 rand_chacha = "0.3"
+criterion = "0.5.1"
+num_cpus = "1.16.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
@@ -83,4 +85,9 @@ harness = false
 [[bench]]
 name = "time_now"
 path = "time_now.rs"
+harness = false
+
+[[bench]]
+name = "spawn2"
+path = "spawn2.rs"
 harness = false

--- a/benches/spawn2.rs
+++ b/benches/spawn2.rs
@@ -1,26 +1,8 @@
 use std::time::Instant;
 
 use criterion::*;
-use criterion::black_box;
-
-// fn foo() {
-//     // ...
-// }
-//
-// fn spawn_tasks(c: &mut Criterion) {
-//     c.bench_function("spawn_tasks", move |b| {
-//         b.iter_custom(|iters| {
-//             let start = Instant::now();
-//             for _i in 0..iters {
-//                 black_box(foo());
-//             }
-//             start.elapsed()
-//         })
-//     });
-// }
 
 fn spawn_tasks_current_thread(c: &mut Criterion) {
-    // 先使用默认的 worker threads 配置
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -28,21 +10,15 @@ fn spawn_tasks_current_thread(c: &mut Criterion) {
     c.bench_function("spawn_tasks_current_thread", move |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
-            runtime.block_on(
-                async {
-                    black_box(
-                        job(iters as usize, 1).await
-                    );
-                }
-            );
+            runtime.block_on(async {
+                black_box(job(iters as usize, 1).await);
+            });
             start.elapsed()
-        }
-        )
+        })
     });
 }
 
 fn spawn_tasks_current_thread_parallel(c: &mut Criterion) {
-    // 先使用默认的 worker threads 配置
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -50,78 +26,52 @@ fn spawn_tasks_current_thread_parallel(c: &mut Criterion) {
     c.bench_function("spawn_tasks_current_thread_parallel", move |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
-            runtime.block_on(
-                async {
-                    black_box(
-                        job(iters as usize, num_cpus::get_physical()).await
-                    );
-                }
-            );
+            runtime.block_on(async {
+                black_box(job(iters as usize, num_cpus::get_physical()).await);
+            });
             start.elapsed()
-        }
-        )
+        })
     });
 }
 
-
 fn spawn_tasks(c: &mut Criterion) {
-    // 先使用默认的 worker threads 配置
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .build()
-        .unwrap();
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
 
     c.bench_function("spawn_tasks", move |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
-            runtime.block_on(
-                async {
-                    black_box(
-                        job(iters as usize, 1).await
-                    );
-                }
-            );
+            runtime.block_on(async {
+                black_box(job(iters as usize, 1).await);
+            });
             start.elapsed()
-        }
-        )
+        })
     });
 }
 
 fn spawn_tasks_parallel(c: &mut Criterion) {
-    // 先使用默认的 worker threads 配置
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .build()
-        .unwrap();
+    let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
     c.bench_function("spawn_tasks_parallel", move |b| {
         b.iter_custom(|iters| {
             let start = Instant::now();
-            runtime.block_on(
-                async {
-                    black_box(
-                        job(iters as usize, num_cpus::get_physical()).await
-                    );
-                }
-            );
+            runtime.block_on(async {
+                black_box(job(iters as usize, num_cpus::get_physical()).await);
+            });
             start.elapsed()
-        }
-        )
+        })
     });
 }
 
 async fn job(iters: usize, procs: usize) {
-    // cpu number 个线程并发负责 spwan task
     for _ in 0..procs {
         let mut threads_handles = Vec::with_capacity(procs);
-        // 每一个线程负责的任务是，进行 iters/num_cpus 个 task 的启动
         threads_handles.push(tokio::spawn(async move {
             let mut thread_handles = Vec::with_capacity(iters / procs);
             for _ in 0..iters / procs {
-                thread_handles.push(tokio::spawn(
-                    async {
-                        let val = 1 + 1;
-                        tokio::task::yield_now().await;
-                        black_box(val)
-                    }
-                ));
+                thread_handles.push(tokio::spawn(async {
+                    let val = 1 + 1;
+                    tokio::task::yield_now().await;
+                    black_box(val)
+                }));
             }
             for handle in thread_handles {
                 handle.await.unwrap();

--- a/benches/spawn2.rs
+++ b/benches/spawn2.rs
@@ -1,0 +1,143 @@
+use std::time::Instant;
+
+use criterion::*;
+use criterion::black_box;
+
+// fn foo() {
+//     // ...
+// }
+//
+// fn spawn_tasks(c: &mut Criterion) {
+//     c.bench_function("spawn_tasks", move |b| {
+//         b.iter_custom(|iters| {
+//             let start = Instant::now();
+//             for _i in 0..iters {
+//                 black_box(foo());
+//             }
+//             start.elapsed()
+//         })
+//     });
+// }
+
+fn spawn_tasks_current_thread(c: &mut Criterion) {
+    // 先使用默认的 worker threads 配置
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    c.bench_function("spawn_tasks_current_thread", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            runtime.block_on(
+                async {
+                    black_box(
+                        job(iters as usize, 1).await
+                    );
+                }
+            );
+            start.elapsed()
+        }
+        )
+    });
+}
+
+fn spawn_tasks_current_thread_parallel(c: &mut Criterion) {
+    // 先使用默认的 worker threads 配置
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    c.bench_function("spawn_tasks_current_thread_parallel", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            runtime.block_on(
+                async {
+                    black_box(
+                        job(iters as usize, num_cpus::get_physical()).await
+                    );
+                }
+            );
+            start.elapsed()
+        }
+        )
+    });
+}
+
+
+fn spawn_tasks(c: &mut Criterion) {
+    // 先使用默认的 worker threads 配置
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .build()
+        .unwrap();
+
+    c.bench_function("spawn_tasks", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            runtime.block_on(
+                async {
+                    black_box(
+                        job(iters as usize, 1).await
+                    );
+                }
+            );
+            start.elapsed()
+        }
+        )
+    });
+}
+
+fn spawn_tasks_parallel(c: &mut Criterion) {
+    // 先使用默认的 worker threads 配置
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .build()
+        .unwrap();
+    c.bench_function("spawn_tasks_parallel", move |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            runtime.block_on(
+                async {
+                    black_box(
+                        job(iters as usize, num_cpus::get_physical()).await
+                    );
+                }
+            );
+            start.elapsed()
+        }
+        )
+    });
+}
+
+async fn job(iters: usize, procs: usize) {
+    // cpu number 个线程并发负责 spwan task
+    for _ in 0..procs {
+        let mut threads_handles = Vec::with_capacity(procs);
+        // 每一个线程负责的任务是，进行 iters/num_cpus 个 task 的启动
+        threads_handles.push(tokio::spawn(async move {
+            let mut thread_handles = Vec::with_capacity(iters / procs);
+            for _ in 0..iters / procs {
+                thread_handles.push(tokio::spawn(
+                    async {
+                        let val = 1 + 1;
+                        tokio::task::yield_now().await;
+                        black_box(val)
+                    }
+                ));
+            }
+            for handle in thread_handles {
+                handle.await.unwrap();
+            }
+        }));
+        for handle in threads_handles {
+            handle.await.unwrap();
+        }
+    }
+}
+
+criterion_group!(
+    benches,
+    spawn_tasks_current_thread,
+    spawn_tasks_current_thread_parallel,
+    spawn_tasks,
+    spawn_tasks_parallel
+);
+criterion_main!(benches);

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -381,7 +381,7 @@ impl Spawner {
         #[cfg(not(all(tokio_unstable, feature = "tracing")))]
         let _ = name;
 
-        let (task, handle) = task::unowned(fut,Some(BlockingSchedule::new(rt)), id);
+        let (task, handle) = task::unowned(fut, Some(BlockingSchedule::new(rt)), id);
 
         let spawned = self.spawn_task(Task::new(task, is_mandatory), rt);
         (handle, spawned)

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -120,7 +120,7 @@ struct Shared {
 }
 
 pub(crate) struct Task {
-    task: task::UnownedTask<BlockingSchedule>,
+    task: task::UnownedTask,
     mandatory: Mandatory,
 }
 
@@ -151,7 +151,7 @@ impl From<SpawnError> for io::Error {
 }
 
 impl Task {
-    pub(crate) fn new(task: task::UnownedTask<BlockingSchedule>, mandatory: Mandatory) -> Task {
+    pub(crate) fn new(task: task::UnownedTask, mandatory: Mandatory) -> Task {
         Task { task, mandatory }
     }
 
@@ -381,7 +381,7 @@ impl Spawner {
         #[cfg(not(all(tokio_unstable, feature = "tracing")))]
         let _ = name;
 
-        let (task, handle) = task::unowned(fut, BlockingSchedule::new(rt), id);
+        let (task, handle) = task::unowned(fut,Some(BlockingSchedule::new(rt)), id);
 
         let spawned = self.spawn_task(Task::new(task, is_mandatory), rt);
         (handle, spawned)

--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -37,7 +37,7 @@ impl BlockingSchedule {
 }
 
 impl task::Schedule for BlockingSchedule {
-    fn release(&self, _task: &Task<Self>) -> Option<Task<Self>> {
+    fn release(&self, _task: &Task) -> Option<Task> {
         #[cfg(feature = "test-util")]
         {
             match &self.handle.inner {
@@ -54,7 +54,7 @@ impl task::Schedule for BlockingSchedule {
         None
     }
 
-    fn schedule(&self, _task: task::Notified<Self>) {
+    fn schedule(&self, _task: task::Notified) {
         unreachable!();
     }
 }

--- a/tokio/src/runtime/scheduler/inject.rs
+++ b/tokio/src/runtime/scheduler/inject.rs
@@ -22,13 +22,13 @@ cfg_metrics! {
 
 /// Growable, MPMC queue used to inject new tasks into the scheduler and as an
 /// overflow queue when the local, fixed-size, array queue overflows.
-pub(crate) struct Inject<T: 'static> {
-    shared: Shared<T>,
+pub(crate) struct Inject {
+    shared: Shared,
     synced: Mutex<Synced>,
 }
 
-impl<T: 'static> Inject<T> {
-    pub(crate) fn new() -> Inject<T> {
+impl Inject {
+    pub(crate) fn new() -> Inject {
         let (shared, synced) = Shared::new();
 
         Inject {
@@ -54,13 +54,13 @@ impl<T: 'static> Inject<T> {
     /// Pushes a value into the queue.
     ///
     /// This does nothing if the queue is closed.
-    pub(crate) fn push(&self, task: task::Notified<T>) {
+    pub(crate) fn push(&self, task: task::Notified) {
         let mut synced = self.synced.lock();
         // safety: passing correct `Synced`
         unsafe { self.shared.push(&mut synced, task) }
     }
 
-    pub(crate) fn pop(&self) -> Option<task::Notified<T>> {
+    pub(crate) fn pop(&self) -> Option<task::Notified> {
         if self.shared.is_empty() {
             return None;
         }

--- a/tokio/src/runtime/scheduler/inject/metrics.rs
+++ b/tokio/src/runtime/scheduler/inject/metrics.rs
@@ -1,6 +1,6 @@
 use super::Inject;
 
-impl<T: 'static> Inject<T> {
+impl Inject {
     pub(crate) fn len(&self) -> usize {
         self.shared.len()
     }

--- a/tokio/src/runtime/scheduler/inject/pop.rs
+++ b/tokio/src/runtime/scheduler/inject/pop.rs
@@ -2,26 +2,22 @@ use super::Synced;
 
 use crate::runtime::task;
 
-use std::marker::PhantomData;
-
-pub(crate) struct Pop<'a, T: 'static> {
+pub(crate) struct Pop<'a> {
     len: usize,
     synced: &'a mut Synced,
-    _p: PhantomData<T>,
 }
 
-impl<'a, T: 'static> Pop<'a, T> {
-    pub(super) fn new(len: usize, synced: &'a mut Synced) -> Pop<'a, T> {
+impl<'a> Pop<'a> {
+    pub(super) fn new(len: usize, synced: &'a mut Synced) -> Pop<'a> {
         Pop {
             len,
             synced,
-            _p: PhantomData,
         }
     }
 }
 
-impl<'a, T: 'static> Iterator for Pop<'a, T> {
-    type Item = task::Notified<T>;
+impl<'a> Iterator for Pop<'a> {
+    type Item = task::Notified;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.len == 0 {
@@ -42,13 +38,13 @@ impl<'a, T: 'static> Iterator for Pop<'a, T> {
     }
 }
 
-impl<'a, T: 'static> ExactSizeIterator for Pop<'a, T> {
+impl<'a> ExactSizeIterator for Pop<'a> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'a, T: 'static> Drop for Pop<'a, T> {
+impl<'a> Drop for Pop<'a> {
     fn drop(&mut self) {
         for _ in self.by_ref() {}
     }

--- a/tokio/src/runtime/scheduler/inject/pop.rs
+++ b/tokio/src/runtime/scheduler/inject/pop.rs
@@ -9,10 +9,7 @@ pub(crate) struct Pop<'a> {
 
 impl<'a> Pop<'a> {
     pub(super) fn new(len: usize, synced: &'a mut Synced) -> Pop<'a> {
-        Pop {
-            len,
-            synced,
-        }
+        Pop { len, synced }
     }
 }
 

--- a/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
+++ b/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
@@ -19,7 +19,7 @@ impl AsMut<Synced> for Synced {
     }
 }
 
-impl<T: 'static> Shared<T> {
+impl Shared {
     /// Pushes several values into the queue.
     ///
     /// # Safety
@@ -29,7 +29,7 @@ impl<T: 'static> Shared<T> {
     pub(crate) unsafe fn push_batch<L, I>(&self, shared: L, mut iter: I)
     where
         L: Lock<Synced>,
-        I: Iterator<Item = task::Notified<T>>,
+        I: Iterator<Item = task::Notified>,
     {
         let first = match iter.next() {
             Some(first) => first.into_raw(),
@@ -84,7 +84,7 @@ impl<T: 'static> Shared<T> {
             while let Some(task) = curr {
                 curr = task.get_queue_next();
 
-                let _ = unsafe { task::Notified::<T>::from_raw(task) };
+                let _ = unsafe { task::Notified::from_raw(task) };
             }
 
             return;

--- a/tokio/src/runtime/scheduler/inject/synced.rs
+++ b/tokio/src/runtime/scheduler/inject/synced.rs
@@ -20,7 +20,7 @@ unsafe impl Send for Synced {}
 unsafe impl Sync for Synced {}
 
 impl Synced {
-    pub(super) fn pop<T: 'static>(&mut self) -> Option<task::Notified<T>> {
+    pub(super) fn pop(&mut self) -> Option<task::Notified> {
         let task = self.head?;
 
         self.head = unsafe { task.get_queue_next() };

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -27,7 +27,8 @@ cfg_rt_multi_thread! {
 
 use crate::runtime::driver;
 
-use super::task::Schedule;
+#[cfg(feature = "rt")]
+use crate::runtime::task::Schedule;
 
 #[derive(Debug, Clone)]
 pub(crate) enum Handle {
@@ -130,7 +131,7 @@ cfg_rt! {
                 Handle::MultiThreadAlt(h) => multi_thread_alt::Handle::spawn(h, future, id),
             }
         }
-
+        #[cfg(feature = "rt")]
         pub(crate) fn release(&self, task: &Task) -> Option<Task>
         {
             match self {
@@ -144,6 +145,7 @@ cfg_rt! {
             }
         }
 
+        #[cfg(feature = "rt")]
         pub(crate) fn schedule(&self, task: Notified)
         {
             match self {
@@ -156,7 +158,7 @@ cfg_rt! {
                 Handle::MultiThreadAlt(h) => h.schedule(task),
             }
         }
-
+        #[cfg(feature = "rt")]
         pub(crate) fn yield_now(&self, task: Notified) {
             match self {
                 Handle::CurrentThread(h) => h.yield_now(task),

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -51,7 +51,7 @@ impl Handle {
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+        let (handle, notified) = me.shared.owned.bind(future, None, id);
 
         me.schedule_option_task_without_yield(notified);
 

--- a/tokio/src/runtime/scheduler/multi_thread/overflow.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/overflow.rs
@@ -3,23 +3,23 @@ use crate::runtime::task;
 #[cfg(test)]
 use std::cell::RefCell;
 
-pub(crate) trait Overflow<T: 'static> {
-    fn push(&self, task: task::Notified<T>);
+pub(crate) trait Overflow {
+    fn push(&self, task: task::Notified);
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<T>>;
+        I: Iterator<Item = task::Notified>;
 }
 
 #[cfg(test)]
-impl<T: 'static> Overflow<T> for RefCell<Vec<task::Notified<T>>> {
-    fn push(&self, task: task::Notified<T>) {
+impl Overflow for RefCell<Vec<task::Notified>> {
+    fn push(&self, task: task::Notified) {
         self.borrow_mut().push(task);
     }
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<T>>,
+        I: Iterator<Item = task::Notified>,
     {
         self.borrow_mut().extend(iter);
     }

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -33,7 +33,7 @@ pub(crate) struct Local {
 /// Consumer handle. May be used from many threads.
 pub(crate) struct Steal(Arc<Inner>);
 
-pub(crate) struct Inner{
+pub(crate) struct Inner {
     /// Concurrently updated by many threads.
     ///
     /// Contains two `UnsignedShort` values. The LSB byte is the "real" head of

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -547,7 +547,7 @@ impl Steal {
 }
 
 cfg_metrics! {
-    impl<T> Steal<T> {
+    impl Steal {
         pub(crate) fn len(&self) -> usize {
             self.0.len() as _
         }

--- a/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
@@ -1,6 +1,5 @@
 use super::{Core, Handle, Shared};
 
-use crate::loom::sync::Arc;
 use crate::runtime::scheduler::multi_thread::Stats;
 use crate::runtime::task::trace::trace_multi_thread;
 use crate::runtime::{dump, WorkerMetrics};

--- a/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
@@ -59,7 +59,7 @@ impl Handle {
 
 impl Shared {
     /// Steal all tasks from remotes into a single local queue.
-    pub(super) fn steal_all(&self) -> super::queue::Local<Arc<Handle>> {
+    pub(super) fn steal_all(&self) -> super::queue::Local {
         let (_steal, mut local) = super::queue::local();
 
         let worker_metrics = WorkerMetrics::new();

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
@@ -48,7 +48,7 @@ impl Handle {
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+        let (handle, notified) = me.shared.owned.bind(future, None, id);
 
         if let Some(notified) = notified {
             me.shared.schedule_task(notified, false);

--- a/tokio/src/runtime/scheduler/multi_thread_alt/overflow.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/overflow.rs
@@ -3,23 +3,23 @@ use crate::runtime::task;
 #[cfg(test)]
 use std::cell::RefCell;
 
-pub(crate) trait Overflow<T: 'static> {
-    fn push(&self, task: task::Notified<T>);
+pub(crate) trait Overflow {
+    fn push(&self, task: task::Notified);
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<T>>;
+        I: Iterator<Item = task::Notified>;
 }
 
 #[cfg(test)]
-impl<T: 'static> Overflow<T> for RefCell<Vec<task::Notified<T>>> {
-    fn push(&self, task: task::Notified<T>) {
+impl Overflow for RefCell<Vec<task::Notified>> {
+    fn push(&self, task: task::Notified) {
         self.borrow_mut().push(task);
     }
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<T>>,
+        I: Iterator<Item = task::Notified>,
     {
         self.borrow_mut().extend(iter);
     }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker/taskdump.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker/taskdump.rs
@@ -59,7 +59,7 @@ impl Handle {
 
 impl Shared {
     /// Steal all tasks from remotes into a single local queue.
-    pub(super) fn steal_all(&self) -> super::queue::Local<Arc<Handle>> {
+    pub(super) fn steal_all(&self) -> super::queue::Local {
         let (_steal, mut local) = super::queue::local();
 
         let worker_metrics = WorkerMetrics::new();

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -142,7 +142,7 @@ pub(super) struct CoreStage<T: Future> {
 #[repr(C)]
 pub(super) struct Core<T: Future, S> {
     /// Scheduler used to drive this future.
-    pub(super) scheduler: S,
+    pub(super) scheduler: Option<S>,
 
     /// The task's ID, used for populating `JoinError`s.
     pub(super) task_id: Id,
@@ -211,7 +211,7 @@ pub(super) enum Stage<T: Future> {
 impl<T: Future, S: Schedule> Cell<T, S> {
     /// Allocates a new task cell, containing the header, trailer, and core
     /// structures.
-    pub(super) fn new(future: T, scheduler: S, state: State, task_id: Id) -> Box<Cell<T, S>> {
+    pub(super) fn new(future: T, scheduler: Option<S>, state: State, task_id: Id) -> Box<Cell<T, S>> {
         // Separated into a non-generic function to reduce LLVM codegen
         fn new_header(
             state: State,

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -256,12 +256,17 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         #[cfg(debug_assertions)]
         {
             // Using a separate function for this code avoids instantiating it separately for every `T`.
-            unsafe fn check<S>(header: &Header, trailer: &Trailer, scheduler: &S, task_id: &Id) {
+            unsafe fn check<S>(
+                header: &Header,
+                trailer: &Trailer,
+                scheduler: &Option<S>,
+                task_id: &Id,
+            ) {
                 let trailer_addr = trailer as *const Trailer as usize;
                 let trailer_ptr = unsafe { Header::get_trailer(NonNull::from(header)) };
                 assert_eq!(trailer_addr, trailer_ptr.as_ptr() as usize);
 
-                let scheduler_addr = scheduler as *const S as usize;
+                let scheduler_addr = scheduler as *const Option<S> as usize;
                 let scheduler_ptr = unsafe { Header::get_scheduler::<S>(NonNull::from(header)) };
                 assert_eq!(scheduler_addr, scheduler_ptr.as_ptr() as usize);
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -431,9 +431,9 @@ impl Header {
     ///
     /// The generic type S must be set to the correct scheduler type for this
     /// task.
-    pub(super) unsafe fn get_scheduler<S>(me: NonNull<Header>) -> NonNull<S> {
+    pub(super) unsafe fn get_scheduler<S>(me: NonNull<Header>) -> NonNull<Option<S>> {
         let offset = me.as_ref().vtable.scheduler_offset;
-        let scheduler = me.as_ptr().cast::<u8>().add(offset).cast::<S>();
+        let scheduler = me.as_ptr().cast::<u8>().add(offset).cast::<Option<S>>();
         NonNull::new_unchecked(scheduler)
     }
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -211,7 +211,12 @@ pub(super) enum Stage<T: Future> {
 impl<T: Future, S: Schedule> Cell<T, S> {
     /// Allocates a new task cell, containing the header, trailer, and core
     /// structures.
-    pub(super) fn new(future: T, scheduler: Option<S>, state: State, task_id: Id) -> Box<Cell<T, S>> {
+    pub(super) fn new(
+        future: T,
+        scheduler: Option<S>,
+        state: State,
+        task_id: Id,
+    ) -> Box<Cell<T, S>> {
         // Separated into a non-generic function to reduce LLVM codegen
         fn new_header(
             state: State,

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -535,7 +535,7 @@ fn panic_to_error<S: Schedule>(
     panic: Box<dyn Any + Send + 'static>,
 ) -> JoinError {
     // if task has a scheduler, then use it, otherwise use scheduer in the context of current thread
-    if let Some(scheduler) = scheduler{
+    if let Some(scheduler) = scheduler {
         scheduler.unhandled_panic();
     }
     JoinError::panic(task_id, panic)

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -155,7 +155,7 @@ where
                 // The `poll_inner` call has given us two ref-counts back.
                 // We give one of them to a new task and call `yield_now`.
 
-                // if task has a scheduler, then use it, otherwise use scheduer in context of thread
+                // if task has a scheduler, then use it, otherwise use scheduer in the context of current thread
                 match &self.core().scheduler {
                     Some(scheduler) => {
                         scheduler.yield_now(Notified(self.get_new_task()));
@@ -350,7 +350,7 @@ where
         // never destroyed, so that's ok.
         let me = ManuallyDrop::new(self.get_new_task());
 
-        // if task has a scheduler, then use it, otherwise use scheduer in context of thread
+        // if task has a scheduler, then use it, otherwise use scheduer in the context of current thread
         match &self.core().scheduler {
             Some(scheduler) => {
                 if let Some(task) = scheduler.release(&me) {
@@ -534,7 +534,7 @@ fn panic_to_error<S: Schedule>(
     task_id: Id,
     panic: Box<dyn Any + Send + 'static>,
 ) -> JoinError {
-    // if task has a scheduler, then use it, otherwise use scheduer in context of thread
+    // if task has a scheduler, then use it, otherwise use scheduer in the context of current thread
     if let Some(scheduler) = scheduler{
         scheduler.unhandled_panic();
     }

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -535,13 +535,8 @@ fn panic_to_error<S: Schedule>(
     panic: Box<dyn Any + Send + 'static>,
 ) -> JoinError {
     // if task has a scheduler, then use it, otherwise use scheduer in context of thread
-    match scheduler {
-        Some(scheduler) => {
-            scheduler.unhandled_panic();
-        }
-        None => {
-            // currently do nothing here
-        }
+    if let Some(scheduler) = scheduler{
+        scheduler.unhandled_panic();
     }
     JoinError::panic(task_id, panic)
 }

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -154,12 +154,12 @@ where
             PollFuture::Notified => {
                 // The `poll_inner` call has given us two ref-counts back.
                 // We give one of them to a new task and call `yield_now`.
-                
+
                 // if task has a scheduler, then use it, otherwise use scheduer in context of thread
                 match &self.core().scheduler {
-                    Some(scheduler) =>{
+                    Some(scheduler) => {
                         scheduler.yield_now(Notified(self.get_new_task()));
-                    },
+                    }
                     None => {
                         crate::task::yield_now2(Notified(self.get_new_task()));
                     }
@@ -351,7 +351,7 @@ where
         let me = ManuallyDrop::new(self.get_new_task());
 
         // if task has a scheduler, then use it, otherwise use scheduer in context of thread
-        match &self.core().scheduler{
+        match &self.core().scheduler {
             Some(scheduler) => {
                 if let Some(task) = scheduler.release(&me) {
                     mem::forget(task);
@@ -359,18 +359,16 @@ where
                 } else {
                     1
                 }
-            },
+            }
             None => {
-                if let Some(task) = crate::task::release(&me){
+                if let Some(task) = crate::task::release(&me) {
                     mem::forget(task);
                     2
-                }else{
-                1
+                } else {
+                    1
                 }
-            },
-        } 
-
-        
+            }
+        }
     }
 
     /// Creates a new task that holds its own ref-count.
@@ -536,11 +534,11 @@ fn panic_to_error<S: Schedule>(
     task_id: Id,
     panic: Box<dyn Any + Send + 'static>,
 ) -> JoinError {
-   // if task has a scheduler, then use it, otherwise use scheduer in context of thread
-   match scheduler{
-       Some(scheduler) => {
+    // if task has a scheduler, then use it, otherwise use scheduer in context of thread
+    match scheduler {
+        Some(scheduler) => {
             scheduler.unhandled_panic();
-        },
+        }
         None => {
             // currently do nothing here
         }

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -161,7 +161,7 @@ where
                         scheduler.yield_now(Notified(self.get_new_task()));
                     }
                     None => {
-                        crate::task::yield_now2(Notified(self.get_new_task()));
+                        crate::task::schedule::yield_now(Notified(self.get_new_task()));
                     }
                 }
                 // The remaining ref-count is now dropped. We kept the extra
@@ -361,7 +361,7 @@ where
                 }
             }
             None => {
-                if let Some(task) = crate::task::release(&me) {
+                if let Some(task) = crate::task::schedule::release(&me) {
                     mem::forget(task);
                     2
                 } else {

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -195,7 +195,7 @@ cfg_taskdump! {
         /// Locks the tasks, and calls `f` on an iterator over them.
         pub(crate) fn for_each<F>(&self, f: F)
         where
-            F: FnMut(&Task<S>)
+            F: FnMut(&Task)
         {
             self.inner.lock().list.for_each(f)
         }

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -91,7 +91,7 @@ impl<S> OwnedTasks<S> {
     pub(crate) fn bind<T>(
         &self,
         task: T,
-        scheduler: Option<S>,   
+        scheduler: Option<S>,
         id: super::Id,
     ) -> (JoinHandle<T::Output>, Option<Notified>)
     where

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -328,9 +328,7 @@ cfg_rt! {
 
 impl Task {
     unsafe fn new(raw: RawTask) -> Task {
-        Task {
-            raw,
-        }
+        Task { raw }
     }
 
     unsafe fn from_raw(ptr: NonNull<Header>) -> Task {
@@ -405,9 +403,7 @@ impl UnownedTask {
 
     fn into_task(self) -> Task {
         // Convert into a task.
-        let task = Task {
-            raw: self.raw,
-        };
+        let task = Task { raw: self.raw };
         mem::forget(self);
 
         // Drop a ref-count since an UnownedTask holds two.
@@ -421,9 +417,7 @@ impl UnownedTask {
         mem::forget(self);
 
         // Transfer one ref-count to a Task object.
-        let task = Task {
-            raw,
-        };
+        let task = Task { raw };
 
         // Use the other ref-count to poll the task.
         raw.poll();

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -85,7 +85,7 @@ impl<T: Future, S: Schedule> OffsetHelper<T, S> {
     const ID_OFFSET: usize = get_id_offset(
         std::mem::size_of::<Header>(),
         std::mem::align_of::<Core<T, S>>(),
-        std::mem::size_of::<S>(),
+        std::mem::size_of::<Option<S>>(),
         std::mem::align_of::<Id>(),
     );
 }

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -279,7 +279,7 @@ unsafe fn poll<T: Future, S: Schedule>(ptr: NonNull<Header>) {
 unsafe fn schedule<S: Schedule>(ptr: NonNull<Header>) {
     use crate::runtime::task::{Notified, Task};
 
-    let scheduler = Header::get_scheduler::<Option<S>>(ptr).as_ref();
+    let scheduler = Header::get_scheduler::<S>(ptr).as_ref();
     let notify = Notified(Task::from_raw(ptr.cast()));
     match scheduler {
         Some(scheduler) => scheduler.schedule(notify),

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -283,7 +283,7 @@ unsafe fn schedule<S: Schedule>(ptr: NonNull<Header>) {
     let notify = Notified(Task::from_raw(ptr.cast()));
     match scheduler {
         Some(scheduler) => scheduler.schedule(notify),
-        None => crate::task::schedule(notify),
+        None => crate::task::schedule::schedule(notify),
     }
 }
 

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -258,8 +258,8 @@ impl<T: Future> Future for Root<T> {
 /// Trace and poll all tasks of the current_thread runtime.
 pub(in crate::runtime) fn trace_current_thread(
     owned: &OwnedTasks<Arc<current_thread::Handle>>,
-    local: &mut VecDeque<Notified<Arc<current_thread::Handle>>>,
-    injection: &Inject<Arc<current_thread::Handle>>,
+    local: &mut VecDeque<Notified>,
+    injection: &Inject,
 ) -> Vec<Trace> {
     // clear the local and injection queues
     local.clear();
@@ -299,9 +299,9 @@ cfg_rt_multi_thread! {
     /// Must be called with the same `synced` that `injection` was created with.
     pub(in crate::runtime) unsafe fn trace_multi_thread(
         owned: &OwnedTasks<Arc<multi_thread::Handle>>,
-        local: &mut multi_thread::queue::Local<Arc<multi_thread::Handle>>,
+        local: &mut multi_thread::queue::Local,
         synced: &Mutex<Synced>,
-        injection: &Shared<Arc<multi_thread::Handle>>,
+        injection: &Shared,
     ) -> Vec<Trace> {
         // clear the local queue
         while let Some(notified) = local.pop() {

--- a/tokio/src/runtime/tests/loom_multi_thread/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/queue.rs
@@ -116,7 +116,7 @@ fn steal_overflow() {
 fn multi_stealer() {
     const NUM_TASKS: usize = 5;
 
-    fn steal_tasks(steal: queue::Steal<NoopSchedule>) -> usize {
+    fn steal_tasks(steal: queue::Steal) -> usize {
         let mut stats = new_stats();
         let (_, mut local) = queue::local();
 

--- a/tokio/src/runtime/tests/loom_multi_thread/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/queue.rs
@@ -1,5 +1,5 @@
 use crate::runtime::scheduler::multi_thread::{queue, Stats};
-use crate::runtime::tests::{unowned, NoopSchedule};
+use crate::runtime::tests::unowned;
 
 use loom::thread;
 use std::cell::RefCell;

--- a/tokio/src/runtime/tests/loom_multi_thread_alt/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt/queue.rs
@@ -116,7 +116,7 @@ fn steal_overflow() {
 fn multi_stealer() {
     const NUM_TASKS: usize = 5;
 
-    fn steal_tasks(steal: queue::Steal<NoopSchedule>) -> usize {
+    fn steal_tasks(steal: queue::Steal) -> usize {
         let mut stats = new_stats();
         let (_, mut local) = queue::local();
 

--- a/tokio/src/runtime/tests/loom_multi_thread_alt/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt/queue.rs
@@ -1,5 +1,5 @@
 use crate::runtime::scheduler::multi_thread::{queue, Stats};
-use crate::runtime::tests::{unowned, NoopSchedule};
+use crate::runtime::tests::unowned;
 
 use loom::thread;
 use std::cell::RefCell;

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -12,11 +12,11 @@ mod noop_scheduler {
     pub(crate) struct NoopSchedule;
 
     impl task::Schedule for NoopSchedule {
-        fn release(&self, _task: &Task<Self>) -> Option<Task<Self>> {
+        fn release(&self, _task: &Task) -> Option<Task> {
             None
         }
 
-        fn schedule(&self, _task: task::Notified<Self>) {
+        fn schedule(&self, _task: task::Notified) {
             unreachable!();
         }
     }
@@ -40,7 +40,7 @@ mod unowned_wrapper {
     }
 
     #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-    pub(crate) fn unowned<T>(task: T) -> (Notified<NoopSchedule>, JoinHandle<T::Output>)
+    pub(crate) fn unowned<T>(task: T) -> (Notified, JoinHandle<T::Output>)
     where
         T: std::future::Future + Send + 'static,
         T::Output: Send + 'static,

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -45,7 +45,7 @@ mod unowned_wrapper {
         T: std::future::Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, handle) = crate::runtime::task::unowned(task, NoopSchedule, Id::next());
+        let (task, handle) = crate::runtime::task::unowned(task, Some(NoopSchedule), Id::next());
         (task.into_notified(), handle)
     }
 }

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -27,7 +27,7 @@ mod unowned_wrapper {
     use crate::runtime::tests::NoopSchedule;
 
     #[cfg(all(tokio_unstable, feature = "tracing"))]
-    pub(crate) fn unowned<T>(task: T) -> (Notified<NoopSchedule>, JoinHandle<T::Output>)
+    pub(crate) fn unowned<T>(task: T) -> (Notified, JoinHandle<T::Output>)
     where
         T: std::future::Future + Send + 'static,
         T::Output: Send + 'static,
@@ -35,7 +35,7 @@ mod unowned_wrapper {
         use tracing::Instrument;
         let span = tracing::trace_span!("test_span");
         let task = task.instrument(span);
-        let (task, handle) = crate::runtime::task::unowned(task, NoopSchedule, Id::next());
+        let (task, handle) = crate::runtime::task::unowned(task, Some(NoopSchedule), Id::next());
         (task.into_notified(), handle)
     }
 

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -273,11 +273,11 @@ fn stress2() {
 struct Runtime;
 
 impl Schedule for Runtime {
-    fn release(&self, _task: &Task<Self>) -> Option<Task<Self>> {
+    fn release(&self, _task: &Task) -> Option<Task> {
         None
     }
 
-    fn schedule(&self, _task: task::Notified<Self>) {
+    fn schedule(&self, _task: task::Notified) {
         unreachable!();
     }
 }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -260,7 +260,7 @@ struct Inner {
 }
 
 struct Core {
-    queue: VecDeque<task::Notified<Runtime>>,
+    queue: VecDeque<task::Notified>,
 }
 
 static CURRENT: Mutex<Option<Runtime>> = Mutex::new(None);
@@ -301,7 +301,7 @@ impl Runtime {
         self.0.core.try_lock().unwrap().queue.is_empty()
     }
 
-    fn next_task(&self) -> task::Notified<Runtime> {
+    fn next_task(&self) -> task::Notified {
         self.0.core.try_lock().unwrap().queue.pop_front().unwrap()
     }
 
@@ -321,11 +321,11 @@ impl Runtime {
 }
 
 impl Schedule for Runtime {
-    fn release(&self, task: &Task<Self>) -> Option<Task<Self>> {
+    fn release(&self, task: &Task) -> Option<Task> {
         self.0.owned.remove(task)
     }
 
-    fn schedule(&self, task: task::Notified<Self>) {
+    fn schedule(&self, task: task::Notified) {
         self.0.core.try_lock().unwrap().queue.push_back(task);
     }
 }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -53,7 +53,7 @@ fn create_drop1() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     drop(notified);
@@ -70,7 +70,7 @@ fn create_drop2() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     drop(join);
@@ -87,7 +87,7 @@ fn drop_abort_handle1() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     let abort = join.abort_handle();
@@ -107,7 +107,7 @@ fn drop_abort_handle2() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     let abort = join.abort_handle();
@@ -128,7 +128,7 @@ fn create_shutdown1() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     drop(join);
@@ -145,7 +145,7 @@ fn create_shutdown2() {
             drop(ad);
             unreachable!()
         },
-        NoopSchedule,
+        Some(NoopSchedule),
         Id::next(),
     );
     handle.assert_not_dropped();
@@ -156,7 +156,7 @@ fn create_shutdown2() {
 
 #[test]
 fn unowned_poll() {
-    let (task, _) = unowned(async {}, NoopSchedule, Id::next());
+    let (task, _) = unowned(async {}, Some(NoopSchedule), Id::next());
     task.run();
 }
 
@@ -271,7 +271,7 @@ impl Runtime {
         T: 'static + Send + Future,
         T::Output: 'static + Send,
     {
-        let (handle, notified) = self.0.owned.bind(future, self.clone(), Id::next());
+        let (handle, notified) = self.0.owned.bind::<Self>(future, None, Id::next());
 
         if let Some(notified) = notified {
             self.schedule(notified);

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -915,7 +915,10 @@ impl Context {
         // Safety: called from the thread that owns the `LocalSet`
         let (handle, notified) = {
             self.shared.local_state.assert_called_from_owner_thread();
-            self.shared.local_state.owned.bind(future, Some(self.shared.clone()), id)
+            self.shared
+                .local_state
+                .owned
+                .bind(future, Some(self.shared.clone()), id)
         };
 
         if let Some(notified) = notified {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -915,7 +915,7 @@ impl Context {
         // Safety: called from the thread that owns the `LocalSet`
         let (handle, notified) = {
             self.shared.local_state.assert_called_from_owner_thread();
-            self.shared.local_state.owned.bind(future, None, id)
+            self.shared.local_state.owned.bind(future, Some(self.shared.clone()), id)
         };
 
         if let Some(notified) = notified {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -915,10 +915,7 @@ impl Context {
         // Safety: called from the thread that owns the `LocalSet`
         let (handle, notified) = {
             self.shared.local_state.assert_called_from_owner_thread();
-            self.shared
-                .local_state
-                .owned
-                .bind(future, None, id)
+            self.shared.local_state.owned.bind(future, None, id)
         };
 
         if let Some(notified) = notified {
@@ -1091,10 +1088,7 @@ impl LocalState {
         self.owned.is_empty()
     }
 
-    unsafe fn assert_owner(
-        &self,
-        task: task::Notified,
-    ) -> task::LocalNotified {
+    unsafe fn assert_owner(&self, task: task::Notified) -> task::LocalNotified {
         // The caller ensures it is called from the same thread that owns
         // the LocalSet.
         self.assert_called_from_owner_thread();

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -285,6 +285,9 @@ cfg_rt! {
 
     mod spawn;
     pub use spawn::spawn;
+    pub(crate) use spawn::release;
+    pub(crate) use spawn::schedule;
+    pub(crate) use spawn::yield_now2;
 
     cfg_rt_multi_thread! {
         pub use blocking::block_in_place;

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -285,7 +285,7 @@ cfg_rt! {
 
     mod spawn;
     pub use spawn::spawn;
-    
+
     pub(crate) mod schedule;
 
     cfg_rt_multi_thread! {

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -285,9 +285,8 @@ cfg_rt! {
 
     mod spawn;
     pub use spawn::spawn;
-    pub(crate) use spawn::release;
-    pub(crate) use spawn::schedule;
-    pub(crate) use spawn::yield_now2;
+    
+    pub(crate) mod schedule;
 
     cfg_rt_multi_thread! {
         pub use blocking::block_in_place;

--- a/tokio/src/task/schedule.rs
+++ b/tokio/src/task/schedule.rs
@@ -1,0 +1,31 @@
+cfg_rt! {
+use crate::runtime::task::Notified;
+use crate::runtime::task::Task;
+
+pub(crate) fn release(task: &Task) -> Option<Task> {
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.release(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}
+
+pub(crate) fn schedule(task: Notified) {
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.schedule(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}
+
+pub(crate) fn yield_now(task: Notified) {
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.yield_now(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}
+}

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -204,3 +204,37 @@ cfg_rt! {
         }
     }
 }
+
+
+use crate::runtime::task::Task;
+use crate::runtime::task::Notified;
+
+pub(crate) fn release(task: &Task) -> Option<Task>
+{
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.release(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}
+
+pub(crate) fn schedule(task: Notified)
+{
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.schedule(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}
+
+pub(crate) fn yield_now2(task: Notified)
+{
+    use crate::runtime::context;
+
+    match context::with_current(|handle| handle.yield_now(task)) {
+        Ok(join_handle) => join_handle,
+        Err(e) => panic!("{}", e),
+    }
+}

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -204,33 +204,3 @@ cfg_rt! {
         }
     }
 }
-
-use crate::runtime::task::Notified;
-use crate::runtime::task::Task;
-
-pub(crate) fn release(task: &Task) -> Option<Task> {
-    use crate::runtime::context;
-
-    match context::with_current(|handle| handle.release(task)) {
-        Ok(join_handle) => join_handle,
-        Err(e) => panic!("{}", e),
-    }
-}
-
-pub(crate) fn schedule(task: Notified) {
-    use crate::runtime::context;
-
-    match context::with_current(|handle| handle.schedule(task)) {
-        Ok(join_handle) => join_handle,
-        Err(e) => panic!("{}", e),
-    }
-}
-
-pub(crate) fn yield_now2(task: Notified) {
-    use crate::runtime::context;
-
-    match context::with_current(|handle| handle.yield_now(task)) {
-        Ok(join_handle) => join_handle,
-        Err(e) => panic!("{}", e),
-    }
-}

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -205,12 +205,10 @@ cfg_rt! {
     }
 }
 
-
-use crate::runtime::task::Task;
 use crate::runtime::task::Notified;
+use crate::runtime::task::Task;
 
-pub(crate) fn release(task: &Task) -> Option<Task>
-{
+pub(crate) fn release(task: &Task) -> Option<Task> {
     use crate::runtime::context;
 
     match context::with_current(|handle| handle.release(task)) {
@@ -219,8 +217,7 @@ pub(crate) fn release(task: &Task) -> Option<Task>
     }
 }
 
-pub(crate) fn schedule(task: Notified)
-{
+pub(crate) fn schedule(task: Notified) {
     use crate::runtime::context;
 
     match context::with_current(|handle| handle.schedule(task)) {
@@ -229,8 +226,7 @@ pub(crate) fn schedule(task: Notified)
     }
 }
 
-pub(crate) fn yield_now2(task: Notified)
-{
+pub(crate) fn yield_now2(task: Notified) {
     use crate::runtime::context;
 
     match context::with_current(|handle| handle.yield_now(task)) {


### PR DESCRIPTION
## Motivation

I belive we can remove the `Arc::clone()` call by removing the scheduler handle reference in all tasks.

For those tasks are owned, we could always use the scheduler in thread local CONTEXT.

## Solution

By removing ref(`Arc`) of scheduler in owned tasks, we could got a better performance, espically when we call `tokio::spawn` very frequently in multiple threads.

And we keep ref of scheduler in unowned tasks, which do not depend on the sheduler in thread local CONTEXT.

The cargo build can be more quickly by removing the generic parameter `S`.

Here are the benchmark results of [spawn2](https://github.com/wathenjiang/tokio/blob/remove_ref_of_scheduler/benches/spawn2.rs#L1C1-L2C1).

The current version:

```rust
Gnuplot not found, using plotters backend
spawn_tasks_current_thread
                        time:   [673.18 ns 680.79 ns 687.52 ns]
                        change: [-6.2656% -2.7726% +1.1065%] (p = 0.15 > 0.05)
                        No change in performance detected.

spawn_tasks_current_thread_parallel
                        time:   [521.01 ns 521.75 ns 522.35 ns]
                        change: [-1.4901% -0.6725% +0.1920%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

spawn_tasks             time:   [966.28 ns 976.72 ns 985.98 ns]
                        change: [+0.1574% +1.6134% +2.9634%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild

spawn_tasks_parallel    time:   [893.21 ns 898.49 ns 903.49 ns]
                        change: [+0.3002% +1.3720% +2.4327%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe
```


This PR version: 

```rust
# cargo bench --bench spawn2
    Finished bench [optimized] target(s) in 0.07s
     Running spawn2.rs (/root/rustproject/fork_tokio/target/release/deps/spawn2-b48a6368b3e3dabc)
Gnuplot not found, using plotters backend
spawn_tasks_current_thread
                        time:   [650.39 ns 662.56 ns 672.59 ns]
                        change: [-6.8428% -3.3240% +0.2419%] (p = 0.08 > 0.05)
                        No change in performance detected.

spawn_tasks_current_thread_parallel
                        time:   [526.50 ns 527.29 ns 528.10 ns]
                        change: [-1.9903% -1.1432% -0.2422%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 22 outliers among 100 measurements (22.00%)
  6 (6.00%) low severe
  11 (11.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

spawn_tasks             time:   [902.32 ns 911.90 ns 921.01 ns]
                        change: [-1.1438% +0.5670% +2.4469%] (p = 0.54 > 0.05)
                        No change in performance detected.

spawn_tasks_parallel    time:   [819.78 ns 826.17 ns 832.07 ns]
                        change: [-2.1597% -0.5893% +1.1337%] (p = 0.50 > 0.05)
                        No change in performance detected.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  2 (2.00%) high severe
```








