### PR TITLE
chore: release v1.25.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.25.2"
+version = "1.25.3"
 dependencies = [
  "async-stream",
  "autocfg",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.25.2", features = ["full"] }
+tokio = { version = "1.25.3", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 1.25.3 (December 17th, 2023)
 
 ### Fixed
-- io: add budgeting to tokio::runtime::io::registration::async_io ([#6221])
+- io: add budgeting to `tokio::runtime::io::registration::async_io` ([#6221])
 
 [#6221]: https://github.com/tokio-rs/tokio/pull/6221
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.25.3 (December 17th, 2023)
+
+### Fixed
+- io: add budgeting to tokio::runtime::io::registration::async_io ([#6221])
+
+[#6221]: https://github.com/tokio-rs/tokio/pull/6221
+
 # 1.25.2 (September 22, 2023)
 
 Forward ports 1.20.6 changes.

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.25.2"
+version = "1.25.3"
 edition = "2018"
 rust-version = "1.49"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.25.2", features = ["full"] }
+tokio = { version = "1.25.3", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.25.3 (December 17th, 2023)

### Fixed
- io: add budgeting to `tokio::runtime::io::registration::async_io` ([#6221])

[#6221]: https://github.com/tokio-rs/tokio/pull/6221
