### PR TITLE
docs: gate taskdump compiler_error behind not(doc)

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -471,6 +471,7 @@ compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
 
 #[cfg(all(
     tokio_taskdump,
+    not(doc),
     not(all(
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Docs don't build on macOS because of the `compile_error!` warning intended to prevent customers from using task dumps on unsupported platforms.

## Solution

Add `not(doc)` so that rustdoc doesn't hit the compile failure

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
