### PR TITLE
Don't take the tail lock when dropping broadcast channel's `Recv` future

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -27,6 +27,11 @@ path = "spawn.rs"
 harness = false
 
 [[bench]]
+name = "sync_broadcast"
+path = "sync_broadcast.rs"
+harness = false
+
+[[bench]]
 name = "sync_mpsc"
 path = "sync_mpsc.rs"
 harness = false

--- a/benches/sync_broadcast.rs
+++ b/benches/sync_broadcast.rs
@@ -1,0 +1,82 @@
+use rand::{Rng, RngCore, SeedableRng};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use tokio::sync::{broadcast, Notify};
+
+use criterion::measurement::WallTime;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
+
+fn rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(6)
+        .build()
+        .unwrap()
+}
+
+fn do_work(rng: &mut impl RngCore) -> u32 {
+    use std::fmt::Write;
+    let mut message = String::new();
+    for i in 1..=10 {
+        let _ = write!(&mut message, " {i}={}", rng.gen::<f64>());
+    }
+    message
+        .as_bytes()
+        .iter()
+        .map(|&c| c as u32)
+        .fold(0, u32::wrapping_add)
+}
+
+fn contention_impl<const N_TASKS: usize>(g: &mut BenchmarkGroup<WallTime>) {
+    let rt = rt();
+
+    let (tx, _rx) = broadcast::channel::<usize>(1000);
+    let wg = Arc::new((AtomicUsize::new(0), Notify::new()));
+
+    for n in 0..N_TASKS {
+        let wg = wg.clone();
+        let mut rx = tx.subscribe();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(n as u64);
+        rt.spawn(async move {
+            while let Ok(_) = rx.recv().await {
+                let r = do_work(&mut rng);
+                let _ = black_box(r);
+                if wg.0.fetch_sub(1, Ordering::Relaxed) == 1 {
+                    wg.1.notify_one();
+                }
+            }
+        });
+    }
+
+    const N_ITERS: usize = 100;
+
+    g.bench_function(N_TASKS.to_string(), |b| {
+        b.iter(|| {
+            rt.block_on({
+                let wg = wg.clone();
+                let tx = tx.clone();
+                async move {
+                    for i in 0..N_ITERS {
+                        assert_eq!(wg.0.fetch_add(N_TASKS, Ordering::Relaxed), 0);
+                        tx.send(i).unwrap();
+                        while wg.0.load(Ordering::Relaxed) > 0 {
+                            wg.1.notified().await;
+                        }
+                    }
+                }
+            })
+        })
+    });
+}
+
+fn bench_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("contention");
+    contention_impl::<10>(&mut group);
+    contention_impl::<100>(&mut group);
+    contention_impl::<500>(&mut group);
+    contention_impl::<1000>(&mut group);
+    group.finish();
+}
+
+criterion_group!(contention, bench_contention);
+
+criterion_main!(contention);

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -128,7 +128,7 @@ use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
+use std::sync::atomic::Ordering::{Acquire, Release, SeqCst};
 use std::task::{Context, Poll, Waker};
 use std::usize;
 
@@ -1424,10 +1424,9 @@ impl<'a, T> Drop for Recv<'a, T> {
             let mut tail = self.receiver.shared.tail.lock();
 
             // Safety: tail lock is held.
-            // Relaxed order suffices because we hold the tail lock.
             let queued = self
                 .waiter
-                .with(|ptr| unsafe { (*ptr).queued.load(Relaxed) });
+                .with_mut(|ptr| unsafe { *(*ptr).queued.get_mut() });
 
             if queued {
                 // Remove the node

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1430,9 +1430,10 @@ impl<'a, T> Drop for Recv<'a, T> {
             let mut tail = self.receiver.shared.tail.lock();
 
             // Safety: tail lock is held.
+            // `Relaxed` order suffices because we hold the tail lock.
             let queued = self
                 .waiter
-                .with_mut(|ptr| unsafe { *(*ptr).queued.get_mut() });
+                .with_mut(|ptr| unsafe { (*ptr).queued.load(Relaxed) });
 
             if queued {
                 // Remove the node

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1114,7 +1114,7 @@ impl<T> Receiver<T> {
                                 // If the waiter is not already queued, enqueue it.
                                 // `Relaxed` order suffices: we have synchronized with
                                 // all writers through the tail lock that we hold.
-                                if (*ptr).queued.load(Relaxed) {
+                                if !(*ptr).queued.load(Relaxed) {
                                     // `Relaxed` order suffices: all the readers will
                                     // synchronize with this write through the tail lock.
                                     (*ptr).queued.store(true, Relaxed);


### PR DESCRIPTION
## Motivation

As stated in #5465, the broadcast channel is subject to contention when the number of consumers is high. This PR tries to alleviate this issue by allowing `Recv::drop` to skip taking a lock if a value is successfully received.

## Solution

The proposed solution is to make the `queued` variable atomic. This way, `Recv` can atomically determine that the contained waiter is not enqueued for notification, so no synchronization with producers is required.

The PR includes a benchmark that on my machine shows the following results vs master:

```
contention/10           time:   [3.6555 ms 3.6723 ms 3.6895 ms]
                        change: [+1.6649% +2.3708% +3.0364%] (p = 0.00 < 0.05)

contention/100          time:   [18.266 ms 18.300 ms 18.336 ms]
                        change: [-13.471% -13.245% -13.032%] (p = 0.00 < 0.05)

contention/500          time:   [75.161 ms 75.410 ms 75.631 ms]
                        change: [-22.168% -21.858% -21.588%] (p = 0.00 < 0.05)

contention/1000         time:   [126.48 ms 130.42 ms 134.38 ms]
                        change: [-43.144% -41.486% -39.650%] (p = 0.00 < 0.05)
```

The low-contention case is slightly degraded (maybe just noise), but under high contention the proposed solution performs significantly better.

See #6284 for other approaches and more discussion.