### PR TITLE
time: do not panic on Interval::poll_tick if the sum of the timeout and period overflow

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -482,7 +482,7 @@ impl Interval {
         } else {
             timeout
                 .checked_add(self.period)
-                .unwrap_or_else(|| Instant::far_future())
+                .unwrap_or_else(Instant::far_future)
         };
 
         // When we arrive here, the internal delay returned `Poll::Ready`.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -482,7 +482,7 @@ impl Interval {
         } else {
             timeout
                 .checked_add(self.period)
-                .unwrap_or(Instant::far_future())
+                .unwrap_or_else(|| Instant::far_future())
         };
 
         // When we arrive here, the internal delay returned `Poll::Ready`.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -480,7 +480,9 @@ impl Interval {
             self.missed_tick_behavior
                 .next_timeout(timeout, now, self.period)
         } else {
-            timeout + self.period
+            timeout
+                .checked_add(self.period)
+                .unwrap_or(Instant::far_future())
         };
 
         // When we arrive here, the internal delay returned `Poll::Ready`.

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -6,7 +6,7 @@ use std::task::{Context, Poll};
 
 use futures::{Stream, StreamExt};
 use tokio::time::{self, Duration, Instant, Interval, MissedTickBehavior};
-use tokio_test::{assert_pending, assert_ready_eq, task};
+use tokio_test::{assert_pending, assert_ready, assert_ready_eq, task};
 
 // Takes the `Interval` task, `start` variable, and optional time deltas
 // For each time delta, it polls the `Interval` and asserts that the result is
@@ -468,4 +468,10 @@ async fn stream_with_interval_poll_tick_no_waking() {
     // `Poll::Pending` and neither does [tokio::time::Interval] reschedule the
     // task when returning `Poll::Ready`.
     assert_eq!(items, vec![]);
+}
+
+#[tokio::test(start_paused = true)]
+async fn interval_doesnt_panic_max_duration_when_polling() {
+    let mut timer = task::spawn(time::interval(Duration::MAX));
+    assert_ready!(timer.enter(|cx, mut timer| timer.poll_tick(cx)));
 }


### PR DESCRIPTION
## Motivation
when calling [tokio::time::interval(Duration::MAX)](https://docs.rs/tokio/latest/tokio/time/fn.interval.html) runtime panics with:
```
overflow when adding duration to instant
```
see reproduction [here](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cf23e831d76f4bd503f1a177b16a9a4a). Panic happens when adding `timeout` to to the `delay` deadline.

## Solution

This PR addresses the panic by calling [`Instant::checked_add`](https://doc.rust-lang.org/std/time/struct.Instant.html#method.checked_add) falling back to `Instant::far_future()` when it overflows. If needed I can add a test for it and update the documentation mentioning this behaviour.

Thanks!
