### PR TITLE
feat: impl Clone for task_local where T: Clone

### DIFF
--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -264,16 +264,16 @@ impl<T: 'static> LocalKey<T> {
     }
 }
 
-impl<T: Copy + 'static> LocalKey<T> {
+impl<T: Clone + 'static> LocalKey<T> {
     /// Returns a copy of the task-local value
-    /// if the task-local value implements `Copy`.
+    /// if the task-local value implements `Clone`.
     ///
     /// # Panics
     ///
     /// This function will panic if the task local doesn't have a value set.
     #[track_caller]
     pub fn get(&'static self) -> T {
-        self.with(|v| *v)
+        self.with(|v| v.clone())
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

From [the docs](https://docs.rs/tokio/1.36.0/tokio/task/struct.LocalKey.html) it is clear one can `LocalKey::get()` a copy of `T`.
I hard a hard time finding how to get a clone of `T` (my `T` is not `Copy`, it's a struct of `Arc`s).

## Solution

This PR adds a `clone` method alongside the existing `get` method.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
