### PR TITLE
Derive common traits for NamedPipeInfo struct

### DIFF
--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -2626,7 +2626,7 @@ pub enum PipeEnd {
 /// Information about a named pipe.
 ///
 /// Constructed through [`NamedPipeServer::info`] or [`NamedPipeClient::info`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct PipeInfo {
     /// Indicates the mode of a named pipe.

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -2626,7 +2626,7 @@ pub enum PipeEnd {
 /// Information about a named pipe.
 ///
 /// Constructed through [`NamedPipeServer::info`] or [`NamedPipeClient::info`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub struct PipeInfo {
     /// Indicates the mode of a named pipe.


### PR DESCRIPTION
## Motivation

I would like to use windows named pipes as the transport for GRPC with tonic. That requires that the transport implement [Connected](https://docs.rs/tonic/latest/tonic/transport/server/trait.Connected.html), which requires the info struct implement Clone. While a wrapper struct could be used, NamedPipeInfo doesn't seem to have any particular reason not to implement Clone directly.


## Solution

Add Clone (And a few other useful traits already derived on the members of NamedPipeInfo) to the derive macro.

