### PR TITLE
Handle return type properly

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["full", "extra-traits", "visit"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #6306

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Explicitly state the return type of the last statement such that the compiler gives the proper error if the types do not match.

I'm looking for some initial feedback. As I'm writing this description, I'm realizing that I could probably wrap the entire body instead of just the last statement.

The error now looks like this:
```
error[E0308]: mismatched types
 --> src/main.rs:2:20
  |
2 | async fn main() -> Result<(), ()> {
  |          ----      ^^^^^^^^^^^^^^ expected `Result<(), ()>`, found `()`
  |          |
  |          implicitly returns `()` as its body has no tail or `return` expression
3 |     Ok(())?;
4 |     Ok(());
  |           - help: remove this semicolon to return this value
  |
  = note:   expected enum `Result<(), ()>`
          found unit type `()`

For more information about this error, try `rustc --explain E0308`.
error: could not compile `a-thing` (bin "a-thing") due to 1 previous error
```
