### PR TITLE
fix minor typos, build warnings, and clippy warnings on tests

### DIFF
--- a/benches/copy.rs
+++ b/benches/copy.rs
@@ -64,7 +64,7 @@ impl SlowHddWriter {
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         // If we hit a service interval, the buffer can be cleared
         let res = self.service_intervals.poll_tick(cx).map(|_| Ok(()));
-        if let Poll::Ready(_) = res {
+        if res.is_ready() {
             self.buffer_used = 0;
         }
         res
@@ -123,7 +123,7 @@ impl AsyncWrite for SlowHddWriter {
         cx: &mut std::task::Context<'_>,
         bufs: &[std::io::IoSlice<'_>],
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
-        let writeable = bufs.into_iter().fold(0, |acc, buf| acc + buf.len());
+        let writeable = bufs.iter().fold(0, |acc, buf| acc + buf.len());
         self.write_bytes(cx, writeable)
     }
 

--- a/benches/rt_multi_threaded.rs
+++ b/benches/rt_multi_threaded.rs
@@ -38,7 +38,7 @@ fn rt_multi_spawn_many_local(c: &mut Criterion) {
                     });
                 }
 
-                let _ = rx.recv().unwrap();
+                rx.recv().unwrap();
             });
         })
     });
@@ -165,7 +165,7 @@ fn rt_multi_yield_many(c: &mut Criterion) {
             }
 
             for _ in 0..TASKS {
-                let _ = rx.recv().unwrap();
+                rx.recv().unwrap();
             }
         })
     });

--- a/benches/sync_broadcast.rs
+++ b/benches/sync_broadcast.rs
@@ -37,7 +37,7 @@ fn contention_impl<const N_TASKS: usize>(g: &mut BenchmarkGroup<WallTime>) {
         let mut rx = tx.subscribe();
         let mut rng = rand::rngs::StdRng::seed_from_u64(n as u64);
         rt.spawn(async move {
-            while let Ok(_) = rx.recv().await {
+            while rx.recv().await.is_ok() {
                 let r = do_work(&mut rng);
                 let _ = black_box(r);
                 if wg.0.fetch_sub(1, Ordering::Relaxed) == 1 {

--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -4,6 +4,7 @@ use criterion::measurement::WallTime;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
 
 #[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
 struct Medium([usize; 64]);
 impl Default for Medium {
     fn default() -> Self {
@@ -12,6 +13,7 @@ impl Default for Medium {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
 struct Large([Medium; 64]);
 impl Default for Large {
     fn default() -> Self {

--- a/examples/custom-executor-tokio-context.rs
+++ b/examples/custom-executor-tokio-context.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // Without the `HandleExt.wrap()` there would be a panic because there is
     // no timer running, since it would be referencing runtime r1.
-    let _ = rt1.block_on(rt2.wrap(async move {
+    rt1.block_on(rt2.wrap(async move {
         let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
         println!("addr: {:?}", listener.local_addr());
         tx.send(()).unwrap();

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -259,11 +259,11 @@ mod date {
         unix_date: u64,
     }
 
-    thread_local!(static LAST: RefCell<LastRenderedNow> = RefCell::new(LastRenderedNow {
+    thread_local!(static LAST: RefCell<LastRenderedNow> = const { RefCell::new(LastRenderedNow {
         bytes: [0; 128],
         amt: 0,
         unix_date: 0,
-    }));
+    }) });
 
     impl fmt::Display for Now {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/stress-test/examples/simple_echo_tcp.rs
+++ b/stress-test/examples/simple_echo_tcp.rs
@@ -42,7 +42,7 @@ fn main() {
                 .write_all(one_mega_random_bytes.as_slice())
                 .await
                 .unwrap();
-            stream.read(&mut buff).await.unwrap();
+            let _ = stream.read(&mut buff).await.unwrap();
         }
         tx.send(()).unwrap();
     });

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -218,6 +218,7 @@ where
             // Make sure we've got room for at least one byte to read to ensure
             // that we don't get a spurious 0 that looks like EOF.
             state.buffer.reserve(1);
+            #[allow(clippy::blocks_in_conditions)]
             let bytect = match poll_read_buf(pinned.inner.as_mut(), cx, &mut state.buffer).map_err(
                 |err| {
                     trace!("Got an error, going to errored state");

--- a/tokio-util/src/task/task_tracker.rs
+++ b/tokio-util/src/task/task_tracker.rs
@@ -41,7 +41,7 @@ use tokio::{
 /// unique features is required:
 ///
 ///  1. When tasks exit, a `TaskTracker` will allow the task to immediately free its memory.
-///  2. By not closing the `TaskTracker`, [`wait`] will be prevented from from returning even if
+///  2. By not closing the `TaskTracker`, [`wait`] will be prevented from returning even if
 ///     the `TaskTracker` is empty.
 ///  3. A `TaskTracker` does not require mutable access to insert tasks.
 ///  4. A `TaskTracker` can be cloned to share it with many tasks.

--- a/tokio/src/macros/ready.rs
+++ b/tokio/src/macros/ready.rs
@@ -1,6 +1,7 @@
 macro_rules! ready {
     ($e:expr $(,)?) => {
         match $e {
+            #[allow(clippy::blocks_in_conditions)]
             std::task::Poll::Ready(t) => t,
             std::task::Poll::Pending => return std::task::Poll::Pending,
         }

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -804,6 +804,7 @@ impl UdpSocket {
     ///
     /// [`connect`]: method@Self::connect
     pub fn poll_recv(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        #[allow(clippy::blocks_in_conditions)]
         let n = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1340,6 +1341,7 @@ impl UdpSocket {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1595,6 +1597,7 @@ impl UdpSocket {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1161,6 +1161,7 @@ impl UnixDatagram {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1262,6 +1263,7 @@ impl UnixDatagram {
     ///
     /// [`connect`]: method@Self::connect
     pub fn poll_recv(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        #[allow(clippy::blocks_in_conditions)]
         let n = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -430,7 +430,7 @@ impl Runtime {
     ///
     /// Note however, that because we do not wait for any blocking tasks to complete, this
     /// may result in a resource leak (in that any blocking tasks are still running until they
-    /// return.
+    /// return).
     ///
     /// See the [struct level documentation](Runtime#shutdown) for more details.
     ///

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -52,6 +52,7 @@ fn notify_waiters_handles_panicking_waker() {
 
     let notify = Arc::new(Notify::new());
 
+    #[allow(dead_code)]
     struct PanickingWaker(Arc<Notify>);
 
     impl ArcWake for PanickingWaker {

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -268,6 +268,7 @@ fn release_permits_at_drop() {
 
     let sem = Arc::new(Semaphore::new(1));
 
+    #[allow(dead_code)]
     struct ReleaseOnDrop(Option<OwnedSemaphorePermit>);
 
     impl ArcWake for ReleaseOnDrop {

--- a/tokio/src/util/markers.rs
+++ b/tokio/src/util/markers.rs
@@ -1,8 +1,10 @@
 /// Marker for types that are `Sync` but not `Send`
+#[allow(dead_code)]
 pub(crate) struct SyncNotSend(*mut ());
 
 unsafe impl Sync for SyncNotSend {}
 
 cfg_rt! {
+    #[allow(dead_code)]
     pub(crate) struct NotSendOrSync(*mut ());
 }

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1089,7 +1089,7 @@ rt_test! {
         use std::thread;
 
         thread_local!(
-            static R: RefCell<Option<Runtime>> = RefCell::new(None);
+            static R: RefCell<Option<Runtime>> = const { RefCell::new(None) };
         );
 
         thread::spawn(|| {
@@ -1402,7 +1402,7 @@ rt_test! {
         }
 
         std::thread_local! {
-            static TL_DATA: RefCell<Option<TLData>> = RefCell::new(None);
+            static TL_DATA: RefCell<Option<TLData>> = const { RefCell::new(None) };
         };
 
         let (send, recv) = channel();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -34,7 +34,7 @@ async fn local_current_thread_scheduler() {
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -55,7 +55,7 @@ async fn local_threadpool() {
 #[tokio::test(flavor = "multi_thread")]
 async fn localset_future_threadpool() {
     thread_local! {
-        static ON_LOCAL_THREAD: Cell<bool> = Cell::new(false);
+        static ON_LOCAL_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_LOCAL_THREAD.with(|cell| cell.set(true));
@@ -118,7 +118,7 @@ async fn local_threadpool_timer() {
     // This test ensures that runtime services like the timer are properly
     // set for the local task set.
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -158,7 +158,7 @@ fn enter_guard_spawn() {
 #[should_panic]
 fn local_threadpool_blocking_in_place() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -182,7 +182,7 @@ fn local_threadpool_blocking_in_place() {
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool_blocking_run() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -212,7 +212,7 @@ async fn local_threadpool_blocking_run() {
 async fn all_spawns_are_local() {
     use futures::future;
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -238,7 +238,7 @@ async fn all_spawns_are_local() {
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_spawn_is_local() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -274,7 +274,7 @@ async fn nested_spawn_is_local() {
 #[test]
 fn join_local_future_elsewhere() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));


### PR DESCRIPTION
no "special" clippy flags, just: `cargo clippy --all-features --all-targets`.