### PR TITLE
fs: update cfg attr in `fs::read_dir`

### DIFF
--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -140,6 +140,7 @@ impl ReadDir {
                     target_os = "illumos",
                     target_os = "haiku",
                     target_os = "vxworks",
+                    target_os = "aix",
                     target_os = "nto",
                     target_os = "vita",
                 )))]
@@ -203,6 +204,7 @@ pub struct DirEntry {
         target_os = "illumos",
         target_os = "haiku",
         target_os = "vxworks",
+        target_os = "aix",
         target_os = "nto",
         target_os = "vita",
     )))]
@@ -336,6 +338,7 @@ impl DirEntry {
             target_os = "illumos",
             target_os = "haiku",
             target_os = "vxworks",
+            target_os = "aix",
             target_os = "nto",
             target_os = "vita",
         )))]


### PR DESCRIPTION
This change updates the cfg attribute to prevent unnecessary file metadata fetching on a new target.

The current `DirEntry::file_type` implementation returns a pre-parsed value from `fs::read_dir` for most targets. Some Unix operating systems are excluded because of the overhead of fetching metadata to get the file type. However, as the Rust compiler has been updated, a new target has been added and an update is needed. The cfg attribute is taken from [the std implementation](https://github.com/rust-lang/rust/blob/b0fedc07ce52a7647272a34fadbf4c5585a79c0b/library/std/src/sys/unix/fs.rs#L909-L917).

Related Issue: #5806