### PR TITLE
Make tokio `Runtime` be unwind-safe

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -480,6 +480,10 @@ impl Drop for Runtime {
     }
 }
 
+impl std::panic::UnwindSafe for Runtime {}
+
+impl std::panic::RefUnwindSafe for Runtime {}
+
 cfg_metrics! {
     impl Runtime {
         /// TODO


### PR DESCRIPTION
Closes: https://github.com/tokio-rs/tokio/issues/6188