### PR TITLE
net: add support for getting abstract namespace from socketaddr

### DIFF
--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -25,7 +25,7 @@ impl SocketAddr {
 
     /// Returns the contents of this address if it is an abstract namespace.
     ///
-    /// Documentation reflected in [`SocketAddr`]
+    /// See also the standard library documentation on [`SocketAddr`].
     ///
     /// [`SocketAddr`]: std::os::unix::net::SocketAddr
     pub fn as_abstract_namespace(&self) -> Option<&[u8]> {

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -22,6 +22,15 @@ impl SocketAddr {
     pub fn as_pathname(&self) -> Option<&Path> {
         self.0.as_pathname()
     }
+
+    /// Returns the contents of this address if it is an abstract namespace.
+    ///
+    /// Documentation reflected in [`SocketAddr`]
+    ///
+    /// [`SocketAddr`]: std::os::unix::net::SocketAddr
+    pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
+        self.0.as_abstract_namespace()
+    }
 }
 
 impl fmt::Debug for SocketAddr {


### PR DESCRIPTION
## Motivation

I am using a UnixListener which is connected to from systemd from
and abstract namespace socket, which I would like to have the name of.

## Solution

Add the as_abstract_namespace function to the wrapper.


I am not sure where to test this, please let me know where to
add a test and I will add one.
