### PR TITLE
chore: prepare Tokio v1.33.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.33.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,86 @@
+# 1.33.0 (October 8, 2023)
+
+### Changed
+
+- fix cache line size for RISC-V ([#5994])
+- fs: add vectored writes to `tokio::fs::File` ([#5958])
+- io: mark `Interest::add` with `#[must_use]` ([#6037])
+- io: use memchr from libc ([#5960])
+- io: support vectored writes for `DuplexStream` ([#5985])
+- io: add `SyncIOBridge::into_inner` ([#5971])
+- macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])
+- sync: use Acquire/Release orderings instead of SeqCst in `watch` ([#6018])
+- sync: prevent lock poisoning in `watch::Receiver::wait_for` ([#6021])
+- task: fix `spawn_local` source location ([#5984])
+
+### Added
+
+- io: add `Interest::remove` method ([#5906])
+- io: implement `Seek` for `SyncIoBridge` ([#6058])
+- net: add Apple tvOS support ([#6045])
+- sync: add `?Sized` bound to `{MutexGuard,OwnedMutexGuard}::map` ([#5997])
+- sync: add const fn `OnceCell::from_value` ([#5903])
+- sync: add `watch::Sender::new` ([#5998])
+- sync: add `watch::Receiver::mark_unseen` ([#5962], [#6014], [#6017])
+
+### Removed
+
+- remove unused `stats` feature ([#5952])
+
+### Documented
+
+- add missing backticks in code examples ([#5938], [#6056])
+- fix typos ([#5988], [#6030])
+- process: document that `Child::wait` is cancel safe ([#5977])
+- sync: add examples for `Semaphore` ([#5939], [#5956], [#5978], [#6031], [#6032], [#6050])
+- sync: document that `broadcast` capacity is a lower bound ([#6042])
+- sync: document that `const_new` is not instrumented ([#6002])
+- sync: improve cancel-safety documentation for `mpsc::Sender::send` ([#5947])
+- sync: improve docs for `watch` channel ([#5954])
+- taskdump: render taskdump documentation on docs.rs ([#5972])
+
+### Unstable
+
+- taskdump: fix potential deadlock ([#6036])
+
+[#5903]: https://github.com/tokio-rs/tokio/pull/5903
+[#5906]: https://github.com/tokio-rs/tokio/pull/5906
+[#5938]: https://github.com/tokio-rs/tokio/pull/5938
+[#5939]: https://github.com/tokio-rs/tokio/pull/5939
+[#5947]: https://github.com/tokio-rs/tokio/pull/5947
+[#5952]: https://github.com/tokio-rs/tokio/pull/5952
+[#5954]: https://github.com/tokio-rs/tokio/pull/5954
+[#5956]: https://github.com/tokio-rs/tokio/pull/5956
+[#5958]: https://github.com/tokio-rs/tokio/pull/5958
+[#5960]: https://github.com/tokio-rs/tokio/pull/5960
+[#5962]: https://github.com/tokio-rs/tokio/pull/5962
+[#5971]: https://github.com/tokio-rs/tokio/pull/5971
+[#5972]: https://github.com/tokio-rs/tokio/pull/5972
+[#5973]: https://github.com/tokio-rs/tokio/pull/5973
+[#5977]: https://github.com/tokio-rs/tokio/pull/5977
+[#5978]: https://github.com/tokio-rs/tokio/pull/5978
+[#5984]: https://github.com/tokio-rs/tokio/pull/5984
+[#5985]: https://github.com/tokio-rs/tokio/pull/5985
+[#5988]: https://github.com/tokio-rs/tokio/pull/5988
+[#5994]: https://github.com/tokio-rs/tokio/pull/5994
+[#5997]: https://github.com/tokio-rs/tokio/pull/5997
+[#5998]: https://github.com/tokio-rs/tokio/pull/5998
+[#6002]: https://github.com/tokio-rs/tokio/pull/6002
+[#6014]: https://github.com/tokio-rs/tokio/pull/6014
+[#6017]: https://github.com/tokio-rs/tokio/pull/6017
+[#6018]: https://github.com/tokio-rs/tokio/pull/6018
+[#6021]: https://github.com/tokio-rs/tokio/pull/6021
+[#6030]: https://github.com/tokio-rs/tokio/pull/6030
+[#6031]: https://github.com/tokio-rs/tokio/pull/6031
+[#6032]: https://github.com/tokio-rs/tokio/pull/6032
+[#6036]: https://github.com/tokio-rs/tokio/pull/6036
+[#6037]: https://github.com/tokio-rs/tokio/pull/6037
+[#6042]: https://github.com/tokio-rs/tokio/pull/6042
+[#6045]: https://github.com/tokio-rs/tokio/pull/6045
+[#6050]: https://github.com/tokio-rs/tokio/pull/6050
+[#6056]: https://github.com/tokio-rs/tokio/pull/6056
+[#6058]: https://github.com/tokio-rs/tokio/pull/6058
+
 # 1.32.0 (August 16, 2023)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -6,7 +6,6 @@
 - fs: add vectored writes to `tokio::fs::File` ([#5958])
 - io: mark `Interest::add` with `#[must_use]` ([#6037])
 - io: support vectored writes for `DuplexStream` ([#5985])
-- io: add `SyncIOBridge::into_inner` ([#5971])
 - macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])
 - sync: use Acquire/Release orderings instead of SeqCst in `watch` ([#6018])
 - sync: prevent lock poisoning in `watch::Receiver::wait_for` ([#6021])
@@ -15,7 +14,6 @@
 ### Added
 
 - io: add `Interest::remove` method ([#5906])
-- io: implement `Seek` for `SyncIoBridge` ([#6058])
 - net: add Apple tvOS support ([#6045])
 - sync: add `?Sized` bound to `{MutexGuard,OwnedMutexGuard}::map` ([#5997])
 - sync: add const fn `OnceCell::from_value` ([#5903])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -5,7 +5,6 @@
 - fix cache line size for RISC-V ([#5994])
 - fs: add vectored writes to `tokio::fs::File` ([#5958])
 - io: mark `Interest::add` with `#[must_use]` ([#6037])
-- io: use memchr from libc ([#5960])
 - io: support vectored writes for `DuplexStream` ([#5985])
 - io: add `SyncIOBridge::into_inner` ([#5971])
 - macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,24 +1,27 @@
-# 1.33.0 (October 8, 2023)
+# 1.33.0 (October 9, 2023)
 
-### Changed
+### Fixed
 
-- fix cache line size for RISC-V ([#5994])
-- fs: add vectored writes to `tokio::fs::File` ([#5958])
 - io: mark `Interest::add` with `#[must_use]` ([#6037])
-- io: support vectored writes for `DuplexStream` ([#5985])
-- macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])
-- sync: use Acquire/Release orderings instead of SeqCst in `watch` ([#6018])
+- runtime: fix cache line size for RISC-V ([#5994])
 - sync: prevent lock poisoning in `watch::Receiver::wait_for` ([#6021])
 - task: fix `spawn_local` source location ([#5984])
 
+### Changed
+
+- macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])
+- sync: use Acquire/Release orderings instead of SeqCst in `watch` ([#6018])
+
 ### Added
 
+- fs: add vectored writes to `tokio::fs::File` ([#5958])
 - io: add `Interest::remove` method ([#5906])
+- io: add vectored writes to `DuplexStream` ([#5985])
 - net: add Apple tvOS support ([#6045])
 - sync: add `?Sized` bound to `{MutexGuard,OwnedMutexGuard}::map` ([#5997])
-- sync: add const fn `OnceCell::from_value` ([#5903])
-- sync: add `watch::Sender::new` ([#5998])
 - sync: add `watch::Receiver::mark_unseen` ([#5962], [#6014], [#6017])
+- sync: add `watch::Sender::new` ([#5998])
+- sync: add const fn `OnceCell::from_value` ([#5903])
 
 ### Removed
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.32.0"
+version = "1.33.0"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.33.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.33.0 (October 9, 2023)

### Fixed

- io: mark `Interest::add` with `#[must_use]` ([#6037])
- runtime: fix cache line size for RISC-V ([#5994])
- sync: prevent lock poisoning in `watch::Receiver::wait_for` ([#6021])
- task: fix `spawn_local` source location ([#5984])

### Changed

- macros: use `::core` imports instead of `::std` in `tokio::test` ([#5973])
- sync: use Acquire/Release orderings instead of SeqCst in `watch` ([#6018])

### Added

- fs: add vectored writes to `tokio::fs::File` ([#5958])
- io: add `Interest::remove` method ([#5906])
- io: add vectored writes to `DuplexStream` ([#5985])
- net: add Apple tvOS support ([#6045])
- sync: add `?Sized` bound to `{MutexGuard,OwnedMutexGuard}::map` ([#5997])
- sync: add `watch::Receiver::mark_unseen` ([#5962], [#6014], [#6017])
- sync: add `watch::Sender::new` ([#5998])
- sync: add const fn `OnceCell::from_value` ([#5903])

### Removed

- remove unused `stats` feature ([#5952])

### Documented

- add missing backticks in code examples ([#5938], [#6056])
- fix typos ([#5988], [#6030])
- process: document that `Child::wait` is cancel safe ([#5977])
- sync: add examples for `Semaphore` ([#5939], [#5956], [#5978], [#6031], [#6032], [#6050])
- sync: document that `broadcast` capacity is a lower bound ([#6042])
- sync: document that `const_new` is not instrumented ([#6002])
- sync: improve cancel-safety documentation for `mpsc::Sender::send` ([#5947])
- sync: improve docs for `watch` channel ([#5954])
- taskdump: render taskdump documentation on docs.rs ([#5972])

### Unstable

- taskdump: fix potential deadlock ([#6036])

[#5903]: https://github.com/tokio-rs/tokio/pull/5903
[#5906]: https://github.com/tokio-rs/tokio/pull/5906
[#5938]: https://github.com/tokio-rs/tokio/pull/5938
[#5939]: https://github.com/tokio-rs/tokio/pull/5939
[#5947]: https://github.com/tokio-rs/tokio/pull/5947
[#5952]: https://github.com/tokio-rs/tokio/pull/5952
[#5954]: https://github.com/tokio-rs/tokio/pull/5954
[#5956]: https://github.com/tokio-rs/tokio/pull/5956
[#5958]: https://github.com/tokio-rs/tokio/pull/5958
[#5960]: https://github.com/tokio-rs/tokio/pull/5960
[#5962]: https://github.com/tokio-rs/tokio/pull/5962
[#5971]: https://github.com/tokio-rs/tokio/pull/5971
[#5972]: https://github.com/tokio-rs/tokio/pull/5972
[#5973]: https://github.com/tokio-rs/tokio/pull/5973
[#5977]: https://github.com/tokio-rs/tokio/pull/5977
[#5978]: https://github.com/tokio-rs/tokio/pull/5978
[#5984]: https://github.com/tokio-rs/tokio/pull/5984
[#5985]: https://github.com/tokio-rs/tokio/pull/5985
[#5988]: https://github.com/tokio-rs/tokio/pull/5988
[#5994]: https://github.com/tokio-rs/tokio/pull/5994
[#5997]: https://github.com/tokio-rs/tokio/pull/5997
[#5998]: https://github.com/tokio-rs/tokio/pull/5998
[#6002]: https://github.com/tokio-rs/tokio/pull/6002
[#6014]: https://github.com/tokio-rs/tokio/pull/6014
[#6017]: https://github.com/tokio-rs/tokio/pull/6017
[#6018]: https://github.com/tokio-rs/tokio/pull/6018
[#6021]: https://github.com/tokio-rs/tokio/pull/6021
[#6030]: https://github.com/tokio-rs/tokio/pull/6030
[#6031]: https://github.com/tokio-rs/tokio/pull/6031
[#6032]: https://github.com/tokio-rs/tokio/pull/6032
[#6036]: https://github.com/tokio-rs/tokio/pull/6036
[#6037]: https://github.com/tokio-rs/tokio/pull/6037
[#6042]: https://github.com/tokio-rs/tokio/pull/6042
[#6045]: https://github.com/tokio-rs/tokio/pull/6045
[#6050]: https://github.com/tokio-rs/tokio/pull/6050
[#6056]: https://github.com/tokio-rs/tokio/pull/6056
[#6058]: https://github.com/tokio-rs/tokio/pull/6058