### PR TITLE
macros: allow if let Some() pattern

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -605,6 +605,11 @@ macro_rules! select {
     (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } $p:pat = $f:expr => $h:expr, $($r:tt)* ) => {
         $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, } $($r)*)
     };
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } $p:pat = $f:expr, if let $z:pat = $c:expr => $h:block $($r:tt)* ) => {{
+        if let $z = $c {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, } $($r)*)
+        }
+    }};
 
     // ===== Entry point =====
 

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -629,6 +629,23 @@ async fn mut_ref_patterns() {
     };
 }
 
+#[maybe_tokio_test]
+async fn if_let_patterns() {
+    let maybe_x = Some(10);
+    let mut result = 0;
+
+    async fn foo(x: u32) -> u32 {
+        x
+    }
+
+    tokio::select! {
+        res = foo(x), if let Some(x) = maybe_x => { result = res; }
+        else => { result = 0 }
+    };
+
+    assert_eq!(result, 10);
+}
+
 #[cfg(tokio_unstable)]
 mod unstable {
     use tokio::runtime::RngSeed;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
- Closes #4173 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
- Add `if let Some() pattern` in `select!` macros

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
