### PR TITLE
time: reduce iteration count in short_sleeps test

### DIFF
--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -189,7 +189,7 @@ async fn greater_than_max() {
 
 #[tokio::test]
 async fn short_sleeps() {
-    for _ in 0..10000 {
+    for _ in 0..1000 {
         tokio::time::sleep(std::time::Duration::from_millis(0)).await;
     }
 }


### PR DESCRIPTION
We've had test failures due to this test being really slow. In the run below, CI later timed out while running some later tests:
```
        SLOW [> 60.000s] tokio::time_sleep short_sleeps
        SLOW [>120.000s] tokio::time_sleep short_sleeps
        PASS [ 147.928s] tokio::time_sleep short_sleeps
------------
     Summary [ 238.734s] 1186 tests run: 1186 passed (2 slow), 13 skipped
```
Reducing the number of iterations should help with this.