### PR TITLE
sync::watch: Change wording from "unseen" to "unchanged"

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -27,11 +27,11 @@
 //! ## Change notifications
 //!
 //! The [`Receiver`] half provides an asynchronous [`changed`] method. This
-//! method is ready when a new, *unseen* value is sent via the [`Sender`] half.
+//! method is ready when a new, *unchanged* value is sent via the [`Sender`] half.
 //!
 //! * [`Receiver::changed()`] returns `Ok(())` on receiving a new value, or
 //!   `Err(`[`error::RecvError`]`)` if the [`Sender`] has been dropped.
-//! * If the current value is *unseen* when calling [`changed`], then
+//! * If the current value is *unchanged* when calling [`changed`], then
 //!   [`changed`] will return immediately. If the current value is *seen*, then
 //!   it will sleep until either a new message is sent via the [`Sender`] half,
 //!   or the [`Sender`] is dropped.
@@ -380,7 +380,7 @@ mod state {
     impl Version {
         /// Get the initial version when creating the channel.
         pub(super) fn initial() -> Self {
-            // The initial version is 1 so that `mark_unseen` can decrement by one.
+            // The initial version is 1 so that `mark_unchanged` can decrement by one.
             // (The value is 2 due to the closed bit.)
             Version(2)
         }
@@ -644,8 +644,8 @@ impl<T> Receiver<T> {
         Ok(self.version != new_version)
     }
 
-    /// Marks the state as unseen.
-    pub fn mark_unseen(&mut self) {
+    /// Marks the state as unchanged.
+    pub fn mark_unchanged(&mut self) {
         self.version.decrement();
     }
 

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -49,19 +49,19 @@ fn rx_version_underflow() {
     let (_tx, mut rx) = watch::channel("one");
 
     // Version starts at 2, validate we do not underflow
-    rx.mark_unseen();
-    rx.mark_unseen();
+    rx.mark_unchanged();
+    rx.mark_unchanged();
 }
 
 #[test]
-fn rx_mark_unseen() {
+fn rx_mark_unchanged() {
     let (tx, mut rx) = watch::channel("one");
 
     let mut rx2 = rx.clone();
     let mut rx3 = rx.clone();
     let mut rx4 = rx.clone();
     {
-        rx.mark_unseen();
+        rx.mark_unchanged();
         assert!(rx.has_changed().unwrap());
 
         let mut t = spawn(rx.changed());
@@ -76,7 +76,7 @@ fn rx_mark_unseen() {
     }
 
     {
-        rx3.mark_unseen();
+        rx3.mark_unchanged();
         assert_eq!(*rx3.borrow(), "one");
 
         assert!(rx3.has_changed().unwrap());
@@ -94,7 +94,7 @@ fn rx_mark_unseen() {
         assert!(rx4.has_changed().unwrap());
         assert_eq!(*rx4.borrow_and_update(), "two");
 
-        rx4.mark_unseen();
+        rx4.mark_unchanged();
         assert!(rx4.has_changed().unwrap());
         assert_eq!(*rx4.borrow_and_update(), "two")
     }


### PR DESCRIPTION
## Motivation

To keep the wording in the API consistent as discussed in #5962.

## Solution

Rename the newly added (and yet unreleased) method `mark_unseen()` to `mark_unchanged()` in `sync::watch::Receiver`.