### PR TITLE
runtime: move the task out of the lifo_slot in block_in_place

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -401,8 +401,8 @@ where
         };
 
         // If we heavily call `spawn_blocking`, there might be no available thread to
-        // run this core. Expect the task in the lifo_slot, all tasks in cores can be
-        // stolen, so we move the task ouf of the lifo_slot to the run_queue.
+        // run this core. Except for the task in the lifo_slot, all tasks can be
+        // stolen, so we move the task out of the lifo_slot to the run_queue.
         if let Some(task) = core.lifo_slot.take() {
             core.run_queue
                 .push_back_or_overflow(task, &*cx.worker.handle, &mut core.stats);

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -395,10 +395,18 @@ where
         let cx = maybe_cx.expect("no .is_some() == false cases above should lead here");
 
         // Get the worker core. If none is set, then blocking is fine!
-        let core = match cx.core.borrow_mut().take() {
+        let mut core = match cx.core.borrow_mut().take() {
             Some(core) => core,
             None => return Ok(()),
         };
+
+        // If we heavily call `spawn_blocking`, there might be no available thread to
+        // run this core. Expect the task in the lifo_slot, all tasks in cores can be
+        // stolen, so we move the task ouf of the lifo_slot to the run_queue.
+        if let Some(task) = core.lifo_slot.take() {
+            core.run_queue
+                .push_back_or_overflow(task, &*cx.worker.handle, &mut core.stats);
+        }
 
         // We are taking the core from the context and sending it to another
         // thread.


### PR DESCRIPTION
If we heavily call the `spawn_blocking`, there might be no available thread to run the current core. Except the task in the lifo_slot, all tasks in cores can be stolen, so we move the task from the lifo_slot to the run_queue before calling the `spawn_blocking` in the `block_in_place`.

This can prevent the starvation of the task in `lifo_slot` in edge cases.