### PR TITLE
docs: transition_to_idle doesn't return boolean

### DIFF
--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -141,7 +141,6 @@ impl State {
 
     /// Transitions the task from `Running` -> `Idle`.
     ///
-    /// Returns `true` if the transition to `Idle` is successful, `false` otherwise.
     /// The transition to `Idle` fails if the task has been flagged to be
     /// cancelled.
     pub(super) fn transition_to_idle(&self) -> TransitionToIdle {


### PR DESCRIPTION
## Motivation

Small change to the docs of `transition_to_idle`. The method doesn't return `bool` but a value of the `TransitionToIdle` enum.