### PR TITLE
Disallow `blocking_{send,recv}` on wasm32

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -776,7 +776,6 @@ impl<T> Sender<T> {
     /// }
     /// ```
     #[track_caller]
-    #[cfg(feature = "sync")]
     #[cfg(all(feature = "sync"), not(target_arch = "wasm32"))]
     #[cfg_attr(docsrs, doc(alias = "send_blocking"))]
     pub fn blocking_send(&self, value: T) -> Result<(), SendError<T>> {

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -401,7 +401,7 @@ impl<T> Receiver<T> {
     /// }
     /// ```
     #[track_caller]
-    #[cfg(feature = "sync")]
+    #[cfg(all(feature = "sync"), not(target_arch = "wasm32"))]
     #[cfg_attr(docsrs, doc(alias = "recv_blocking"))]
     pub fn blocking_recv(&mut self) -> Option<T> {
         crate::future::block_on(self.recv())
@@ -777,6 +777,7 @@ impl<T> Sender<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
+    #[cfg(all(feature = "sync"), not(target_arch = "wasm32"))]
     #[cfg_attr(docsrs, doc(alias = "send_blocking"))]
     pub fn blocking_send(&self, value: T) -> Result<(), SendError<T>> {
         crate::future::block_on(self.send(value))


### PR DESCRIPTION
These current don't work on wasm32 and will panic in runtime

https://github.com/tokio-rs/tokio/issues/5548
