### PR TITLE
windows-sys 0.52

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 
 [[example]]
 name = "chat"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -121,11 +121,11 @@ libc = { version = "0.2.149" }
 nix = { version = "0.27.1", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.48"
+version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_Security_Authorization",


### PR DESCRIPTION
AFAICT, this does not require any actual code edits within tokio.

## Motivation

De-duplicate windows-sys dependencies between 0.48 and 0.52 which the ecosystem is currently split between.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Update tokio to 0.52. While this will temporarily include 0.48 and 0.52 in tokio's tree, I've submitted a variety of PRs to move the ecosystem forward.