### PR TITLE
Improved the code with clippy 1.80

### DIFF
--- a/benches/time_timeout.rs
+++ b/benches/time_timeout.rs
@@ -40,7 +40,7 @@ fn do_timeout_test(c: &mut Criterion, workers: usize, name: &str) {
         b.iter_custom(|iters| {
             let start = Instant::now();
             runtime.block_on(async {
-                black_box(spawn_timeout_job(iters as usize, workers).await);
+                black_box(spawn_timeout_job(iters as usize, workers)).await;
             });
             start.elapsed()
         })
@@ -77,7 +77,7 @@ fn do_sleep_test(c: &mut Criterion, workers: usize, name: &str) {
         b.iter_custom(|iters| {
             let start = Instant::now();
             runtime.block_on(async {
-                black_box(spawn_sleep_job(iters as usize, workers).await);
+                black_box(spawn_sleep_job(iters as usize, workers)).await;
             });
             start.elapsed()
         })

--- a/tokio-stream/src/wrappers/interval.rs
+++ b/tokio-stream/src/wrappers/interval.rs
@@ -33,7 +33,7 @@ impl Stream for IntervalStream {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (std::usize::MAX, None)
+        (usize::MAX, None)
     }
 }
 

--- a/tokio-util/src/codec/any_delimiter_codec.rs
+++ b/tokio-util/src/codec/any_delimiter_codec.rs
@@ -2,7 +2,7 @@ use crate::codec::decoder::Decoder;
 use crate::codec::encoder::Encoder;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use std::{cmp, fmt, io, str, usize};
+use std::{cmp, fmt, io, str};
 
 const DEFAULT_SEEK_DELIMITERS: &[u8] = b",;\n\r";
 const DEFAULT_SEQUENCE_WRITER: &[u8] = b",";

--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -2,7 +2,7 @@ use crate::codec::decoder::Decoder;
 use crate::codec::encoder::Encoder;
 
 use bytes::{Buf, BufMut, BytesMut};
-use std::{cmp, fmt, io, str, usize};
+use std::{cmp, fmt, io, str};
 
 /// A simple [`Decoder`] and [`Encoder`] implementation that splits up data into lines.
 ///

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -7,7 +7,6 @@ pub(crate) use self::stack::Stack;
 
 use std::borrow::Borrow;
 use std::fmt::Debug;
-use std::usize;
 
 /// Timing wheel implementation.
 ///

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -2,7 +2,6 @@ use crate::loom::sync::atomic::AtomicUsize;
 
 use std::fmt;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
-use std::usize;
 
 pub(super) struct State {
     val: AtomicUsize,

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -127,7 +127,7 @@ impl Semaphore {
     /// implementation used three bits, so we will continue to reserve them to
     /// avoid a breaking change if additional flags need to be added in the
     /// future.
-    pub(crate) const MAX_PERMITS: usize = std::usize::MAX >> 3;
+    pub(crate) const MAX_PERMITS: usize = usize::MAX >> 3;
     const CLOSED: usize = 1;
     // The least-significant bit in the number of permits is reserved to use
     // as a flag indicating that the semaphore has been closed. Consequently

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -129,7 +129,6 @@ use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
 use std::task::{Context, Poll, Waker};
-use std::usize;
 
 /// Sending-half of the [`broadcast`] channel.
 ///

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -21,7 +21,7 @@ pub(crate) use write_guard::RwLockWriteGuard;
 pub(crate) use write_guard_mapped::RwLockMappedWriteGuard;
 
 #[cfg(not(loom))]
-const MAX_READS: u32 = std::u32::MAX >> 3;
+const MAX_READS: u32 = u32::MAX >> 3;
 
 #[cfg(loom)]
 const MAX_READS: u32 = 10;

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -286,8 +286,6 @@ fn zero_capacity() {
 #[should_panic]
 #[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
 fn capacity_too_big() {
-    use std::usize;
-
     broadcast::channel::<()>(1 + (usize::MAX >> 1));
 }
 


### PR DESCRIPTION
I improved the code with clippy 1.80 (nightly  2024-05-16). The code compiles, doesn't cause any warnings with clippy 1.77 and 1.80, and all tests succeed. I know you don't like it when people use a newer version of clippy, let alone the current nightly version, but I wanted to contribute and I don't know enough to contribute more.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
I'm trying to improve the code of libraries I use and I use Tokio a lot.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Replaced cmp::max(2, cmp::min(...)) with clamp, removed usize imports, replaced std::usize:: and std::u32:: with usize:: and u32:: respectively, moved parentheses to put the future into the blackbox instead of the unit value.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->