### PR TITLE
sync: Implement `Clone` for `watch::Sender` 

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -148,7 +148,7 @@ pub struct Sender<T> {
 
 impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
-        self.shared.ref_count_tx.fetch_add(1, AcqRel);
+        self.shared.ref_count_tx.fetch_add(1, Relaxed);
 
         Self {
             shared: self.shared.clone(),

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -1316,20 +1316,15 @@ impl<T> Drop for Sender<T> {
 
             // Fetch the latest state.
             let current_state = self.shared.state.load();
-            let currrent_ref_count = current_state.0;
+            let currrent_state_inner = current_state.0;
 
-            // We try to update the state with compare_exchange.
-            //
-            // If another task closes the sender or clones the sender again while loading
-            // the latest state, the `compare_exchange` here will fail. In that case,
-            // we do nothing in this sender's drop.
             if self
                 .shared
                 .state
                 .0
                 .compare_exchange(
-                    currrent_ref_count,
-                    currrent_ref_count | CLOSED_BIT,
+                    currrent_state_inner,
+                    currrent_state_inner | CLOSED_BIT,
                     AcqRel,
                     Relaxed,
                 )


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
This PR attempt to resolve https://github.com/tokio-rs/tokio/issues/4809.

Currently, watch channel has only one sender but this enable it to be mpmc by adding a `clone` of the sender.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
As with the reciever, the `ref_count_tx` field is added to the shared structure to record the number of senders; this counter is incremented by the sender's `clone` method and decremented by the `drop` method.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
