### PR TITLE
`tokio::select!`: clarify documentation

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -133,10 +133,10 @@
 ///
 /// Cancellation safety can be defined in the following way: If you have a
 /// future that has not yet completed, then it must be a no-op to drop that
-/// future and recreate it. This definition is motivated by the situation where
-/// a `select!` is used in a loop. Without this guarantee, you would lose your
-/// progress when another branch completes and you restart the `select!` by
-/// going around the loop.
+/// future and restart it from the beginning. This definition is motivated by
+/// the situation where a `select!` is used in a loop. Without this guarantee,
+/// you would lose your progress when another branch completes and you restart
+/// the `select!` by going around the loop.
 ///
 /// Be aware that cancelling something that is not cancellation safe is not
 /// necessarily wrong. For example, if you are cancelling a task because the


### PR DESCRIPTION
This confused me, as "recreate" seems to imply a bit-for-bit copy that retains the state of the future at the `await` point it's cancelled at. "Restart from the beginning" is more accurate.