### PR TITLE
Update nix and mio-aio dev-dependencies to the latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,3 @@ members = [
 
 [workspace.metadata.spellcheck]
 config = "spellcheck.toml"
-

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -118,7 +118,7 @@ signal-hook-registry = { version = "1.1.1", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.149" }
-nix = { version = "0.27.1", default-features = false, features = ["fs", "socket"] }
+nix = { version = "0.29.0", default-features = false, features = ["aio", "fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.48"
@@ -149,7 +149,7 @@ rand = "0.8.0"
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { version = "0.8.0", features = ["tokio"] }
+mio-aio = { version = "0.9.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -489,12 +489,10 @@ async fn anon_pipe_spawn_echo() -> std::io::Result<()> {
 #[cfg(target_os = "linux")]
 async fn anon_pipe_from_owned_fd() -> std::io::Result<()> {
     use nix::fcntl::OFlag;
-    use std::os::unix::io::{FromRawFd, OwnedFd};
 
     const DATA: &[u8] = b"this is some data to write to the pipe";
 
-    let fds = nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
-    let (rx_fd, tx_fd) = unsafe { (OwnedFd::from_raw_fd(fds.0), OwnedFd::from_raw_fd(fds.1)) };
+    let (rx_fd, tx_fd) = nix::unistd::pipe2(OFlag::O_CLOEXEC | OFlag::O_NONBLOCK)?;
 
     let mut rx = pipe::Receiver::from_owned_fd(rx_fd)?;
     let mut tx = pipe::Sender::from_owned_fd(tx_fd)?;


### PR DESCRIPTION
## Motivation

Use the latest version of Nix as requested by @fkm3 .

## Solution

Update Nix to the latest version.  This version uses I/O Safety for most functions.  It also necessitates updating the mio-aio dev dependency.

This PR supersedes #6474 , but it depends on unreleased nix and mio-aio crates.