### PR TITLE
Enable unexpected cfg checking in all in-repo builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -995,23 +995,6 @@ jobs:
         run: cargo check-external-types --all-features
         working-directory: tokio
 
-  check-unexpected-lints-cfgs:
-    name: check unexpected lints and cfgs
-    needs: basics
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust ${{ env.rust_nightly }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.rust_nightly }}
-      - name: don't allow warnings
-        run: sed -i '/#!\[allow(unknown_lints, unexpected_cfgs)\]/d' */src/lib.rs */tests/*.rs
-      - name: check for unknown lints and cfgs
-        run: cargo check --all-features --tests
-        env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom,tokio_unstable,tokio_taskdump,fuzzing,mio_unsupported_force_poll_poll,tokio_internal_mt_counters,fs,tokio_no_parking_lot,tokio_no_tuning_tests) -Funexpected_cfgs -Funknown_lints
-
   check-fuzzing:
     name: check-fuzzing
     needs: basics

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -15,6 +15,7 @@ description = """
 Utilities to work with `Stream` and `tokio`.
 """
 categories = ["asynchronous"]
+exclude = ["build.rs"]
 
 [features]
 default = ["time"]

--- a/tokio-stream/build.rs
+++ b/tokio-stream/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Warning: build.rs is not published to crates.io.
+
+    println!("cargo:rustc-cfg=check_cfg");
+    println!("cargo:rustc-check-cfg=cfg(check_cfg)");
+    println!("cargo:rustc-check-cfg=cfg(loom)");
+}

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -15,6 +15,7 @@ description = """
 Testing utilities for Tokio- and futures-based code
 """
 categories = ["asynchronous", "development-tools::testing"]
+exclude = ["build.rs"]
 
 [dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }

--- a/tokio-test/build.rs
+++ b/tokio-test/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // Warning: build.rs is not published to crates.io.
+
+    println!("cargo:rustc-cfg=check_cfg");
+    println!("cargo:rustc-check-cfg=cfg(check_cfg)");
+    println!("cargo:rustc-check-cfg=cfg(loom)");
+}

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -15,6 +15,7 @@ description = """
 Additional utilities for working with Tokio.
 """
 categories = ["asynchronous"]
+exclude = ["build.rs"]
 
 [features]
 # No features on by default

--- a/tokio-util/build.rs
+++ b/tokio-util/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    // Warning: build.rs is not published to crates.io.
+
+    println!("cargo:rustc-cfg=check_cfg");
+    println!("cargo:rustc-check-cfg=cfg(check_cfg)");
+    println!("cargo:rustc-check-cfg=cfg(loom)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_unstable)");
+}

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "rt", tokio_unstable))]
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -20,6 +20,7 @@ backed applications.
 """
 categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures"]
+exclude = ["build.rs"]
 
 [features]
 # Include nothing by default

--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    // Warning: build.rs is not published to crates.io.
+
+    println!("cargo:rustc-cfg=check_cfg");
+    println!("cargo:rustc-check-cfg=cfg(check_cfg)");
+    println!("cargo:rustc-check-cfg=cfg(fs)");
+    println!("cargo:rustc-check-cfg=cfg(fuzzing)");
+    println!("cargo:rustc-check-cfg=cfg(loom)");
+    println!("cargo:rustc-check-cfg=cfg(mio_unsupported_force_poll_poll)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_internal_mt_counters)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_no_parking_lot)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_no_tuning_tests)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_taskdump)");
+    println!("cargo:rustc-check-cfg=cfg(tokio_unstable)");
+}

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 
 #[cfg(not(any(feature = "full", target_family = "wasm")))]
 compile_error!("run main Tokio tests with `--features full`");

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![cfg(all(
     tokio_unstable,
     tokio_taskdump,

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![cfg(feature = "macros")]
 #![allow(clippy::disallowed_names)]
 

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable, not(target_os = "wasi")))]
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
 

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
 #![cfg(tokio_unstable)]

--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![cfg(all(tokio_unstable, feature = "tracing"))]
 
 use std::rc::Rc;

--- a/tokio/tests/task_id.rs
+++ b/tokio/tests/task_id.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable))]
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_yield_now.rs
+++ b/tokio/tests/task_yield_now.rs
@@ -1,4 +1,4 @@
-#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg_attr(not(check_cfg), allow(unknown_lints, unexpected_cfgs))]
 #![cfg(all(feature = "full", tokio_unstable))]
 
 use tokio::task;


### PR DESCRIPTION
Submitted for consideration as an alternative to #6538.

This approach relies on having `build.rs` in the repo, but using `package.exclude` in Cargo.toml to exclude `build.rs` from getting published to crates.io. This mitigates the concern about build scripts hurting performance too much for users. Users who build tokio as a git dependency would still get the slowdown from the build scripts, but this should be uncommon.

The benefit of this approach is to "shift left" the unexpected cfgs signal for tokio contributors. Every `cargo check` in the tokio repo will be checking for unexpected cfgs and reporting warnings, rather than this being something contributors see only in CI after opening a PR.