### PR TITLE
io: increase `ScheduledIo` tick resolution

### DIFF
--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -165,11 +165,11 @@ enum State {
 //
 // | shutdown | driver tick | readiness |
 // |----------+-------------+-----------|
-// |   1 bit  |   8 bits    +   16 bits |
+// |   1 bit  |  15 bits    +   16 bits |
 
 const READINESS: bit::Pack = bit::Pack::least_significant(16);
 
-const TICK: bit::Pack = READINESS.then(8);
+const TICK: bit::Pack = READINESS.then(15);
 
 const SHUTDOWN: bit::Pack = TICK.then(1);
 


### PR DESCRIPTION
While this is no current evidence that increasing the tick resolution is necessary, since we have available bits, we might as well use them.

This is a follow up to #6134