### PR TITLE
Make `TokenBucket::close` into a destructor

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -195,9 +195,10 @@ use std::sync::Arc;
 /// }
 ///
 /// #[tokio::main]
+/// # async fn _hidden() {}
+/// # #[tokio::main(flavor = "current_thread", start_paused = true)]
 /// async fn main() {
-/// #   tokio::time::pause();
-///     let capacity = 5; // operation per second
+///     let capacity = 5;
 ///     let update_interval = Duration::from_secs_f32(1.0 / capacity as f32);
 ///     let bucket = TokenBucket::new(update_interval, capacity);
 ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -147,7 +147,7 @@ use std::sync::Arc;
 /// [token bucket]: https://en.wikipedia.org/wiki/Token_bucket
 /// ```
 /// use std::sync::Arc;
-/// use tokio::sync::{AcquireError, Semaphore};
+/// use tokio::sync::Semaphore;
 /// use tokio::time::{interval, Duration};
 ///
 /// struct TokenBucket {
@@ -196,6 +196,7 @@ use std::sync::Arc;
 ///
 /// #[tokio::main]
 /// async fn main() {
+/// #   tokio::time::pause();
 ///     let capacity = 5; // operation per second
 ///     let update_interval = Duration::from_secs_f32(1.0 / capacity as f32);
 ///     let bucket = TokenBucket::new(update_interval, capacity);


### PR DESCRIPTION
This makes the `TokenBucket::close` method into a destructor so you can't forget to kill the task.

Follow up to #5978. I didn't think of this when I reviewed the original PR.

cc @maminrayej 

[Rendered](https://deploy-preview-6032--tokio-rs.netlify.app/tokio/sync/struct.semaphore#rate-limiting-using-a-token-bucket)