### PR TITLE
macro select no branch else only

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -608,6 +608,10 @@ macro_rules! select {
 
     // ===== Entry point =====
 
+    ($(biased;)? else => $else:expr $(,)? ) => {{
+        $else
+    }};
+
     (biased; $p:pat = $($t:tt)* ) => {
         $crate::select!(@{ start=0; () } $p = $($t)*)
     };
@@ -617,6 +621,7 @@ macro_rules! select {
         // fair and avoids always polling the first future.
         $crate::select!(@{ start={ $crate::macros::support::thread_rng_n(BRANCHES) }; () } $p = $($t)*)
     };
+
     () => {
         compile_error!("select! requires at least one branch.")
     };

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -23,6 +23,25 @@ async fn sync_one_lit_expr_comma() {
 }
 
 #[maybe_tokio_test]
+async fn no_branch_else_only() {
+    let foo = tokio::select! {
+        else => 1,
+    };
+
+    assert_eq!(foo, 1);
+}
+
+#[maybe_tokio_test]
+async fn no_branch_else_only_biased() {
+    let foo = tokio::select! {
+        biased;
+        else => 1,
+    };
+
+    assert_eq!(foo, 1);
+}
+
+#[maybe_tokio_test]
 async fn nested_one() {
     let foo = tokio::select! {
         foo = async { 1 } => tokio::select! {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Closes #6338

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
It's the propesed <s>"Alternative 3"</s> "Alternative 5" described in [here](https://github.com/tokio-rs/tokio/issues/6338).
It simply adds a special case for when the `select!` has no branches except for the `else` fallback branch (for the case with and without `biased` mode). It will simply expand to the code in `$else`.

I added 2 tests case too to cover it.
