### PR TITLE
feat: generate function declaration in macro for better type check compile error message

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.rs
+++ b/tests-build/tests/fail/macros_type_mismatch.rs
@@ -12,14 +12,6 @@ async fn missing_return_type() {
 
 #[tokio::main]
 async fn extra_semicolon() -> Result<(), ()> {
-    /* TODO(taiki-e): help message still wrong
-    help: try using a variant of the expected enum
-       |
-    23 |     Ok(Ok(());)
-       |
-    23 |     Err(Ok(());)
-       |
-    */
     Ok(());
 }
 

--- a/tests-build/tests/fail/macros_type_mismatch.rs
+++ b/tests-build/tests/fail/macros_type_mismatch.rs
@@ -32,4 +32,10 @@ async fn issue_4635() {
     ;
 }
 
+#[tokio::main]
+async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
+    Ok(())?;
+    Ok(());
+}
+
 fn main() {}

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -57,3 +57,31 @@ error[E0308]: mismatched types
 31 |     return 1;
 32 |     ;
    |     ^ expected `()`, found integer
+
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> tests/fail/macros_type_mismatch.rs:37:11
+   |
+35 | #[tokio::main]
+   | -------------- this function should return `Result` or `Option` to accept `?`
+36 | async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
+37 |     Ok(())?;
+   |           ^ cannot use the `?` operator in an async block that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, _>>` is not implemented for `()`
+
+error[E0308]: mismatched types
+  --> tests/fail/macros_type_mismatch.rs:38:5
+   |
+36 | async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
+   |                                                 -------------- expected `Result<(), ()>` because of return type
+37 |     Ok(())?;
+38 |     Ok(());
+   |     ^^^^^^^ expected `Result<(), ()>`, found `()`
+   |
+   = note:   expected enum `Result<(), ()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+38 ~     Ok(());;
+39 +     Ok(())
+   |

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -6,82 +6,51 @@ error[E0308]: mismatched types
   |
   = note: expected unit type `()`
                   found enum `Result<(), _>`
-help: a return type might be missing here
-  |
-4 | async fn missing_semicolon_or_return_type() -> _ {
-  |                                             ++++
-help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panicking if the value is a `Result::Err`
-  |
-5 |     Ok(()).expect("REASON")
-  |           +++++++++++++++++
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:10:5
+  --> tests/fail/macros_type_mismatch.rs:10:12
    |
 10 |     return Ok(());
-   |     ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
+   |            ^^^^^^ expected `()`, found `Result<(), _>`
    |
    = note: expected unit type `()`
                    found enum `Result<(), _>`
-help: a return type might be missing here
-   |
-9  | async fn missing_return_type() -> _ {
-   |                                ++++
-help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panicking if the value is a `Result::Err`
-   |
-10 |     return Ok(());.expect("REASON")
-   |                   +++++++++++++++++
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:23:5
+  --> tests/fail/macros_type_mismatch.rs:14:46
    |
-14 | async fn extra_semicolon() -> Result<(), ()> {
-   |                               -------------- expected `Result<(), ()>` because of return type
-...
-23 |     Ok(());
-   |     ^^^^^^^ expected `Result<(), ()>`, found `()`
+14 |   async fn extra_semicolon() -> Result<(), ()> {
+   |  ______________________________________________^
+15 | |     /* TODO(taiki-e): help message still wrong
+16 | |     help: try using a variant of the expected enum
+17 | |        |
+...  |
+23 | |     Ok(());
+   | |           - help: remove this semicolon to return this value
+24 | | }
+   | |_^ expected `Result<(), ()>`, found `()`
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try adding an expression at the end of the block
-   |
-23 ~     Ok(());;
-24 +     Ok(())
-   |
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:32:5
+  --> tests/fail/macros_type_mismatch.rs:31:12
    |
-30 | async fn issue_4635() {
-   |                      - help: try adding a return type: `-> i32`
+30 | async fn issue_4635() -> () {
+   |                          -- expected `()` because of return type
 31 |     return 1;
-32 |     ;
-   |     ^ expected `()`, found integer
-
-error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
-  --> tests/fail/macros_type_mismatch.rs:37:11
-   |
-35 | #[tokio::main]
-   | -------------- this function should return `Result` or `Option` to accept `?`
-36 | async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
-37 |     Ok(())?;
-   |           ^ cannot use the `?` operator in an async block that returns `()`
-   |
-   = help: the trait `FromResidual<Result<Infallible, _>>` is not implemented for `()`
+   |            ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:38:5
+  --> tests/fail/macros_type_mismatch.rs:36:64
    |
-36 | async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
-   |                                                 -------------- expected `Result<(), ()>` because of return type
-37 |     Ok(())?;
-38 |     Ok(());
-   |     ^^^^^^^ expected `Result<(), ()>`, found `()`
+36 |   async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
+   |  ________________________________________________________________^
+37 | |     Ok(())?;
+38 | |     Ok(());
+   | |           - help: remove this semicolon to return this value
+39 | | }
+   | |_^ expected `Result<(), ()>`, found `()`
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
-help: try adding an expression at the end of the block
-   |
-38 ~     Ok(());;
-39 +     Ok(())
-   |

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -21,36 +21,32 @@ error[E0308]: mismatched types
    |
 14 |   async fn extra_semicolon() -> Result<(), ()> {
    |  ______________________________________________^
-15 | |     /* TODO(taiki-e): help message still wrong
-16 | |     help: try using a variant of the expected enum
-17 | |        |
-...  |
-23 | |     Ok(());
+15 | |     Ok(());
    | |           - help: remove this semicolon to return this value
-24 | | }
+16 | | }
    | |_^ expected `Result<(), ()>`, found `()`
    |
    = note:   expected enum `Result<(), ()>`
            found unit type `()`
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:31:12
+  --> tests/fail/macros_type_mismatch.rs:23:12
    |
-29 | #[tokio::main]
+21 | #[tokio::main]
    |               - help: try adding a return type: `-> i32`
-30 | async fn issue_4635() {
-31 |     return 1;
+22 | async fn issue_4635() {
+23 |     return 1;
    |            ^ expected `()`, found integer
 
 error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:36:64
+  --> tests/fail/macros_type_mismatch.rs:28:64
    |
-36 |   async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
+28 |   async fn extra_semicolon_with_try_operator() -> Result<(), ()> {
    |  ________________________________________________________________^
-37 | |     Ok(())?;
-38 | |     Ok(());
+29 | |     Ok(())?;
+30 | |     Ok(());
    | |           - help: remove this semicolon to return this value
-39 | | }
+31 | | }
    | |_^ expected `Result<(), ()>`, found `()`
    |
    = note:   expected enum `Result<(), ()>`

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -36,8 +36,9 @@ error[E0308]: mismatched types
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:31:12
    |
-30 | async fn issue_4635() -> () {
-   |                          -- expected `()` because of return type
+29 | #[tokio::main]
+   |               - help: try adding a return type: `-> i32`
+30 | async fn issue_4635() {
 31 |     return 1;
    |            ^ expected `()`, found integer
 

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -1,6 +1,7 @@
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::parse::{Parse, ParseStream, Parser};
+use syn::spanned::Spanned;
 use syn::{braced, Attribute, Ident, Path, Signature, Visibility};
 
 // syn::AttributeArgs does not implement syn::Parse
@@ -381,6 +382,14 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
     };
 
     let body = input.body();
+    let unique_fn_name = Ident::new("__tokio_internal_async_body", Span::call_site());
+    let generics = &input.sig.generics;
+    let fn_output = match &input.sig.output {
+        syn::ReturnType::Default => None,
+        syn::ReturnType::Type(_, ret_type) => Some(quote_spanned! {input.output_span()=>
+            -> #ret_type
+        }),
+    };
 
     // For test functions pin the body to the stack and use `Pin<&mut dyn
     // Future>` to reduce the amount of `Runtime::block_on` (and related
@@ -392,21 +401,15 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
     // We don't do this for the main function as it should only be used once so
     // there will be no benefit.
     let body = if is_test {
-        let output_type = match &input.sig.output {
-            // For functions with no return value syn doesn't print anything,
-            // but that doesn't work as `Output` for our boxed `Future`, so
-            // default to `()` (the same type as the function output).
-            syn::ReturnType::Default => quote! { () },
-            syn::ReturnType::Type(_, ret_type) => quote! { #ret_type },
-        };
         quote! {
-            let body = async #body;
+            async fn #unique_fn_name #generics() #fn_output #body
+            let body = #unique_fn_name();
             #crate_path::pin!(body);
-            let body: ::core::pin::Pin<&mut dyn ::core::future::Future<Output = #output_type>> = body;
         }
     } else {
         quote! {
-            let body = async #body;
+            async fn #unique_fn_name #generics() #fn_output #body
+            let body = #unique_fn_name();
         }
     };
 
@@ -488,6 +491,11 @@ impl ItemFn {
             brace_token: self.brace_token,
             stmts: &self.stmts,
         }
+    }
+
+    /// Get the span of the output type of the function item.
+    fn output_span(&self) -> Span {
+        self.sig.output.span()
     }
 
     /// Convert our local function item into a token stream.

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -407,12 +407,14 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
     // there will be no benefit.
     let body = if is_test {
         quote! {
+            #[allow(unused_must_use)]
             async fn #unique_fn_name #generics() #fn_output #body
             let body = #unique_fn_name();
             #crate_path::pin!(body);
         }
     } else {
         quote! {
+            #[allow(unused_must_use)]
             async fn #unique_fn_name #generics() #fn_output #body
             let body = #unique_fn_name();
         }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -370,10 +370,15 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
     };
 
     let body_ident = quote! { body };
+    let return_or_nothing = match &input.sig.output {
+        syn::ReturnType::Type(_, ty) if matches!(**ty, syn::Type::Never(_)) => quote! {},
+        _ => quote! { return },
+    };
+
     let last_block = quote_spanned! {last_stmt_end_span=>
         #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
         {
-            return #rt
+            #return_or_nothing #rt
                 .enable_all()
                 .build()
                 .expect("Failed building the Runtime")

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -25,10 +25,16 @@ async fn unused_braces_test() { assert_eq!(1 + 1, 2) }
 fn trait_method() {
     trait A {
         fn f(self);
+
+        fn g(self);
     }
     impl A for () {
         #[tokio::main]
-        async fn f(self) {}
+        async fn f(self) {
+            self.g()
+        }
+
+        fn g(self) {}
     }
     ().f()
 }


### PR DESCRIPTION
## Motivation
issue #6306 

`parse_knobs` method creates an async block and then calls it. While doing so, the return type of original function is erased for the async block.
This slightly changes the compiler error message from type mismatch.

## Solution
Create a temporary function with original return type preserved instead of creating an async block.

## Caveats
1. If users call __tokio_internal_async_body inside their main function it will infinitely recurse.
2. I don't think it will, but this might have some erroneous behavior on successfully compiled binary so I would appreciate if someone can find out if this implementation is sound.
3. This is a breaking change for compile error tests, since compiler error message for typecheck will change.