### PR TITLE
time: positively check the deadline before reading the state of TimerEntry in Sleep

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -577,7 +577,6 @@ impl TimerEntry {
         self.driver.driver().time()
     }
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
     pub(crate) fn clock(&self) -> &super::Clock {
         self.driver.driver().clock()
     }

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -137,7 +137,7 @@ fn worker_park_count() {
     let rt = current_thread();
     let metrics = rt.metrics();
     rt.block_on(async {
-        time::sleep(Duration::from_millis(1)).await;
+        time::sleep(Duration::from_millis(100)).await;
     });
     drop(rt);
     assert!(1 <= metrics.worker_park_count(0));
@@ -145,7 +145,7 @@ fn worker_park_count() {
     let rt = threaded();
     let metrics = rt.metrics();
     rt.block_on(async {
-        time::sleep(Duration::from_millis(1)).await;
+        time::sleep(Duration::from_millis(100)).await;
     });
     drop(rt);
     assert!(1 <= metrics.worker_park_count(0));
@@ -160,7 +160,7 @@ fn worker_noop_count() {
     let rt = current_thread();
     let metrics = rt.metrics();
     rt.block_on(async {
-        time::sleep(Duration::from_millis(1)).await;
+        time::sleep(Duration::from_millis(100)).await;
     });
     drop(rt);
     assert!(0 < metrics.worker_noop_count(0));
@@ -168,7 +168,7 @@ fn worker_noop_count() {
     let rt = threaded();
     let metrics = rt.metrics();
     rt.block_on(async {
-        time::sleep(Duration::from_millis(1)).await;
+        time::sleep(Duration::from_millis(100)).await;
     });
     drop(rt);
     assert!(0 < metrics.worker_noop_count(0));

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -116,7 +116,7 @@ fn ready_in_busy_loop() {
             });
     });
 
-    std::thread::sleep(std::time::Duration::from_millis(10));
+    std::thread::sleep(std::time::Duration::from_secs(2));
 
     assert!(handle.is_finished());
 }

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -89,6 +89,7 @@ async fn timeout_value() {
     assert!(Instant::now() >= now + dur);
 }
 
+#[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
 #[test]
 fn ready_in_busy_loop() {
     async fn never_pending() {}


### PR DESCRIPTION
This is for fixing the issue https://github.com/tokio-rs/tokio/issues/6545.