### PR TITLE
chore: Fixing failures with the latest compilers

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,24 +1,36 @@
 error[E0308]: mismatched types
  --> tests/fail/macros_type_mismatch.rs:5:5
   |
-4 | async fn missing_semicolon_or_return_type() {
-  |                                             - help: a return type might be missing here: `-> _`
 5 |     Ok(())
   |     ^^^^^^ expected `()`, found `Result<(), _>`
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
+help: a return type might be missing here
+  |
+4 | async fn missing_semicolon_or_return_type() -> _ {
+  |                                             ++++
+help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panicking if the value is a `Result::Err`
+  |
+5 |     Ok(()).expect("REASON")
+  |           +++++++++++++++++
 
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:10:5
    |
-9  | async fn missing_return_type() {
-   |                                - help: a return type might be missing here: `-> _`
 10 |     return Ok(());
    |     ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`
+help: a return type might be missing here
+   |
+9  | async fn missing_return_type() -> _ {
+   |                                ++++
+help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panicking if the value is a `Result::Err`
+   |
+10 |     return Ok(());.expect("REASON")
+   |                   +++++++++++++++++
 
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:23:5
@@ -41,7 +53,7 @@ error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:32:5
    |
 30 | async fn issue_4635() {
-   |                       - help: try adding a return type: `-> i32`
+   |                      - help: try adding a return type: `-> i32`
 31 |     return 1;
 32 |     ;
    |     ^ expected `()`, found integer

--- a/tokio/src/future/mod.rs
+++ b/tokio/src/future/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod maybe_done;
 
 mod poll_fn;
+#[allow(unused_imports)]
 pub use poll_fn::poll_fn;
 
 cfg_process! {


### PR DESCRIPTION
This try to fixes errors occured with the latest 1.75.0 compiler changes.

How to fail can be found [here](https://github.com/tokio-rs/tokio/actions/runs/7355955020).