### PR TITLE
Lint markdown docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - minrust
       - minimal-versions
       - fmt
+      - markdown-lint
       - clippy
       - docs
       - loom-compile
@@ -82,6 +83,7 @@ jobs:
     needs:
       - clippy
       - fmt
+      - markdown-lint
       - docs
       - minrust
     steps:
@@ -744,6 +746,13 @@ jobs:
             printf "Please run \`rustfmt --edition 2021 \$(git ls-files '*.rs')\` to fix rustfmt errors.\nSee CONTRIBUTING.md for more details.\n" >&2
             exit 1
           fi
+
+  markdown-lint:
+    name: markdown-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DavidAnson/markdownlint-cli2-action@v16
 
   clippy:
     name: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # Change to specific Rust release to pin
   rust_stable: stable
   rust_nightly: nightly-2023-10-21
-  rust_clippy: '1.77'
+  rust_clippy: "1.77"
   # When updating this, also update:
   # - README.md
   # - tokio/README.md
@@ -25,7 +25,7 @@ env:
   # - tokio-util/Cargo.toml
   # - tokio-test/Cargo.toml
   # - tokio-stream/Cargo.toml
-  rust_min: '1.63'
+  rust_min: "1.63"
 
 defaults:
   run:
@@ -104,7 +104,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -136,7 +136,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -166,7 +166,7 @@ jobs:
       - name: Install Rust ${{ env.rust_nightly }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_nightly }}
+          toolchain: ${{ env.rust_nightly }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -178,7 +178,7 @@ jobs:
         run: |
           set -euxo pipefail
           RUSTFLAGS="$RUSTFLAGS -C panic=abort -Zpanic-abort-tests" cargo nextest run --workspace --exclude tokio-macros --exclude tests-build --all-features --tests
-  
+
   test-integration-tests-per-feature:
     needs: basics
     name: Run integration tests for each feature
@@ -194,7 +194,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
         with:
@@ -234,7 +234,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
 
       - name: Enable parking_lot send_guard feature
         # Inserts the line "plsend = ["parking_lot/send_guard"]" right after [features]
@@ -281,7 +281,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
 
       - name: Install Valgrind
         uses: taiki-e/install-action@valgrind
@@ -320,7 +320,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -354,7 +354,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
@@ -388,7 +388,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+          toolchain: ${{ env.rust_stable }}
       - name: Install cargo-nextest
         uses: taiki-e/install-action@v2
         with:
@@ -538,7 +538,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
-          qemu: '7.2'
+          qemu: "7.2"
 
       - uses: Swatinem/rust-cache@v2
       - name: Tests run with all features (including parking_lot)
@@ -578,7 +578,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: ${{ matrix.target }}
-          qemu: '7.2'
+          qemu: "7.2"
 
       - name: Remove `parking_lot` from `full` feature
         run: sed -i '0,/parking_lot/{/parking_lot/d;}' tokio/Cargo.toml
@@ -615,7 +615,7 @@ jobs:
       - uses: taiki-e/setup-cross-toolchain-action@v1
         with:
           target: i686-unknown-linux-gnu
-          qemu: '7.2'
+          qemu: "7.2"
 
       - uses: Swatinem/rust-cache@v2
       - name: test tokio --all-features
@@ -662,7 +662,10 @@ jobs:
           # Try with unstable feature flags
           - { name: "--unstable", rustflags: "--cfg tokio_unstable -Dwarnings" }
           # Try with unstable and taskdump feature flags
-          - { name: "--unstable --taskdump", rustflags: "--cfg tokio_unstable -Dwarnings --cfg tokio_taskdump" }
+          - {
+              name: "--unstable --taskdump",
+              rustflags: "--cfg tokio_unstable -Dwarnings --cfg tokio_taskdump",
+            }
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust ${{ env.rust_nightly }}
@@ -1037,4 +1040,3 @@ jobs:
           sed '1d; $d' spellcheck.dic | LC_ALL=en_US.UTF8 sort -uc
       - name: Run cargo-spellcheck
         run: cargo spellcheck --code 1
-

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+line-length:
+  line_length: 100

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,7 +1,11 @@
 # Code of Conduct
 
-The Tokio project adheres to the [Rust Code of Conduct](https://www.rust-lang.org/policies/code-of-conduct). This describes the minimum behavior expected from all contributors.
+The Tokio project adheres to the [Rust Code of Conduct][code-of-conduct]. This describes the minimum
+behavior expected from all contributors.
 
 ## Enforcement
 
-Instances of violations of the Code of Conduct can be reported by contacting the project team at [moderation@tokio.rs](mailto:moderation@tokio.rs).
+Instances of violations of the Code of Conduct can be reported by contacting the project team at
+[moderation@tokio.rs](mailto:moderation@tokio.rs).
+
+[code-of-conduct]: https://www.rust-lang.org/policies/code-of-conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,24 @@
 # Contributing to Tokio
 
-:balloon: Thanks for your help improving the project! We are so happy to have
-you!
+:balloon: Thanks for your help improving the project! We are so happy to have you!
 
-There are opportunities to contribute to Tokio at any level. It doesn't matter if
-you are just getting started with Rust or are the most weathered expert, we can
-use your help.
+There are opportunities to contribute to Tokio at any level. It doesn't matter if you are just
+getting started with Rust or are the most weathered expert, we can use your help.
 
 **No contribution is too small and all contributions are valued.**
 
-This guide will help you get started. **Do not let this guide intimidate you**.
-It should be considered a map to help you navigate the process.
+This guide will help you get started. **Do not let this guide intimidate you**. It should be
+considered a map to help you navigate the process.
 
-The [dev channel][dev] is available for any concerns not covered in this guide, please join
-us!
+The [dev channel][dev] is available for any concerns not covered in this guide, please join us!
 
 [dev]: https://discord.gg/tokio
 
 ## Conduct
 
-The Tokio project adheres to the [Rust Code of Conduct][coc]. This describes
-the _minimum_ behavior expected from all contributors. Instances of violations of the
-Code of Conduct can be reported by contacting the project team at
-[moderation@tokio.rs](mailto:moderation@tokio.rs).
+The Tokio project adheres to the [Rust Code of Conduct][coc]. This describes the _minimum_ behavior
+expected from all contributors. Instances of violations of the Code of Conduct can be reported by
+contacting the project team at [moderation@tokio.rs](mailto:moderation@tokio.rs).
 
 [coc]: https://github.com/rust-lang/rust/blob/master/CODE_OF_CONDUCT.md
 
@@ -30,50 +26,44 @@ Code of Conduct can be reported by contacting the project team at
 
 For any issue, there are fundamentally three ways an individual can contribute:
 
-1. By opening the issue for discussion: For instance, if you believe that you
-   have discovered a bug in Tokio, creating a new issue in [the tokio-rs/tokio
-   issue tracker][issue] is the way to report it.
-
-2. By helping to triage the issue: This can be done by providing
-   supporting details (a test case that demonstrates a bug), providing
-   suggestions on how to address the issue, or ensuring that the issue is tagged
-   correctly.
-
-3. By helping to resolve the issue: Typically this is done either in the form of
-   demonstrating that the issue reported is not a problem after all, or more
-   often, by opening a Pull Request that changes some bit of something in
-   Tokio in a concrete and reviewable manner.
+1. By opening the issue for discussion: For instance, if you believe that you have discovered a bug
+   in Tokio, creating a new issue in [the tokio-rs/tokio issue tracker][issue] is the way to report
+   it.
+2. By helping to triage the issue: This can be done by providing supporting details (a test case
+   that demonstrates a bug), providing suggestions on how to address the issue, or ensuring that the
+   issue is tagged correctly.
+3. By helping to resolve the issue: Typically this is done either in the form of demonstrating that
+   the issue reported is not a problem after all, or more often, by opening a Pull Request that
+   changes some bit of something in Tokio in a concrete and reviewable manner.
 
 [issue]: https://github.com/tokio-rs/tokio/issues
 
-**Anybody can participate in any stage of contribution**. We urge you to
-participate in the discussion around bugs and participate in reviewing PRs.
+**Anybody can participate in any stage of contribution**. We urge you to participate in the
+discussion around bugs and participate in reviewing PRs.
 
 ### Asking for General Help
 
-If you have reviewed existing documentation and still have questions or are
-having problems, you can [open a discussion] asking for help.
+If you have reviewed existing documentation and still have questions or are having problems, you can
+[open a discussion] asking for help.
 
-In exchange for receiving help, we ask that you contribute back a documentation
-PR that helps others avoid the problems that you encountered.
+In exchange for receiving help, we ask that you contribute back a documentation PR that helps others
+avoid the problems that you encountered.
 
 [open a discussion]: https://github.com/tokio-rs/tokio/discussions/new
 
 ### Submitting a Bug Report
 
 When opening a new issue in the Tokio issue tracker, you will be presented
-with a basic template that should be filled in. If you believe that you have
-uncovered a bug, please fill out this form, following the template to the best
-of your ability. Do not worry if you cannot answer every detail, just fill in
-what you can.
+with a basic template that should be filled in. If you believe that you have uncovered a bug, please
+fill out this form, following the template to the best of your ability. Do not worry if you cannot
+answer every detail, just fill in what you can.
 
-The two most important pieces of information we need in order to properly
-evaluate the report is a description of the behavior you are seeing and a simple
-test case we can use to recreate the problem on our own. If we cannot recreate
-the issue, it becomes impossible for us to fix.
+The two most important pieces of information we need in order to properly evaluate the report is a
+description of the behavior you are seeing and a simple test case we can use to recreate the problem
+on our own. If we cannot recreate the issue, it becomes impossible for us to fix.
 
-In order to rule out the possibility of bugs introduced by userland code, test
-cases should be limited, as much as possible, to using only Tokio APIs.
+In order to rule out the possibility of bugs introduced by userland code, test cases should be
+limited, as much as possible, to using only Tokio APIs.
 
 See [How to create a Minimal, Complete, and Verifiable example][mcve].
 
@@ -81,59 +71,53 @@ See [How to create a Minimal, Complete, and Verifiable example][mcve].
 
 ### Triaging a Bug Report
 
-Once an issue has been opened, it is not uncommon for there to be discussion
-around it. Some contributors may have differing opinions about the issue,
-including whether the behavior being seen is a bug or a feature. This discussion
-is part of the process and should be kept focused, helpful, and professional.
+Once an issue has been opened, it is not uncommon for there to be discussion around it. Some
+contributors may have differing opinions about the issue, including whether the behavior being seen
+is a bug or a feature. This discussion is part of the process and should be kept focused, helpful,
+and professional.
 
-Short, clipped responses—that provide neither additional context nor supporting
-detail—are not helpful or professional. To many, such responses are simply
-annoying and unfriendly.
+Short, clipped responses—that provide neither additional context nor supporting detail—are not
+helpful or professional. To many, such responses are simply annoying and unfriendly.
 
-Contributors are encouraged to help one another make forward progress as much as
-possible, empowering one another to solve issues collaboratively. If you choose
-to comment on an issue that you feel either is not a problem that needs to be
-fixed, or if you encounter information in an issue that you feel is incorrect,
-explain why you feel that way with additional supporting context, and be willing
-to be convinced that you may be wrong. By doing so, we can often reach the
-correct outcome much faster.
+Contributors are encouraged to help one another make forward progress as much as possible,
+empowering one another to solve issues collaboratively. If you choose to comment on an issue that
+you feel either is not a problem that needs to be fixed, or if you encounter information in an issue
+that you feel is incorrect, explain why you feel that way with additional supporting context, and be
+willing to be convinced that you may be wrong. By doing so, we can often reach the correct outcome
+much faster.
 
 ### Resolving a Bug Report
 
-In the majority of cases, issues are resolved by opening a Pull Request. The
-process for opening and reviewing a Pull Request is similar to that of opening
-and triaging issues, but carries with it a necessary review and approval
-workflow that ensures that the proposed changes meet the minimal quality and
-functional guidelines of the Tokio project.
+In the majority of cases, issues are resolved by opening a Pull Request. The process for opening and
+reviewing a Pull Request is similar to that of opening and triaging issues, but carries with it a
+necessary review and approval workflow that ensures that the proposed changes meet the minimal
+quality and functional guidelines of the Tokio project.
 
 ## Pull Requests
 
-Pull Requests are the way concrete changes are made to the code, documentation,
-and dependencies in the Tokio repository.
+Pull Requests are the way concrete changes are made to the code, documentation, and dependencies in
+the Tokio repository.
 
-Even tiny pull requests (e.g., one character pull request fixing a typo in API
-documentation) are greatly appreciated. Before making a large change, it is
-usually a good idea to first open an issue describing the change to solicit
-feedback and guidance. This will increase the likelihood of the PR getting
-merged.
+Even tiny pull requests (e.g., one character pull request fixing a typo in API documentation) are
+greatly appreciated. Before making a large change, it is usually a good idea to first open an issue
+describing the change to solicit feedback and guidance. This will increase the likelihood of the PR
+getting merged.
 
 ### Cargo Commands
 
-Due to the extensive use of features in Tokio, you will often need to add extra
-arguments to many common cargo commands. This section lists some commonly needed
-commands.
+Due to the extensive use of features in Tokio, you will often need to add extra arguments to many
+common cargo commands. This section lists some commonly needed commands.
 
 Some commands just need the `--all-features` argument:
 
-```
+```shell
 cargo build --all-features
 cargo check --all-features
 cargo test --all-features
 ```
 
-Ideally, you should use the same version of clippy as the one used in CI
-(defined by `env.rust_clippy` in [ci.yml][ci.yml]), because newer versions
-might have new lints:
+Ideally, you should use the same version of clippy as the one used in CI (defined by
+`env.rust_clippy` in [ci.yml][ci.yml]), because newer versions might have new lints:
 
 [ci.yml]: .github/workflows/ci.yml
 
@@ -148,67 +132,71 @@ When updating this, also update:
 - tokio-stream/Cargo.toml
 -->
 
-```
+```shell
 cargo +1.77 clippy --all --tests --all-features
 ```
 
-When building documentation, a simple `cargo doc` is not sufficient. To produce
-documentation equivalent to what will be produced in docs.rs's builds of Tokio's
-docs, please use:
+When building documentation, a simple `cargo doc` is not sufficient. To produce documentation
+equivalent to what will be produced in docs.rs's builds of Tokio's docs, please use:
 
+```shell
+RUSTDOCFLAGS="--cfg docsrs --cfg tokio_unstable" RUSTFLAGS="--cfg docsrs --cfg tokio_unstable" \
+    cargo +nightly doc --all-features [--open]
 ```
-RUSTDOCFLAGS="--cfg docsrs --cfg tokio_unstable" RUSTFLAGS="--cfg docsrs --cfg tokio_unstable" cargo +nightly doc --all-features [--open]
-```
 
-This turns on indicators to display the Cargo features required for
-conditionally compiled APIs in Tokio, and it enables documentation of unstable
-Tokio features. Notice that it is necessary to pass cfg flags to both RustDoc
-*and* rustc.
+This turns on indicators to display the Cargo features required for conditionally compiled APIs in
+Tokio, and it enables documentation of unstable Tokio features. Notice that it is necessary to pass
+cfg flags to both RustDoc _and_ rustc.
 
-There is a more concise way to build docs.rs-equivalent docs by using [`cargo
-docs-rs`], which reads the above documentation flags out of Tokio's Cargo.toml
-as docs.rs itself does.
+There is a more concise way to build docs.rs-equivalent docs by using [`cargo docs-rs`], which reads
+the above documentation flags out of Tokio's Cargo.toml as docs.rs itself does.
 
 [`cargo docs-rs`]: https://github.com/dtolnay/cargo-docs-rs
 
-```
+```shell
 cargo install cargo-docs-rs
 cargo +nightly docs-rs [--open]
 ```
 
-The `cargo fmt` command does not work on the Tokio codebase. You can use the
-command below instead:
+The `cargo fmt` command does not work on the Tokio codebase. You can use the command below instead:
 
-```
+```shell
 # Mac or Linux
 rustfmt --check --edition 2021 $(git ls-files '*.rs')
+```
 
+```powershell
 # Powershell
 Get-ChildItem . -Filter "*.rs" -Recurse | foreach { rustfmt --check --edition 2021 $_.FullName }
 ```
+
 The `--check` argument prints the things that need to be fixed. If you remove
 it, `rustfmt` will update your files locally instead.
 
 You can run loom tests with
-```
+
+```shell
 cd tokio # tokio crate in workspace
 LOOM_MAX_PREEMPTIONS=1 LOOM_MAX_BRANCHES=10000 RUSTFLAGS="--cfg loom -C debug_assertions" \
     cargo test --lib --release --features full -- --test-threads=1 --nocapture
 ```
+
 Additionally, you can also add `--cfg tokio_unstable` to the `RUSTFLAGS` environment variable to
-run loom tests that test unstable features. 
+run loom tests that test unstable features.
 
 You can run miri tests with
-```
+
+```shell
 MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers" \
     cargo +nightly miri test --features full --lib
 ```
 
 ### Performing spellcheck on tokio codebase
 
-You can perform spell-check on tokio codebase. For details of how to use the spellcheck tool, feel free to visit
-https://github.com/drahnr/cargo-spellcheck
-```
+You can perform spell-check on tokio codebase. For details of how to use the spellcheck tool, feel
+free to visit <https://github.com/drahnr/cargo-spellcheck>
+
+```shell
 # First install the spell-check plugin
 cargo install --locked cargo-spellcheck
 
@@ -216,92 +204,94 @@ cargo install --locked cargo-spellcheck
 cargo spellcheck check
 ```
 
-if the command rejects a word, you should backtick the rejected word if it's code related. If not, the 
-rejected word should be put into `spellcheck.dic` file. 
+if the command rejects a word, you should backtick the rejected word if it's code related. If not,
+the rejected word should be put into `spellcheck.dic` file.
 
-Note that when you add a word into the file, you should also update the first line which tells the spellcheck tool
-the total number of words included in the file
+Note that when you add a word into the file, you should also update the first line which tells the
+spellcheck tool the total number of words included in the file
 
 ### Tests
 
-If the change being proposed alters code (as opposed to only documentation for
-example), it is either adding new functionality to Tokio or it is fixing
-existing, broken functionality. In both of these cases, the pull request should
-include one or more tests to ensure that Tokio does not regress in the future.
-There are two ways to write tests: [integration tests][integration-tests]
-and [documentation tests][documentation-tests].
-(Tokio avoids [unit tests][unit-tests] as much as possible).
+If the change being proposed alters code (as opposed to only documentation for example), it is
+either adding new functionality to Tokio or it is fixing existing, broken functionality. In both of
+these cases, the pull request should include one or more tests to ensure that Tokio does not regress
+in the future. There are two ways to write tests: [integration tests][integration-tests] and
+[documentation tests][documentation-tests]. (Tokio avoids [unit tests][unit-tests] as much as
+possible).
 
-Tokio uses [conditional compilation attributes][conditional-compilation]
-throughout the codebase, to modify rustc's behavior. Code marked with such
-attributes can be enabled using RUSTFLAGS and RUSTDOCFLAGS environment
-variables. One of the most prevalent flags passed in these variables is
-the `--cfg` option. To run tests in a particular file, check first what
-options #![cfg] declaration defines for that file.
+Tokio uses [conditional compilation attributes][conditional-compilation] throughout the codebase, to
+modify rustc's behavior. Code marked with such attributes can be enabled using RUSTFLAGS and
+RUSTDOCFLAGS environment variables. One of the most prevalent flags passed in these variables is the
+`--cfg` option. To run tests in a particular file, check first what options #![cfg] declaration
+defines for that file.
 
-For instance, to run a test marked with the 'tokio_unstable' cfg option,
-you must pass this flag to the compiler when running the test.
-```
-$ RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --all-features --test rt_metrics
+For instance, to run a test marked with the 'tokio_unstable' cfg option, you must pass this flag to
+the compiler when running the test.
+
+```shell
+RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --all-features --test rt_metrics
 ```
 
 #### Integration tests
 
-Integration tests go in the same crate as the code they are testing. Each sub
-crate should have a `dev-dependency` on `tokio` itself. This makes all Tokio
-utilities available to use in tests, no matter the crate being tested.
+Integration tests go in the same crate as the code they are testing. Each sub crate should have a
+`dev-dependency` on `tokio` itself. This makes all Tokio utilities available to use in tests, no
+matter the crate being tested.
 
-The best strategy for writing a new integration test is to look at existing
-integration tests in the crate and follow the style.
+The best strategy for writing a new integration test is to look at existing integration tests in the
+crate and follow the style.
 
 #### Fuzz tests
 
-Some of our crates include a set of fuzz tests, this will be marked by a
-directory `fuzz`. It is a good idea to run fuzz tests after each change.
-To get started with fuzz testing you'll need to install
-[cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
+Some of our crates include a set of fuzz tests, this will be marked by a directory `fuzz`. It is a
+good idea to run fuzz tests after each change. To get started with fuzz testing you'll need to
+install [cargo-fuzz](https://github.com/rust-fuzz/cargo-fuzz).
 
-`cargo install cargo-fuzz`
+```shell
+cargo install --locked cargo-fuzz
+```
 
 To list the available fuzzing harnesses you can run;
 
-```bash
-$ cd tokio
-$ cargo fuzz list
+```shell
+cd tokio
+cargo fuzz list
+```
+
+```text
 fuzz_linked_list
 ````
 
 Running a fuzz test is as simple as;
 
-`cargo fuzz run fuzz_linked_list`
+```shell
+cargo fuzz run fuzz_linked_list
+```
 
-**NOTE**: Keep in mind that by default when running a fuzz test the fuzz
-harness will run forever and will only exit if you `ctrl-c` or it finds
-a bug.
+**NOTE**: Keep in mind that by default when running a fuzz test the fuzz harness will run forever
+and will only exit if you `ctrl-c` or it finds a bug.
 
 #### Documentation tests
 
-Ideally, every API has at least one [documentation test] that demonstrates how to
-use the API. Documentation tests are run with `cargo test --doc`. This ensures
-that the example is correct and provides additional test coverage.
+Ideally, every API has at least one [documentation test] that demonstrates how to use the API.
+Documentation tests are run with `cargo test --doc`. This ensures that the example is correct and
+provides additional test coverage.
 
-The trick to documentation tests is striking a balance between being succinct
-for a reader to understand and actually testing the API.
+The trick to documentation tests is striking a balance between being succinct for a reader to
+understand and actually testing the API.
 
-Same as with integration tests, when writing a documentation test, the full
-`tokio` crate is available. This is especially useful for getting access to the
-runtime to run the example.
+Same as with integration tests, when writing a documentation test, the full `tokio` crate is
+available. This is especially useful for getting access to the runtime to run the example.
 
-The documentation tests will be visible from both the crate specific
-documentation **and** the `tokio` facade documentation via the re-export. The
-example should be written from the point of view of a user that is using the
-`tokio` crate. As such, the example should use the API via the facade and not by
-directly referencing the crate.
+The documentation tests will be visible from both the crate specific documentation **and** the
+`tokio` facade documentation via the re-export. The example should be written from the point of view
+of a user that is using the `tokio` crate. As such, the example should use the API via the facade
+and not by directly referencing the crate.
 
 The type level example for `tokio_timer::Timeout` provides a good example of a
 documentation test:
 
-```
+```rust
 /// // import the `timeout` function, usually this is done
 /// // with `use tokio::prelude::*`
 /// use tokio::prelude::FutureExt;
@@ -327,18 +317,18 @@ documentation test:
 /// # }
 ```
 
-Given that this is a *type* level documentation test and the primary way users
-of `tokio` will create an instance of `Timeout` is by using
-`FutureExt::timeout`, this is how the documentation test is structured.
+Given that this is a _type_ level documentation test and the primary way users of `tokio` will
+create an instance of `Timeout` is by using `FutureExt::timeout`, this is how the documentation test
+is structured.
 
-Lines that start with `/// #` are removed when the documentation is generated.
-They are only there to get the test to run. The `block_on_all` function is the
-easiest way to execute a future from a test.
+Lines that start with `/// #` are removed when the documentation is generated. They are only there
+to get the test to run. The `block_on_all` function is the easiest way to execute a future from a
+test.
 
-If this were a documentation test for the `Timeout::new` function, then the
-example would explicitly use `Timeout::new`. For example:
+If this were a documentation test for the `Timeout::new` function, then the example would explicitly
+use `Timeout::new`. For example:
 
-```
+```rust
 /// use tokio::timer::Timeout;
 /// use futures::Future;
 /// use futures::sync::oneshot;
@@ -357,11 +347,11 @@ example would explicitly use `Timeout::new`. For example:
 
 ### Benchmarks
 
-You can run benchmarks locally for the changes you've made to the tokio codebase.
-Tokio currently uses [Criterion](https://github.com/bheisler/criterion.rs) as its benchmarking tool. To run a benchmark
-against the changes you have made, for example, you can run;
+You can run benchmarks locally for the changes you've made to the tokio codebase. Tokio currently
+uses [Criterion](https://github.com/bheisler/criterion.rs) as its benchmarking tool. To run a
+benchmark against the changes you have made, for example, you can run;
 
-```bash
+```shell
 cd benches
 
 # Run all benchmarks.
@@ -381,43 +371,41 @@ You can also refer to Criterion docs for additional options and details.
 ### Commits
 
 It is a recommended best practice to keep your changes as logically grouped as
-possible within individual commits. There is no limit to the number of commits
-any single Pull Request may have, and many contributors find it easier to review
-changes that are split across multiple commits.
+possible within individual commits. There is no limit to the number of commits any single Pull
+Request may have, and many contributors find it easier to review changes that are split across
+multiple commits.
 
-That said, if you have a number of commits that are "checkpoints" and don't
-represent a single logical change, please squash those together.
+That said, if you have a number of commits that are "checkpoints" and don't represent a single
+logical change, please squash those together.
 
-Note that multiple commits often get squashed when they are landed (see the
-notes about [commit squashing](#commit-squashing)).
+Note that multiple commits often get squashed when they are landed (see the notes about [commit
+squashing](#commit-squashing)).
 
 #### Commit message guidelines
 
 A good commit message should describe what changed and why.
 
 1. The first line should:
+   - contain a short description of the change (preferably 50 characters or less, and no more than
+     72 characters)
+   - be entirely in lowercase with the exception of proper nouns, acronyms, and the words that refer
+     to code, like function/variable names
+   - start with an imperative verb
+   - not have a period at the end
+   - be prefixed with the name of the module being changed; usually this is the same as the M-*
+     label on the PR
 
-  * contain a short description of the change (preferably 50 characters or less,
-    and no more than 72 characters)
-  * be entirely in lowercase with the exception of proper nouns, acronyms, and
-    the words that refer to code, like function/variable names
-  * start with an imperative verb
-  * not have a period at the end
-  * be prefixed with the name of the module being changed; usually this is the
-    same as the M-* label on the PR
+   Examples:
 
-  Examples:
-
-  * time: introduce `Timeout` and deprecate `Deadline`
-  * codec: export `Encoder`, `Decoder`, `Framed*`
-  * ci: fix the FreeBSD ci configuration
+   - ``time: introduce `Timeout` and deprecate `Deadline``
+   - ``codec: export `Encoder`, `Decoder`, `Framed*` ``
+   - ``ci: fix the FreeBSD ci configuration``
 
 2. Keep the second line blank.
 3. Wrap all other lines at 72 columns (except for long URLs).
-4. If your patch fixes an open issue, you can add a reference to it at the end
-   of the log. Use the `Fixes: #` prefix and the issue number. For other
-   references use `Refs: #`. `Refs` may include multiple issues, separated by a
-   comma.
+4. If your patch fixes an open issue, you can add a reference to it at the end of the log. Use the
+   `Fixes: #` prefix and the issue number. For other references use `Refs: #`. `Refs` may include
+   multiple issues, separated by a comma.
 
    Examples:
 
@@ -444,111 +432,102 @@ Refs: #453, #154
 
 ### Opening the Pull Request
 
-From within GitHub, opening a new Pull Request will present you with a
-[template] that should be filled out. Please try to do your best at filling out
-the details, but feel free to skip parts if you're not sure what to put.
+From within GitHub, opening a new Pull Request will present you with a [template] that should be
+filled out. Please try to do your best at filling out the details, but feel free to skip parts if
+you're not sure what to put.
 
 [template]: .github/PULL_REQUEST_TEMPLATE.md
 
 ### Discuss and update
 
-You will probably get feedback or requests for changes to your Pull Request.
-This is a big part of the submission process so don't be discouraged! Some
-contributors may sign off on the Pull Request right away, others may have
-more detailed comments or feedback. This is a necessary part of the process
-in order to evaluate whether the changes are correct and necessary.
+You will probably get feedback or requests for changes to your Pull Request. This is a big part of
+the submission process so don't be discouraged! Some contributors may sign off on the Pull Request
+right away, others may have more detailed comments or feedback. This is a necessary part of the
+process in order to evaluate whether the changes are correct and necessary.
 
-**Any community member can review a PR and you might get conflicting feedback**.
-Keep an eye out for comments from code owners to provide guidance on conflicting
-feedback.
+**Any community member can review a PR and you might get conflicting feedback**. Keep an eye out for
+comments from code owners to provide guidance on conflicting feedback.
 
 **Once the PR is open, do not rebase the commits**. See [Commit Squashing](#commit-squashing) for
 more details.
 
 ### Commit Squashing
 
-In most cases, **do not squash commits that you add to your Pull Request during
-the review process**. When the commits in your Pull Request land, they may be
-squashed into one commit per logical change. Metadata will be added to the
-commit message (including links to the Pull Request, links to relevant issues,
-and the names of the reviewers). The commit history of your Pull Request,
+In most cases, **do not squash commits that you add to your Pull Request during the review
+process**. When the commits in your Pull Request land, they may be squashed into one commit per
+logical change. Metadata will be added to the commit message (including links to the Pull Request,
+links to relevant issues, and the names of the reviewers). The commit history of your Pull Request,
 however, will stay intact on the Pull Request page.
 
 ## Reviewing Pull Requests
 
 **Any Tokio community member is welcome to review any pull request**.
 
-All Tokio contributors who choose to review and provide feedback on Pull
-Requests have a responsibility to both the project and the individual making the
-contribution. Reviews and feedback must be helpful, insightful, and geared
-towards improving the contribution as opposed to simply blocking it. If there
-are reasons why you feel the PR should not land, explain what those are. Do not
-expect to be able to block a Pull Request from advancing simply because you say
-"No" without giving an explanation. Be open to having your mind changed. Be open
-to working with the contributor to make the Pull Request better.
+All Tokio contributors who choose to review and provide feedback on Pull Requests have a
+responsibility to both the project and the individual making the contribution. Reviews and feedback
+must be helpful, insightful, and geared towards improving the contribution as opposed to simply
+blocking it. If there are reasons why you feel the PR should not land, explain what those are. Do
+not expect to be able to block a Pull Request from advancing simply because you say "No" without
+giving an explanation. Be open to having your mind changed. Be open to working with the contributor
+to make the Pull Request better.
 
-Reviews that are dismissive or disrespectful of the contributor or any other
-reviewers are strictly counter to the Code of Conduct.
+Reviews that are dismissive or disrespectful of the contributor or any other reviewers are strictly
+counter to the Code of Conduct.
 
-When reviewing a Pull Request, the primary goals are for the codebase to improve
-and for the person submitting the request to succeed. **Even if a Pull Request
-does not land, the submitters should come away from the experience feeling like
-their effort was not wasted or unappreciated**. Every Pull Request from a new
-contributor is an opportunity to grow the community.
+When reviewing a Pull Request, the primary goals are for the codebase to improve and for the person
+submitting the request to succeed. **Even if a Pull Request does not land, the submitters should
+come away from the experience feeling like their effort was not wasted or unappreciated**. Every
+Pull Request from a new contributor is an opportunity to grow the community.
 
-### Review a bit at a time.
+### Review a bit at a time
 
 Do not overwhelm new contributors.
 
-It is tempting to micro-optimize and make everything about relative performance,
-perfect grammar, or exact style matches. Do not succumb to that temptation.
+It is tempting to micro-optimize and make everything about relative performance, perfect grammar, or
+exact style matches. Do not succumb to that temptation.
 
 Focus first on the most significant aspects of the change:
 
 1. Does this change make sense for Tokio?
 2. Does this change make Tokio better, even if only incrementally?
 3. Are there clear bugs or larger scale issues that need attending to?
-4. Is the commit message readable and correct? If it contains a breaking change
-   is it clear enough?
+4. Is the commit message readable and correct? If it contains a breaking change is it clear enough?
 
-Note that only **incremental** improvement is needed to land a PR. This means
-that the PR does not need to be perfect, only better than the status quo. Follow
-up PRs may be opened to continue iterating.
+Note that only **incremental** improvement is needed to land a PR. This means that the PR does not
+need to be perfect, only better than the status quo. Follow up PRs may be opened to continue
+iterating.
 
-When changes are necessary, *request* them, do not *demand* them, and **do not
-assume that the submitter already knows how to add a test or run a benchmark**.
+When changes are necessary, _request_ them, do not _demand_ them, and **do not assume that the
+submitter already knows how to add a test or run a benchmark**.
 
-Specific performance optimization techniques, coding styles and conventions
-change over time. The first impression you give to a new contributor never does.
+Specific performance optimization techniques, coding styles and conventions change over time. The
+first impression you give to a new contributor never does.
 
-Nits (requests for small changes that are not essential) are fine, but try to
-avoid stalling the Pull Request. Most nits can typically be fixed by the Tokio
-Collaborator landing the Pull Request but they can also be an opportunity for
-the contributor to learn a bit more about the project.
+Nits (requests for small changes that are not essential) are fine, but try to avoid stalling the
+Pull Request. Most nits can typically be fixed by the Tokio Collaborator landing the Pull Request
+but they can also be an opportunity for the contributor to learn a bit more about the project.
 
-It is always good to clearly indicate nits when you comment: e.g.
-`Nit: change foo() to bar(). But this is not blocking.`
+It is always good to clearly indicate nits when you comment: e.g. `Nit: change foo() to bar(). But
+this is not blocking.`
 
-If your comments were addressed but were not folded automatically after new
-commits or if they proved to be mistaken, please, [hide them][hiding-a-comment]
-with the appropriate reason to keep the conversation flow concise and relevant.
+If your comments were addressed but were not folded automatically after new commits or if they
+proved to be mistaken, please, [hide them][hiding-a-comment] with the appropriate reason to keep the
+conversation flow concise and relevant.
 
 ### Be aware of the person behind the code
 
-Be aware that *how* you communicate requests and reviews in your feedback can
-have a significant impact on the success of the Pull Request. Yes, we may land
-a particular change that makes Tokio better, but the individual might just not
-want to have anything to do with Tokio ever again. The goal is not just having
-good code.
+Be aware that _how_ you communicate requests and reviews in your feedback can have a significant
+impact on the success of the Pull Request. Yes, we may land a particular change that makes Tokio
+better, but the individual might just not want to have anything to do with Tokio ever again. The
+goal is not just having good code.
 
 ### Abandoned or Stalled Pull Requests
 
-If a Pull Request appears to be abandoned or stalled, it is polite to first
-check with the contributor to see if they intend to continue the work before
-checking if they would mind if you took it over (especially if it just has nits
-left). When doing so, it is courteous to give the original contributor credit
-for the work they started (either by preserving their name and email address in
-the commit log, or by using an `Author: ` meta-data tag in the commit.
+If a Pull Request appears to be abandoned or stalled, it is polite to first check with the
+contributor to see if they intend to continue the work before checking if they would mind if you
+took it over (especially if it just has nits left). When doing so, it is courteous to give the
+original contributor credit for the work they started (either by preserving their name and email
+address in the commit log, or by using an `Author:` meta-data tag in the commit).
 
 _Adapted from the [Node.js contributing guide][node]_.
 
@@ -558,85 +537,82 @@ _Adapted from the [Node.js contributing guide][node]_.
 
 ## Keeping track of issues and PRs
 
-The Tokio GitHub repository has a lot of issues and PRs to keep track of. This
-section explains the meaning of various labels, as well as our [GitHub
-project][project]. The section is primarily targeted at maintainers.  Most
-contributors aren't able to set these labels.
+The Tokio GitHub repository has a lot of issues and PRs to keep track of. This section explains the
+meaning of various labels, as well as our [GitHub project][project]. The section is primarily
+targeted at maintainers.  Most contributors aren't able to set these labels.
 
 ### Area
 
 The area label describes the crates relevant to this issue or PR.
 
- - **A-tokio** This issue concerns the main Tokio crate.
- - **A-tokio-util** This issue concerns the `tokio-util` crate.
- - **A-tokio-tls** This issue concerns the `tokio-tls` crate. Only used for
-   older issues, as the crate has been moved to another repository.
- - **A-tokio-test** The issue concerns the `tokio-test` crate.
- - **A-tokio-macros** This issue concerns the `tokio-macros` crate. Should only
-   be used for the procedural macros, and not `join!` or `select!`.
- - **A-ci** This issue concerns our GitHub Actions setup.
+- **A-tokio** This issue concerns the main Tokio crate.
+- **A-tokio-util** This issue concerns the `tokio-util` crate.
+- **A-tokio-tls** This issue concerns the `tokio-tls` crate. Only used for older issues, as the
+  crate has been moved to another repository.
+- **A-tokio-test** The issue concerns the `tokio-test` crate.
+- **A-tokio-macros** This issue concerns the `tokio-macros` crate. Should only be used for the
+  procedural macros, and not `join!` or `select!`.
+- **A-ci** This issue concerns our GitHub Actions setup.
 
 ### Category
 
- - **C-bug** This is a bug-report. Bug-fix PRs use `C-enhancement` instead.
- - **C-enhancement** This is a PR that adds a new features.
- - **C-maintenance** This is an issue or PR about stuff such as documentation,
-   GitHub Actions or code quality.
- - **C-feature-request** This is a feature request. Implementations of feature
-   requests use `C-enhancement` instead.
- - **C-feature-accepted** If you submit a PR for this feature request, we wont
-   close it with the reason "we don't want this". Issues with this label should
-   also have the `C-feature-request` label.
- - **C-musing** Stuff like tracking issues or roadmaps. "musings about a better
-   world"
- - **C-proposal** A proposal of some kind, and a request for comments.
- - **C-question** A user question. Large overlap with GitHub discussions.
- - **C-request** A non-feature request, e.g. "please add deprecation notices to
-   `-alpha.*` versions of crates"
+- **C-bug** This is a bug-report. Bug-fix PRs use `C-enhancement` instead.
+- **C-enhancement** This is a PR that adds a new features.
+- **C-maintenance** This is an issue or PR about stuff such as documentation, GitHub Actions or code
+  quality.
+- **C-feature-request** This is a feature request. Implementations of feature requests use
+  `C-enhancement` instead.
+- **C-feature-accepted** If you submit a PR for this feature request, we wont close it with the
+  reason "we don't want this". Issues with this label should also have the `C-feature-request`
+  label.
+- **C-musing** Stuff like tracking issues or roadmaps. "musings about a better world"
+- **C-proposal** A proposal of some kind, and a request for comments.
+- **C-question** A user question. Large overlap with GitHub discussions.
+- **C-request** A non-feature request, e.g. "please add deprecation notices to `-alpha.*` versions
+  of crates"
 
 ### Calls for participation
 
- - **E-help-wanted** Stuff where we want help. Often seen together with `C-bug`
-   or `C-feature-accepted`.
- - **E-easy** This is easy, ranging from quick documentation fixes to stuff you
-   can do after reading the tutorial on our website.
- - **E-medium** This is not `E-easy` or `E-hard`.
- - **E-hard** This either involves very tricky code, is something we don't know
-   how to solve, or is difficult for some other reason.
- - **E-needs-mvce** This bug is missing a minimal complete and verifiable
-   example.
+- **E-help-wanted** Stuff where we want help. Often seen together with `C-bug` or
+  `C-feature-accepted`.
+- **E-easy** This is easy, ranging from quick documentation fixes to stuff you can do after reading
+  the tutorial on our website.
+- **E-medium** This is not `E-easy` or `E-hard`.
+- **E-hard** This either involves very tricky code, is something we don't know how to solve, or is
+  difficult for some other reason.
+- **E-needs-mvce** This bug is missing a minimal complete and verifiable example.
 
-The "E-" prefix is the same as used in the Rust compiler repository. Some
-issues are missing a difficulty rating, but feel free to ask on our Discord
-server if you want to know how difficult an issue likely is.
+The "E-" prefix is the same as used in the Rust compiler repository. Some issues are missing a
+difficulty rating, but feel free to ask on our Discord server if you want to know how difficult an
+issue likely is.
 
 ### Module
 
 The module label provides a more fine grained categorization than **Area**.
 
- - **M-blocking** Things relevant to `spawn_blocking`, `block_in_place`.
- - **M-codec** The `tokio_util::codec` module.
- - **M-compat** The `tokio_util::compat` module.
- - **M-coop** Things relevant to coop.
- - **M-fs** The `tokio::fs` module.
- - **M-io** The `tokio::io` module.
- - **M-macros** Issues about any kind of macro.
- - **M-net** The `tokio::net` module.
- - **M-process** The `tokio::process` module.
- - **M-runtime** The `tokio::runtime` module.
- - **M-signal** The `tokio::signal` module.
- - **M-sync** The `tokio::sync` module.
- - **M-task** The `tokio::task` module.
- - **M-time** The `tokio::time` module.
- - **M-tracing** Tracing support in Tokio.
+- **M-blocking** Things relevant to `spawn_blocking`, `block_in_place`.
+- **M-codec** The `tokio_util::codec` module.
+- **M-compat** The `tokio_util::compat` module.
+- **M-coop** Things relevant to coop.
+- **M-fs** The `tokio::fs` module.
+- **M-io** The `tokio::io` module.
+- **M-macros** Issues about any kind of macro.
+- **M-net** The `tokio::net` module.
+- **M-process** The `tokio::process` module.
+- **M-runtime** The `tokio::runtime` module.
+- **M-signal** The `tokio::signal` module.
+- **M-sync** The `tokio::sync` module.
+- **M-task** The `tokio::task` module.
+- **M-time** The `tokio::time` module.
+- **M-tracing** Tracing support in Tokio.
 
 ### Topic
 
 Some extra information.
 
- - **T-docs** This is about documentation.
- - **T-performance** This is about performance.
- - **T-v0.1.x** This is about old Tokio.
+- **T-docs** This is about documentation.
+- **T-performance** This is about performance.
+- **T-v0.1.x** This is about old Tokio.
 
 Any label not listed here is not in active use.
 
@@ -646,86 +622,77 @@ Any label not listed here is not in active use.
 
 Tokio ≥1.0.0 comes with LTS guarantees:
 
- * A minimum of 5 years of maintenance.
- * A minimum of 3 years before a hypothetical 2.0 release.
+- A minimum of 5 years of maintenance.
+- A minimum of 3 years before a hypothetical 2.0 release.
 
 The goal of these guarantees is to provide stability to the ecosystem.
 
 ## Minimum Supported Rust Version (MSRV)
 
- * All Tokio ≥1.0.0 releases will support at least a 6-month old Rust
-   compiler release.
- * The MSRV will only be increased on 1.x releases.
+- All Tokio ≥1.0.0 releases will support at least a 6-month old Rust compiler release.
+- The MSRV will only be increased on 1.x releases.
 
 ## Versioning Policy
 
 With Tokio ≥1.0.0:
 
- * Patch (1.\_.x) releases _should only_ contain bug fixes or documentation
-   changes. Besides this, these releases should not substantially change
-   runtime behavior.
- * Minor (1.x) releases may contain new functionality, MSRV increases (see
-   above), minor dependency updates, deprecations, and larger internal
-   implementation changes.
+- Patch (1.\_.x) releases _should only_ contain bug fixes or documentation changes. Besides this,
+  these releases should not substantially change runtime behavior.
+- Minor (1.x) releases may contain new functionality, MSRV increases (see above), minor dependency
+  updates, deprecations, and larger internal implementation changes.
 
 This is as defined by [Semantic Versioning 2.0](https://semver.org/).
 
 ## Releasing
 
-Since the Tokio project consists of a number of crates, many of which depend on
-each other, releasing new versions to crates.io can involve some complexities.
-When releasing a new version of a crate, follow these steps:
+Since the Tokio project consists of a number of crates, many of which depend on each other,
+releasing new versions to crates.io can involve some complexities. When releasing a new version of a
+crate, follow these steps:
 
-1. **Ensure that the release crate has no path dependencies.** When the HEAD
-   version of a Tokio crate requires unreleased changes in another Tokio crate,
-   the crates.io dependency on the second crate will be replaced with a path
-   dependency. Crates with path dependencies cannot be published, so before
-   publishing the dependent crate, any path dependencies must also be published.
-   This should be done through a form of depth-first tree traversal:
+1. **Ensure that the release crate has no path dependencies.** When the HEAD version of a Tokio
+   crate requires unreleased changes in another Tokio crate, the crates.io dependency on the second
+   crate will be replaced with a path dependency. Crates with path dependencies cannot be published,
+   so before publishing the dependent crate, any path dependencies must also be published. This
+   should be done through a form of depth-first tree traversal:
 
-   1. Starting with the first path dependency in the crate to be released,
-      inspect the `Cargo.toml` for the dependency. If the dependency has any
-      path dependencies of its own, repeat this step with the first such
-      dependency.
+   1. Starting with the first path dependency in the crate to be released, inspect the `Cargo.toml`
+      for the dependency. If the dependency has any path dependencies of its own, repeat this step
+      with the first such dependency.
    2. Begin the release process for the path dependency.
-   3. Once the path dependency has been published to crates.io, update the
-      dependent crate to depend on the crates.io version.
-   4. When all path dependencies have been published, the dependent crate may
-      be published.
+   3. Once the path dependency has been published to crates.io, update the dependent crate to depend
+      on the crates.io version.
+   4. When all path dependencies have been published, the dependent crate may be published.
 
    To verify that a crate is ready to publish, run:
 
-   ```bash
+   ```shell
    bin/publish --dry-run <CRATE NAME> <CRATE VERSION>
    ```
 
-2. **Update Cargo metadata.** After releasing any path dependencies, update the
-   `version` field in `Cargo.toml` to the new version, and the `documentation`
-   field to the docs.rs URL of the new version.
-3. **Update other documentation links.** Update the "Documentation" link in the
-   crate's `README.md` to point to the docs.rs URL of the new version.
-4. **Update the changelog for the crate.** Each crate in the Tokio repository
-   has its own `CHANGELOG.md` in that crate's subdirectory. Any changes to that
-   crate since the last release should be added to the changelog. Change
-   descriptions may be taken from the Git history, but should be edited to
-   ensure a consistent format, based on [Keep A Changelog][keep-a-changelog].
+2. **Update Cargo metadata.** After releasing any path dependencies, update the `version` field in
+   `Cargo.toml` to the new version, and the `documentation` field to the docs.rs URL of the new
+   version.
+3. **Update other documentation links.** Update the "Documentation" link in the crate's `README.md`
+   to point to the docs.rs URL of the new version.
+4. **Update the changelog for the crate.** Each crate in the Tokio repository has its own
+   `CHANGELOG.md` in that crate's subdirectory. Any changes to that crate since the last release
+   should be added to the changelog. Change descriptions may be taken from the Git history, but
+   should be edited to ensure a consistent format, based on [Keep A Changelog][keep-a-changelog].
    Other entries in that crate's changelog may also be used for reference.
-5. **Perform a final audit for breaking changes.** Compare the HEAD version of
-   crate with the Git tag for the most recent release version. If there are any
-   breaking API changes, determine if those changes can be made without breaking
-   existing APIs. If so, resolve those issues. Otherwise, if it is necessary to
-   make a breaking release, update the version numbers to reflect this.
-6. **Open a pull request with your changes.** Once that pull request has been
-   approved by a maintainer and the pull request has been merged, continue to
-   the next step.
+5. **Perform a final audit for breaking changes.** Compare the HEAD version of crate with the Git
+   tag for the most recent release version. If there are any breaking API changes, determine if
+   those changes can be made without breaking existing APIs. If so, resolve those issues. Otherwise,
+   if it is necessary to make a breaking release, update the version numbers to reflect this.
+6. **Open a pull request with your changes.** Once that pull request has been approved by a
+   maintainer and the pull request has been merged, continue to the next step.
 7. **Release the crate.** Run the following command:
 
-   ```bash
+   ```shell
    bin/publish <NAME OF CRATE> <VERSION>
    ```
 
-   Your editor and prompt you to edit a message for the tag. Copy the changelog
-   entry for that release version into your editor and close the window.
+   Your editor and prompt you to edit a message for the tag. Copy the changelog entry for that
+   release version into your editor and close the window.
 
 [keep-a-changelog]: https://github.com/olivierlacan/keep-a-changelog/blob/master/CHANGELOG.md
 [unit-tests]: https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Tokio
 
-A runtime for writing reliable, asynchronous, and slim applications with
-the Rust programming language. It is:
+A runtime for writing reliable, asynchronous, and slim applications with the Rust programming
+language.
 
-* **Fast**: Tokio's zero-cost abstractions give you bare-metal
-  performance.
+Tokio is:
 
-* **Reliable**: Tokio leverages Rust's ownership, type system, and
-  concurrency model to reduce bugs and ensure thread safety.
-
-* **Scalable**: Tokio has a minimal footprint, and handles backpressure
-  and cancellation naturally.
+- **Fast**: Tokio's zero-cost abstractions give you bare-metal performance.
+- **Reliable**: Tokio leverages Rust's ownership, type system, and concurrency model to reduce bugs
+  and ensure thread safety.
+- **Scalable**: Tokio has a minimal footprint, and handles backpressure and cancellation naturally.
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -33,17 +31,14 @@ the Rust programming language. It is:
 
 ## Overview
 
-Tokio is an event-driven, non-blocking I/O platform for writing
-asynchronous applications with the Rust programming language. At a high
-level, it provides a few major components:
+Tokio is an event-driven, non-blocking I/O platform for writing asynchronous applications with the
+Rust programming language. At a high level, it provides a few major components:
 
-* A multithreaded, work-stealing based task [scheduler].
-* A reactor backed by the operating system's event queue (epoll, kqueue,
-  IOCP, etc...).
-* Asynchronous [TCP and UDP][net] sockets.
+- A multithreaded, work-stealing based task [scheduler].
+- A reactor backed by the operating system's event queue (epoll, kqueue, IOCP, etc...).
+- Asynchronous [TCP and UDP][net] sockets.
 
-These components provide the runtime components necessary for building
-an asynchronous application.
+These components provide the runtime components necessary for building an asynchronous application.
 
 [net]: https://docs.rs/tokio/latest/tokio/net/index.html
 [scheduler]: https://docs.rs/tokio/latest/tokio/runtime/index.html
@@ -58,7 +53,8 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 [dependencies]
 tokio = { version = "1.37.0", features = ["full"] }
 ```
-Then, on your main.rs:
+
+Then, in your main.rs:
 
 ```rust,no_run
 use tokio::net::TcpListener;
@@ -97,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-More examples can be found [here][examples]. For a larger "real world" example, see the
+The Tokio github repository contains more [examples]. For a larger "real world" example, see the
 [mini-redis] repository.
 
 [examples]: https://github.com/tokio-rs/tokio/tree/master/examples
@@ -108,10 +104,10 @@ To see a list of the available features flags that can be enabled, check our
 
 ## Getting Help
 
-First, see if the answer to your question can be found in the [Guides] or the
-[API documentation]. If the answer is not there, there is an active community in
-the [Tokio Discord server][chat]. We would be happy to try to answer your
-question. You can also ask your question on [the discussions page][discussions].
+First, see if the answer to your question can be found in the [Guides] or the [API documentation].
+If the answer is not there, there is an active community in the [Tokio Discord server][chat]. We
+would be happy to try to answer your question. You can also ask your question on [the discussions
+page][discussions].
 
 [Guides]: https://tokio.rs/tokio/tutorial
 [API documentation]: https://docs.rs/tokio/latest/tokio
@@ -121,34 +117,28 @@ question. You can also ask your question on [the discussions page][discussions].
 
 ## Contributing
 
-:balloon: Thanks for your help improving the project! We are so happy to have
-you! We have a [contributing guide][guide] to help you get involved in the Tokio
-project.
+:balloon: Thanks for your help improving the project! We are so happy to have you! We have a
+[contributing guide][guide] to help you get involved in the Tokio project.
 
 [guide]: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
 
 ## Related Projects
 
-In addition to the crates in this repository, the Tokio project also maintains
-several other libraries, including:
+In addition to the crates in this repository, the Tokio project also maintains several other
+libraries, including:
 
-* [`axum`]: A web application framework that focuses on ergonomics and modularity.
-
-* [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
-
-* [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
-
-* [`warp`]: A super-easy, composable, web server framework for warp speeds.
-
-* [`tower`]: A library of modular and reusable components for building robust networking clients and servers.
-
-* [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware diagnostics.
-
-* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
-
-* [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
-
-* [`loom`]: A testing tool for concurrent Rust code.
+- [`axum`]: A web application framework that focuses on ergonomics and modularity.
+- [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
+- [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and
+  flexibility.
+- [`warp`]: A super-easy, composable, web server framework for warp speeds.
+- [`tower`]: A library of modular and reusable components for building robust networking clients and
+  servers.
+- [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware
+  diagnostics.
+- [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
+- [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
+- [`loom`]: A testing tool for concurrent Rust code.
 
 [`axum`]: https://github.com/tokio-rs/axum
 [`warp`]: https://github.com/seanmonstar/warp
@@ -164,11 +154,11 @@ several other libraries, including:
 
 The Tokio repository contains multiple crates. Each crate has its own changelog.
 
- * `tokio` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md)
- * `tokio-util` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md)
- * `tokio-stream` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/CHANGELOG.md)
- * `tokio-macros` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-macros/CHANGELOG.md)
- * `tokio-test` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-test/CHANGELOG.md)
+- [`tokio` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md)
+- [`tokio-util` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md)
+- [`tokio-stream` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/CHANGELOG.md)
+- [`tokio-macros`changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-macros/CHANGELOG.md)
+- [`tokio-test` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-test/CHANGELOG.md)
 
 ## Supported Rust Versions
 
@@ -184,58 +174,57 @@ When updating this, also update:
 - tokio-stream/Cargo.toml
 -->
 
-Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
-least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at least** 6 months.
+When increasing the MSRV, the new Rust version must have been released at least six months ago. The
+current MSRV is 1.63.
 
-Note that the MSRV is not increased automatically, and only as part of a minor
-release. The MSRV history for past minor releases can be found below:
+Note that the MSRV is not increased automatically, and only as part of a minor release. The MSRV
+history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
- * 1.27 to 1.29 - Rust 1.56
- * 1.17 to 1.26 - Rust 1.49
- * 1.15 to 1.16 - Rust 1.46
- * 1.0 to 1.14 - Rust 1.45
+- 1.30 to now - Rust 1.63
+- 1.27 to 1.29 - Rust 1.56
+- 1.17 to 1.26 - Rust 1.49
+- 1.15 to 1.16 - Rust 1.46
+- 1.0 to 1.14 - Rust 1.45
 
-Note that although we try to avoid the situation where a dependency transitively
-increases the MSRV of Tokio, we do not guarantee that this does not happen.
-However, every minor release will have some set of versions of dependencies that
-works with the MSRV of that minor release.
+Note that although we try to avoid the situation where a dependency transitively increases the MSRV
+of Tokio, we do not guarantee that this does not happen. However, every minor release will have some
+set of versions of dependencies that works with the MSRV of that minor release.
 
 ## Release schedule
 
-Tokio doesn't follow a fixed release schedule, but we typically make one to two
-new minor releases each month. We make patch releases for bugfixes as necessary.
+Tokio doesn't follow a fixed release schedule, but we typically make one to two new minor releases
+each month. We make patch releases for bugfixes as necessary.
 
 ## Bug patching policy
 
-For the purposes of making patch releases with bugfixes, we have designated
-certain minor releases as LTS (long term support) releases. Whenever a bug
-warrants a patch release with a fix for the bug, it will be backported and
-released as a new patch release for each LTS minor version. Our current LTS
+For the purposes of making patch releases with bugfixes, we have designated certain minor releases
+as LTS (long term support) releases. Whenever a bug warrants a patch release with a fix for the bug,
+it will be backported and released as a new patch release for each LTS minor version. Our current
+LTS
 releases are:
 
- * `1.32.x` - LTS release until September 2024. (MSRV 1.63)
- * `1.36.x` - LTS release until March 2025. (MSRV 1.63)
+- `1.32.x` - LTS release until September 2024. (MSRV 1.63)
+- `1.36.x` - LTS release until March 2025. (MSRV 1.63)
 
-Each LTS release will continue to receive backported fixes for at least a year.
-If you wish to use a fixed minor release in your project, we recommend that you
-use an LTS release.
+Each LTS release will continue to receive backported fixes for at least a year. If you wish to use a
+fixed minor release in your project, we recommend that you use an LTS release.
 
-To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.32.x` patch release, you
-can use the following dependency specification:
-```text
+To use a fixed minor version, you can specify the version with a tilde. For example, to specify that
+you wish to use the newest `1.32.x` patch release, you can use the following dependency
+specification:
+
+```toml
 tokio = { version = "~1.32", features = [...] }
 ```
 
 ### Previous LTS releases
 
- * `1.8.x` - LTS release until February 2022.
- * `1.14.x` - LTS release until June 2022.
- * `1.18.x` - LTS release until June 2023.
- * `1.20.x` - LTS release until September 2023.
- * `1.25.x` - LTS release until March 2024.
+- `1.8.x` - LTS release until February 2022.
+- `1.14.x` - LTS release until June 2022.
+- `1.18.x` - LTS release until June 2023.
+- `1.20.x` - LTS release until September 2023.
+- `1.25.x` - LTS release until March 2024.
 
 ## License
 
@@ -245,6 +234,5 @@ This project is licensed under the [MIT license].
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Tokio by you, shall be licensed as MIT, without any additional
-terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+Tokio by you, shall be licensed as MIT, without any additional terms or conditions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,13 +1,28 @@
-## Report a security issue
+# Report a security issue
 
-The Tokio project team welcomes security reports and is committed to providing prompt attention to security issues. Security issues should be reported privately via [security@tokio.rs](mailto:security@tokio.rs). Security issues should not be reported via the public GitHub Issue tracker.
+The Tokio project team welcomes security reports and is committed to providing prompt attention to
+security issues. Security issues should be reported privately via
+[security@tokio.rs](mailto:security@tokio.rs). Security issues should not be reported via the public
+GitHub Issue tracker.
 
 ## Vulnerability coordination
 
-Remediation of security vulnerabilities is prioritized by the project team. The project team coordinates remediation with third-party project stakeholders via [GitHub Security Advisories](https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories). Third-party stakeholders may include the reporter of the issue, affected direct or indirect users of Tokio, and maintainers of upstream dependencies if applicable.
+Remediation of security vulnerabilities is prioritized by the project team. The project team
+coordinates remediation with third-party project stakeholders via [GitHub Security
+Advisories][github-advisories]. Third-party stakeholders may include the reporter of the issue,
+affected direct or indirect users of Tokio, and maintainers of upstream dependencies if applicable.
 
-Downstream project maintainers and Tokio users can request participation in coordination of applicable security issues by sending your contact email address, GitHub username(s) and any other salient information to [security@tokio.rs](mailto:security@tokio.rs). Participation in security issue coordination processes is at the discretion of the Tokio team.
+Downstream project maintainers and Tokio users can request participation in coordination of
+applicable security issues by sending your contact email address, GitHub username(s) and any other
+salient information to [security@tokio.rs](mailto:security@tokio.rs). Participation in security
+issue coordination processes is at the discretion of the Tokio team.
 
 ## Security advisories
 
-The project team is committed to transparency in the security issue disclosure process. The Tokio team announces security issues via [project GitHub Release notes](https://github.com/tokio-rs/tokio/releases) and the [RustSec advisory database](https://github.com/RustSec/advisory-db) (i.e. `cargo-audit`).
+The project team is committed to transparency in the security issue disclosure process. The Tokio
+team announces security issues via [project GitHub Release notes][release-notes] and the [RustSec
+advisory database][rustsec-advisories] (i.e. `cargo-audit`).
+
+[github-advisories]: https://help.github.com/en/github/managing-security-vulnerabilities/about-github-security-advisories
+[release-notes]: https://github.com/tokio-rs/tokio/releases
+[rustsec-advisories]: https://github.com/RustSec/advisory-db

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,16 +1,14 @@
 # Tokio
 
-A runtime for writing reliable, asynchronous, and slim applications with
-the Rust programming language. It is:
+A runtime for writing reliable, asynchronous, and slim applications with the Rust programming
+language.
 
-* **Fast**: Tokio's zero-cost abstractions give you bare-metal
-  performance.
+Tokio is:
 
-* **Reliable**: Tokio leverages Rust's ownership, type system, and
-  concurrency model to reduce bugs and ensure thread safety.
-
-* **Scalable**: Tokio has a minimal footprint, and handles backpressure
-  and cancellation naturally.
+- **Fast**: Tokio's zero-cost abstractions give you bare-metal performance.
+- **Reliable**: Tokio leverages Rust's ownership, type system, and concurrency model to reduce bugs
+  and ensure thread safety.
+- **Scalable**: Tokio has a minimal footprint, and handles backpressure and cancellation naturally.
 
 [![Crates.io][crates-badge]][crates-url]
 [![MIT licensed][mit-badge]][mit-url]
@@ -33,17 +31,14 @@ the Rust programming language. It is:
 
 ## Overview
 
-Tokio is an event-driven, non-blocking I/O platform for writing
-asynchronous applications with the Rust programming language. At a high
-level, it provides a few major components:
+Tokio is an event-driven, non-blocking I/O platform for writing asynchronous applications with the
+Rust programming language. At a high level, it provides a few major components:
 
-* A multithreaded, work-stealing based task [scheduler].
-* A reactor backed by the operating system's event queue (epoll, kqueue,
-  IOCP, etc...).
-* Asynchronous [TCP and UDP][net] sockets.
+- A multithreaded, work-stealing based task [scheduler].
+- A reactor backed by the operating system's event queue (epoll, kqueue, IOCP, etc...).
+- Asynchronous [TCP and UDP][net] sockets.
 
-These components provide the runtime components necessary for building
-an asynchronous application.
+These components provide the runtime components necessary for building an asynchronous application.
 
 [net]: https://docs.rs/tokio/latest/tokio/net/index.html
 [scheduler]: https://docs.rs/tokio/latest/tokio/runtime/index.html
@@ -58,7 +53,8 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 [dependencies]
 tokio = { version = "1.37.0", features = ["full"] }
 ```
-Then, on your main.rs:
+
+Then, in your main.rs:
 
 ```rust,no_run
 use tokio::net::TcpListener;
@@ -97,7 +93,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-More examples can be found [here][examples]. For a larger "real world" example, see the
+The Tokio github repository contains more [examples]. For a larger "real world" example, see the
 [mini-redis] repository.
 
 [examples]: https://github.com/tokio-rs/tokio/tree/master/examples
@@ -108,10 +104,10 @@ To see a list of the available features flags that can be enabled, check our
 
 ## Getting Help
 
-First, see if the answer to your question can be found in the [Guides] or the
-[API documentation]. If the answer is not there, there is an active community in
-the [Tokio Discord server][chat]. We would be happy to try to answer your
-question. You can also ask your question on [the discussions page][discussions].
+First, see if the answer to your question can be found in the [Guides] or the [API documentation].
+If the answer is not there, there is an active community in the [Tokio Discord server][chat]. We
+would be happy to try to answer your question. You can also ask your question on [the discussions
+page][discussions].
 
 [Guides]: https://tokio.rs/tokio/tutorial
 [API documentation]: https://docs.rs/tokio/latest/tokio
@@ -121,34 +117,28 @@ question. You can also ask your question on [the discussions page][discussions].
 
 ## Contributing
 
-:balloon: Thanks for your help improving the project! We are so happy to have
-you! We have a [contributing guide][guide] to help you get involved in the Tokio
-project.
+:balloon: Thanks for your help improving the project! We are so happy to have you! We have a
+[contributing guide][guide] to help you get involved in the Tokio project.
 
 [guide]: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md
 
 ## Related Projects
 
-In addition to the crates in this repository, the Tokio project also maintains
-several other libraries, including:
+In addition to the crates in this repository, the Tokio project also maintains several other
+libraries, including:
 
-* [`axum`]: A web application framework that focuses on ergonomics and modularity.
-
-* [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
-
-* [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and flexibility.
-
-* [`warp`]: A super-easy, composable, web server framework for warp speeds.
-
-* [`tower`]: A library of modular and reusable components for building robust networking clients and servers.
-
-* [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware diagnostics.
-
-* [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
-
-* [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
-
-* [`loom`]: A testing tool for concurrent Rust code.
+- [`axum`]: A web application framework that focuses on ergonomics and modularity.
+- [`hyper`]: A fast and correct HTTP/1.1 and HTTP/2 implementation for Rust.
+- [`tonic`]: A gRPC over HTTP/2 implementation focused on high performance, interoperability, and
+  flexibility.
+- [`warp`]: A super-easy, composable, web server framework for warp speeds.
+- [`tower`]: A library of modular and reusable components for building robust networking clients and
+  servers.
+- [`tracing`] (formerly `tokio-trace`): A framework for application-level tracing and async-aware
+  diagnostics.
+- [`mio`]: A low-level, cross-platform abstraction over OS I/O APIs that powers `tokio`.
+- [`bytes`]: Utilities for working with bytes, including efficient byte buffers.
+- [`loom`]: A testing tool for concurrent Rust code.
 
 [`axum`]: https://github.com/tokio-rs/axum
 [`warp`]: https://github.com/seanmonstar/warp
@@ -164,11 +154,11 @@ several other libraries, including:
 
 The Tokio repository contains multiple crates. Each crate has its own changelog.
 
- * `tokio` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md)
- * `tokio-util` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md)
- * `tokio-stream` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/CHANGELOG.md)
- * `tokio-macros` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-macros/CHANGELOG.md)
- * `tokio-test` - [view changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-test/CHANGELOG.md)
+- [`tokio` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio/CHANGELOG.md)
+- [`tokio-util` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md)
+- [`tokio-stream` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-stream/CHANGELOG.md)
+- [`tokio-macros`changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-macros/CHANGELOG.md)
+- [`tokio-test` changelog](https://github.com/tokio-rs/tokio/blob/master/tokio-test/CHANGELOG.md)
 
 ## Supported Rust Versions
 
@@ -184,58 +174,57 @@ When updating this, also update:
 - tokio-stream/Cargo.toml
 -->
 
-Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
-least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at least** 6 months.
+When increasing the MSRV, the new Rust version must have been released at least six months ago. The
+current MSRV is 1.63.
 
-Note that the MSRV is not increased automatically, and only as part of a minor
-release. The MSRV history for past minor releases can be found below:
+Note that the MSRV is not increased automatically, and only as part of a minor release. The MSRV
+history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
- * 1.27 to 1.29 - Rust 1.56
- * 1.17 to 1.26 - Rust 1.49
- * 1.15 to 1.16 - Rust 1.46
- * 1.0 to 1.14 - Rust 1.45
+- 1.30 to now - Rust 1.63
+- 1.27 to 1.29 - Rust 1.56
+- 1.17 to 1.26 - Rust 1.49
+- 1.15 to 1.16 - Rust 1.46
+- 1.0 to 1.14 - Rust 1.45
 
-Note that although we try to avoid the situation where a dependency transitively
-increases the MSRV of Tokio, we do not guarantee that this does not happen.
-However, every minor release will have some set of versions of dependencies that
-works with the MSRV of that minor release.
+Note that although we try to avoid the situation where a dependency transitively increases the MSRV
+of Tokio, we do not guarantee that this does not happen. However, every minor release will have some
+set of versions of dependencies that works with the MSRV of that minor release.
 
 ## Release schedule
 
-Tokio doesn't follow a fixed release schedule, but we typically make one to two
-new minor releases each month. We make patch releases for bugfixes as necessary.
+Tokio doesn't follow a fixed release schedule, but we typically make one to two new minor releases
+each month. We make patch releases for bugfixes as necessary.
 
 ## Bug patching policy
 
-For the purposes of making patch releases with bugfixes, we have designated
-certain minor releases as LTS (long term support) releases. Whenever a bug
-warrants a patch release with a fix for the bug, it will be backported and
-released as a new patch release for each LTS minor version. Our current LTS
+For the purposes of making patch releases with bugfixes, we have designated certain minor releases
+as LTS (long term support) releases. Whenever a bug warrants a patch release with a fix for the bug,
+it will be backported and released as a new patch release for each LTS minor version. Our current
+LTS
 releases are:
 
- * `1.32.x` - LTS release until September 2024. (MSRV 1.63)
- * `1.36.x` - LTS release until March 2025. (MSRV 1.63)
+- `1.32.x` - LTS release until September 2024. (MSRV 1.63)
+- `1.36.x` - LTS release until March 2025. (MSRV 1.63)
 
-Each LTS release will continue to receive backported fixes for at least a year.
-If you wish to use a fixed minor release in your project, we recommend that you
-use an LTS release.
+Each LTS release will continue to receive backported fixes for at least a year. If you wish to use a
+fixed minor release in your project, we recommend that you use an LTS release.
 
-To use a fixed minor version, you can specify the version with a tilde. For
-example, to specify that you wish to use the newest `1.32.x` patch release, you
-can use the following dependency specification:
-```text
+To use a fixed minor version, you can specify the version with a tilde. For example, to specify that
+you wish to use the newest `1.32.x` patch release, you can use the following dependency
+specification:
+
+```toml
 tokio = { version = "~1.32", features = [...] }
 ```
 
 ### Previous LTS releases
 
- * `1.8.x` - LTS release until February 2022.
- * `1.14.x` - LTS release until June 2022.
- * `1.18.x` - LTS release until June 2023.
- * `1.20.x` - LTS release until September 2023.
- * `1.25.x` - LTS release until March 2024.
+- `1.8.x` - LTS release until February 2022.
+- `1.14.x` - LTS release until June 2022.
+- `1.18.x` - LTS release until June 2023.
+- `1.20.x` - LTS release until September 2023.
+- `1.25.x` - LTS release until March 2024.
 
 ## License
 
@@ -245,6 +234,5 @@ This project is licensed under the [MIT license].
 
 ### Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in Tokio by you, shall be licensed as MIT, without any additional
-terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+Tokio by you, shall be licensed as MIT, without any additional terms or conditions.


### PR DESCRIPTION
- **docs: lint and reformat the main markdown files**
- **style: automatically format ci.yaml**

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

When saving changes to markdown files in VSCode with a fairly standard setup (markdown lint extension installed),
often the extension will reformat areas of the docs unrelated to the the specific change. This PR makes everything
neat (100 character lines, consistent list characters, code languages on fenced code blocks etc.)

## Solution

Reformatted the root level markdown docs
Added a markdown lint config file to set the line length (picked 100 chars as a reasonable compromise. 120 is generally too long for docs, while 80 seems overly constraining).
Added a markdown lint action to the ci.yml - currently this only points at the markdown docs in the root of the project, not those deeper in the project tree, but this could be ratcheted down to cover those once they're also similarly reformatted.
