### PR TITLE
chore: fix dead code warning

### DIFF
--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -4,6 +4,7 @@ use criterion::measurement::WallTime;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
 
 #[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
 struct Medium([usize; 64]);
 impl Default for Medium {
     fn default() -> Self {
@@ -12,6 +13,7 @@ impl Default for Medium {
 }
 
 #[derive(Debug, Copy, Clone)]
+#[allow(dead_code)]
 struct Large([Medium; 64]);
 impl Default for Large {
     fn default() -> Self {

--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -4,8 +4,7 @@ use criterion::measurement::WallTime;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
 
 #[derive(Debug, Copy, Clone)]
-#[allow(dead_code)]
-struct Medium([usize; 64]);
+struct Medium(#[allow(dead_code)] [usize; 64]);
 impl Default for Medium {
     fn default() -> Self {
         Medium([0; 64])
@@ -13,8 +12,7 @@ impl Default for Medium {
 }
 
 #[derive(Debug, Copy, Clone)]
-#[allow(dead_code)]
-struct Large([Medium; 64]);
+struct Large(#[allow(dead_code)] [Medium; 64]);
 impl Default for Large {
     fn default() -> Self {
         Large([Medium::default(); 64])

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -52,8 +52,7 @@ fn notify_waiters_handles_panicking_waker() {
 
     let notify = Arc::new(Notify::new());
 
-    #[allow(dead_code)]
-    struct PanickingWaker(Arc<Notify>);
+    struct PanickingWaker(#[allow(dead_code)] Arc<Notify>);
 
     impl ArcWake for PanickingWaker {
         fn wake_by_ref(_arc_self: &Arc<Self>) {

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -52,6 +52,7 @@ fn notify_waiters_handles_panicking_waker() {
 
     let notify = Arc::new(Notify::new());
 
+    #[allow(dead_code)]
     struct PanickingWaker(Arc<Notify>);
 
     impl ArcWake for PanickingWaker {

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -268,6 +268,7 @@ fn release_permits_at_drop() {
 
     let sem = Arc::new(Semaphore::new(1));
 
+    #[allow(dead_code)]
     struct ReleaseOnDrop(Option<OwnedSemaphorePermit>);
 
     impl ArcWake for ReleaseOnDrop {

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -268,8 +268,7 @@ fn release_permits_at_drop() {
 
     let sem = Arc::new(Semaphore::new(1));
 
-    #[allow(dead_code)]
-    struct ReleaseOnDrop(Option<OwnedSemaphorePermit>);
+    struct ReleaseOnDrop(#[allow(dead_code)] Option<OwnedSemaphorePermit>);
 
     impl ArcWake for ReleaseOnDrop {
         fn wake_by_ref(_arc_self: &Arc<Self>) {}

--- a/tokio/src/util/markers.rs
+++ b/tokio/src/util/markers.rs
@@ -1,10 +1,8 @@
 /// Marker for types that are `Sync` but not `Send`
-#[allow(dead_code)]
-pub(crate) struct SyncNotSend(*mut ());
+pub(crate) struct SyncNotSend(#[allow(dead_code)] *mut ());
 
 unsafe impl Sync for SyncNotSend {}
 
 cfg_rt! {
-    #[allow(dead_code)]
-    pub(crate) struct NotSendOrSync(*mut ());
+    pub(crate) struct NotSendOrSync(#[allow(dead_code)] *mut ());
 }

--- a/tokio/src/util/markers.rs
+++ b/tokio/src/util/markers.rs
@@ -1,8 +1,10 @@
 /// Marker for types that are `Sync` but not `Send`
+#[allow(dead_code)]
 pub(crate) struct SyncNotSend(*mut ());
 
 unsafe impl Sync for SyncNotSend {}
 
 cfg_rt! {
+    #[allow(dead_code)]
     pub(crate) struct NotSendOrSync(*mut ());
 }


### PR DESCRIPTION
Resolves breakage of CI after release of Rust 1.77.