### PR TITLE
runtime: prevent using unhandled_panic option on multi-thread runtime

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -824,6 +824,9 @@ impl Builder {
         ///   will immediately terminate and further calls to
         ///   [`Runtime::block_on`] will panic.
         ///
+        /// # Panics
+        /// This method panics if called on a runtime other than [`Kind::CurrentThread`].
+        ///
         /// # Unstable
         ///
         /// This option is currently unstable and its implementation is
@@ -861,6 +864,10 @@ impl Builder {
         ///
         /// [`JoinHandle`]: struct@crate::task::JoinHandle
         pub fn unhandled_panic(&mut self, behavior: UnhandledPanic) -> &mut Self {
+            if !matches!(self.kind, Kind::CurrentThread) {
+                panic!("unhandled panic option is only supported in current thread runtime");
+            }
+
             self.unhandled_panic = behavior;
             self
         }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -825,7 +825,7 @@ impl Builder {
         ///   [`Runtime::block_on`] will panic.
         ///
         /// # Panics
-        /// This method panics if called with [`UnhandledPanic::ShutdownRuntime`] 
+        /// This method panics if called with [`UnhandledPanic::ShutdownRuntime`]
         /// on a runtime other than the current thread runtime.
         ///
         /// # Unstable

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -825,7 +825,7 @@ impl Builder {
         ///   [`Runtime::block_on`] will panic.
         ///
         /// # Panics
-        /// This method panics if called on a runtime other than [`Kind::CurrentThread`].
+        /// This method panics if called on a runtime other than the current thread runtime.
         ///
         /// # Unstable
         ///

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -825,7 +825,8 @@ impl Builder {
         ///   [`Runtime::block_on`] will panic.
         ///
         /// # Panics
-        /// This method panics if called on a runtime other than the current thread runtime.
+        /// This method panics if called with [`UnhandledPanic::ShutdownRuntime`] 
+        /// on a runtime other than the current thread runtime.
         ///
         /// # Unstable
         ///
@@ -864,8 +865,8 @@ impl Builder {
         ///
         /// [`JoinHandle`]: struct@crate::task::JoinHandle
         pub fn unhandled_panic(&mut self, behavior: UnhandledPanic) -> &mut Self {
-            if !matches!(self.kind, Kind::CurrentThread) {
-                panic!("unhandled panic option is only supported in current thread runtime");
+            if !matches!(self.kind, Kind::CurrentThread) && matches!(behavior, UnhandledPanic::ShutdownRuntime) {
+                panic!("UnhandledPanic::ShutdownRuntime is only supported in current thread runtime");
             }
 
             self.unhandled_panic = behavior;


### PR DESCRIPTION
This PR documents and enforces the fact that the `unhandled_panic` option is only implemented for the current thread runtime, since it has caused confusion before: #6222.