### PR TITLE
Revert "net: add `SocketAddr::as_abstract_namespace` (#6144)"

### DIFF
--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -22,15 +22,6 @@ impl SocketAddr {
     pub fn as_pathname(&self) -> Option<&Path> {
         self.0.as_pathname()
     }
-
-    /// Returns the contents of this address if it is an abstract namespace.
-    ///
-    /// See also the standard library documentation on [`SocketAddr`].
-    ///
-    /// [`SocketAddr`]: std::os::unix::net::SocketAddr
-    pub fn as_abstract_namespace(&self) -> Option<&[u8]> {
-        self.0.as_abstract_namespace()
-    }
 }
 
 impl fmt::Debug for SocketAddr {


### PR DESCRIPTION
This reverts #6144.

I don't want to add this method until after we've upgraded to mio v1.0.