### PR TITLE
Fix misleading NamedPipeServer example

### DIFF
--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -75,7 +75,8 @@ use self::doc::*;
 /// let server = tokio::spawn(async move {
 ///     loop {
 ///         // Wait for a client to connect.
-///         let connected = server.connect().await?;
+///         server.connect().await?;
+///         let connected_client = server;
 ///
 ///         // Construct the next server to be connected before sending the one
 ///         // we already have of onto a task. This ensures that the server


### PR DESCRIPTION
## Motivation

The previous NamedPipeServer doc example seemed to imply that the return type of `NamedPipeServer::connect()` was a `Future<Result<some_kind_of_client>>>`, however, `connect()` returns a `Future<Result<()>>>`. The following line of code reopening the pipe would shadow the newly connected pipe immediately, making the following spawned task pointless.


## Solution

Instead, now it binds the original named pipe to a new variable after a client connects, allowing for the subsequent task to be able use the connection.

