### PR TITLE
sync: update watch channel docs

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -278,7 +278,7 @@
 //!
 //! ## `watch` channel
 //!
-//! The [`watch` channel] supports sending **many** values from a **single**
+//! The [`watch` channel] supports sending **many** values from a **many**
 //! producer to **many** consumers. However, only the **most recent** value is
 //! stored in the channel. Consumers are notified when a new value is sent, but
 //! there is no guarantee that consumers will see **all** values.

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
 
-//! A single-producer, multi-consumer channel that only retains the *last* sent
+//! A multi-producer, multi-consumer channel that only retains the *last* sent
 //! value.
 //!
 //! This channel is useful for watching for changes to a value from multiple


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Follow up to https://github.com/tokio-rs/tokio/pull/6388.

With the above pull request, the watch channel is no longer necessarily a single producer. This PR updates docs that specify single producer.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
