### PR TITLE
opt: use unwrap_or_else instead of unwrap_or avoid the eager evaluation

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -1016,7 +1016,7 @@ impl Builder {
 
     fn get_num_skip(&self) -> usize {
         self.num_skip
-            .unwrap_or(self.length_field_offset + self.length_field_len)
+            .unwrap_or_else(|| self.length_field_offset + self.length_field_len)
     }
 }
 


### PR DESCRIPTION
For `LengthDelimitedCodec`, using `unwrap_or_else` instead of `unwrap_or` can avoid the eager evaluation in some use cases.