### PR TITLE
`sync::watch`: Use Acquire/Release memory ordering instead of SeqCst

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -1063,7 +1063,9 @@ impl<T> Sender<T> {
                 }
             };
 
-            self.shared.state.increment_version_after_updating_shared_value_while_locked();
+            self.shared
+                .state
+                .increment_version_after_updating_shared_value_while_locked();
 
             // Release the write lock.
             //

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -429,7 +429,7 @@ mod state {
         }
 
         /// Increment the version counter.
-        pub(super) fn increment_version_after_updating_shared_value_while_locked(&self) {
+        pub(super) fn increment_version_while_locked(&self) {
             // Use `Release` ordering to ensure that the shared value
             // has been written before updating the version. The shared
             // value is still protected by an exclusive lock during this
@@ -1062,9 +1062,7 @@ impl<T> Sender<T> {
                 }
             };
 
-            self.shared
-                .state
-                .increment_version_after_updating_shared_value_while_locked();
+            self.shared.state.increment_version_while_locked();
 
             // Release the write lock.
             //

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -439,8 +439,7 @@ mod state {
 
         /// Set the closed bit in the state.
         pub(super) fn set_closed(&self) {
-            // Relaxed ordering is sufficient here.
-            self.0.fetch_or(CLOSED_BIT, Ordering::Relaxed);
+            self.0.fetch_or(CLOSED_BIT, Ordering::Release);
         }
     }
 }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -411,7 +411,7 @@ mod state {
 
     impl AtomicState {
         /// Create a new `AtomicState` that is not closed and which has the
-        /// version set to `Version::initial()`.
+        /// version set to `Version::INITIAL`.
         pub(super) fn new() -> Self {
             AtomicState(AtomicUsize::new(Version::INITIAL.0))
         }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -114,7 +114,7 @@
 use crate::sync::notify::Notify;
 
 use crate::loom::sync::atomic::AtomicUsize;
-use crate::loom::sync::atomic::Ordering::*;
+use crate::loom::sync::atomic::Ordering::Relaxed;
 use crate::loom::sync::{Arc, RwLock, RwLockReadGuard};
 use std::fmt;
 use std::mem;

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -439,10 +439,8 @@ mod state {
 
         /// Set the closed bit in the state.
         pub(super) fn set_closed(&self) {
-            // Use `Release` ordering to ensure that storing the version
-            // state is seen by the receiver side that uses `Acquire` for
-            // loading the state.
-            self.0.fetch_or(CLOSED_BIT, Ordering::Release);
+            // Relaxed ordering is sufficient here.
+            self.0.fetch_or(CLOSED_BIT, Ordering::Relaxed);
         }
     }
 }

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -429,10 +429,11 @@ mod state {
         }
 
         /// Increment the version counter.
-        pub(super) fn increment_version(&self) {
-            // Use `Release` ordering to ensure that storing the version
-            // state is seen by the receiver side that uses `Acquire` for
-            // loading the state.
+        pub(super) fn increment_version_after_updating_shared_value_while_locked(&self) {
+            // Use `Release` ordering to ensure that the shared value
+            // has been written before updating the version. The shared
+            // value is still protected by an exclusive lock during this
+            // method.
             self.0.fetch_add(STEP_SIZE, Ordering::Release);
         }
 
@@ -1064,7 +1065,7 @@ impl<T> Sender<T> {
                 }
             };
 
-            self.shared.state.increment_version();
+            self.shared.state.increment_version_after_updating_shared_value_while_locked();
 
             // Release the write lock.
             //


### PR DESCRIPTION
## Motivation

`SeqCst` is overly restrictive.

## Solution

Use `Release` (`Sender`: store / single writer) and `Acquire` (`Receiver`: load / multiple readers) memory ordering for a safe handover.