### PR TITLE
feat(tokio-util): Add CancellationTokenWithReason

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -53,7 +53,7 @@ use pin_project_lite::pin_project;
 /// }
 /// ```
 pub struct CancellationToken {
-    inner: Arc<tree_node::TreeNode>,
+    inner: Arc<tree_node::TreeNode<()>>,
 }
 
 impl std::panic::UnwindSafe for CancellationToken {}
@@ -196,7 +196,7 @@ impl CancellationToken {
     /// `false` from `is_cancelled` on another child node. However, once the
     /// call to `cancel` returns, all child nodes have been fully cancelled.
     pub fn cancel(&self) {
-        tree_node::cancel(&self.inner);
+        tree_node::cancel(&self.inner, ());
     }
 
     /// Returns `true` if the `CancellationToken` is cancelled.

--- a/tokio-util/src/sync/cancellation_token/tree_node.rs
+++ b/tokio-util/src/sync/cancellation_token/tree_node.rs
@@ -83,6 +83,11 @@ pub(crate) fn is_cancelled<T>(node: &Arc<TreeNode<T>>) -> bool {
     node.inner.lock().unwrap().is_cancelled.is_some()
 }
 
+/// Returns whether or not the node is cancelled
+pub(crate) fn with_cancelled<T, R>(node: &Arc<TreeNode<T>>, f: impl FnOnce(&Option<T>) -> R) -> R {
+    f(&node.inner.lock().unwrap().is_cancelled)
+}
+
 /// Creates a child node
 pub(crate) fn child_node<T: Clone>(parent: &Arc<TreeNode<T>>) -> Arc<TreeNode<T>> {
     let mut locked_parent = parent.inner.lock().unwrap();

--- a/tokio-util/src/sync/cancellation_token/tree_node.rs
+++ b/tokio-util/src/sync/cancellation_token/tree_node.rs
@@ -43,18 +43,18 @@ use crate::loom::sync::{Arc, Mutex, MutexGuard};
 /// A node of the cancellation tree structure
 ///
 /// The actual data it holds is wrapped inside a mutex for synchronization.
-pub(crate) struct TreeNode {
-    inner: Mutex<Inner>,
+pub(crate) struct TreeNode<T> {
+    inner: Mutex<Inner<T>>,
     waker: tokio::sync::Notify,
 }
-impl TreeNode {
+impl<T> TreeNode<T> {
     pub(crate) fn new() -> Self {
         Self {
             inner: Mutex::new(Inner {
                 parent: None,
                 parent_idx: 0,
                 children: vec![],
-                is_cancelled: false,
+                is_cancelled: None,
                 num_handles: 1,
             }),
             waker: tokio::sync::Notify::new(),
@@ -70,33 +70,33 @@ impl TreeNode {
 ///
 /// This struct exists so that the data of the node can be wrapped
 /// in a Mutex.
-struct Inner {
-    parent: Option<Arc<TreeNode>>,
+struct Inner<T> {
+    parent: Option<Arc<TreeNode<T>>>,
     parent_idx: usize,
-    children: Vec<Arc<TreeNode>>,
-    is_cancelled: bool,
+    children: Vec<Arc<TreeNode<T>>>,
+    is_cancelled: Option<T>,
     num_handles: usize,
 }
 
 /// Returns whether or not the node is cancelled
-pub(crate) fn is_cancelled(node: &Arc<TreeNode>) -> bool {
-    node.inner.lock().unwrap().is_cancelled
+pub(crate) fn is_cancelled<T>(node: &Arc<TreeNode<T>>) -> bool {
+    node.inner.lock().unwrap().is_cancelled.is_some()
 }
 
 /// Creates a child node
-pub(crate) fn child_node(parent: &Arc<TreeNode>) -> Arc<TreeNode> {
+pub(crate) fn child_node<T: Clone>(parent: &Arc<TreeNode<T>>) -> Arc<TreeNode<T>> {
     let mut locked_parent = parent.inner.lock().unwrap();
 
     // Do not register as child if we are already cancelled.
     // Cancelled trees can never be uncancelled and therefore
     // need no connection to parents or children any more.
-    if locked_parent.is_cancelled {
+    if let Some(reason) = &locked_parent.is_cancelled {
         return Arc::new(TreeNode {
             inner: Mutex::new(Inner {
                 parent: None,
                 parent_idx: 0,
                 children: vec![],
-                is_cancelled: true,
+                is_cancelled: Some(reason.clone()),
                 num_handles: 1,
             }),
             waker: tokio::sync::Notify::new(),
@@ -108,7 +108,7 @@ pub(crate) fn child_node(parent: &Arc<TreeNode>) -> Arc<TreeNode> {
             parent: Some(parent.clone()),
             parent_idx: locked_parent.children.len(),
             children: vec![],
-            is_cancelled: false,
+            is_cancelled: None,
             num_handles: 1,
         }),
         waker: tokio::sync::Notify::new(),
@@ -122,7 +122,7 @@ pub(crate) fn child_node(parent: &Arc<TreeNode>) -> Arc<TreeNode> {
 /// Disconnects the given parent from all of its children.
 ///
 /// Takes a reference to [Inner] to make sure the parent is already locked.
-fn disconnect_children(node: &mut Inner) {
+fn disconnect_children<T>(node: &mut Inner<T>) {
     for child in std::mem::take(&mut node.children) {
         let mut locked_child = child.inner.lock().unwrap();
         locked_child.parent_idx = 0;
@@ -147,9 +147,9 @@ fn disconnect_children(node: &mut Inner) {
 ///
 /// The locked child and optionally its locked parent, if a parent exists, get passed
 /// to the `func` argument via (node, None) or (node, Some(parent)).
-fn with_locked_node_and_parent<F, Ret>(node: &Arc<TreeNode>, func: F) -> Ret
+fn with_locked_node_and_parent<T, F, Ret>(node: &Arc<TreeNode<T>>, func: F) -> Ret
 where
-    F: FnOnce(MutexGuard<'_, Inner>, Option<MutexGuard<'_, Inner>>) -> Ret,
+    F: FnOnce(MutexGuard<'_, Inner<T>>, Option<MutexGuard<'_, Inner<T>>>) -> Ret,
 {
     use std::sync::TryLockError;
 
@@ -199,7 +199,7 @@ where
 /// otherwise there is a potential for a deadlock as invariant #2 would be violated.
 ///
 /// To acquire the locks for node and parent, use [`with_locked_node_and_parent`].
-fn move_children_to_parent(node: &mut Inner, parent: &mut Inner) {
+fn move_children_to_parent<T>(node: &mut Inner<T>, parent: &mut Inner<T>) {
     // Pre-allocate in the parent, for performance
     parent.children.reserve(node.children.len());
 
@@ -217,7 +217,7 @@ fn move_children_to_parent(node: &mut Inner, parent: &mut Inner) {
 ///
 /// `parent` MUST be the parent of `node`.
 /// To acquire the locks for node and parent, use [`with_locked_node_and_parent`].
-fn remove_child(parent: &mut Inner, mut node: MutexGuard<'_, Inner>) {
+fn remove_child<T>(parent: &mut Inner<T>, mut node: MutexGuard<'_, Inner<T>>) {
     // Query the position from where to remove a node
     let pos = node.parent_idx;
     node.parent = None;
@@ -246,7 +246,7 @@ fn remove_child(parent: &mut Inner, mut node: MutexGuard<'_, Inner>) {
 }
 
 /// Increases the reference count of handles.
-pub(crate) fn increase_handle_refcount(node: &Arc<TreeNode>) {
+pub(crate) fn increase_handle_refcount<T>(node: &Arc<TreeNode<T>>) {
     let mut locked_node = node.inner.lock().unwrap();
 
     // Once no handles are left over, the node gets detached from the tree.
@@ -260,7 +260,7 @@ pub(crate) fn increase_handle_refcount(node: &Arc<TreeNode>) {
 ///
 /// Once no handle is left, we can remove the node from the
 /// tree and connect its parent directly to its children.
-pub(crate) fn decrease_handle_refcount(node: &Arc<TreeNode>) {
+pub(crate) fn decrease_handle_refcount<T>(node: &Arc<TreeNode<T>>) {
     let num_handles = {
         let mut locked_node = node.inner.lock().unwrap();
         locked_node.num_handles -= 1;
@@ -294,10 +294,10 @@ pub(crate) fn decrease_handle_refcount(node: &Arc<TreeNode>) {
 }
 
 /// Cancels a node and its children.
-pub(crate) fn cancel(node: &Arc<TreeNode>) {
+pub(crate) fn cancel<T: Clone>(node: &Arc<TreeNode<T>>, reason: T) {
     let mut locked_node = node.inner.lock().unwrap();
 
-    if locked_node.is_cancelled {
+    if locked_node.is_cancelled.is_some() {
         return;
     }
 
@@ -313,7 +313,7 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
         locked_child.parent_idx = 0;
 
         // If child is already cancelled, detaching is enough
-        if locked_child.is_cancelled {
+        if locked_child.is_cancelled.is_some() {
             continue;
         }
 
@@ -328,7 +328,7 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
             locked_grandchild.parent_idx = 0;
 
             // If grandchild is already cancelled, detaching is enough
-            if locked_grandchild.is_cancelled {
+            if locked_grandchild.is_cancelled.is_some() {
                 continue;
             }
 
@@ -336,7 +336,7 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
             // Otherwise, just cancel them right away, no need for another iteration.
             if locked_grandchild.children.is_empty() {
                 // Cancel the grandchild
-                locked_grandchild.is_cancelled = true;
+                locked_grandchild.is_cancelled = Some(reason.clone());
                 locked_grandchild.children = Vec::new();
                 drop(locked_grandchild);
                 grandchild.waker.notify_waiters();
@@ -350,7 +350,7 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
         }
 
         // Cancel the child
-        locked_child.is_cancelled = true;
+        locked_child.is_cancelled = Some(reason.clone());
         locked_child.children = Vec::new();
         drop(locked_child);
         child.waker.notify_waiters();
@@ -360,7 +360,7 @@ pub(crate) fn cancel(node: &Arc<TreeNode>) {
     }
 
     // Cancel the node itself.
-    locked_node.is_cancelled = true;
+    locked_node.is_cancelled = Some(reason);
     locked_node.children = Vec::new();
     drop(locked_node);
     node.waker.notify_waiters();

--- a/tokio-util/src/sync/cancellation_token_with_reason.rs
+++ b/tokio-util/src/sync/cancellation_token_with_reason.rs
@@ -1,7 +1,6 @@
-//! An asynchronously awaitable `CancellationToken`.
+//! An asynchronously awaitable `CancellationTokenWithReason`.
 //! The token allows to signal a cancellation request to one or more tasks.
 pub(crate) mod guard;
-pub(super) mod tree_node;
 
 use crate::loom::sync::Arc;
 use crate::util::MaybeDangling;
@@ -9,34 +8,36 @@ use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
-use guard::DropGuard;
+use guard::DropGuardWithReason;
 use pin_project_lite::pin_project;
+
+use super::cancellation_token::tree_node;
 
 /// A token which can be used to signal a cancellation request to one or more
 /// tasks.
 ///
-/// Tasks can call [`CancellationToken::cancelled()`] in order to
+/// Tasks can call [`CancellationTokenWithReason::cancelled()`] in order to
 /// obtain a Future which will be resolved when cancellation is requested.
 ///
-/// Cancellation can be requested through the [`CancellationToken::cancel`] method.
+/// Cancellation can be requested through the [`CancellationTokenWithReason::cancel`] method.
 ///
 /// # Examples
 ///
 /// ```no_run
 /// use tokio::select;
-/// use tokio_util::sync::CancellationToken;
+/// use tokio_util::sync::CancellationTokenWithReason;
 ///
 /// #[tokio::main]
 /// async fn main() {
-///     let token = CancellationToken::new();
+///     let token = CancellationTokenWithReason::new();
 ///     let cloned_token = token.clone();
 ///
 ///     let join_handle = tokio::spawn(async move {
 ///         // Wait for either cancellation or a very long time
 ///         select! {
-///             _ = cloned_token.cancelled() => {
+///             cancel_value = cloned_token.cancelled() => {
 ///                 // The token was cancelled
-///                 5
+///                 cancel_value
 ///             }
 ///             _ = tokio::time::sleep(std::time::Duration::from_secs(9999)) => {
 ///                 99
@@ -46,38 +47,38 @@ use pin_project_lite::pin_project;
 ///
 ///     tokio::spawn(async move {
 ///         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-///         token.cancel();
+///         token.cancel(5);
 ///     });
 ///
 ///     assert_eq!(5, join_handle.await.unwrap());
 /// }
 /// ```
-pub struct CancellationToken {
-    inner: Arc<tree_node::TreeNode<()>>,
+pub struct CancellationTokenWithReason<T> {
+    inner: Arc<tree_node::TreeNode<T>>,
 }
 
-impl std::panic::UnwindSafe for CancellationToken {}
-impl std::panic::RefUnwindSafe for CancellationToken {}
+impl<T> std::panic::UnwindSafe for CancellationTokenWithReason<T> {}
+impl<T> std::panic::RefUnwindSafe for CancellationTokenWithReason<T> {}
 
 pin_project! {
-    /// A Future that is resolved once the corresponding [`CancellationToken`]
+    /// A Future that is resolved once the corresponding [`CancellationTokenWithReason`]
     /// is cancelled.
     #[must_use = "futures do nothing unless polled"]
-    pub struct WaitForCancellationFuture<'a> {
-        cancellation_token: &'a CancellationToken,
+    pub struct WaitForCancellationWithReasonFuture<'a, T> {
+        cancellation_token: &'a CancellationTokenWithReason<T>,
         #[pin]
         future: tokio::sync::futures::Notified<'a>,
     }
 }
 
 pin_project! {
-    /// A Future that is resolved once the corresponding [`CancellationToken`]
+    /// A Future that is resolved once the corresponding [`CancellationTokenWithReason`]
     /// is cancelled.
     ///
     /// This is the counterpart to [`WaitForCancellationFuture`] that takes
-    /// [`CancellationToken`] by value instead of using a reference.
+    /// [`CancellationTokenWithReason`] by value instead of using a reference.
     #[must_use = "futures do nothing unless polled"]
-    pub struct WaitForCancellationFutureOwned {
+    pub struct WaitForCancellationWithReasonFutureOwned<T> {
         // This field internally has a reference to the cancellation token, but camouflages
         // the relationship with `'static`. To avoid Undefined Behavior, we must ensure
         // that the reference is only used while the cancellation token is still alive. To
@@ -95,53 +96,62 @@ pin_project! {
         // for more info.
         #[pin]
         future: MaybeDangling<tokio::sync::futures::Notified<'static>>,
-        cancellation_token: CancellationToken,
+        cancellation_token: CancellationTokenWithReason<T>,
     }
 }
 
-// ===== impl CancellationToken =====
+// ===== impl CancellationTokenWithReason =====
 
-impl core::fmt::Debug for CancellationToken {
+impl<T: core::fmt::Debug> core::fmt::Debug for CancellationTokenWithReason<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("CancellationToken")
-            .field("is_cancelled", &self.is_cancelled())
-            .finish()
+        tree_node::with_cancelled(&self.inner, |cancel| {
+            f.debug_struct("CancellationTokenWithReason")
+                .field("cancelled", cancel)
+                .finish()
+        })
     }
 }
 
-impl Clone for CancellationToken {
-    /// Creates a clone of the `CancellationToken` which will get cancelled
+impl<T> Clone for CancellationTokenWithReason<T> {
+    /// Creates a clone of the `CancellationTokenWithReason` which will get cancelled
     /// whenever the current token gets cancelled, and vice versa.
     fn clone(&self) -> Self {
         tree_node::increase_handle_refcount(&self.inner);
-        CancellationToken {
+        CancellationTokenWithReason {
             inner: self.inner.clone(),
         }
     }
 }
 
-impl Drop for CancellationToken {
+impl<T> Drop for CancellationTokenWithReason<T> {
     fn drop(&mut self) {
         tree_node::decrease_handle_refcount(&self.inner);
     }
 }
 
-impl Default for CancellationToken {
-    fn default() -> CancellationToken {
-        CancellationToken::new()
+impl<T> Default for CancellationTokenWithReason<T> {
+    fn default() -> CancellationTokenWithReason<T> {
+        CancellationTokenWithReason::new()
     }
 }
 
-impl CancellationToken {
-    /// Creates a new `CancellationToken` in the non-cancelled state.
-    pub fn new() -> CancellationToken {
-        CancellationToken {
+impl<T> CancellationTokenWithReason<T> {
+    /// Creates a new `CancellationTokenWithReason` in the non-cancelled state.
+    pub fn new() -> CancellationTokenWithReason<T> {
+        CancellationTokenWithReason {
             inner: Arc::new(tree_node::TreeNode::new()),
         }
     }
 
-    /// Creates a `CancellationToken` which will get cancelled whenever the
-    /// current token gets cancelled. Unlike a cloned `CancellationToken`,
+    /// Returns `true` if the `CancellationTokenWithReason` is cancelled.
+    pub fn is_cancelled(&self) -> bool {
+        tree_node::is_cancelled(&self.inner)
+    }
+}
+
+impl<T: Clone> CancellationTokenWithReason<T> {
+    /// Creates a `CancellationTokenWithReason` which will get cancelled whenever the
+    /// current token gets cancelled. Unlike a cloned `CancellationTokenWithReason`,
     /// cancelling a child token does not cancel the parent token.
     ///
     /// If the current token is already cancelled, the child token will get
@@ -151,19 +161,19 @@ impl CancellationToken {
     ///
     /// ```no_run
     /// use tokio::select;
-    /// use tokio_util::sync::CancellationToken;
+    /// use tokio_util::sync::CancellationTokenWithReason;
     ///
     /// #[tokio::main]
     /// async fn main() {
-    ///     let token = CancellationToken::new();
+    ///     let token = CancellationTokenWithReason::new();
     ///     let child_token = token.child_token();
     ///
     ///     let join_handle = tokio::spawn(async move {
     ///         // Wait for either cancellation or a very long time
     ///         select! {
-    ///             _ = child_token.cancelled() => {
+    ///             cancel_value = child_token.cancelled() => {
     ///                 // The token was cancelled
-    ///                 5
+    ///                 cancel_value
     ///             }
     ///             _ = tokio::time::sleep(std::time::Duration::from_secs(9999)) => {
     ///                 99
@@ -173,19 +183,19 @@ impl CancellationToken {
     ///
     ///     tokio::spawn(async move {
     ///         tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-    ///         token.cancel();
+    ///         token.cancel(5);
     ///     });
     ///
     ///     assert_eq!(5, join_handle.await.unwrap());
     /// }
     /// ```
-    pub fn child_token(&self) -> CancellationToken {
-        CancellationToken {
+    pub fn child_token(&self) -> CancellationTokenWithReason<T> {
+        CancellationTokenWithReason {
             inner: tree_node::child_node(&self.inner),
         }
     }
 
-    /// Cancel the [`CancellationToken`] and all child tokens which had been
+    /// Cancel the [`CancellationTokenWithReason`] and all child tokens which had been
     /// derived from it.
     ///
     /// This will wake up all tasks which are waiting for cancellation.
@@ -195,13 +205,13 @@ impl CancellationToken {
     /// receive `true` from `is_cancelled` on one child node, and then receive
     /// `false` from `is_cancelled` on another child node. However, once the
     /// call to `cancel` returns, all child nodes have been fully cancelled.
-    pub fn cancel(&self) {
-        tree_node::cancel(&self.inner, ());
+    pub fn cancel(&self, reason: T) {
+        tree_node::cancel(&self.inner, reason);
     }
 
-    /// Returns `true` if the `CancellationToken` is cancelled.
-    pub fn is_cancelled(&self) -> bool {
-        tree_node::is_cancelled(&self.inner)
+    /// Returns `Some(reason)` if the `CancellationTokenWithReason` is cancelled.
+    pub fn get_cancelled(&self) -> Option<T> {
+        tree_node::with_cancelled(&self.inner, Clone::clone)
     }
 
     /// Returns a `Future` that gets fulfilled when cancellation is requested.
@@ -212,8 +222,8 @@ impl CancellationToken {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    pub fn cancelled(&self) -> WaitForCancellationFuture<'_> {
-        WaitForCancellationFuture {
+    pub fn cancelled(&self) -> WaitForCancellationWithReasonFuture<'_, T> {
+        WaitForCancellationWithReasonFuture {
             cancellation_token: self,
             future: self.inner.notified(),
         }
@@ -230,35 +240,41 @@ impl CancellationToken {
     /// # Cancel safety
     ///
     /// This method is cancel safe.
-    pub fn cancelled_owned(self) -> WaitForCancellationFutureOwned {
-        WaitForCancellationFutureOwned::new(self)
+    pub fn cancelled_owned(self) -> WaitForCancellationWithReasonFutureOwned<T>
+    where
+        T: 'static,
+    {
+        WaitForCancellationWithReasonFutureOwned::new(self)
     }
 
     /// Creates a `DropGuard` for this token.
     ///
     /// Returned guard will cancel this token (and all its children) on drop
     /// unless disarmed.
-    pub fn drop_guard(self) -> DropGuard {
-        DropGuard { inner: Some(self) }
+    pub fn drop_guard(self, reason: T) -> DropGuardWithReason<T> {
+        DropGuardWithReason {
+            inner: Some((self, reason)),
+        }
     }
 }
 
 // ===== impl WaitForCancellationFuture =====
 
-impl<'a> core::fmt::Debug for WaitForCancellationFuture<'a> {
+impl<'a, T> core::fmt::Debug for WaitForCancellationWithReasonFuture<'a, T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitForCancellationFuture").finish()
+        f.debug_struct("WaitForCancellationWithReasonFuture")
+            .finish()
     }
 }
 
-impl<'a> Future for WaitForCancellationFuture<'a> {
-    type Output = ();
+impl<'a, T: Clone> Future for WaitForCancellationWithReasonFuture<'a, T> {
+    type Output = T;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
         let mut this = self.project();
         loop {
-            if this.cancellation_token.is_cancelled() {
-                return Poll::Ready(());
+            if let Some(cancel) = this.cancellation_token.get_cancelled() {
+                return Poll::Ready(cancel);
             }
 
             // No wakeups can be lost here because there is always a call to
@@ -276,15 +292,16 @@ impl<'a> Future for WaitForCancellationFuture<'a> {
 
 // ===== impl WaitForCancellationFutureOwned =====
 
-impl core::fmt::Debug for WaitForCancellationFutureOwned {
+impl<T> core::fmt::Debug for WaitForCancellationWithReasonFutureOwned<T> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("WaitForCancellationFutureOwned").finish()
+        f.debug_struct("WaitForCancellationWithReasonFutureOwned<T>")
+            .finish()
     }
 }
 
-impl WaitForCancellationFutureOwned {
-    fn new(cancellation_token: CancellationToken) -> Self {
-        WaitForCancellationFutureOwned {
+impl<T: 'static> WaitForCancellationWithReasonFutureOwned<T> {
+    fn new(cancellation_token: CancellationTokenWithReason<T>) -> Self {
+        WaitForCancellationWithReasonFutureOwned {
             // cancellation_token holds a heap allocation and is guaranteed to have a
             // stable deref, thus it would be ok to move the cancellation_token while
             // the future holds a reference to it.
@@ -301,7 +318,7 @@ impl WaitForCancellationFutureOwned {
     /// The returned future must be destroyed before the cancellation token is
     /// destroyed.
     unsafe fn new_future(
-        cancellation_token: &CancellationToken,
+        cancellation_token: &CancellationTokenWithReason<T>,
     ) -> tokio::sync::futures::Notified<'static> {
         let inner_ptr = Arc::as_ptr(&cancellation_token.inner);
         // SAFETY: The `Arc::as_ptr` method guarantees that `inner_ptr` remains
@@ -311,15 +328,15 @@ impl WaitForCancellationFutureOwned {
     }
 }
 
-impl Future for WaitForCancellationFutureOwned {
-    type Output = ();
+impl<T: 'static + Clone> Future for WaitForCancellationWithReasonFutureOwned<T> {
+    type Output = T;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
         let mut this = self.project();
 
         loop {
-            if this.cancellation_token.is_cancelled() {
-                return Poll::Ready(());
+            if let Some(cancel) = this.cancellation_token.get_cancelled() {
+                return Poll::Ready(cancel);
             }
 
             // No wakeups can be lost here because there is always a call to

--- a/tokio-util/src/sync/cancellation_token_with_reason/guard.rs
+++ b/tokio-util/src/sync/cancellation_token_with_reason/guard.rs
@@ -1,0 +1,28 @@
+use crate::sync::CancellationTokenWithReason;
+
+/// A wrapper for cancellation token which automatically cancels
+/// it on drop. It is created using `drop_guard` method on the `CancellationTokenWithReason`.
+#[derive(Debug)]
+pub struct DropGuardWithReason<T: Clone> {
+    pub(super) inner: Option<(CancellationTokenWithReason<T>, T)>,
+}
+
+impl<T: Clone> DropGuardWithReason<T> {
+    /// Returns stored cancellation token and removes this drop guard instance
+    /// (i.e. it will no longer cancel token). Other guards for this token
+    /// are not affected.
+    pub fn disarm(mut self) -> CancellationTokenWithReason<T> {
+        self.inner
+            .take()
+            .expect("`inner` can be only None in a destructor")
+            .0
+    }
+}
+
+impl<T: Clone> Drop for DropGuardWithReason<T> {
+    fn drop(&mut self) {
+        if let Some((inner, reason)) = self.inner.take() {
+            inner.cancel(reason);
+        }
+    }
+}

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -4,6 +4,11 @@ mod cancellation_token;
 pub use cancellation_token::{
     guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
 };
+mod cancellation_token_with_reason;
+pub use cancellation_token_with_reason::{
+    guard::DropGuardWithReason, CancellationTokenWithReason, WaitForCancellationWithReasonFuture,
+    WaitForCancellationWithReasonFutureOwned,
+};
 
 mod mpsc;
 pub use mpsc::{PollSendError, PollSender};

--- a/tokio-util/tests/sync_cancellation_token_with_reason.rs
+++ b/tokio-util/tests/sync_cancellation_token_with_reason.rs
@@ -1,0 +1,447 @@
+#![warn(rust_2018_idioms)]
+
+use tokio::pin;
+use tokio_util::sync::{CancellationTokenWithReason, WaitForCancellationWithReasonFuture};
+
+use core::future::Future;
+use core::task::{Context, Poll};
+use futures_test::task::new_count_waker;
+
+#[test]
+fn cancel_token() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::new();
+    assert!(!token.is_cancelled());
+
+    let wait_fut = token.cancelled();
+    pin!(wait_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    let wait_fut_2 = token.cancelled();
+    pin!(wait_fut_2);
+
+    token.cancel(5);
+    assert_eq!(wake_counter, 1);
+    assert!(token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        wait_fut_2.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
+fn cancel_token_owned() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::new();
+    assert!(!token.is_cancelled());
+
+    let wait_fut = token.clone().cancelled_owned();
+    pin!(wait_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    let wait_fut_2 = token.clone().cancelled_owned();
+    pin!(wait_fut_2);
+
+    token.cancel(5);
+    assert_eq!(wake_counter, 1);
+    assert!(token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        wait_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        wait_fut_2.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
+fn cancel_token_owned_drop_test() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::<usize>::new();
+
+    let future = token.cancelled_owned();
+    pin!(future);
+
+    assert_eq!(
+        Poll::Pending,
+        future.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    // let future be dropped while pinned and under pending state to
+    // find potential memory related bugs.
+}
+
+#[test]
+fn cancel_child_token_through_parent() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::new();
+
+    let child_token = token.child_token();
+    assert!(!child_token.is_cancelled());
+
+    let child_fut = child_token.cancelled();
+    pin!(child_fut);
+    let parent_fut = token.cancelled();
+    pin!(parent_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    token.cancel(5);
+    assert_eq!(wake_counter, 2);
+    assert!(token.is_cancelled());
+    assert!(child_token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
+fn cancel_grandchild_token_through_parent_if_child_was_dropped() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::new();
+
+    let intermediate_token = token.child_token();
+    let child_token = intermediate_token.child_token();
+    drop(intermediate_token);
+    assert!(!child_token.is_cancelled());
+
+    let child_fut = child_token.cancelled();
+    pin!(child_fut);
+    let parent_fut = token.cancelled();
+    pin!(parent_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    token.cancel(5);
+    assert_eq!(wake_counter, 2);
+    assert!(token.is_cancelled());
+    assert!(child_token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
+fn cancel_child_token_without_parent() {
+    let (waker, wake_counter) = new_count_waker();
+    let token = CancellationTokenWithReason::new();
+
+    let child_token_1 = token.child_token();
+
+    let child_fut = child_token_1.cancelled();
+    pin!(child_fut);
+    let parent_fut = token.cancelled();
+    pin!(parent_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    child_token_1.cancel(10);
+    assert_eq!(wake_counter, 1);
+    assert!(!token.is_cancelled());
+    assert!(child_token_1.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(10),
+        child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+
+    let child_token_2 = token.child_token();
+    let child_fut_2 = child_token_2.cancelled();
+    pin!(child_fut_2);
+
+    assert_eq!(
+        Poll::Pending,
+        child_fut_2.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+
+    token.cancel(5);
+    assert_eq!(wake_counter, 3);
+    assert!(token.is_cancelled());
+    assert!(child_token_2.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        child_fut_2.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+}
+
+#[test]
+fn create_child_token_after_parent_was_cancelled() {
+    for drop_child_first in [true, false].iter().cloned() {
+        let (waker, wake_counter) = new_count_waker();
+        let token = CancellationTokenWithReason::new();
+        token.cancel(5);
+
+        let child_token = token.child_token();
+        assert!(child_token.is_cancelled());
+
+        {
+            let child_fut = child_token.cancelled();
+            pin!(child_fut);
+            let parent_fut = token.cancelled();
+            pin!(parent_fut);
+
+            assert_eq!(
+                Poll::Ready(5),
+                child_fut.as_mut().poll(&mut Context::from_waker(&waker))
+            );
+            assert_eq!(
+                Poll::Ready(5),
+                parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+            );
+            assert_eq!(wake_counter, 0);
+        }
+
+        if drop_child_first {
+            drop(child_token);
+            drop(token);
+        } else {
+            drop(token);
+            drop(child_token);
+        }
+    }
+}
+
+#[test]
+fn drop_multiple_child_tokens() {
+    for drop_first_child_first in &[true, false] {
+        let token = CancellationTokenWithReason::<usize>::new();
+        let mut child_tokens = [None, None, None];
+        for child in &mut child_tokens {
+            *child = Some(token.child_token());
+        }
+
+        assert!(!token.is_cancelled());
+        assert!(!child_tokens[0].as_ref().unwrap().is_cancelled());
+
+        for i in 0..child_tokens.len() {
+            if *drop_first_child_first {
+                child_tokens[i] = None;
+            } else {
+                child_tokens[child_tokens.len() - 1 - i] = None;
+            }
+            assert!(!token.is_cancelled());
+        }
+
+        drop(token);
+    }
+}
+
+#[test]
+fn cancel_only_all_descendants() {
+    // ARRANGE
+    let (waker, wake_counter) = new_count_waker();
+
+    let parent_token = CancellationTokenWithReason::new();
+    let token = parent_token.child_token();
+    let sibling_token = parent_token.child_token();
+    let child1_token = token.child_token();
+    let child2_token = token.child_token();
+    let grandchild_token = child1_token.child_token();
+    let grandchild2_token = child1_token.child_token();
+    let great_grandchild_token = grandchild_token.child_token();
+
+    assert!(!parent_token.is_cancelled());
+    assert!(!token.is_cancelled());
+    assert!(!sibling_token.is_cancelled());
+    assert!(!child1_token.is_cancelled());
+    assert!(!child2_token.is_cancelled());
+    assert!(!grandchild_token.is_cancelled());
+    assert!(!grandchild2_token.is_cancelled());
+    assert!(!great_grandchild_token.is_cancelled());
+
+    let parent_fut = parent_token.cancelled();
+    let fut = token.cancelled();
+    let sibling_fut = sibling_token.cancelled();
+    let child1_fut = child1_token.cancelled();
+    let child2_fut = child2_token.cancelled();
+    let grandchild_fut = grandchild_token.cancelled();
+    let grandchild2_fut = grandchild2_token.cancelled();
+    let great_grandchild_fut = great_grandchild_token.cancelled();
+
+    pin!(parent_fut);
+    pin!(fut);
+    pin!(sibling_fut);
+    pin!(child1_fut);
+    pin!(child2_fut);
+    pin!(grandchild_fut);
+    pin!(grandchild2_fut);
+    pin!(great_grandchild_fut);
+
+    assert_eq!(
+        Poll::Pending,
+        parent_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        sibling_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        child1_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        child2_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        grandchild_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        grandchild2_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Pending,
+        great_grandchild_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 0);
+
+    // ACT
+    token.cancel(5);
+
+    // ASSERT
+    assert_eq!(wake_counter, 6);
+    assert!(!parent_token.is_cancelled());
+    assert!(token.is_cancelled());
+    assert!(!sibling_token.is_cancelled());
+    assert!(child1_token.is_cancelled());
+    assert!(child2_token.is_cancelled());
+    assert!(grandchild_token.is_cancelled());
+    assert!(grandchild2_token.is_cancelled());
+    assert!(great_grandchild_token.is_cancelled());
+
+    assert_eq!(
+        Poll::Ready(5),
+        fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        child1_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        child2_fut.as_mut().poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        grandchild_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        grandchild2_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(
+        Poll::Ready(5),
+        great_grandchild_fut
+            .as_mut()
+            .poll(&mut Context::from_waker(&waker))
+    );
+    assert_eq!(wake_counter, 6);
+}
+
+#[test]
+fn drop_parent_before_child_tokens() {
+    let token = CancellationTokenWithReason::<usize>::new();
+    let child1 = token.child_token();
+    let child2 = token.child_token();
+
+    drop(token);
+    assert!(!child1.is_cancelled());
+
+    drop(child1);
+    drop(child2);
+}
+
+#[test]
+fn derives_send_sync() {
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    assert_send::<CancellationTokenWithReason<usize>>();
+    assert_sync::<CancellationTokenWithReason<usize>>();
+
+    assert_send::<WaitForCancellationWithReasonFuture<'static, usize>>();
+    assert_sync::<WaitForCancellationWithReasonFuture<'static, usize>>();
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

#5249

I wanted a way to propagate a reason to the tasks I am cancelling, eg whether it was via a timeout, or via a termination. As the issue states, Go's context.Context has a [WithCancelCause](https://pkg.go.dev/context#WithCancelCause) feature that is similar.

For now I am making this as a third party crate, but I felt it was easy enough to suggest upstream. Feel free to bikeshed or reject.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. Make `cancellation_token/tree_node.rs` generic over the cancel reason. Replace `is_cancelled: bool` with `cancelled: Option<T>`.
2. Copy `cancellation_token.rs` to `cancellation_token_with_reason.rs` and make the necessary changes to support the reason.
