### PR TITLE
macros: fix trait_method breaking change detection

### DIFF
--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -25,10 +25,16 @@ async fn unused_braces_test() { assert_eq!(1 + 1, 2) }
 fn trait_method() {
     trait A {
         fn f(self);
+
+        fn g(self);
     }
     impl A for () {
         #[tokio::main]
-        async fn f(self) {}
+        async fn f(self) {
+            self.g()
+        }
+
+        fn g(self) {}
     }
     ().f()
 }


### PR DESCRIPTION
## Motivation
Context: #6307 
The test `trait_method` was designed to prevent breaking changes for `#[tokio::main]` on trait methods.
However, previous implementation didn't access self so it was unable to catch some case of breaking changes.

## Solution
Created another method `g(self)` and called it to access `self`.