### PR TITLE
io: implement AsyncBufRead for Join

### DIFF
--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -1,6 +1,6 @@
 //! Join two values implementing `AsyncRead` and `AsyncWrite` into a single one.
 
-use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
+use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 use std::io;
 use std::pin::Pin;
@@ -113,5 +113,18 @@ where
 
     fn is_write_vectored(&self) -> bool {
         self.writer.is_write_vectored()
+    }
+}
+
+impl<R, W> AsyncBufRead for Join<R, W>
+where
+    R: AsyncBufRead,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        self.project().reader.poll_fill_buf(cx)
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().reader.consume(amt)
     }
 }


### PR DESCRIPTION
## Motivation
The Join struct implements the AsyncRead and AsyncWrite interface. This PR implements the AsyncReadBuf interface.
Fixes https://github.com/tokio-rs/tokio/issues/6446

## Solution
We implement the AsyncReadBuf interface for the Join, if the Reader also implements the AsyncReadBuf interface.
