### PR TITLE
fs: Spawn new write task while buf is not empty

### DIFF
--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -263,6 +263,22 @@ impl Buf {
         self.buf.clear();
         res
     }
+
+    pub(crate) fn write_to_partial<T: Write>(&mut self, wr: &mut T) -> io::Result<()> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let res = uninterruptibly!(wr.write(self.bytes()));
+
+        match res {
+            Ok(n) => {
+                self.pos += n;
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
 }
 
 cfg_fs! {


### PR DESCRIPTION
## Motivation

Fix https://github.com/tokio-rs/tokio/issues/6325

tokio::fs could have data loss if flush failed.

## Solution

This PR changed the `poll_flush` to rebuild the write buf is still empty.

To make it possible, I store an `Arc<StdFile>` in `State`. This change also remove the need to close file for most IO operations (alought it doesn't has big impact on the performance).