### PR TITLE
Add `mark_unchanged` method to `watch::Receiver`

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -673,15 +673,6 @@ impl<T> Receiver<T> {
     ///
     /// The current value will be considered seen by the receiver.
     ///
-    /// After calling this method in a single-threaded context, a subsequent call to
-    /// [`has_changed()`](Self::has_changed) will return `false`, and a subsequent call
-    /// to [`changed()`](Self::changed) will yield.
-    ///
-    /// After calling this method in a multi-threaded context, subsequent
-    /// behaviour will vary depending on if a value is sent concurrently.
-    /// For example, a new value could be sent before this method returns
-    /// which would cause a call to [`changed`](Self::changed) to return immediately
-    ///
     /// This is useful if you are not interested in the current value
     /// visible in the receiver.
     pub fn mark_unchanged(&mut self) {

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -669,6 +669,22 @@ impl<T> Receiver<T> {
         self.version.decrement();
     }
 
+    /// Marks the state as unchanged.
+    ///
+    /// The current value can will be considered seen by the receiver.
+    ///
+    /// After invoking this method [`has_changed()`](Self::has_changed)
+    /// *MAY* return `false` and [`changed()`](Self::changed) *MAY* not return
+    /// immediately. This is because a new value could be sent before
+    /// this method returns.
+    ///
+    /// This is useful if you are not interested in the current value
+    /// visible in the receiver.
+    pub fn mark_unchanged(&mut self) {
+        let current_version = self.shared.state.load().version();
+        self.version = current_version;
+    }
+
     /// Waits for a change notification, then marks the newest value as seen.
     ///
     /// If the newest value in the channel has not yet been marked seen when

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -671,12 +671,16 @@ impl<T> Receiver<T> {
 
     /// Marks the state as unchanged.
     ///
-    /// The current value can will be considered seen by the receiver.
+    /// The current value will be considered seen by the receiver.
     ///
-    /// After invoking this method [`has_changed()`](Self::has_changed)
-    /// *MAY* return `false` and [`changed()`](Self::changed) *MAY* not return
-    /// immediately. This is because a new value could be sent before
-    /// this method returns.
+    /// After calling this method in a single-threaded context, a subsequent call to
+    /// [`has_changed()`](Self::has_changed) will return `false`, and a subsequent call
+    /// to [`changed()`](Self::changed) will yield.
+    ///
+    /// After calling this method in a multi-threaded context, subsequent
+    /// behaviour will vary depending on if a value is sent concurrently.
+    /// For example, a new value could be sent before this method returns
+    /// which would cause a call to [`changed`](Self::changed) to return immediately
     ///
     /// This is useful if you are not interested in the current value
     /// visible in the receiver.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #6086

## Solution

`watch::Receiver` now has a method `mark_unchanged` that just sets that receiver's version to the current version