### PR TITLE
sync: Add `forget_permits` method to semaphore

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -372,7 +372,7 @@ impl Semaphore {
     ///
     /// If there are insufficient permits and it's not possible to reduce by n,
     /// return the number of permits that were actually reduced.
-    pub(crate) fn decrease_permits(&self, n: usize) -> usize {
+    pub(crate) fn forget_permits(&self, n: usize) -> usize {
         if n == 0 {
             return 0;
         }

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -368,6 +368,31 @@ impl Semaphore {
         assert_eq!(rem, 0);
     }
 
+    /// Decrease a semaphore's permits by a maximum of `n`.
+    ///
+    /// If there are insufficient permits and it's not possible to reduce by n,
+    /// return the number of permits that were actually reduced.
+    pub(crate) fn decrease_permits(&self, n: usize) -> usize {
+        if n == 0 {
+            return 0;
+        }
+
+        let mut curr_bits = self.permits.load(Acquire);
+        loop {
+            let curr = curr_bits >> Self::PERMIT_SHIFT;
+            let new = curr.saturating_sub(n);
+            match self.permits.compare_exchange_weak(
+                curr_bits,
+                new << Self::PERMIT_SHIFT,
+                AcqRel,
+                Acquire,
+            ) {
+                Ok(_) => return std::cmp::min(curr, n),
+                Err(actual) => curr_bits = actual,
+            };
+        }
+    }
+
     fn poll_acquire(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -370,7 +370,7 @@ impl Semaphore {
 
     /// Decrease a semaphore's permits by a maximum of `n`.
     ///
-    /// If there are insufficient permits and it's not possible to reduce by n,
+    /// If there are insufficient permits and it's not possible to reduce by `n`,
     /// return the number of permits that were actually reduced.
     pub(crate) fn forget_permits(&self, n: usize) -> usize {
         if n == 0 {

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -481,6 +481,14 @@ impl Semaphore {
         self.ll_sem.release(n);
     }
 
+    /// Decrease a semaphore's permits by a maximum of `n`.
+    ///
+    /// If there are insufficient permits and it's not possible to reduce by n,
+    /// return the number of permits that were actually reduced.
+    pub fn decrease_permits(&self, n: usize) -> usize {
+        self.ll_sem.decrease_permits(n)
+    }
+
     /// Acquires a permit from the semaphore.
     ///
     /// If the semaphore has been closed, this returns an [`AcquireError`].

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -483,7 +483,7 @@ impl Semaphore {
 
     /// Decrease a semaphore's permits by a maximum of `n`.
     ///
-    /// If there are insufficient permits and it's not possible to reduce by n,
+    /// If there are insufficient permits and it's not possible to reduce by `n`,
     /// return the number of permits that were actually reduced.
     pub fn forget_permits(&self, n: usize) -> usize {
         self.ll_sem.forget_permits(n)

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -485,8 +485,8 @@ impl Semaphore {
     ///
     /// If there are insufficient permits and it's not possible to reduce by n,
     /// return the number of permits that were actually reduced.
-    pub fn decrease_permits(&self, n: usize) -> usize {
-        self.ll_sem.decrease_permits(n)
+    pub fn forget_permits(&self, n: usize) -> usize {
+        self.ll_sem.forget_permits(n)
     }
 
     /// Acquires a permit from the semaphore.

--- a/tokio/src/sync/tests/loom_semaphore_batch.rs
+++ b/tokio/src/sync/tests/loom_semaphore_batch.rs
@@ -213,3 +213,31 @@ fn release_during_acquire() {
         assert_eq!(10, semaphore.available_permits());
     })
 }
+
+#[test]
+fn concurrent_permit_updates() {
+    loom::model(move || {
+        let semaphore = Arc::new(Semaphore::new(5));
+        let t1 = {
+            let semaphore = semaphore.clone();
+            thread::spawn(move || semaphore.release(3))
+        };
+        let t2 = {
+            let semaphore = semaphore.clone();
+            thread::spawn(move || {
+                semaphore
+                    .try_acquire(1)
+                    .expect("try_acquire should succeed")
+            })
+        };
+        let t3 = {
+            let semaphore = semaphore.clone();
+            thread::spawn(move || semaphore.decrease_permits(2))
+        };
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+        t3.join().unwrap();
+        assert_eq!(semaphore.available_permits(), 5);
+    })
+}

--- a/tokio/src/sync/tests/loom_semaphore_batch.rs
+++ b/tokio/src/sync/tests/loom_semaphore_batch.rs
@@ -232,7 +232,7 @@ fn concurrent_permit_updates() {
         };
         let t3 = {
             let semaphore = semaphore.clone();
-            thread::spawn(move || semaphore.decrease_permits(2))
+            thread::spawn(move || semaphore.forget_permits(2))
         };
 
         t1.join().unwrap();

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -289,11 +289,11 @@ fn release_permits_at_drop() {
 }
 
 #[test]
-fn decrease_permits_basic() {
+fn forget_permits_basic() {
     let s = Semaphore::new(10);
-    assert_eq!(s.decrease_permits(4), 4);
+    assert_eq!(s.forget_permits(4), 4);
     assert_eq!(s.available_permits(), 6);
-    assert_eq!(s.decrease_permits(10), 6);
+    assert_eq!(s.forget_permits(10), 6);
     assert_eq!(s.available_permits(), 0);
 }
 
@@ -305,6 +305,6 @@ fn update_permits_many_times() {
     s.release(5);
     assert_ready_ok!(acquire.poll());
     assert_eq!(s.available_permits(), 3);
-    assert_eq!(s.decrease_permits(3), 3);
+    assert_eq!(s.forget_permits(3), 3);
     assert_eq!(s.available_permits(), 0);
 }

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -287,3 +287,24 @@ fn release_permits_at_drop() {
         assert!(fut.as_mut().poll(&mut cx).is_pending());
     }
 }
+
+#[test]
+fn decrease_permits_basic() {
+    let s = Semaphore::new(10);
+    assert_eq!(s.decrease_permits(4), 4);
+    assert_eq!(s.available_permits(), 6);
+    assert_eq!(s.decrease_permits(10), 6);
+    assert_eq!(s.available_permits(), 0);
+}
+
+#[test]
+fn update_permits_many_times() {
+    let s = Semaphore::new(5);
+    let mut acquire = task::spawn(s.acquire(7));
+    assert_pending!(acquire.poll());
+    s.release(5);
+    assert_ready_ok!(acquire.poll());
+    assert_eq!(s.available_permits(), 3);
+    assert_eq!(s.decrease_permits(3), 3);
+    assert_eq!(s.available_permits(), 0);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

This PR adds a method to the semaphore that reduces the number of permits.

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
resolve https://github.com/tokio-rs/tokio/issues/5308.
## Solution
Implement `forget_permits` that reduces the semaphore's permits by a maximum of `n` and returns the number of permits that were actually reduced.
