### PR TITLE
Prepare Tokio v1.25.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
-      - uses: Swatinem/rust-cache@v2
+          override: true
+      # - uses: Swatinem/rust-cache@v1 -> CI failure observed due to insufficient storage space
       - name: asan
         run: cargo test --workspace --all-features --target x86_64-unknown-linux-gnu --tests -- --test-threads 1
         env:
@@ -330,9 +331,11 @@ jobs:
           target: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      - name: check --feature-powerset
-        run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
+        uses: taiki-e/install-action@v2 
+        with: 
+          tool: cargo-hack
+      - name: check --each-feature
+        run: cargo hack check --all --each-feature -Z avoid-dev-deps
       # Try with unstable feature flags
       - name: check --feature-powerset --unstable
         run: cargo hack check --all --feature-powerset --depth 2 -Z avoid-dev-deps --keep-going
@@ -365,7 +368,9 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
+        uses: taiki-e/install-action@v2 
+        with: 
+          tool: cargo-hack
       - name: "check --all-features -Z minimal-versions"
         run: |
           # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
@@ -475,10 +480,10 @@ jobs:
           - macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install Rust ${{ env.rust_stable }}
+      - name: Install Rust 1.65.0
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.rust_stable }}
+          toolchain: 1.65.0
       - uses: Swatinem/rust-cache@v2
       - name: Test hyper
         run: |
@@ -542,8 +547,9 @@ jobs:
 
       # Install dependencies
       - name: Install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-
+        uses: taiki-e/install-action@v2 
+        with: 
+          tool: cargo-hack
       - name: Install wasm32-wasi target
         run: rustup target add wasm32-wasi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "quote"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "predicates"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,4 +326,13 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tracing",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
 ]

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.25.1", features = ["full"] }
+tokio = { version = "1.25.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.25.2 (September 22, 2023)
+
+Forward ports 1.20.6 changes.
+
+### Changed
+
+- io: use `memchr` from `libc` ([#5960])
+
+[#5960]: https://github.com/tokio-rs/tokio/pull/5960
+
 # 1.25.1 (May 28, 2023)
 
 Forward ports 1.18.6 changes.

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -344,6 +344,16 @@ wasm32-wasi target is given unstable support for the `net` feature.
 [#4956]: https://github.com/tokio-rs/tokio/pull/4956
 [#4959]: https://github.com/tokio-rs/tokio/pull/4959
 
+# 1.20.6 (September 22, 2023)
+
+This is a backport of a change from 1.27.0.
+
+### Changed
+
+- io: use `memchr` from `libc` ([#5960])
+
+[#5960]: https://github.com/tokio-rs/tokio/pull/5960
+
 # 1.20.5 (May 28, 2023)
 
 Forward ports 1.18.6 changes.

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -42,7 +42,7 @@ full = [
 ]
 
 fs = []
-io-util = ["memchr", "bytes"]
+io-util = ["bytes"]
 # stdin, stdout, stderr
 io-std = []
 macros = ["tokio-macros"]
@@ -103,7 +103,6 @@ pin-project-lite = "0.2.0"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
-memchr = { version = "2.2", optional = true }
 mio = { version = "0.8.4", optional = true, default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.25.1"
+version = "1.25.2"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.25.1", features = ["full"] }
+tokio = { version = "1.25.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/src/future/mod.rs
+++ b/tokio/src/future/mod.rs
@@ -20,6 +20,7 @@ cfg_sync! {
 
 cfg_trace! {
     mod trace;
+    #[allow(unused_imports)]
     pub(crate) use trace::InstrumentedFuture as Future;
 }
 

--- a/tokio/src/io/util/read_until.rs
+++ b/tokio/src/io/util/read_until.rs
@@ -1,4 +1,5 @@
 use crate::io::AsyncBufRead;
+use crate::util::memchr;
 
 use pin_project_lite::pin_project;
 use std::future::Future;

--- a/tokio/src/util/memchr.rs
+++ b/tokio/src/util/memchr.rs
@@ -1,0 +1,74 @@
+//! Search for a byte in a byte array using libc.
+//!
+//! When nothing pulls in libc, then just use a trivial implementation. Note
+//! that we only depend on libc on unix.
+
+#[cfg(not(all(unix, feature = "libc")))]
+pub(crate) fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+    haystack.iter().position(|val| needle == *val)
+}
+
+#[cfg(all(unix, feature = "libc"))]
+pub(crate) fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
+    let start = haystack.as_ptr();
+
+    // SAFETY: `start` is valid for `haystack.len()` bytes.
+    let ptr = unsafe { libc::memchr(start.cast(), needle as _, haystack.len()) };
+
+    if ptr.is_null() {
+        None
+    } else {
+        Some(ptr as usize - start as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::memchr;
+
+    #[test]
+    fn memchr_test() {
+        let haystack = b"123abc456\0\xffabc\n";
+
+        assert_eq!(memchr(b'1', haystack), Some(0));
+        assert_eq!(memchr(b'2', haystack), Some(1));
+        assert_eq!(memchr(b'3', haystack), Some(2));
+        assert_eq!(memchr(b'4', haystack), Some(6));
+        assert_eq!(memchr(b'5', haystack), Some(7));
+        assert_eq!(memchr(b'6', haystack), Some(8));
+        assert_eq!(memchr(b'7', haystack), None);
+        assert_eq!(memchr(b'a', haystack), Some(3));
+        assert_eq!(memchr(b'b', haystack), Some(4));
+        assert_eq!(memchr(b'c', haystack), Some(5));
+        assert_eq!(memchr(b'd', haystack), None);
+        assert_eq!(memchr(b'A', haystack), None);
+        assert_eq!(memchr(0, haystack), Some(9));
+        assert_eq!(memchr(0xff, haystack), Some(10));
+        assert_eq!(memchr(0xfe, haystack), None);
+        assert_eq!(memchr(1, haystack), None);
+        assert_eq!(memchr(b'\n', haystack), Some(14));
+        assert_eq!(memchr(b'\r', haystack), None);
+    }
+
+    #[test]
+    fn memchr_all() {
+        let mut arr = Vec::new();
+        for b in 0..=255 {
+            arr.push(b);
+        }
+        for b in 0..=255 {
+            assert_eq!(memchr(b, &arr), Some(b as usize));
+        }
+        arr.reverse();
+        for b in 0..=255 {
+            assert_eq!(memchr(b, &arr), Some(255 - b as usize));
+        }
+    }
+
+    #[test]
+    fn memchr_empty() {
+        for b in 0..=255 {
+            assert_eq!(memchr(b, b""), None);
+        }
+    }
+}

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -76,3 +76,6 @@ cfg_rt_multi_thread! {
 pub(crate) mod trace;
 
 pub(crate) mod error;
+
+#[cfg(feature = "io-util")]
+pub(crate) mod memchr;


### PR DESCRIPTION
# 1.25.2 (September 22, 2023)

Forward ports 1.20.6 changes.

### Changed

- io: use `memchr` from `libc` ([#5960])

[#5960]: https://github.com/tokio-rs/tokio/pull/5960