### PR TITLE
util: no default features for hashbrown

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -45,7 +45,7 @@ slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
 
 [target.'cfg(tokio_unstable)'.dependencies]
-hashbrown = { version = "0.14.0", optional = true }
+hashbrown = { version = "0.14.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }


### PR DESCRIPTION
Don't enable default features for hashbrown. This means that we no longer use ahash.

Suggested in [#6538 (comment)](https://www.github.com/tokio-rs/tokio/pull/6538#discussion_r1590334134).