### PR TITLE
sync: use usize instead of u32 for `SemaphorePermit::split`

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -994,7 +994,12 @@ impl<'a> SemaphorePermit<'a> {
     /// Splits `n` permits from `self` and returns a new [`SemaphorePermit`] instance that holds `n` permits.
     ///
     /// If there are insufficient permits and it's not possible to reduce by `n`, returns `None`.
-    pub fn split(&mut self, n: u32) -> Option<Self> {
+    pub fn split(&mut self, n: usize) -> Option<Self> {
+        let n = match u32::try_from(n) {
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+
         if n > self.permits {
             return None;
         }
@@ -1008,8 +1013,8 @@ impl<'a> SemaphorePermit<'a> {
     }
 
     /// Returns the number of permits held by `self`.
-    pub fn num_permits(&self) -> u32 {
-        self.permits
+    pub fn num_permits(&self) -> usize {
+        self.permits as usize
     }
 }
 
@@ -1047,7 +1052,12 @@ impl OwnedSemaphorePermit {
     /// # Note
     ///
     /// It will clone the owned `Arc<Semaphore>` to construct the new instance.
-    pub fn split(&mut self, n: u32) -> Option<Self> {
+    pub fn split(&mut self, n: usize) -> Option<Self> {
+        let n = match u32::try_from(n) {
+            Ok(n) => n,
+            Err(_) => return None,
+        };
+
         if n > self.permits {
             return None;
         }
@@ -1066,8 +1076,8 @@ impl OwnedSemaphorePermit {
     }
 
     /// Returns the number of permits held by `self`.
-    pub fn num_permits(&self) -> u32 {
-        self.permits
+    pub fn num_permits(&self) -> usize {
+        self.permits as usize
     }
 }
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -995,10 +995,7 @@ impl<'a> SemaphorePermit<'a> {
     ///
     /// If there are insufficient permits and it's not possible to reduce by `n`, returns `None`.
     pub fn split(&mut self, n: usize) -> Option<Self> {
-        let n = match u32::try_from(n) {
-            Ok(n) => n,
-            Err(_) => return None,
-        };
+        let n = u32::try_from(n).ok()?;
 
         if n > self.permits {
             return None;
@@ -1053,10 +1050,7 @@ impl OwnedSemaphorePermit {
     ///
     /// It will clone the owned `Arc<Semaphore>` to construct the new instance.
     pub fn split(&mut self, n: usize) -> Option<Self> {
-        let n = match u32::try_from(n) {
-            Ok(n) => n,
-            Err(_) => return None,
-        };
+        let n = u32::try_from(n).ok()?;
 
         if n > self.permits {
             return None;


### PR DESCRIPTION
Using u32 in the semaphore methods was a design mistake, see #4446. We should not add more methods using u32.

This is not a breaking change since we have not made a release since #6472.