### PR TITLE
net: add option to set and retrieve IPV6_V6ONLY option to TcpSocket

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -528,6 +528,50 @@ impl TcpSocket {
         self.inner.bind_device(interface)
     }
 
+    /// Get the value for the `IPV6_V6ONLY` option on this socket.
+    ///
+    /// For more information about this option, see [`set_only_v6`].
+    ///
+    /// [`set_only_v6`]: Self::set_only_v6
+    pub fn only_v6(&self) -> io::Result<bool> {
+        self.inner.only_v6()
+    }
+
+    /// Set the value for the `IPV6_V6ONLY` option on this socket.
+    ///
+    /// If this is set to `true` then the socket is restricted to sending and
+    /// receiving IPv6 packets only. In this case two IPv4 and IPv6 applications
+    /// can bind the same port at the same time.
+    ///
+    /// If this is set to `false` then the socket can be used to send and
+    /// receive packets from an IPv4-mapped IPv6 address.
+    ///
+    /// This option is specific to IPv6 sockets and it must be set before binding
+    /// to any address. Its support and default value are platform specific. Refer
+    /// to the target platform's documentation for more details.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::net::TcpSocket;
+    ///
+    /// use std::{io, net::Ipv6Addr};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let socket = TcpSocket::new_v6()?;
+    ///     socket.set_only_v6(true)?;
+    ///     assert!(socket.only_v6().unwrap());
+    ///     socket.bind((Ipv6Addr::UNSPECIFIED, 8080).into())?;
+    ///
+    ///     let listener = socket.listen(1024)?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn set_only_v6(&self, only_v6: bool) -> io::Result<()> {
+        self.inner.set_only_v6(only_v6)
+    }
+
     /// Gets the local address of this socket.
     ///
     /// Will fail on windows if called before `bind`.


### PR DESCRIPTION
Adding fine control over the IPV6_V6ONLY option allows for consistency across systems instead of relying on system defaults.

## Motivation
Currently there is no way to access this option without resorting to the `socket2` library and converting a socket to `std::net::TcpListener` and then to `tokio::net::TcpListener`. This process can be error prone as there are other options that the net runtime expects to be set like the `nonblocking` option.

This is an example of the function I'm using myself to "solve" this problem.
```rust
use std::net::{Ipv6Addr, SocketAddr};
use tokio::net::TcpListener;
fn tokio_tcp_listener_v6(port: u16, v6only: bool) -> io::Result<TcpListener> {
	let addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), port);
	let socket = socket2::Socket::new(socket2::Domain::IPV6, socket2::Type::STREAM, None)?;
	#[cfg(not(windows))]
	socket.set_reuse_address(true)?;
	socket.set_only_v6(v6only)?;
	socket.set_nonblocking(true)?;
	socket.bind(&addr.into())?;
	socket.listen(1024)?;

	let listener = std::net::TcpListener::from(socket);
	let listener = TcpListener::from_std(listener)?;
	Ok(listener)
}
```

## Solution

The `TcpSocket` interface already uses the socket2 library underneath so adding a couple of functions to retrieve and set the IPV6_V6ONLY option is absolutely trivial and allows code to setup a listener to be straightforward and to have less direct dependencies:

```rust
use std::net::{Ipv6Addr, SocketAddr};
use tokio::net::{TcpListener, TcpSocket};
fn tokio_tcp_listener_v6(port: u16, v6only: bool) -> io::Result<TcpListener> {
	let socket = TcpSocket::new_v6()?;
	socket.set_only_v6(v6only)?;
	socket.bind((Ipv6Addr::UNSPECIFIED, port).into())?;
	let listener = socket.listen(1024)?;
	Ok(listener)
}
```
