### PR TITLE
io: allow `clear_readiness` after io driver shutdown

### DIFF
--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -210,8 +210,8 @@ impl ScheduledIo {
     pub(super) fn set_readiness(&self, tick: Tick, f: impl Fn(Ready) -> Ready) {
         let mut current = self.readiness.load(Acquire);
 
-        // The shutdown bit should not be set
-        debug_assert_eq!(0, SHUTDOWN.unpack(current));
+        // If the io driver is shut down, then you are only allowed to clear readiness.
+        debug_assert!(SHUTDOWN.unpack(current) == 0 || matches!(tick, Tick::Clear(_)));
 
         loop {
             // Mask out the tick bits so that the modifying function doesn't see

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -579,6 +579,23 @@ fn driver_shutdown_wakes_poll() {
 }
 
 #[test]
+fn driver_shutdown_then_clear_readiness() {
+    let rt = rt();
+
+    let (a, _b) = socketpair();
+    let afd_a = {
+        let _enter = rt.enter();
+        AsyncFd::new(a).unwrap()
+    };
+
+    let mut write_ready = rt.block_on(afd_a.writable()).unwrap();
+
+    std::mem::drop(rt);
+
+    write_ready.clear_ready();
+}
+
+#[test]
 fn driver_shutdown_wakes_poll_race() {
     // TODO: make this a loom test
     for _ in 0..100 {


### PR DESCRIPTION
Trying to perform an IO operation after runtime shutdown currently results in an error, and this is intentional. However, if you perform an IO operation, then shut down the runtime, and then call `clear_readiness`, then this does not trigger that error. Instead, it hits an internal `debug_assert!` codepath.

We fix this by allowing `clear_readiness` after runtime shutdown.

Fixes: #6066