### PR TITLE
Fixed typo

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1267,8 +1267,8 @@ impl TcpStream {
     /// Unlike [`split`], the owned halves can be moved to separate tasks, however
     /// this comes at the cost of a heap allocation.
     ///
-    /// **Note:** Dropping the write half will shut down the write half of the TCP
-    /// stream. This is equivalent to calling [`shutdown()`] on the `TcpStream`.
+    /// **Note:** Dropping the write half will shut down the TCP stream.
+    /// This is equivalent to calling [`shutdown()`] on the `TcpStream`.
     ///
     /// [`split`]: TcpStream::split()
     /// [`shutdown()`]: fn@crate::io::AsyncWriteExt::shutdown


### PR DESCRIPTION
Fixed typo

## Motivation

- There was a typo in the docs for `into_split()`

## Solution

- Changed docs to be more clear
