### PR TITLE
Mark 1.36 as an LTS release

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,18 +215,18 @@ warrants a patch release with a fix for the bug, it will be backported and
 released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
- * `1.25.x` - LTS release until March 2024. (MSRV 1.49)
  * `1.32.x` - LTS release until September 2024. (MSRV 1.63)
+ * `1.36.x` - LTS release until March 2025. (MSRV 1.63)
 
 Each LTS release will continue to receive backported fixes for at least a year.
 If you wish to use a fixed minor release in your project, we recommend that you
 use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.25.x` patch release, you
+example, to specify that you wish to use the newest `1.32.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.25", features = [...] }
+tokio = { version = "~1.32", features = [...] }
 ```
 
 ### Previous LTS releases
@@ -235,6 +235,7 @@ tokio = { version = "~1.25", features = [...] }
  * `1.14.x` - LTS release until June 2022.
  * `1.18.x` - LTS release until June 2023.
  * `1.20.x` - LTS release until September 2023.
+ * `1.25.x` - LTS release until March 2024.
 
 ## License
 

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -215,18 +215,18 @@ warrants a patch release with a fix for the bug, it will be backported and
 released as a new patch release for each LTS minor version. Our current LTS
 releases are:
 
- * `1.25.x` - LTS release until March 2024. (MSRV 1.49)
  * `1.32.x` - LTS release until September 2024. (MSRV 1.63)
+ * `1.36.x` - LTS release until March 2025. (MSRV 1.63)
 
 Each LTS release will continue to receive backported fixes for at least a year.
 If you wish to use a fixed minor release in your project, we recommend that you
 use an LTS release.
 
 To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.25.x` patch release, you
+example, to specify that you wish to use the newest `1.32.x` patch release, you
 can use the following dependency specification:
 ```text
-tokio = { version = "~1.25", features = [...] }
+tokio = { version = "~1.32", features = [...] }
 ```
 
 ### Previous LTS releases
@@ -235,6 +235,7 @@ tokio = { version = "~1.25", features = [...] }
  * `1.14.x` - LTS release until June 2022.
  * `1.18.x` - LTS release until June 2023.
  * `1.20.x` - LTS release until September 2023.
+ * `1.25.x` - LTS release until March 2024.
 
 ## License
 


### PR DESCRIPTION
This PR marks the latest release of Tokio as an LTS release, replacing the previous 1.25.x series that has just expired as an LTS.