### PR TITLE
ci: fix docs on latest nightly

### DIFF
--- a/tokio/src/doc/mod.rs
+++ b/tokio/src/doc/mod.rs
@@ -20,4 +20,26 @@
 #[derive(Debug)]
 pub enum NotDefinedHere {}
 
+impl mio::event::Source for NotDefinedHere {
+    fn register(
+        &mut self,
+        registry: &mio::Registry,
+        token: mio::Token,
+        interests: mio::Interest,
+    ) -> std::io::Result<()> {
+        Ok(())
+    }
+    fn reregister(
+        &mut self,
+        registry: &mio::Registry,
+        token: mio::Token,
+        interests: mio::Interest,
+    ) -> std::io::Result<()> {
+        Ok(())
+    }
+    fn deregister(&mut self, registry: &mio::Registry) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 pub mod os;


### PR DESCRIPTION
Since the latest nightly, rustdoc has started failing with the following error:
```
error[E0277]: the trait bound `doc::NotDefinedHere: mio::event::Source` is not satisfied
   --> tokio/src/net/windows/named_pipe.rs:104:9
    |
104 |     io: PollEvented<mio_windows::NamedPipe>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `mio::event::Source` is not implemented for `doc::NotDefinedHere`
    |
    = help: the following other types implement trait `mio::event::Source`:
              std::boxed::Box<T>
              mio::unix::SourceFd<'a>
              mio::unix::pipe::Sender
              mio::unix::pipe::Receiver
              mio::io_source::IoSource<T>
              mio::net::TcpListener
              mio::net::TcpStream
              mio::net::UdpSocket
            and 4 others
note: required by a bound in `io::poll_evented::PollEvented`
   --> tokio/src/io/poll_evented.rs:65:38
    |
65  |     pub(crate) struct PollEvented<E: Source> {
    |                                      ^^^^^^ required by this bound in `PollEvented`

error[E0277]: the trait bound `doc::NotDefinedHere: mio::event::Source` is not satisfied
   --> tokio/src/net/windows/named_pipe.rs:977:9
    |
977 |     io: PollEvented<mio_windows::NamedPipe>,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `mio::event::Source` is not implemented for `doc::NotDefinedHere`
    |
    = help: the following other types implement trait `mio::event::Source`:
              std::boxed::Box<T>
              mio::unix::SourceFd<'a>
              mio::unix::pipe::Sender
              mio::unix::pipe::Receiver
              mio::io_source::IoSource<T>
              mio::net::TcpListener
              mio::net::TcpStream
              mio::net::UdpSocket
            and 4 others
note: required by a bound in `io::poll_evented::PollEvented`
   --> tokio/src/io/poll_evented.rs:65:38
    |
65  |     pub(crate) struct PollEvented<E: Source> {
    |                                      ^^^^^^ required by this bound in `PollEvented`
```
