### PR TITLE
Add worker id to `on_thread_park()` callback (for stuck worker watchdog)

### DIFF
--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -2,7 +2,7 @@
     any(not(all(tokio_unstable, feature = "full")), target_family = "wasm"),
     allow(dead_code)
 )]
-use crate::runtime::Callback;
+use crate::runtime::CallbackWorker;
 use crate::util::RngSeedGenerator;
 
 pub(crate) struct Config {
@@ -16,10 +16,10 @@ pub(crate) struct Config {
     pub(crate) local_queue_capacity: usize,
 
     /// Callback for a worker parking itself
-    pub(crate) before_park: Option<Callback>,
+    pub(crate) before_park: Option<CallbackWorker>,
 
     /// Callback for a worker unparking itself
-    pub(crate) after_unpark: Option<Callback>,
+    pub(crate) after_unpark: Option<CallbackWorker>,
 
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -406,4 +406,7 @@ cfg_rt! {
 
     /// After thread starts / before thread stops
     type Callback = std::sync::Arc<dyn Fn() + Send + Sync>;
+
+    /// Before thread parks / after thread unparks
+    type CallbackWorker = std::sync::Arc<dyn Fn(usize) + Send + Sync>;
 }

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -351,7 +351,7 @@ impl Context {
         let mut driver = core.driver.take().expect("driver missing");
 
         if let Some(f) = &handle.shared.config.before_park {
-            let (c, ()) = self.enter(core, || f());
+            let (c, ()) = self.enter(core, || f(0));
             core = c;
         }
 
@@ -371,7 +371,7 @@ impl Context {
         }
 
         if let Some(f) = &handle.shared.config.after_unpark {
-            let (c, ()) = self.enter(core, || f());
+            let (c, ()) = self.enter(core, || f(0));
             core = c;
         }
 

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1129,7 +1129,7 @@ impl Worker {
 
     fn park(&mut self, cx: &Context, mut core: Box<Core>) -> NextTaskResult {
         if let Some(f) = &cx.shared().config.before_park {
-            f();
+            f(core.index);
         }
 
         if self.can_transition_to_parked(&mut core) {
@@ -1140,7 +1140,7 @@ impl Worker {
         }
 
         if let Some(f) = &cx.shared().config.after_unpark {
-            f();
+            f(core.index);
         }
 
         Ok((None, core))


### PR DESCRIPTION
It's possible to find out from WorkerMetrics which workers are not actively polling for tasks.  However it's not possible to tell if non-polling workers are merely idle (parked) or if they are stuck. By adding the worker id (same usize as used in WorkerMetrics calls) to the on_thread_park() and on_thread_unpark() callbacks it is possible to track which specific workers are parked.  Then any worker that is not polling tasks and is not parked is a worker that is stuck.

With this information it's possible to create a watchdog that alerts or kills the process if a worker is stuck for too long.

Fixes #6353

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

If a task gets stuck and doesn't yield back to the tokio runtime, other tasks can be starved (even if other workers are idle).  I would like a watchdog that can detect when a task is stuck, and either alert or kill the process.

Using `WorkerMetrics` and `worker_poll_count()` it's possible to determine if a worker is not polling for new tasks.  However it's not possible to tell if that worker is merely parked, or stuck.


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Include a worker id in the `on_thread_park()` and `on_thread_unpark()` callbacks so that the idle / busy status of each worker can be inferred.  Then it's possible for a watchdog thread to monitor `worker_poll_count()` and the parked/unparked status of each worker, and do something about it.