### PR TITLE
Add `is_closed`, `is_empty` and `len` to `mpsc::Receiver` and `mpsc::UnboundedReceiver`

### DIFF
--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -208,6 +208,11 @@ impl<T> Block<T> {
         self.header.ready_slots.fetch_or(TX_CLOSED, Release);
     }
 
+    pub(crate) unsafe fn is_closed(&self) -> bool {
+        let ready_bits = self.header.ready_slots.load(Acquire);
+        is_tx_closed(ready_bits)
+    }
+
     /// Resets the block to a blank state. This enables reusing blocks in the
     /// channel.
     ///

--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -168,6 +168,20 @@ impl<T> Block<T> {
         Some(Read::Value(value.assume_init()))
     }
 
+    /// Returns true if the sender half of the list is closed and there is no
+    /// value in the slot to be consumed
+    ///
+    /// # Safety
+    ///
+    /// To maintain safety, the caller must ensure:
+    ///
+    /// * No concurrent access to the slot.
+    pub(crate) fn is_closed_and_empty(&self, slot_index: usize) -> bool {
+        let offset = offset(slot_index);
+        let ready_bits = self.header.ready_slots.load(Acquire);
+        !is_ready(ready_bits, offset) && is_tx_closed(ready_bits)
+    }
+
     /// Writes a value to the block at the given offset.
     ///
     /// # Safety

--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -168,18 +168,17 @@ impl<T> Block<T> {
         Some(Read::Value(value.assume_init()))
     }
 
-    /// Returns true if the sender half of the list is closed and there is no
-    /// value in the slot to be consumed
+    /// Returns true if there is a value in the slot to be consumed
     ///
     /// # Safety
     ///
     /// To maintain safety, the caller must ensure:
     ///
     /// * No concurrent access to the slot.
-    pub(crate) fn is_closed_and_empty(&self, slot_index: usize) -> bool {
+    pub(crate) fn has_value(&self, slot_index: usize) -> bool {
         let offset = offset(slot_index);
         let ready_bits = self.header.ready_slots.load(Acquire);
-        !is_ready(ready_bits, offset) && is_tx_closed(ready_bits)
+        is_ready(ready_bits, offset)
     }
 
     /// Writes a value to the block at the given offset.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -511,6 +511,25 @@ impl<T> Receiver<T> {
         self.chan.is_empty()
     }
 
+    /// Returns the number of messages in the channel.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::channel(10);
+    ///     assert_eq!(0, rx.len());
+    ///
+    ///     tx.send(0).await.unwrap();
+    ///     assert_eq!(1, rx.len());
+    /// }
+    /// ```
+    pub fn len(&self) -> usize {
+        self.chan.len()
+    }
+
     /// Polls to receive the next message on this channel.
     ///
     /// This method returns:

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -463,6 +463,39 @@ impl<T> Receiver<T> {
         self.chan.close();
     }
 
+    /// Checks if a channel is closed.
+    ///
+    /// This method returns `true` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer. The channel is closed
+    /// when all senders have been dropped, or when [`close`] is called.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::channel(10);
+    ///     assert!(!rx.is_closed());
+    ///
+    ///     tx.send(100).await.unwrap();
+    ///     tx.send(200).await.unwrap();
+    ///
+    ///     rx.close();
+    ///     assert!(!rx.is_closed());
+    ///     assert_eq!(rx.recv().await, Some(100));
+    ///
+    ///     assert!(!rx.is_closed());
+    ///     assert_eq!(rx.recv().await, Some(200));
+    ///     assert!(rx.recv().await.is_none());
+    ///     
+    ///     assert!(rx.is_closed());
+    /// }
+    /// ```
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed_and_empty()
+    }
+
     /// Polls to receive the next message on this channel.
     ///
     /// This method returns:

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -465,8 +465,7 @@ impl<T> Receiver<T> {
 
     /// Checks if a channel is closed.
     ///
-    /// This method returns `true` if the channel has been closed and there are
-    /// no remaining messages in the channel's buffer. The channel is closed
+    /// This method returns `true` if the channel has been closed. The channel is closed
     /// when all [`Sender`] have been dropped, or when [`Receiver::close`] is called.
     ///
     /// [`Sender`]: crate::sync::mpsc::Sender
@@ -478,25 +477,38 @@ impl<T> Receiver<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let (tx, mut rx) = mpsc::channel(10);
+    ///     let (_tx, mut rx) = mpsc::channel::<()>(10);
     ///     assert!(!rx.is_closed());
-    ///
-    ///     tx.send(100).await.unwrap();
-    ///     tx.send(200).await.unwrap();
     ///
     ///     rx.close();
-    ///     assert!(!rx.is_closed());
-    ///     assert_eq!(rx.recv().await, Some(100));
-    ///
-    ///     assert!(!rx.is_closed());
-    ///     assert_eq!(rx.recv().await, Some(200));
-    ///     assert!(rx.recv().await.is_none());
     ///     
     ///     assert!(rx.is_closed());
     /// }
     /// ```
-    pub fn is_closed(&mut self) -> bool {
-        self.chan.is_closed_and_empty()
+    pub fn is_closed(&self) -> bool {
+        self.chan.is_closed()
+    }
+
+    /// Checks if a channel is empty.
+    ///
+    /// This method returns `true` if the channel has no messages.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::channel(10);
+    ///     assert!(rx.is_empty());
+    ///
+    ///     tx.send(0).await.unwrap();
+    ///     assert!(!rx.is_empty());
+    /// }
+    ///
+    /// ```
+    pub fn is_empty(&mut self) -> bool {
+        self.chan.is_empty()
     }
 
     /// Polls to receive the next message on this channel.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -467,7 +467,10 @@ impl<T> Receiver<T> {
     ///
     /// This method returns `true` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer. The channel is closed
-    /// when all senders have been dropped, or when [`close`] is called.
+    /// when all [`Sender`] have been dropped, or when [`Receiver::close`] is called.
+    ///
+    /// [`Sender`]: crate::sync::mpsc::Sender
+    /// [`Receiver::close`]: crate::sync::mpsc::Receiver::close
     ///
     /// # Examples
     /// ```

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -499,7 +499,7 @@ impl<T> Receiver<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let (tx, mut rx) = mpsc::channel(10);
+    ///     let (tx, rx) = mpsc::channel(10);
     ///     assert!(rx.is_empty());
     ///
     ///     tx.send(0).await.unwrap();
@@ -507,7 +507,7 @@ impl<T> Receiver<T> {
     /// }
     ///
     /// ```
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.chan.is_empty()
     }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -257,7 +257,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     pub(crate) fn is_empty(&self) -> bool {
         self.inner.rx_fields.with(|rx_fields_ptr| {
             let rx_fields = unsafe { &*rx_fields_ptr };
-            rx_fields.list.is_empty()
+            rx_fields.list.is_empty(&self.inner.tx)
         })
     }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -254,10 +254,10 @@ impl<T, S: Semaphore> Rx<T, S> {
         self.inner.semaphore.is_closed() || self.inner.tx_count.load(Acquire) == 0
     }
 
-    pub(crate) fn is_empty(&mut self) -> bool {
-        self.inner.rx_fields.with_mut(|rx_fields_ptr| {
-            let rx_fields = unsafe { &mut *rx_fields_ptr };
-            rx_fields.list.is_empty(&self.inner.tx)
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.rx_fields.with(|rx_fields_ptr| {
+            let rx_fields = unsafe { &*rx_fields_ptr };
+            rx_fields.list.is_empty()
         })
     }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -261,6 +261,13 @@ impl<T, S: Semaphore> Rx<T, S> {
         })
     }
 
+    pub(crate) fn len(&self) -> usize {
+        self.inner.rx_fields.with(|rx_fields_ptr| {
+            let rx_fields = unsafe { &*rx_fields_ptr };
+            rx_fields.list.len(&self.inner.tx)
+        })
+    }
+
     /// Receive the next value
     pub(crate) fn recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         use super::block::Read;

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -237,6 +237,21 @@ impl<T> Rx<T> {
         }
     }
 
+    pub(crate) fn len(&self, tx: &Tx<T>) -> usize {
+        let tail_position = tx.tail_position.load(Acquire);
+        let tail = tx.block_tail.load(Acquire);
+
+        unsafe {
+            let tail_block = &mut *tail;
+
+            if tail_block.is_closed() {
+                tail_position - self.index - 1
+            } else {
+                tail_position - self.index
+            }
+        }
+    }
+
     /// Pops the next value off the queue.
     pub(crate) fn pop(&mut self, tx: &Tx<T>) -> Option<block::Read<T>> {
         // Advance `head`, if needed

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -230,10 +230,30 @@ impl<T> fmt::Debug for Tx<T> {
 }
 
 impl<T> Rx<T> {
-    pub(crate) fn is_empty(&self) -> bool {
-        unsafe {
-            let block = self.head.as_ref();
-            !block.has_value(self.index)
+    pub(crate) fn is_empty(&self, tx: &Tx<T>) -> bool {
+        let block = unsafe { self.head.as_ref() };
+        if block.has_value(self.index) {
+            return false;
+        }
+
+        // It is possible that a block has no value "now" but the list is still not empty.
+        // To be sure, it is necessary to check the tail position against the current index.
+        //
+        // One edge case is when all the senders are dropped, there will be a last block in the
+        // tail position, but it will be closed
+
+        let tail_position = tx.tail_position.load(Acquire);
+        if self.index == tail_position {
+            true
+        } else if tail_position - self.index == 1 {
+            let tail = tx.block_tail.load(Acquire);
+
+            unsafe {
+                let tail_block = &mut *tail;
+                tail_block.is_closed()
+            }
+        } else {
+            false
         }
     }
 

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -230,12 +230,7 @@ impl<T> fmt::Debug for Tx<T> {
 }
 
 impl<T> Rx<T> {
-    pub(crate) fn is_empty(&mut self, tx: &Tx<T>) -> bool {
-        // Advance `head`, if needed
-        if self.try_advancing_head() {
-            self.reclaim_blocks(tx);
-        }
-
+    pub(crate) fn is_empty(&self) -> bool {
         unsafe {
             let block = self.head.as_ref();
             !block.has_value(self.index)

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -241,14 +241,15 @@ impl<T> Rx<T> {
         let tail_position = tx.tail_position.load(Acquire);
         let tail = tx.block_tail.load(Acquire);
 
-        unsafe {
+        let is_closed = unsafe {
             let tail_block = &mut *tail;
+            tail_block.is_closed()
+        };
 
-            if tail_block.is_closed() {
-                tail_position - self.index - 1
-            } else {
-                tail_position - self.index
-            }
+        if is_closed {
+            tail_position - self.index - 1
+        } else {
+            tail_position - self.index
         }
     }
 

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -230,7 +230,7 @@ impl<T> fmt::Debug for Tx<T> {
 }
 
 impl<T> Rx<T> {
-    pub(crate) fn is_closed_and_empty(&mut self, tx: &Tx<T>) -> bool {
+    pub(crate) fn is_empty(&mut self, tx: &Tx<T>) -> bool {
         // Advance `head`, if needed
         if self.try_advancing_head() {
             self.reclaim_blocks(tx);
@@ -238,13 +238,8 @@ impl<T> Rx<T> {
 
         unsafe {
             let block = self.head.as_ref();
-            block.is_closed_and_empty(self.index)
+            !block.has_value(self.index)
         }
-    }
-
-    pub(crate) fn is_at_tail_position(&mut self, tx: &Tx<T>) -> bool {
-        let tail_position = tx.tail_position.load(Acquire);
-        tail_position == self.index
     }
 
     /// Pops the next value off the queue.

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -366,7 +366,7 @@ impl<T> UnboundedReceiver<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let (tx, mut rx) = mpsc::unbounded_channel();
+    ///     let (tx, rx) = mpsc::unbounded_channel();
     ///     assert!(rx.is_empty());
     ///
     ///     tx.send(0).unwrap();
@@ -374,7 +374,7 @@ impl<T> UnboundedReceiver<T> {
     /// }
     ///
     /// ```
-    pub fn is_empty(&mut self) -> bool {
+    pub fn is_empty(&self) -> bool {
         self.chan.is_empty()
     }
 

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -332,8 +332,7 @@ impl<T> UnboundedReceiver<T> {
 
     /// Checks if a channel is closed.
     ///
-    /// This method returns `true` if the channel has been closed and there are
-    /// no remaining messages in the channel's buffer. The channel is closed
+    /// This method returns `true` if the channel has been closed. The channel is closed
     /// when all [`UnboundedSender`] have been dropped, or when [`UnboundedReceiver::close`] is called.
     ///
     /// [`UnboundedSender`]: crate::sync::mpsc::UnboundedSender
@@ -345,25 +344,38 @@ impl<T> UnboundedReceiver<T> {
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let (tx, mut rx) = mpsc::unbounded_channel();
+    ///     let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
     ///     assert!(!rx.is_closed());
-    ///
-    ///     let _ = tx.send(100);
-    ///     let _ = tx.send(200);
     ///
     ///     rx.close();
-    ///     assert!(!rx.is_closed());
-    ///     assert_eq!(rx.recv().await, Some(100));
-    ///
-    ///     assert!(!rx.is_closed());
-    ///     assert_eq!(rx.recv().await, Some(200));
-    ///     assert!(rx.recv().await.is_none());
     ///     
     ///     assert!(rx.is_closed());
     /// }
     /// ```
-    pub fn is_closed(&mut self) -> bool {
-        self.chan.is_closed_and_empty()
+    pub fn is_closed(&self) -> bool {
+        self.chan.is_closed()
+    }
+
+    /// Checks if a channel is empty.
+    ///
+    /// This method returns `true` if the channel has no messages.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::unbounded_channel();
+    ///     assert!(rx.is_empty());
+    ///
+    ///     tx.send(0).unwrap();
+    ///     assert!(!rx.is_empty());
+    /// }
+    ///
+    /// ```
+    pub fn is_empty(&mut self) -> bool {
+        self.chan.is_empty()
     }
 
     /// Polls to receive the next message on this channel.

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -334,7 +334,10 @@ impl<T> UnboundedReceiver<T> {
     ///
     /// This method returns `true` if the channel has been closed and there are
     /// no remaining messages in the channel's buffer. The channel is closed
-    /// when all senders have been dropped, or when [`close`] is called.
+    /// when all [`UnboundedSender`] have been dropped, or when [`UnboundedReceiver::close`] is called.
+    ///
+    /// [`UnboundedSender`]: crate::sync::mpsc::UnboundedSender
+    /// [`UnboundedReceiver::close`]: crate::sync::mpsc::UnboundedReceiver::close
     ///
     /// # Examples
     /// ```

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -330,6 +330,39 @@ impl<T> UnboundedReceiver<T> {
         self.chan.close();
     }
 
+    /// Checks if a channel is closed.
+    ///
+    /// This method returns `true` if the channel has been closed and there are
+    /// no remaining messages in the channel's buffer. The channel is closed
+    /// when all senders have been dropped, or when [`close`] is called.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::unbounded_channel();
+    ///     assert!(!rx.is_closed());
+    ///
+    ///     let _ = tx.send(100);
+    ///     let _ = tx.send(200);
+    ///
+    ///     rx.close();
+    ///     assert!(!rx.is_closed());
+    ///     assert_eq!(rx.recv().await, Some(100));
+    ///
+    ///     assert!(!rx.is_closed());
+    ///     assert_eq!(rx.recv().await, Some(200));
+    ///     assert!(rx.recv().await.is_none());
+    ///     
+    ///     assert!(rx.is_closed());
+    /// }
+    /// ```
+    pub fn is_closed(&mut self) -> bool {
+        self.chan.is_closed_and_empty()
+    }
+
     /// Polls to receive the next message on this channel.
     ///
     /// This method returns:

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -378,6 +378,25 @@ impl<T> UnboundedReceiver<T> {
         self.chan.is_empty()
     }
 
+    /// Returns the number of messages in the channel.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::unbounded_channel();
+    ///     assert_eq!(0, rx.len());
+    ///
+    ///     tx.send(0).unwrap();
+    ///     assert_eq!(1, rx.len());
+    /// }
+    /// ```
+    pub fn len(&self) -> usize {
+        self.chan.len()
+    }
+
     /// Polls to receive the next message on this channel.
     ///
     /// This method returns:

--- a/tokio/src/sync/tests/loom_mpsc.rs
+++ b/tokio/src/sync/tests/loom_mpsc.rs
@@ -188,3 +188,37 @@ fn try_recv() {
         }
     });
 }
+
+#[test]
+fn len_nonzero_after_send() {
+    loom::model(|| {
+        let (send, recv) = mpsc::channel(10);
+        let send2 = send.clone();
+
+        let join = thread::spawn(move || {
+            block_on(send2.send("message2")).unwrap();
+        });
+
+        block_on(send.send("message1")).unwrap();
+        assert!(recv.len() != 0);
+
+        join.join().unwrap();
+    });
+}
+
+#[test]
+fn nonempty_after_send() {
+    loom::model(|| {
+        let (send, recv) = mpsc::channel(10);
+        let send2 = send.clone();
+
+        let join = thread::spawn(move || {
+            block_on(send2.send("message2")).unwrap();
+        });
+
+        block_on(send.send("message1")).unwrap();
+        assert!(!recv.is_empty());
+
+        join.join().unwrap();
+    });
+}

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1081,8 +1081,16 @@ async fn test_rx_is_not_closed_when_there_are_messages_and_close_is_called() {
 }
 
 #[tokio::test]
-async fn test_rx_is_closed_after_consuming_messages() {
+async fn test_rx_is_not_closed_when_there_are_permits_but_not_senders() {
     // is_closed should return false when there is a permit (but no senders)
+    let (tx, mut rx) = mpsc::channel::<()>(10);
+    let _permit = tx.reserve_owned().await.expect("Failed to reserve permit");
+    assert!(!rx.is_closed());
+}
+
+#[tokio::test]
+async fn test_rx_is_closed_after_consuming_messages() {
+    // is_closed should return true after consuming messages
     let (tx, mut rx) = mpsc::channel(10);
     for i in 0..10 {
         assert!(tx.send(i).await.is_ok());

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1090,20 +1090,20 @@ async fn test_rx_is_not_closed_when_there_are_permits_but_not_senders() {
 
 #[tokio::test]
 async fn test_rx_is_empty_when_no_messages_were_sent() {
-    let (_tx, mut rx) = mpsc::channel::<()>(10);
+    let (_tx, rx) = mpsc::channel::<()>(10);
     assert!(rx.is_empty())
 }
 
 #[tokio::test]
 async fn test_rx_is_not_empty_when_there_are_messages_in_the_buffer() {
-    let (tx, mut rx) = mpsc::channel::<()>(10);
+    let (tx, rx) = mpsc::channel::<()>(10);
     assert!(tx.send(()).await.is_ok());
     assert!(!rx.is_empty())
 }
 
 #[tokio::test]
 async fn test_rx_is_not_empty_when_the_buffer_is_full() {
-    let (tx, mut rx) = mpsc::channel(10);
+    let (tx, rx) = mpsc::channel(10);
     for i in 0..10 {
         assert!(tx.send(i).await.is_ok());
     }
@@ -1204,13 +1204,13 @@ async fn test_rx_unbounded_is_closed_when_there_are_messages_and_close_is_called
 
 #[tokio::test]
 async fn test_rx_unbounded_is_empty_when_no_messages_were_sent() {
-    let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
+    let (_tx, rx) = mpsc::unbounded_channel::<()>();
     assert!(rx.is_empty())
 }
 
 #[tokio::test]
 async fn test_rx_unbounded_is_not_empty_when_there_are_messages_in_the_buffer() {
-    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (tx, rx) = mpsc::unbounded_channel();
     assert!(tx.send(()).is_ok());
     assert!(!rx.is_empty())
 }

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1060,7 +1060,7 @@ async fn test_rx_is_not_closed_when_there_are_senders_and_buffer_filled() {
 
 #[tokio::test]
 async fn test_rx_is_not_closed_when_there_are_messages_but_not_senders() {
-    // is_closed should return false when there is a permit (but no senders)
+    // is_closed should return false when there are messages in the buffer, but no senders
     let (tx, mut rx) = mpsc::channel(10);
     for i in 0..10 {
         assert!(tx.send(i).await.is_ok());
@@ -1071,7 +1071,7 @@ async fn test_rx_is_not_closed_when_there_are_messages_but_not_senders() {
 
 #[tokio::test]
 async fn test_rx_is_not_closed_when_there_are_messages_and_close_is_called() {
-    // is_closed should return false when there is a permit (but no senders)
+    // is_closed should return false when there are messages in the buffer, and close is called
     let (tx, mut rx) = mpsc::channel(10);
     for i in 0..10 {
         assert!(tx.send(i).await.is_ok());
@@ -1135,7 +1135,7 @@ async fn test_rx_unbounded_is_not_closed_when_there_are_senders() {
 
 #[tokio::test]
 async fn test_rx_unbounded_is_not_closed_when_there_are_messages_but_not_senders() {
-    // is_closed should return false when there is a permit (but no senders)
+    // is_closed should return false when there are messages in the buffer, but no senders
     let (tx, mut rx) = mpsc::unbounded_channel();
     for i in 0..10 {
         assert!(tx.send(i).is_ok());
@@ -1146,7 +1146,7 @@ async fn test_rx_unbounded_is_not_closed_when_there_are_messages_but_not_senders
 
 #[tokio::test]
 async fn test_rx_unbounded_is_not_closed_when_there_are_messages_and_close_is_called() {
-    // is_closed should return false when there is a permit (but no senders)
+    // is_closed should return false when there are messages in the buffer, and close is called
     let (tx, mut rx) = mpsc::unbounded_channel();
     for i in 0..10 {
         assert!(tx.send(i).is_ok());
@@ -1157,7 +1157,7 @@ async fn test_rx_unbounded_is_not_closed_when_there_are_messages_and_close_is_ca
 
 #[tokio::test]
 async fn test_rx_unbounded_is_closed_after_consuming_messages() {
-    // is_closed should return false when there is a permit (but no senders)
+    // is_closed should return true after consuming messages
     let (tx, mut rx) = mpsc::unbounded_channel();
     for i in 0..10 {
         assert!(tx.send(i).is_ok());

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1204,6 +1204,35 @@ async fn test_rx_len_when_consuming_all_messages() {
 }
 
 #[tokio::test]
+async fn test_rx_len_when_close_is_called() {
+    let (tx, mut rx) = mpsc::channel(100);
+    tx.send(()).await.unwrap();
+    rx.close();
+
+    assert_eq!(rx.len(), 1);
+}
+
+#[tokio::test]
+async fn test_rx_len_when_close_is_called_before_dropping_sender() {
+    let (tx, mut rx) = mpsc::channel(100);
+    tx.send(()).await.unwrap();
+    rx.close();
+    drop(tx);
+
+    assert_eq!(rx.len(), 1);
+}
+
+#[tokio::test]
+async fn test_rx_len_when_close_is_called_after_dropping_sender() {
+    let (tx, mut rx) = mpsc::channel(100);
+    tx.send(()).await.unwrap();
+    drop(tx);
+    rx.close();
+
+    assert_eq!(rx.len(), 1);
+}
+
+#[tokio::test]
 async fn test_rx_unbounded_is_closed_when_calling_close_with_sender() {
     // is_closed should return true after calling close but still has a sender
     let (_tx, mut rx) = mpsc::unbounded_channel::<()>();
@@ -1360,6 +1389,35 @@ async fn test_rx_unbounded_len_when_consuming_all_messages() {
         assert!(rx.recv().await.is_some());
         assert_eq!(rx.len(), i);
     }
+}
+
+#[tokio::test]
+async fn test_rx_unbounded_len_when_close_is_called() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tx.send(()).unwrap();
+    rx.close();
+
+    assert_eq!(rx.len(), 1);
+}
+
+#[tokio::test]
+async fn test_rx_unbounded_len_when_close_is_called_before_dropping_sender() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tx.send(()).unwrap();
+    rx.close();
+    drop(tx);
+
+    assert_eq!(rx.len(), 1);
+}
+
+#[tokio::test]
+async fn test_rx_unbounded_len_when_close_is_called_after_dropping_sender() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    tx.send(()).unwrap();
+    drop(tx);
+    rx.close();
+
+    assert_eq!(rx.len(), 1);
 }
 
 fn is_debug<T: fmt::Debug>(_: &T) {}

--- a/tokio/tests/sync_mpsc_weak.rs
+++ b/tokio/tests/sync_mpsc_weak.rs
@@ -511,3 +511,12 @@ fn test_tx_count_weak_unbounded_sender() {
 
     assert!(tx_weak.upgrade().is_none() && tx_weak2.upgrade().is_none());
 }
+
+#[tokio::test]
+async fn test_rx_is_closed_when_dropping_all_senders_except_weak_senders() {
+    // is_closed should return true after dropping all senders except for a weak sender
+    let (tx, mut rx) = mpsc::channel::<()>(10);
+    let _weak_sender = tx.clone().downgrade();
+    drop(tx);
+    assert!(rx.is_closed());
+}

--- a/tokio/tests/sync_mpsc_weak.rs
+++ b/tokio/tests/sync_mpsc_weak.rs
@@ -515,7 +515,7 @@ fn test_tx_count_weak_unbounded_sender() {
 #[tokio::test]
 async fn test_rx_is_closed_when_dropping_all_senders_except_weak_senders() {
     // is_closed should return true after dropping all senders except for a weak sender
-    let (tx, mut rx) = mpsc::channel::<()>(10);
+    let (tx, rx) = mpsc::channel::<()>(10);
     let _weak_sender = tx.clone().downgrade();
     drop(tx);
     assert!(rx.is_closed());
@@ -524,7 +524,7 @@ async fn test_rx_is_closed_when_dropping_all_senders_except_weak_senders() {
 #[tokio::test]
 async fn test_rx_unbounded_is_closed_when_dropping_all_senders_except_weak_senders() {
     // is_closed should return true after dropping all senders except for a weak sender
-    let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+    let (tx, rx) = mpsc::unbounded_channel::<()>();
     let _weak_sender = tx.clone().downgrade();
     drop(tx);
     assert!(rx.is_closed());

--- a/tokio/tests/sync_mpsc_weak.rs
+++ b/tokio/tests/sync_mpsc_weak.rs
@@ -520,3 +520,12 @@ async fn test_rx_is_closed_when_dropping_all_senders_except_weak_senders() {
     drop(tx);
     assert!(rx.is_closed());
 }
+
+#[tokio::test]
+async fn test_rx_unbounded_is_closed_when_dropping_all_senders_except_weak_senders() {
+    // is_closed should return true after dropping all senders except for a weak sender
+    let (tx, mut rx) = mpsc::unbounded_channel::<()>();
+    let _weak_sender = tx.clone().downgrade();
+    drop(tx);
+    assert!(rx.is_closed());
+}


### PR DESCRIPTION
Fixes: #4638
Fixes: #6314

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Taken from #4638

## Solution

Adds a new `is_closed` function to both `mpsc::Receivers` that check if the channel is closed and has no remaining messages in the internal buffer.

Since there are two possible ways to close a channel and they lead to different internal states, it was necessary to add two checks, one for each internal state.