### PR TITLE
Bump nightly to nightly-2024-05-05

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
   image_family: freebsd-14-0
 env:
   RUST_STABLE: stable
-  RUST_NIGHTLY: nightly-2023-10-21
+  RUST_NIGHTLY: nightly-2024-05-05
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1005,6 +1005,8 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ env.rust_nightly }}
+      - name: don't allow warnings
+        run: sed -i '/#!\[allow(unknown_lints, unexpected_cfgs)\]/d' */src/lib.rs
       - name: check tokio
         run: cargo check --all-features
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,11 +599,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # This check is broken on newer nightlies.
-      - name: Install Rust nightly-2023-10-21
+      - name: Install Rust ${{ env.rust_nightly }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2023-10-21
+          toolchain: ${{ env.rust_nightly }}
           components: rust-src
 
       - name: Install cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       - name: check for unknown lints and cfgs
         run: cargo check --all-features --tests
         env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom,tokio_unstable,tokio_taskdump,fuzzing,mio_unsupported_force_poll_poll,tokio_internal_mt_counters,fs,tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom,tokio_unstable,tokio_taskdump,fuzzing,mio_unsupported_force_poll_poll,tokio_internal_mt_counters,fs,tokio_no_parking_lot,tokio_no_tuning_tests) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       - name: check for unknown lints and cfgs
         run: cargo check --all-features --tests
         env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom, tokio_unstable, tokio_taskdump, fuzzing, mio_unsupported_force_poll_poll, tokio_internal_mt_counters, fs, tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom,tokio_unstable,tokio_taskdump,fuzzing,mio_unsupported_force_poll_poll,tokio_internal_mt_counters,fs,tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2023-10-21
+  rust_nightly: nightly-2024-05-05
   rust_clippy: '1.77'
   # When updating this, also update:
   # - README.md
@@ -994,6 +994,21 @@ jobs:
       - name: check-external-types
         run: cargo check-external-types --all-features
         working-directory: tokio
+
+  check-unexpected-lints-cfgs:
+    name: check unexpected lints and cfgs
+    needs: basics
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust ${{ env.rust_nightly }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.rust_nightly }}
+      - name: check tokio
+        run: cargo check --all-features
+        env:
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       - name: check tokio
         run: cargo check --all-features
         env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) -Funexpected_cfgs -Funknown_lints
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) --check-cfg=cfg(tokio_taskdump) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -599,10 +599,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ env.rust_nightly }}
+      # This check is broken on newer nightlies.
+      - name: Install Rust nightly-2023-10-21
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.rust_nightly }}
+          toolchain: nightly-2023-10-21
           components: rust-src
 
       - name: Install cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       - name: check for unknown lints and cfgs
         run: cargo check --all-features --tests
         env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) --check-cfg=cfg(tokio_taskdump) --check-cfg=cfg(fuzzing) --check-cfg=cfg(mio_unsupported_force_poll_poll) --check-cfg=cfg(tokio_internal_mt_counters) --check-cfg=cfg(fs) --check-cfg=cfg(tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom, tokio_unstable, tokio_taskdump, fuzzing, mio_unsupported_force_poll_poll, tokio_internal_mt_counters, fs, tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1006,9 +1006,9 @@ jobs:
         with:
           toolchain: ${{ env.rust_nightly }}
       - name: don't allow warnings
-        run: sed -i '/#!\[allow(unknown_lints, unexpected_cfgs)\]/d' */src/lib.rs
-      - name: check tokio
-        run: cargo check --all-features
+        run: sed -i '/#!\[allow(unknown_lints, unexpected_cfgs)\]/d' */src/lib.rs */tests/*.rs
+      - name: check for unknown lints and cfgs
+        run: cargo check --all-features --tests
         env:
           RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) --check-cfg=cfg(tokio_taskdump) -Funexpected_cfgs -Funknown_lints
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1010,7 +1010,7 @@ jobs:
       - name: check for unknown lints and cfgs
         run: cargo check --all-features --tests
         env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) --check-cfg=cfg(tokio_taskdump) -Funexpected_cfgs -Funknown_lints
+          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom) --check-cfg=cfg(tokio_unstable) --check-cfg=cfg(tokio_taskdump) --check-cfg=cfg(fuzzing) --check-cfg=cfg(mio_unsupported_force_poll_poll) --check-cfg=cfg(tokio_internal_mt_counters) --check-cfg=cfg(fs) --check-cfg=cfg(tokio_no_parking_lot) -Funexpected_cfgs -Funknown_lints
 
   check-fuzzing:
     name: check-fuzzing

--- a/target-specs/README.md
+++ b/target-specs/README.md
@@ -1,0 +1,9 @@
+This is used for the `no-atomic-u64-test` ci check that verifies that Tokio
+works even if the `AtomicU64` type is missing.
+
+When increasing the nightly compiler version, you may need to regenerate this
+target using the following command:
+```
+rustc +nightly -Z unstable-options --print target-spec-json --target i686-unknown-linux-gnu | grep -v 'is-builtin' | sed 's/"max-atomic-width": 64/"max-atomic-width": 32/' > target-specs/i686-unknown-linux-gnu.json
+```
+

--- a/target-specs/i686-unknown-linux-gnu.json
+++ b/target-specs/i686-unknown-linux-gnu.json
@@ -1,29 +1,35 @@
 {
   "arch": "x86",
   "cpu": "pentium4",
+  "crt-objects-fallback": "false",
   "crt-static-respected": true,
-  "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-f64:32:64-f80:32-n8:16:32-S128",
+  "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
   "dynamic-linking": true,
   "env": "gnu",
   "has-rpath": true,
   "has-thread-local": true,
+  "linker-flavor": "gnu-cc",
   "llvm-target": "i686-unknown-linux-gnu",
   "max-atomic-width": 32,
+  "metadata": {
+    "description": null,
+    "host_tools": null,
+    "std": null,
+    "tier": null
+  },
   "os": "linux",
   "position-independent-executables": true,
   "pre-link-args": {
-    "gcc": [
+    "gnu-cc": [
+      "-m32"
+    ],
+    "gnu-lld-cc": [
       "-m32"
     ]
   },
   "relro-level": "full",
   "stack-probes": {
-    "kind": "inline-or-call",
-    "min-llvm-version-for-inline": [
-      16,
-      0,
-      0
-    ]
+    "kind": "inline"
   },
   "supported-sanitizers": [
     "address"

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -29,7 +29,7 @@ codec = []
 time = ["tokio/time","slab"]
 io = []
 io-util = ["io", "tokio/rt", "tokio/io-util"]
-rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown"]
+rt = ["tokio/rt", "tokio/sync", "futures-util", "hashbrown", "ahash"]
 
 __docs_rs = ["futures-util"]
 
@@ -46,6 +46,7 @@ tracing = { version = "0.1.25", default-features = false, features = ["std"], op
 
 [target.'cfg(tokio_unstable)'.dependencies]
 hashbrown = { version = "0.14.0", optional = true }
+ahash = { version = "0.8.7", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -639,7 +639,6 @@ mod builder {
     impl LengthFieldType for u64 {}
 
     #[cfg(any(
-        target_pointer_width = "8",
         target_pointer_width = "16",
         target_pointer_width = "32",
         target_pointer_width = "64",

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "rt", tokio_unstable))]
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -449,7 +449,7 @@
 // TODO: improve once we have MSRV access to const eval to make more flexible.
 #[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error! {
-    "Tokio requires the platform pointer width to be 32, 64, or 128 bits"
+    "Tokio requires the platform pointer width to be at least 32 bits"
 }
 
 #[cfg(all(

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -447,10 +447,7 @@
 // least 32 bits, which a lot of components in Tokio currently assumes.
 //
 // TODO: improve once we have MSRV access to const eval to make more flexible.
-#[cfg(not(any(
-    target_pointer_width = "32",
-    target_pointer_width = "64"
-)))]
+#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
 compile_error! {
     "Tokio requires the platform pointer width to be 32, 64, or 128 bits"
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -449,8 +449,7 @@
 // TODO: improve once we have MSRV access to const eval to make more flexible.
 #[cfg(not(any(
     target_pointer_width = "32",
-    target_pointer_width = "64",
-    target_pointer_width = "128"
+    target_pointer_width = "64"
 )))]
 compile_error! {
     "Tokio requires the platform pointer width to be 32, 64, or 128 bits"

--- a/tokio/src/signal/mod.rs
+++ b/tokio/src/signal/mod.rs
@@ -45,7 +45,9 @@
 use crate::sync::watch::Receiver;
 use std::task::{Context, Poll};
 
+#[cfg(feature = "signal")]
 mod ctrl_c;
+#[cfg(feature = "signal")]
 pub use ctrl_c::ctrl_c;
 
 pub(crate) mod registry;

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -485,10 +485,12 @@ impl Signal {
 }
 
 // Work around for abstracting streams internally
+#[cfg(feature = "process")]
 pub(crate) trait InternalStream {
     fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>>;
 }
 
+#[cfg(feature = "process")]
 impl InternalStream for Signal {
     fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<()>> {
         self.poll_recv(cx)

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, unexpected_cfgs)]
+
 #[cfg(not(any(feature = "full", target_family = "wasm")))]
 compile_error!("run main Tokio tests with `--features full`");
 

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(
     tokio_unstable,
     tokio_taskdump,

--- a/tokio/tests/fs_open_options.rs
+++ b/tokio/tests/fs_open_options.rs
@@ -57,7 +57,11 @@ async fn open_options_create_new() {
 async fn open_options_mode() {
     let mode = format!("{:?}", OpenOptions::new().mode(0o644));
     // TESTING HACK: use Debug output to check the stored data
-    assert!(mode.contains("mode: 420 ") || mode.contains("mode: 0o000644 "), "mode is: {}", mode);
+    assert!(
+        mode.contains("mode: 420 ") || mode.contains("mode: 0o000644 "),
+        "mode is: {}",
+        mode
+    );
 }
 
 #[tokio::test]

--- a/tokio/tests/fs_open_options.rs
+++ b/tokio/tests/fs_open_options.rs
@@ -55,8 +55,9 @@ async fn open_options_create_new() {
 #[tokio::test]
 #[cfg(unix)]
 async fn open_options_mode() {
+    let mode = format!("{:?}", OpenOptions::new().mode(0o644));
     // TESTING HACK: use Debug output to check the stored data
-    assert!(format!("{:?}", OpenOptions::new().mode(0o644)).contains("mode: 420 "));
+    assert!(mode.contains("mode: 420 "), "mode is: {}", mode);
 }
 
 #[tokio::test]

--- a/tokio/tests/fs_open_options.rs
+++ b/tokio/tests/fs_open_options.rs
@@ -57,7 +57,7 @@ async fn open_options_create_new() {
 async fn open_options_mode() {
     let mode = format!("{:?}", OpenOptions::new().mode(0o644));
     // TESTING HACK: use Debug output to check the stored data
-    assert!(mode.contains("mode: 420 "), "mode is: {}", mode);
+    assert!(mode.contains("mode: 420 ") || mode.contains("mode: 0o000644 "), "mode is: {}", mode);
 }
 
 #[tokio::test]

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(feature = "macros")]
 #![allow(clippy::disallowed_names)]
 

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable, not(target_os = "wasi")))]
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
 

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
 #![cfg(tokio_unstable)]

--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -7,8 +7,10 @@ use tokio::time::Duration;
 
 use tokio::runtime::Builder;
 
+#[cfg(panic = "unwind")]
 struct PanicOnDrop;
 
+#[cfg(panic = "unwind")]
 impl Drop for PanicOnDrop {
     fn drop(&mut self) {
         panic!("Well what did you expect would happen...");

--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,3 +1,5 @@
+#![allow(unknown_lints, unexpected_cfgs)]
+
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 mod tests {
     use std::rc::Rc;

--- a/tokio/tests/task_id.rs
+++ b/tokio/tests/task_id.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable))]
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_yield_now.rs
+++ b/tokio/tests/task_yield_now.rs
@@ -1,3 +1,4 @@
+#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(feature = "full", tokio_unstable))]
 
 use tokio::task;


### PR DESCRIPTION
Silence warnings from https://github.com/rust-lang/cargo/pull/13571.

I tried to add a CI step that runs with the lint enabled as well. But it can't be enabled normally because `cargo build` needs to just work for new contributors, and build scripts hurt performance too much.