### PR TITLE
Update tests to nix 0.27.1.

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.149" }
-nix = { version = "0.26", default-features = false, features = ["fs", "socket"] }
+nix = { version = "0.27.1", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(unix, feature = "full"))]
 
-use std::os::unix::io::{AsRawFd, RawFd};
+use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -132,7 +132,14 @@ fn socketpair() -> (FileDescriptor, FileDescriptor) {
         SockFlag::empty(),
     )
     .expect("socketpair");
-    let fds = (FileDescriptor { fd: fd_a }, FileDescriptor { fd: fd_b });
+    let fds = (
+        FileDescriptor {
+            fd: fd_a.into_raw_fd(),
+        },
+        FileDescriptor {
+            fd: fd_b.into_raw_fd(),
+        },
+    );
 
     set_nonblocking(fds.0.fd);
     set_nonblocking(fds.1.fd);


### PR DESCRIPTION
## Motivation

Tokio has a dev dependency on `nix` 0.26, which is an old version. We use tokio in AOSP, where we vendor all third-party crates, and try to have only a single version of each crate. We need to update nix, and currently tokio is blocking this.

## Solution

Updated `nix` dependency from 0.26 to 0.27.1.