### PR TITLE
sync: add instrument code to `Semaphore` leaf future

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -575,6 +575,8 @@ impl Future for Acquire<'_> {
     type Output = Result<(), AcquireError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        ready!(crate::trace::trace_leaf(cx));
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let _resource_span = self.node.ctx.resource_span.clone().entered();
         #[cfg(all(tokio_unstable, feature = "tracing"))]


### PR DESCRIPTION
This commit adds the instrument code for tasktrace to `Semaphore`'s leaf future.