### PR TITLE
chore: rename docsrs to avoid conflicts (relates #6165)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,8 +28,8 @@ task:
 task:
   name: FreeBSD docs
   env:
-    RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
-    RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
+    RUSTFLAGS: --cfg tokio_docsrs --cfg tokio_unstable
+    RUSTDOCFLAGS: --cfg tokio_docsrs --cfg tokio_unstable -Dwarnings
   setup_script:
     - pkg install -y bash
     - curl https://sh.rustup.rs -sSf --output rustup.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,8 +743,8 @@ jobs:
         run: |
           cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable --cfg tokio_taskdump
-          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_docsrs --cfg tokio_unstable --cfg tokio_taskdump
+          RUSTDOCFLAGS: --cfg tokio_docsrs --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
 
   loom-compile:
     name: build loom tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ required for various parts of Tokio are missing. To build the documentation
 correctly, use this command:
 
 ```
-RUSTDOCFLAGS="--cfg docsrs" RUSTFLAGS="--cfg docsrs" cargo +nightly doc --all-features
+RUSTDOCFLAGS="--cfg tokio_docsrs" RUSTFLAGS="--cfg tokio_docsrs" cargo +nightly doc --all-features
 ```
 
 To build documentation including Tokio's unstable features, it is necessary to
@@ -165,7 +165,7 @@ pass `--cfg tokio_unstable` to both RustDoc *and* rustc. To build the
 documentation for unstable features, use this command:
 
 ```
-RUSTDOCFLAGS="--cfg docsrs --cfg tokio_unstable" RUSTFLAGS="--cfg docsrs --cfg tokio_unstable" cargo +nightly doc --all-features
+RUSTDOCFLAGS="--cfg tokio_docsrs --cfg tokio_unstable" RUSTFLAGS="--cfg tokio_docsrs --cfg tokio_unstable" cargo +nightly doc --all-features
 ```
 
 The `cargo fmt` command does not work on the Tokio codebase. You can use the

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,11 +6,11 @@
 
 [build.environment]
   RUSTDOCFLAGS="""
-    --cfg docsrs \
+    --cfg tokio_docsrs \
     --cfg tokio_unstable \
     --cfg tokio_taskdump \
     """
-  RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump --cfg docsrs"
+  RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump --cfg tokio_docsrs"
 
 [[redirects]]
   from = "/"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -50,9 +50,9 @@ futures = { version = "0.3", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "tokio_docsrs"]
 # Issue #3770
 #
-# This should allow `docsrs` to be read across projects, so that `tokio-stream`
-# can pick up stubbed types exported by `tokio`.
-rustc-args = ["--cfg", "docsrs"]
+# This should allow `tokio_docsrs` to be read across projects, so that
+# `tokio-stream` can pick up stubbed types exported by `tokio`.
+rustc-args = ["--cfg", "tokio_docsrs"]

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -9,7 +9,7 @@
     rust_2018_idioms,
     unreachable_pub
 )]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(tokio_docsrs, feature(doc_cfg))]
 #![doc(test(
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))

--- a/tokio-stream/src/macros.rs
+++ b/tokio-stream/src/macros.rs
@@ -2,7 +2,7 @@ macro_rules! cfg_fs {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "fs")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "fs")))]
             $item
         )*
     }
@@ -12,7 +12,7 @@ macro_rules! cfg_io_util {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "io-util")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
             $item
         )*
     }
@@ -22,7 +22,7 @@ macro_rules! cfg_net {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "net")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "net")))]
             $item
         )*
     }
@@ -32,7 +32,7 @@ macro_rules! cfg_time {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "time")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
             $item
         )*
     }
@@ -42,7 +42,7 @@ macro_rules! cfg_sync {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "sync")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "sync")))]
             $item
         )*
     }
@@ -52,7 +52,7 @@ macro_rules! cfg_signal {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "signal")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "signal")))]
             $item
         )*
     }

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -997,7 +997,7 @@ pub trait StreamExt: Stream {
     /// # }
     /// ```
     #[cfg(feature = "time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
     fn timeout(self, duration: Duration) -> Timeout<Self>
     where
         Self: Sized,
@@ -1085,7 +1085,7 @@ pub trait StreamExt: Stream {
     /// # }
     /// ```
     #[cfg(feature = "time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
     fn timeout_repeating(self, interval: Interval) -> TimeoutRepeating<Self>
     where
         Self: Sized,
@@ -1115,7 +1115,7 @@ pub trait StreamExt: Stream {
     /// # }
     /// ```
     #[cfg(feature = "time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
     fn throttle(self, duration: Duration) -> Throttle<Self>
     where
         Self: Sized,
@@ -1170,7 +1170,7 @@ pub trait StreamExt: Stream {
     /// }
     /// ```
     #[cfg(feature = "time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
     #[track_caller]
     fn chunks_timeout(self, max_size: usize, duration: Duration) -> ChunksTimeout<Self>
     where

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -27,9 +27,9 @@ cfg_signal! {
     #[cfg(unix)]
     pub use signal_unix::SignalStream;
 
-    #[cfg(any(windows, docsrs))]
+    #[cfg(any(windows, tokio_docsrs))]
     mod signal_windows;
-    #[cfg(any(windows, docsrs))]
+    #[cfg(any(windows, tokio_docsrs))]
     pub use signal_windows::{CtrlCStream, CtrlBreakStream};
 }
 

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -12,7 +12,7 @@ use std::task::{Context, Poll};
 ///
 /// [`tokio::sync::broadcast::Receiver`]: struct@tokio::sync::broadcast::Receiver
 /// [`Stream`]: trait@crate::Stream
-#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "sync")))]
 pub struct BroadcastStream<T> {
     inner: ReusableBoxFuture<'static, (Result<T, RecvError>, Receiver<T>)>,
 }

--- a/tokio-stream/src/wrappers/interval.rs
+++ b/tokio-stream/src/wrappers/interval.rs
@@ -8,7 +8,7 @@ use tokio::time::{Instant, Interval};
 /// [`Interval`]: struct@tokio::time::Interval
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
 pub struct IntervalStream {
     inner: Interval,
 }

--- a/tokio-stream/src/wrappers/lines.rs
+++ b/tokio-stream/src/wrappers/lines.rs
@@ -11,7 +11,7 @@ pin_project! {
     /// [`tokio::io::Lines`]: struct@tokio::io::Lines
     /// [`Stream`]: trait@crate::Stream
     #[derive(Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct LinesStream<R> {
         #[pin]
         inner: Lines<R>,

--- a/tokio-stream/src/wrappers/read_dir.rs
+++ b/tokio-stream/src/wrappers/read_dir.rs
@@ -9,7 +9,7 @@ use tokio::fs::{DirEntry, ReadDir};
 /// [`tokio::fs::ReadDir`]: struct@tokio::fs::ReadDir
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "fs")))]
 pub struct ReadDirStream {
     inner: ReadDir,
 }

--- a/tokio-stream/src/wrappers/signal_unix.rs
+++ b/tokio-stream/src/wrappers/signal_unix.rs
@@ -8,7 +8,7 @@ use tokio::signal::unix::Signal;
 /// [`Signal`]: struct@tokio::signal::unix::Signal
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "signal"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(unix, feature = "signal"))))]
 pub struct SignalStream {
     inner: Signal,
 }

--- a/tokio-stream/src/wrappers/signal_windows.rs
+++ b/tokio-stream/src/wrappers/signal_windows.rs
@@ -8,7 +8,7 @@ use tokio::signal::windows::{CtrlBreak, CtrlC};
 /// [`CtrlC`]: struct@tokio::signal::windows::CtrlC
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(windows, feature = "signal"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(windows, feature = "signal"))))]
 pub struct CtrlCStream {
     inner: CtrlC,
 }
@@ -50,7 +50,7 @@ impl AsMut<CtrlC> for CtrlCStream {
 /// [`CtrlBreak`]: struct@tokio::signal::windows::CtrlBreak
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(windows, feature = "signal"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(windows, feature = "signal"))))]
 pub struct CtrlBreakStream {
     inner: CtrlBreak,
 }

--- a/tokio-stream/src/wrappers/split.rs
+++ b/tokio-stream/src/wrappers/split.rs
@@ -11,7 +11,7 @@ pin_project! {
     /// [`tokio::io::Split`]: struct@tokio::io::Split
     /// [`Stream`]: trait@crate::Stream
     #[derive(Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct SplitStream<R> {
         #[pin]
         inner: Split<R>,

--- a/tokio-stream/src/wrappers/tcp_listener.rs
+++ b/tokio-stream/src/wrappers/tcp_listener.rs
@@ -9,7 +9,7 @@ use tokio::net::{TcpListener, TcpStream};
 /// [`TcpListener`]: struct@tokio::net::TcpListener
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "net")))]
 pub struct TcpListenerStream {
     inner: TcpListener,
 }

--- a/tokio-stream/src/wrappers/unix_listener.rs
+++ b/tokio-stream/src/wrappers/unix_listener.rs
@@ -9,7 +9,7 @@ use tokio::net::{UnixListener, UnixStream};
 /// [`UnixListener`]: struct@tokio::net::UnixListener
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(unix, feature = "net"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(unix, feature = "net"))))]
 pub struct UnixListenerStream {
     inner: UnixListener,
 }

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -70,7 +70,7 @@ use tokio::sync::watch::error::RecvError;
 ///
 /// [`tokio::sync::watch::Receiver`]: struct@tokio::sync::watch::Receiver
 /// [`Stream`]: trait@crate::Stream
-#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "sync")))]
 pub struct WatchStream<T> {
     inner: ReusableBoxFuture<'static, (Result<(), RecvError>, Receiver<T>)>,
 }

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -61,7 +61,7 @@ tempfile = "3.1.0"
 [package.metadata.docs.rs]
 all-features = true
 # enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
+rustdoc-args = ["--cfg", "tokio_docsrs", "--cfg", "tokio_unstable"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` to rustc, or else
 # dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
+rustc-args = ["--cfg", "tokio_docsrs", "--cfg", "tokio_unstable"]

--- a/tokio-util/src/cfg.rs
+++ b/tokio-util/src/cfg.rs
@@ -2,7 +2,7 @@ macro_rules! cfg_codec {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "codec")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "codec")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "codec")))]
             $item
         )*
     }
@@ -12,7 +12,7 @@ macro_rules! cfg_compat {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "compat")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "compat")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "compat")))]
             $item
         )*
     }
@@ -22,7 +22,7 @@ macro_rules! cfg_net {
     ($($item:item)*) => {
         $(
             #[cfg(all(feature = "net", feature = "codec"))]
-            #[cfg_attr(docsrs, doc(cfg(all(feature = "net", feature = "codec"))))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(all(feature = "net", feature = "codec"))))]
             $item
         )*
     }
@@ -32,7 +32,7 @@ macro_rules! cfg_io {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "io")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "io")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io")))]
             $item
         )*
     }
@@ -43,7 +43,7 @@ cfg_io! {
         ($($item:item)*) => {
             $(
                 #[cfg(feature = "io-util")]
-                #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+                #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
                 $item
             )*
         }
@@ -54,7 +54,7 @@ macro_rules! cfg_rt {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "rt")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }
@@ -64,7 +64,7 @@ macro_rules! cfg_time {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "time")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
             $item
         )*
     }

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -9,7 +9,7 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(tokio_docsrs, feature(doc_cfg))]
 
 //! Utilities for working with Tokio.
 //!

--- a/tokio-util/src/task/join_map.rs
+++ b/tokio-util/src/task/join_map.rs
@@ -100,7 +100,7 @@ use tokio::task::{AbortHandle, Id, JoinError, JoinSet, LocalSet};
 /// [abort]: fn@Self::abort
 /// [abort_matching]: fn@Self::abort_matching
 /// [contains]: fn@Self::contains_key
-#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 pub struct JoinMap<K, V, S = RandomState> {
     /// A map of the [`AbortHandle`]s of the tasks spawned on this `JoinMap`,
     /// indexed by their keys and task IDs.

--- a/tokio-util/src/task/mod.rs
+++ b/tokio-util/src/task/mod.rs
@@ -8,7 +8,7 @@ mod spawn_pinned;
 pub use spawn_pinned::LocalPoolHandle;
 
 #[cfg(tokio_unstable)]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
 pub use join_map::{JoinMap, JoinMapKeys};
 
 pub mod task_tracker;

--- a/tokio-util/src/task/task_tracker.rs
+++ b/tokio-util/src/task/task_tracker.rs
@@ -372,7 +372,7 @@ impl TaskTracker {
     #[inline]
     #[track_caller]
     #[cfg(feature = "rt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn<F>(&self, task: F) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
@@ -387,7 +387,7 @@ impl TaskTracker {
     #[inline]
     #[track_caller]
     #[cfg(feature = "rt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn_on<F>(&self, task: F, handle: &Handle) -> JoinHandle<F::Output>
     where
         F: Future + Send + 'static,
@@ -404,7 +404,7 @@ impl TaskTracker {
     #[inline]
     #[track_caller]
     #[cfg(feature = "rt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn_local<F>(&self, task: F) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
@@ -421,7 +421,7 @@ impl TaskTracker {
     #[inline]
     #[track_caller]
     #[cfg(feature = "rt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn_local_on<F>(&self, task: F, local_set: &LocalSet) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
@@ -437,7 +437,7 @@ impl TaskTracker {
     #[track_caller]
     #[cfg(feature = "rt")]
     #[cfg(not(target_family = "wasm"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn_blocking<F, T>(&self, task: F) -> JoinHandle<T>
     where
         F: FnOnce() -> T,
@@ -459,7 +459,7 @@ impl TaskTracker {
     #[track_caller]
     #[cfg(feature = "rt")]
     #[cfg(not(target_family = "wasm"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn spawn_blocking_on<F, T>(&self, task: F, handle: &Handle) -> JoinHandle<T>
     where
         F: FnOnce() -> T,

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1465,7 +1465,7 @@ The following changes only apply when building with `--cfg tokio_unstable`
 
 ### Fixed
 
- - doc: fix non-doc builds with `--cfg docsrs` ([#4020])
+ - doc: fix non-doc builds with `--cfg tokio_docsrs` ([#4020])
  - io: flush eagerly in `io::copy` ([#4001])
  - runtime: a debug assert was sometimes triggered during shutdown ([#4005])
  - sync: use `spin_loop_hint` instead of `yield_now` in mpsc ([#4037])

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -157,7 +157,7 @@ loom = { version = "0.7", features = ["futures", "checkpoint"] }
 [package.metadata.docs.rs]
 all-features = true
 # enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]
+rustdoc-args = ["--cfg", "tokio_docsrs", "--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` and `--cfg tokio_taskdump`
 # to rustc, or else dependencies will not be enabled, and the docs build will fail.
 rustc-args = ["--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -1003,7 +1003,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     ///
     /// [`WouldBlock`]: std::io::ErrorKind::WouldBlock
     // Alias for old name in 0.x
-    #[cfg_attr(docsrs, doc(alias = "with_io"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "with_io"))]
     pub fn try_io<R>(
         &mut self,
         f: impl FnOnce(&'a AsyncFd<Inner>) -> io::Result<R>,

--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -67,7 +67,10 @@ impl Interest {
 
     /// Returns a `Interest` set representing priority completion interests.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(
+        tokio_docsrs,
+        doc(cfg(any(target_os = "linux", target_os = "android")))
+    )]
     pub const PRIORITY: Interest = Interest(PRIORITY);
 
     /// Returns true if the value includes readable interest.
@@ -145,7 +148,10 @@ impl Interest {
     /// assert!(both.is_priority());
     /// ```
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(
+        tokio_docsrs,
+        doc(cfg(any(target_os = "linux", target_os = "android")))
+    )]
     pub const fn is_priority(self) -> bool {
         self.0 & PRIORITY != 0
     }

--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -24,7 +24,7 @@ const ERROR: usize = 0b0010_0000;
 ///
 /// Specifies the readiness events the caller is interested in when awaiting on
 /// I/O resource readiness states.
-#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "net")))]
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Interest(usize);
 
@@ -67,7 +67,7 @@ impl Interest {
 
     /// Returns a `Interest` set representing priority completion interests.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub const PRIORITY: Interest = Interest(PRIORITY);
 
     /// Returns true if the value includes readable interest.
@@ -145,7 +145,7 @@ impl Interest {
     /// assert!(both.is_priority());
     /// ```
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub const fn is_priority(self) -> bool {
         self.0 & PRIORITY != 0
     }

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -271,7 +271,7 @@ impl<'a> ReadBuf<'a> {
 }
 
 #[cfg(feature = "io-util")]
-#[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
 unsafe impl<'a> bytes::BufMut for ReadBuf<'a> {
     fn remaining_mut(&self) -> usize {
         self.remaining()

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -38,7 +38,10 @@ impl Ready {
 
     /// Returns a `Ready` representing priority readiness.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(
+        tokio_docsrs,
+        doc(cfg(any(target_os = "linux", target_os = "android")))
+    )]
     pub const PRIORITY: Ready = Ready(PRIORITY);
 
     /// Returns a `Ready` representing error readiness.
@@ -186,7 +189,10 @@ impl Ready {
     /// assert!(Ready::PRIORITY.is_priority());
     /// ```
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(
+        tokio_docsrs,
+        doc(cfg(any(target_os = "linux", target_os = "android")))
+    )]
     pub fn is_priority(self) -> bool {
         self.contains(Ready::PRIORITY)
     }

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -16,7 +16,7 @@ const ERROR: usize = 0b10_0000;
 /// Describes the readiness state of an I/O resources.
 ///
 /// `Ready` tracks which operation an I/O resource is ready to perform.
-#[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "net")))]
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Ready(usize);
 
@@ -38,7 +38,7 @@ impl Ready {
 
     /// Returns a `Ready` representing priority readiness.
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub const PRIORITY: Ready = Ready(PRIORITY);
 
     /// Returns a `Ready` representing error readiness.
@@ -186,7 +186,7 @@ impl Ready {
     /// assert!(Ready::PRIORITY.is_priority());
     /// ```
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub fn is_priority(self) -> bool {
         self.contains(Ready::PRIORITY)
     }

--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -23,7 +23,7 @@ pin_project! {
     /// When the `BufReader` is dropped, the contents of its buffer will be
     /// discarded. Creating multiple instances of a `BufReader` on the same
     /// stream can cause data loss.
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct BufReader<R> {
         #[pin]
         pub(super) inner: R,

--- a/tokio/src/io/util/buf_stream.rs
+++ b/tokio/src/io/util/buf_stream.rs
@@ -15,7 +15,7 @@ pin_project! {
     /// types aid with these problems respectively, but do so in only one direction. `BufStream` wraps
     /// one in the other so that both directions are buffered. See their documentation for details.
     #[derive(Debug)]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct BufStream<RW> {
         #[pin]
         inner: BufReader<BufWriter<RW>>,

--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -28,7 +28,7 @@ pin_project! {
     /// [`AsyncWrite`]: AsyncWrite
     /// [`flush`]: super::AsyncWriteExt::flush
     ///
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct BufWriter<W> {
         #[pin]
         pub(super) inner: W,

--- a/tokio/src/io/util/chain.rs
+++ b/tokio/src/io/util/chain.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 pin_project! {
     /// Stream for the [`chain`](super::AsyncReadExt::chain) method.
     #[must_use = "streams do nothing unless polled"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct Chain<T, U> {
         #[pin]
         first: T,

--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -68,7 +68,7 @@ where
 /// # Return value
 ///
 /// Returns a tuple of bytes copied `a` to `b` and bytes copied `b` to `a`.
-#[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
 pub async fn copy_bidirectional<A, B>(a: &mut A, b: &mut B) -> Result<(u64, u64), std::io::Error>
 where
     A: AsyncRead + AsyncWrite + Unpin + ?Sized,

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -19,7 +19,7 @@ pin_project! {
     /// [`lines`]: crate::io::AsyncBufReadExt::lines
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct Lines<R> {
         #[pin]
         reader: R,

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -45,7 +45,7 @@ use std::{
 /// # }
 /// ```
 #[derive(Debug)]
-#[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
 pub struct DuplexStream {
     read: Arc<Mutex<Pipe>>,
     write: Arc<Mutex<Pipe>>,
@@ -81,7 +81,7 @@ struct Pipe {
 ///
 /// The `max_buf_size` argument is the maximum amount of bytes that can be
 /// written to a side before the write returns `Poll::Pending`.
-#[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
 pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
     let one = Arc::new(Mutex::new(Pipe::new(max_buf_size)));
     let two = Arc::new(Mutex::new(Pipe::new(max_buf_size)));

--- a/tokio/src/io/util/split.rs
+++ b/tokio/src/io/util/split.rs
@@ -15,7 +15,7 @@ pin_project! {
     /// [`SplitStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.SplitStream.html
     #[derive(Debug)]
     #[must_use = "streams do nothing unless polled"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct Split<R> {
         #[pin]
         reader: R,

--- a/tokio/src/io/util/take.rs
+++ b/tokio/src/io/util/take.rs
@@ -10,7 +10,7 @@ pin_project! {
     /// Stream for the [`take`](super::AsyncReadExt::take) method.
     #[derive(Debug)]
     #[must_use = "streams do nothing unless you `.await` or poll them"]
-    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
     pub struct Take<R> {
         #[pin]
         inner: R,

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -16,8 +16,8 @@
     no_crate_inject,
     attr(deny(warnings, rust_2018_idioms), allow(dead_code, unused_variables))
 ))]
-#![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, allow(unused_attributes))]
+#![cfg_attr(tokio_docsrs, feature(doc_cfg))]
+#![cfg_attr(tokio_docsrs, allow(unused_attributes))]
 #![cfg_attr(loom, allow(dead_code, unreachable_pub))]
 
 //! A runtime for writing reliable network applications without compromising speed.
@@ -628,14 +628,14 @@ pub mod stream {}
 // local re-exports of platform specific things, allowing for decent
 // documentation to be shimmed in on docs.rs
 
-#[cfg(docsrs)]
+#[cfg(tokio_docsrs)]
 pub mod doc;
 
-#[cfg(docsrs)]
+#[cfg(tokio_docsrs)]
 #[allow(unused)]
 pub(crate) use self::doc::os;
 
-#[cfg(not(docsrs))]
+#[cfg(not(tokio_docsrs))]
 #[allow(unused)]
 pub(crate) use std::os;
 
@@ -655,12 +655,12 @@ cfg_macros! {
     cfg_rt! {
         #[cfg(feature = "rt-multi-thread")]
         #[cfg(not(test))] // Work around for rust-lang/rust#62127
-        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
         #[doc(inline)]
         pub use tokio_macros::main;
 
         #[cfg(feature = "rt-multi-thread")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+        #[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
         #[doc(inline)]
         pub use tokio_macros::test;
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -7,7 +7,7 @@ macro_rules! feature {
     ) => {
         $(
             #[cfg($meta)]
-            #[cfg_attr(docsrs, doc(cfg($meta)))]
+            #[cfg_attr(tokio_docsrs, doc(cfg($meta)))]
             $item
         )*
     }
@@ -18,8 +18,8 @@ macro_rules! feature {
 macro_rules! cfg_windows {
     ($($item:item)*) => {
         $(
-            #[cfg(any(all(doc, docsrs), windows))]
-            #[cfg_attr(docsrs, doc(cfg(windows)))]
+            #[cfg(any(all(doc, tokio_docsrs), windows))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(windows)))]
             $item
         )*
     }
@@ -30,8 +30,8 @@ macro_rules! cfg_windows {
 macro_rules! cfg_unstable_windows {
     ($($item:item)*) => {
         $(
-            #[cfg(all(any(all(doc, docsrs), windows), tokio_unstable))]
-            #[cfg_attr(docsrs, doc(cfg(all(windows, tokio_unstable))))]
+            #[cfg(all(any(all(doc, tokio_docsrs), windows), tokio_unstable))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(all(windows, tokio_unstable))))]
             $item
         )*
     }
@@ -72,8 +72,8 @@ macro_rules! cfg_atomic_waker_impl {
 macro_rules! cfg_aio {
     ($($item:item)*) => {
         $(
-            #[cfg(all(any(docsrs, target_os = "freebsd"), feature = "net"))]
-            #[cfg_attr(docsrs,
+            #[cfg(all(any(tokio_docsrs, target_os = "freebsd"), feature = "net"))]
+            #[cfg_attr(tokio_docsrs,
                 doc(cfg(all(target_os = "freebsd", feature = "net")))
             )]
             $item
@@ -86,7 +86,7 @@ macro_rules! cfg_fs {
         $(
             #[cfg(feature = "fs")]
             #[cfg(not(target_os = "wasi"))]
-            #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "fs")))]
             $item
         )*
     }
@@ -110,7 +110,7 @@ macro_rules! cfg_io_driver {
                 all(unix, feature = "process"),
                 all(unix, feature = "signal"),
             ))]
-            #[cfg_attr(docsrs, doc(cfg(any(
+            #[cfg_attr(tokio_docsrs, doc(cfg(any(
                 feature = "net",
                 all(unix, feature = "process"),
                 all(unix, feature = "signal"),
@@ -159,7 +159,7 @@ macro_rules! cfg_io_std {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "io-std")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "io-std")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-std")))]
             $item
         )*
     }
@@ -169,7 +169,7 @@ macro_rules! cfg_io_util {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "io-util")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "io-util")))]
             $item
         )*
     }
@@ -197,7 +197,7 @@ macro_rules! cfg_macros {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "macros")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
             $item
         )*
     }
@@ -209,7 +209,7 @@ macro_rules! cfg_metrics {
             // For now, metrics is only disabled in loom tests.
             // When stabilized, it might have a dedicated feature flag.
             #[cfg(all(tokio_unstable, not(loom)))]
-            #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
             $item
         )*
     }
@@ -234,7 +234,7 @@ macro_rules! cfg_net_or_process {
     ($($item:item)*) => {
         $(
             #[cfg(any(feature = "net", feature = "process"))]
-            #[cfg_attr(docsrs, doc(cfg(any(feature = "net", feature = "process"))))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(any(feature = "net", feature = "process"))))]
             $item
         )*
     }
@@ -244,7 +244,7 @@ macro_rules! cfg_net {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "net")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "net")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "net")))]
             $item
         )*
     }
@@ -254,7 +254,7 @@ macro_rules! cfg_net_unix {
     ($($item:item)*) => {
         $(
             #[cfg(all(unix, feature = "net"))]
-            #[cfg_attr(docsrs, doc(cfg(all(unix, feature = "net"))))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(all(unix, feature = "net"))))]
             $item
         )*
     }
@@ -263,8 +263,8 @@ macro_rules! cfg_net_unix {
 macro_rules! cfg_net_windows {
     ($($item:item)*) => {
         $(
-            #[cfg(all(any(all(doc, docsrs), windows), feature = "net"))]
-            #[cfg_attr(docsrs, doc(cfg(all(windows, feature = "net"))))]
+            #[cfg(all(any(all(doc, tokio_docsrs), windows), feature = "net"))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(all(windows, feature = "net"))))]
             $item
         )*
     }
@@ -274,7 +274,7 @@ macro_rules! cfg_process {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "process")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "process")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "process")))]
             #[cfg(not(loom))]
             #[cfg(not(target_os = "wasi"))]
             $item
@@ -303,7 +303,7 @@ macro_rules! cfg_signal {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "signal")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "signal")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "signal")))]
             #[cfg(not(loom))]
             #[cfg(not(target_os = "wasi"))]
             $item
@@ -341,7 +341,7 @@ macro_rules! cfg_sync {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "sync")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "sync")))]
             $item
         )*
     }
@@ -357,7 +357,7 @@ macro_rules! cfg_rt {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "rt")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
             $item
         )*
     }
@@ -373,7 +373,7 @@ macro_rules! cfg_rt_multi_thread {
     ($($item:item)*) => {
         $(
             #[cfg(all(feature = "rt-multi-thread", not(target_os = "wasi")))]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt-multi-thread")))]
             $item
         )*
     }
@@ -427,7 +427,7 @@ macro_rules! cfg_test_util {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "test-util")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "test-util")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "test-util")))]
             $item
         )*
     }
@@ -443,7 +443,7 @@ macro_rules! cfg_time {
     ($($item:item)*) => {
         $(
             #[cfg(feature = "time")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
             $item
         )*
     }
@@ -459,7 +459,7 @@ macro_rules! cfg_trace {
     ($($item:item)*) => {
         $(
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
             $item
         )*
     };
@@ -469,7 +469,7 @@ macro_rules! cfg_unstable {
     ($($item:item)*) => {
         $(
             #[cfg(tokio_unstable)]
-            #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
             $item
         )*
     };

--- a/tokio/src/macros/join.rs
+++ b/tokio/src/macros/join.rs
@@ -53,7 +53,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
 macro_rules! join {
     (@ {
         // One `_` for each branch in the `join!` macro. This is not used once

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -397,7 +397,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
 macro_rules! select {
     // Uses a declarative macro to do **most** of the work. While it is possible
     // to implement fully with a declarative macro, a procedural macro is used

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -99,7 +99,7 @@
 /// }
 /// ```
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "macros")))]
 macro_rules! try_join {
     (@ {
         // One `_` for each branch in the `try_join!` macro. This is not used once

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -84,7 +84,7 @@ cfg_net! {
     /// [`AsRawFd`]: https://doc.rust-lang.org/std/os/unix/io/trait.AsRawFd.html
     /// [`AsRawSocket`]: https://doc.rust-lang.org/std/os/windows/io/trait.AsRawSocket.html
     /// [`socket2`]: https://docs.rs/socket2/
-    #[cfg_attr(docsrs, doc(alias = "connect_std"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "connect_std"))]
     pub struct TcpSocket {
         inner: socket2::Socket,
     }
@@ -268,7 +268,7 @@ impl TcpSocket {
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos"))))
     )]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
@@ -303,7 +303,7 @@ impl TcpSocket {
     /// ```
     #[cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos")))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(all(unix, not(target_os = "solaris"), not(target_os = "illumos"))))
     )]
     pub fn reuseport(&self) -> io::Result<bool> {
@@ -461,7 +461,7 @@ impl TcpSocket {
         target_os = "illumos",
     )))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(not(any(
             target_os = "fuchsia",
             target_os = "redox",
@@ -488,7 +488,7 @@ impl TcpSocket {
         target_os = "illumos",
     )))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(not(any(
             target_os = "fuchsia",
             target_os = "redox",
@@ -505,7 +505,7 @@ impl TcpSocket {
     /// This value gets the socket binded device's interface name.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",)))
     )]
     pub fn device(&self) -> io::Result<Option<Vec<u8>>> {
@@ -521,7 +521,7 @@ impl TcpSocket {
     /// If `interface` is `None` or an empty string it removes the binding.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(all(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))
     )]
     pub fn bind_device(&self, interface: Option<&[u8]>) -> io::Result<()> {

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1863,7 +1863,7 @@ impl UdpSocket {
         target_os = "illumos",
     )))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(not(any(
             target_os = "fuchsia",
             target_os = "redox",
@@ -1890,7 +1890,7 @@ impl UdpSocket {
         target_os = "illumos",
     )))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(not(any(
             target_os = "fuchsia",
             target_os = "redox",
@@ -1907,7 +1907,7 @@ impl UdpSocket {
     /// This value gets the socket-bound device's interface name.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux",)))
     )]
     pub fn device(&self) -> io::Result<Option<Vec<u8>>> {
@@ -1923,7 +1923,7 @@ impl UdpSocket {
     /// If `interface` is `None` or an empty string it removes the binding.
     #[cfg(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))]
     #[cfg_attr(
-        docsrs,
+        tokio_docsrs,
         doc(cfg(all(any(target_os = "android", target_os = "fuchsia", target_os = "linux"))))
     )]
     pub fn bind_device(&self, interface: Option<&[u8]>) -> io::Result<()> {

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -89,7 +89,7 @@ cfg_net_unix! {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg_attr(docsrs, doc(alias = "uds"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "uds"))]
     pub struct UnixDatagram {
         io: PollEvented<mio::net::UnixDatagram>,
     }

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -43,7 +43,7 @@ cfg_net_unix! {
     ///     }
     /// }
     /// ```
-    #[cfg_attr(docsrs, doc(alias = "uds"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "uds"))]
     pub struct UnixListener {
         io: PollEvented<mio::net::UnixListener>,
     }

--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -116,7 +116,7 @@ impl OpenOptions {
     ///     .open_receiver("path/to/a/fifo");
     /// ```
     #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(target_os = "linux")))]
     pub fn read_write(&mut self, value: bool) -> &mut Self {
         self.read_write = value;
         self

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -32,7 +32,7 @@ cfg_net_unix! {
     ///
     /// [`shutdown()`]: fn@crate::io::AsyncWriteExt::shutdown
     /// [`UnixListener::accept`]: crate::net::UnixListener::accept
-    #[cfg_attr(docsrs, doc(alias = "uds"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "uds"))]
     pub struct UnixStream {
         io: PollEvented<mio::net::UnixStream>,
     }

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -17,7 +17,7 @@ cfg_io_util! {
 }
 
 // Hide imports which are not used when generating documentation.
-#[cfg(not(docsrs))]
+#[cfg(not(tokio_docsrs))]
 mod doc {
     pub(super) use crate::os::windows::ffi::OsStrExt;
     pub(super) mod windows_sys {
@@ -30,7 +30,7 @@ mod doc {
 }
 
 // NB: none of these shows up in public API, so don't document them.
-#[cfg(docsrs)]
+#[cfg(tokio_docsrs)]
 mod doc {
     pub(super) mod mio_windows {
         pub type NamedPipe = crate::doc::NotDefinedHere;

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -670,7 +670,7 @@ impl Command {
     /// `setuid` call in the child process. Failure in the `setuid`
     /// call will cause the spawn to fail.
     #[cfg(unix)]
-    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(unix)))]
     pub fn uid(&mut self, id: u32) -> &mut Command {
         self.std.uid(id);
         self
@@ -679,7 +679,7 @@ impl Command {
     /// Similar to `uid` but sets the group ID of the child process. This has
     /// the same semantics as the `uid` field.
     #[cfg(unix)]
-    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(unix)))]
     pub fn gid(&mut self, id: u32) -> &mut Command {
         self.std.gid(id);
         self
@@ -690,7 +690,7 @@ impl Command {
     /// Set the first process argument, `argv[0]`, to something other than the
     /// default executable path.
     #[cfg(unix)]
-    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(unix)))]
     pub fn arg0<S>(&mut self, arg: S) -> &mut Command
     where
         S: AsRef<OsStr>,
@@ -729,7 +729,7 @@ impl Command {
     /// working directory have successfully been changed, so output to these
     /// locations may not appear where intended.
     #[cfg(unix)]
-    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(unix)))]
     pub unsafe fn pre_exec<F>(&mut self, f: F) -> &mut Command
     where
         F: FnMut() -> io::Result<()> + Send + Sync + 'static,
@@ -765,7 +765,7 @@ impl Command {
     /// ```
     #[cfg(unix)]
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, tokio_unstable))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(all(unix, tokio_unstable))))]
     pub fn process_group(&mut self, pgroup: i32) -> &mut Command {
         self.std.process_group(pgroup);
         self
@@ -1445,7 +1445,7 @@ impl TryInto<Stdio> for ChildStderr {
 }
 
 #[cfg(unix)]
-#[cfg_attr(docsrs, doc(cfg(unix)))]
+#[cfg_attr(tokio_docsrs, doc(cfg(unix)))]
 mod sys {
     use std::{
         io,
@@ -1482,13 +1482,13 @@ mod sys {
     impl_traits!(ChildStderr);
 }
 
-#[cfg(any(windows, docsrs))]
-#[cfg_attr(docsrs, doc(cfg(windows)))]
+#[cfg(any(windows, tokio_docsrs))]
+#[cfg_attr(tokio_docsrs, doc(cfg(windows)))]
 mod windows {
     use super::*;
     use crate::os::windows::io::{AsHandle, AsRawHandle, BorrowedHandle, OwnedHandle, RawHandle};
 
-    #[cfg(not(docsrs))]
+    #[cfg(not(tokio_docsrs))]
     macro_rules! impl_traits {
         ($type:ty) => {
             impl $type {
@@ -1512,7 +1512,7 @@ mod windows {
         };
     }
 
-    #[cfg(docsrs)]
+    #[cfg(tokio_docsrs)]
     macro_rules! impl_traits {
         ($type:ty) => {
             impl $type {

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -229,7 +229,7 @@ impl Builder {
         ///
         /// Configuration methods can be chained on the return value.
         #[cfg(feature = "rt-multi-thread")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+        #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt-multi-thread")))]
         pub fn new_multi_thread() -> Builder {
             // The number `61` is fairly arbitrary. I believe this value was copied from golang.
             Builder::new(Kind::MultiThread, 61)
@@ -248,7 +248,7 @@ impl Builder {
             ///
             /// Configuration methods can be chained on the return value.
             #[cfg(feature = "rt-multi-thread")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+            #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt-multi-thread")))]
             pub fn new_multi_thread_alt() -> Builder {
                 // The number `61` is fairly arbitrary. I believe this value was copied from golang.
                 Builder::new(Kind::MultiThreadAlt, 61)
@@ -436,7 +436,7 @@ impl Builder {
     /// [`worker_threads`]: Self::worker_threads
     /// [`thread_keep_alive`]: Self::thread_keep_alive
     #[track_caller]
-    #[cfg_attr(docsrs, doc(alias = "max_threads"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "max_threads"))]
     pub fn max_blocking_threads(&mut self, val: usize) -> &mut Self {
         assert!(val > 0, "Max blocking threads cannot be set to 0");
         self.max_blocking_threads = val;

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -176,7 +176,7 @@ impl Runtime {
         /// [threaded scheduler]: index.html#threaded-scheduler
         /// [runtime builder]: crate::runtime::Builder
         #[cfg(feature = "rt-multi-thread")]
-        #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+        #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt-multi-thread")))]
         pub fn new() -> std::io::Result<Runtime> {
             Builder::new_multi_thread().enable_all().build()
         }

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -12,7 +12,7 @@ use std::panic::{RefUnwindSafe, UnwindSafe};
 /// --- it does *not* abort the task.
 ///
 /// [`JoinHandle`]: crate::task::JoinHandle
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 pub struct AbortHandle {
     raw: RawTask,
 }
@@ -58,7 +58,7 @@ impl AbortHandle {
     /// [task ID]: crate::task::Id
     /// [unstable]: crate#unstable-features
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> super::Id {
         // Safety: The header pointer is valid.
         unsafe { Header::get_id(self.raw.header_ptr()) }

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -126,7 +126,7 @@ impl JoinError {
     /// [task ID]: crate::task::Id
     /// [unstable]: crate#unstable-features
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> Id {
         self.id
     }

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -21,7 +21,7 @@ use std::fmt;
 /// features][unstable] for details.
 ///
 /// [unstable]: crate#unstable-features
-#[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct Id(u64);

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -300,7 +300,7 @@ impl<T> JoinHandle<T> {
     /// [task ID]: crate::task::Id
     /// [unstable]: crate#unstable-features
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
     pub fn id(&self) -> super::Id {
         // Safety: The header pointer is valid.
         unsafe { Header::get_id(self.raw.header_ptr()) }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -4,7 +4,7 @@
 //! `Signal` type for receiving notifications of signals.
 
 #![cfg(unix)]
-#![cfg_attr(docsrs, doc(cfg(all(unix, feature = "signal"))))]
+#![cfg_attr(tokio_docsrs, doc(cfg(all(unix, feature = "signal"))))]
 
 use crate::runtime::scheduler;
 use crate::runtime::signal::Handle;

--- a/tokio/src/signal/windows.rs
+++ b/tokio/src/signal/windows.rs
@@ -5,20 +5,20 @@
 //! notifications. These events are listened for via the `SetConsoleCtrlHandler`
 //! function which receives the corresponding windows_sys event type.
 
-#![cfg(any(windows, docsrs))]
-#![cfg_attr(docsrs, doc(cfg(all(windows, feature = "signal"))))]
+#![cfg(any(windows, tokio_docsrs))]
+#![cfg_attr(tokio_docsrs, doc(cfg(all(windows, feature = "signal"))))]
 
 use crate::signal::RxFuture;
 use std::io;
 use std::task::{Context, Poll};
 
-#[cfg(not(docsrs))]
+#[cfg(not(tokio_docsrs))]
 #[path = "windows/sys.rs"]
 mod imp;
-#[cfg(not(docsrs))]
+#[cfg(not(tokio_docsrs))]
 pub(crate) use self::imp::{OsExtraData, OsStorage};
 
-#[cfg(docsrs)]
+#[cfg(tokio_docsrs)]
 #[path = "windows/stub.rs"]
 mod imp;
 

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -402,7 +402,7 @@ impl<T> Receiver<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
-    #[cfg_attr(docsrs, doc(alias = "recv_blocking"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "recv_blocking"))]
     pub fn blocking_recv(&mut self) -> Option<T> {
         crate::future::block_on(self.recv())
     }
@@ -722,7 +722,7 @@ impl<T> Sender<T> {
     /// }
     /// ```
     #[cfg(feature = "time")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "time")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "time")))]
     pub async fn send_timeout(
         &self,
         value: T,
@@ -777,7 +777,7 @@ impl<T> Sender<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
-    #[cfg_attr(docsrs, doc(alias = "send_blocking"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "send_blocking"))]
     pub fn blocking_send(&self, value: T) -> Result<(), SendError<T>> {
         crate::future::block_on(self.send(value))
     }

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -314,7 +314,7 @@ impl<T> UnboundedReceiver<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
-    #[cfg_attr(docsrs, doc(alias = "recv_blocking"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "recv_blocking"))]
     pub fn blocking_recv(&mut self) -> Option<T> {
         crate::future::block_on(self.recv())
     }

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -506,7 +506,7 @@ impl<T: ?Sized> Mutex<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
-    #[cfg_attr(docsrs, doc(alias = "lock_blocking"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "lock_blocking"))]
     pub fn blocking_lock(&self) -> MutexGuard<'_, T> {
         crate::future::block_on(self.lock())
     }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -556,7 +556,7 @@ impl Notify {
     /// }
     /// ```
     // Alias for old name in 0.x
-    #[cfg_attr(docsrs, doc(alias = "notify"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "notify"))]
     pub fn notify_one(&self) {
         // Load the current state
         let mut curr = self.state.load(SeqCst);

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1063,7 +1063,7 @@ impl<T> Receiver<T> {
     /// ```
     #[track_caller]
     #[cfg(feature = "sync")]
-    #[cfg_attr(docsrs, doc(alias = "recv_blocking"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "recv_blocking"))]
     pub fn blocking_recv(self) -> Result<T, RecvError> {
         crate::future::block_on(self)
     }

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -58,7 +58,7 @@ use std::{future::Future, io};
 /// [`spawn`]: Builder::spawn
 /// [`spawn_blocking`]: Builder::spawn_blocking
 #[derive(Default, Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
 pub struct Builder<'a> {
     name: Option<&'a str>,
 }

--- a/tokio/src/task/consume_budget.rs
+++ b/tokio/src/task/consume_budget.rs
@@ -28,7 +28,7 @@ use std::task::Poll;
 /// }
 /// ```
 /// [unstable]: crate#unstable-features
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
 pub async fn consume_budget() {
     let mut status = Poll::Pending;
 

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -51,7 +51,7 @@ use crate::util::IdleNotifiedSet;
 ///     }
 /// }
 /// ```
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 pub struct JoinSet<T> {
     inner: IdleNotifiedSet<JoinHandle<T>>,
 }
@@ -61,7 +61,7 @@ pub struct JoinSet<T> {
 ///
 /// [`task::Builder`]: crate::task::Builder
 #[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
 #[must_use = "builders do nothing unless used to spawn a task"]
 pub struct Builder<'a, T> {
     joinset: &'a mut JoinSet<T>,
@@ -109,7 +109,7 @@ impl<T: 'static> JoinSet<T> {
     /// }
     /// ```
     #[cfg(all(tokio_unstable, feature = "tracing"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
     pub fn build_task(&mut self) -> Builder<'_, T> {
         Builder {
             builder: super::Builder::new(),
@@ -301,7 +301,7 @@ impl<T: 'static> JoinSet<T> {
     /// [task ID]: crate::task::Id
     /// [`JoinError::id`]: fn@crate::task::JoinError::id
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
     pub async fn join_next_with_id(&mut self) -> Option<Result<(Id, T), JoinError>> {
         crate::future::poll_fn(|cx| self.poll_join_next_with_id(cx)).await
     }
@@ -419,7 +419,7 @@ impl<T: 'static> JoinSet<T> {
     /// [coop budget]: crate::task#cooperative-scheduling
     /// [task ID]: crate::task::Id
     #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(tokio_unstable)))]
     pub fn poll_join_next_with_id(
         &mut self,
         cx: &mut Context<'_>,
@@ -476,7 +476,7 @@ impl<T> Default for JoinSet<T> {
 // === impl Builder ===
 
 #[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
 impl<'a, T: 'static> Builder<'a, T> {
     /// Assigns a name to the task which will be spawned.
     pub fn name(self, name: &'a str) -> Self {
@@ -573,7 +573,7 @@ impl<'a, T: 'static> Builder<'a, T> {
 // Manual `Debug` impl so that `Builder` is `Debug` regardless of whether `T` is
 // `Debug`.
 #[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg_attr(tokio_docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
 impl<'a, T> fmt::Debug for Builder<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("join_set::Builder")

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -584,7 +584,7 @@ impl LocalSet {
     /// [`spawn_blocking`]: fn@crate::task::spawn_blocking
     #[track_caller]
     #[cfg(feature = "rt")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     pub fn block_on<F>(&self, rt: &crate::runtime::Runtime, future: F) -> F::Output
     where
         F: Future,

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -311,7 +311,7 @@ cfg_rt! {
     pub use join_set::JoinSet;
     pub use crate::runtime::task::AbortHandle;
 
-    // Uses #[cfg(...)] instead of macro since the macro adds docsrs annotations.
+    // Uses #[cfg(...)] instead of macro since the macro adds tokio_docsrs annotations.
     #[cfg(not(tokio_unstable))]
     mod join_set;
     #[cfg(tokio_unstable)]

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -32,7 +32,7 @@ use std::{fmt, mem, thread};
 ///
 /// [`tokio::task::LocalKey`]: struct@crate::task::LocalKey
 #[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 macro_rules! task_local {
      // empty (base case for the recursion)
     () => {};
@@ -95,7 +95,7 @@ macro_rules! __task_local_inner {
 ///
 /// [`std::thread::LocalKey`]: struct@std::thread::LocalKey
 /// [`task_local!`]: ../macro.task_local.html
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 pub struct LocalKey<T: 'static> {
     #[doc(hidden)]
     pub inner: thread::LocalKey<RefCell<Option<T>>>,

--- a/tokio/src/task/unconstrained.rs
+++ b/tokio/src/task/unconstrained.rs
@@ -5,7 +5,7 @@ use std::task::{Context, Poll};
 
 pin_project! {
     /// Future for the [`unconstrained`](unconstrained) method.
-    #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+    #[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
     #[must_use = "Unconstrained does nothing unless polled"]
     pub struct Unconstrained<F> {
         #[pin]
@@ -39,7 +39,7 @@ where
 /// otherwise.
 ///
 /// See also the usage example in the [task module](index.html#unconstrained).
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 pub fn unconstrained<F>(inner: F) -> Unconstrained<F> {
     Unconstrained { inner }
 }

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -35,7 +35,7 @@ use std::task::{Context, Poll};
 /// which order the runtime polls your tasks in.
 ///
 /// [`tokio::select!`]: macro@crate::select
-#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+#[cfg_attr(tokio_docsrs, doc(cfg(feature = "rt")))]
 pub async fn yield_now() {
     /// Yield implementation
     struct YieldNow {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -57,7 +57,7 @@ use std::task::{self, Poll};
 /// [`Builder::enable_time`]: crate::runtime::Builder::enable_time
 /// [`Builder::enable_all`]: crate::runtime::Builder::enable_all
 // Alias for old name in 0.x
-#[cfg_attr(docsrs, doc(alias = "delay_until"))]
+#[cfg_attr(tokio_docsrs, doc(alias = "delay_until"))]
 #[track_caller]
 pub fn sleep_until(deadline: Instant) -> Sleep {
     Sleep::new_timeout(deadline, trace::caller_location())
@@ -119,8 +119,8 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 /// [`Builder::enable_time`]: crate::runtime::Builder::enable_time
 /// [`Builder::enable_all`]: crate::runtime::Builder::enable_all
 // Alias for old name in 0.x
-#[cfg_attr(docsrs, doc(alias = "delay_for"))]
-#[cfg_attr(docsrs, doc(alias = "wait"))]
+#[cfg_attr(tokio_docsrs, doc(alias = "delay_for"))]
+#[cfg_attr(tokio_docsrs, doc(alias = "wait"))]
 #[track_caller]
 pub fn sleep(duration: Duration) -> Sleep {
     let location = trace::caller_location();
@@ -221,7 +221,7 @@ pin_project! {
     /// [`tokio::pin!`]: ../macro.pin.html
     #[project(!Unpin)]
     // Alias for old name in 0.2
-    #[cfg_attr(docsrs, doc(alias = "Delay"))]
+    #[cfg_attr(tokio_docsrs, doc(alias = "Delay"))]
     #[derive(Debug)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct Sleep {


### PR DESCRIPTION
Since `docsrs` is such a popular cfg item in the ecosystem it might be worthwhile to try and avoid accidental activation like with #6165