### PR TITLE
Add unstable on_thread_park_id() to runtime Builder (for stuck task watchdog)

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -939,9 +939,9 @@ impl Builder {
             self
         }
 
-        /// Same behavior as `on_thread_park` except the id of the thread that is parked is passed
-        /// to the callback function `f`.  The id corresponds to the same `usize` that is used in
-        /// calls to `RuntimeMetrics`.
+        /// Has the same behavior as `on_thread_park` except the id of the thread that is parked
+        /// is passed to the callback function `f`.  The id corresponds to the same `usize` that
+        /// is used in calls to `RuntimeMetrics`.
         ///
         /// Note: if both `on_thread_park` and `on_thread_park_id` are called, only the last one
         /// will be saved.

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -995,6 +995,7 @@ impl Builder {
         ///         }
         ///     });
         ///
+        ///     // Spawn a "stuck" task that doesn't yield properly (should be detected).
         ///     runtime.spawn(async { thread::sleep(time::Duration::from_secs(3)) });
         ///     runtime.block_on(async {
         ///          let _ = done_rx.await;

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -2,7 +2,7 @@
     any(not(all(tokio_unstable, feature = "full")), target_family = "wasm"),
     allow(dead_code)
 )]
-use crate::runtime::Callback;
+use crate::runtime::CallbackWorker;
 use crate::util::RngSeedGenerator;
 
 pub(crate) struct Config {
@@ -16,10 +16,10 @@ pub(crate) struct Config {
     pub(crate) local_queue_capacity: usize,
 
     /// Callback for a worker parking itself
-    pub(crate) before_park: Option<Callback>,
+    pub(crate) before_park: Option<CallbackWorker>,
 
     /// Callback for a worker unparking itself
-    pub(crate) after_unpark: Option<Callback>,
+    pub(crate) after_unpark: Option<CallbackWorker>,
 
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -406,4 +406,7 @@ cfg_rt! {
 
     /// After thread starts / before thread stops
     type Callback = std::sync::Arc<dyn Fn() + Send + Sync>;
+
+    /// Before thread parks / after thread unparks
+    type CallbackWorker = std::sync::Arc<dyn Fn(usize) + Send + Sync>;
 }

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -351,7 +351,7 @@ impl Context {
         let mut driver = core.driver.take().expect("driver missing");
 
         if let Some(f) = &handle.shared.config.before_park {
-            let (c, ()) = self.enter(core, || f());
+            let (c, ()) = self.enter(core, || f(0));
             core = c;
         }
 
@@ -371,7 +371,7 @@ impl Context {
         }
 
         if let Some(f) = &handle.shared.config.after_unpark {
-            let (c, ()) = self.enter(core, || f());
+            let (c, ()) = self.enter(core, || f(0));
             core = c;
         }
 

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1129,7 +1129,7 @@ impl Worker {
 
     fn park(&mut self, cx: &Context, mut core: Box<Core>) -> NextTaskResult {
         if let Some(f) = &cx.shared().config.before_park {
-            f();
+            f(core.index);
         }
 
         if self.can_transition_to_parked(&mut core) {
@@ -1140,7 +1140,7 @@ impl Worker {
         }
 
         if let Some(f) = &cx.shared().config.after_unpark {
-            f();
+            f(core.index);
         }
 
         Ok((None, core))

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -681,7 +681,7 @@ fn budget_exhaustion_yield_with_joins() {
 }
 
 #[test]
-fn on_thread_park_unpark() {
+fn on_thread_park_unpark_id() {
     const THREADS: usize = 8;
 
     // Keeps track whether or not each worker is parked
@@ -696,11 +696,11 @@ fn on_thread_park_unpark() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(THREADS)
         .enable_all()
-        .on_thread_park(move |worker| {
+        .on_thread_park_id(move |worker| {
             // worker is parked
             bools_park[worker].store(true, atomic::Ordering::Release);
         })
-        .on_thread_unpark(move |worker| {
+        .on_thread_unpark_id(move |worker| {
             bools_unpark[worker].store(false, atomic::Ordering::Release);
         })
         .build()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Fixes #6353.  I'm looking for a way to detect when a task is not yielding back to tokio properly.  Currently such a task can cause other random tasks to not get run.  We had an incident where a buggy task went into a busy loop and put a service into a zombie state: it still was responding to most requests, but some background tasks were not running as expected.

If there is an existing way to detect a stuck task, I'd be delighted to be enlightened.

## Solution

Add a new method `on_thread_park_id()` that includes the worker id being parked.  This allows a watchdog process to determine which workers are not parked and also not polling (available already from `RuntimeMetrics::worker_poll_count()`).  The watchdog code would look something like this:

```
fn main() {
    const WORKERS: usize = 4;
    const UNPARKED: AtomicBool = AtomicBool::new(false);
    static PARKED: [AtomicBool; WORKERS] = [UNPARKED; WORKERS];

    let runtime = runtime::Builder::new_multi_thread()
        .worker_threads(WORKERS)
        .on_thread_park_id(|id| PARKED[id].store(true, Ordering::Release))
        .on_thread_unpark_id(|id| PARKED[id].store(false, Ordering::Release))
        .build()
        .unwrap();

    let metrics = runtime.handle().metrics();
    thread::spawn(move || {
        let mut stuck_secs = [0; WORKERS];
        let mut prev_poll_counts = [None; WORKERS];
        loop {
            thread::sleep(time::Duration::from_secs(1));
            for ii in 0..WORKERS {
                if PARKED[ii].load(Ordering::Acquire) {
                    prev_poll_counts[ii] = None;
                } else {
                    let poll_count = metrics.worker_poll_count(ii);
                    if Some(poll_count) == prev_poll_counts[ii] {
                        stuck_secs[ii] += 1;
                        println!("*** worker {} is stuck >= {} secs ***", ii, stuck_secs[ii]);
                    } else {
                        prev_poll_counts[ii] = Some(poll_count);
                        stuck_secs[ii] = 0;
                    }
                }
            }
        }
    });

    runtime.spawn(async { loop {} });
    runtime.block_on(async {
        loop {
            tokio::task::yield_now().await
        }
    });
}
```

Rather than printing, a real watchdog implementation could call `std::process::abort()` if the task stays stuck past some duration (e.g. 10 seconds).  