### PR TITLE
io: document cancel safety of `AsyncReadExt`'s primitive read functions

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -330,6 +330,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is cancel safe. If this method is used as an event in a
+            /// [`tokio::select!`](crate::select) statement and some other branch
+            /// completes first, it is guaranteed that no data were read.
+            ///
             /// # Examples
             ///
             /// Read unsigned 8 bit integers from an `AsyncRead`:
@@ -367,6 +373,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is cancel safe. If this method is used as an event in a
+            /// [`tokio::select!`](crate::select) statement and some other branch
+            /// completes first, it is guaranteed that no data were read.
             ///
             /// # Examples
             ///
@@ -407,6 +419,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read unsigned 16 bit big-endian integers from a `AsyncRead`:
@@ -444,6 +462,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -483,6 +507,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read unsigned 32-bit big-endian integers from a `AsyncRead`:
@@ -521,6 +551,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 32-bit big-endian integers from a `AsyncRead`:
@@ -557,6 +593,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -597,6 +639,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 64-bit big-endian integers from a `AsyncRead`:
@@ -633,6 +681,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -674,6 +728,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 128-bit big-endian integers from a `AsyncRead`:
@@ -714,6 +774,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read 32-bit floating point type from a `AsyncRead`:
@@ -750,6 +816,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -790,6 +862,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read unsigned 16 bit little-endian integers from a `AsyncRead`:
@@ -827,6 +905,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -866,6 +950,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read unsigned 32-bit little-endian integers from a `AsyncRead`:
@@ -904,6 +994,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 32-bit little-endian integers from a `AsyncRead`:
@@ -940,6 +1036,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -980,6 +1082,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 64-bit little-endian integers from a `AsyncRead`:
@@ -1016,6 +1124,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///
@@ -1057,6 +1171,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read signed 128-bit little-endian integers from a `AsyncRead`:
@@ -1097,6 +1217,12 @@ cfg_io_util! {
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
             ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
+            ///
             /// # Examples
             ///
             /// Read 32-bit floating point type from a `AsyncRead`:
@@ -1133,6 +1259,12 @@ cfg_io_util! {
             /// This method returns the same errors as [`AsyncReadExt::read_exact`].
             ///
             /// [`AsyncReadExt::read_exact`]: AsyncReadExt::read_exact
+            ///
+            /// # Cancel safety
+            ///
+            /// This method is not cancellation safe. If the method is used as the
+            /// event in a [`tokio::select!`](crate::select) statement and some
+            /// other branch completes first, then some data may be lost.
             ///
             /// # Examples
             ///


### PR DESCRIPTION
Resolves #6332.