### PR TITLE
sync: add  a `rwlock()` method to owned `RwLock` guards

### DIFF
--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -155,14 +155,14 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
     /// let lock = Arc::new(RwLock::new(Foo(1)));
     ///
     /// let guard = lock.clone().read_owned().await;
-    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// assert!(Arc::ptr_eq(&lock, OwnedRwLockReadGuard::rwlock(&guard)));
     ///
     /// let guard = OwnedRwLockReadGuard::map(guard, |f| &f.0);
-    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// assert!(Arc::ptr_eq(&lock, OwnedRwLockReadGuard::rwlock(&guard)));
     /// # }
     /// ```
-    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
-        &self.lock
+    pub fn rwlock(this: &Self) -> &Arc<RwLock<T>> {
+        &this.lock
     }
 }
 

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -138,6 +138,32 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
             resource_span: this.resource_span,
         })
     }
+
+    /// Returns a reference to the original `Arc<RwLock>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockReadGuard};
+    ///
+    /// #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// struct Foo(u32);
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(Foo(1)));
+    ///
+    /// let guard = lock.clone().read_owned().await;
+    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    ///
+    /// let guard = OwnedRwLockReadGuard::map(guard, |f| &f.0);
+    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// # }
+    /// ```
+    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
+        &self.lock
+    }
 }
 
 impl<T: ?Sized, U: ?Sized> ops::Deref for OwnedRwLockReadGuard<T, U> {

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -390,6 +390,26 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
 
         guard
     }
+
+    /// Returns a reference to the original `Arc<RwLock>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::RwLock;
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(1));
+    ///
+    /// let guard = lock.clone().write_owned().await;
+    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// # }
+    /// ```
+    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
+        &self.lock
+    }
 }
 
 impl<T: ?Sized> ops::Deref for OwnedRwLockWriteGuard<T> {

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -397,18 +397,18 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tokio::sync::RwLock;
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// let lock = Arc::new(RwLock::new(1));
     ///
     /// let guard = lock.clone().write_owned().await;
-    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// assert!(Arc::ptr_eq(&lock, OwnedRwLockWriteGuard::rwlock(&guard)));
     /// # }
     /// ```
-    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
-        &self.lock
+    pub fn rwlock(this: &Self) -> &Arc<RwLock<T>> {
+        &this.lock
     }
 }
 

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -162,7 +162,11 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
+    /// use tokio::sync::{
+    ///     RwLock,
+    ///     OwnedRwLockWriteGuard,
+    ///     OwnedRwLockMappedWriteGuard,
+    /// };
     ///
     /// # #[tokio::main]
     /// # async fn main() {
@@ -170,11 +174,11 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
     ///
     /// let guard = lock.clone().write_owned().await;
     /// let guard = OwnedRwLockWriteGuard::map(guard, |x| x);
-    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// assert!(Arc::ptr_eq(&lock, OwnedRwLockMappedWriteGuard::rwlock(&guard)));
     /// # }
     /// ```
-    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
-        &self.lock
+    pub fn rwlock(this: &Self) -> &Arc<RwLock<T>> {
+        &this.lock
     }
 }
 

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -155,6 +155,27 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
             resource_span: this.resource_span,
         })
     }
+
+    /// Returns a reference to the original `Arc<RwLock>`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::{RwLock, OwnedRwLockMappedWriteGuard};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// let lock = Arc::new(RwLock::new(1));
+    ///
+    /// let guard = lock.clone().write_owned().await;
+    /// let guard = OwnedRwLockMappedWriteGuard::map(guard, |x| x);
+    /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
+    /// # }
+    /// ```
+    pub fn rwlock(&self) -> &Arc<RwLock<T>> {
+        &self.lock
+    }
 }
 
 impl<T: ?Sized, U: ?Sized> ops::Deref for OwnedRwLockMappedWriteGuard<T, U> {

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -162,14 +162,14 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
     ///
     /// ```
     /// use std::sync::Arc;
-    /// use tokio::sync::{RwLock, OwnedRwLockMappedWriteGuard};
+    /// use tokio::sync::{RwLock, OwnedRwLockWriteGuard};
     ///
     /// # #[tokio::main]
     /// # async fn main() {
     /// let lock = Arc::new(RwLock::new(1));
     ///
     /// let guard = lock.clone().write_owned().await;
-    /// let guard = OwnedRwLockMappedWriteGuard::map(guard, |x| x);
+    /// let guard = OwnedRwLockWriteGuard::map(guard, |x| x);
     /// assert!(Arc::ptr_eq(&lock, guard.rwlock()));
     /// # }
     /// ```


### PR DESCRIPTION
Adds a `rwlock()` method returning a reference to the original `Arc<RwLock>` to the `Owned*` guards.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`Mutex` guards and `Semaphore` permits already have similar methods.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A similar, `rwlock()`, method is added to the `Owned*` guards. The "normal" guards don't actually hold a reference to the original `RwLock` and I don't think that it can be added to them without changing these types' definitions.