### PR TITLE
chore: remove useless `wrapping_sub` in `new_with_receiver_count`

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -510,10 +510,10 @@ impl<T> Sender<T> {
 
         let mut buffer = Vec::with_capacity(capacity);
 
-        for i in 0..capacity {
+        for _ in 0..capacity {
             buffer.push(RwLock::new(Slot {
                 rem: AtomicUsize::new(0),
-                pos: (i as u64).wrapping_sub(capacity as u64),
+                pos: 0,
                 val: UnsafeCell::new(None),
             }));
         }


### PR DESCRIPTION
It seems the result of `wrapping_sub` is always `0`.