### PR TITLE
runtime: fix leaking registration entries when os registration fails

### DIFF
--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -220,8 +220,17 @@ impl Handle {
         let scheduled_io = self.registrations.allocate(&mut self.synced.lock())?;
         let token = scheduled_io.token();
 
-        // TODO: if this returns an err, the `ScheduledIo` leaks...
-        self.registry.register(source, token, interest.to_mio())?;
+        // we should remove the `scheduled_io` from the `registrations` set if registering
+        // the `source` with the OS fails. Otherwise it will leak the `scheduled_io`.
+        if let Err(e) = self.registry.register(source, token, interest.to_mio()) {
+            // safety: `scheduled_io` is part of the `registartions` set.
+            unsafe {
+                self.registrations
+                    .remove(&mut self.synced.lock(), &scheduled_io)
+            };
+
+            return Err(e);
+        }
 
         // TODO: move this logic to `RegistrationSet` and use a `CountedLinkedList`
         self.metrics.incr_fd_count();

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -223,7 +223,7 @@ impl Handle {
         // we should remove the `scheduled_io` from the `registrations` set if registering
         // the `source` with the OS fails. Otherwise it will leak the `scheduled_io`.
         if let Err(e) = self.registry.register(source, token, interest.to_mio()) {
-            // safety: `scheduled_io` is part of the `registartions` set.
+            // safety: `scheduled_io` is part of the `registrations` set.
             unsafe {
                 self.registrations
                     .remove(&mut self.synced.lock(), &scheduled_io)

--- a/tokio/src/runtime/io/registration_set.rs
+++ b/tokio/src/runtime/io/registration_set.rs
@@ -102,12 +102,20 @@ impl RegistrationSet {
     }
 
     pub(super) fn release(&self, synced: &mut Synced) {
-        for io in synced.pending_release.drain(..) {
+        let pending = std::mem::take(&mut synced.pending_release);
+
+        for io in pending {
             // safety: the registration is part of our list
-            let _ = unsafe { synced.registrations.remove(io.as_ref().into()) };
+            unsafe { self.remove(synced, io.as_ref()) }
         }
 
         self.num_pending_release.store(0, Release);
+    }
+
+    // This function is marked as unsafe, because the caller must make sure that
+    // `io` is part of the registration set.
+    pub(super) unsafe fn remove(&self, synced: &mut Synced, io: &ScheduledIo) {
+        let _ = synced.registrations.remove(io.into());
     }
 }
 


### PR DESCRIPTION
It is possible for `add_source` to fail when registering a source with the OS and leak the allocated slot in the registration set. This PR removes the allocated slot in the case of a failure in order to prevent this issue.

I could call `registrations.deregister` and let the `io::Driver` remove the slot on its next `turn`. But since the registration failed, and there won't be any event for the provided source, I believe it is safe to remove the entry directly.