### PR TITLE
tokio-util: remove `'static` bound on `impl Sink for PollSender`

### DIFF
--- a/tokio-util/src/sync/mpsc.rs
+++ b/tokio-util/src/sync/mpsc.rs
@@ -303,7 +303,7 @@ impl<T> Clone for PollSender<T> {
     }
 }
 
-impl<T: Send + 'static> Sink<T> for PollSender<T> {
+impl<T: Send> Sink<T> for PollSender<T> {
     type Error = PollSendError<T>;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
## Motivation

In PR #5665, the `'static` bound has been removed on values sent into `PollSender`. One of this bound was remaining on the `PollSender` implementation of `Sink`.

## Solution

This patch removes the bound and adds some tests on the `Sink` interface for `PollSender`.