### PR TITLE
Add apple tvos support

### DIFF
--- a/tokio-util/tests/udp.rs
+++ b/tokio-util/tests/udp.rs
@@ -13,7 +13,10 @@ use futures::sink::SinkExt;
 use std::io;
 use std::sync::Arc;
 
-#[cfg_attr(any(target_os = "macos", target_os = "ios"), allow(unused_assignments))]
+#[cfg_attr(
+    any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+    allow(unused_assignments)
+)]
 #[tokio::test]
 async fn send_framed_byte_codec() -> std::io::Result<()> {
     let mut a_soc = UdpSocket::bind("127.0.0.1:0").await?;
@@ -41,7 +44,7 @@ async fn send_framed_byte_codec() -> std::io::Result<()> {
         b_soc = b.into_inner();
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
     // test sending & receiving an empty message
     {
         let mut a = UdpFramed::new(a_soc, ByteCodec);

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -45,7 +45,7 @@ pub(crate) use self::impl_netbsd::get_peer_cred;
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 pub(crate) use self::impl_bsd::get_peer_cred;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 pub(crate) use self::impl_macos::get_peer_cred;
 
 #[cfg(any(target_os = "solaris", target_os = "illumos"))]
@@ -187,7 +187,7 @@ pub(crate) mod impl_bsd {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
 pub(crate) mod impl_macos {
     use crate::net::unix::{self, UnixStream};
 


### PR DESCRIPTION
This PR allows using tokio lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64