### PR TITLE
sync::watch::Receiver: Fix code comment

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -824,7 +824,7 @@ fn maybe_changed<T>(
     }
 
     if state.is_closed() {
-        // All receivers have dropped.
+        // The sender has been dropped.
         return Some(Err(error::RecvError(())));
     }
 


### PR DESCRIPTION
The `CLOSED_BIT` in the shared state tracks whether the single sender has been dropped.