### PR TITLE
Put import of os submodule behind 'net' feature to fix doc generation…

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -630,6 +630,7 @@ pub mod stream {}
 #[cfg(docsrs)]
 pub mod doc;
 
+#[cfg(feature = "net")]
 #[cfg(docsrs)]
 #[allow(unused)]
 pub(crate) use self::doc::os;


### PR DESCRIPTION
… without the 'net' feature.

Fixes https://github.com/tokio-rs/tokio/issues/6359.

## Motivation

Fixes doc generation without `net` feature.


## Solution

Put `os` submodule import into root module behind `feature="net"` gate, because of assumptions made elsewhere.

Tested on macOS.

PS. Didn't bother to update change log because it's such an edge-case.