### PR TITLE
runtime: make improvements to `global_queue_interval`

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -758,6 +758,10 @@ impl Builder {
     ///
     /// [the module documentation]: crate::runtime#multi-threaded-runtime-behavior-at-the-time-of-writing
     ///
+    /// # Panics
+    ///
+    /// This function will panic if 0 is passed as an argument.
+    ///
     /// # Examples
     ///
     /// ```
@@ -769,6 +773,7 @@ impl Builder {
     /// # }
     /// ```
     pub fn global_queue_interval(&mut self, val: u32) -> &mut Self {
+        assert!(val > 0, "global_queue_interval must be greater than 0");
         self.global_queue_interval = Some(val);
         self
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -772,6 +772,7 @@ impl Builder {
     ///     .build();
     /// # }
     /// ```
+    #[track_caller]
     pub fn global_queue_interval(&mut self, val: u32) -> &mut Self {
         assert!(val > 0, "global_queue_interval must be greater than 0");
         self.global_queue_interval = Some(val);

--- a/tokio/src/runtime/scheduler/multi_thread/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/stats.rs
@@ -63,7 +63,7 @@ impl Stats {
         let tasks_per_interval = (TARGET_GLOBAL_QUEUE_INTERVAL / self.task_poll_time_ewma) as u32;
 
         cmp::max(
-            // We don't want to return less than 2 as that would result in the
+            // If we are using self-tuning, we don't want to return less than 2 as that would result in the
             // global queue always getting checked first.
             2,
             cmp::min(

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -985,8 +985,6 @@ impl Core {
             .stats
             .tuned_global_queue_interval(&worker.handle.shared.config);
 
-        debug_assert!(next > 1);
-
         // Smooth out jitter
         if abs_diff(self.global_queue_interval, next) > 2 {
             self.global_queue_interval = next;

--- a/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/stats.rs
@@ -82,7 +82,7 @@ impl Stats {
         let tasks_per_interval = (TARGET_GLOBAL_QUEUE_INTERVAL / self.task_poll_time_ewma) as u32;
 
         cmp::max(
-            // We don't want to return less than 2 as that would result in the
+            // If we are using self-tuning, we don't want to return less than 2 as that would result in the
             // global queue always getting checked first.
             2,
             cmp::min(

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1288,8 +1288,6 @@ impl Worker {
     fn tune_global_queue_interval(&mut self, cx: &Context, core: &mut Core) {
         let next = core.stats.tuned_global_queue_interval(&cx.shared().config);
 
-        debug_assert!(next > 1);
-
         // Smooth out jitter
         if abs_diff(self.global_queue_interval, next) > 2 {
             self.global_queue_interval = next;

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -664,7 +664,6 @@ impl Worker {
     /// Ensure core's state is set correctly for the worker to start using.
     fn reset_acquired_core(&mut self, cx: &Context, synced: &mut Synced, core: &mut Core) {
         self.global_queue_interval = core.stats.tuned_global_queue_interval(&cx.shared().config);
-        debug_assert!(self.global_queue_interval > 1);
 
         // Reset `lifo_enabled` here in case the core was previously stolen from
         // a task that had the LIFO slot disabled.

--- a/tokio/tests/rt_panic.rs
+++ b/tokio/tests/rt_panic.rs
@@ -70,6 +70,18 @@ fn builder_max_blocking_threads_panic_caller() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+#[test]
+fn builder_global_queue_interval_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _ = Builder::new_multi_thread().global_queue_interval(0).build();
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
 fn current_thread() -> Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -493,7 +493,7 @@ fn max_blocking_threads_set_to_zero() {
 /// when global_queue_interval is set to 1.
 #[test]
 fn global_queue_interval_set_to_one() {
-    let rt = tokio::runtime::Builder::new_multi_thread_alt()
+    let rt = tokio::runtime::Builder::new_multi_thread()
         .global_queue_interval(1)
         .build()
         .unwrap();

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -501,11 +501,14 @@ fn global_queue_interval_set_to_one() {
     // Perform a simple work.
     let cnt = Arc::new(AtomicUsize::new(0));
     rt.block_on(async {
+        let mut set = tokio::task::JoinSet::new();
         for _ in 0..10 {
             let cnt = cnt.clone();
-            tokio::spawn(async move { cnt.fetch_add(1, Ordering::Relaxed) })
-                .await
-                .unwrap();
+            set.spawn(async move { cnt.fetch_add(1, Ordering::Relaxed) });
+        }
+
+        while let Some(res) = set.join_next().await {
+            res.unwrap();
         }
     });
     assert_eq!(cnt.load(Relaxed), 10);

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -10,8 +10,8 @@ use tokio_test::{assert_err, assert_ok};
 use futures::future::poll_fn;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 
@@ -484,6 +484,31 @@ fn max_blocking_threads_set_to_zero() {
         .max_blocking_threads(0)
         .build()
         .unwrap();
+}
+
+/// Regression test for #6445.
+///
+/// After #6445, setting `global_queue_interval` to 1 is now technically valid.
+/// This test confirms that there is no regression in `multi_thread_runtime`
+/// when global_queue_interval is set to 1.
+#[test]
+fn global_queue_interval_set_to_one() {
+    let rt = tokio::runtime::Builder::new_multi_thread_alt()
+        .global_queue_interval(1)
+        .build()
+        .unwrap();
+
+    // Perform a simple work.
+    let cnt = Arc::new(AtomicUsize::new(0));
+    rt.block_on(async {
+        for _ in 0..10 {
+            let cnt = cnt.clone();
+            tokio::spawn(async move { cnt.fetch_add(1, Ordering::Relaxed) })
+                .await
+                .unwrap();
+        }
+    });
+    assert_eq!(cnt.load(Relaxed), 10);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -494,7 +494,7 @@ fn max_blocking_threads_set_to_zero() {
 /// when global_queue_interval is set to 1.
 #[test]
 fn global_queue_interval_set_to_one() {
-    let rt = tokio::runtime::Builder::new_multi_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread_alt()
         .global_queue_interval(1)
         .build()
         .unwrap();

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -487,6 +487,31 @@ fn max_blocking_threads_set_to_zero() {
         .unwrap();
 }
 
+/// Regression test for #6445.
+///
+/// After #6445, setting `global_queue_interval` to 1 is now technically valid.
+/// This test confirms that there is no regression in `multi_thread_runtime`
+/// when global_queue_interval is set to 1.
+#[test]
+fn global_queue_interval_set_to_one() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .global_queue_interval(1)
+        .build()
+        .unwrap();
+
+    // Perform a simple work.
+    let cnt = Arc::new(AtomicUsize::new(0));
+    rt.block_on(async {
+        for _ in 0..10 {
+            let cnt = cnt.clone();
+            tokio::spawn(async move { cnt.fetch_add(1, Relaxed) })
+                .await
+                .unwrap();
+        }
+    });
+    assert_eq!(cnt.load(Relaxed), 10);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hang_on_shutdown() {
     let (sync_tx, sync_rx) = std::sync::mpsc::channel::<()>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Resolve #5713. Currently specifying 0 or 1 for `global_queue_interval` causes a panic.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
This PR:
* Added documentation indicating that setting global_queue_interval to 0 is not allowed and included an assert in the builder.
* Removed the `debug_assert!(next > 1)` that could be triggered when global_queue_interval is set to 1.
  * Although it's still unclear whether there is a practical benefit to always prioritize checking the global queue first, but i guess it's probably better than causing a panic in debug builds.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
