### PR TITLE
benches: fix benchmarking conflicts

### DIFF
--- a/benches/rt_current_thread.rs
+++ b/benches/rt_current_thread.rs
@@ -80,10 +80,10 @@ fn rt() -> Runtime {
 }
 
 criterion_group!(
-    scheduler,
+    rt_curr_scheduler,
     spawn_many_local,
     spawn_many_remote_idle,
     spawn_many_remote_busy
 );
 
-criterion_main!(scheduler);
+criterion_main!(rt_curr_scheduler);

--- a/benches/rt_multi_threaded.rs
+++ b/benches/rt_multi_threaded.rs
@@ -263,7 +263,7 @@ fn stall() {
 }
 
 criterion_group!(
-    scheduler,
+    rt_multi_scheduler,
     spawn_many_local,
     spawn_many_remote_idle,
     spawn_many_remote_busy1,
@@ -273,4 +273,4 @@ criterion_group!(
     chained_spawn,
 );
 
-criterion_main!(scheduler);
+criterion_main!(rt_multi_scheduler);


### PR DESCRIPTION
Because the name overlaps, criterion confuses these benchmarks when computing regressions.