### PR TITLE
chore: update CI to clippy 1.77

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2023-10-21
-  rust_clippy: '1.76'
+  rust_clippy: '1.77'
   # When updating this, also update:
   # - README.md
   # - tokio/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ When updating this, also update:
 -->
 
 ```
-cargo +1.76 clippy --all --tests --all-features
+cargo +1.77 clippy --all --tests --all-features
 ```
 
 When building documentation normally, the markers that list the features

--- a/tokio-util/tests/compat.rs
+++ b/tokio-util/tests/compat.rs
@@ -15,6 +15,7 @@ async fn compat_file_seek() -> futures_util::io::Result<()> {
         .read(true)
         .write(true)
         .create(true)
+        .truncate(true)
         .open(temp_file)
         .await?
         .compat_write();

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -112,6 +112,7 @@ impl Driver {
         // Drain the pipe completely so we can receive a new readiness event
         // if another signal has come in.
         let mut buf = [0; 128];
+        #[allow(clippy::unused_io_amount)]
         loop {
             match self.receiver.read(&mut buf) {
                 Ok(0) => panic!("EOF on self-pipe"),

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -150,7 +150,7 @@ fn socketpair() -> (FileDescriptor, FileDescriptor) {
 
 fn drain(mut fd: &FileDescriptor) {
     let mut buf = [0u8; 512];
-
+    #[allow(clippy::unused_io_amount)]
     loop {
         match fd.read(&mut buf[..]) {
             Err(e) if e.kind() == ErrorKind::WouldBlock => break,

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1089,7 +1089,7 @@ rt_test! {
         use std::thread;
 
         thread_local!(
-            static R: RefCell<Option<Runtime>> = RefCell::new(None);
+            static R: RefCell<Option<Runtime>> = const { RefCell::new(None) };
         );
 
         thread::spawn(|| {
@@ -1402,7 +1402,7 @@ rt_test! {
         }
 
         std::thread_local! {
-            static TL_DATA: RefCell<Option<TLData>> = RefCell::new(None);
+            static TL_DATA: RefCell<Option<TLData>> = const { RefCell::new(None) };
         };
 
         let (send, recv) = channel();

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -34,7 +34,7 @@ async fn local_current_thread_scheduler() {
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -55,7 +55,7 @@ async fn local_threadpool() {
 #[tokio::test(flavor = "multi_thread")]
 async fn localset_future_threadpool() {
     thread_local! {
-        static ON_LOCAL_THREAD: Cell<bool> = Cell::new(false);
+        static ON_LOCAL_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_LOCAL_THREAD.with(|cell| cell.set(true));
@@ -118,7 +118,7 @@ async fn local_threadpool_timer() {
     // This test ensures that runtime services like the timer are properly
     // set for the local task set.
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -158,7 +158,7 @@ fn enter_guard_spawn() {
 #[should_panic]
 fn local_threadpool_blocking_in_place() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -182,7 +182,7 @@ fn local_threadpool_blocking_in_place() {
 #[tokio::test(flavor = "multi_thread")]
 async fn local_threadpool_blocking_run() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -212,7 +212,7 @@ async fn local_threadpool_blocking_run() {
 async fn all_spawns_are_local() {
     use futures::future;
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -238,7 +238,7 @@ async fn all_spawns_are_local() {
 #[tokio::test(flavor = "multi_thread")]
 async fn nested_spawn_is_local() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));
@@ -274,7 +274,7 @@ async fn nested_spawn_is_local() {
 #[test]
 fn join_local_future_elsewhere() {
     thread_local! {
-        static ON_RT_THREAD: Cell<bool> = Cell::new(false);
+        static ON_RT_THREAD: Cell<bool> = const { Cell::new(false) };
     }
 
     ON_RT_THREAD.with(|cell| cell.set(true));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
This updates the CI to use clippy version 1.77 which is aligned with the rust stable version.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

**Ignored Lints**
The following functions accept the `clippy:unused_io_amount` by the virtue that they handle left over IO in that they are purposefully discarding all IO.
* tokio/src/runtime/signal/mod.rs - process
* tokio/tests/io_async_fd.rs - drain
