### PR TITLE
tokio(metrics): fix blocking_threads count

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -8,7 +8,8 @@ impl Handle {
     }
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
-        self.blocking_spawner.num_threads()
+        // workers are currently spawned within the blocking_spawned
+        self.blocking_spawner.num_threads() - self.num_workers()
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -9,7 +9,9 @@ impl Handle {
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
         // workers are currently spawned using spawn_blocking
-        self.blocking_spawner.num_threads().saturating_sub(self.num_workers())
+        self.blocking_spawner
+            .num_threads()
+            .saturating_sub(self.num_workers())
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -9,7 +9,7 @@ impl Handle {
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
         // workers are currently spawned within the blocking_spawned
-        self.blocking_spawner.num_threads() - self.num_workers()
+        self.blocking_spawner.num_threads().saturating_sub(self.num_workers())
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -8,7 +8,7 @@ impl Handle {
     }
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
-        // workers are currently spawned within the blocking_spawned
+        // workers are currently spawned using spawn_blocking
         self.blocking_spawner.num_threads().saturating_sub(self.num_workers())
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
@@ -8,8 +8,10 @@ impl Handle {
     }
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
-        // workers are currently spawned within the blocking_spawned
-        self.blocking_spawner.num_threads().saturating_sub(self.num_workers())
+        // workers are currently spawned using spawn_blocking
+        self.blocking_spawner
+            .num_threads()
+            .saturating_sub(self.num_workers())
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
@@ -8,7 +8,8 @@ impl Handle {
     }
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
-        self.blocking_spawner.num_threads()
+        // workers are currently spawned within the blocking_spawned
+        self.blocking_spawner.num_threads() - self.num_workers()
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
@@ -9,7 +9,7 @@ impl Handle {
 
     pub(crate) fn num_blocking_threads(&self) -> usize {
         // workers are currently spawned within the blocking_spawned
-        self.blocking_spawner.num_threads() - self.num_workers()
+        self.blocking_spawner.num_threads().saturating_sub(self.num_workers())
     }
 
     pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -26,6 +26,11 @@ fn num_blocking_threads() {
     assert_eq!(0, rt.metrics().num_blocking_threads());
     let _ = rt.block_on(rt.spawn_blocking(move || {}));
     assert_eq!(1, rt.metrics().num_blocking_threads());
+
+    let rt = threaded();
+    assert_eq!(0, rt.metrics().num_blocking_threads());
+    let _ = rt.block_on(rt.spawn_blocking(move || {}));
+    assert_eq!(1, rt.metrics().num_blocking_threads());
 }
 
 #[test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Fixes #6550

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

For the multithreaded scheduler handles, subtract the number of worker threads from the blocking threads count.