### PR TITLE
time: add Future::timeout method via FutureExt

### DIFF
--- a/tokio-util/src/time/mod.rs
+++ b/tokio-util/src/time/mod.rs
@@ -16,6 +16,33 @@ pub mod delay_queue;
 
 #[doc(inline)]
 pub use delay_queue::DelayQueue;
+use futures_core::Future;
+use tokio::time::Timeout;
+
+/// A trait which contains a variety of conevenient adapters and utilities for `Future`s.
+pub trait FutureExt: Future + Sized {
+    /// A wrapper around [`tokio::time::timeout`], with the advantage that it is easier to write
+    /// fluent call chains.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use tokio::{sync::oneshot, time::Duration};
+    /// use tokio_util::time::FutureExt;
+    ///
+    /// # async fn dox() {
+    /// let (tx, rx) = oneshot::channel::<()>();
+    ///
+    /// let res = rx.timeout(Duration::from_millis(10)).await;
+    /// assert!(res.is_err());
+    /// # }
+    /// ```
+    fn timeout(self, timeout: Duration) -> Timeout<Self> {
+        tokio::time::timeout(timeout, self)
+    }
+}
+
+impl<T: Future + Sized> FutureExt for T {}
 
 // ===== Internal utils =====
 

--- a/tokio-util/src/time/mod.rs
+++ b/tokio-util/src/time/mod.rs
@@ -8,7 +8,9 @@
 //!
 //! This type must be used from within the context of the `Runtime`.
 
+use futures_core::Future;
 use std::time::Duration;
+use tokio::time::Timeout;
 
 mod wheel;
 
@@ -16,11 +18,9 @@ pub mod delay_queue;
 
 #[doc(inline)]
 pub use delay_queue::DelayQueue;
-use futures_core::Future;
-use tokio::time::Timeout;
 
-/// A trait which contains a variety of conevenient adapters and utilities for `Future`s.
-pub trait FutureExt: Future + Sized {
+/// A trait which contains a variety of convenient adapters and utilities for `Future`s.
+pub trait FutureExt: Future {
     /// A wrapper around [`tokio::time::timeout`], with the advantage that it is easier to write
     /// fluent call chains.
     ///
@@ -37,12 +37,15 @@ pub trait FutureExt: Future + Sized {
     /// assert!(res.is_err());
     /// # }
     /// ```
-    fn timeout(self, timeout: Duration) -> Timeout<Self> {
+    fn timeout(self, timeout: Duration) -> Timeout<Self>
+    where
+        Self: Sized,
+    {
         tokio::time::timeout(timeout, self)
     }
 }
 
-impl<T: Future + Sized> FutureExt for T {}
+impl<T: Future + ?Sized> FutureExt for T {}
 
 // ===== Internal utils =====
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Closes https://github.com/tokio-rs/tokio/issues/6047

## Solution
We simply add an extension trait, wrapping the existing `time::timeout` method to reduce duplication.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
