### PR TITLE
docs: fix docsrs builds with the fs feature enabled

### DIFF
--- a/tokio/src/doc/mod.rs
+++ b/tokio/src/doc/mod.rs
@@ -43,5 +43,5 @@ impl mio::event::Source for NotDefinedHere {
     }
 }
 
-#[cfg(feature = "net")]
+#[cfg(any(feature = "net", feature = "fs"))]
 pub mod os;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -630,7 +630,7 @@ pub mod stream {}
 #[cfg(docsrs)]
 pub mod doc;
 
-#[cfg(feature = "net")]
+#[cfg(any(feature = "net", feature = "fs"))]
 #[cfg(docsrs)]
 #[allow(unused)]
 pub(crate) use self::doc::os;


### PR DESCRIPTION
If you enable `--cfg docsrs` with the `fs` feature but without the `net` feature, [tokio docs doesn't docbuild](https://github.com/rune-rs/rune/actions/runs/9225256293/job/25382370737?pr=709).

The `docs::os` module need to be defined if the `fs` feature is enabled since [it's used here](https://github.com/tokio-rs/tokio/blob/cba86cf1b1edea8cd131f168a99953e6e35739d2/tokio/src/fs/file.rs#L913).

I genuinely have no idea if this interferes with #6166 or any of those related issues. Some tests would be nice, but I'm not sure if we want to set them up. Testing feature combinations for the sole benefit of dependent `docsrs` builds seems awkward. We might just prefer having these always being exported with `#[allow(unused)]` to avoid future regressions.