### PR TITLE
Adding support for QNX OS

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -39,10 +39,10 @@ impl UCred {
 ))]
 pub(crate) use self::impl_linux::get_peer_cred;
 
-#[cfg(target_os = "netbsd")]
+#[cfg(any(target_os = "netbsd", target_os = "nto"))]
 pub(crate) use self::impl_netbsd::get_peer_cred;
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "nto"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 pub(crate) use self::impl_bsd::get_peer_cred;
 
 #[cfg(any(
@@ -120,7 +120,7 @@ pub(crate) mod impl_linux {
     }
 }
 
-#[cfg(target_os = "netbsd")]
+#[cfg(any(target_os = "netbsd", target_os = "nto"))]
 pub(crate) mod impl_netbsd {
     use crate::net::unix::{self, UnixStream};
 
@@ -162,7 +162,7 @@ pub(crate) mod impl_netbsd {
     }
 }
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "nto"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
 pub(crate) mod impl_bsd {
     use crate::net::unix::{self, UnixStream};
 

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -42,7 +42,7 @@ pub(crate) use self::impl_linux::get_peer_cred;
 #[cfg(target_os = "netbsd")]
 pub(crate) use self::impl_netbsd::get_peer_cred;
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "nto"))]
 pub(crate) use self::impl_bsd::get_peer_cred;
 
 #[cfg(any(
@@ -162,7 +162,7 @@ pub(crate) mod impl_netbsd {
     }
 }
 
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "nto"))]
 pub(crate) mod impl_bsd {
     use crate::net::unix::{self, UnixStream};
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -673,8 +673,7 @@ impl Command {
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn uid(&mut self, id: u32) -> &mut Command {
         #[cfg(target_os = "nto")]
-        self.std.uid(id as i32);
-        #[cfg(not(target_os = "nto"))]
+        let id = id as i32;
         self.std.uid(id);
         self
     }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -684,8 +684,7 @@ impl Command {
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn gid(&mut self, id: u32) -> &mut Command {
         #[cfg(target_os = "nto")]
-        self.std.gid(id as i32);
-        #[cfg(not(target_os = "nto"))]
+        let id = id as i32;
         self.std.gid(id);
         self
     }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -672,6 +672,9 @@ impl Command {
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn uid(&mut self, id: u32) -> &mut Command {
+        #[cfg(target_os = "nto")]
+        self.std.uid(id as i32);
+        #[cfg(not(target_os = "nto"))]
         self.std.uid(id);
         self
     }
@@ -681,6 +684,9 @@ impl Command {
     #[cfg(unix)]
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn gid(&mut self, id: u32) -> &mut Command {
+        #[cfg(target_os = "nto")]
+        self.std.gid(id as i32);
+        #[cfg(not(target_os = "nto"))]
         self.std.gid(id);
         self
     }


### PR DESCRIPTION
This enables tokio to be used on QNX.
It also depends on

https://github.com/tokio-rs/mio/pull/1766

@AkhilTThomas I added you to the fork, so you can write there as well

The changes are rather trivial, the main thing is a i32/u32 type mismatch that is handled

Not so sure what is expected/can done in terms of testing, as I assume there are no QNX machines in CI? What are the expectations here?

Once this is in acceptable form, would we need to backport it on one of the many version branches?
As just tokio users we would appreciate some form of QNX support being available out of the box on released tokio versions, (even if would be hidden behind a "here be dragons, we have no idea what this does" kind-of flag )

