### PR TITLE
chore: Remove old comment 

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -272,7 +272,6 @@ impl CachedParkThread {
         use std::task::Context;
         use std::task::Poll::Ready;
 
-        // `get_unpark()` should not return a Result
         let waker = self.waker()?;
         let mut cx = Context::from_waker(&waker);
 


### PR DESCRIPTION
Maybe `get_unpark()` doesn't exist in tokio anymore?