### PR TITLE
tests: update nix dependency to 0.28

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.149" }
-nix = { version = "0.27.1", default-features = false, features = ["fs", "socket"] }
+nix = { version = "0.28.0", default-features = false, features = ["fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.149" }
-nix = { version = "0.28.0", default-features = false, features = ["fs", "socket"] }
+nix = { version = "0.28.0", default-features = false, features = ["aio", "fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -489,12 +489,10 @@ async fn anon_pipe_spawn_echo() -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 async fn anon_pipe_from_owned_fd() -> std::io::Result<()> {
     use nix::fcntl::OFlag;
-    use std::os::unix::io::{FromRawFd, OwnedFd};
 
     const DATA: &[u8] = b"this is some data to write to the pipe";
 
-    let fds = nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
-    let (rx_fd, tx_fd) = unsafe { (OwnedFd::from_raw_fd(fds.0), OwnedFd::from_raw_fd(fds.1)) };
+    let (rx_fd, tx_fd) = nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
 
     let mut rx = pipe::Receiver::from_owned_fd(rx_fd)?;
     let mut tx = pipe::Sender::from_owned_fd(tx_fd)?;


### PR DESCRIPTION
`nix::unistd::write` now requies an `trait AsFd`, which `RawFd` does not implement, so, the `struct FileDescriptor` field has been switched to `OwnedFd`. An alternative solution is to use `BorrowedFd::borrow_raw`, but that requires unsafe code.