### PR TITLE
docs: add --locked to cargo install commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,7 +172,7 @@ as docs.rs itself does.
 [`cargo docs-rs`]: https://github.com/dtolnay/cargo-docs-rs
 
 ```
-cargo install cargo-docs-rs
+cargo install --locked cargo-docs-rs
 cargo +nightly docs-rs [--open]
 ```
 
@@ -261,7 +261,7 @@ directory `fuzz`. It is a good idea to run fuzz tests after each change.
 To get started with fuzz testing you'll need to install
 [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
 
-`cargo install cargo-fuzz`
+`cargo install --locked cargo-fuzz`
 
 To list the available fuzzing harnesses you can run;
 


### PR DESCRIPTION
https://github.com/tokio-rs/tokio/pull/6475\#discussion_r1561492918

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
