### PR TITLE
tokio-util: allow encoding borrowed buffers at `LengthDelimitedCodec`

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -623,7 +623,7 @@ impl<'a> Encoder<&'a [u8]> for LengthDelimitedCodec {
         }
 
         // Write the frame to the buffer
-        dst.extend_from_slice(&data[..]);
+        dst.extend_from_slice(data);
 
         Ok(())
     }

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -581,6 +581,14 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
     type Error = io::Error;
 
     fn encode(&mut self, data: Bytes, dst: &mut BytesMut) -> Result<(), io::Error> {
+        <Self as Encoder<&'_ [u8]>>::encode(self, &data, dst)
+    }
+}
+
+impl<'a> Encoder<&'a [u8]> for LengthDelimitedCodec {
+    type Error = io::Error;
+
+    fn encode(&mut self, data: &'a [u8], dst: &mut BytesMut) -> Result<(), io::Error> {
         let n = data.len();
 
         if n > self.builder.max_frame_len {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes #6116

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `<'a> Encoder<&'a [u8]>` for `LengthDelimitedCodec`.
Call into `<'a> Encoder<&'a [u8]>` in `Encoder<Bytes>` of `LengthDelimitedCodec`.