### PR TITLE
tokio: distinguish LocalSet::enter() with being polled

### DIFF
--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -313,7 +313,9 @@ struct LocalDataEnterGuard<'a> {
 impl<'a> Drop for LocalDataEnterGuard<'a> {
     fn drop(&mut self) {
         self.local_data_ref.ctx.set(self.ctx.take());
-        self.local_data_ref.wake_on_schedule.set(self.wake_on_schedule)
+        self.local_data_ref
+            .wake_on_schedule
+            .set(self.wake_on_schedule)
     }
 }
 
@@ -402,10 +404,15 @@ pub struct LocalEnterGuard {
 
 impl Drop for LocalEnterGuard {
     fn drop(&mut self) {
-        CURRENT.with(|LocalData { ctx, wake_on_schedule }| {
-            ctx.set(self.ctx.take());
-            wake_on_schedule.set(self.wake_on_schedule);
-        })
+        CURRENT.with(
+            |LocalData {
+                 ctx,
+                 wake_on_schedule,
+             }| {
+                ctx.set(self.ctx.take());
+                wake_on_schedule.set(self.wake_on_schedule);
+            },
+        )
     }
 }
 
@@ -447,11 +454,20 @@ impl LocalSet {
     ///
     /// [`spawn_local`]: fn@crate::task::spawn_local
     pub fn enter(&self) -> LocalEnterGuard {
-        CURRENT.with(|LocalData { ctx, wake_on_schedule, .. }| {
-            let ctx = ctx.replace(Some(self.context.clone()));
-            let wake_on_schedule = wake_on_schedule.replace(true);
-            LocalEnterGuard { ctx, wake_on_schedule }
-        })
+        CURRENT.with(
+            |LocalData {
+                 ctx,
+                 wake_on_schedule,
+                 ..
+             }| {
+                let ctx = ctx.replace(Some(self.context.clone()));
+                let wake_on_schedule = wake_on_schedule.replace(true);
+                LocalEnterGuard {
+                    ctx,
+                    wake_on_schedule,
+                }
+            },
+        )
     }
 
     /// Spawns a `!Send` task onto the local task set.

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -295,10 +295,7 @@ impl LocalData {
     fn enter(&self, ctx: Rc<Context>, entered: bool) -> LocalEnterGuard {
         let ctx = self.ctx.replace(Some(ctx));
         let entered = self.entered.replace(entered);
-        LocalEnterGuard {
-            ctx,
-            entered,
-        }
+        LocalEnterGuard { ctx, entered }
     }
 }
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -573,6 +573,8 @@ async fn spawn_wakes_localset() {
     }
 }
 
+/// Checks that the task wakes up with `enter`.
+/// <https://github.com/tokio-rs/tokio/issues/5020>.
 #[tokio::test]
 async fn sleep_with_local_enter_guard() {
     let local = LocalSet::new();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -574,7 +574,7 @@ async fn spawn_wakes_localset() {
 }
 
 /// Checks that the task wakes up with `enter`.
-/// <https://github.com/tokio-rs/tokio/issues/5020>.
+/// Reproduces <https://github.com/tokio-rs/tokio/issues/5020>.
 #[tokio::test]
 async fn sleep_with_local_enter_guard() {
     let local = LocalSet::new();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -573,6 +573,25 @@ async fn spawn_wakes_localset() {
     }
 }
 
+#[tokio::test]
+async fn sleep_with_local_enter_guard() {
+    let local = LocalSet::new();
+    let _guard = local.enter();
+
+    let (tx, rx) = oneshot::channel();
+
+    local
+        .run_until(async move {
+            tokio::task::spawn_local(async move {
+                time::sleep(Duration::ZERO).await;
+
+                tx.send(()).expect("failed to send");
+            });
+            assert_eq!(rx.await, Ok(()));
+        })
+        .await;
+}
+
 #[test]
 fn store_local_set_in_thread_local_with_runtime() {
     use tokio::runtime::Runtime;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This fixes: https://github.com/tokio-rs/tokio/issues/5020

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

If we enter a `LocalSet`, then the `LocalEnterGuard` sets `CURRENT` with it. But the `CURRENT` is being used with both of these two situations:
1. task::spawn_local()
2. being polled
But as we know, `LocalEnterGuard` should be related only with (1). When we schedule it, we should check if it is being polled, or just being entered. So I added a boolean variable to distinguish these situations.