### PR TITLE
io: optimizing the chances of large write in copy_bidirectional and copy

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -116,11 +116,16 @@ impl CopyBuffer {
         };
 
         loop {
-            // If our buffer is empty, then we need to read some data to
-            // continue.
-            if self.pos == self.cap && !self.read_done {
-                self.pos = 0;
-                self.cap = 0;
+            let is_buffer_empty = self.pos == self.cap;
+            let is_buffer_not_full = self.cap < self.buf.len();
+
+            // If our buffer is empty or not full yet, then we try to read some
+            // data to continue.
+            if (is_buffer_empty || is_buffer_not_full) && !self.read_done {
+                if is_buffer_empty {
+                    self.pos = 0;
+                    self.cap = 0;
+                }
 
                 match self.poll_fill_buf(cx, reader.as_mut()) {
                     Poll::Ready(Ok(())) => {

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -289,9 +289,9 @@ cfg_io_util! {
 }
 
 impl<R, W> Future for Copy<'_, R, W>
-    where
-        R: AsyncRead + Unpin + ?Sized,
-        W: AsyncWrite + Unpin + ?Sized,
+where
+    R: AsyncRead + Unpin + ?Sized,
+    W: AsyncWrite + Unpin + ?Sized,
 {
     type Output = io::Result<u64>;
 

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -127,9 +127,9 @@ impl CopyBuffer {
                         coop.made_progress();
                         return Poll::Ready(Err(err));
                     }
-                    // Ignore pending reads when our buffer is not empty, because
-                    // we can try to write data immediately.
                     Poll::Pending => {
+                        // Ignore pending reads when our buffer is not empty, because
+                        // we can try to write data immediately.
                         if self.pos == self.cap {
                             // Try flushing when the reader has no progress to avoid deadlock
                             // when the reader depends on buffered writer.

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -189,10 +189,6 @@ impl CopyBuffer {
                 "writer returned length larger than input slice"
             );
 
-            if self.pos != self.cap {
-                continue;
-            }
-
             // All data has been written, the buffer can be considered empty again
             self.pos = 0;
             self.cap = 0;

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -32,8 +32,8 @@ impl CopyBuffer {
         cx: &mut Context<'_>,
         reader: Pin<&mut R>,
     ) -> Poll<io::Result<()>>
-        where
-            R: AsyncRead + ?Sized,
+    where
+        R: AsyncRead + ?Sized,
     {
         let me = &mut *self;
         let mut buf = ReadBuf::new(&mut me.buf);
@@ -54,9 +54,9 @@ impl CopyBuffer {
         mut reader: Pin<&mut R>,
         mut writer: Pin<&mut W>,
     ) -> Poll<io::Result<usize>>
-        where
-            R: AsyncRead + ?Sized,
-            W: AsyncWrite + ?Sized,
+    where
+        R: AsyncRead + ?Sized,
+        W: AsyncWrite + ?Sized,
     {
         let me = &mut *self;
         match writer.as_mut().poll_write(cx, &me.buf[me.pos..me.cap]) {
@@ -78,9 +78,9 @@ impl CopyBuffer {
         mut reader: Pin<&mut R>,
         mut writer: Pin<&mut W>,
     ) -> Poll<io::Result<u64>>
-        where
-            R: AsyncRead + ?Sized,
-            W: AsyncWrite + ?Sized,
+    where
+        R: AsyncRead + ?Sized,
+        W: AsyncWrite + ?Sized,
     {
         ready!(crate::trace::trace_leaf(cx));
         #[cfg(any(


### PR DESCRIPTION
Although this PR was originally related to https://github.com/tokio-rs/tokio/issues/6519#issue-2267067024, it aims now to improve a bit the chances of large write in `io::copy` and `io::copy_bidirectional`.

## Motivation

`tokio::io::copy_bidirectional` and `tokio::io::copy` can, in some circumstances, lead to some non-optimal chances of large write when both writing and reading are pending ([see here](https://github.com/tokio-rs/tokio/blob/master/tokio/src/io/util/copy.rs#L64-L68)). For more information, refer to the issue linked above.

This PR aims to improve this behavior by reading more often.

## Solution

### Changelog

- Try to read when the buffer is not full
- Reset partially the buffer state as soon as data is fully written

### Benchmarks

```shell
copy_mem_to_mem         time:   [131.88 µs 133.09 µs 134.48 µs]
                        change: [-4.3908% -2.6619% -1.0456%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

copy_mem_to_slow_hdd    time:   [181.26 ms 181.30 ms 181.35 ms]
                        change: [-0.0183% +0.0132% +0.0477%] (p = 0.44 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

copy_chunk_to_mem       time:   [128.11 ms 128.13 ms 128.16 ms]
                        change: [-0.0458% -0.0191% +0.0075%] (p = 0.16 > 0.05)
                        No change in performance detected.

copy_chunk_to_slow_hdd  time:   [141.29 ms 141.43 ms 141.59 ms]
                        change: [-5.1731% -4.7362% -4.2937%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) high mild
  9 (9.00%) high severe
```
