### PR TITLE
io: mark Interest::add as must_use

### DIFF
--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -163,6 +163,7 @@ impl Interest {
     ///
     /// assert!(BOTH.is_readable());
     /// assert!(BOTH.is_writable());
+    #[must_use = "this returns the result of the operation, without modifying the original"]
     pub const fn add(self, other: Interest) -> Interest {
         Self(self.0 | other.0)
     }


### PR DESCRIPTION
Like in https://github.com/tokio-rs/mio/pull/1694. 

Marking `is_*` methods makes little bit less sense to me but if that's something desirable I'll mark those as well.