### PR TITLE
docs: `stdin` is always `inherit` by default

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -544,11 +544,9 @@ impl Command {
 
     /// Sets configuration for the child process's standard input (stdin) handle.
     ///
-    /// Defaults to [`inherit`] when used with `spawn` or `status`, and
-    /// defaults to [`piped`] when used with `output`.
+    /// Defaults to [`inherit`].
     ///
     /// [`inherit`]: std::process::Stdio::inherit
-    /// [`piped`]: std::process::Stdio::piped
     ///
     /// # Examples
     ///


### PR DESCRIPTION
The code for `output` indicates that only sets `stdout` and `stderr` (as one would expect, IMO), yet the docs for `stdin` indicated that it too would be set. This seems like it was just a simple copy/paste typo, so correct `stdin` to note that it just defaults to `inherit`.

Fixes #6577.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

See #6577; the docs for `stdin` seem to disagree with the code for `output`.

## Solution

Adjust the documentation to match the code.
