### PR TITLE
Add read_until_slice

### DIFF
--- a/tokio/src/io/util/async_buf_read_ext.rs
+++ b/tokio/src/io/util/async_buf_read_ext.rs
@@ -2,6 +2,7 @@ use crate::io::util::fill_buf::{fill_buf, FillBuf};
 use crate::io::util::lines::{lines, Lines};
 use crate::io::util::read_line::{read_line, ReadLine};
 use crate::io::util::read_until::{read_until, ReadUntil};
+use crate::io::util::read_until_slice::{read_until_slice, ReadUntilSlice};
 use crate::io::util::split::{split, Split};
 use crate::io::AsyncBufRead;
 
@@ -99,6 +100,96 @@ cfg_io_util! {
         {
             read_until(self, byte, buf)
         }
+
+        /// Reads all bytes into `buf` until the delimiter or EOF is reached.
+        ///
+        /// Equivalent to:
+        ///
+        /// ```ignore
+        /// async fn read_until_slice<'a, 'b>(&'a mut self, delimiter: &'b [u8], buf: &'a mut Vec<u8>) -> io::Result<usize>;
+        /// ```
+        ///
+        /// This function will read bytes from the underlying stream until the
+        /// delimiter or EOF is found. Once found, all bytes up to, and including,
+        /// the delimiter (if found) will be appended to `buf`.
+        ///
+        /// If successful, this function will return the total number of bytes read.
+        ///
+        /// If this function returns `Ok(0)`, the stream has reached EOF.
+        ///
+        /// # Errors
+        ///
+        /// This function will ignore all instances of [`ErrorKind::Interrupted`] and
+        /// will otherwise return any errors returned by [`fill_buf`].
+        ///
+        /// If an I/O error is encountered then all bytes read so far will be
+        /// present in `buf` and its length will have been adjusted appropriately.
+        ///
+        /// [`fill_buf`]: AsyncBufRead::poll_fill_buf
+        /// [`ErrorKind::Interrupted`]: std::io::ErrorKind::Interrupted
+        ///
+        /// # Cancel safety
+        ///
+        /// This method is not cancellation safe. If the method is used as the
+        /// event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is not guaranted to find the
+        /// delimiter in the next call to `read_until_slice`.
+        ///
+        /// This function does not behave like [`read_until`] because the
+        /// delimiter can be split across multiple read calls and thus might
+        /// haven partially read in a previous call to `read_until_slice`.
+        ///
+        /// # Examples
+        ///
+        /// [`std::io::Cursor`][`Cursor`] is a type that implements `BufRead`. In
+        /// this example, we use [`Cursor`] to read all the bytes in a byte slice
+        /// in hyphen delimited segments:
+        ///
+        /// [`Cursor`]: std::io::Cursor
+        ///
+        /// ```
+        /// use tokio::io::AsyncBufReadExt;
+        ///
+        /// use std::io::Cursor;
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///     let mut cursor = Cursor::new(b"lorem\r\nipsum");
+        ///     let mut buf = vec![];
+        ///
+        ///     // cursor is at 'l'
+        ///     let num_bytes = cursor.read_until_slice(b"\r\n", &mut buf)
+        ///         .await
+        ///         .expect("reading from cursor won't fail");
+        ///
+        ///     assert_eq!(num_bytes, 7);
+        ///     assert_eq!(buf, b"lorem\r\n");
+        ///     buf.clear();
+        ///
+        ///     // cursor is at 'i'
+        ///     let num_bytes = cursor.read_until_slice(b"\r\n", &mut buf)
+        ///         .await
+        ///         .expect("reading from cursor won't fail");
+        ///
+        ///     assert_eq!(num_bytes, 5);
+        ///     assert_eq!(buf, b"ipsum");
+        ///     buf.clear();
+        ///
+        ///     // cursor is at EOF
+        ///     let num_bytes = cursor.read_until_slice(b"\r\n", &mut buf)
+        ///         .await
+        ///         .expect("reading from cursor won't fail");
+        ///     assert_eq!(num_bytes, 0);
+        ///     assert_eq!(buf, b"");
+        /// }
+        /// ```
+        fn read_until_slice<'a, 'b>(&'a mut self, delimiter: &'b [u8], buf: &'a mut Vec<u8>) -> ReadUntilSlice<'a, 'b, Self>
+        where
+            Self: Unpin,
+        {
+            read_until_slice(self, delimiter, buf)
+        }
+
 
         /// Reads all bytes until a newline (the 0xA byte) is reached, and append
         /// them to the provided buffer.

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -59,6 +59,7 @@ cfg_io_util! {
 
     mod read_to_string;
     mod read_until;
+    mod read_until_slice;
 
     mod repeat;
     pub use repeat::{repeat, Repeat};

--- a/tokio/src/io/util/read_until_slice.rs
+++ b/tokio/src/io/util/read_until_slice.rs
@@ -1,0 +1,156 @@
+use crate::io::AsyncBufRead;
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io;
+use std::marker::PhantomPinned;
+use std::mem;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// Future for the [`read_until_slice`](super::AsyncReadExt::read_to_slice) method.
+    /// The delimiter is included in the resulting vector.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct ReadUntilSlice<'a, 'b, R: ?Sized> {
+        reader: &'a mut R,
+        delimiter: &'b [u8],
+        buf: &'a mut Vec<u8>,
+        // The number of bytes appended to buf. This can be less than buf.len() if
+        // the buffer was not empty when the operation was started.
+        read: usize,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+pub(crate) fn read_until_slice<'a, 'b, R>(
+    reader: &'a mut R,
+    delimiter: &'b [u8],
+    buf: &'a mut Vec<u8>,
+) -> ReadUntilSlice<'a, 'b, R>
+where
+    R: AsyncBufRead + ?Sized + Unpin,
+{
+    ReadUntilSlice {
+        reader,
+        delimiter,
+        buf,
+        read: 0,
+        _pin: PhantomPinned,
+    }
+}
+
+pub(crate) fn read_until_slice_internal<R: AsyncBufRead + ?Sized>(
+    mut reader: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    delimiter: &'_ [u8],
+    buf: &mut Vec<u8>,
+    read: &mut usize,
+) -> Poll<io::Result<usize>> {
+    let mut match_len = 0usize;
+    loop {
+        let (done, used) = {
+            let available = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            if let Some(i) = search(delimiter, &mut match_len, available) {
+                buf.extend_from_slice(&available[..i]);
+                (true, i)
+            } else {
+                buf.extend_from_slice(available);
+                (false, available.len())
+            }
+        };
+        reader.as_mut().consume(used);
+        *read += used;
+        if done || used == 0 {
+            return Poll::Ready(Ok(mem::replace(read, 0)));
+        }
+    }
+}
+
+/// Searches a partial needle in the haystack.
+///
+/// Returns the position of the end of the needle in the haystack if found.
+fn search(needle: &[u8], match_len: &mut usize, haystack: &[u8]) -> Option<usize> {
+    let haystack_len = haystack.len();
+    let needle_len = needle.len();
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..haystack_len {
+        if haystack[i] == needle[*match_len] {
+            *match_len += 1;
+            if *match_len == needle_len {
+                return Some(i + 1);
+            }
+        } else if *match_len > 0 {
+            *match_len = 0;
+        }
+    }
+    None
+}
+
+impl<R: AsyncBufRead + ?Sized + Unpin> Future for ReadUntilSlice<'_, '_, R> {
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
+        read_until_slice_internal(Pin::new(*me.reader), cx, me.delimiter, me.buf, me.read)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::search;
+
+    #[test]
+    fn search_test() {
+        let haystack = b"123abc456\0\xffabc\n";
+        let mut match_len = 0;
+
+        assert_eq!(search(b"ab", &mut match_len, haystack), Some(5));
+        assert_eq!(match_len, 2);
+        match_len = 0;
+        assert_eq!(search(&[0xff], &mut match_len, haystack), Some(11));
+        assert_eq!(match_len, 1);
+        match_len = 0;
+        assert_eq!(search(b"\n", &mut match_len, haystack), Some(15));
+        assert_eq!(match_len, 1);
+        match_len = 0;
+        assert_eq!(search(b"\r", &mut match_len, haystack), None);
+        assert_eq!(match_len, 0);
+    }
+
+    #[test]
+    fn split_needle_test() {
+        let haystack1 = b"123abc\r";
+        let haystack2 = b"\n987gfd";
+        let mut match_len = 0;
+
+        assert_eq!(search(b"\r\n", &mut match_len, haystack1), None);
+        assert_eq!(match_len, 1);
+        assert_eq!(search(b"\r\n", &mut match_len, haystack2), Some(1));
+        assert_eq!(match_len, 2);
+    }
+
+    #[test]
+    fn invalid_needle_test() {
+        let haystack1 = b"123abc\r";
+        let haystack2 = b"a\n987gfd";
+        let mut match_len = 0;
+
+        assert_eq!(search(b"\r\n", &mut match_len, haystack1), None);
+        assert_eq!(match_len, 1);
+        assert_eq!(search(b"\r\n", &mut match_len, haystack2), None);
+        assert_eq!(match_len, 0);
+    }
+
+    #[test]
+    fn small_haystack_test() {
+        let haystack = b"\r";
+        let mut match_len = 0;
+
+        assert_eq!(search(b"\r\n", &mut match_len, haystack), None);
+        assert_eq!(match_len, 1);
+    }
+}

--- a/tokio/tests/io_read_until_slice.rs
+++ b/tokio/tests/io_read_until_slice.rs
@@ -1,0 +1,202 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use std::io::ErrorKind;
+use tokio::io::{AsyncBufReadExt, BufReader, Error};
+use tokio_test::{assert_ok, io::Builder};
+
+#[tokio::test]
+async fn read_until_slice_single_byte() {
+    let mut buf = vec![];
+    let mut rd: &[u8] = b"hello world";
+
+    let n = assert_ok!(rd.read_until_slice(b" ", &mut buf).await);
+    assert_eq!(n, 6);
+    assert_eq!(buf, b"hello ");
+    buf.clear();
+    let n = assert_ok!(rd.read_until_slice(b" ", &mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf, b"world");
+    buf.clear();
+    let n = assert_ok!(rd.read_until_slice(b" ", &mut buf).await);
+    assert_eq!(n, 0);
+    assert_eq!(buf, []);
+}
+
+#[tokio::test]
+async fn read_until_slice_two_bytes() {
+    let mut buf = vec![];
+    let mut rd: &[u8] = b"hello  world";
+
+    let n = assert_ok!(rd.read_until_slice(b"  ", &mut buf).await);
+    assert_eq!(n, 7);
+    assert_eq!(buf, b"hello  ");
+    buf.clear();
+    let n = assert_ok!(rd.read_until_slice(b"  ", &mut buf).await);
+    assert_eq!(n, 5);
+    assert_eq!(buf, b"world");
+    buf.clear();
+    let n = assert_ok!(rd.read_until_slice(b"  ", &mut buf).await);
+    assert_eq!(n, 0);
+    assert_eq!(buf, []);
+}
+
+#[tokio::test]
+async fn read_until_slice_not_all_ready_single_byte() {
+    let mock = Builder::new()
+        .read(b"Hello Wor")
+        .read(b"ld#Fizz\xffBuz")
+        .read(b"z#1#2")
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"We say ".to_vec();
+    let bytes = read.read_until_slice(b"#", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Hello World#".len());
+    assert_eq!(chunk, b"We say Hello World#");
+
+    chunk = b"I solve ".to_vec();
+    let bytes = read.read_until_slice(b"#", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Fizz\xffBuzz#".len());
+    assert_eq!(chunk, b"I solve Fizz\xffBuzz#");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"#", &mut chunk).await.unwrap();
+    assert_eq!(bytes, 2);
+    assert_eq!(chunk, b"1#");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"#", &mut chunk).await.unwrap();
+    assert_eq!(bytes, 1);
+    assert_eq!(chunk, b"2");
+}
+
+#[tokio::test]
+async fn read_until_slice_not_all_ready_mutliple_bytes() {
+    let mock = Builder::new()
+        .read(b"Hello Wor")
+        .read(b"ld! #Fizz\xffBuz")
+        .read(b"z###1###2")
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"We say ".to_vec();
+    let bytes = read.read_until_slice(b"! #", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Hello World! #".len());
+    assert_eq!(chunk, b"We say Hello World! #");
+
+    chunk = b"I solve ".to_vec();
+    let bytes = read.read_until_slice(b"###", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Fizz\xffBuzz###".len());
+    assert_eq!(chunk, b"I solve Fizz\xffBuzz###");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"###", &mut chunk).await.unwrap();
+    assert_eq!(bytes, 4);
+    assert_eq!(chunk, b"1###");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"###", &mut chunk).await.unwrap();
+    assert_eq!(bytes, 1);
+    assert_eq!(chunk, b"2");
+}
+
+#[tokio::test]
+async fn read_until_slice_not_all_ready_mid_delimiter() {
+    let mock = Builder::new()
+        .read(b"Hello World! ")
+        .read(b" Welcome!")
+        .read(b" ")
+        .read(b" --")
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"We say ".to_vec();
+    let bytes = read.read_until_slice(b"!  ", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Hello World!  ".len());
+    assert_eq!(chunk, b"We say Hello World!  ");
+
+    chunk = b"You are ".to_vec();
+    let bytes = read.read_until_slice(b"!  ", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Welcome!  ".len());
+    assert_eq!(chunk, b"You are Welcome!  ");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"!  ", &mut chunk).await.unwrap();
+    assert_eq!(bytes, 2);
+    assert_eq!(chunk, b"--");
+}
+
+#[tokio::test]
+async fn read_until_slice_fail_single_byte() {
+    let mock = Builder::new()
+        .read(b"Hello \xffWor")
+        .read_error(Error::new(ErrorKind::Other, "The world has no end"))
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"Foo".to_vec();
+    let err = read
+        .read_until_slice(b"#", &mut chunk)
+        .await
+        .expect_err("Should fail");
+    assert_eq!(err.kind(), ErrorKind::Other);
+    assert_eq!(err.to_string(), "The world has no end");
+    assert_eq!(chunk, b"FooHello \xffWor");
+}
+
+#[tokio::test]
+async fn read_until_slice_fail_two_bytes() {
+    let mock = Builder::new()
+        .read(b"Hello \xffWor")
+        .read_error(Error::new(ErrorKind::Other, "The world has no end"))
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"Foo".to_vec();
+    let err = read
+        .read_until_slice(b"\xff\xff", &mut chunk)
+        .await
+        .expect_err("Should fail");
+    assert_eq!(err.kind(), ErrorKind::Other);
+    assert_eq!(err.to_string(), "The world has no end");
+    assert_eq!(chunk, b"FooHello \xffWor");
+}
+
+#[tokio::test]
+async fn read_until_slice_small_buffer() {
+    let mock = Builder::new().read(b"Value\r").read(b"\nOther").build();
+
+    let mut read = BufReader::with_capacity(2, mock);
+
+    let mut chunk = b"Foo".to_vec();
+    let bytes = read.read_until_slice(b"\r\n", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Value\r\n".len());
+    assert_eq!(chunk, b"FooValue\r\n");
+
+    chunk.clear();
+    let bytes = read.read_until_slice(b"\r\n", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Other".len());
+    assert_eq!(chunk, b"Other");
+}
+
+#[tokio::test]
+async fn read_until_slice_delimiter_splitted() {
+    let mock = Builder::new()
+        .read(b"Some\r")
+        .read(b"Other\n")
+        .read(b"Value")
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let mut chunk = b"Foo".to_vec();
+    let bytes = read.read_until_slice(b"\r\n", &mut chunk).await.unwrap();
+    assert_eq!(bytes, b"Some\rOther\nValue".len());
+    assert_eq!(chunk, b"FooSome\rOther\nValue");
+}

--- a/tokio/tests/io_read_until_slice.rs
+++ b/tokio/tests/io_read_until_slice.rs
@@ -186,7 +186,7 @@ async fn read_until_slice_small_buffer() {
 }
 
 #[tokio::test]
-async fn read_until_slice_delimiter_splitted() {
+async fn read_until_slice_split_delimiter() {
     let mock = Builder::new()
         .read(b"Some\r")
         .read(b"Other\n")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Right now there is no built-in way to read until a sequence of bytes is found from a `BufReader`.
I first improved the algorithm in https://github.com/programingjd/read_until_slice but I think this should be supported natively.

## Solution

The code is very similar to `read_until`, but it keeps track of a `match_len` in the needle. That allows us to match more than one character across multiple reads, but it does make the function not cancel safe. I find this solution elegant since it doesn't require us to keep another buffer.