### PR TITLE
Add Apple watchOS support

### DIFF
--- a/tokio-util/tests/udp.rs
+++ b/tokio-util/tests/udp.rs
@@ -14,7 +14,12 @@ use std::io;
 use std::sync::Arc;
 
 #[cfg_attr(
-    any(target_os = "macos", target_os = "ios", target_os = "tvos"),
+    any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    ),
     allow(unused_assignments)
 )]
 #[tokio::test]
@@ -44,7 +49,12 @@ async fn send_framed_byte_codec() -> std::io::Result<()> {
         b_soc = b.into_inner();
     }
 
-    #[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "tvos")))]
+    #[cfg(not(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "tvos",
+        target_os = "watchos"
+    )))]
     // test sending & receiving an empty message
     {
         let mut a = UdpFramed::new(a_soc, ByteCodec);

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -45,7 +45,12 @@ pub(crate) use self::impl_netbsd::get_peer_cred;
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 pub(crate) use self::impl_bsd::get_peer_cred;
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
 pub(crate) use self::impl_macos::get_peer_cred;
 
 #[cfg(any(target_os = "solaris", target_os = "illumos"))]
@@ -187,7 +192,12 @@ pub(crate) mod impl_bsd {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios", target_os = "tvos"))]
+#[cfg(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "tvos",
+    target_os = "watchos"
+))]
 pub(crate) mod impl_macos {
     use crate::net::unix::{self, UnixStream};
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This is a sibling PR to #6045. watchOS and tvOS have similar tier status (tier-3) from rustc. I have validated that this change fixes the watchOS build in https://github.com/liveview-native/liveview-native-core/pull/33.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `target_os = "watchos"` next to places to where `tvos` occurs.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
