### PR TITLE
chore: fix deprecated circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test-arm:
     machine:
-      image: ubuntu-2004:202101-01
+      image: default
     resource_class: arm.medium
     environment:
       # Change to pin rust version


### PR DESCRIPTION
## Motivation
The ubuntu image currently being used for the circleci ARM test is deprecated
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177

We did see a [failing CI test ](https://app.circleci.com/pipelines/github/tokio-rs/tokio/5524/workflows/44c44024-a642-4835-93b4-7ab454397deb/jobs/5297?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)on PR #6378  during the recent circleci brown out on 4th March 


```
This job was rejected because the image 'ubuntu-2004:202101-01' is [unavailable](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/)
```

## Solution

Updated circleci to use the default image tag.   

Note this also updates it to use `22.04` rather than `20.04`
