### PR TITLE
macros: append generated test attribute so others are aware of it

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -46,7 +46,7 @@ async fn test_crate_not_path_invalid() {}
 async fn test_has_second_test_attr() {}
 
 #[tokio::test]
-#[::core::prelude::v1::test]
+#[tokio::test]
 async fn test_has_generated_second_test_attr() {}
 
 fn main() {}

--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -45,4 +45,8 @@ async fn test_crate_not_path_invalid() {}
 #[test]
 async fn test_has_second_test_attr() {}
 
+#[tokio::test]
+#[::core::prelude::v1::test]
+async fn test_has_generated_second_test_attr() {}
+
 fn main() {}

--- a/tests-build/tests/fail/macros_invalid_input.rs
+++ b/tests-build/tests/fail/macros_invalid_input.rs
@@ -46,6 +46,22 @@ async fn test_crate_not_path_invalid() {}
 async fn test_has_second_test_attr() {}
 
 #[tokio::test]
+#[::core::prelude::v1::test]
+async fn test_has_second_test_attr_v1() {}
+
+#[tokio::test]
+#[core::prelude::rust_2015::test]
+async fn test_has_second_test_attr_rust_2015() {}
+
+#[tokio::test]
+#[::std::prelude::rust_2018::test]
+async fn test_has_second_test_attr_rust_2018() {}
+
+#[tokio::test]
+#[std::prelude::rust_2021::test]
+async fn test_has_second_test_attr_rust_2021() {}
+
+#[tokio::test]
 #[tokio::test]
 async fn test_has_generated_second_test_attr() {}
 

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -83,9 +83,33 @@ error: second test attribute is supplied, consider removing or changing the orde
    | ^^^^^^^
 
 error: second test attribute is supplied, consider removing or changing the order of your test attributes
-  --> $DIR/macros_invalid_input.rs:48:1
+  --> $DIR/macros_invalid_input.rs:49:1
    |
-48 | #[tokio::test]
+49 | #[::core::prelude::v1::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
+  --> $DIR/macros_invalid_input.rs:53:1
+   |
+53 | #[core::prelude::rust_2015::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
+  --> $DIR/macros_invalid_input.rs:57:1
+   |
+57 | #[::std::prelude::rust_2018::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
+  --> $DIR/macros_invalid_input.rs:61:1
+   |
+61 | #[std::prelude::rust_2021::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
+  --> $DIR/macros_invalid_input.rs:64:1
+   |
+64 | #[tokio::test]
    | ^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `tokio::test` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -87,3 +87,5 @@ error: second test attribute is supplied, consider removing or changing the orde
    |
 48 | #[tokio::test]
    | ^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `tokio::test` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -76,7 +76,7 @@ error: Failed to parse value of `crate` as path: "456"
 41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
-error: second test attribute is supplied, try to order it after `tokio::test`
+error: second test attribute is supplied, consider removing it or ordering it after `tokio::test`
   --> $DIR/macros_invalid_input.rs:45:1
    |
 45 | #[test]
@@ -94,16 +94,16 @@ note: the lint level is defined here
 1  | #![deny(duplicate_macro_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: second test attribute is supplied, try to order it after `tokio::test`
+error: second test attribute is supplied, consider removing it or ordering it after `tokio::test`
   --> $DIR/macros_invalid_input.rs:49:1
    |
-49 | #[::core::prelude::v1::test::test]
+49 | #[::core::prelude::v1::test]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: duplicated attribute
   --> $DIR/macros_invalid_input.rs:49:1
    |
-49 | #[::core::prelude::v1::test::test]
+49 | #[::core::prelude::v1::test]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -82,20 +82,7 @@ error: second test attribute is supplied, consider removing or changing the orde
 45 | #[test]
    | ^^^^^^^
 
-error: duplicated attribute
-  --> $DIR/macros_invalid_input.rs:45:1
-   |
-45 | #[test]
-   | ^^^^^^^
-   |
-
 error: second test attribute is supplied, consider removing or changing the order of your test attributes
-  --> $DIR/macros_invalid_input.rs:49:1
-   |
-49 | #[::core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: duplicated attribute
   --> $DIR/macros_invalid_input.rs:49:1
    |
 49 | #[::core::prelude::v1::test]

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -76,7 +76,7 @@ error: Failed to parse value of `crate` as path: "456"
 41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
-error: second test attribute is supplied, consider removing it or ordering it after `tokio::test`
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
   --> $DIR/macros_invalid_input.rs:45:1
    |
 45 | #[test]
@@ -94,17 +94,17 @@ note: the lint level is defined here
 1  | #![deny(duplicate_macro_attributes)]
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: second test attribute is supplied, consider removing it or ordering it after `tokio::test`
+error: second test attribute is supplied, consider removing or changing the order of your test attributes
   --> $DIR/macros_invalid_input.rs:49:1
    |
 49 | #[::core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: duplicated attribute
   --> $DIR/macros_invalid_input.rs:49:1
    |
 49 | #[::core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/macros_invalid_input.rs:1:9

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -88,11 +88,6 @@ error: duplicated attribute
 45 | #[test]
    | ^^^^^^^
    |
-note: the lint level is defined here
-  --> $DIR/macros_invalid_input.rs:1:9
-   |
-1  | #![deny(duplicate_macro_attributes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: second test attribute is supplied, consider removing or changing the order of your test attributes
   --> $DIR/macros_invalid_input.rs:49:1
@@ -105,9 +100,3 @@ error: duplicated attribute
    |
 49 | #[::core::prelude::v1::test]
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-note: the lint level is defined here
-  --> $DIR/macros_invalid_input.rs:1:9
-   |
-1  | #![deny(duplicate_macro_attributes)]
-   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -76,7 +76,7 @@ error: Failed to parse value of `crate` as path: "456"
 41 | #[tokio::test(crate = "456")]
    |                       ^^^^^
 
-error: second test attribute is supplied
+error: second test attribute is supplied, try to order it after `tokio::test`
   --> $DIR/macros_invalid_input.rs:45:1
    |
 45 | #[test]
@@ -87,6 +87,24 @@ error: duplicated attribute
    |
 45 | #[test]
    | ^^^^^^^
+   |
+note: the lint level is defined here
+  --> $DIR/macros_invalid_input.rs:1:9
+   |
+1  | #![deny(duplicate_macro_attributes)]
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: second test attribute is supplied, try to order it after `tokio::test`
+  --> $DIR/macros_invalid_input.rs:49:1
+   |
+49 | #[::core::prelude::v1::test::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: duplicated attribute
+  --> $DIR/macros_invalid_input.rs:49:1
+   |
+49 | #[::core::prelude::v1::test::test]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
 note: the lint level is defined here
   --> $DIR/macros_invalid_input.rs:1:9

--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -83,7 +83,7 @@ error: second test attribute is supplied, consider removing or changing the orde
    | ^^^^^^^
 
 error: second test attribute is supplied, consider removing or changing the order of your test attributes
-  --> $DIR/macros_invalid_input.rs:49:1
+  --> $DIR/macros_invalid_input.rs:48:1
    |
-49 | #[::core::prelude::v1::test]
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+48 | #[tokio::test]
+   | ^^^^^^^^^^^^^^

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -471,7 +471,7 @@ pub(crate) fn test(args: TokenStream, item: TokenStream, rt_multi_thread: bool) 
         Err(e) => return token_stream_with_error(item, e),
     };
     let config = if let Some(attr) = input.attrs().find(|attr| is_test_attribute(*attr)) {
-        let msg = "second test attribute is supplied, consider removing it or ordering it after `tokio::test`";
+        let msg = "second test attribute is supplied, consider removing or changing the order of your test attributes";
         Err(syn::Error::new_spanned(attr, msg))
     } else {
         AttributeArgs::parse_terminated


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Improve compatibility among multiple test proc macros.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
1. Add `#[::core::prelude::v1::test]` to the end of test proc macros. This way, proc macros process later can choose to not generate `#[::core::prelude::v1::test]` to avoid duplicated test runs.
2. Forbid `#[::core::prelude::v1::test]` to avoid duplicated test runs as `tokio::test` is transforming an invalid test signature to one accepted by `#[test]`. This is consistent with what we currently treat `#[test]`.

## Links
1. frondeus/test-case#143
2. https://github.com/rust-lang/reference/issues/692
3. https://github.com/rust-lang/rust/issues/67839