### PR TITLE
ci: downgrade to QEMU 7.2 for cross-compile builds (#6361)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+          qemu: '7.2'
 
       - uses: Swatinem/rust-cache@v2
       - name: Tests run with all features (including parking_lot)
@@ -576,6 +577,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
+          qemu: '7.2'
 
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
@@ -612,6 +614,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: i686-unknown-linux-gnu
+          qemu: '7.2'
 
       - uses: Swatinem/rust-cache@v2
       - name: test tokio --all-features


### PR DESCRIPTION

## Motivation

We're seeing this intermittent test failure #6361 on cross-compiled builds.  The errors I've seen are on the test `cross-test-with-parking_lot` for target `aarch64-unknown-linux-gnu`

Here's an example: https://github.com/tokio-rs/tokio/actions/runs/7918173089/job/21616135686#step:7:611

```
2024-02-15T15:26:37.7973513Z thread 'alt_threaded_scheduler_4_threads::panic_in_block_on' panicked at tokio/tests/rt_common.rs:880:29:
2024-02-15T15:26:37.7975804Z explicit panic
2024-02-15T15:26:37.7977671Z stack backtrace:
2024-02-15T15:26:37.7979839Z qemu-aarch64: QEMU internal SIGSEGV {code=MAPERR, addr=0x20}
```

## Solution

The QEMU internal SIGSEGV points to a potential QEMU bug.  This change downgrades QEMU to 7.2 for the cross-compilation builds which is reported to be a more stable version.    

I didn't observe the QEMU crash on the `alt_threaded_scheduler_4_threads::panic_in_block_on` test with QEMU 7.2 whereas I was seeing it with QEMU 8.2.1.   

This is an intermittent issue though so who knows for sure if it's fixed!    I think this is worth trying for a week or so and we can keep an eye on it to see if it is helping.   

