### PR TITLE
Using sharded locks instead of a global lock for Timers

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -702,7 +702,7 @@ impl Builder {
         }
     }
 
-    fn get_cfg(&self) -> driver::Cfg {
+    fn get_cfg(&self, workers: usize) -> driver::Cfg {
         driver::Cfg {
             enable_pause_time: match self.kind {
                 Kind::CurrentThread => true,
@@ -715,6 +715,7 @@ impl Builder {
             enable_time: self.enable_time,
             start_paused: self.start_paused,
             nevents: self.nevents,
+            workers,
         }
     }
 
@@ -1095,7 +1096,7 @@ impl Builder {
         use crate::runtime::scheduler::{self, CurrentThread};
         use crate::runtime::{runtime::Scheduler, Config};
 
-        let (driver, driver_handle) = driver::Driver::new(self.get_cfg())?;
+        let (driver, driver_handle) = driver::Driver::new(self.get_cfg(1))?;
 
         // Blocking pool
         let blocking_pool = blocking::create_blocking_pool(self, self.max_blocking_threads);
@@ -1248,7 +1249,7 @@ cfg_rt_multi_thread! {
 
             let core_threads = self.worker_threads.unwrap_or_else(num_cpus);
 
-            let (driver, driver_handle) = driver::Driver::new(self.get_cfg())?;
+            let (driver, driver_handle) = driver::Driver::new(self.get_cfg(core_threads))?;
 
             // Create the blocking pool
             let blocking_pool =

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1296,7 +1296,7 @@ cfg_rt_multi_thread! {
                 use crate::runtime::scheduler::MultiThreadAlt;
 
                 let core_threads = self.worker_threads.unwrap_or_else(num_cpus);
-                let (driver, driver_handle) = driver::Driver::new(self.get_cfg())?;
+                let (driver, driver_handle) = driver::Driver::new(self.get_cfg(core_threads))?;
 
                 // Create the blocking pool
                 let blocking_pool =

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -57,7 +57,7 @@ struct Context {
     #[cfg(feature = "rt")]
     runtime: Cell<EnterRuntime>,
 
-    #[cfg(any(feature = "rt", feature = "macros"))]
+    #[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
     rng: Cell<Option<FastRand>>,
 
     /// Tracks the amount of "work" a task may still do before yielding back to

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -100,7 +100,7 @@ tokio_thread_local! {
             #[cfg(feature = "rt")]
             runtime: Cell::new(EnterRuntime::NotEntered),
 
-            #[cfg(any(feature = "rt", feature = "macros"))]
+            #[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
             rng: Cell::new(None),
 
             budget: Cell::new(coop::Budget::unconstrained()),

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -121,7 +121,11 @@ tokio_thread_local! {
     }
 }
 
-#[cfg(any(feature = "macros", all(feature = "sync", feature = "rt")))]
+#[cfg(any(
+    feature = "time",
+    feature = "macros",
+    all(feature = "sync", feature = "rt")
+))]
 pub(crate) fn thread_rng_n(n: u32) -> u32 {
     CONTEXT.with(|ctx| {
         let mut rng = ctx.rng.get().unwrap_or_else(FastRand::new);

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -3,7 +3,7 @@ use crate::runtime::coop;
 
 use std::cell::Cell;
 
-#[cfg(any(feature = "rt", feature = "macros"))]
+#[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
 use crate::util::rand::FastRand;
 
 cfg_rt! {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -40,6 +40,7 @@ pub(crate) struct Cfg {
     pub(crate) enable_pause_time: bool,
     pub(crate) start_paused: bool,
     pub(crate) nevents: usize,
+    pub(crate) workers: usize,
 }
 
 impl Driver {
@@ -48,7 +49,8 @@ impl Driver {
 
         let clock = create_clock(cfg.enable_pause_time, cfg.start_paused);
 
-        let (time_driver, time_handle) = create_time_driver(cfg.enable_time, io_stack, &clock);
+        let (time_driver, time_handle) =
+            create_time_driver(cfg.enable_time, io_stack, &clock, cfg.workers);
 
         Ok((
             Self { inner: time_driver },
@@ -306,9 +308,10 @@ cfg_time! {
         enable: bool,
         io_stack: IoStack,
         clock: &Clock,
+        workers: usize,
     ) -> (TimeDriver, TimeHandle) {
         if enable {
-            let (driver, handle) = crate::runtime::time::Driver::new(io_stack, clock);
+            let (driver, handle) = crate::runtime::time::Driver::new(io_stack, clock, workers as u32);
 
             (TimeDriver::Enabled { driver }, Some(handle))
         } else {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -364,6 +364,7 @@ cfg_not_time! {
         _enable: bool,
         io_stack: IoStack,
         _clock: &Clock,
+        _workers: usize,
     ) -> (TimeDriver, TimeHandle) {
         (io_stack, ())
     }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -742,7 +742,7 @@ impl Context {
     pub(crate) fn defer(&self, waker: &Waker) {
         self.defer.defer(waker);
     }
-    
+
     #[allow(dead_code)]
     pub(crate) fn get_worker_index(&self) -> usize {
         self.worker.index

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -742,6 +742,10 @@ impl Context {
     pub(crate) fn defer(&self, waker: &Waker) {
         self.defer.defer(waker);
     }
+
+    pub(crate) fn get_worker_index(&self) -> usize {
+        self.worker.index
+    }
 }
 
 impl Core {

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -742,7 +742,8 @@ impl Context {
     pub(crate) fn defer(&self, waker: &Waker) {
         self.defer.defer(waker);
     }
-
+    
+    #[allow(dead_code)]
     pub(crate) fn get_worker_index(&self) -> usize {
         self.worker.index
     }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1312,7 +1312,7 @@ impl Context {
         &self.handle.shared
     }
 
-    #[allow(dead_code)]
+    #[cfg_attr(not(feature = "time"), allow(dead_code))]
     pub(crate) fn get_worker_index(&self) -> usize {
         self.index
     }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1311,7 +1311,8 @@ impl Context {
     fn shared(&self) -> &Shared {
         &self.handle.shared
     }
-
+    
+    #[allow(dead_code)]
     pub(crate) fn get_worker_index(&self) -> usize {
         self.index
     }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1311,6 +1311,10 @@ impl Context {
     fn shared(&self) -> &Shared {
         &self.handle.shared
     }
+
+    pub(crate) fn get_worker_index(&self) -> usize {
+        self.index
+    }
 }
 
 impl Core {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1311,7 +1311,7 @@ impl Context {
     fn shared(&self) -> &Shared {
         &self.handle.shared
     }
-    
+
     #[allow(dead_code)]
     pub(crate) fn get_worker_index(&self) -> usize {
         self.index

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -527,7 +527,7 @@ impl TimerEntry {
     cfg_not_rt! {
         fn get_shard_id(&self) -> u32 {
             let shard_size = self.driver.driver().time().inner.get_shard_size();
-            let id = crate::runtime::context::thread_rng_n(shard_size);
+            let id = context::thread_rng_n(shard_size);
             id % shard_size
         }
     }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -665,7 +665,7 @@ cfg_rt! {
             Some(scheduler::Context::MultiThread(ctx)) => ctx.get_worker_index() as u32,
             #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
             Some(scheduler::Context::MultiThreadAlt(ctx)) => ctx.get_worker_index() as u32,
-            _ => context::thread_rng_n(shard_size),
+            None => context::thread_rng_n(shard_size),
         });
         id % shard_size
     }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -542,9 +542,8 @@ impl TimerEntry {
 
     /// Cancels and deregisters the timer. This operation is irreversible.
     pub(crate) fn cancel(self: Pin<&mut Self>) {
-        // Avoid calling the `clear_entry` method, because it has not been
-        // initialized or registered.
-        if !self.is_inner_init() || !self.inner().might_be_registered() {
+        // Avoid calling the `clear_entry` method, because it has not been initialized yet.
+        if !self.is_inner_init() {
             return;
         }
         // We need to perform an acq/rel fence with the driver thread, and the

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -494,37 +494,13 @@ impl TimerEntry {
     fn inner(&self) -> &TimerShared {
         let inner = unsafe { &*self.inner.get() };
         if inner.is_none() {
-            let shard_id = self.get_shard_id();
+            let shard_size = self.driver.driver().time().inner.get_shard_size();
+            let shard_id = generate_shard_id(shard_size);
             unsafe {
                 *self.inner.get() = Some(TimerShared::new(shard_id));
             }
         }
         return inner.as_ref().unwrap();
-    }
-
-    // Gets the shard id. If current thread is a worker thread, we use its worker index as a shard id.
-    // Otherwise, we use a random number generator to obtain the shard id.
-    cfg_rt! {
-        fn get_shard_id(&self) -> u32 {
-            let shard_size = self.driver.driver().time().inner.get_shard_size();
-            let id = context::with_scheduler(|ctx| match ctx {
-                Some(scheduler::Context::CurrentThread(_ctx)) => 0,
-                #[cfg(feature = "rt-multi-thread")]
-                Some(scheduler::Context::MultiThread(ctx)) => ctx.get_worker_index() as u32,
-                #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-                Some(scheduler::Context::MultiThreadAlt(ctx)) => ctx.get_worker_index() as u32,
-                _ => context::thread_rng_n(shard_size),
-            });
-            id % shard_size
-        }
-    }
-
-    cfg_not_rt! {
-        fn get_shard_id(&self) -> u32 {
-            let shard_size = self.driver.driver().time().inner.get_shard_size();
-            let id = context::thread_rng_n(shard_size);
-            id % shard_size
-        }
     }
 
     pub(crate) fn deadline(&self) -> Instant {
@@ -676,5 +652,27 @@ impl TimerHandle {
 impl Drop for TimerEntry {
     fn drop(&mut self) {
         unsafe { Pin::new_unchecked(self) }.as_mut().cancel();
+    }
+}
+
+// Generates a shard id. If current thread is a worker thread, we use its worker index as a shard id.
+// Otherwise, we use a random number generator to obtain the shard id.
+cfg_rt! {
+    fn generate_shard_id(shard_size: u32) -> u32 {
+        let id = context::with_scheduler(|ctx| match ctx {
+            Some(scheduler::Context::CurrentThread(_ctx)) => 0,
+            #[cfg(feature = "rt-multi-thread")]
+            Some(scheduler::Context::MultiThread(ctx)) => ctx.get_worker_index() as u32,
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            Some(scheduler::Context::MultiThreadAlt(ctx)) => ctx.get_worker_index() as u32,
+            _ => context::thread_rng_n(shard_size),
+        });
+        id % shard_size
+    }
+}
+
+cfg_not_rt! {
+    fn generate_shard_id(shard_size: usize) -> u32 {
+        context::thread_rng_n(shard_size) % shard_size
     }
 }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -513,7 +513,7 @@ impl TimerEntry {
         let shard_size = self.driver.driver().time().inner.get_shard_size();
         let id = context::with_scheduler(|ctx| match ctx {
             #[cfg(feature = "rt")]
-            Some(scheduler::Context::CurrentThread(ctx)) => 0,
+            Some(scheduler::Context::CurrentThread(_ctx)) => 0,
             #[cfg(feature = "rt-multi-thread")]
             Some(scheduler::Context::MultiThread(ctx)) => ctx.get_worker_index() as u32,
             #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -518,7 +518,7 @@ impl TimerEntry {
                 Some(scheduler::Context::MultiThread(ctx)) => ctx.get_worker_index() as u32,
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 Some(scheduler::Context::MultiThreadAlt(ctx)) => ctx.get_worker_index() as u32,
-                _ => crate::runtime::context::thread_rng_n(shard_size),
+                _ => context::thread_rng_n(shard_size),
             });
             id % shard_size
         }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -673,6 +673,6 @@ cfg_rt! {
 
 cfg_not_rt! {
     fn generate_shard_id(shard_size: u32) -> u32 {
-        context::thread_rng_n(shard_size) % shard_size
+        context::thread_rng_n(shard_size)
     }
 }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -542,8 +542,9 @@ impl TimerEntry {
 
     /// Cancels and deregisters the timer. This operation is irreversible.
     pub(crate) fn cancel(self: Pin<&mut Self>) {
-        // Avoid calling the `clear_entry` method, because it has not been initialized yet.
-        if !self.is_inner_init() {
+        // Avoid calling the `clear_entry` method, because it has not been
+        // initialized or registered.
+        if !self.is_inner_init() || !self.inner().might_be_registered() {
             return;
         }
         // We need to perform an acq/rel fence with the driver thread, and the

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -672,7 +672,7 @@ cfg_rt! {
 }
 
 cfg_not_rt! {
-    fn generate_shard_id(shard_size: usize) -> u32 {
+    fn generate_shard_id(shard_size: u32) -> u32 {
         context::thread_rng_n(shard_size) % shard_size
     }
 }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -258,7 +258,7 @@ impl Handle {
     pub(self) fn process_at_time(&self, now: u64) {
         let shards = self.inner.get_shard_size();
         // For fairness, randomly select one to start.
-        let start = rand::thread_rng_n(shards);
+        let start = crate::runtime::context::thread_rng_n(shards);
 
         let next_wake_up = (start..shards + start)
             .filter_map(|i| self.process_at_sharded_time(i, now))
@@ -436,25 +436,6 @@ impl Inner {
 impl fmt::Debug for Inner {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Inner").finish()
-    }
-}
-
-mod rand {
-    use crate::util::rand::FastRand;
-    use std::cell::Cell;
-
-    // Used by `TimerEntry`.
-    pub(crate) fn thread_rng_n(n: u32) -> u32 {
-        thread_local! {
-            static THREAD_RNG: Cell<FastRand> = Cell::new(FastRand::new());
-        }
-
-        THREAD_RNG.with(|cell_rng| {
-            let mut rng = cell_rng.get();
-            let ret = rng.fastrand_n(n);
-            cell_rng.set(rng);
-            ret
-        })
     }
 }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -26,8 +26,8 @@ use crate::time::error::Error;
 use crate::time::{Clock, Duration};
 use crate::util::WakeList;
 
+use crate::loom::sync::atomic::AtomicU64;
 use std::fmt;
-use std::sync::atomic::AtomicU64;
 use std::{num::NonZeroU64, ptr::NonNull};
 
 /// Time implementation that drives [`Sleep`][sleep], [`Interval`][interval], and [`Timeout`][timeout].

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -35,9 +35,7 @@ struct AtomicOptionNonZeroU64(AtomicU64);
 // A helper type to store the `next_wake`.
 impl AtomicOptionNonZeroU64 {
     fn new(val: Option<u64>) -> Self {
-        Self {
-            0: AtomicU64::new(Self::turn(val)),
-        }
+        Self(AtomicU64::new(Self::turn(val)))
     }
 
     fn store(&self, val: Option<u64>) {

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -155,7 +155,7 @@ impl Driver {
         let handle = Handle {
             time_source,
             inner: Inner {
-                next_wake: AtomicOptionNonZeroU64::new(Some(0)),
+                next_wake: AtomicOptionNonZeroU64::new(None),
                 wheels: wheels.into_boxed_slice(),
                 is_shutdown: AtomicBool::new(false),
                 #[cfg(feature = "test-util")]

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -68,7 +68,7 @@ fn single_timer() {
         // This may or may not return Some (depending on how it races with the
         // thread). If it does return None, however, the timer should complete
         // synchronously.
-        time.process_at_time(time.time_source().now(clock) + 2_000_000_000);
+        time.process_at_time(0, time.time_source().now(clock) + 2_000_000_000);
 
         jh.join().unwrap();
     })
@@ -102,7 +102,7 @@ fn drop_timer() {
         let clock = handle.inner.driver().clock();
 
         // advance 2s in the future.
-        time.process_at_time(time.time_source().now(clock) + 2_000_000_000);
+        time.process_at_time(0, time.time_source().now(clock) + 2_000_000_000);
 
         jh.join().unwrap();
     })
@@ -138,7 +138,7 @@ fn change_waker() {
         let clock = handle.inner.driver().clock();
 
         // advance 2s
-        time.process_at_time(time.time_source().now(clock) + 2_000_000_000);
+        time.process_at_time(0, time.time_source().now(clock) + 2_000_000_000);
 
         jh.join().unwrap();
     })
@@ -181,6 +181,7 @@ fn reset_future() {
 
         // This may or may not return a wakeup time.
         handle.process_at_time(
+            0,
             handle
                 .time_source()
                 .instant_to_tick(start + Duration::from_millis(1500)),
@@ -189,6 +190,7 @@ fn reset_future() {
         assert!(!finished_early.load(Ordering::Relaxed));
 
         handle.process_at_time(
+            0,
             handle
                 .time_source()
                 .instant_to_tick(start + Duration::from_millis(2500)),
@@ -231,7 +233,7 @@ fn poll_process_levels() {
     }
 
     for t in 1..normal_or_miri(1024, 64) {
-        handle.inner.driver().time().process_at_time(t as u64);
+        handle.inner.driver().time().process_at_time(0, t as u64);
 
         for (deadline, future) in entries.iter_mut().enumerate() {
             let mut context = Context::from_waker(noop_waker_ref());
@@ -260,8 +262,8 @@ fn poll_process_levels_targeted() {
 
     let handle = handle.inner.driver().time();
 
-    handle.process_at_time(62);
+    handle.process_at_time(0, 62);
     assert!(e1.as_mut().poll_elapsed(&mut context).is_pending());
-    handle.process_at_time(192);
-    handle.process_at_time(192);
+    handle.process_at_time(0, 192);
+    handle.process_at_time(0, 192);
 }

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -49,7 +49,7 @@ cfg_rt! {
     pub(crate) mod sharded_list;
 }
 
-#[cfg(any(feature = "rt", feature = "macros"))]
+#[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
 pub(crate) mod rand;
 
 cfg_rt! {

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -49,7 +49,7 @@ cfg_rt! {
     pub(crate) mod sharded_list;
 }
 
-#[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
+#[cfg(any(feature = "rt", feature = "macros"))]
 pub(crate) mod rand;
 
 cfg_rt! {

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -71,7 +71,6 @@ impl FastRand {
     #[cfg(any(
         feature = "macros",
         feature = "rt-multi-thread",
-        feature = "time",
         all(feature = "sync", feature = "rt")
     ))]
     pub(crate) fn fastrand_n(&mut self, n: u32) -> u32 {

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -71,6 +71,7 @@ impl FastRand {
     #[cfg(any(
         feature = "macros",
         feature = "rt-multi-thread",
+        feature = "time",
         all(feature = "sync", feature = "rt")
     ))]
     pub(crate) fn fastrand_n(&mut self, n: u32) -> u32 {

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -1,7 +1,5 @@
-#[cfg(any(feature = "rt", feature = "time"))]
-mod rt;
-
 cfg_rt! {
+    mod rt;
     pub(crate) use rt::RngSeedGenerator;
 
     cfg_unstable! {

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -1,5 +1,7 @@
+#[cfg(any(feature = "rt", feature = "time"))]
+mod rt;
+
 cfg_rt! {
-    mod rt;
     pub(crate) use rt::RngSeedGenerator;
 
     cfg_unstable! {


### PR DESCRIPTION
## Motivation

As part of addressing https://github.com/tokio-rs/tokio/issues/6504, this PR attempts to implement a shard approach to improve `timeout` and `sleep` performance in specific scenarios.

When high concurrency, a large number of `timeout`s or `sleep`s are registered to Timer, the global lock contention is very severe. By sharding the lock, this performance issue can be significantly reduced.

## Solution

- Thread local storage random number generation is used to achieve sharding.
- Because the wheel data structure is a multi-layered linked list, the current shard size is consistent with the number of workers. I hope that the creation of a runtime will not require more time, and the serial lock acquisition in the park method will not take too much time.