### PR TITLE
ci: update FreeBSD image to 14

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'tokio-.*')
 auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
-  image_family: freebsd-13-2
+  image_family: freebsd-14-0
 env:
   RUST_STABLE: stable
   RUST_NIGHTLY: nightly-2023-10-21


### PR DESCRIPTION
I saw the CI job fail due to the older FreeBSD no longer being available.