### PR TITLE
Allow dynamically sized types in tokio_util::io::poll_read_buf

### DIFF
--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -120,7 +120,7 @@ pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
 /// [`File`]: tokio::fs::File
 /// [vectored writes]: tokio::io::AsyncWrite::poll_write_vectored
 #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
-pub fn poll_write_buf<T: AsyncWrite, B: Buf>(
+pub fn poll_write_buf<T: AsyncWrite + ?Sized, B: Buf>(
     io: Pin<&mut T>,
     cx: &mut Context<'_>,
     buf: &mut B,

--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -46,7 +46,7 @@ use std::task::{Context, Poll};
 /// # }
 /// ```
 #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
-pub fn poll_read_buf<T: AsyncRead, B: BufMut>(
+pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
     io: Pin<&mut T>,
     cx: &mut Context<'_>,
     buf: &mut B,


### PR DESCRIPTION
## Motivation
This PR should fix the issue #6429

## Solution
I added `?Sized` to the trait bounds of the `io` parameter of `tokio_util::io::poll_read_buf` to allow dynamically sized parameters like `&mut (dyn tokio::io::AsyncRead + Unpin)` as well.


Closes #6429 