### PR TITLE
implement try_join_next

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -322,7 +322,6 @@ impl<T: 'static> JoinSet<T> {
         }
     }
 
-
     /// Aborts all tasks and waits for them to finish shutting down.
     ///
     /// Calling this method is equivalent to calling [`abort_all`] and then calling [`join_next`] in

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -317,10 +317,7 @@ impl<T: 'static> JoinSet<T> {
             let res = entry.with_value_and_context(|jh, ctx| {
                 // Since this function is not async and cannot be forced to yield, we should
                 // disable budgeting when we want to check for the `JoinHandle` readiness.
-                let fut = unconstrained(jh);
-                pin!(fut);
-
-                fut.poll(ctx)
+                Pin::new(&mut unconstrained(jh)).poll(ctx)
             });
 
             if let Poll::Ready(res) = res {

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -328,6 +328,37 @@ impl<T: 'static> JoinSet<T> {
         }
     }
 
+    /// Tries to join one of the tasks in the set that has completed and return its output,
+    /// along with the [task ID] of the completed task.
+    ///
+    /// Returns `None` if the set is empty.
+    ///
+    /// When this method returns an error, then the id of the task that failed can be accessed
+    /// using the [`JoinError::id`] method.
+    ///
+    /// [task ID]: crate::task::Id
+    /// [`JoinError::id`]: fn@crate::task::JoinError::id
+    #[cfg(tokio_unstable)]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    pub fn try_join_next_with_id(&mut self) -> Option<Result<(Id, T), JoinError>> {
+        // Loop over all notified `JoinHandle`s to find one that's ready, or until none are left.
+        loop {
+            let mut entry = self.inner.try_pop_notified()?;
+
+            let res = entry.with_value_and_context(|jh, ctx| {
+                // Since this function is not async and cannot be forced to yield, we should
+                // disable budgeting when we want to check for the `JoinHandle` readiness.
+                Pin::new(&mut unconstrained(jh)).poll(ctx)
+            });
+
+            if let Poll::Ready(res) = res {
+                let entry = entry.remove();
+
+                return Some(res.map(|output| (entry.id(), output)));
+            }
+        }
+    }
+
     /// Aborts all tasks and waits for them to finish shutting down.
     ///
     /// Calling this method is equivalent to calling [`abort_all`] and then calling [`join_next`] in

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -230,7 +230,6 @@ async fn join_set_coop() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn try_join_next() {
-    // Large enough to trigger coop.
     const TASK_NUM: u32 = 1000;
 
     static SEM: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(0);
@@ -250,19 +249,17 @@ async fn try_join_next() {
     let _ = SEM.acquire_many(TASK_NUM).await.unwrap();
 
     let mut count = 0;
-    let mut coop_count = 0;
-    while count != TASK_NUM {
+    loop {
         match set.try_join_next() {
             Some(Ok(())) => {
                 count += 1;
             }
             Some(Err(err)) => panic!("failed: {}", err),
             None => {
-                coop_count += 1;
-                tokio::task::yield_now().await;
+                break;
             }
         }
     }
-    assert!(coop_count >= 1);
+
     assert_eq!(count, TASK_NUM);
 }

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -228,7 +228,7 @@ async fn join_set_coop() {
     assert_eq!(count, TASK_NUM);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn try_join_next() {
     const TASK_NUM: u32 = 1000;
 
@@ -264,7 +264,7 @@ async fn try_join_next() {
 }
 
 #[cfg(tokio_unstable)]
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn try_join_next_with_id() {
     const TASK_NUM: u32 = 1000;
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -228,25 +228,24 @@ async fn join_set_coop() {
     assert_eq!(count, TASK_NUM);
 }
 
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn try_join_next() {
     const TASK_NUM: u32 = 1000;
 
-    static SEM: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(0);
+    let (send, recv) = tokio::sync::watch::channel(());
 
     let mut set = JoinSet::new();
 
     for _ in 0..TASK_NUM {
-        set.spawn(async {
-            SEM.add_permits(1);
-        });
+        let mut recv = recv.clone();
+        set.spawn(async move { recv.changed().await.unwrap() });
     }
+    drop(recv);
 
-    // Wait for all tasks to complete.
-    //
-    // Since this is a `current_thread` runtime, there's no race condition
-    // between the last permit being added and the task completing.
-    let _ = SEM.acquire_many(TASK_NUM).await.unwrap();
+    assert!(set.try_join_next().is_none());
+
+    send.send_replace(());
+    send.closed().await;
 
     let mut count = 0;
     loop {
@@ -265,28 +264,27 @@ async fn try_join_next() {
 }
 
 #[cfg(tokio_unstable)]
-#[tokio::test(flavor = "current_thread")]
+#[tokio::test]
 async fn try_join_next_with_id() {
     const TASK_NUM: u32 = 1000;
 
-    static SEM: tokio::sync::Semaphore = tokio::sync::Semaphore::const_new(0);
+    let (send, recv) = tokio::sync::watch::channel(());
 
     let mut set = JoinSet::new();
     let mut spawned = std::collections::HashSet::with_capacity(TASK_NUM as usize);
 
     for _ in 0..TASK_NUM {
-        let handle = set.spawn(async {
-            SEM.add_permits(1);
-        });
+        let mut recv = recv.clone();
+        let handle = set.spawn(async move { recv.changed().await.unwrap() });
 
         spawned.insert(handle.id());
     }
+    drop(recv);
 
-    // Wait for all tasks to complete.
-    //
-    // Since this is a `current_thread` runtime, there's no race condition
-    // between the last permit being added and the task completing.
-    let _ = SEM.acquire_many(TASK_NUM).await.unwrap();
+    assert!(set.try_join_next_with_id().is_none());
+
+    send.send_replace(());
+    send.closed().await;
 
     let mut count = 0;
     let mut joined = std::collections::HashSet::with_capacity(TASK_NUM as usize);


### PR DESCRIPTION
This PR implements the `try_join_next` function on `JoinSet`. It also adds a test to make sure the implementation works.

There is also `join_next_with_id` which is unstable. I could also add `try_join_next_with_id` if this implementation is acceptable. Or, it could be added later on when `join_next_with_id` is stable.

Resolves #6277.