### PR TITLE
io: make `repeat` and `sink` cooperative

### DIFF
--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -1,3 +1,4 @@
+use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 use std::fmt;
@@ -135,20 +136,6 @@ impl AsyncWrite for Empty {
 impl fmt::Debug for Empty {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Empty { .. }")
-    }
-}
-
-cfg_coop! {
-    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<()> {
-        let coop = ready!(crate::runtime::coop::poll_proceed(cx));
-        coop.made_progress();
-        Poll::Ready(())
-    }
-}
-
-cfg_not_coop! {
-    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<()> {
-        Poll::Ready(())
     }
 }
 

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -85,6 +85,20 @@ cfg_io_util! {
     // used by `BufReader` and `BufWriter`
     // https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/io.rs#L1
     const DEFAULT_BUF_SIZE: usize = 8 * 1024;
+
+    cfg_coop! {
+        fn poll_proceed_and_make_progress(cx: &mut std::task::Context<'_>) -> std::task::Poll<()> {
+            let coop = ready!(crate::runtime::coop::poll_proceed(cx));
+            coop.made_progress();
+            std::task::Poll::Ready(())
+        }
+    }
+
+    cfg_not_coop! {
+        fn poll_proceed_and_make_progress(_: &mut std::task::Context<'_>) -> std::task::Poll<()> {
+            std::task::Poll::Ready(())
+        }
+    }
 }
 
 cfg_not_io_util! {

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -1,3 +1,4 @@
+use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::{AsyncRead, ReadBuf};
 
 use std::io;
@@ -60,20 +61,6 @@ impl AsyncRead for Repeat {
             buf.put_slice(&[self.byte]);
         }
         Poll::Ready(Ok(()))
-    }
-}
-
-cfg_coop! {
-    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<()> {
-        let coop = ready!(crate::runtime::coop::poll_proceed(cx));
-        coop.made_progress();
-        Poll::Ready(())
-    }
-}
-
-cfg_not_coop! {
-    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<()> {
-        Poll::Ready(())
     }
 }
 

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -63,12 +63,16 @@ impl AsyncWrite for Sink {
     }
 
     #[inline]
-    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        ready!(crate::trace::trace_leaf(cx));
+        ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 
     #[inline]
-    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        ready!(crate::trace::trace_leaf(cx));
+        ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 }

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -1,3 +1,4 @@
+use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::AsyncWrite;
 
 use std::fmt;
@@ -75,20 +76,6 @@ impl AsyncWrite for Sink {
 impl fmt::Debug for Sink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Sink { .. }")
-    }
-}
-
-cfg_coop! {
-    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<()> {
-        let coop = ready!(crate::runtime::coop::poll_proceed(cx));
-        coop.made_progress();
-        Poll::Ready(())
-    }
-}
-
-cfg_not_coop! {
-    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<()> {
-        Poll::Ready(())
     }
 }
 

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -53,9 +53,11 @@ impl AsyncWrite for Sink {
     #[inline]
     fn poll_write(
         self: Pin<&mut Self>,
-        _: &mut Context<'_>,
+        cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
+        ready!(crate::trace::trace_leaf(cx));
+        ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(buf.len()))
     }
 
@@ -73,6 +75,20 @@ impl AsyncWrite for Sink {
 impl fmt::Debug for Sink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("Sink { .. }")
+    }
+}
+
+cfg_coop! {
+    fn poll_proceed_and_make_progress(cx: &mut Context<'_>) -> Poll<()> {
+        let coop = ready!(crate::runtime::coop::poll_proceed(cx));
+        coop.made_progress();
+        Poll::Ready(())
+    }
+}
+
+cfg_not_coop! {
+    fn poll_proceed_and_make_progress(_: &mut Context<'_>) -> Poll<()> {
+        Poll::Ready(())
     }
 }
 

--- a/tokio/tests/io_repeat.rs
+++ b/tokio/tests/io_repeat.rs
@@ -4,7 +4,7 @@
 use tokio::io::AsyncReadExt;
 
 #[tokio::test]
-async fn repeat_is_cooperative() {
+async fn repeat_poll_read_is_cooperative() {
     tokio::select! {
         biased;
         _ = async {

--- a/tokio/tests/io_repeat.rs
+++ b/tokio/tests/io_repeat.rs
@@ -1,0 +1,18 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full"))]
+
+use tokio::io::AsyncReadExt;
+
+#[tokio::test]
+async fn repeat_is_cooperative() {
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                let mut buf = [0u8; 4096];
+                tokio::io::repeat(0b101).read_exact(&mut buf).await.unwrap();
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}

--- a/tokio/tests/io_sink.rs
+++ b/tokio/tests/io_sink.rs
@@ -4,13 +4,39 @@
 use tokio::io::AsyncWriteExt;
 
 #[tokio::test]
-async fn sink_is_cooperative() {
+async fn sink_poll_write_is_cooperative() {
     tokio::select! {
         biased;
         _ = async {
             loop {
                 let buf = vec![1, 2, 3];
                 tokio::io::sink().write_all(&buf).await.unwrap();
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}
+
+#[tokio::test]
+async fn sink_poll_flush_is_cooperative() {
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                tokio::io::sink().flush().await.unwrap();
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}
+
+#[tokio::test]
+async fn sink_poll_shutdown_is_cooperative() {
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                tokio::io::sink().shutdown().await.unwrap();
             }
         } => {},
         _ = tokio::task::yield_now() => {}

--- a/tokio/tests/io_sink.rs
+++ b/tokio/tests/io_sink.rs
@@ -1,0 +1,18 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full"))]
+
+use tokio::io::AsyncWriteExt;
+
+#[tokio::test]
+async fn sink_is_cooperative() {
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                let buf= vec![1, 2, 3];
+                let _ = tokio::io::sink().write(&buf).await.unwrap();
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {}
+    }
+}

--- a/tokio/tests/io_sink.rs
+++ b/tokio/tests/io_sink.rs
@@ -9,7 +9,7 @@ async fn sink_is_cooperative() {
         biased;
         _ = async {
             loop {
-                let buf= vec![1, 2, 3];
+                let buf = vec![1, 2, 3];
                 let _ = tokio::io::sink().write(&buf).await.unwrap();
             }
         } => {},

--- a/tokio/tests/io_sink.rs
+++ b/tokio/tests/io_sink.rs
@@ -10,7 +10,7 @@ async fn sink_is_cooperative() {
         _ = async {
             loop {
                 let buf = vec![1, 2, 3];
-                let _ = tokio::io::sink().write(&buf).await.unwrap();
+                tokio::io::sink().write_all(&buf).await.unwrap();
             }
         } => {},
         _ = tokio::task::yield_now() => {}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->
Closes https://github.com/tokio-rs/tokio/issues/6249.
## Motivation
`repeat` and `sink` will always succeed without checking the coop budget, so this PR enables them to yield control back to the runtime.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Add a `coop` hook to its implementation. In addition, add instruments for tracing, as previous works have done.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Related work
https://github.com/tokio-rs/tokio/pull/6221, https://github.com/tokio-rs/tokio/pull/4478, https://github.com/tokio-rs/tokio/pull/4300, 
