### PR TITLE
feat: add spawn_blocking and spawn_blocking_on to the JoinSet builder

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -308,7 +308,7 @@ impl<T: 'static> JoinSet<T> {
 
     /// Tries to join one of the tasks in the set that has completed and return its output.
     ///
-    /// Returns `None` if the set is empty.    
+    /// Returns `None` if the set is empty.
     pub fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
         // Loop over all notified `JoinHandle`s to find one that's ready, or until none are left.
         loop {
@@ -621,6 +621,29 @@ impl<'a, T: 'static> Builder<'a, T> {
         T: Send,
     {
         Ok(self.joinset.insert(self.builder.spawn_on(future, handle)?))
+    }
+
+    /// Spawn the blocking code on the blocking threadpool with this builder's
+    /// settings, and store it in the [`JoinSet`].
+    ///
+    /// # Returns
+    ///
+    /// An [`AbortHandle`] that can be used to remotely cancel the task.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if called outside of a Tokio runtime.
+    ///
+    /// [`LocalSet`]: crate::task::LocalSet
+    /// [`AbortHandle`]: crate::task::AbortHandle
+    #[track_caller]
+    pub fn spawn_blocking<F>(self, f: F) -> std::io::Result<AbortHandle>
+    where
+        F: FnOnce() -> T,
+        F: Send + 'static,
+        T: Send,
+    {
+        Ok(self.joinset.insert(self.builder.spawn_blocking(f)?))
     }
 
     /// Spawn the provided task on the current [`LocalSet`] with this builder's


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

close https://github.com/tokio-rs/tokio/issues/6565

## Solution

1. Added the spawn_blocking API to the builder.
2. Added the spawn_blocking_on API to the builder.
