### PR TITLE
fix(macros/lib.rs): macro fails to compile with no_implicit_prelude issue#5683

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -288,7 +288,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// To use the multi-threaded runtime, the macro can be configured using
 ///
 /// ```no_run
-/// #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+/// #[test(flavor = "multi_thread", worker_threads = 1)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -306,7 +306,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// separate current-thread runtime.
 ///
 /// ```no_run
-/// #[tokio::test]
+/// #[test]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -317,7 +317,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Using the multi-thread runtime
 ///
 /// ```no_run
-/// #[tokio::test(flavor = "multi_thread")]
+/// #[test(flavor = "multi_thread")]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -341,7 +341,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Using current thread runtime
 ///
 /// ```no_run
-/// #[tokio::test]
+/// #[test]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -365,7 +365,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Set number of worker threads
 ///
 /// ```no_run
-/// #[tokio::test(flavor ="multi_thread", worker_threads = 2)]
+/// #[test(flavor ="multi_thread", worker_threads = 2)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -390,7 +390,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Configure the runtime to start with time paused
 ///
 /// ```no_run
-/// #[tokio::test(start_paused = true)]
+/// #[test(start_paused = true)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }
@@ -434,7 +434,7 @@ pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ## Usage
 ///
 /// ```no_run
-/// #[tokio::test]
+/// #[test]
 /// async fn my_test() {
 ///     assert!(true);
 /// }


### PR DESCRIPTION
…5683, issue(#5683)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
I'm passionate about Rust and deeply committed to open source. Contributing to Tokio would be an exciting journey, a chance to deepen my Rust skills, tackle real-world challenges, and collaborate with the community. It's an opportunity for personal growth, networking, and giving back to a project that's critical for countless developers. I'm eager to be a part of Tokio's future and contribute to its continued success.
-->

## Solution

<!--
The solution involves explicitly using "#[test]" instead of "#[::tokio::test]" to make it work seamlessly with "#![no_implicit_prelude]" in Rust. This ensures compatibility, enabling better import control and avoiding conflicts with the standard Rust prelude.
-->
