### PR TITLE
docs: fix new doc warnings in 1.73.0

### DIFF
--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -22,13 +22,12 @@ cfg_io_util! {
 /// Generally speaking, when using `OpenOptions`, you'll first call [`new`],
 /// then chain calls to methods to set each option, then call either
 /// [`open_receiver`] or [`open_sender`], passing the path of the FIFO file you
-/// are trying to open. This will give you a [`io::Result`][result] with a pipe
-/// end inside that you can further operate on.
+/// are trying to open. This will give you a [`io::Result`] with a pipe end
+/// inside that you can further operate on.
 ///
 /// [`new`]: OpenOptions::new
 /// [`open_receiver`]: OpenOptions::open_receiver
 /// [`open_sender`]: OpenOptions::open_sender
-/// [result]: std::io::Result
 ///
 /// # Examples
 ///

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -80,23 +80,23 @@ tokio_thread_local! {
             #[cfg(feature = "rt")]
             thread_id: Cell::new(None),
 
-            /// Tracks the current runtime handle to use when spawning,
-            /// accessing drivers, etc...
+            // Tracks the current runtime handle to use when spawning,
+            // accessing drivers, etc...
             #[cfg(feature = "rt")]
             current: current::HandleCell::new(),
 
-            /// Tracks the current scheduler internal context
+            // Tracks the current scheduler internal context
             #[cfg(feature = "rt")]
             scheduler: Scoped::new(),
 
             #[cfg(feature = "rt")]
             current_task_id: Cell::new(None),
 
-            /// Tracks if the current thread is currently driving a runtime.
-            /// Note, that if this is set to "entered", the current scheduler
-            /// handle may not reference the runtime currently executing. This
-            /// is because other runtime handles may be set to current from
-            /// within a runtime.
+            // Tracks if the current thread is currently driving a runtime.
+            // Note, that if this is set to "entered", the current scheduler
+            // handle may not reference the runtime currently executing. This
+            // is because other runtime handles may be set to current from
+            // within a runtime.
             #[cfg(feature = "rt")]
             runtime: Cell::new(EnterRuntime::NotEntered),
 

--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -85,7 +85,6 @@
 //! }
 //! ```
 //!
-//! [oneshot]: oneshot
 //! [`JoinHandle`]: crate::task::JoinHandle
 //!
 //! ## `mpsc` channel
@@ -175,11 +174,11 @@
 //! }
 //! ```
 //!
-//! The [`mpsc`][mpsc] and [`oneshot`][oneshot] channels can be combined to
-//! provide a request / response type synchronization pattern with a shared
-//! resource. A task is spawned to synchronize a resource and waits on commands
-//! received on a [`mpsc`][mpsc] channel. Each command includes a
-//! [`oneshot`][oneshot] `Sender` on which the result of the command is sent.
+//! The [`mpsc`] and [`oneshot`] channels can be combined to provide a request /
+//! response type synchronization pattern with a shared resource. A task is
+//! spawned to synchronize a resource and waits on commands received on a
+//! [`mpsc`] channel. Each command includes a [`oneshot`] `Sender` on which the
+//! result of the command is sent.
 //!
 //! **Example:** use a task to synchronize a `u64` counter. Each task sends an
 //! "fetch and increment" command. The counter value **before** the increment is
@@ -235,8 +234,6 @@
 //!     }
 //! }
 //! ```
-//!
-//! [mpsc]: mpsc
 //!
 //! ## `broadcast` channel
 //!
@@ -416,24 +413,24 @@
 //! operate in a similar way as their `std` counterparts but will wait
 //! asynchronously instead of blocking the thread.
 //!
-//! * [`Barrier`](Barrier) Ensures multiple tasks will wait for each other to
-//!   reach a point in the program, before continuing execution all together.
+//! * [`Barrier`] Ensures multiple tasks will wait for each other to reach a
+//!   point in the program, before continuing execution all together.
 //!
-//! * [`Mutex`](Mutex) Mutual Exclusion mechanism, which ensures that at most
-//!   one thread at a time is able to access some data.
+//! * [`Mutex`] Mutual Exclusion mechanism, which ensures that at most one
+//!   thread at a time is able to access some data.
 //!
-//! * [`Notify`](Notify) Basic task notification. `Notify` supports notifying a
+//! * [`Notify`] Basic task notification. `Notify` supports notifying a
 //!   receiving task without sending data. In this case, the task wakes up and
 //!   resumes processing.
 //!
-//! * [`RwLock`](RwLock) Provides a mutual exclusion mechanism which allows
-//!   multiple readers at the same time, while allowing only one writer at a
-//!   time. In some cases, this can be more efficient than a mutex.
+//! * [`RwLock`] Provides a mutual exclusion mechanism which allows multiple
+//!   readers at the same time, while allowing only one writer at a time. In
+//!   some cases, this can be more efficient than a mutex.
 //!
-//! * [`Semaphore`](Semaphore) Limits the amount of concurrency. A semaphore
-//!   holds a number of permits, which tasks may request in order to enter a
-//!   critical section. Semaphores are useful for implementing limiting or
-//!   bounding of any kind.
+//! * [`Semaphore`] Limits the amount of concurrency. A semaphore holds a
+//!   number of permits, which tasks may request in order to enter a critical
+//!   section. Semaphores are useful for implementing limiting or bounding of
+//!   any kind.
 
 cfg_sync! {
     /// Named future types.


### PR DESCRIPTION
This fixes new documentation warnings in 1.73.0.
```
warning: unused doc comment
  --> tokio/src/runtime/context.rs:83:13
   |
83 |             /// Tracks the current runtime handle to use when spawning,
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
86 |             current: current::HandleCell::new(),
   |             ----------------------------------- rustdoc does not generate documentation for expression fields
   |
   = help: use `//` for a plain comment
   = note: `#[warn(unused_doc_comments)]` on by default

warning: unused doc comment
  --> tokio/src/runtime/context.rs:84:13
   |
84 |             /// accessing drivers, etc...
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
85 |             #[cfg(feature = "rt")]
86 |             current: current::HandleCell::new(),
   |             ----------------------------------- rustdoc does not generate documentation for expression fields
   |
   = help: use `//` for a plain comment

warning: unused doc comment
  --> tokio/src/runtime/context.rs:88:13
   |
88 |             /// Tracks the current scheduler internal context
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
89 |             #[cfg(feature = "rt")]
90 |             scheduler: Scoped::new(),
   |             ------------------------ rustdoc does not generate documentation for expression fields
   |
   = help: use `//` for a plain comment

warning: unused doc comment
   --> tokio/src/runtime/context.rs:95:13
    |
95  |             /// Tracks if the current thread is currently driving a runtime.
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
101 |             runtime: Cell::new(EnterRuntime::NotEntered),
    |             -------------------------------------------- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment

warning: unused doc comment
   --> tokio/src/runtime/context.rs:96:13
    |
96  |             /// Note, that if this is set to "entered", the current scheduler
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
101 |             runtime: Cell::new(EnterRuntime::NotEntered),
    |             -------------------------------------------- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment

warning: unused doc comment
   --> tokio/src/runtime/context.rs:97:13
    |
97  |             /// handle may not reference the runtime currently executing. This
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
101 |             runtime: Cell::new(EnterRuntime::NotEntered),
    |             -------------------------------------------- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment

warning: unused doc comment
   --> tokio/src/runtime/context.rs:98:13
    |
98  |             /// is because other runtime handles may be set to current from
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
101 |             runtime: Cell::new(EnterRuntime::NotEntered),
    |             -------------------------------------------- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment

warning: unused doc comment
   --> tokio/src/runtime/context.rs:99:13
    |
99  |             /// within a runtime.
    |             ^^^^^^^^^^^^^^^^^^^^^
100 |             #[cfg(feature = "rt")]
101 |             runtime: Cell::new(EnterRuntime::NotEntered),
    |             -------------------------------------------- rustdoc does not generate documentation for expression fields
    |
    = help: use `//` for a plain comment

warning: redundant explicit link target
  --> tokio/src/net/unix/pipe.rs:25:61
   |
25 | /// are trying to open. This will give you a [`io::Result`][result] with a pipe
   |                                               ------------  ^^^^^^ explicit target is redundant
   |                                               |
   |                                               because label contains path that resolves to same destination
   |
note: referenced explicit link target defined here
  --> tokio/src/net/unix/pipe.rs:31:15
   |
31 | /// [result]: std::io::Result
   |               ^^^^^^^^^^^^^^^
   = note: when a link's destination is not specified,
           the label is used to resolve intra-doc links
   = note: `#[warn(rustdoc::redundant_explicit_links)]` on by default
help: remove explicit link target
   |
25 | /// are trying to open. This will give you a [`io::Result`] with a pipe
   |                                              ~~~~~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:178:18
    |
178 | //! The [`mpsc`][mpsc] and [`oneshot`][oneshot] channels can be combined to
    |          ------  ^^^^ explicit target is redundant
    |          |
    |          because label contains path that resolves to same destination
    |
note: referenced explicit link target defined here
   --> tokio/src/sync/mod.rs:239:13
    |
239 | //! [mpsc]: mpsc
    |             ^^^^
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
178 | //! The [`mpsc`] and [`oneshot`][oneshot] channels can be combined to
    |         ~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:178:40
    |
178 | //! The [`mpsc`][mpsc] and [`oneshot`][oneshot] channels can be combined to
    |                             ---------  ^^^^^^^ explicit target is redundant
    |                             |
    |                             because label contains path that resolves to same destination
    |
note: referenced explicit link target defined here
   --> tokio/src/sync/mod.rs:88:16
    |
88  | //! [oneshot]: oneshot
    |                ^^^^^^^
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
178 | //! The [`mpsc`][mpsc] and [`oneshot`] channels can be combined to
    |                            ~~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:181:28
    |
181 | //! received on a [`mpsc`][mpsc] channel. Each command includes a
    |                    ------  ^^^^ explicit target is redundant
    |                    |
    |                    because label contains path that resolves to same destination
    |
note: referenced explicit link target defined here
   --> tokio/src/sync/mod.rs:239:13
    |
239 | //! [mpsc]: mpsc
    |             ^^^^
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
181 | //! received on a [`mpsc`] channel. Each command includes a
    |                   ~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:182:17
    |
182 | //! [`oneshot`][oneshot] `Sender` on which the result of the command is sent.
    |      ---------  ^^^^^^^ explicit target is redundant
    |      |
    |      because label contains path that resolves to same destination
    |
note: referenced explicit link target defined here
   --> tokio/src/sync/mod.rs:88:16
    |
88  | //! [oneshot]: oneshot
    |                ^^^^^^^
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
182 | //! [`oneshot`] `Sender` on which the result of the command is sent.
    |     ~~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:419:19
    |
419 | //! * [`Barrier`](Barrier) Ensures multiple tasks will wait for each other to
    |        ---------  ^^^^^^^ explicit target is redundant
    |        |
    |        because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
419 | //! * [`Barrier`] Ensures multiple tasks will wait for each other to
    |       ~~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:422:17
    |
422 | //! * [`Mutex`](Mutex) Mutual Exclusion mechanism, which ensures that at most
    |        -------  ^^^^^ explicit target is redundant
    |        |
    |        because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
422 | //! * [`Mutex`] Mutual Exclusion mechanism, which ensures that at most
    |       ~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:425:18
    |
425 | //! * [`Notify`](Notify) Basic task notification. `Notify` supports notifying a
    |        --------  ^^^^^^ explicit target is redundant
    |        |
    |        because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
425 | //! * [`Notify`] Basic task notification. `Notify` supports notifying a
    |       ~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:429:18
    |
429 | //! * [`RwLock`](RwLock) Provides a mutual exclusion mechanism which allows
    |        --------  ^^^^^^ explicit target is redundant
    |        |
    |        because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
429 | //! * [`RwLock`] Provides a mutual exclusion mechanism which allows
    |       ~~~~~~~~~~

warning: redundant explicit link target
   --> tokio/src/sync/mod.rs:433:21
    |
433 | //! * [`Semaphore`](Semaphore) Limits the amount of concurrency. A semaphore
    |        -----------  ^^^^^^^^^ explicit target is redundant
    |        |
    |        because label contains path that resolves to same destination
    |
    = note: when a link's destination is not specified,
            the label is used to resolve intra-doc links
help: remove explicit link target
    |
433 | //! * [`Semaphore`] Limits the amount of concurrency. A semaphore
    |       ~~~~~~~~~~~~~
```