### PR TITLE
feat: walk_dir function (finds all files in sub directories)

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -94,3 +94,7 @@ path = "named-pipe-multi-client.rs"
 [[example]]
 name = "dump"
 path = "dump.rs"
+
+[[example]]
+name = "walk"
+path = "walk.rs"

--- a/examples/walk.rs
+++ b/examples/walk.rs
@@ -1,0 +1,11 @@
+use std::error::Error;
+use tokio::fs::walk_dir;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut rx = walk_dir("./").await?; // awaiting this function starts
+    while let Some(item) = rx.recv().await {
+        println!("{:?}", item);
+    }
+    Ok(())
+}

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -277,6 +277,9 @@ pub use self::copy::copy;
 mod try_exists;
 pub use self::try_exists::try_exists;
 
+mod walk_dir;
+pub use self::walk_dir::walk_dir;
+
 #[cfg(test)]
 mod mocks;
 

--- a/tokio/src/fs/walk_dir.rs
+++ b/tokio/src/fs/walk_dir.rs
@@ -1,0 +1,40 @@
+use std::path::PathBuf;
+
+use crate::io;
+use crate::sync::mpsc;
+use crate::sync::mpsc::Receiver;
+
+const WALKER_CHANNEL_BUFFER_SIZE: usize = 32;
+
+/// Search for all files under that 'path' recursively, and send the file paths over the channel
+/// # Example:
+/// use tokio::fs::walk_dir;
+/// let mut rx = walk_dir("./").await.unwrap();
+/// while let Some(item) = rx.recv().await {
+///    println!("{:?}", item);
+/// }
+pub async fn walk_dir(path: impl AsRef<str>) -> io::Result<Receiver<PathBuf>> {
+    let path = PathBuf::from(path.as_ref());
+
+    let (tx, rx) = mpsc::channel::<PathBuf>(WALKER_CHANNEL_BUFFER_SIZE);
+
+    crate::spawn(async move {
+        let mut dirs = Vec::<PathBuf>::with_capacity(1000);
+        dirs.push(path);
+
+        while let Some(dir) = dirs.pop() {
+            let mut ls = super::read_dir(dir).await?;
+
+            while let Ok(Some(item)) = ls.next_entry().await {
+                if item.metadata().await?.is_dir() {
+                    dirs.push(item.path());
+                } else {
+                    tx.send(item.path()).await.unwrap_or(());
+                }
+            }
+        }
+        Ok::<(), std::io::Error>(())
+    });
+
+    Ok(rx)
+}


### PR DESCRIPTION

# Motivation
I was working on my [personal project](https://github.com/ali77gh/ProjectAnalyzer/) and using Tokio as my runtime. I needed to walk through directories recursively, find files, and perform other tasks. I struggled a lot to accomplish this with Tokio, which made me wonder why there is no walk function in Tokio's file system module. It seems like a lightweight and useful feature to have.
Python, for instance, has [os.walk](https://docs.python.org/3/library/os.html#os.walk) in its standard library.

# Solution
With all that said, I added the `walk_dir()` function to `tokio::fs` to make it easier for others to search over files recursively 
using Tokio.

If there is any type of problem in this pull request. Just let me know.