### PR TITLE
sync: add `detach` method to the permit types

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -990,6 +990,24 @@ impl<'a> SemaphorePermit<'a> {
         self.permits += other.permits;
         other.permits = 0;
     }
+    
+    /// Detaches `n` permits from `self` and returns a new [`SemaphorePermit`] instance that holds `n` permits.
+    /// 
+    /// It guarantees at least one permit held by both `self` and the new instance.
+    ///
+    /// If there are insufficient permits and it's not possible to reduce by `n`, returns `None`.
+    pub fn detach(&mut self, n: u32) -> Option<Self> {
+        if n == 0 || n >= self.permits {
+            return None;
+        }
+        
+        self.permits -= n;
+        
+        Some(Self {
+            sem: self.sem,
+            permits: n,
+        })
+    }
 }
 
 impl OwnedSemaphorePermit {
@@ -1017,6 +1035,28 @@ impl OwnedSemaphorePermit {
         );
         self.permits += other.permits;
         other.permits = 0;
+    }
+
+    /// Detaches `n` permits from `self` and returns a new [`OwnedSemaphorePermit`] instance that holds `n` permits.
+    ///
+    /// It guarantees at least one permit held by both `self` and the new instance.
+    ///
+    /// If there are insufficient permits and it's not possible to reduce by `n`, returns `None`.
+    /// 
+    /// # Note
+    /// 
+    /// It will clone the owned `Arc<Semaphore>` to construct the new instance.
+    pub fn detach(&mut self, n: u32) -> Option<Self> {
+        if n == 0 || n >= self.permits {
+            return None;
+        }
+
+        self.permits -= n;
+
+        Some(Self {
+            sem: self.sem.clone(),
+            permits: n,
+        })
     }
 
     /// Returns the [`Semaphore`] from which this permit was acquired.

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -88,6 +88,22 @@ fn merge_unrelated_permits() {
     p1.merge(p2);
 }
 
+#[test]
+fn detach() {
+    let sem = Semaphore::new(5);
+    let mut p1 = sem.try_acquire_many(3).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    let mut p2 = p1.detach(1).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    assert!(p1.detach(0).is_none());
+    drop(p1);
+    assert_eq!(sem.available_permits(), 4);
+    assert!(p2.detach(1).is_none());
+    assert!(p2.detach(2).is_none());
+    drop(p2);
+    assert_eq!(sem.available_permits(), 5);
+}
+
 #[tokio::test]
 #[cfg(feature = "full")]
 async fn stress_test() {

--- a/tokio/tests/sync_semaphore_owned.rs
+++ b/tokio/tests/sync_semaphore_owned.rs
@@ -114,6 +114,22 @@ fn merge_unrelated_permits() {
     p1.merge(p2)
 }
 
+#[test]
+fn detach() {
+    let sem = Arc::new(Semaphore::new(5));
+    let mut p1 = sem.clone().try_acquire_many_owned(3).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    let mut p2 = p1.detach(1).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    assert!(p1.detach(0).is_none());
+    drop(p1);
+    assert_eq!(sem.available_permits(), 4);
+    assert!(p2.detach(1).is_none());
+    assert!(p2.detach(2).is_none());
+    drop(p2);
+    assert_eq!(sem.available_permits(), 5);
+}
+
 #[tokio::test]
 #[cfg(feature = "full")]
 async fn stress_test() {


### PR DESCRIPTION
Add `detach` method to `SemaphorePermit` and `OwnedSemaphorePermit`.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Assume there are two tasks named `A` and `B`, and we have a `Semaphore` with two permits.

`A` needs one permit, `B` needs two permits at first and one permit later.

If `B` executes first, it calls `acquire_many` to get a `SemaphorePermit` with two permits. After doing some work, one of the permits is unnecessary for `B` to continue the work, but we can only release all permits at once.

In this case, `A` has to wait until `B` finishes all works or `B` releases its two permits and acquires one permit again to continue the remaining work without blocking `A`.

Since we have the `merge` method, I believe that the corresponding inverse operation is reasonable.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Adds the `detach` method to `SemaphorePermit` and `OwnedSemaphorePermit` to allow us to detach some permits from the source permits.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
