### PR TITLE
style: Rename spawn<T> to spawn<F>

### DIFF
--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -161,14 +161,14 @@ cfg_rt! {
     /// error[E0391]: cycle detected when processing `main`
     /// ```
     #[track_caller]
-    pub fn spawn<T>(future: T) -> JoinHandle<T::Output>
+    pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
     where
-        T: Future + Send + 'static,
-        T::Output: Send + 'static,
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
     {
         // preventing stack overflows on debug mode, by quickly sending the
         // task to the heap.
-        if cfg!(debug_assertions) && std::mem::size_of::<T>() > 2048 {
+        if cfg!(debug_assertions) && std::mem::size_of::<F>() > 2048 {
             spawn_inner(Box::pin(future), None)
         } else {
             spawn_inner(future, None)


### PR DESCRIPTION
Rename tokio::task::spawn<T> to tokio::task::spawn<F>, to match spawn_local.

## Motivation

I was flipping back and forth between the docs page for [spawn](https://docs.rs/tokio/latest/tokio/task/fn.spawn.html#) and [spawn_local](https://docs.rs/tokio/latest/tokio/task/fn.spawn_local.html#) to understand the differences in which constraints they impose upon their future. I thought it was weird that one is generic over T and one over F.

## Solution

I think they should match, and F is more descriptive (F for Future).
