### PR TITLE
io: drop the `Sized` requirements from `AsyncReadExt.read_buf`

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -245,8 +245,8 @@ cfg_io_util! {
         /// ```
         fn read_buf<'a, B>(&'a mut self, buf: &'a mut B) -> ReadBuf<'a, Self, B>
         where
-            Self: Sized + Unpin,
-            B: BufMut,
+            Self: Unpin,
+            B: BufMut + ?Sized,
         {
             read_buf(self, buf)
         }

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -10,8 +10,8 @@ use std::task::{Context, Poll};
 
 pub(crate) fn read_buf<'a, R, B>(reader: &'a mut R, buf: &'a mut B) -> ReadBuf<'a, R, B>
 where
-    R: AsyncRead + Unpin,
-    B: BufMut,
+    R: AsyncRead + Unpin + ?Sized,
+    B: BufMut + ?Sized,
 {
     ReadBuf {
         reader,
@@ -24,7 +24,7 @@ pin_project! {
     /// Future returned by [`read_buf`](crate::io::AsyncReadExt::read_buf).
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
-    pub struct ReadBuf<'a, R, B> {
+    pub struct ReadBuf<'a, R: ?Sized, B: ?Sized> {
         reader: &'a mut R,
         buf: &'a mut B,
         #[pin]
@@ -34,8 +34,8 @@ pin_project! {
 
 impl<R, B> Future for ReadBuf<'_, R, B>
 where
-    R: AsyncRead + Unpin,
-    B: BufMut,
+    R: AsyncRead + Unpin + ?Sized,
+    B: BufMut + ?Sized,
 {
     type Output = io::Result<usize>;
 


### PR DESCRIPTION
## Motivation

`AsyncReadExt.read_buf` takes both `Self` and its buffer argument by mut ref, yet requires `Sized` for both of them,
disallowing `dyn Trait` for no good reason.

## Solution

Remove the explicit `Sized` requirement for `Self`, and introduce `?Sized` in relevant places.

See also #6161