### PR TITLE
tokio-test: mark `tokio_test::task::Spawn` as `must_use`

### DIFF
--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -49,6 +49,7 @@ pub fn spawn<T>(task: T) -> Spawn<T> {
 /// Future spawned on a mock task that can be used to poll the future or stream
 /// without needing pinning or context types.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Spawn<T> {
     task: MockTask,
     future: Pin<Box<T>>,


### PR DESCRIPTION
A task passed to `Spawn` will not be executed unless it is polled, and it would be more helpful to add `must_use` annotation.