### PR TITLE
typo fixes

### DIFF
--- a/benches/copy.rs
+++ b/benches/copy.rs
@@ -29,7 +29,7 @@ const WRITE_SERVICE_PERIOD: Duration = Duration::from_millis(20);
 // because another writer claimed the buffer space
 const PROBABILITY_FLUSH_WAIT: f64 = 0.1;
 
-/// A slow writer that aims to simulate HDD behaviour under heavy load.
+/// A slow writer that aims to simulate HDD behavior under heavy load.
 ///
 /// There is a limited buffer, which is fully drained on the next write after
 /// a time limit is reached. Flush waits for the time limit to be reached

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -507,7 +507,7 @@ impl ItemFn {
 
         // Inner attributes require extra care, since they're not supported on
         // blocks (which is what we're expanded into) we instead lift them
-        // outside of the function. This matches the behaviour of `syn`.
+        // outside of the function. This matches the behavior of `syn`.
         for mut attr in self.inner_attrs {
             attr.style = syn::AttrStyle::Outer;
             attr.to_tokens(&mut tokens);

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1616,7 +1616,7 @@ Forward ports 1.5.1 fixes.
 - net: add ready/try methods to `NamedPipe{Client,Server}` ([#3866], [#3899])
 - sync: add `watch::Receiver::borrow_and_update` ([#3813])
 - sync: implement `From<T>` for `OnceCell<T>` ([#3877])
-- time: allow users to specify Interval behaviour when delayed ([#3721])
+- time: allow users to specify Interval behavior when delayed ([#3721])
 
 ### Added (unstable)
 
@@ -1630,7 +1630,7 @@ Forward ports 1.5.1 fixes.
 
 - doc: document cancellation safety ([#3900])
 - time: add wait alias to sleep ([#3897])
-- time: document auto-advancing behaviour of runtime ([#3763])
+- time: document auto-advancing behavior of runtime ([#3763])
 
 [#3163]: https://github.com/tokio-rs/tokio/pull/3163
 [#3721]: https://github.com/tokio-rs/tokio/pull/3721
@@ -1877,7 +1877,7 @@ a kernel bug. ([#3803])
 
 - doc: doc aliases for pre-1.0 function names ([#3523])
 - io: fix typos ([#3541])
-- io: note the EOF behaviour of `read_until` ([#3536])
+- io: note the EOF behavior of `read_until` ([#3536])
 - io: update `AsyncRead::poll_read` doc ([#3557])
 - net: update `UdpSocket` splitting doc ([#3517])
 - runtime: add link to `LocalSet` on `new_current_thread` ([#3508])

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -747,7 +747,7 @@ impl Command {
     /// tokio's MSRV is sufficiently new. See [the documentation on
     /// unstable features][unstable] for details about using unstable features.
     ///
-    /// If you want similar behaviour without using this unstable feature you can
+    /// If you want similar behavior without using this unstable feature you can
     /// create a [`std::process::Command`] and convert that into a
     /// [`tokio::process::Command`] using the `From` trait.
     ///


### PR DESCRIPTION
Minor spelling coordination between documents.

## Motivation

Standardizes spelling of `behavior`.

## Solution

All instances modified in-place.
