### PR TITLE
Fix obsolete reference to “stream ID” in `ReadHalf::unsplit()` documentation.

### DIFF
--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -79,8 +79,7 @@ impl<T> ReadHalf<T> {
     ///
     /// If this `ReadHalf` and the given `WriteHalf` do not originate from the
     /// same `split` operation this method will panic.
-    /// This can be checked ahead of time by comparing the stream ID
-    /// of the two halves.
+    /// This can be checked ahead of time by calling [`is_pair_of()`](Self::is_pair_of).
     #[track_caller]
     pub fn unsplit(self, wr: WriteHalf<T>) -> T
     where


### PR DESCRIPTION
## Motivation

`SplitStreamId`s were added in 5bf78d77ada685826b33fd62e69df179f3de8a1c and removed the next day in c7719a2d2962f83854193b4c9131ee275a5a4475, and never made it into a release. Therefore, the documentation for `unsplit()` mentioning “comparing the stream ID” is incorrect (and has been since its introduction in tokio 0.2.10).

## Solution

Describe the actual method for checking the precondition of `ReadHalf::unsplit()`: calling `ReadHalf::is_pair_of()`.