### PR TITLE
fix incorrect line number in sync::Mutex documentation

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -103,7 +103,7 @@ use std::{fmt, mem, ptr};
 ///    threads.
 /// 2. Each spawned task obtains a lock and releases it on every iteration.
 /// 3. Mutation of the data protected by the Mutex is done by de-referencing
-///    the obtained lock as seen on lines 12 and 19.
+///    the obtained lock as seen on lines 13 and 20.
 ///
 /// Tokio's Mutex works in a simple FIFO (first in, first out) style where all
 /// calls to [`lock`] complete in the order they were performed. In that way the


### PR DESCRIPTION
## Motivation

The code for dereferencing (*) is on lines 13 and 20.

## Solution

Fix line number