### PR TITLE
feat(oneshot channel): ensure msg won't be dropped on sender side when send returns ok

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -84,7 +84,7 @@ signal = [
   "windows-sys/Win32_Foundation",
   "windows-sys/Win32_System_Console",
 ]
-sync = ["rustversion"]
+sync = []
 test-util = ["rt", "sync", "time"]
 time = []
 
@@ -92,12 +92,12 @@ time = []
 tokio-macros = { version = "~2.2.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
+rustversion = { version = "1.0.16" }
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
 mio = { version = "0.8.9", optional = true, default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
-rustversion = { version = "1.0.16", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,7 @@ time = []
 tokio-macros = { version = "~2.2.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
-rustversion = { version = "1.0.16" }
+rustversion = { git = "https://github.com/wenym1/rustversion", rev = "0b11410" }
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -84,7 +84,7 @@ signal = [
   "windows-sys/Win32_Foundation",
   "windows-sys/Win32_System_Console",
 ]
-sync = []
+sync = ["rustversion"]
 test-util = ["rt", "sync", "time"]
 time = []
 
@@ -97,6 +97,7 @@ pin-project-lite = "0.2.11"
 bytes = { version = "1.0.0", optional = true }
 mio = { version = "0.8.9", optional = true, default-features = false }
 num_cpus = { version = "1.8.0", optional = true }
+rustversion = { version = "1.0.16", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,6 @@ time = []
 tokio-macros = { version = "~2.2.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
-rustversion = { git = "https://github.com/wenym1/rustversion", rev = "0b11410" }
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
@@ -153,8 +152,7 @@ wasm-bindgen-test = "0.3.0"
 mio-aio = { version = "0.8.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = { git = "https://github.com/wenym1/loom", rev = "4edf9435", features = ["futures", "checkpoint"] }
-#loom = { path = "/Users/william/repo/loom", features = ["futures", "checkpoint"] }
+loom = { version = "0.7", features = ["futures", "checkpoint"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -153,7 +153,8 @@ wasm-bindgen-test = "0.3.0"
 mio-aio = { version = "0.8.0", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
-loom = { version = "0.7", features = ["futures", "checkpoint"] }
+loom = { git = "https://github.com/wenym1/loom", rev = "4edf9435", features = ["futures", "checkpoint"] }
+#loom = { path = "/Users/william/repo/loom", features = ["futures", "checkpoint"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -651,6 +651,7 @@ impl<T> Sender<T> {
 
             #[cfg(loom)]
             {
+                drop(inner);
                 // The `loom::sync::Arc` does not implement `into_inner` yet.
                 Ok(())
             }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -628,15 +628,15 @@ impl<T> Sender<T> {
         });
 
         if let Some(inner) = Arc::into_inner(inner) {
-            if let Some(value) = inner.value.with_mut(|ptr| unsafe {
+            if let Some(t) = inner.value.with_mut(|ptr| unsafe {
                 // SAFETY: we have successfully returned with `Some`, which means we are the
-                // only accessor the ptr.
+                // only accessor to `ptr`.
                 //
                 // Note: value can be `None` even though we have previously set it as `Some`,
                 // because the value may have been consumed by receiver before we reach here.
                 (*ptr).take()
             }) {
-                Err(value)
+                Err(t)
             } else {
                 Ok(())
             }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1075,11 +1075,9 @@ impl<T> Drop for Receiver<T> {
             let state = inner.close();
 
             if state.is_complete() {
-                drop(unsafe {
-                    // SAFETY: we have ensured that the `VALUE_SENT` bit has been set,
-                    // so only the receiver can access the value.
-                    inner.consume_value()
-                });
+                // SAFETY: we have ensured that the `VALUE_SENT` bit has been set,
+                // so only the receiver can access the value.
+                drop(unsafe { inner.consume_value() });
             }
 
             #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -1260,10 +1258,9 @@ impl<T> Drop for Inner<T> {
             }
         }
 
+        // SAFETY: we have `&mut self`, and therefore we have
+        // exclusive access to the value.
         unsafe {
-            // SAFETY: we have `&mut self`, and therefore we have
-            // exclusive access to the value.
-            //
             // Note: the assertion holds because if the value has been sent by sender,
             // we must ensure that the value must have been consumed by the receiver before
             // dropping the `Inner`.

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -629,30 +629,20 @@ impl<T> Sender<T> {
 
         #[rustversion::since(1.70)]
         fn consume_inner<T>(inner: Arc<Inner<T>>) -> Result<(), T> {
-            #[cfg(not(loom))]
-            {
-                if let Some(inner) = Arc::into_inner(inner) {
-                    if let Some(t) = inner.value.with_mut(|ptr| unsafe {
-                        // SAFETY: we have successfully returned with `Some`, which means we are the
-                        // only accessor to `ptr`.
-                        //
-                        // Note: value can be `None` even though we have previously set it as `Some`,
-                        // because the value may have been consumed by receiver before we reach here.
-                        (*ptr).take()
-                    }) {
-                        Err(t)
-                    } else {
-                        Ok(())
-                    }
+            if let Some(inner) = Arc::into_inner(inner) {
+                if let Some(t) = inner.value.with_mut(|ptr| unsafe {
+                    // SAFETY: we have successfully returned with `Some`, which means we are the
+                    // only accessor to `ptr`.
+                    //
+                    // Note: value can be `None` even though we have previously set it as `Some`,
+                    // because the value may have been consumed by receiver before we reach here.
+                    (*ptr).take()
+                }) {
+                    Err(t)
                 } else {
                     Ok(())
                 }
-            }
-
-            #[cfg(loom)]
-            {
-                drop(inner);
-                // The `loom::sync::Arc` does not implement `into_inner` yet.
+            } else {
                 Ok(())
             }
         }

--- a/tokio/src/sync/tests/loom_oneshot.rs
+++ b/tokio/src/sync/tests/loom_oneshot.rs
@@ -176,12 +176,9 @@ fn checking_tx_send_ok_not_drop() {
             }
         });
 
-        // rx thread
-        let rx_thread_join_handle = thread::spawn(move || {
-            drop(rx);
-        });
+        // main thread is the rx thread
+        drop(rx);
 
         tx_thread_join_handle.join().unwrap();
-        rx_thread_join_handle.join().unwrap();
     });
 }

--- a/tokio/src/sync/tests/loom_oneshot.rs
+++ b/tokio/src/sync/tests/loom_oneshot.rs
@@ -162,7 +162,10 @@ fn checking_tx_send_ok_not_drop() {
         }
     }
 
-    loom::model(|| {
+    let mut builder = loom::model::Builder::new();
+    builder.preemption_bound = Some(2);
+
+    builder.check(|| {
         let (tx, rx) = oneshot::channel();
 
         // tx thread


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Related: https://github.com/risingwavelabs/risingwave/issues/6617.

When we use `oneshot::Sender`, it is intuitive to assume that when `tx.send(msg)` returns with `Ok(())`, the `msg` will have been added to the buffer and either will be consumed by the `rx.await`, or dropped along with dropping `rx`, but in either way, `msg` should not be dropped on the `tx` side.

However, in the current implementation, the assumption does not hold. It might happen that, even though `tx.send(msg)` returns with `Ok(())`, the `msg` is still dropped on the sender side.

The current struct of `Sender` is 
```
struct Sender<T> {
    inner: Option<Arc<Inner<T>>>,
}
```

In the current implementation, in `tx.send(msg)`, `msg` will be added to `inner`. Before `msg` gets consumed by `rx`, the struct `Inner` holds the ownership of `msg`. `Inner` is protected by `Arc` with reference counting to avoid memory leak. When the reference counting of `Arc<Inner>` decreases to 0, `msg` gets dropped along with `Inner`. However, in the following execution flow, `msg` will be dropped on sender side when `tx.send(msg)` returns `Ok(())`.
```
pub fn send(mut self, t: T) -> Result<(), T> {
    let inner = self.inner.take().unwrap();

    inner.value.with_mut(|ptr| unsafe {
        *ptr = Some(t);
    });

    if !inner.complete() {
        unsafe {
            return Err(inner.consume_value().unwrap());
        }
    }

    // assume that rx not dropped yet here, ref count of `Arc<Inner>` is 2
-> rx dropped here, ref count becomes 1

    Ok(())
-> variable `inner` gets dropped,  ref count decreases to 0, `msg` gets dropped along with dropping `Inner`, but we return with `Ok(())`
}
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The problem happens due to the implicit drop of variable `inner`. We are not aware of whether or not dropping `inner` will decreases the `Arc` ref count to 0 and further drop the `Inner`. 

Therefore, in this PR, we can leverage the [Arc::into_inner](https://doc.rust-lang.org/std/sync/struct.Arc.html#method.into_inner) to explicitly consume the variable `inner` so that we can atomically decrease the ref count and check whether the `Inner` will be further dropped. If `Inner` is going to be dropped, we can then take the `msg` out and return with `Err(msg)` if the msg has not been consumed by `rx` yet.
