### PR TITLE
Update mio-aio to 0.8

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,8 +1,0 @@
-# See https://github.com/rustsec/rustsec/blob/59e1d2ad0b9cbc6892c26de233d4925074b4b97b/cargo-audit/audit.toml.example for example.
-
-[advisories]
-ignore = [
-    # We depend on nix 0.22 only via mio-aio, a dev-dependency.
-    # https://github.com/tokio-rs/tokio/pull/4255#issuecomment-974786349
-    "RUSTSEC-2021-0119",
-]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -149,7 +149,7 @@ rand = "0.8.0"
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { version = "0.7.0", features = ["tokio"] }
+mio-aio = { version = "0.8.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }


### PR DESCRIPTION
This is a test-only dependency.  The main reason for the update is to avoid transitively depending on a Nix version with a CVE.

mio-aio 0.8.0 has a substantially different API than 0.7.0.  Notably, it no longer includes any lio_listio functionality.  So to test Tokio's handling of EVFILT_LIO events we must go low-level and call libc::lio_listio directly.

Supersedes #6260

## Motivation

Eliminate a transitive dev dependency on a Nix version with a CVE.

## Solution

Update the mio-aio dev dependency to 0.8.0