### PR TITLE
fix: prevent optimize of try_lock in park.rs leading to race conditions (#6355)

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -7,6 +7,7 @@ use crate::loom::sync::{Arc, Condvar, Mutex};
 use crate::runtime::driver::{self, Driver};
 use crate::util::TryLock;
 
+use std::hint::black_box;
 use std::sync::atomic::Ordering::SeqCst;
 use std::time::Duration;
 
@@ -71,7 +72,7 @@ impl Parker {
         // Only parking with zero is supported...
         assert_eq!(duration, Duration::from_millis(0));
 
-        if let Some(mut driver) = self.inner.shared.driver.try_lock() {
+        if let Some(mut driver) = black_box(self.inner.shared.driver.try_lock()) {
             driver.park_timeout(handle, duration);
         }
     }


### PR DESCRIPTION
## Motivation

This PR addresses the issue described in #6355, it fixes a segmentation fault in `park_timeout()` on riscv64.

## Solution

Following the rust documentation on [black_box in std::hint](https://doc.rust-lang.org/std/hint/fn.black_box.html) it's possible to instruct the compiler to prevent optimizing a specific call.

https://github.com/tokio-rs/tokio/blob/b32826bc937a34e4d871c89bb2c3711ed3e20cdc/tokio/src/runtime/scheduler/multi_thread/park.rs#L74

Wrapping `try_lock()` with `black_box()` in [park.rs:74](https://github.com/tokio-rs/tokio/blob/b32826bc937a34e4d871c89bb2c3711ed3e20cdc/tokio/src/runtime/scheduler/multi_thread/park.rs#L74) causes the compiler to block optimizations for the call and prevents omission of the call.

Tested on Alpine Linux edge (riscv64)

See https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/50419 for details.