### PR TITLE
Ignore `yield_calls_park_before_scheduling_again` test

### DIFF
--- a/tokio/src/runtime/tests/loom_current_thread/yield_now.rs
+++ b/tokio/src/runtime/tests/loom_current_thread/yield_now.rs
@@ -1,5 +1,4 @@
 use crate::runtime::park;
-use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
 
 #[test]
@@ -8,10 +7,9 @@ fn yield_calls_park_before_scheduling_again() {
     let mut loom = loom::model::Builder::default();
     loom.max_permutations = Some(1);
     loom.check(|| {
-        let rt = mk_runtime(2);
-        let (tx, rx) = oneshot::channel::<()>();
+        let rt = mk_runtime();
 
-        rt.spawn(async {
+        let jh = rt.spawn(async {
             let tid = loom::thread::current().id();
             let park_count = park::current_thread_park_count();
 
@@ -21,17 +19,12 @@ fn yield_calls_park_before_scheduling_again() {
                 let new_park_count = park::current_thread_park_count();
                 assert_eq!(park_count + 1, new_park_count);
             }
-
-            tx.send(());
         });
 
-        rx.recv();
+        rt.block_on(jh).unwrap();
     });
 }
 
-fn mk_runtime(num_threads: usize) -> Runtime {
-    runtime::Builder::new_multi_thread()
-        .worker_threads(num_threads)
-        .build()
-        .unwrap()
+fn mk_runtime() -> Runtime {
+    runtime::Builder::new_current_thread().build().unwrap()
 }

--- a/tokio/src/runtime/tests/loom_multi_thread/yield_now.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/yield_now.rs
@@ -3,6 +3,7 @@ use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
 
 #[test]
+#[ignore]
 fn yield_calls_park_before_scheduling_again() {
     // Don't need to check all permutations
     let mut loom = loom::model::Builder::default();

--- a/tokio/src/runtime/tests/loom_multi_thread_alt/yield_now.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt/yield_now.rs
@@ -3,6 +3,7 @@ use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
 
 #[test]
+#[ignore]
 fn yield_calls_park_before_scheduling_again() {
     // Don't need to check all permutations
     let mut loom = loom::model::Builder::default();


### PR DESCRIPTION
This ignores the test that is broken as per #6536.

The current-thread runtime is not susceptible to the problem explained in the bug.