### PR TITLE
sync: reorder const_new before new_with

### DIFF
--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -132,6 +132,47 @@ impl<T> OnceCell<T> {
         }
     }
 
+    /// Creates a new empty `OnceCell` instance.
+    ///
+    /// Equivalent to `OnceCell::new`, except that it can be used in static
+    /// variables.
+    ///
+    /// When using the `tracing` [unstable feature], a `OnceCell` created with
+    /// `const_new` will not be instrumented. As such, it will not be visible
+    /// in [`tokio-console`]. Instead, [`OnceCell::new`] should be used to
+    /// create an instrumented object if that is needed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::sync::OnceCell;
+    ///
+    /// static ONCE: OnceCell<u32> = OnceCell::const_new();
+    ///
+    /// async fn get_global_integer() -> &'static u32 {
+    ///     ONCE.get_or_init(|| async {
+    ///         1 + 1
+    ///     }).await
+    /// }
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let result = get_global_integer().await;
+    ///     assert_eq!(*result, 2);
+    /// }
+    /// ```
+    ///
+    /// [`tokio-console`]: https://github.com/tokio-rs/console
+    /// [unstable feature]: crate#unstable-features
+    #[cfg(not(all(loom, test)))]
+    pub const fn const_new() -> Self {
+        OnceCell {
+            value_set: AtomicBool::new(false),
+            value: UnsafeCell::new(MaybeUninit::uninit()),
+            semaphore: Semaphore::const_new(1),
+        }
+    }
+
     /// Creates a new `OnceCell` that contains the provided value, if any.
     ///
     /// If the `Option` is `None`, this is equivalent to `OnceCell::new`.
@@ -184,47 +225,6 @@ impl<T> OnceCell<T> {
             value_set: AtomicBool::new(true),
             value: UnsafeCell::new(MaybeUninit::new(value)),
             semaphore: Semaphore::const_new_closed(),
-        }
-    }
-
-    /// Creates a new empty `OnceCell` instance.
-    ///
-    /// Equivalent to `OnceCell::new`, except that it can be used in static
-    /// variables.
-    ///
-    /// When using the `tracing` [unstable feature], a `OnceCell` created with
-    /// `const_new` will not be instrumented. As such, it will not be visible
-    /// in [`tokio-console`]. Instead, [`OnceCell::new`] should be used to
-    /// create an instrumented object if that is needed.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use tokio::sync::OnceCell;
-    ///
-    /// static ONCE: OnceCell<u32> = OnceCell::const_new();
-    ///
-    /// async fn get_global_integer() -> &'static u32 {
-    ///     ONCE.get_or_init(|| async {
-    ///         1 + 1
-    ///     }).await
-    /// }
-    ///
-    /// #[tokio::main]
-    /// async fn main() {
-    ///     let result = get_global_integer().await;
-    ///     assert_eq!(*result, 2);
-    /// }
-    /// ```
-    ///
-    /// [`tokio-console`]: https://github.com/tokio-rs/console
-    /// [unstable feature]: crate#unstable-features
-    #[cfg(not(all(loom, test)))]
-    pub const fn const_new() -> Self {
-        OnceCell {
-            value_set: AtomicBool::new(false),
-            value: UnsafeCell::new(MaybeUninit::uninit()),
-            semaphore: Semaphore::const_new(1),
         }
     }
 


### PR DESCRIPTION
This reorders the functions on `OnceCell` so that they appear in this order: `new`, `const_new`, `new_with`, `const_new_with`. Changing the order improves the documentation, as they appear in the same order there.

I know that the diff doesn't show it that way, but I really did just reorder the methods.