### PR TITLE
Remove unnecessary uses of #[cfg(not(test))]

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -418,7 +418,6 @@ fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenS
     tokens
 }
 
-#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub(crate) fn main(args: TokenStream, item: TokenStream, rt_multi_thread: bool) -> TokenStream {
     // If any of the steps for this macro fail, we still want to expand to an item that is as close
     // to the expected output as possible. This helps out IDEs such that completions and other

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -202,7 +202,6 @@ use proc_macro::TokenStream;
 /// }
 /// ```
 #[proc_macro_attribute]
-#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::main(args.into(), item.into(), true).into()
 }
@@ -267,7 +266,6 @@ pub fn main(args: TokenStream, item: TokenStream) -> TokenStream {
 /// }
 /// ```
 #[proc_macro_attribute]
-#[cfg(not(test))] // Work around for rust-lang/rust#62127
 pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
     entry::main(args.into(), item.into(), false).into()
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -674,7 +674,6 @@ cfg_macros! {
 
     // Always fail if rt is not enabled.
     cfg_not_rt! {
-        #[cfg(not(test))]
         #[doc(inline)]
         pub use tokio_macros::main_fail as main;
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -654,7 +654,6 @@ cfg_macros! {
 
     cfg_rt! {
         #[cfg(feature = "rt-multi-thread")]
-        #[cfg(not(test))] // Work around for rust-lang/rust#62127
         #[cfg_attr(docsrs, doc(cfg(feature = "macros")))]
         #[doc(inline)]
         pub use tokio_macros::main;
@@ -665,7 +664,6 @@ cfg_macros! {
         pub use tokio_macros::test;
 
         cfg_not_rt_multi_thread! {
-            #[cfg(not(test))] // Work around for rust-lang/rust#62127
             #[doc(inline)]
             pub use tokio_macros::main_rt as main;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The main and main-rt macro functions both have the #[cfg(not(test))] with a comment indicating that its inclusion is a workaround for rust-lang/rust#62127, which has since been resolved. Because rust-analyzer enables test by default, this means that these functions are greyed out when using rust-analyzer in VSCode without configuration changes.

## Solution

Remove all uses of #[cfg(not(test))] in the tokio-macros crate that are accompanied by comments mentioning rust-lang/rust#62127 as the motivation for usage.

It's possible that the usage in https://github.com/tokio-rs/tokio/blob/8093712604e54a434658e693ca80535d906e26a7/tokio/src/lib.rs#L677 is also unnecessary, since it appears in the context of using main as an identifier. I'm less sure about that one since it doesn't have a comment mentioning rust-lang/rust#62127, so I've left it alone for now.
