### PR TITLE
chore: prepare Tokio v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.36.0", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,71 @@
+# 1.37.0 (March 28th, 2024)
+
+### Added
+
+- fs: add `set_max_buf_size` to `tokio::fs::File` ([#6411])
+- io: add `try_new` and `try_with_interest` to `AsyncFd` ([#6345])
+- sync: add `forget_permits` method to semaphore ([#6331])
+- sync: add `is_closed`, `is_empty`, and `len` to mpsc receivers ([#6348])
+- sync: add a `rwlock()` method to owned `RwLock` guards ([#6418])
+- sync: expose strong and weak counts of mpsc sender handles ([#6405])
+- sync: implement `Clone` for `watch::Sender` ([#6388])
+- task: add `TaskLocalFuture::take_value` ([#6340])
+- task: implement `FromIterator` for `JoinSet` ([#6300])
+
+### Changed
+
+- io: make `io::split` use a mutex instead of a spinlock ([#6403])
+
+### Fixed
+
+- docs: fix docsrs build without net feature ([#6360])
+- macros: allow select with only else branch ([#6339])
+- runtime: fix leaking registration entries when os registration fails ([#6329])
+
+### Documented
+
+- io: document cancel safety of `AsyncBufReadExt::fill_buf` ([#6431])
+- io: document cancel safety of `AsyncReadExt`'s primitive read functions ([#6337])
+- runtime: add doc link from `Runtime` to `#[tokio::main]` ([#6366])
+- runtime: make the `enter` example deterministic ([#6351])
+- sync: add Semaphore example for limiting the number of outgoing requests ([#6419])
+- sync: fix missing period in broadcast docs ([#6377])
+- sync: mark `mpsc::Sender::downgrade` with `#[must_use]` ([#6326])
+- sync: reorder `const_new` before `new_with` ([#6392])
+- sync: update watch channel docs ([#6395])
+- task: fix documentation links ([#6336])
+
+### Changed (unstable)
+
+- runtime: include task `Id` in taskdumps ([#6328])
+- runtime: panic if `unhandled_panic` is enabled when not supported ([#6410])
+
+[#6300]: https://github.com/tokio-rs/tokio/pull/6300
+[#6326]: https://github.com/tokio-rs/tokio/pull/6326
+[#6328]: https://github.com/tokio-rs/tokio/pull/6328
+[#6329]: https://github.com/tokio-rs/tokio/pull/6329
+[#6331]: https://github.com/tokio-rs/tokio/pull/6331
+[#6336]: https://github.com/tokio-rs/tokio/pull/6336
+[#6337]: https://github.com/tokio-rs/tokio/pull/6337
+[#6339]: https://github.com/tokio-rs/tokio/pull/6339
+[#6340]: https://github.com/tokio-rs/tokio/pull/6340
+[#6345]: https://github.com/tokio-rs/tokio/pull/6345
+[#6348]: https://github.com/tokio-rs/tokio/pull/6348
+[#6351]: https://github.com/tokio-rs/tokio/pull/6351
+[#6360]: https://github.com/tokio-rs/tokio/pull/6360
+[#6366]: https://github.com/tokio-rs/tokio/pull/6366
+[#6377]: https://github.com/tokio-rs/tokio/pull/6377
+[#6388]: https://github.com/tokio-rs/tokio/pull/6388
+[#6392]: https://github.com/tokio-rs/tokio/pull/6392
+[#6395]: https://github.com/tokio-rs/tokio/pull/6395
+[#6403]: https://github.com/tokio-rs/tokio/pull/6403
+[#6405]: https://github.com/tokio-rs/tokio/pull/6405
+[#6410]: https://github.com/tokio-rs/tokio/pull/6410
+[#6411]: https://github.com/tokio-rs/tokio/pull/6411
+[#6418]: https://github.com/tokio-rs/tokio/pull/6418
+[#6419]: https://github.com/tokio-rs/tokio/pull/6419
+[#6431]: https://github.com/tokio-rs/tokio/pull/6431
+
 # 1.36.0 (February 2nd, 2024)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.36.0"
+version = "1.37.0"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.36.0", features = ["full"] }
+tokio = { version = "1.37.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.37.0 (March 28th, 2024)

### Added

- fs: add `set_max_buf_size` to `tokio::fs::File` ([#6411])
- io: add `try_new` and `try_with_interest` to `AsyncFd` ([#6345])
- sync: add `forget_permits` method to semaphore ([#6331])
- sync: add `is_closed`, `is_empty`, and `len` to mpsc receivers ([#6348])
- sync: add a `rwlock()` method to owned `RwLock` guards ([#6418])
- sync: expose strong and weak counts of mpsc sender handles ([#6405])
- sync: implement `Clone` for `watch::Sender` ([#6388])
- task: add `TaskLocalFuture::take_value` ([#6340])
- task: implement `FromIterator` for `JoinSet` ([#6300])

### Changed

- io: make `io::split` use a mutex instead of a spinlock ([#6403])

### Fixed

- docs: fix docsrs build without net feature ([#6360])
- macros: allow select with only else branch ([#6339])
- runtime: fix leaking registration entries when os registration fails ([#6329])

### Documented

- io: document cancel safety of `AsyncBufReadExt::fill_buf` ([#6431])
- io: document cancel safety of `AsyncReadExt`'s primitive read functions ([#6337])
- runtime: add doc link from `Runtime` to `#[tokio::main]` ([#6366])
- runtime: make the `enter` example deterministic ([#6351])
- sync: add Semaphore example for limiting the number of outgoing requests ([#6419])
- sync: fix missing period in broadcast docs ([#6377])
- sync: mark `mpsc::Sender::downgrade` with `#[must_use]` ([#6326])
- sync: reorder `const_new` before `new_with` ([#6392])
- sync: update watch channel docs ([#6395])
- task: fix documentation links ([#6336])

### Changed (unstable)

- runtime: include task `Id` in taskdumps ([#6328])
- runtime: panic if `unhandled_panic` is enabled when not supported ([#6410])

[#6300]: https://github.com/tokio-rs/tokio/pull/6300
[#6326]: https://github.com/tokio-rs/tokio/pull/6326
[#6328]: https://github.com/tokio-rs/tokio/pull/6328
[#6329]: https://github.com/tokio-rs/tokio/pull/6329
[#6331]: https://github.com/tokio-rs/tokio/pull/6331
[#6336]: https://github.com/tokio-rs/tokio/pull/6336
[#6337]: https://github.com/tokio-rs/tokio/pull/6337
[#6339]: https://github.com/tokio-rs/tokio/pull/6339
[#6340]: https://github.com/tokio-rs/tokio/pull/6340
[#6345]: https://github.com/tokio-rs/tokio/pull/6345
[#6348]: https://github.com/tokio-rs/tokio/pull/6348
[#6351]: https://github.com/tokio-rs/tokio/pull/6351
[#6360]: https://github.com/tokio-rs/tokio/pull/6360
[#6366]: https://github.com/tokio-rs/tokio/pull/6366
[#6377]: https://github.com/tokio-rs/tokio/pull/6377
[#6388]: https://github.com/tokio-rs/tokio/pull/6388
[#6392]: https://github.com/tokio-rs/tokio/pull/6392
[#6395]: https://github.com/tokio-rs/tokio/pull/6395
[#6403]: https://github.com/tokio-rs/tokio/pull/6403
[#6405]: https://github.com/tokio-rs/tokio/pull/6405
[#6410]: https://github.com/tokio-rs/tokio/pull/6410
[#6411]: https://github.com/tokio-rs/tokio/pull/6411
[#6418]: https://github.com/tokio-rs/tokio/pull/6418
[#6419]: https://github.com/tokio-rs/tokio/pull/6419
[#6431]: https://github.com/tokio-rs/tokio/pull/6431