### PR TITLE
util: Make tracing optional when codec is enabled

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -25,7 +25,7 @@ full = ["codec", "compat", "io-util", "time", "net", "rt"]
 
 net = ["tokio/net"]
 compat = ["futures-io",]
-codec = ["tracing"]
+codec = []
 time = ["tokio/time","slab"]
 io = []
 io-util = ["io", "tokio/rt", "tokio/io-util"]

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -12,7 +12,6 @@ use std::borrow::{Borrow, BorrowMut};
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tracing::trace;
 
 pin_project! {
     #[derive(Debug)]

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -24,6 +24,9 @@ mod cfg;
 
 mod loom;
 
+#[macro_use]
+mod tracing;
+
 cfg_codec! {
     pub mod codec;
 }

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -24,10 +24,10 @@ mod cfg;
 
 mod loom;
 
-#[macro_use]
-mod tracing;
-
 cfg_codec! {
+    #[macro_use]
+    mod tracing;
+
     pub mod codec;
 }
 

--- a/tokio-util/src/tracing.rs
+++ b/tokio-util/src/tracing.rs
@@ -1,0 +1,6 @@
+macro_rules! trace {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "tracing")]
+        tracing::trace!($($arg)*);
+    };
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I maintain a library that implements the websocket protocol using tokio-util's `FramedRead` for decoding frames. I conduct testing using `cargo-minvers` in CI to ensure that my minimum dependency versions are correct and working as they are intended to.

proc-macro2 is a crate that very, very often breaks with newer rustc versions (most recently, a rustc update broke versions prior to 1.0.60, see [this issue](https://github.com/dtolnay/proc-macro2/issues/398)). tracing-attributes depends on proc-macro2  and regularly has to bump the minimum version to fix their own `cargo-minvers` checks (see [this commit bumping the dependency](https://github.com/tokio-rs/tracing/commit/29f74c52c2535785da52d5b24c90f29be15c3481)).

My issue lies exactly here. tokio-util's codec module depends on tracing, which in turn breaks my minvers check every once in a while due to the tracing version required by tokio-util being too low with the recent rustc I run my checks with. Of course bumping the dependency in tokio-util makes little sense, so my current "fix" is to pin the minimum version of tracing in my crate myself ([like so](https://github.com/Gelbpunkt/tokio-websockets/blob/main/Cargo.toml#L19)).

But that is just tedious and seems wrong for a dependency that is only used for `trace!` macro calls. A lot of headaches and needless CI failures could just be fixed by not depending on `tracing`. 

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This PR makes the tracing usage in the codec module optional, allowing people to opt-in to the events or out of the regular minvers breakage.