### PR TITLE
fs: add `set_max_buf_size` to `tokio::fs::File`

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -533,7 +533,7 @@ impl File {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn set_max_buf_size(&mut self, max_buf_size: usize) {
+    pub async fn set_max_buf_size(&self, max_buf_size: usize) {
         let mut inner = self.inner.lock().await;
         inner.state = State::Idle(Some(Buf::with_capacity_and_max_buf_size(0, max_buf_size)));
     }

--- a/tokio/src/fs/file/tests.rs
+++ b/tokio/src/fs/file/tests.rs
@@ -231,7 +231,7 @@ fn flush_while_idle() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn read_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = crate::io::blocking::MAX_BUF;
+    let chunk_a = crate::io::blocking::DEFAULT_MAX_BUF_SIZE;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;
@@ -303,7 +303,7 @@ fn read_with_buffer_larger_than_max() {
 #[cfg_attr(miri, ignore)] // takes a really long time with miri
 fn write_with_buffer_larger_than_max() {
     // Chunks
-    let chunk_a = crate::io::blocking::MAX_BUF;
+    let chunk_a = crate::io::blocking::DEFAULT_MAX_BUF_SIZE;
     let chunk_b = chunk_a * 2;
     let chunk_c = chunk_a * 3;
     let chunk_d = chunk_a * 4;

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -30,6 +30,7 @@ mock! {
         pub fn open(pb: PathBuf) -> io::Result<Self>;
         pub fn set_len(&self, size: u64) -> io::Result<()>;
         pub fn set_permissions(&self, _perm: Permissions) -> io::Result<()>;
+        pub fn set_max_buf_size(&self, max_buf_size: usize);
         pub fn sync_all(&self) -> io::Result<()>;
         pub fn sync_data(&self) -> io::Result<()>;
         pub fn try_clone(&self) -> io::Result<Self>;

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -181,6 +181,28 @@ fn tempfile() -> NamedTempFile {
 }
 
 #[tokio::test]
+async fn set_max_buf_size_read() {
+    let mut tempfile = tempfile();
+    tempfile.write_all(HELLO).unwrap();
+    let mut file = File::open(tempfile.path()).await.unwrap();
+    let mut buf = [0; 1024];
+    file.set_max_buf_size(1).await;
+
+    // A single read operation reads a maximum of 1 byte.
+    assert_eq!(file.read(&mut buf).await.unwrap(), 1);
+}
+
+#[tokio::test]
+async fn set_max_buf_size_write() {
+    let tempfile = tempfile();
+    let mut file = File::create(tempfile.path()).await.unwrap();
+    file.set_max_buf_size(1).await;
+
+    // A single write operation writes a maximum of 1 byte.
+    assert_eq!(file.write(HELLO).await.unwrap(), 1);
+}
+
+#[tokio::test]
 #[cfg(unix)]
 async fn file_debug_fmt() {
     let tempfile = tempfile();

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -186,7 +186,7 @@ async fn set_max_buf_size_read() {
     tempfile.write_all(HELLO).unwrap();
     let mut file = File::open(tempfile.path()).await.unwrap();
     let mut buf = [0; 1024];
-    file.set_max_buf_size(1).await;
+    file.set_max_buf_size(1);
 
     // A single read operation reads a maximum of 1 byte.
     assert_eq!(file.read(&mut buf).await.unwrap(), 1);
@@ -196,7 +196,7 @@ async fn set_max_buf_size_read() {
 async fn set_max_buf_size_write() {
     let tempfile = tempfile();
     let mut file = File::create(tempfile.path()).await.unwrap();
-    file.set_max_buf_size(1).await;
+    file.set_max_buf_size(1);
 
     // A single write operation writes a maximum of 1 byte.
     assert_eq!(file.write(HELLO).await.unwrap(), 1);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
https://github.com/tokio-rs/tokio/pull/5397 enhanced performance by updating the `tokio::fs::File`'s MAX_BUF from 16KiB to 2MiB for operations involving `AsyncWrite` / `AsyncRead`. Related to this, it would also be useful to provide an API that allows to customize this default.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This introduce a `set_max_buf_size` to `tokio::fs::File` to customize the maximum buffer size.
If this is not set, the current default of 2MiB will be applied. In the current implementation, this `max_buf_size` will be applicable for both read and write operations.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
