### PR TITLE
feat(rt): revise some const values in runtime

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -217,9 +217,10 @@ impl Builder {
     pub fn new_current_thread() -> Builder {
         #[cfg(loom)]
         const EVENT_INTERVAL: u32 = 4;
-        // The number `61` is fairly arbitrary. I believe this value was copied from golang.
+        // The number was `61` which was copied from golang previously, we
+        // changed it to `64` for better performance.
         #[cfg(not(loom))]
-        const EVENT_INTERVAL: u32 = 61;
+        const EVENT_INTERVAL: u32 = 64;
 
         Builder::new(Kind::CurrentThread, EVENT_INTERVAL)
     }
@@ -231,8 +232,9 @@ impl Builder {
         #[cfg(feature = "rt-multi-thread")]
         #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
         pub fn new_multi_thread() -> Builder {
-            // The number `61` is fairly arbitrary. I believe this value was copied from golang.
-            Builder::new(Kind::MultiThread, 61)
+            // The number was `61` which was copied from golang previously, we
+            // changed it to `64` for better performance.
+            Builder::new(Kind::MultiThread, 64)
         }
 
         cfg_unstable! {
@@ -250,8 +252,9 @@ impl Builder {
             #[cfg(feature = "rt-multi-thread")]
             #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
             pub fn new_multi_thread_alt() -> Builder {
-                // The number `61` is fairly arbitrary. I believe this value was copied from golang.
-                Builder::new(Kind::MultiThreadAlt, 61)
+                // The number was `61` which was copied from golang previously, we
+                // changed it to `64` for better performance.
+                Builder::new(Kind::MultiThreadAlt, 64)
             }
         }
     }
@@ -746,7 +749,7 @@ impl Builder {
     ///
     /// A scheduler "tick" roughly corresponds to one `poll` invocation on a task.
     ///
-    /// By default the global queue interval is 31 for the current-thread scheduler. Please see
+    /// By default the global queue interval is 32 for the current-thread scheduler. Please see
     /// [the module documentation] for the default behavior of the multi-thread scheduler.
     ///
     /// Schedulers have a local queue of already-claimed tasks, and a global queue of incoming
@@ -764,7 +767,7 @@ impl Builder {
     /// # use tokio::runtime;
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
-    ///     .global_queue_interval(31)
+    ///     .global_queue_interval(32)
     ///     .build();
     /// # }
     /// ```
@@ -778,7 +781,7 @@ impl Builder {
     ///
     /// A scheduler "tick" roughly corresponds to one `poll` invocation on a task.
     ///
-    /// By default, the event interval is `61` for all scheduler types.
+    /// By default, the event interval is `64` for all scheduler types.
     ///
     /// Setting the event interval determines the effective "priority" of delivering
     /// these external events (which may wake up additional tasks), compared to
@@ -796,7 +799,7 @@ impl Builder {
     /// # use tokio::runtime;
     /// # pub fn main() {
     /// let rt = runtime::Builder::new_multi_thread()
-    ///     .event_interval(31)
+    ///     .event_interval(32)
     ///     .build();
     /// # }
     /// ```

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -242,12 +242,12 @@
 //! to be scheduled: the global queue and the local queue. The runtime will prefer
 //! to choose the next task to schedule from the local queue, and will only pick a
 //! task from the global queue if the local queue is empty, or if it has picked
-//! a task from the local queue 31 times in a row. The number 31 can be
+//! a task from the local queue 32 times in a row. The number 32 can be
 //! changed using the [`global_queue_interval`] setting.
 //!
 //! The runtime will check for new IO or timer events whenever there are no
-//! tasks ready to be scheduled, or when it has scheduled 61 tasks in a row. The
-//! number 61 may be changed using the [`event_interval`] setting.
+//! tasks ready to be scheduled, or when it has scheduled 64 tasks in a row. The
+//! number 64 may be changed using the [`event_interval`] setting.
 //!
 //! When a task is woken from within a task running on the runtime, then the
 //! woken task is added directly to the local queue. Otherwise, the task is
@@ -280,8 +280,8 @@
 //! local queue.
 //!
 //! The runtime will check for new IO or timer events whenever there are no
-//! tasks ready to be scheduled, or when it has scheduled 61 tasks in a row. The
-//! number 61 may be changed using the [`event_interval`] setting.
+//! tasks ready to be scheduled, or when it has scheduled 64 tasks in a row. The
+//! number 64 may be changed using the [`event_interval`] setting.
 //!
 //! The multi thread runtime uses [the lifo slot optimization]: Whenever a task
 //! wakes up another task, the other task is added to the worker thread's lifo

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -112,7 +112,7 @@ const INITIAL_CAPACITY: usize = 64;
 /// Used if none is specified. This is a temporary constant and will be removed
 /// as we unify tuning logic between the multi-thread and current-thread
 /// schedulers.
-const DEFAULT_GLOBAL_QUEUE_INTERVAL: u32 = 31;
+const DEFAULT_GLOBAL_QUEUE_INTERVAL: u32 = 32;
 
 impl CurrentThread {
     pub(crate) fn new(

--- a/tokio/src/runtime/scheduler/multi_thread/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/stats.rs
@@ -34,10 +34,10 @@ const TASK_POLL_TIME_EWMA_ALPHA: f64 = 0.1;
 const TARGET_GLOBAL_QUEUE_INTERVAL: f64 = Duration::from_micros(200).as_nanos() as f64;
 
 /// Max value for the global queue interval. This is 2x the previous default
-const MAX_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 127;
+const MAX_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 128;
 
 /// This is the previous default
-const TARGET_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 61;
+const TARGET_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 64;
 
 impl Stats {
     pub(crate) fn new(worker_metrics: &WorkerMetrics) -> Stats {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
@@ -52,10 +52,10 @@ const TASK_POLL_TIME_EWMA_ALPHA: f64 = 0.1;
 const TARGET_GLOBAL_QUEUE_INTERVAL: f64 = Duration::from_micros(200).as_nanos() as f64;
 
 /// Max value for the global queue interval. This is 2x the previous default
-const MAX_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 127;
+const MAX_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 128;
 
 /// This is the previous default
-const TARGET_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 61;
+const TARGET_TASKS_POLLED_PER_GLOBAL_QUEUE_INTERVAL: u32 = 64;
 
 impl Stats {
     pub(crate) const DEFAULT_GLOBAL_QUEUE_INTERVAL: u32 =

--- a/tokio/src/runtime/tests/loom_multi_thread_alt.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt.rs
@@ -322,7 +322,7 @@ mod group_c {
             let pool = runtime::Builder::new_multi_thread_alt()
                 .worker_threads(2)
                 // Set the intervals to avoid tuning logic
-                .global_queue_interval(61)
+                .global_queue_interval(64)
                 .local_queue_capacity(1)
                 .build()
                 .unwrap();
@@ -357,7 +357,7 @@ mod group_c {
             let pool = runtime::Builder::new_multi_thread_alt()
                 .worker_threads(2)
                 // Set the intervals to avoid tuning logic
-                .global_queue_interval(61)
+                .global_queue_interval(64)
                 .local_queue_capacity(DEPTH)
                 .build()
                 .unwrap();
@@ -460,7 +460,7 @@ fn mk_pool(num_threads: usize) -> Runtime {
     runtime::Builder::new_multi_thread_alt()
         .worker_threads(num_threads)
         // Set the intervals to avoid tuning logic
-        .global_queue_interval(61)
+        .global_queue_interval(64)
         .build()
         .unwrap()
 }

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -205,7 +205,7 @@ mod tests {
 
                 // Yield so the previous broadcast can get received
                 //
-                // This yields many times since the block_on task is only polled every 61
+                // This yields many times since the block_on task is only polled every 64
                 // ticks.
                 for _ in 0..100 {
                     crate::task::yield_now().await;

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -387,10 +387,10 @@ cfg_rt! {
 const INITIAL_CAPACITY: usize = 64;
 
 /// Max number of tasks to poll per tick.
-const MAX_TASKS_PER_TICK: usize = 61;
+const MAX_TASKS_PER_TICK: usize = 64;
 
 /// How often it check the remote queue first.
-const REMOTE_FIRST_INTERVAL: u8 = 31;
+const REMOTE_FIRST_INTERVAL: u8 = 32;
 
 /// Context guard for `LocalSet`
 pub struct LocalEnterGuard {

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -644,8 +644,8 @@ fn test_tuning() {
     }
 
     let flag = Arc::new(AtomicBool::new(true));
-    let counter = Arc::new(AtomicUsize::new(61));
-    let interval = Arc::new(AtomicUsize::new(61));
+    let counter = Arc::new(AtomicUsize::new(64));
+    let interval = Arc::new(AtomicUsize::new(64));
 
     {
         let flag = flag.clone();

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -617,8 +617,8 @@ fn test_tuning() {
     }
 
     let flag = Arc::new(AtomicBool::new(true));
-    let counter = Arc::new(AtomicUsize::new(61));
-    let interval = Arc::new(AtomicUsize::new(61));
+    let counter = Arc::new(AtomicUsize::new(64));
+    let interval = Arc::new(AtomicUsize::new(64));
 
     {
         let flag = flag.clone();


### PR DESCRIPTION
## Motivation

Previously the const values in runtime were copied from Go and it seems a little arbitrary.

But values such as `64`, `32` are much more performant then `61`, `31`.

Here's the generated assembly code: https://godbolt.org/z/6jscb4TY3

## Solution

This PR changed the constants to `64` and `32`.