### PR TITLE
util: add documentation about cancel safety of `SinkExt::send`

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -19,11 +19,18 @@ pin_project! {
     ///
     /// You can create a `Framed` instance by using the [`Decoder::framed`] adapter, or
     /// by using the `new` function seen below.
+    /// 
+    /// # Cancellation safety
+    ///
+    /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
+    /// `tokio::select!` statement and some other branch completes first, then it is
+    /// guaranteed that the message was not sent, but the message itself is lost.
     ///
     /// [`Stream`]: futures_core::Stream
     /// [`Sink`]: futures_sink::Sink
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`Decoder::framed`]: crate::codec::Decoder::framed()
+    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
     pub struct Framed<T, U> {
         #[pin]
         inner: FramedImpl<T, U, RWFrames>

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -25,12 +25,16 @@ pin_project! {
     /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
     /// `tokio::select!` statement and some other branch completes first, then it is
     /// guaranteed that the message was not sent, but the message itself is lost.
+    /// * [`tokio_stream::StreamExt::next`]: This method is cancel safe. The returned
+    /// future only holds onto a reference to the underlying stream, so dropping it will
+    /// never lose a value.
     ///
     /// [`Stream`]: futures_core::Stream
     /// [`Sink`]: futures_sink::Sink
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`Decoder::framed`]: crate::codec::Decoder::framed()
-    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
+    /// [`futures_util::sink::SinkExt::send`]: futures_util::sink::SinkExt::send
+    /// [`tokio_stream::StreamExt::next`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.next
     pub struct Framed<T, U> {
         #[pin]
         inner: FramedImpl<T, U, RWFrames>

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -19,7 +19,7 @@ pin_project! {
     ///
     /// You can create a `Framed` instance by using the [`Decoder::framed`] adapter, or
     /// by using the `new` function seen below.
-    /// 
+    ///
     /// # Cancellation safety
     ///
     /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -22,11 +22,15 @@ pin_project! {
     /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
     /// `tokio::select!` statement and some other branch completes first, then it is
     /// guaranteed that the message was not sent, but the message itself is lost.
+    /// * [`tokio_stream::StreamExt::next`]: This method is cancel safe. The returned
+    /// future only holds onto a reference to the underlying stream, so dropping it will
+    /// never lose a value.
     ///
     /// [`Stream`]: futures_core::Stream
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`codec`]: crate::codec
-    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
+    /// [`futures_util::sink::SinkExt::send`]: futures_util::sink::SinkExt::send
+    /// [`tokio_stream::StreamExt::next`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.next
     pub struct FramedRead<T, D> {
         #[pin]
         inner: FramedImpl<T, D, ReadFrame>,

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -18,10 +18,6 @@ pin_project! {
     /// examples on the [`codec`] module.
     ///
     /// # Cancellation safety
-    ///
-    /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
-    /// `tokio::select!` statement and some other branch completes first, then it is
-    /// guaranteed that the message was not sent, but the message itself is lost.
     /// * [`tokio_stream::StreamExt::next`]: This method is cancel safe. The returned
     /// future only holds onto a reference to the underlying stream, so dropping it will
     /// never lose a value.
@@ -29,7 +25,6 @@ pin_project! {
     /// [`Stream`]: futures_core::Stream
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`codec`]: crate::codec
-    /// [`futures_util::sink::SinkExt::send`]: futures_util::sink::SinkExt::send
     /// [`tokio_stream::StreamExt::next`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.next
     pub struct FramedRead<T, D> {
         #[pin]

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -17,9 +17,16 @@ pin_project! {
     /// For examples of how to use `FramedRead` with a codec, see the
     /// examples on the [`codec`] module.
     ///
+    /// # Cancellation safety
+    ///
+    /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
+    /// `tokio::select!` statement and some other branch completes first, then it is
+    /// guaranteed that the message was not sent, but the message itself is lost.
+    ///
     /// [`Stream`]: futures_core::Stream
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`codec`]: crate::codec
+    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
     pub struct FramedRead<T, D> {
         #[pin]
         inner: FramedImpl<T, D, ReadFrame>,

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -23,14 +23,10 @@ pin_project! {
     /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
     /// `tokio::select!` statement and some other branch completes first, then it is
     /// guaranteed that the message was not sent, but the message itself is lost.
-    /// * [`tokio_stream::StreamExt::next`]: This method is cancel safe. The returned
-    /// future only holds onto a reference to the underlying stream, so dropping it will
-    /// never lose a value.
     ///
     /// [`Sink`]: futures_sink::Sink
     /// [`codec`]: crate::codec
     /// [`futures_util::sink::SinkExt::send`]: futures_util::sink::SinkExt::send
-    /// [`tokio_stream::StreamExt::next`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.next
     pub struct FramedWrite<T, E> {
         #[pin]
         inner: FramedImpl<T, E, WriteFrame>,

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -23,10 +23,14 @@ pin_project! {
     /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
     /// `tokio::select!` statement and some other branch completes first, then it is
     /// guaranteed that the message was not sent, but the message itself is lost.
+    /// * [`tokio_stream::StreamExt::next`]: This method is cancel safe. The returned
+    /// future only holds onto a reference to the underlying stream, so dropping it will
+    /// never lose a value.
     ///
     /// [`Sink`]: futures_sink::Sink
     /// [`codec`]: crate::codec
-    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
+    /// [`futures_util::sink::SinkExt::send`]: futures_util::sink::SinkExt::send
+    /// [`tokio_stream::StreamExt::next`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.next
     pub struct FramedWrite<T, E> {
         #[pin]
         inner: FramedImpl<T, E, WriteFrame>,

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -18,8 +18,15 @@ pin_project! {
     /// For examples of how to use `FramedWrite` with a codec, see the
     /// examples on the [`codec`] module.
     ///
+    /// # Cancellation safety
+    ///
+    /// * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
+    /// `tokio::select!` statement and some other branch completes first, then it is
+    /// guaranteed that the message was not sent, but the message itself is lost.
+    ///
     /// [`Sink`]: futures_sink::Sink
     /// [`codec`]: crate::codec
+    /// [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
     pub struct FramedWrite<T, E> {
         #[pin]
         inner: FramedImpl<T, E, WriteFrame>,

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -17,20 +17,7 @@
 //! [`tokio`] crate. However, `tokio-util` _will_ respect Rust's
 //! semantic versioning policy, especially with regard to breaking changes.
 //!
-//! # Cancellation safety
-//!
-//! When using `tokio::select!` in a loop to receive messages from multiple sources,
-//! you should make sure that the receive call is cancellation safe to avoid
-//! losing messages. This section goes through various common methods and
-//! describes whether they are cancel safe.  The lists in this section are not
-//! exhaustive.
-//!
-//! * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
-//! `tokio::select!` statement and some other branch completes first, then it is
-//! guaranteed that the message was not sent, but the message itself is lost.
-//!
 //! [`tokio`]: https://docs.rs/tokio
-//! [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
 
 #[macro_use]
 mod cfg;

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -17,7 +17,20 @@
 //! [`tokio`] crate. However, `tokio-util` _will_ respect Rust's
 //! semantic versioning policy, especially with regard to breaking changes.
 //!
+//! # Cancellation safety
+//!
+//! When using `tokio::select!` in a loop to receive messages from multiple sources,
+//! you should make sure that the receive call is cancellation safe to avoid
+//! losing messages. This section goes through various common methods and
+//! describes whether they are cancel safe.  The lists in this section are not
+//! exhaustive.
+//!
+//! * [`futures_util::sink::SinkExt::send`]: if send is used as the event in a
+//! `tokio::select!` statement and some other branch completes first, then it is
+//! guaranteed that the message was not sent, but the message itself is lost.
+//!
 //! [`tokio`]: https://docs.rs/tokio
+//! [`futures_util::sink::SinkExt::send`]: https://docs.rs/futures-util/latest/futures_util/sink/trait.SinkExt.html#method.send
 
 #[macro_use]
 mod cfg;


### PR DESCRIPTION
Since types in different sub-modules in `tokio-util` implement `Sink`, I decided to put the doc in the top level module.

Resolves #5310.