### PR TITLE
ci: gate unwind tests and add ci step for tesing with panic=abort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,10 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ env.rust_stable }}
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+            toolchain: ${{ env.rust_nightly }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -148,6 +152,11 @@ jobs:
           cargo nextest run --workspace --all-features
           cargo test --doc --workspace --all-features
 
+      - name: test all --all-features panic=abort
+        run: |
+          set -euxo pipefail
+          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo +nightly nextest run --workspace --exclude tokio-macros --all-features --tests
+  
   test-integration-tests-per-feature:
     needs: basics
     name: Run integration tests for each feature

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
       - name: test all --all-features panic=abort
         run: |
           set -euxo pipefail
-          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --exclude tests-build --all-features --tests
+          RUSTFLAGS="$RUSTFLAGS -C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --exclude tests-build --all-features --tests
   
   test-integration-tests-per-feature:
     needs: basics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,10 +134,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ env.rust_stable }}
-      - name: Install Rust ${{ env.rust_nightly }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-            toolchain: ${{ env.rust_nightly }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -151,6 +147,28 @@ jobs:
           set -euxo pipefail
           cargo nextest run --workspace --all-features
           cargo test --doc --workspace --all-features
+
+  test-workspace-all-features-panic-abort:
+    needs: basics
+    name: test all crates in the workspace with all features and panic=abort
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-latest
+          - ubuntu-latest
+          - macos-latest
+    steps:
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+            toolchain: ${{ env.rust_nightly }}
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - uses: Swatinem/rust-cache@v2
 
       - name: test all --all-features panic=abort
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
       - name: test all --all-features panic=abort
         run: |
           set -euxo pipefail
-          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --all-features --tests
+          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --exclude tests-build --all-features --tests
   
   test-integration-tests-per-feature:
     needs: basics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - name: test all --all-features panic=abort
         run: |
           set -euxo pipefail
-          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo +nightly nextest run --workspace --exclude tokio-macros --all-features --tests
+          RUSTFLAGS="-C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --all-features --tests
   
   test-integration-tests-per-feature:
     needs: basics

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,6 +159,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Install Rust ${{ env.rust_nightly }}
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/tokio-stream/tests/stream_panic.rs
+++ b/tokio-stream/tests/stream_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "time", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(panic = "unwind")]
 
 use parking_lot::{const_mutex, Mutex};
 use std::error::Error;
@@ -40,7 +41,6 @@ fn test_panic<Func: FnOnce() + panic::UnwindSafe>(func: Func) -> Option<String> 
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn stream_chunks_timeout_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let iter = vec![1, 2, 3].into_iter();

--- a/tokio-stream/tests/stream_panic.rs
+++ b/tokio-stream/tests/stream_panic.rs
@@ -40,6 +40,7 @@ fn test_panic<Func: FnOnce() + panic::UnwindSafe>(func: Func) -> Option<String> 
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn stream_chunks_timeout_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let iter = vec![1, 2, 3].into_iter();

--- a/tokio-util/tests/panic.rs
+++ b/tokio-util/tests/panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery
+#![cfg(panic = "unwind")]
 
 use parking_lot::{const_mutex, Mutex};
 use std::error::Error;
@@ -49,7 +50,6 @@ fn test_panic<Func: FnOnce() + panic::UnwindSafe>(func: Func) -> Option<String> 
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn sync_bridge_new_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let _ = SyncIoBridge::new(tokio::io::empty());
@@ -62,7 +62,6 @@ fn sync_bridge_new_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn poll_sender_send_item_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let (send, _) = channel::<u32>(3);
@@ -78,7 +77,6 @@ fn poll_sender_send_item_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn local_pool_handle_new_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let _ = LocalPoolHandle::new(0);
@@ -91,7 +89,6 @@ fn local_pool_handle_new_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn local_pool_handle_spawn_pinned_by_idx_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -108,7 +105,6 @@ fn local_pool_handle_spawn_pinned_by_idx_panic_caller() -> Result<(), Box<dyn Er
     Ok(())
 }
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_insert_at_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -130,7 +126,6 @@ fn delay_queue_insert_at_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_insert_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -148,7 +143,6 @@ fn delay_queue_insert_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_remove_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -168,7 +162,6 @@ fn delay_queue_remove_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_reset_at_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -190,7 +183,6 @@ fn delay_queue_reset_at_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_reset_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -209,7 +201,6 @@ fn delay_queue_reset_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg(panic = "unwind")]
 fn delay_queue_reserve_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();

--- a/tokio-util/tests/panic.rs
+++ b/tokio-util/tests/panic.rs
@@ -49,6 +49,7 @@ fn test_panic<Func: FnOnce() + panic::UnwindSafe>(func: Func) -> Option<String> 
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn sync_bridge_new_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let _ = SyncIoBridge::new(tokio::io::empty());
@@ -61,6 +62,7 @@ fn sync_bridge_new_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn poll_sender_send_item_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let (send, _) = channel::<u32>(3);
@@ -76,7 +78,7 @@ fn poll_sender_send_item_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-
+#[cfg(panic = "unwind")]
 fn local_pool_handle_new_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let _ = LocalPoolHandle::new(0);
@@ -89,7 +91,7 @@ fn local_pool_handle_new_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-
+#[cfg(panic = "unwind")]
 fn local_pool_handle_spawn_pinned_by_idx_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -106,6 +108,7 @@ fn local_pool_handle_spawn_pinned_by_idx_panic_caller() -> Result<(), Box<dyn Er
     Ok(())
 }
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_insert_at_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -127,6 +130,7 @@ fn delay_queue_insert_at_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_insert_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -144,6 +148,7 @@ fn delay_queue_insert_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_remove_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -163,6 +168,7 @@ fn delay_queue_remove_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_reset_at_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -184,6 +190,7 @@ fn delay_queue_reset_at_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_reset_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();
@@ -202,6 +209,7 @@ fn delay_queue_reset_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(panic = "unwind")]
 fn delay_queue_reserve_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = basic();

--- a/tokio-util/tests/spawn_pinned.rs
+++ b/tokio-util/tests/spawn_pinned.rs
@@ -71,6 +71,7 @@ async fn can_spawn_multiple_futures() {
 /// A panic in the spawned task causes the join handle to return an error.
 /// But, you can continue to spawn tasks.
 #[tokio::test]
+#[cfg(panic = "unwind")]
 async fn task_panic_propagates() {
     let pool = task::LocalPoolHandle::new(1);
 
@@ -95,6 +96,7 @@ async fn task_panic_propagates() {
 /// A panic during task creation causes the join handle to return an error.
 /// But, you can continue to spawn tasks.
 #[tokio::test]
+#[cfg(panic = "unwind")]
 async fn callback_panic_does_not_kill_worker() {
     let pool = task::LocalPoolHandle::new(1);
 

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -805,6 +805,7 @@ async fn item_expiry_greater_than_wheel() {
 
 #[cfg_attr(target_os = "wasi", ignore = "FIXME: Does not seem to work with WASI")]
 #[tokio::test(start_paused = true)]
+#[cfg(panic = "unwind")]
 async fn remove_after_compact() {
     let now = Instant::now();
     let mut queue = DelayQueue::new();
@@ -822,6 +823,7 @@ async fn remove_after_compact() {
 
 #[cfg_attr(target_os = "wasi", ignore = "FIXME: Does not seem to work with WASI")]
 #[tokio::test(start_paused = true)]
+#[cfg(panic = "unwind")]
 async fn remove_after_compact_poll() {
     let now = Instant::now();
     let mut queue = task::spawn(DelayQueue::new());

--- a/tokio/src/runtime/tests/task_combinations.rs
+++ b/tokio/src/runtime/tests/task_combinations.rs
@@ -64,8 +64,8 @@ enum CombiAbortSource {
     AbortHandle,
 }
 
-#[cfg(panic = "unwind")]
 #[test]
+#[cfg_attr(panic = "abort", ignore)]
 fn test_combinations() {
     let mut rt = &[
         CombiRuntime::CurrentThread,

--- a/tokio/tests/io_panic.rs
+++ b/tokio/tests/io_panic.rs
@@ -137,6 +137,7 @@ fn unsplit_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn async_fd_new_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::io::unix::AsyncFd;
     use tokio::runtime::Builder;
@@ -159,6 +160,7 @@ fn async_fd_new_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn async_fd_with_interest_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::io::unix::AsyncFd;
     use tokio::io::Interest;

--- a/tokio/tests/io_panic.rs
+++ b/tokio/tests/io_panic.rs
@@ -55,7 +55,6 @@ mod unix {
     }
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn read_buf_initialize_unfilled_to_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {

--- a/tokio/tests/io_panic.rs
+++ b/tokio/tests/io_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support panic recovery
+#![cfg(panic = "unwind")]
 
 use std::task::{Context, Poll};
 use std::{error::Error, pin::Pin};
@@ -70,7 +71,6 @@ fn read_buf_initialize_unfilled_to_panic_caller() -> Result<(), Box<dyn Error>> 
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn read_buf_advance_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -86,7 +86,6 @@ fn read_buf_advance_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn read_buf_set_filled_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -102,7 +101,6 @@ fn read_buf_set_filled_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn read_buf_put_slice_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -120,7 +118,6 @@ fn read_buf_put_slice_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn unsplit_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -137,7 +134,6 @@ fn unsplit_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn async_fd_new_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::io::unix::AsyncFd;
     use tokio::runtime::Builder;
@@ -160,7 +156,6 @@ fn async_fd_new_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn async_fd_with_interest_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::io::unix::AsyncFd;
     use tokio::io::Interest;

--- a/tokio/tests/join_handle_panic.rs
+++ b/tokio/tests/join_handle_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery
+#![cfg(panic = "unwind")]
 
 struct PanicsOnDrop;
 
@@ -9,7 +10,6 @@ impl Drop for PanicsOnDrop {
     }
 }
 
-#[cfg(panic = "unwind")]
 #[tokio::test]
 async fn test_panics_do_not_propagate_when_dropping_join_handle() {
     let join_handle = tokio::spawn(async move { PanicsOnDrop });

--- a/tokio/tests/net_panic.rs
+++ b/tokio/tests/net_panic.rs
@@ -75,6 +75,7 @@ fn tcp_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -96,6 +97,7 @@ fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -118,6 +120,7 @@ fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixStream;
 
@@ -141,6 +144,7 @@ fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
+#[cfg(panic = "unwind")]
 fn unix_datagram_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use std::os::unix::net::UnixDatagram as StdUDS;
     use tokio::net::UnixDatagram;

--- a/tokio/tests/net_panic.rs
+++ b/tokio/tests/net_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(panic = "unwind")]
 
 use std::error::Error;
 use tokio::net::{TcpListener, TcpStream};
@@ -10,7 +11,6 @@ mod support {
 }
 use support::panic::test_panic;
 
-#[cfg(panic = "unwind")]
 #[test]
 fn udp_socket_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use std::net::SocketAddr;
@@ -33,7 +33,6 @@ fn udp_socket_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn tcp_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -52,7 +51,6 @@ fn tcp_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn tcp_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
@@ -75,7 +73,6 @@ fn tcp_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -97,7 +94,6 @@ fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -120,7 +116,6 @@ fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixStream;
 
@@ -144,7 +139,6 @@ fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg(panic = "unwind")]
 fn unix_datagram_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use std::os::unix::net::UnixDatagram as StdUDS;
     use tokio::net::UnixDatagram;
@@ -170,7 +164,6 @@ fn unix_datagram_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 #[cfg(windows)]
 fn server_options_max_instances_panic_caller() -> Result<(), Box<dyn Error>> {

--- a/tokio/tests/process_issue_2174.rs
+++ b/tokio/tests/process_issue_2174.rs
@@ -17,7 +17,7 @@ use tokio::time;
 use tokio_test::assert_err;
 
 #[tokio::test]
-#[cfg(panic = "unwind")]
+#[cfg_attr(panic = "abort", ignore)]
 async fn issue_2174() {
     let mut child = Command::new("sleep")
         .arg("2")

--- a/tokio/tests/process_issue_2174.rs
+++ b/tokio/tests/process_issue_2174.rs
@@ -17,6 +17,7 @@ use tokio::time;
 use tokio_test::assert_err;
 
 #[tokio::test]
+#[cfg(panic = "unwind")]
 async fn issue_2174() {
     let mut child = Command::new("sleep")
         .arg("2")

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -3,8 +3,8 @@
 
 use tokio::runtime::Runtime;
 
-#[cfg(panic = "unwind")]
 #[test]
+#[cfg_attr(panic = "abort", ignore)]
 fn basic_enter() {
     let rt1 = rt();
     let rt2 = rt();
@@ -16,9 +16,9 @@ fn basic_enter() {
     drop(enter1);
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 #[should_panic]
+#[cfg_attr(panic = "abort", ignore)]
 fn interleave_enter_different_rt() {
     let rt1 = rt();
     let rt2 = rt();
@@ -30,9 +30,9 @@ fn interleave_enter_different_rt() {
     drop(enter2);
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 #[should_panic]
+#[cfg_attr(panic = "abort", ignore)]
 fn interleave_enter_same_rt() {
     let rt1 = rt();
 
@@ -44,9 +44,9 @@ fn interleave_enter_same_rt() {
     drop(enter3);
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 #[cfg(not(target_os = "wasi"))]
+#[cfg_attr(panic = "abort", ignore)]
 fn interleave_then_enter() {
     let _ = std::panic::catch_unwind(|| {
         let rt1 = rt();

--- a/tokio/tests/rt_panic.rs
+++ b/tokio/tests/rt_panic.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(not(target_os = "wasi"))] // Wasi doesn't support panic recovery
+#![cfg(panic = "unwind")]
 
 use futures::future;
 use std::error::Error;
@@ -11,7 +12,6 @@ mod support {
 }
 use support::panic::test_panic;
 
-#[cfg(panic = "unwind")]
 #[test]
 fn current_handle_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -24,7 +24,6 @@ fn current_handle_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn into_panic_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(move || {
@@ -47,7 +46,6 @@ fn into_panic_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn builder_worker_threads_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -60,7 +58,6 @@ fn builder_worker_threads_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn builder_max_blocking_threads_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {

--- a/tokio/tests/signal_panic.rs
+++ b/tokio/tests/signal_panic.rs
@@ -12,6 +12,7 @@ mod support {
 use support::panic::test_panic;
 
 #[test]
+#[cfg(panic = "unwind")]
 fn signal_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = Builder::new_current_thread().build().unwrap();

--- a/tokio/tests/signal_panic.rs
+++ b/tokio/tests/signal_panic.rs
@@ -1,6 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
+#![cfg(panic = "unwind")]
 
 use std::error::Error;
 use tokio::runtime::Builder;
@@ -12,7 +13,6 @@ mod support {
 use support::panic::test_panic;
 
 #[test]
-#[cfg(panic = "unwind")]
 fn signal_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = Builder::new_current_thread().build().unwrap();

--- a/tokio/tests/sync_panic.rs
+++ b/tokio/tests/sync_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(panic = "unwind")]
 
 use std::{error::Error, sync::Arc};
 use tokio::{
@@ -12,7 +13,6 @@ mod support {
 }
 use support::panic::test_panic;
 
-#[cfg(panic = "unwind")]
 #[test]
 fn broadcast_channel_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -25,7 +25,6 @@ fn broadcast_channel_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn mutex_blocking_lock_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -42,7 +41,6 @@ fn mutex_blocking_lock_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn oneshot_blocking_recv_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -59,7 +57,6 @@ fn oneshot_blocking_recv_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn rwlock_with_max_readers_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -72,7 +69,6 @@ fn rwlock_with_max_readers_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn rwlock_blocking_read_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -89,7 +85,6 @@ fn rwlock_blocking_read_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn rwlock_blocking_write_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -106,7 +101,6 @@ fn rwlock_blocking_write_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn mpsc_bounded_channel_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -119,7 +113,6 @@ fn mpsc_bounded_channel_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn mpsc_bounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -136,7 +129,6 @@ fn mpsc_bounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Erro
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn mpsc_bounded_sender_blocking_send_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -153,7 +145,6 @@ fn mpsc_bounded_sender_blocking_send_panic_caller() -> Result<(), Box<dyn Error>
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn mpsc_unbounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -170,7 +161,6 @@ fn mpsc_unbounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Er
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn semaphore_merge_unrelated_owned_permits() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -187,7 +177,6 @@ fn semaphore_merge_unrelated_owned_permits() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn semaphore_merge_unrelated_permits() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {

--- a/tokio/tests/task_panic.rs
+++ b/tokio/tests/task_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
+#![cfg(panic = "unwind")]
 
 use futures::future;
 use std::error::Error;
@@ -11,7 +12,6 @@ mod support {
 }
 use support::panic::test_panic;
 
-#[cfg(panic = "unwind")]
 #[test]
 fn block_in_place_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -27,7 +27,6 @@ fn block_in_place_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn local_set_spawn_local_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -42,7 +41,6 @@ fn local_set_spawn_local_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn local_set_block_on_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -60,7 +58,6 @@ fn local_set_block_on_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn spawn_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -73,7 +70,6 @@ fn spawn_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn local_key_sync_scope_panic_caller() -> Result<(), Box<dyn Error>> {
     tokio::task_local! {
@@ -94,7 +90,6 @@ fn local_key_sync_scope_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn local_key_with_panic_caller() -> Result<(), Box<dyn Error>> {
     tokio::task_local! {
@@ -111,7 +106,6 @@ fn local_key_with_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn local_key_get_panic_caller() -> Result<(), Box<dyn Error>> {
     tokio::task_local! {

--- a/tokio/tests/time_panic.rs
+++ b/tokio/tests/time_panic.rs
@@ -1,5 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery
+#![cfg(panic = "unwind")]
 
 use futures::future;
 use std::error::Error;
@@ -12,7 +13,6 @@ mod support {
 }
 use support::panic::test_panic;
 
-#[cfg(panic = "unwind")]
 #[test]
 fn pause_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -30,7 +30,6 @@ fn pause_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn resume_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -47,7 +46,6 @@ fn resume_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn interval_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -60,7 +58,6 @@ fn interval_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn interval_at_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
@@ -73,7 +70,6 @@ fn interval_at_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(panic = "unwind")]
 #[test]
 fn timeout_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -36,7 +36,7 @@ async fn pause_time_in_main_threads() {
     tokio::time::pause();
 }
 
-#[cfg(panic = "unwind")]
+#[cfg_attr(panic = "abort", ignore)]
 #[cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threads
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn pause_time_in_spawn_threads() {


### PR DESCRIPTION
Verifies that all tests pass with panic=abort by adding a step to CI. Also, gates tests that need unwinding with `#[cfg(panic = "unwind")]`.

Resolves #6109.