### PR TITLE
Implementation of notify_one_last method

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -587,6 +587,8 @@ impl Notify {
     ///
     /// Check the [`notify_one()`] documentation for more info and
     /// examples.
+    ///
+    /// [`notify_one()`]: Notify::notify_one
     pub fn notify_one_last_in(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);
     }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -290,12 +290,14 @@ impl AtomicNotification {
         let data: usize = match notification {
             Notification::All => NOTIFICATION_ALL & NOTIFICATION_TYPE_MASK,
             Notification::One(NotifyOneStrategy::Fifo) => {
-                (((NOTIFICATION_NOTIFY_ONE_STRATEGY_FIFO) << NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT)
+                (((NOTIFICATION_NOTIFY_ONE_STRATEGY_FIFO)
+                    << NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT)
                     & NOTIFICATION_NOTIFY_ONE_STRATEGY_MASK)
                     | (NOTIFICATION_ONE & NOTIFICATION_TYPE_MASK)
             }
             Notification::One(NotifyOneStrategy::Lifo) => {
-                (((NOTIFICATION_NOTIFY_ONE_STRATEGY_LIFO) << NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT)
+                (((NOTIFICATION_NOTIFY_ONE_STRATEGY_LIFO)
+                    << NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT)
                     & NOTIFICATION_NOTIFY_ONE_STRATEGY_MASK)
                     | (NOTIFICATION_ONE & NOTIFICATION_TYPE_MASK)
             }
@@ -303,19 +305,23 @@ impl AtomicNotification {
         self.0.store(data, Release);
     }
 
-
     fn load(&self, ordering: Ordering) -> Option<Notification> {
         let data = self.0.load(ordering);
         let notification = match data & NOTIFICATION_TYPE_MASK {
             NOTIFICATION_NONE => None,
             NOTIFICATION_ONE => {
-                match (data & NOTIFICATION_NOTIFY_ONE_STRATEGY_MASK) >> NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT
+                match (data & NOTIFICATION_NOTIFY_ONE_STRATEGY_MASK)
+                    >> NOTIFICATION_NOTIFY_ONE_STRATEGY_SHIFT
                 {
-                    NOTIFICATION_NOTIFY_ONE_STRATEGY_FIFO => Some(Notification::One(NotifyOneStrategy::Fifo)),
-                    NOTIFICATION_NOTIFY_ONE_STRATEGY_LIFO => Some(Notification::One(NotifyOneStrategy::Lifo)),
+                    NOTIFICATION_NOTIFY_ONE_STRATEGY_FIFO => {
+                        Some(Notification::One(NotifyOneStrategy::Fifo))
+                    }
+                    NOTIFICATION_NOTIFY_ONE_STRATEGY_LIFO => {
+                        Some(Notification::One(NotifyOneStrategy::Lifo))
+                    }
                     _ => unreachable!(),
                 }
-            },
+            }
             NOTIFICATION_ALL => Some(Notification::All),
             _ => unreachable!(),
         };

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -613,7 +613,7 @@ impl Notify {
     /// This function behaves similar to `notify_one`. The only difference is that it wakes
     /// the most recently added waiter instead of the oldest waiter.
     ///
-    /// Check the `notify_one` documentation for more info and
+    /// Check the [`notify_one`] documentation for more info and
     /// examples.
     pub fn notify_one_last_in(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -260,8 +260,8 @@ const NOTIFICATION_NONE: usize = 0b000;
 // Notification type used by `notify_one`.
 const NOTIFICATION_ONE: usize = 0b001;
 
-// Notification type used by `notify_one_last`.
-const NOTIFICATION_ONE_LAST: usize = 0b101;
+// Notification type used by `notify_last`.
+const NOTIFICATION_LAST: usize = 0b101;
 
 // Notification type used by `notify_waiters`.
 const NOTIFICATION_ALL: usize = 0b010;
@@ -283,7 +283,7 @@ impl AtomicNotification {
         let data: usize = match notification {
             Notification::All => NOTIFICATION_ALL,
             Notification::One(NotifyOneStrategy::Fifo) => NOTIFICATION_ONE,
-            Notification::One(NotifyOneStrategy::Lifo) => NOTIFICATION_ONE_LAST,
+            Notification::One(NotifyOneStrategy::Lifo) => NOTIFICATION_LAST,
         };
         self.0.store(data, Release);
     }
@@ -293,7 +293,7 @@ impl AtomicNotification {
         match data {
             NOTIFICATION_NONE => None,
             NOTIFICATION_ONE => Some(Notification::One(NotifyOneStrategy::Fifo)),
-            NOTIFICATION_ONE_LAST => Some(Notification::One(NotifyOneStrategy::Lifo)),
+            NOTIFICATION_LAST => Some(Notification::One(NotifyOneStrategy::Lifo)),
             NOTIFICATION_ALL => Some(Notification::All),
             _ => unreachable!(),
         }
@@ -589,7 +589,7 @@ impl Notify {
     /// examples.
     ///
     /// [`notify_one()`]: Notify::notify_one
-    pub fn notify_one_last(&self) {
+    pub fn notify_last(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);
     }
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -585,7 +585,7 @@ impl Notify {
     /// This function behaves similar to `notify_one`. The only difference is that it wakes
     /// the most recently added waiter instead of the oldest waiter.
     ///
-    /// Check the [`notify_one`] documentation for more info and
+    /// Check the [`notify_one()`] documentation for more info and
     /// examples.
     pub fn notify_one_last_in(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -608,7 +608,7 @@ impl Notify {
     ///
     /// Check the `notify_one` documentation for more info and
     /// examples.
-    pub fn notify_one_lifo(&self) {
+    pub fn notify_one_last_in(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);
     }
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -260,8 +260,8 @@ const NOTIFICATION_NONE: usize = 0b000;
 // Notification type used by `notify_one`.
 const NOTIFICATION_ONE: usize = 0b001;
 
-// Notification type used by `notify_one_last_in`.
-const NOTIFICATION_ONE_LAST_IN: usize = 0b101;
+// Notification type used by `notify_one_last`.
+const NOTIFICATION_ONE_LAST: usize = 0b101;
 
 // Notification type used by `notify_waiters`.
 const NOTIFICATION_ALL: usize = 0b010;
@@ -283,7 +283,7 @@ impl AtomicNotification {
         let data: usize = match notification {
             Notification::All => NOTIFICATION_ALL,
             Notification::One(NotifyOneStrategy::Fifo) => NOTIFICATION_ONE,
-            Notification::One(NotifyOneStrategy::Lifo) => NOTIFICATION_ONE_LAST_IN,
+            Notification::One(NotifyOneStrategy::Lifo) => NOTIFICATION_ONE_LAST,
         };
         self.0.store(data, Release);
     }
@@ -293,7 +293,7 @@ impl AtomicNotification {
         match data {
             NOTIFICATION_NONE => None,
             NOTIFICATION_ONE => Some(Notification::One(NotifyOneStrategy::Fifo)),
-            NOTIFICATION_ONE_LAST_IN => Some(Notification::One(NotifyOneStrategy::Lifo)),
+            NOTIFICATION_ONE_LAST => Some(Notification::One(NotifyOneStrategy::Lifo)),
             NOTIFICATION_ALL => Some(Notification::All),
             _ => unreachable!(),
         }
@@ -589,7 +589,7 @@ impl Notify {
     /// examples.
     ///
     /// [`notify_one()`]: Notify::notify_one
-    pub fn notify_one_last_in(&self) {
+    pub fn notify_one_last(&self) {
         self.notify_with_strategy(NotifyOneStrategy::Lifo);
     }
 

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -604,7 +604,7 @@ impl Notify {
     /// Notifies the last waiting task.
     ///
     /// This function behaves identically to `notify_one` but using a
-    /// LIFO algorithm to dequeue the waiters, if there are any.
+    /// LIFO algorithm to notify waiters from the queue, if there are any.
     ///
     /// Check the `notify_one` documentation for more info and
     /// examples.

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -604,7 +604,7 @@ impl Notify {
     /// Notifies the last waiting task.
     ///
     /// This function behaves identically to `notify_one` but using a
-    /// LIFO algorithm for dequeuing the waiters, if there are any.
+    /// LIFO algorithm to dequeue the waiters, if there are any.
     ///
     /// Check the `notify_one` documentation for more info and
     /// examples.

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -307,7 +307,7 @@ impl AtomicNotification {
 
     fn load(&self, ordering: Ordering) -> Option<Notification> {
         let data = self.0.load(ordering);
-        let notification = match data & NOTIFICATION_TYPE_MASK {
+        match data & NOTIFICATION_TYPE_MASK {
             NOTIFICATION_NONE => None,
             NOTIFICATION_ONE => {
                 match (data & NOTIFICATION_NOTIFY_ONE_STRATEGY_MASK)
@@ -324,8 +324,7 @@ impl AtomicNotification {
             }
             NOTIFICATION_ALL => Some(Notification::All),
             _ => unreachable!(),
-        };
-        notification
+        }
     }
 
     /// Clears the notification.

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -610,8 +610,8 @@ impl Notify {
 
     /// Notifies the last waiting task.
     ///
-    /// This function behaves identically to `notify_one` but using a
-    /// LIFO algorithm to notify waiters from the queue, if there are any.
+    /// This function behaves similar to `notify_one`. The only difference is that it wakes
+    /// the most recently added waiter instead of the oldest waiter.
     ///
     /// Check the `notify_one` documentation for more info and
     /// examples.

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -151,8 +151,8 @@ impl<L: Link> LinkedList<L, L::Target> {
             let head = self.head?;
             self.head = L::pointers(head).as_ref().get_next();
 
-            if let Some(next) = L::pointers(head).as_ref().get_next() {
-                L::pointers(next).as_mut().set_prev(None);
+            if let Some(new_head) = L::pointers(head).as_ref().get_next() {
+                L::pointers(new_head).as_mut().set_prev(None);
             } else {
                 self.tail = None;
             }

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -144,7 +144,7 @@ impl<L: Link> LinkedList<L, L::Target> {
         }
     }
 
-    /// Removes the firt element from a list and returns it, or None if it is
+    /// Removes the first element from a list and returns it, or None if it is
     /// empty.
     pub(crate) fn pop_front(&mut self) -> Option<L::Handle> {
         unsafe {

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -144,6 +144,26 @@ impl<L: Link> LinkedList<L, L::Target> {
         }
     }
 
+    /// Removes the firt element from a list and returns it, or None if it is
+    /// empty.
+    pub(crate) fn pop_front(&mut self) -> Option<L::Handle> {
+        unsafe {
+            let head = self.head?;
+            self.head = L::pointers(head).as_ref().get_next();
+
+            if let Some(next) = L::pointers(head).as_ref().get_next() {
+                L::pointers(next).as_mut().set_prev(None);
+            } else {
+                self.tail = None;
+            }
+
+            L::pointers(head).as_mut().set_prev(None);
+            L::pointers(head).as_mut().set_next(None);
+
+            Some(L::from_raw(head))
+        }
+    }
+
     /// Removes the last element from a list and returns it, or None if it is
     /// empty.
     pub(crate) fn pop_back(&mut self) -> Option<L::Handle> {

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -173,11 +173,11 @@ fn notified_multi_notify_drop_one_last_in() {
 
     notify.notify_one_last_in();
 
-    drop(notified1);
+    drop(notified3);
 
     // latest waiter added should be the one to woken up
-    assert_ready!(notified3.poll());
-    assert_pending!(notified2.poll());
+    assert_ready!(notified2.poll());
+    assert_pending!(notified1.poll());
 }
 
 #[test]

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -22,7 +22,7 @@ fn notify_notified_one() {
 }
 
 #[test]
-fn notify_multi_notified_one_fifo() {
+fn notify_multi_notified_one_first_in() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -38,7 +38,7 @@ fn notify_multi_notified_one_fifo() {
 }
 
 #[test]
-fn notify_multi_notified_one_lifo() {
+fn notify_multi_notified_one_last_in() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -48,7 +48,7 @@ fn notify_multi_notified_one_lifo() {
     assert_pending!(notified2.poll());
 
     // should wakeup the last one
-    notify.notify_one_lifo();
+    notify.notify_one_last_in();
     assert_pending!(notified1.poll());
     assert_ready!(notified2.poll());
 }
@@ -138,7 +138,7 @@ fn notified_multi_notify_drop_one() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_fifo() {
+fn notified_multi_notify_drop_one_first_in() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -160,7 +160,7 @@ fn notified_multi_notify_drop_one_fifo() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_lifo() {
+fn notified_multi_notify_drop_one_last_in() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -171,7 +171,7 @@ fn notified_multi_notify_drop_one_lifo() {
     assert_pending!(notified2.poll());
     assert_pending!(notified3.poll());
 
-    notify.notify_one_lifo();
+    notify.notify_one_last_in();
 
     drop(notified1);
 

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -22,6 +22,38 @@ fn notify_notified_one() {
 }
 
 #[test]
+fn notify_multi_notified_one_fifo() {
+    let notify = Notify::new();
+    let mut notified1 = spawn(async { notify.notified().await });
+    let mut notified2 = spawn(async { notify.notified().await });
+
+    // add two waiters into the queue
+    assert_pending!(notified1.poll());
+    assert_pending!(notified2.poll());
+
+    // should wakeup the first one
+    notify.notify_one();
+    assert_ready!(notified1.poll());
+    assert_pending!(notified2.poll());
+}
+
+#[test]
+fn notify_multi_notified_one_lifo() {
+    let notify = Notify::new();
+    let mut notified1 = spawn(async { notify.notified().await });
+    let mut notified2 = spawn(async { notify.notified().await });
+
+    // add two waiters into the queue
+    assert_pending!(notified1.poll());
+    assert_pending!(notified2.poll());
+
+    // should wakeup the last one
+    notify.notify_one_lifo();
+    assert_pending!(notified1.poll());
+    assert_ready!(notified2.poll());
+}
+
+#[test]
 fn notified_one_notify() {
     let notify = Notify::new();
     let mut notified = spawn(async { notify.notified().await });
@@ -103,6 +135,49 @@ fn notified_multi_notify_drop_one() {
 
     assert!(notified2.is_woken());
     assert_ready!(notified2.poll());
+}
+
+#[test]
+fn notified_multi_notify_drop_one_fifo() {
+    let notify = Notify::new();
+    let mut notified1 = spawn(async { notify.notified().await });
+    let mut notified2 = spawn(async { notify.notified().await });
+    let mut notified3 = spawn(async { notify.notified().await });
+
+    // add waiters by order of poll execution
+    assert_pending!(notified1.poll());
+    assert_pending!(notified2.poll());
+    assert_pending!(notified3.poll());
+
+    // by default fifo
+    notify.notify_one();
+
+    drop(notified1);
+
+    // next waiter should be the one to be to woken up
+    assert_ready!(notified2.poll());
+    assert_pending!(notified3.poll());
+}
+
+#[test]
+fn notified_multi_notify_drop_one_lifo() {
+    let notify = Notify::new();
+    let mut notified1 = spawn(async { notify.notified().await });
+    let mut notified2 = spawn(async { notify.notified().await });
+    let mut notified3 = spawn(async { notify.notified().await });
+
+    // add waiters by order of poll execution
+    assert_pending!(notified1.poll());
+    assert_pending!(notified2.poll());
+    assert_pending!(notified3.poll());
+
+    notify.notify_one_lifo();
+
+    drop(notified1);
+
+    // latest waiter added should be the one to woken up
+    assert_ready!(notified3.poll());
+    assert_pending!(notified2.poll());
 }
 
 #[test]

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -22,7 +22,7 @@ fn notify_notified_one() {
 }
 
 #[test]
-fn notify_multi_notified_one_first() {
+fn notify_multi_notified_one() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -38,7 +38,7 @@ fn notify_multi_notified_one_first() {
 }
 
 #[test]
-fn notify_multi_notified_one_last() {
+fn notify_multi_notified_last() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -48,7 +48,7 @@ fn notify_multi_notified_one_last() {
     assert_pending!(notified2.poll());
 
     // should wakeup the last one
-    notify.notify_one_last();
+    notify.notify_last();
     assert_pending!(notified1.poll());
     assert_ready!(notified2.poll());
 }
@@ -138,7 +138,7 @@ fn notified_multi_notify_drop_one() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_first() {
+fn notified_multi_notify_one_drop() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -160,7 +160,7 @@ fn notified_multi_notify_drop_one_first() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_last() {
+fn notified_multi_notify_last_drop() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -171,7 +171,7 @@ fn notified_multi_notify_drop_one_last() {
     assert_pending!(notified2.poll());
     assert_pending!(notified3.poll());
 
-    notify.notify_one_last();
+    notify.notify_last();
 
     drop(notified3);
 

--- a/tokio/tests/sync_notify.rs
+++ b/tokio/tests/sync_notify.rs
@@ -22,7 +22,7 @@ fn notify_notified_one() {
 }
 
 #[test]
-fn notify_multi_notified_one_first_in() {
+fn notify_multi_notified_one_first() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -38,7 +38,7 @@ fn notify_multi_notified_one_first_in() {
 }
 
 #[test]
-fn notify_multi_notified_one_last_in() {
+fn notify_multi_notified_one_last() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -48,7 +48,7 @@ fn notify_multi_notified_one_last_in() {
     assert_pending!(notified2.poll());
 
     // should wakeup the last one
-    notify.notify_one_last_in();
+    notify.notify_one_last();
     assert_pending!(notified1.poll());
     assert_ready!(notified2.poll());
 }
@@ -138,7 +138,7 @@ fn notified_multi_notify_drop_one() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_first_in() {
+fn notified_multi_notify_drop_one_first() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -160,7 +160,7 @@ fn notified_multi_notify_drop_one_first_in() {
 }
 
 #[test]
-fn notified_multi_notify_drop_one_last_in() {
+fn notified_multi_notify_drop_one_last() {
     let notify = Notify::new();
     let mut notified1 = spawn(async { notify.notified().await });
     let mut notified2 = spawn(async { notify.notified().await });
@@ -171,7 +171,7 @@ fn notified_multi_notify_drop_one_last_in() {
     assert_pending!(notified2.poll());
     assert_pending!(notified3.poll());
 
-    notify.notify_one_last_in();
+    notify.notify_one_last();
 
     drop(notified3);
 


### PR DESCRIPTION
A new notify_one_last_in method is implemented for notifying the most recent waiter, LIFO, instead of the oldest one, FIFO, which is used by the current notify_one method.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
As explained here https://github.com/tokio-rs/tokio/issues/6506 the `notify_one_last_in` method provides the user a method for waking up the most recent waiter rather than the oldest one. When using a LIFO strategy we sacrifice waiters that have been waiting longer by first dequeuing the ones that have been in the queue for shorter time, this should provide benefits in situations of contention where LIFO dequeueing should provide a better latency observation compared to the usage of the FIFO.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Ive followed main recommendations for storing the strategy for dequeueing followed by the user as  part of the waiter notification state. No impact on the memory footprint should be observed.
