### PR TITLE
net: Expose UdpSocket::try_clone

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1990,6 +1990,16 @@ impl UdpSocket {
     pub fn take_error(&self) -> io::Result<Option<io::Error>> {
         self.io.take_error()
     }
+
+    /// Creates a new independently owned handle to the underlying socket.
+    ///
+    /// Cloned sockets don't share wakers, allowing multiple tasks to perform I/O in the same
+    /// direction concurrently.
+    ///
+    /// See [`std::net::UdpSocket::try_clone`] for further details.
+    pub fn try_clone(&self) -> io::Result<Self> {
+        Self::from_std(self.as_socket().try_clone()?.into())
+    }
 }
 
 impl TryFrom<std::net::UdpSocket> for UdpSocket {


### PR DESCRIPTION
## Motivation

Applications sending many UDP packets (e.g. QUIC servers) benefit from parallelism, since at least Linux UDP sends scale almost linearly with thread count. However, Tokio's `UdpSocket` only stores one waker per direction, so if backpressure from the kernel send queue suspends multiple senders, only one gets woken.

## Solution

Cloning the UDP socket should allow concurrent I/O from multiple tasks without wakers getting clobbered.
