### PR TITLE
chore: prepare tokio-test v0.4.4

### DIFF
--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 0.4.4 (March 14, 2024)
+
+- task: mark `Spawn` as `#[must_use]` ([#6371])
+- test: increase MSRV to 1.63 ([#6126])
+- test: update category slug ([#5953])
+
+[#5953]: https://github.com/tokio-rs/tokio/pull/5953
+[#6126]: https://github.com/tokio-rs/tokio/pull/6126
+[#6371]: https://github.com/tokio-rs/tokio/pull/6371
+
 # 0.4.3 (August 23, 2023)
 
 - deps: fix minimum required version of `async-stream` ([#5347])

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-test"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-test-0.4.x" git tag.
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.4.4 (March 14, 2024)

- task: mark `Spawn` as `#[must_use]` ([#6371])
- test: increase MSRV to 1.63 ([#6126])
- test: update category slug ([#5953])

[#5953]: https://github.com/tokio-rs/tokio/pull/5953
[#6126]: https://github.com/tokio-rs/tokio/pull/6126
[#6371]: https://github.com/tokio-rs/tokio/pull/6371