### PR TITLE
tests: remove tests module from integration tests

### DIFF
--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,81 +1,80 @@
-#[cfg(all(tokio_unstable, feature = "tracing"))]
-mod tests {
-    use std::rc::Rc;
-    use tokio::{
-        task::{Builder, LocalSet},
-        test,
-    };
+#![cfg(all(tokio_unstable, feature = "tracing"))]
 
-    #[test]
-    async fn spawn_with_name() {
-        let result = Builder::new()
-            .name("name")
-            .spawn(async { "task executed" })
-            .unwrap()
-            .await;
+use std::rc::Rc;
+use tokio::{
+    task::{Builder, LocalSet},
+    test,
+};
 
-        assert_eq!(result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_with_name() {
+    let result = Builder::new()
+        .name("name")
+        .spawn(async { "task executed" })
+        .unwrap()
+        .await;
 
-    #[test]
-    async fn spawn_blocking_with_name() {
-        let result = Builder::new()
-            .name("name")
-            .spawn_blocking(|| "task executed")
-            .unwrap()
-            .await;
+    assert_eq!(result.unwrap(), "task executed");
+}
 
-        assert_eq!(result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_blocking_with_name() {
+    let result = Builder::new()
+        .name("name")
+        .spawn_blocking(|| "task executed")
+        .unwrap()
+        .await;
 
-    #[test]
-    async fn spawn_local_with_name() {
-        let unsend_data = Rc::new("task executed");
-        let result = LocalSet::new()
-            .run_until(async move {
-                Builder::new()
-                    .name("name")
-                    .spawn_local(async move { unsend_data })
-                    .unwrap()
-                    .await
-            })
-            .await;
+    assert_eq!(result.unwrap(), "task executed");
+}
 
-        assert_eq!(*result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_local_with_name() {
+    let unsend_data = Rc::new("task executed");
+    let result = LocalSet::new()
+        .run_until(async move {
+            Builder::new()
+                .name("name")
+                .spawn_local(async move { unsend_data })
+                .unwrap()
+                .await
+        })
+        .await;
 
-    #[test]
-    async fn spawn_without_name() {
-        let result = Builder::new()
-            .spawn(async { "task executed" })
-            .unwrap()
-            .await;
+    assert_eq!(*result.unwrap(), "task executed");
+}
 
-        assert_eq!(result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_without_name() {
+    let result = Builder::new()
+        .spawn(async { "task executed" })
+        .unwrap()
+        .await;
 
-    #[test]
-    async fn spawn_blocking_without_name() {
-        let result = Builder::new()
-            .spawn_blocking(|| "task executed")
-            .unwrap()
-            .await;
+    assert_eq!(result.unwrap(), "task executed");
+}
 
-        assert_eq!(result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_blocking_without_name() {
+    let result = Builder::new()
+        .spawn_blocking(|| "task executed")
+        .unwrap()
+        .await;
 
-    #[test]
-    async fn spawn_local_without_name() {
-        let unsend_data = Rc::new("task executed");
-        let result = LocalSet::new()
-            .run_until(async move {
-                Builder::new()
-                    .spawn_local(async move { unsend_data })
-                    .unwrap()
-                    .await
-            })
-            .await;
+    assert_eq!(result.unwrap(), "task executed");
+}
 
-        assert_eq!(*result.unwrap(), "task executed");
-    }
+#[test]
+async fn spawn_local_without_name() {
+    let unsend_data = Rc::new("task executed");
+    let result = LocalSet::new()
+        .run_until(async move {
+            Builder::new()
+                .spawn_local(async move { unsend_data })
+                .unwrap()
+                .await
+        })
+        .await;
+
+    assert_eq!(*result.unwrap(), "task executed");
 }


### PR DESCRIPTION
Wrapping tests in `mod tests` only makes sense for tests inside `src/`.