### PR TITLE
Bump to 1.65

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ env:
   # - tokio-util/Cargo.toml
   # - tokio-test/Cargo.toml
   # - tokio-stream/Cargo.toml
-  rust_min: 1.63.0
+  rust_min: 1.65.0
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+released at least six months ago. The current MSRV is 1.65.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
+ * 1.40 to now - Rust 1.65
+ * 1.30 to 1.35 - Rust 1.63
  * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 criterion = "0.5.1"
 rand = "0.8"
 rand_chacha = "0.3"
-num_cpus = "1.16.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-macros"
 # - Create "tokio-macros-1.x.y" git tag.
 version = "2.2.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-stream"
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.14"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-test"
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.3"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-util"
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.10"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio"
 # - Create "v1.x.y" git tag.
 version = "1.35.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.65"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"
@@ -71,10 +71,7 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt = []
-rt-multi-thread = [
-  "num_cpus",
-  "rt",
-]
+rt-multi-thread = ["rt"]
 signal = [
   "libc",
   "mio/os-poll",
@@ -96,7 +93,6 @@ pin-project-lite = "0.2.11"
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
 mio = { version = "0.8.9", optional = true, default-features = false }
-num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -186,12 +186,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+released at least six months ago. The current MSRV is 1.65.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
+ * 1.40 to now - Rust 1.65
+ * 1.30 to 1.35 - Rust 1.63
  * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -97,7 +97,13 @@ pub(crate) mod sys {
                 assert!(n > 0, "\"{}\" cannot be set to 0", ENV_WORKER_THREADS);
                 n
             }
-            Err(std::env::VarError::NotPresent) => usize::max(1, num_cpus::get()),
+            Err(std::env::VarError::NotPresent) => usize::max(
+                1,
+                std::thread::available_parallelism()
+                    .ok()
+                    .and_then(|el| el.try_into().ok())
+                    .unwrap_or_default(),
+            ),
             Err(std::env::VarError::NotUnicode(e)) => {
                 panic!(
                     "\"{}\" must be valid unicode, error: {:?}",


### PR DESCRIPTION
Replaces the `num_cpus` project with the built-in `std::thread::available_parallelism()` method to decrease the number of transient dependency for downstream crates.

Bumping to `1.65` instead of `1.64` to allow the possible inner usage of `let_else` and GAT.