### PR TITLE
feat: add task counter pairs

### DIFF
--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -75,7 +75,15 @@ impl RuntimeMetrics {
             self.handle.inner.num_blocking_threads()
         }
 
-        /// Returns the number of active tasks in the runtime.
+        #[deprecated = "Renamed to num_active_tasks"]
+        /// Renamed to [`RuntimeMetrics::num_active_tasks`]
+        pub fn active_tasks_count(&self) -> usize {
+            self.num_active_tasks()
+        }
+
+        /// Returns the current number of active tasks in the runtime.
+        ///
+        /// This value increases and decreases over time as tasks are spawned and as they are completed or cancelled.
         ///
         /// # Examples
         ///
@@ -86,12 +94,36 @@ impl RuntimeMetrics {
         /// async fn main() {
         ///    let metrics = Handle::current().metrics();
         ///
-        ///     let n = metrics.active_tasks_count();
+        ///     let n = metrics.num_active_tasks();
         ///     println!("Runtime has {} active tasks", n);
         /// }
         /// ```
-        pub fn active_tasks_count(&self) -> usize {
+        pub fn num_active_tasks(&self) -> usize {
             self.handle.inner.active_tasks_count()
+        }
+
+        /// Returns the number of tasks spawned in this runtime since it was created.
+        ///
+        /// This count starts at zero when the runtime is created and increases by one each time a task is spawned.
+        ///
+        /// The counter is monotonically increasing. It is never decremented or
+        /// reset to zero.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Handle;
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///    let metrics = Handle::current().metrics();
+        ///
+        ///     let n = metrics.spawned_tasks_count();
+        ///     println!("Runtime has had {} tasks spawned", n);
+        /// }
+        /// ```
+        pub fn spawned_tasks_count(&self) -> u64 {
+            self.handle.inner.spawned_tasks_count()
         }
 
         /// Returns the number of idle threads, which have spawned by the runtime

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -536,6 +536,10 @@ cfg_unstable_metrics! {
         pub(crate) fn active_tasks_count(&self) -> usize {
             self.shared.owned.active_tasks_count()
         }
+
+        pub(crate) fn spawned_tasks_count(&self) -> u64 {
+            self.shared.owned.spawned_tasks_count()
+        }
     }
 }
 

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -191,6 +191,10 @@ cfg_rt! {
                 match_flavor!(self, Handle(handle) => handle.active_tasks_count())
             }
 
+            pub(crate) fn spawned_tasks_count(&self) -> u64 {
+                match_flavor!(self, Handle(handle) => handle.spawned_tasks_count())
+            }
+
             pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {
                 match_flavor!(self, Handle(handle) => handle.scheduler_metrics())
             }

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -25,6 +25,10 @@ impl Handle {
             self.shared.owned.active_tasks_count()
         }
 
+        pub(crate) fn spawned_tasks_count(&self) -> u64 {
+            self.shared.owned.spawned_tasks_count()
+        }
+
         pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {
             &self.shared.scheduler_metrics
         }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
@@ -22,6 +22,10 @@ impl Handle {
         self.shared.owned.active_tasks_count()
     }
 
+    pub(crate) fn spawned_tasks_count(&self) -> u64 {
+        self.shared.owned.spawned_tasks_count()
+    }
+
     pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {
         &self.shared.scheduler_metrics
     }

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -170,6 +170,10 @@ impl<S: 'static> OwnedTasks<S> {
         self.list.len()
     }
 
+    pub(crate) fn spawned_tasks_count(&self) -> u64 {
+        self.list.added()
+    }
+
     pub(crate) fn remove(&self, task: &Task<S>) -> Option<Task<S>> {
         // If the task's owner ID is `None` then it is not part of any list and
         // doesn't need removing.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

https://github.com/tokio-rs/tokio/issues/4073#issuecomment-1643611711

> Metrics like active_tasks_count or injection_queue_depth are fast-moving gauges and even taking a snapshot every few seconds doesn't say much about what's going inside Tokio. It would be better to use two counters: one for additions, one for removals

We're hoping to add a [prometheus exporter for the tokio metrics](https://github.com/neondatabase/neon/pull/5647) information, but a sample rate of 15 seconds will likely miss a lot of task spikes. I could implement some level of eager aggregation, but as the linked comment says, you can still miss some with a sample rate of 500ms. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

In `CountedLinkedList`, replace the `count: usize` with a pair of `u64`s that can only be incremented. One `u64` for added items and one for removed items. 

Open to bikeshedding on the terminology

--- 

## Open questions

- [ ] should the active task API return all 3 values in 1, rather than require 3 separate lock calls?
- [ ] what other APIs are current gauges and should be counters?
