### PR TITLE
chore: update rust-version to 1.63 in all crates

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-macros"
 # - Create "tokio-macros-1.x.y" git tag.
 version = "2.1.0"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-stream"
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.14"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-test"
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.3"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-util"
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.10"
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"


### PR DESCRIPTION
Refs: #6125