### PR TITLE
docs: Runtime::metrics() documentation

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -491,7 +491,8 @@ impl std::panic::RefUnwindSafe for Runtime {}
 
 cfg_metrics! {
     impl Runtime {
-        /// TODO
+        /// Returns a view that lets you get information about how the runtime
+        /// is performing.
         pub fn metrics(&self) -> crate::runtime::RuntimeMetrics {
             self.handle.metrics()
         }


### PR DESCRIPTION
reused the comment on Handle::metrics() to help communicate that
they are the same thing.

Resolves: https://github.com/tokio-rs/tokio/issues/6486

I tried to make a doctest but struggled to get Cargo to actually run it.
The --cfg tokio_unstable was able to get the compiler to notice syntax
errors in the cfg_metrics!{} block, but it did not run the doctest.

Rather than commit a non-running doctest, I simply followed suit with
the existing comment on runtime::Handle::metrics.