### PR TITLE
readme: fix the guide for running loom tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,9 +184,11 @@ it, `rustfmt` will update your files locally instead.
 You can run loom tests with
 ```
 cd tokio # tokio crate in workspace
-LOOM_MAX_PREEMPTIONS=1 RUSTFLAGS="--cfg loom" \
+LOOM_MAX_PREEMPTIONS=1 LOOM_MAX_BRANCHES=10000 RUSTFLAGS="--cfg loom -C debug_assertions" \
     cargo test --lib --release --features full -- --test-threads=1 --nocapture
 ```
+Additionally, you can also add `--cfg tokio_unstable` to the `RUSTFLAGS` environment variable to
+run loom tests that test unstable features. 
 
 You can run miri tests with
 ```

--- a/tokio/src/runtime/tests/loom_multi_thread_alt.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt.rs
@@ -1,3 +1,5 @@
+#![cfg(tokio_unstable)]
+
 mod queue;
 mod shutdown;
 mod yield_now;


### PR DESCRIPTION
I found out that the guide for running loom tests doesn't work. This PR adds:
* `-C debug_assertions` to `RUSTFLAGS` since there is a `compile_error` that prevents the loom tests in the `runtime` module to run without debug assertions.
* `LOOM_MAX_BRANCHES=10000` to make it consistent with how CI is configured.
* `#![cfg(tokio_unstable)]` to `loom_multi_thread_alt.rs` to gate this test file appropriately.