### PR TITLE
Update `windows-sys` 0.52

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 
 [[example]]
 name = "chat"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,11 +117,11 @@ libc = { version = "0.2.149" }
 nix = { version = "0.29.0", default-features = false, features = ["aio", "fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",


### PR DESCRIPTION
This is the first update to the `windows-sys` crate in 8 months.  https://github.com/microsoft/windows-rs/releases/tag/0.52.0