### PR TITLE
time: avoid traversing entries in the time wheel twice

### DIFF
--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -415,16 +415,16 @@ impl TimerShared {
 }
 
 unsafe impl linked_list::Link for TimerShared {
-    type Handle = NonNull<TimerShared>;
+    type Handle = TimerHandle;
 
     type Target = TimerShared;
 
     fn as_raw(handle: &Self::Handle) -> NonNull<Self::Target> {
-        *handle
+        handle.inner
     }
 
     unsafe fn from_raw(ptr: NonNull<Self::Target>) -> Self::Handle {
-        ptr
+        TimerHandle { inner: ptr }
     }
 
     unsafe fn pointers(
@@ -592,10 +592,6 @@ impl TimerHandle {
     /// the entry must not be in any wheel linked lists.
     pub(super) unsafe fn fire(self, completed_state: TimerResult) -> Option<Waker> {
         self.inner.as_ref().state.fire(completed_state)
-    }
-
-    pub(super) fn inner(&self) -> NonNull<TimerShared> {
-        self.inner
     }
 }
 

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -313,7 +313,7 @@ unsafe impl Sync for TimerEntry {}
 /// memory safety, all operations are unsafe.
 #[derive(Debug)]
 pub(crate) struct TimerHandle {
-    pub(super) inner: NonNull<TimerShared>,
+    inner: NonNull<TimerShared>,
 }
 
 pub(super) type EntryList = crate::util::linked_list::LinkedList<TimerShared, TimerShared>;
@@ -586,6 +586,10 @@ impl TimerHandle {
     /// the entry must not be in any wheel linked lists.
     pub(super) unsafe fn fire(self, completed_state: TimerResult) -> Option<Waker> {
         self.inner.as_ref().state.fire(completed_state)
+    }
+
+    pub(super) fn inner(&self) -> NonNull<TimerShared> {
+        self.inner
     }
 }
 

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -170,7 +170,8 @@ impl StateCell {
         // with relaxed ordering.
         let mut cur_state = self.state.load(Ordering::Relaxed);
         loop {
-            // This entry in current `guarded_list` can not be removed in its original entry list.
+            // This entry is in the `guarded_list`, so it can not be removed
+            // from the entry list with the same `level` and `slot`.
             // Because its state is STATE_DEREGISTERED, it has been fired.
             if cur_state == STATE_DEREGISTERED {
                 break Err(cur_state);

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -170,6 +170,10 @@ impl StateCell {
         // with relaxed ordering.
         let mut cur_state = self.state.load(Ordering::Relaxed);
         loop {
+            // Because its state is STATE_DEREGISTERED, it has been fired.
+            if cur_state == STATE_DEREGISTERED {
+                break Err(cur_state);
+            }
             // improve the error message for things like
             // https://github.com/tokio-rs/tokio/issues/3675
             assert!(

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -318,30 +318,35 @@ pub(crate) struct TimerHandle {
 
 #[derive(Debug, Default)]
 pub(super) struct EntryList {
-    counter: usize,
+    count: usize,
     list: crate::util::linked_list::LinkedList<TimerShared, TimerShared>,
 }
 
 impl EntryList {
-    pub(super) fn push_front(&mut self, val: TimerHandle) {
-        self.counter += 1;
-        self.list.push_front(val);
+    pub(super) fn push_front(&mut self, node: TimerHandle) {
+        self.count += 1;
+        self.list.push_front(node);
+    }
+
+    pub(super) unsafe fn remove(&mut self, node: NonNull<TimerShared>) {
+        self.list.remove(node);
+        self.count -= 1;
     }
 
     pub(super) fn is_empty(&self) -> bool {
-        self.counter == 0
+        self.count == 0
     }
 
     pub(super) fn pop_back(&mut self) -> Option<TimerHandle> {
         let node = self.list.pop_back();
         if node.is_some() {
-            self.counter -= 1;
+            self.count -= 1;
         }
         node
     }
 
     pub(super) fn count(&self) -> usize {
-        self.counter
+        self.count
     }
 }
 /// The shared state structure of a timer. This structure is shared between the

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -21,9 +21,8 @@
 //!
 //! Each timer has a state field associated with it. This field contains either
 //! the current scheduled time, or a special flag value indicating its state.
-//! This state can either indicate that the timer is on the 'pending' queue (and
-//! thus will be fired with an `Ok(())` result soon) or that it has already been
-//! fired/deregistered.
+//! This state can either indicate that the timer is firing (and thus will be fired
+//! with an `Ok(())` result soon) or that it has already been fired/deregistered.
 //!
 //! This single state field allows for code that is firing the timer to
 //! synchronize with any racing `reset` calls reliably.
@@ -49,10 +48,10 @@
 //! There is of course a race condition between timer reset and timer
 //! expiration. If the driver fails to observe the updated expiration time, it
 //! could trigger expiration of the timer too early. However, because
-//! [`mark_pending`][mark_pending] performs a compare-and-swap, it will identify this race and
-//! refuse to mark the timer as pending.
+//! [`mark_firing`][mark_firing] performs a compare-and-swap, it will identify this race and
+//! refuse to mark the timer as firing.
 //!
-//! [mark_pending]: TimerHandle::mark_pending
+//! [mark_firing]: TimerHandle::mark_firing
 
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicU64;
@@ -71,8 +70,9 @@ use std::{marker::PhantomPinned, pin::Pin, ptr::NonNull};
 type TimerResult = Result<(), crate::time::error::Error>;
 
 const STATE_DEREGISTERED: u64 = u64::MAX;
-const STATE_PENDING_FIRE: u64 = STATE_DEREGISTERED - 1;
-const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
+const STATE_OVERFLOW: u64 = STATE_DEREGISTERED - 1;
+const STATE_FIRE: u64 = STATE_DEREGISTERED - 2;
+const STATE_MIN_VALUE: u64 = STATE_FIRE;
 /// The largest safe integer to use for ticks.
 ///
 /// This value should be updated if any other signal values are added above.
@@ -123,8 +123,13 @@ impl StateCell {
         }
     }
 
-    fn is_pending(&self) -> bool {
-        self.state.load(Ordering::Relaxed) == STATE_PENDING_FIRE
+    /// Marks this timer as being moved to the overflow list.
+    fn mark_overflow(&self) {
+        self.state.store(STATE_OVERFLOW, Ordering::Relaxed);
+    }
+
+    fn is_overflow(&self) -> bool {
+        self.state.load(Ordering::Relaxed) == STATE_OVERFLOW
     }
 
     /// Returns the current expiration time, or None if not currently scheduled.
@@ -162,14 +167,13 @@ impl StateCell {
         }
     }
 
-    /// Marks this timer as being moved to the pending list, if its scheduled
-    /// time is not after `not_after`.
+    /// Marks this timer firing, if its scheduled time is not after `not_after`.
     ///
     /// If the timer is scheduled for a time after `not_after`, returns an Err
     /// containing the current scheduled time.
     ///
     /// SAFETY: Must hold the driver lock.
-    unsafe fn mark_pending(&self, not_after: u64) -> Result<(), u64> {
+    unsafe fn mark_firing(&self, not_after: u64) -> Result<(), u64> {
         // Quick initial debug check to see if the timer is already fired. Since
         // firing the timer can only happen with the driver lock held, we know
         // we shouldn't be able to "miss" a transition to a fired state, even
@@ -181,7 +185,7 @@ impl StateCell {
             // https://github.com/tokio-rs/tokio/issues/3675
             assert!(
                 cur_state < STATE_MIN_VALUE,
-                "mark_pending called when the timer entry is in an invalid state"
+                "mark_firing called when the timer entry is in an invalid state"
             );
 
             if cur_state > not_after {
@@ -190,7 +194,7 @@ impl StateCell {
 
             match self.state.compare_exchange_weak(
                 cur_state,
-                STATE_PENDING_FIRE,
+                STATE_FIRE,
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
@@ -246,9 +250,10 @@ impl StateCell {
 
     /// Attempts to adjust the timer to a new timestamp.
     ///
-    /// If the timer has already been fired, is pending firing, or the new
+    /// If the timer has already been fired, is firing, or the new
     /// timestamp is earlier than the old timestamp, (or occasionally
-    /// spuriously) returns Err without changing the timer's state. In this
+    /// spuriously), or the timer is in the overflow,
+    /// returns Err without changing the timer's state. In this
     /// case, the timer must be deregistered and re-registered.
     fn extend_expiration(&self, new_timestamp: u64) -> Result<(), ()> {
         let mut prior = self.state.load(Ordering::Relaxed);
@@ -447,6 +452,10 @@ impl TimerShared {
     pub(super) fn shard_id(&self) -> u32 {
         self.shard_id
     }
+
+    pub(super) fn is_overflow(&self) -> bool {
+        self.state.is_overflow()
+    }
 }
 
 unsafe impl linked_list::Link for TimerShared {
@@ -598,10 +607,6 @@ impl TimerHandle {
         unsafe { self.inner.as_ref().sync_when() }
     }
 
-    pub(super) unsafe fn is_pending(&self) -> bool {
-        unsafe { self.inner.as_ref().state.is_pending() }
-    }
-
     /// Forcibly sets the true and cached expiration times to the given tick.
     ///
     /// SAFETY: The caller must ensure that the handle remains valid, the driver
@@ -610,7 +615,7 @@ impl TimerHandle {
         self.inner.as_ref().set_expiration(tick);
     }
 
-    /// Attempts to mark this entry as pending. If the expiration time is after
+    /// Attempts to mark this entry as firing. If the expiration time is after
     /// `not_after`, however, returns an Err with the current expiration time.
     ///
     /// If an `Err` is returned, the `cached_when` value will be updated to this
@@ -618,11 +623,10 @@ impl TimerHandle {
     ///
     /// SAFETY: The caller must ensure that the handle remains valid, the driver
     /// lock is held, and that the timer is not in any wheel linked lists.
-    /// After returning Ok, the entry must be added to the pending list.
-    pub(super) unsafe fn mark_pending(&self, not_after: u64) -> Result<(), u64> {
-        match self.inner.as_ref().state.mark_pending(not_after) {
+    pub(super) unsafe fn mark_firing(&self, not_after: u64) -> Result<(), u64> {
+        match self.inner.as_ref().state.mark_firing(not_after) {
             Ok(()) => {
-                // mark this as being on the pending queue in cached_when
+                // mark this as being firing in cached_when
                 self.inner.as_ref().set_cached_when(u64::MAX);
                 Ok(())
             }
@@ -646,6 +650,14 @@ impl TimerHandle {
     /// the entry must not be in any wheel linked lists.
     pub(super) unsafe fn fire(self, completed_state: TimerResult) -> Option<Waker> {
         self.inner.as_ref().state.fire(completed_state)
+    }
+
+    /// Marks the entry is in wheel's overflow entry list.
+    /// SAFETY: The driver lock must be held while invoking this function, and
+    /// the entry must not be in any wheel linked lists,
+    /// and will be pushed into the overflow entry list.
+    pub(super) unsafe fn mark_overflow(&self) {
+        self.inner.as_ref().state.mark_overflow();
     }
 }
 

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -170,13 +170,6 @@ impl StateCell {
         // with relaxed ordering.
         let mut cur_state = self.state.load(Ordering::Relaxed);
         loop {
-            // This entry is in the `guarded_list`, so it can not be removed
-            // from the entry list with the same `level` and `slot`.
-            // Because its state is STATE_DEREGISTERED, it has been fired.
-            if cur_state == STATE_DEREGISTERED {
-                break Err(cur_state);
-            }
-
             // improve the error message for things like
             // https://github.com/tokio-rs/tokio/issues/3675
             assert!(

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -331,10 +331,8 @@ pub(crate) struct TimerShared {
     /// Only accessed under the entry lock.
     pointers: linked_list::Pointers<TimerShared>,
 
-    /// The expiration time for which this entry is currently registered.
-    /// Generally owned by the driver, but is accessed by the entry when not
-    /// registered.
-    cached_when: AtomicU64,
+    /// The last poll count of this entry.
+    last_poll_count: AtomicU64,
 
     /// Current state. This records whether the timer entry is currently under
     /// the ownership of the driver, and if not, its current state (not
@@ -350,7 +348,10 @@ unsafe impl Sync for TimerShared {}
 impl std::fmt::Debug for TimerShared {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TimerShared")
-            .field("cached_when", &self.cached_when.load(Ordering::Relaxed))
+            .field(
+                "last_poll_count",
+                &self.last_poll_count.load(Ordering::Relaxed),
+            )
             .field("state", &self.state)
             .finish()
     }
@@ -368,7 +369,7 @@ impl TimerShared {
     pub(super) fn new(shard_id: u32) -> Self {
         Self {
             shard_id,
-            cached_when: AtomicU64::new(0),
+            last_poll_count: AtomicU64::new(0),
             pointers: linked_list::Pointers::new(),
             state: StateCell::default(),
             _p: PhantomPinned,
@@ -376,30 +377,17 @@ impl TimerShared {
     }
 
     /// Gets the cached time-of-expiration value.
-    pub(super) fn cached_when(&self) -> u64 {
-        // Cached-when is only accessed under the driver lock, so we can use relaxed
-        self.cached_when.load(Ordering::Relaxed)
+    pub(super) fn last_poll_count(&self) -> u64 {
+        // This field is only accessed under the driver lock, so we can use relaxed.
+        self.last_poll_count.load(Ordering::Relaxed)
     }
 
-    /// Gets the true time-of-expiration value, and copies it into the cached
-    /// time-of-expiration value.
+    /// Sets the poll_count of this entry.
     ///
     /// SAFETY: Must be called with the driver lock held, and when this entry is
     /// not in any timer wheel lists.
-    pub(super) unsafe fn sync_when(&self) -> u64 {
-        let true_when = self.true_when();
-
-        self.cached_when.store(true_when, Ordering::Relaxed);
-
-        true_when
-    }
-
-    /// Sets the cached time-of-expiration value.
-    ///
-    /// SAFETY: Must be called with the driver lock held, and when this entry is
-    /// not in any timer wheel lists.
-    unsafe fn set_cached_when(&self, when: u64) {
-        self.cached_when.store(when, Ordering::Relaxed);
+    unsafe fn set_last_poll_count(&self, poll_count: u64) {
+        self.last_poll_count.store(poll_count, Ordering::Relaxed);
     }
 
     /// Returns the true time-of-expiration value, with relaxed memory ordering.
@@ -414,7 +402,6 @@ impl TimerShared {
     /// in the timer wheel.
     pub(super) unsafe fn set_expiration(&self, t: u64) {
         self.state.set_expiration(t);
-        self.cached_when.store(t, Ordering::Relaxed);
     }
 
     /// Sets the true time-of-expiration only if it is after the current.
@@ -584,12 +571,16 @@ impl TimerEntry {
 }
 
 impl TimerHandle {
-    pub(super) unsafe fn cached_when(&self) -> u64 {
-        unsafe { self.inner.as_ref().cached_when() }
+    pub(super) unsafe fn last_poll_count(&self) -> u64 {
+        unsafe { self.inner.as_ref().last_poll_count() }
     }
 
-    pub(super) unsafe fn sync_when(&self) -> u64 {
-        unsafe { self.inner.as_ref().sync_when() }
+    pub(super) unsafe fn set_last_poll_count(&self, poll_count: u64) {
+        unsafe { self.inner.as_ref().set_last_poll_count(poll_count) }
+    }
+
+    pub(super) unsafe fn true_when(&self) -> u64 {
+        unsafe { self.inner.as_ref().true_when() }
     }
 
     /// Forcibly sets the true and cached expiration times to the given tick.
@@ -609,17 +600,7 @@ impl TimerHandle {
     /// SAFETY: The caller must ensure that the handle remains valid, the driver
     /// lock is held, and that the timer is not in any wheel linked lists.
     pub(super) unsafe fn mark_firing(&self, not_after: u64) -> Result<(), u64> {
-        match self.inner.as_ref().state.mark_firing(not_after) {
-            Ok(()) => {
-                // mark this as being firing in cached_when
-                self.inner.as_ref().set_cached_when(u64::MAX);
-                Ok(())
-            }
-            Err(tick) => {
-                self.inner.as_ref().set_cached_when(tick);
-                Err(tick)
-            }
-        }
+        self.inner.as_ref().state.mark_firing(not_after)
     }
 
     /// Attempts to transition to a terminal state. If the state is already a

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -328,11 +328,6 @@ impl EntryList {
         self.list.push_front(val);
     }
 
-    pub(super) unsafe fn remove(&mut self, node: NonNull<TimerShared>) -> Option<TimerHandle> {
-        self.counter -= 1;
-        self.list.remove(node)
-    }
-
     pub(super) fn is_empty(&self) -> bool {
         self.counter == 0
     }

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -316,39 +316,8 @@ pub(crate) struct TimerHandle {
     inner: NonNull<TimerShared>,
 }
 
-#[derive(Debug, Default)]
-pub(super) struct EntryList {
-    count: usize,
-    list: crate::util::linked_list::LinkedList<TimerShared, TimerShared>,
-}
+pub(super) type EntryList = crate::util::linked_list::LinkedList<TimerShared, TimerShared>;
 
-impl EntryList {
-    pub(super) fn push_front(&mut self, node: TimerHandle) {
-        self.count += 1;
-        self.list.push_front(node);
-    }
-
-    pub(super) unsafe fn remove(&mut self, node: NonNull<TimerShared>) {
-        self.list.remove(node);
-        self.count -= 1;
-    }
-
-    pub(super) fn is_empty(&self) -> bool {
-        self.count == 0
-    }
-
-    pub(super) fn pop_back(&mut self) -> Option<TimerHandle> {
-        let node = self.list.pop_back();
-        if node.is_some() {
-            self.count -= 1;
-        }
-        node
-    }
-
-    pub(super) fn count(&self) -> usize {
-        self.count
-    }
-}
 /// The shared state structure of a timer. This structure is shared between the
 /// frontend (`Entry`) and driver backend.
 ///

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -8,7 +8,7 @@
 
 mod entry;
 pub(crate) use entry::TimerEntry;
-use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION};
+use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION, STATE_DEREGISTERED};
 
 mod handle;
 pub(crate) use self::handle::Handle;
@@ -362,9 +362,10 @@ impl Handle {
                             }
                         }
                     }
-                    Err(expiration_tick) => {
+                    Err(state) if state == STATE_DEREGISTERED => {}
+                    Err(state) => {
                         // Safety: This Entry has not expired.
-                        unsafe { lock.reinsert_entry(entry, deadline, expiration_tick) };
+                        unsafe { lock.reinsert_entry(entry, deadline, state) };
                     }
                 }
             }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -334,9 +334,6 @@ impl Handle {
             // they actually need to be dropped down a level. We then reinsert them
             // back into the same position; we must make sure we don't then process
             // those entries again or we'll end up in an infinite loop.
-
-            // This can also happens when other threads concurrently add entries to
-            // this currently traversing slot.
             let count = lock.get_entries_count(&expiration);
             for _ in 0..count {
                 if let Some(entry) = lock.get_mut_entries(&expiration).pop_back() {

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -294,108 +294,78 @@ impl Handle {
         self.process_at_time(start, now);
     }
 
-    pub(self) fn process_at_time(&self, start: u32, mut now: u64) {
+    pub(self) fn process_at_time(&self, start: u32, now: u64) {
         let shards = self.inner.get_shard_size();
 
         let expiration_time = (start..shards + start)
-            .filter_map(|id| {
-                let lock = self.inner.lock_sharded_wheel(id);
-                if now < lock.elapsed() {
-                    // Time went backwards! This normally shouldn't happen as the Rust language
-                    // guarantees that an Instant is monotonic, but can happen when running
-                    // Linux in a VM on a Windows host due to std incorrectly trusting the
-                    // hardware clock to be monotonic.
-                    //
-                    // See <https://github.com/tokio-rs/tokio/issues/3619> for more information.
-                    now = lock.elapsed();
-                }
-                drop(lock);
-                self.process_at_sharded_overflow(id, now);
-                self.process_at_sharded_levels(id, now)
-            })
+            .filter_map(|i| self.process_at_sharded_time(i, now))
             .min();
 
         self.inner.next_wake.store(next_wake_time(expiration_time));
     }
 
-    // Attempts to handle the entries in the overflow of this shard.
-    pub(self) fn process_at_sharded_overflow(&self, id: u32, now: u64) {
-        let mut lock = self.inner.lock_sharded_wheel(id);
-        if !lock.might_check_overflow(now) {
-            return;
-        }
-        // Note that we need to take _all_ of the entries off the overflwo list
-        // before processing any of them. This is important because it's possible
-        // that those entries might need to be reinserted into the same slot.
-        //
-        // This happens only on the overflow entry list, when an entry is inserted
-        // more than MAX_DURATION into the future. When this happens, we then reinsert
-        // them back into the same position; we must make sure we don't then process
-        // those entries again or we'll end up in an infinite loop.
-        let mut overflow = lock.take_overflow();
-        let mut waker_list = WakeList::new();
-        while let Some(entry) = overflow.pop_back() {
-            unsafe {
-                entry.set_expiration(entry.cached_when());
-                if let Err((entry, crate::time::error::InsertError::Elapsed)) = lock.insert(entry) {
-                    if let Some(waker) = entry.fire(Ok(())) {
-                        waker_list.push(waker);
-                    }
-                    if !waker_list.can_push() {
-                        // Wake a batch of wakers. To avoid deadlock,
-                        // we must do this with the lock temporarily dropped.
-                        drop(lock);
-                        waker_list.wake_all();
-
-                        lock = self.inner.lock_sharded_wheel(id);
-                    }
-                }
-            }
-        }
-
-        drop(lock);
-        waker_list.wake_all();
-    }
-
     // Returns the next wakeup time of this shard.
-    pub(self) fn process_at_sharded_levels(&self, id: u32, now: u64) -> Option<u64> {
+    pub(self) fn process_at_sharded_time(&self, id: u32, mut now: u64) -> Option<u64> {
         let mut waker_list = WakeList::new();
         let mut lock = self.inner.lock_sharded_wheel(id);
+
+        if now < lock.elapsed() {
+            // Time went backwards! This normally shouldn't happen as the Rust language
+            // guarantees that an Instant is monotonic, but can happen when running
+            // Linux in a VM on a Windows host due to std incorrectly trusting the
+            // hardware clock to be monotonic.
+            //
+            // See <https://github.com/tokio-rs/tokio/issues/3619> for more information.
+            now = lock.elapsed();
+        }
 
         while let Some(expiration) = lock.poll(now) {
-            while let Some(entry) = lock.get_mut_entries(&expiration).pop_back() {
-                // Try to expire the entry; this is cheap (doesn't synchronize) if
-                // the timer is not expired, and updates cached_when.
-                match unsafe { entry.mark_firing(expiration.deadline) } {
-                    Ok(()) => {
-                        // Entry was expired.
-                        // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
-                        if let Some(waker) = unsafe { entry.fire(Ok(())) } {
-                            waker_list.push(waker);
+            // Gets the number of entries in this slot, which will be
+            // the maximum number of times we traverse.
+            // Limiting the maximum number of iterations is very important,
+            // because it's possible that those entries might need to be
+            // reinserted into the same slot.
 
-                            if !waker_list.can_push() {
-                                // Wake a batch of wakers. To avoid deadlock,
-                                // we must do this with the lock temporarily dropped.
-                                drop(lock);
-                                waker_list.wake_all();
+            // This happens on the highest level, when an entry is inserted
+            // more than MAX_DURATION into the future. When this happens, we wrap
+            // around, and process some entries a multiple of MAX_DURATION before
+            // they actually need to be dropped down a level. We then reinsert them
+            // back into the same position; we must make sure we don't then process
+            // those entries again or we'll end up in an infinite loop.
 
-                                lock = self.inner.lock_sharded_wheel(id);
+            // This can also happens when other threads concurrently add entry to
+            // this currently traversing slot.
+            let count = lock.get_entries_count(&expiration);
+            for _ in 0..count {
+                if let Some(entry) = lock.get_mut_entries(&expiration).pop_back() {
+                    // Try to expire the entry; this is cheap (doesn't synchronize) if
+                    // the timer is not expired, and updates cached_when.
+                    match unsafe { entry.mark_firing(expiration.deadline) } {
+                        Ok(()) => {
+                            // Entry was expired.
+                            // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
+                            if let Some(waker) = unsafe { entry.fire(Ok(())) } {
+                                waker_list.push(waker);
+
+                                if !waker_list.can_push() {
+                                    // Wake a batch of wakers. To avoid deadlock,
+                                    // we must do this with the lock temporarily dropped.
+                                    drop(lock);
+                                    waker_list.wake_all();
+
+                                    lock = self.inner.lock_sharded_wheel(id);
+                                }
                             }
                         }
-                    }
-                    Err(expiration_tick) => {
-                        // If the Entry is extended to a overflow expiration,
-                        // then push it into the overflow entry list.
-                        if lock.is_overflow(expiration_tick) {
-                            lock.push_to_overflow(entry);
-                        } else {
+                        Err(expiration_tick) => {
                             lock.add_entry(entry, expiration.clone(), expiration_tick);
                         }
                     }
                 }
             }
-            // the slot is empty here
-            lock.mark_empty(&expiration);
+            lock.occupied_bit_maintain(&expiration);
+            // This slot maybe empty,
+            // lock.mark_empty(&expiration);
             lock.set_elapsed(expiration.deadline);
         }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -358,7 +358,7 @@ impl Handle {
                             }
                         }
                         Err(expiration_tick) => {
-                            lock.add_entry(entry, expiration.clone(), expiration_tick);
+                            lock.add_entry(entry, &expiration, expiration_tick);
                         }
                     }
                 }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -333,7 +333,7 @@ impl Handle {
             // back into the same position; we must make sure we don't then process
             // those entries again or we'll end up in an infinite loop.
 
-            // This can also happens when other threads concurrently add entry to
+            // This can also happens when other threads concurrently add entries to
             // this currently traversing slot.
             let count = lock.get_entries_count(&expiration);
             for _ in 0..count {
@@ -364,8 +364,6 @@ impl Handle {
                 }
             }
             lock.occupied_bit_maintain(&expiration);
-            // This slot maybe empty,
-            // lock.mark_empty(&expiration);
             lock.set_elapsed(expiration.deadline);
         }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -8,7 +8,7 @@
 
 mod entry;
 pub(crate) use entry::TimerEntry;
-use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION, STATE_DEREGISTERED};
+use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION};
 
 mod handle;
 pub(crate) use self::handle::Handle;
@@ -342,7 +342,7 @@ impl Handle {
                 match unsafe { entry.mark_firing(deadline) } {
                     Ok(()) => {
                         // Entry was expired.
-                        // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
+                        // SAFETY: We hold the driver lock, andcargo test --doc --workspace --all-features just removed the entry from any linked lists.
                         if let Some(waker) = unsafe { entry.fire(Ok(())) } {
                             waker_list.push(waker);
 
@@ -356,7 +356,6 @@ impl Handle {
                             }
                         }
                     }
-                    Err(state) if state == STATE_DEREGISTERED => {}
                     Err(state) => {
                         // Safety: This Entry has not expired.
                         unsafe { lock.reinsert_entry(entry, deadline, state) };

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -8,7 +8,7 @@
 
 mod entry;
 pub(crate) use entry::TimerEntry;
-use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION};
+use entry::{EntryList, TimerHandle, TimerShared, MAX_SAFE_MILLIS_DURATION, STATE_DEREGISTERED};
 
 mod handle;
 pub(crate) use self::handle::Handle;
@@ -342,7 +342,7 @@ impl Handle {
                 match unsafe { entry.mark_firing(deadline) } {
                     Ok(()) => {
                         // Entry was expired.
-                        // SAFETY: We hold the driver lock, andcargo test --doc --workspace --all-features just removed the entry from any linked lists.
+                        // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
                         if let Some(waker) = unsafe { entry.fire(Ok(())) } {
                             waker_list.push(waker);
 
@@ -356,6 +356,7 @@ impl Handle {
                             }
                         }
                     }
+                    Err(state) if state == STATE_DEREGISTERED => {}
                     Err(state) => {
                         // Safety: This Entry has not expired.
                         unsafe { lock.reinsert_entry(entry, deadline, state) };

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -320,6 +320,8 @@ impl Handle {
         }
 
         while let Some(expiration) = lock.poll(now) {
+            lock.set_elapsed(expiration.deadline);
+
             // Gets the number of entries in this slot, which will be
             // the maximum number of times we traverse.
             // Limiting the maximum number of iterations is very important,
@@ -364,7 +366,6 @@ impl Handle {
                 }
             }
             lock.occupied_bit_maintain(&expiration);
-            lock.set_elapsed(expiration.deadline);
         }
 
         let next_wake_up = lock.poll_at();

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -334,7 +334,7 @@ impl Handle {
             // they actually need to be dropped down a level. We then reinsert them
             // back into the same position; we must make sure we don't then process
             // those entries again or we'll end up in an infinite loop.
-            let mut max_traversals = if expiration.level == wheel::MAX_LEVEL_INDEX{
+            let mut max_traversals = if expiration.level == wheel::MAX_LEVEL_INDEX {
                 lock.highest_level_counter(expiration.slot)
             } else {
                 usize::MAX

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -121,7 +121,7 @@ impl Level {
     pub(crate) unsafe fn add_entry(&mut self, item: TimerHandle) {
         let slot = slot_for(item.true_when(), self.level);
 
-        self.slot[slot].push_front(item.inner);
+        self.slot[slot].push_front(item.inner());
 
         self.occupied |= occupied_bit(slot);
     }

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -20,7 +20,6 @@ pub(crate) struct Level {
 }
 
 /// Indicates when a slot must be processed next.
-#[derive(Debug, Clone)]
 pub(crate) struct Expiration {
     /// The level containing the slot.
     pub(crate) level: usize,

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -34,7 +34,7 @@ pub(crate) struct Expiration {
 /// Level multiplier.
 ///
 /// Being a power of 2 is very important.
-pub(super) const LEVEL_MULT: usize = 64;
+const LEVEL_MULT: usize = 64;
 
 impl Level {
     pub(crate) fn new(level: usize) -> Level {

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -130,7 +130,6 @@ impl Level {
     pub(crate) unsafe fn remove_entry(&mut self, item: NonNull<TimerShared>) {
         let slot = slot_for(unsafe { item.as_ref().cached_when() }, self.level);
 
-        unsafe { self.slot[slot].remove(item) };
         if self.slot[slot].is_empty() {
             // The bit is currently set
             debug_assert!(self.occupied & occupied_bit(slot) != 0);
@@ -140,15 +139,15 @@ impl Level {
         }
     }
 
-    pub(crate) fn get_entries_count(&self, slot: usize) -> usize {
+    pub(super) fn get_entries_count(&self, slot: usize) -> usize {
         self.slot[slot].count()
     }
 
-    pub(crate) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {
+    pub(super) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {
         &mut self.slot[slot]
     }
 
-    pub(crate) fn occupied_bit_maintain(&mut self, slot: usize) {
+    pub(super) fn occupied_bit_maintain(&mut self, slot: usize) {
         if self.slot[slot].is_empty() {
             self.occupied &= !occupied_bit(slot);
         } else {

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -20,7 +20,7 @@ pub(crate) struct Level {
 }
 
 /// Indicates when a slot must be processed next.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Expiration {
     /// The level containing the slot.
     pub(crate) level: usize,
@@ -140,10 +140,15 @@ impl Level {
         }
     }
 
-    pub(crate) fn take_slot(&mut self, slot: usize) -> EntryList {
-        self.occupied &= !occupied_bit(slot);
+    pub(crate) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {
+        &mut self.slot[slot]
+    }
 
-        std::mem::take(&mut self.slot[slot])
+    // Marks the slot empty. The caller must ensure all
+    // entries in the slot have been popped out.
+    pub(crate) fn mark_empty(&mut self, slot: usize) {
+        debug_assert!(self.slot[slot].is_empty());
+        self.occupied &= !occupied_bit(slot);
     }
 }
 

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -130,6 +130,7 @@ impl Level {
     pub(crate) unsafe fn remove_entry(&mut self, item: NonNull<TimerShared>) {
         let slot = slot_for(unsafe { item.as_ref().cached_when() }, self.level);
 
+        unsafe { self.slot[slot].remove(item) };
         if self.slot[slot].is_empty() {
             // The bit is currently set
             debug_assert!(self.occupied & occupied_bit(slot) != 0);

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -140,15 +140,20 @@ impl Level {
         }
     }
 
+    pub(crate) fn get_entries_count(&self, slot: usize) -> usize {
+        self.slot[slot].count()
+    }
+
     pub(crate) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {
         &mut self.slot[slot]
     }
 
-    // Marks the slot empty. The caller must ensure all
-    // entries in the slot have been popped out.
-    pub(crate) fn mark_empty(&mut self, slot: usize) {
-        debug_assert!(self.slot[slot].is_empty());
-        self.occupied &= !occupied_bit(slot);
+    pub(crate) fn occupied_bit_maintain(&mut self, slot: usize) {
+        if self.slot[slot].is_empty() {
+            self.occupied &= !occupied_bit(slot);
+        } else {
+            self.occupied |= occupied_bit(slot);
+        }
     }
 }
 

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -118,18 +118,16 @@ impl Level {
         Some(slot)
     }
 
-    pub(crate) unsafe fn add_entry(&mut self, item: TimerHandle) -> usize {
-        let slot = slot_for(item.cached_when(), self.level);
+    pub(crate) unsafe fn add_entry(&mut self, item: TimerHandle) {
+        let slot = slot_for(item.true_when(), self.level);
 
         self.slot[slot].push_front(item);
 
         self.occupied |= occupied_bit(slot);
-
-        slot
     }
 
-    pub(crate) unsafe fn remove_entry(&mut self, item: NonNull<TimerShared>) -> usize {
-        let slot = slot_for(unsafe { item.as_ref().cached_when() }, self.level);
+    pub(crate) unsafe fn remove_entry(&mut self, item: NonNull<TimerShared>) {
+        let slot = slot_for(unsafe { item.as_ref().true_when() }, self.level);
 
         unsafe { self.slot[slot].remove(item) };
         if self.slot[slot].is_empty() {
@@ -139,7 +137,6 @@ impl Level {
             // Unset the bit
             self.occupied ^= occupied_bit(slot);
         }
-        slot
     }
 
     pub(super) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -121,7 +121,7 @@ impl Level {
     pub(crate) unsafe fn add_entry(&mut self, item: TimerHandle) {
         let slot = slot_for(item.true_when(), self.level);
 
-        self.slot[slot].push_front(item);
+        self.slot[slot].push_front(item.inner);
 
         self.occupied |= occupied_bit(slot);
     }
@@ -131,16 +131,13 @@ impl Level {
 
         unsafe { self.slot[slot].remove(item) };
         if self.slot[slot].is_empty() {
-            // The bit is currently set
-            debug_assert!(self.occupied & occupied_bit(slot) != 0);
-
             // Unset the bit
             self.occupied ^= occupied_bit(slot);
         }
     }
 
-    pub(super) fn get_mut_entries(&mut self, slot: usize) -> &mut EntryList {
-        &mut self.slot[slot]
+    pub(super) fn take_slot(&mut self, slot: usize) -> EntryList {
+        std::mem::take(&mut self.slot[slot])
     }
 
     pub(super) fn occupied_bit_maintain(&mut self, slot: usize) {

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -121,7 +121,7 @@ impl Level {
     pub(crate) unsafe fn add_entry(&mut self, item: TimerHandle) {
         let slot = slot_for(item.true_when(), self.level);
 
-        self.slot[slot].push_front(item.inner());
+        self.slot[slot].push_front(item);
 
         self.occupied |= occupied_bit(slot);
     }

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -41,7 +41,7 @@ pub(crate) struct Wheel {
 /// Number of levels. Each level has 64 slots. By using 6 levels with 64 slots
 /// each, the timer is able to track time up to 2 years into the future with a
 /// precision of 1 millisecond.
-pub(super) const NUM_LEVELS: usize = 6;
+const NUM_LEVELS: usize = 6;
 
 /// The max level index.
 pub(super) const MAX_LEVEL_INDEX: usize = NUM_LEVELS - 1;

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -187,7 +187,7 @@ impl Wheel {
     pub(super) fn add_entry(
         &mut self,
         entry: TimerHandle,
-        expiration: Expiration,
+        expiration: &Expiration,
         expiration_tick: u64,
     ) {
         let level = level_for(expiration.deadline, expiration_tick);

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -150,7 +150,7 @@ impl Wheel {
         let wake_up = self.next_expiration().map(|expiration| expiration.deadline);
         min_option(wake_up, self.overflow_when)
     }
-    /// Pushs the entry into overflow.
+    /// Pushes the entry into overflow.
     pub(super) fn push_to_overflow(&mut self, entry: TimerHandle) {
         unsafe {
             entry.mark_overflow();

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -7,6 +7,7 @@ use self::level::Level;
 
 use std::{array, ptr::NonNull};
 
+use super::entry::MAX_SAFE_MILLIS_DURATION;
 use super::EntryList;
 
 /// Timing wheel implementation.
@@ -114,7 +115,7 @@ impl Wheel {
     pub(crate) unsafe fn remove(&mut self, item: NonNull<TimerShared>) {
         unsafe {
             let when = item.as_ref().true_when();
-            if when != u64::MAX {
+            if when <= MAX_SAFE_MILLIS_DURATION {
                 debug_assert!(
                     self.elapsed <= when,
                     "elapsed={}; when={}",

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -123,13 +123,16 @@ impl Wheel {
                 );
 
                 let level = self.level_for(when);
+                // If the entry is not contained in the `slot` list,
+                // then it is contained by a guarded list.
                 self.levels[level].remove_entry(item);
             }
         }
     }
 
     /// Reinserts `item` to the timing wheel.
-    pub(super) fn reinsert_entry(&mut self, entry: TimerHandle, elapsed: u64, when: u64) {
+    /// Safety: This entry must not have expired.
+    pub(super) unsafe fn reinsert_entry(&mut self, entry: TimerHandle, elapsed: u64, when: u64) {
         let level = level_for(elapsed, when);
         unsafe { self.levels[level].add_entry(entry) };
     }

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -334,6 +334,7 @@ feature! {
         feature = "sync",
         feature = "rt",
         feature = "signal",
+        feature = "time",
     )]
 
     /// An intrusive linked list, but instead of keeping pointers to the head


### PR DESCRIPTION
## Motivation

Currently we use a pending linked list to temporarily store the timer entry to be fired. 

If there are a large number of timers that need to be waken at once, then there will be a cache miss issue here.


## Solution

For synchronizing the state between threads, when we want to modify the state of entries in wheel, we must hold the lock of wheel. However, when we hold a lock, in order to avoid the deadlock issue, we are not allowed wake the walker of entries.

Furthermore, to avoid the issue of the infinite loop, we need to take all of the entries off the slot before processing any of them. And, throughout this process, we always hold the lock.

The main reasons for using a `pending` linked list currently mentioned above.

In addition to supporting random deletion, `slot` linked list only have FIFO `insert_head` and `pop_back`. Given this, if a counter is introduced for each slot, the maximum number of `pop_back`s can be determined before traversing the slot, which solves the issue of the infinite loop.

Furthermore, by solving the infinite loop issue, we no longer need to take all of the entries off the slot before processing any of them. Finally, in this PR, we removed the `pending` linked list.

Expected benefits are as follows

- Since there is no need to traverse the linked list twice, the wake-up time will be reduced.
- Since there is no need to process all entries in the linked list after locking, the lock contention of time wheel will be reduced.