### PR TITLE
Add missing period to docstring for broadcast::Sender::receiver_count

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -741,7 +741,7 @@ impl<T> Sender<T> {
         self.shared.buffer[idx].read().unwrap().rem.load(SeqCst) == 0
     }
 
-    /// Returns the number of active receivers
+    /// Returns the number of active receivers.
     ///
     /// An active receiver is a [`Receiver`] handle returned from [`channel`] or
     /// [`subscribe`]. These are the handles that will receive values sent on


### PR DESCRIPTION
## Motivation

Missing period at the end of a docstring sentence.

## Solution

Add the missing period.
