### PR TITLE
sync: document that `const_new()` is not instrumented

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -371,6 +371,11 @@ impl<T: ?Sized> Mutex<T> {
 
     /// Creates a new lock in an unlocked state ready for use.
     ///
+    /// When using the `tracing` [unstable feature], a `Mutex` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`Mutex::new`] should be used to create
+    /// an instrumented object if that is needed.
+    ///
     /// # Examples
     ///
     /// ```
@@ -378,6 +383,9 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// static LOCK: Mutex<i32> = Mutex::const_new(5);
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new(t: T) -> Self
     where

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -436,6 +436,11 @@ impl Notify {
 
     /// Create a new `Notify`, initialized without a permit.
     ///
+    /// When using the `tracing` [unstable feature], a `Notify` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`Notify::new`] should be used to create
+    /// an instrumented object if that is needed.
+    ///
     /// # Examples
     ///
     /// ```
@@ -443,6 +448,9 @@ impl Notify {
     ///
     /// static NOTIFY: Notify = Notify::const_new();
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new() -> Notify {
         Notify {

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -153,6 +153,11 @@ impl<T> OnceCell<T> {
     ///
     /// # Example
     ///
+    /// When using the `tracing` [unstable feature], a `OnceCell` created with
+    /// `const_new_with` will not be instrumented. As such, it will not be
+    /// visible in [`tokio-console`]. Instead, [`OnceCell::new_with`] should be
+    /// used to create an instrumented object if that is needed.
+    ///
     /// ```
     /// use tokio::sync::OnceCell;
     ///
@@ -170,6 +175,9 @@ impl<T> OnceCell<T> {
     ///     assert_eq!(*result, 1);
     /// }
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new_with(value: T) -> Self {
         OnceCell {
@@ -183,6 +191,11 @@ impl<T> OnceCell<T> {
     ///
     /// Equivalent to `OnceCell::new`, except that it can be used in static
     /// variables.
+    ///
+    /// When using the `tracing` [unstable feature], a `OnceCell` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`OnceCell::new`] should be used to
+    /// create an instrumented object if that is needed.
     ///
     /// # Example
     ///
@@ -203,6 +216,9 @@ impl<T> OnceCell<T> {
     ///     assert_eq!(*result, 2);
     /// }
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new() -> Self {
         OnceCell {

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -327,6 +327,11 @@ impl<T: ?Sized> RwLock<T> {
 
     /// Creates a new instance of an `RwLock<T>` which is unlocked.
     ///
+    /// When using the `tracing` [unstable feature], a `RwLock` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`RwLock::new`] should be used to create
+    /// an instrumented object if that is needed.
+    ///
     /// # Examples
     ///
     /// ```
@@ -334,6 +339,9 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// static LOCK: RwLock<i32> = RwLock::const_new(5);
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new(value: T) -> RwLock<T>
     where

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -194,6 +194,11 @@ impl Semaphore {
 
     /// Creates a new semaphore with the initial number of permits.
     ///
+    /// When using the `tracing` [unstable feature], a `Semaphore` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`Semaphore::new`] should be used to
+    /// create an instrumented object if that is needed.
+    ///
     /// # Examples
     ///
     /// ```
@@ -201,6 +206,9 @@ impl Semaphore {
     ///
     /// static SEM: Semaphore = Semaphore::const_new(10);
     /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
     #[cfg(not(all(loom, test)))]
     pub const fn const_new(permits: usize) -> Self {
         Self {


### PR DESCRIPTION
## Motivation

The mutex created by `Mutex::const_new()` does not contain the tracing
instrumentation that drives `tokio-console`.

The same is true of `Notify`, `OnceCell` (including `const_new_with()`),
`RwLock`, and `Semaphore`.

## Solution

This change adds documentation to each of the `const_*` constructors,
explaining that objects created this way will not be instrumented and
therefore will not appear in `tokio-console`. A link to the non-const
variant is provided in each case.
