### PR TITLE
reame: remove rdbc and add axum to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ project.
 In addition to the crates in this repository, the Tokio project also maintains
 several other libraries, including:
 
+* [`axum`]: A web application framework that focuses on ergonomics and modularity.
+
 * [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
 
 * [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
@@ -142,21 +144,18 @@ several other libraries, including:
 
 * [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware diagnostics.
 
-* [`rdbc`]: A Rust database connectivity library for MySQL, Postgres and SQLite.
-
-* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers
-  `tokio`.
+* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
 
 * [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
 
-* [`loom`]: A testing tool for concurrent Rust code
+* [`loom`]: A testing tool for concurrent Rust code.
 
+[`axum`]: https://github.com/tokio-rs/axum
 [`warp`]: https://github.com/seanmonstar/warp
 [`hyper`]: https://github.com/hyperium/hyper
 [`tonic`]: https://github.com/hyperium/tonic
 [`tower`]: https://github.com/tower-rs/tower
 [`loom`]: https://github.com/tokio-rs/loom
-[`rdbc`]: https://github.com/tokio-rs/rdbc
 [`tracing`]: https://github.com/tokio-rs/tracing
 [`mio`]: https://github.com/tokio-rs/mio
 [`bytes`]: https://github.com/tokio-rs/bytes

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -132,6 +132,8 @@ project.
 In addition to the crates in this repository, the Tokio project also maintains
 several other libraries, including:
 
+* [`axum`]: A web application framework that focuses on ergonomics and modularity.
+
 * [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
 
 * [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
@@ -142,21 +144,18 @@ several other libraries, including:
 
 * [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware diagnostics.
 
-* [`rdbc`]: A Rust database connectivity library for MySQL, Postgres and SQLite.
-
-* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers
-  `tokio`.
+* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
 
 * [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
 
-* [`loom`]: A testing tool for concurrent Rust code
+* [`loom`]: A testing tool for concurrent Rust code.
 
+[`axum`]: https://github.com/tokio-rs/axum
 [`warp`]: https://github.com/seanmonstar/warp
 [`hyper`]: https://github.com/hyperium/hyper
 [`tonic`]: https://github.com/hyperium/tonic
 [`tower`]: https://github.com/tower-rs/tower
 [`loom`]: https://github.com/tokio-rs/loom
-[`rdbc`]: https://github.com/tokio-rs/rdbc
 [`tracing`]: https://github.com/tokio-rs/tracing
 [`mio`]: https://github.com/tokio-rs/mio
 [`bytes`]: https://github.com/tokio-rs/bytes


### PR DESCRIPTION
We should mention axum in this list.

Also remove rdbc, because the rdbc project doesn't seem to be maintained anymore.