### PR TITLE
Ignore flaky `worker_steal_count` test

### DIFF
--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -175,6 +175,7 @@ fn worker_noop_count() {
 }
 
 #[test]
+#[ignore] // this test is flaky, see https://github.com/tokio-rs/tokio/issues/6470
 fn worker_steal_count() {
     // This metric only applies to the multi-threaded runtime.
     //


### PR DESCRIPTION
This test is flaky, so mark it with `#[ignore]` to reduce flakiness of ci.

See #6470 for the issue about fixing the flakiness of the test.