### PR TITLE
Optimize sync::watch::Sender::send()

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -918,7 +918,7 @@ impl<T> Sender<T> {
             return Err(error::SendError(value));
         }
 
-        self.send_replace(value);
+        self.send_modify(|old| *old = value);
         Ok(())
     }
 


### PR DESCRIPTION
## Motivation

Do not rely on the compiler to detect and optimize the discarded return value away.

## Solution

Delegate to a more appropriate method.