### PR TITLE
io: add Join utility

### DIFF
--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -7,116 +7,124 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-cfg_io_util! {
-    pin_project_lite::pin_project! {
-        /// Joins two values implementing `AsyncRead` and `AsyncWrite` into a
-        /// single handle.
-        pub struct Join<R, W> {
-            #[pin]
-            reader: R,
-            #[pin]
-            writer: W,
-        }
+/// Join two values implementing `AsyncRead` and `AsyncWrite` into a
+/// single handle.
+pub fn join<R, W>(reader: R, writer: W) -> Join<R, W>
+where
+    R: AsyncRead,
+    W: AsyncWrite,
+{
+    Join { reader, writer }
+}
+
+pin_project_lite::pin_project! {
+    /// Joins two values implementing `AsyncRead` and `AsyncWrite` into a
+    /// single handle.
+    pub struct Join<R, W> {
+        #[pin]
+        reader: R,
+        #[pin]
+        writer: W,
+    }
+}
+
+impl<R, W> Join<R, W>
+where
+    R: AsyncRead,
+    W: AsyncWrite,
+{
+    /// Splits this `Join` back into its `AsyncRead` and `AsyncWrite`
+    /// components.
+    pub fn into_inner(self) -> (R, W) {
+        (self.reader, self.writer)
     }
 
-    impl<R, W> Join<R, W>
-    where
-        R: AsyncRead + Unpin,
-        W: AsyncWrite + Unpin,
-    {
-        /// Join two values implementing `AsyncRead` and `AsyncWrite` into a
-        /// single handle.
-        pub fn new(reader: R, writer: W) -> Self {
-            Self { reader, writer }
-        }
-
-        /// Splits this `Join` back into its `AsyncRead` and `AsyncWrite`
-        /// components.
-        pub fn split(self) -> (R, W) {
-            (self.reader, self.writer)
-        }
-
-        /// Returns a reference to the inner reader.
-        pub fn reader(&self) -> &R {
-            &self.reader
-        }
-
-        /// Returns a reference to the inner writer.
-        pub fn writer(&self) -> &W {
-            &self.writer
-        }
-
-        /// Returns a mutable reference to the inner reader.
-        pub fn reader_mut(&mut self) -> &mut R {
-            &mut self.reader
-        }
-
-        /// Returns a mutable reference to the inner writer.
-        pub fn writer_mut(&mut self) -> &mut W {
-            &mut self.writer
-        }
+    /// Returns a reference to the inner reader.
+    pub fn reader(&self) -> &R {
+        &self.reader
     }
 
-    impl<R, W> AsyncRead for Join<R, W>
-    where
-        R: AsyncRead + Unpin,
-    {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &mut ReadBuf<'_>,
-        ) -> Poll<Result<(), io::Error>> {
-            self.project().reader.poll_read(cx, buf)
-        }
+    /// Returns a reference to the inner writer.
+    pub fn writer(&self) -> &W {
+        &self.writer
     }
 
-    impl<R, W> AsyncWrite for Join<R, W>
-    where
-        W: AsyncWrite + Unpin,
-    {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<Result<usize, io::Error>> {
-            self.project().writer.poll_write(cx, buf)
-        }
-
-        fn poll_flush(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), io::Error>> {
-            self.project().writer.poll_flush(cx)
-        }
-
-        fn poll_shutdown(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-        ) -> Poll<Result<(), io::Error>> {
-            self.project().writer.poll_shutdown(cx)
-        }
-
-        fn poll_write_vectored(
-            self: Pin<&mut Self>,
-            cx: &mut Context<'_>,
-            bufs: &[io::IoSlice<'_>]
-        ) -> Poll<Result<usize, io::Error>> {
-            self.project().writer.poll_write_vectored(cx, bufs)
-        }
-
-        fn is_write_vectored(&self) -> bool {
-            self.writer.is_write_vectored()
-        }
+    /// Returns a mutable reference to the inner reader.
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
     }
 
-    impl<R, W> fmt::Debug for Join<R, W>
-        where R: fmt::Debug, W: fmt::Debug
-    {
-        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-            fmt.debug_struct("Join")
-                .field("writer", &self.writer)
-                .field("reader", &self.reader)
-                .finish()
-        }
+    /// Returns a mutable reference to the inner writer.
+    pub fn writer_mut(&mut self) -> &mut W {
+        &mut self.writer
+    }
+
+    /// Returns a pinned mutable reference to the inner reader.
+    pub fn reader_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
+        self.project().reader
+    }
+
+    /// Returns a pinned mutable reference to the inner writer.
+    pub fn writer_pin_mut(self: Pin<&mut Self>) -> Pin<&mut W> {
+        self.project().writer
+    }
+}
+
+impl<R, W> AsyncRead for Join<R, W>
+where
+    R: AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        self.project().reader.poll_read(cx, buf)
+    }
+}
+
+impl<R, W> AsyncWrite for Join<R, W>
+where
+    W: AsyncWrite + Unpin,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().writer.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().writer.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.project().writer.poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.project().writer.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.writer.is_write_vectored()
+    }
+}
+
+impl<R, W> fmt::Debug for Join<R, W>
+where
+    R: fmt::Debug,
+    W: fmt::Debug,
+{
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Join")
+            .field("writer", &self.writer)
+            .field("reader", &self.reader)
+            .finish()
     }
 }

--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -2,7 +2,6 @@
 
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 
-use std::fmt;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -20,6 +19,7 @@ where
 pin_project_lite::pin_project! {
     /// Joins two values implementing `AsyncRead` and `AsyncWrite` into a
     /// single handle.
+    #[derive(Debug)]
     pub struct Join<R, W> {
         #[pin]
         reader: R,
@@ -113,18 +113,5 @@ where
 
     fn is_write_vectored(&self) -> bool {
         self.writer.is_write_vectored()
-    }
-}
-
-impl<R, W> fmt::Debug for Join<R, W>
-where
-    R: fmt::Debug,
-    W: fmt::Debug,
-{
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt.debug_struct("Join")
-            .field("writer", &self.writer)
-            .field("reader", &self.reader)
-            .finish()
     }
 }

--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -72,7 +72,7 @@ where
 
 impl<R, W> AsyncRead for Join<R, W>
 where
-    R: AsyncRead + Unpin,
+    R: AsyncRead,
 {
     fn poll_read(
         self: Pin<&mut Self>,
@@ -85,7 +85,7 @@ where
 
 impl<R, W> AsyncWrite for Join<R, W>
 where
-    W: AsyncWrite + Unpin,
+    W: AsyncWrite,
 {
     fn poll_write(
         self: Pin<&mut Self>,

--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -1,0 +1,122 @@
+//! Join two values implementing `AsyncRead` and `AsyncWrite` into a single one.
+
+use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use std::fmt;
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+cfg_io_util! {
+    pin_project_lite::pin_project! {
+        /// Joins two values implementing `AsyncRead` and `AsyncWrite` into a
+        /// single handle.
+        pub struct Join<R, W> {
+            #[pin]
+            reader: R,
+            #[pin]
+            writer: W,
+        }
+    }
+
+    impl<R, W> Join<R, W>
+    where
+        R: AsyncRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        /// Join two values implementing `AsyncRead` and `AsyncWrite` into a
+        /// single handle.
+        pub fn new(reader: R, writer: W) -> Self {
+            Self { reader, writer }
+        }
+
+        /// Splits this `Join` back into its `AsyncRead` and `AsyncWrite`
+        /// components.
+        pub fn split(self) -> (R, W) {
+            (self.reader, self.writer)
+        }
+
+        /// Returns a reference to the inner reader.
+        pub fn reader(&self) -> &R {
+            &self.reader
+        }
+
+        /// Returns a reference to the inner writer.
+        pub fn writer(&self) -> &W {
+            &self.writer
+        }
+
+        /// Returns a mutable reference to the inner reader.
+        pub fn reader_mut(&mut self) -> &mut R {
+            &mut self.reader
+        }
+
+        /// Returns a mutable reference to the inner writer.
+        pub fn writer_mut(&mut self) -> &mut W {
+            &mut self.writer
+        }
+    }
+
+    impl<R, W> AsyncRead for Join<R, W>
+    where
+        R: AsyncRead + Unpin,
+    {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            self.project().reader.poll_read(cx, buf)
+        }
+    }
+
+    impl<R, W> AsyncWrite for Join<R, W>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            self.project().writer.poll_write(cx, buf)
+        }
+
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            self.project().writer.poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            self.project().writer.poll_shutdown(cx)
+        }
+
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[io::IoSlice<'_>]
+        ) -> Poll<Result<usize, io::Error>> {
+            self.project().writer.poll_write_vectored(cx, bufs)
+        }
+
+        fn is_write_vectored(&self) -> bool {
+            self.writer.is_write_vectored()
+        }
+    }
+
+    impl<R, W> fmt::Debug for Join<R, W>
+        where R: fmt::Debug, W: fmt::Debug
+    {
+        fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt.debug_struct("Join")
+                .field("writer", &self.writer)
+                .field("reader", &self.reader)
+                .finish()
+        }
+    }
+}

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -266,7 +266,7 @@ cfg_io_util! {
     mod split;
     pub use split::{split, ReadHalf, WriteHalf};
     mod join;
-    pub use join::Join;
+    pub use join::{join, Join};
 
     pub(crate) mod seek;
     pub(crate) mod util;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -265,6 +265,8 @@ cfg_io_std! {
 cfg_io_util! {
     mod split;
     pub use split::{split, ReadHalf, WriteHalf};
+    mod join;
+    pub use join::Join;
 
     pub(crate) mod seek;
     pub(crate) mod util;

--- a/tokio/tests/io_join.rs
+++ b/tokio/tests/io_join.rs
@@ -1,0 +1,83 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Join, ReadBuf};
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+struct R;
+
+impl AsyncRead for R {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        buf.put_slice(&[b'z']);
+        Poll::Ready(Ok(()))
+    }
+}
+
+struct W;
+
+impl AsyncWrite for W {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Poll::Ready(Ok(1))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        _bufs: &[io::IoSlice<'_>],
+    ) -> Poll<Result<usize, io::Error>> {
+        Poll::Ready(Ok(2))
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        true
+    }
+}
+
+#[test]
+fn is_send_and_sync() {
+    fn assert_bound<T: Send + Sync>() {}
+
+    assert_bound::<Join<W, R>>();
+}
+
+#[test]
+fn method_delegation() {
+    let mut rw = Join::new(R, W);
+    let mut buf = [0; 1];
+
+    tokio_test::block_on(async move {
+        assert_eq!(1, rw.read(&mut buf).await.unwrap());
+        assert_eq!(b'z', buf[0]);
+
+        assert_eq!(1, rw.write(&[b'x']).await.unwrap());
+        assert_eq!(
+            2,
+            rw.write_vectored(&[io::IoSlice::new(&[b'x'])])
+                .await
+                .unwrap()
+        );
+        assert!(rw.is_write_vectored());
+
+        assert!(rw.flush().await.is_ok());
+        assert!(rw.shutdown().await.is_ok());
+    });
+}

--- a/tokio/tests/io_join.rs
+++ b/tokio/tests/io_join.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(feature = "full")]
 
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Join, ReadBuf};
+use tokio::io::{join, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, Join, ReadBuf};
 
 use std::io;
 use std::pin::Pin;
@@ -61,7 +61,7 @@ fn is_send_and_sync() {
 
 #[test]
 fn method_delegation() {
-    let mut rw = Join::new(R, W);
+    let mut rw = join(R, W);
     let mut buf = [0; 1];
 
     tokio_test::block_on(async move {


### PR DESCRIPTION
Adds a simple `Join` utility to join an `AsyncRead` and `AsyncWrite` into a single value.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I have been writing some async networking code, and ran into this problem a few times. I wrote a similar utility in my code, and figured others may find it useful as well.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
