### PR TITLE
watch::Receiver::wait_for(): Prevent poisoning of the lock

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -699,7 +699,7 @@ impl<T> Receiver<T> {
         changed_impl(&self.shared, &mut self.version).await
     }
 
-    /// Waits for a value that satisifes the provided condition.
+    /// Waits for a value that satisfies the provided condition.
     ///
     /// This method will call the provided closure whenever something is sent on
     /// the channel. Once the closure returns `true`, this method will return a


### PR DESCRIPTION
## Motivation

If the provided closure panics the lock is poisoned.

## Solution

Adopt the `catch_unwind()` strategy that is already used elsewhere. 