### PR TITLE
chore: update CI to clippy 1.76

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2023-10-21
-  rust_clippy: '1.75'
+  rust_clippy: '1.76'
   # When updating this, also update:
   # - README.md
   # - tokio/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ When updating this, also update:
 -->
 
 ```
-cargo +1.75 clippy --all --tests --all-features
+cargo +1.76 clippy --all --tests --all-features
 ```
 
 When building documentation normally, the markers that list the features

--- a/benches/copy.rs
+++ b/benches/copy.rs
@@ -64,7 +64,7 @@ impl SlowHddWriter {
     ) -> std::task::Poll<Result<(), std::io::Error>> {
         // If we hit a service interval, the buffer can be cleared
         let res = self.service_intervals.poll_tick(cx).map(|_| Ok(()));
-        if let Poll::Ready(_) = res {
+        if res.is_ready() {
             self.buffer_used = 0;
         }
         res
@@ -123,7 +123,7 @@ impl AsyncWrite for SlowHddWriter {
         cx: &mut std::task::Context<'_>,
         bufs: &[std::io::IoSlice<'_>],
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
-        let writeable = bufs.into_iter().fold(0, |acc, buf| acc + buf.len());
+        let writeable = bufs.iter().fold(0, |acc, buf| acc + buf.len());
         self.write_bytes(cx, writeable)
     }
 

--- a/benches/rt_multi_threaded.rs
+++ b/benches/rt_multi_threaded.rs
@@ -38,7 +38,7 @@ fn rt_multi_spawn_many_local(c: &mut Criterion) {
                     });
                 }
 
-                let _ = rx.recv().unwrap();
+                rx.recv().unwrap();
             });
         })
     });
@@ -165,7 +165,7 @@ fn rt_multi_yield_many(c: &mut Criterion) {
             }
 
             for _ in 0..TASKS {
-                let _ = rx.recv().unwrap();
+                rx.recv().unwrap();
             }
         })
     });

--- a/benches/sync_broadcast.rs
+++ b/benches/sync_broadcast.rs
@@ -37,7 +37,7 @@ fn contention_impl<const N_TASKS: usize>(g: &mut BenchmarkGroup<WallTime>) {
         let mut rx = tx.subscribe();
         let mut rng = rand::rngs::StdRng::seed_from_u64(n as u64);
         rt.spawn(async move {
-            while let Ok(_) = rx.recv().await {
+            while (rx.recv().await).is_ok() {
                 let r = do_work(&mut rng);
                 let _ = black_box(r);
                 if wg.0.fetch_sub(1, Ordering::Relaxed) == 1 {

--- a/examples/custom-executor-tokio-context.rs
+++ b/examples/custom-executor-tokio-context.rs
@@ -23,7 +23,7 @@ fn main() {
 
     // Without the `HandleExt.wrap()` there would be a panic because there is
     // no timer running, since it would be referencing runtime r1.
-    let _ = rt1.block_on(rt2.wrap(async move {
+    rt1.block_on(rt2.wrap(async move {
         let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
         println!("addr: {:?}", listener.local_addr());
         tx.send(()).unwrap();

--- a/stress-test/examples/simple_echo_tcp.rs
+++ b/stress-test/examples/simple_echo_tcp.rs
@@ -42,7 +42,7 @@ fn main() {
                 .write_all(one_mega_random_bytes.as_slice())
                 .await
                 .unwrap();
-            stream.read(&mut buff).await.unwrap();
+            let _ = stream.read(&mut buff).await.unwrap();
         }
         tx.send(()).unwrap();
     });

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -218,6 +218,7 @@ where
             // Make sure we've got room for at least one byte to read to ensure
             // that we don't get a spurious 0 that looks like EOF.
             state.buffer.reserve(1);
+            #[allow(clippy::blocks_in_conditions)]
             let bytect = match poll_read_buf(pinned.inner.as_mut(), cx, &mut state.buffer).map_err(
                 |err| {
                     trace!("Got an error, going to errored state");

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -804,6 +804,7 @@ impl UdpSocket {
     ///
     /// [`connect`]: method@Self::connect
     pub fn poll_recv(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        #[allow(clippy::blocks_in_conditions)]
         let n = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1340,6 +1341,7 @@ impl UdpSocket {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1595,6 +1597,7 @@ impl UdpSocket {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1161,6 +1161,7 @@ impl UnixDatagram {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<SocketAddr>> {
+        #[allow(clippy::blocks_in_conditions)]
         let (n, addr) = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {
@@ -1262,6 +1263,7 @@ impl UnixDatagram {
     ///
     /// [`connect`]: method@Self::connect
     pub fn poll_recv(&self, cx: &mut Context<'_>, buf: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        #[allow(clippy::blocks_in_conditions)]
         let n = ready!(self.io.registration().poll_read_io(cx, || {
             // Safety: will not read the maybe uninitialized bytes.
             let b = unsafe {


### PR DESCRIPTION
This updates the CI to use clippy version 1.76 which is aligned with the rust stable version.


