### PR TITLE
chore: prepare tokio-stream v0.1.15

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.1.15 (March 14th, 2024)
+
+This release bumps the MSRV of tokio-stream to 1.63.
+
+- docs: fix typo in argument name ([#6389])
+- docs: fix typo in peekable docs ([#6130])
+- docs: link to latest version of tokio-util docs ([#5694])
+- docs: typographic improvements ([#6262])
+- stream: add `StreamExt::peekable` ([#6095])
+
+[#5694]: https://github.com/tokio-rs/tokio/pull/5694
+[#6095]: https://github.com/tokio-rs/tokio/pull/6095
+[#6130]: https://github.com/tokio-rs/tokio/pull/6130
+[#6262]: https://github.com/tokio-rs/tokio/pull/6262
+[#6389]: https://github.com/tokio-rs/tokio/pull/6389
+
 # 0.1.14 (April 26th, 2023)
 
 This bugfix release bumps the minimum version of Tokio to 1.15, which is

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.1.15 (March 14th, 2024)

This release bumps the MSRV of tokio-stream to 1.63.

- docs: fix typo in argument name ([#6389])
- docs: fix typo in peekable docs ([#6130])
- docs: link to latest version of tokio-util docs ([#5694])
- docs: typographic improvements ([#6262])
- stream: add `StreamExt::peekable` ([#6095])

[#5694]: https://github.com/tokio-rs/tokio/pull/5694
[#6095]: https://github.com/tokio-rs/tokio/pull/6095
[#6130]: https://github.com/tokio-rs/tokio/pull/6130
[#6262]: https://github.com/tokio-rs/tokio/pull/6262
[#6389]: https://github.com/tokio-rs/tokio/pull/6389