### PR TITLE
net: expose keepalive option on `TcpSocket`

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -185,6 +185,11 @@ impl TcpSocket {
         Ok(TcpSocket { inner })
     }
 
+    /// Enable sending of keep-alive messages on connection-oriented sockets.
+    pub fn set_keepalive(&self, keepalive: bool) -> io::Result<()> {
+        self.inner.set_keepalive(keepalive)
+    }
+
     /// Allows the socket to bind to an in-use address.
     ///
     /// Behavior is platform specific. Refer to the target platform's

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -185,9 +185,14 @@ impl TcpSocket {
         Ok(TcpSocket { inner })
     }
 
-    /// Enable sending of keep-alive messages.
+    /// Sets value for the `SO_KEEPALIVE` option on this socket.
     pub fn set_keepalive(&self, keepalive: bool) -> io::Result<()> {
         self.inner.set_keepalive(keepalive)
+    }
+
+    /// Gets the value of the `SO_KEEPALIVE` option on this socket.
+    pub fn keepalive(&self) -> io::Result<bool> {
+        self.inner.keepalive()
     }
 
     /// Allows the socket to bind to an in-use address.

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -185,7 +185,7 @@ impl TcpSocket {
         Ok(TcpSocket { inner })
     }
 
-    /// Enable sending of keep-alive messages on connection-oriented sockets.
+    /// Enable sending of keep-alive messages.
     pub fn set_keepalive(&self, keepalive: bool) -> io::Result<()> {
         self.inner.set_keepalive(keepalive)
     }


### PR DESCRIPTION
It was decided in the Discord discussion to only support enabling the keep-alive option since it is portable across different platforms.

Resolves #6214.