### PR TITLE
docs: fix typo in `tokio::task` documentation

### DIFF
--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -283,7 +283,7 @@
 //!
 //! #### unconstrained
 //!
-//! If necessary, [`task::unconstrained`] lets you opt a future out of of Tokio's cooperative
+//! If necessary, [`task::unconstrained`] lets you opt a future out of Tokio's cooperative
 //! scheduling. When a future is wrapped with `unconstrained`, it will never be forced to yield to
 //! Tokio. For example:
 //!


### PR DESCRIPTION
## Motivation

Improve the crate's documentation.

## Solution

Fix a small typo in the documentation of `tokio::task`.