### PR TITLE
chore: prepare Tokio v1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,101 @@
+# 1.38.0 (May 30th, 2024)
+
+This release marks the beginning of stabilization for runtime metrics. It
+stabilizes `RuntimeMetrics::worker_count`. Future releases will continue to
+stabilize more metrics.
+
+### Added
+
+- fs: add `File::create_new` ([#6573])
+- io: add `copy_bidirectional_with_sizes` ([#6500])
+- io: implement `AsyncBufRead` for `Join` ([#6449])
+- net: add Apple visionOS support ([#6465])
+- net: implement `Clone` for `NamedPipeInfo` ([#6586])
+- net: support QNX OS ([#6421])
+- sync: add `Notify::notify_last` ([#6520])
+- sync: add `mpsc::Receiver::{capacity,max_capacity}` ([#6511])
+- sync: add `split` method to the semaphore permit ([#6472], [#6478])
+- task: add `tokio::task::join_set::Builder::spawn_blocking` ([#6578])
+- wasm: support rt-multi-thread with wasm32-wasi-preview1-threads ([#6510])
+
+### Changed
+
+- macros: make `#[tokio::test]` append `#[test]` at the end of the attribute list ([#6497])
+- metrics: fix `blocking_threads` count ([#6551])
+- metrics: stabilize `RuntimeMetrics::worker_count` ([#6556])
+- runtime: move task out of the `lifo_slot` in `block_in_place` ([#6596])
+- runtime: panic if `global_queue_interval` is zero ([#6445])
+- sync: always drop message in destructor for oneshot receiver ([#6558])
+- sync: instrument `Semaphore` for task dumps ([#6499])
+- sync: use FIFO ordering when waking batches of wakers ([#6521])
+- task: make `LocalKey::get` work with Clone types ([#6433])
+- tests: update nix and mio-aio dev-dependencies ([#6552])
+- time: clean up implementation ([#6517])
+- time: lazily init timers on first poll ([#6512])
+- time: remove the `true_when` field in `TimerShared` ([#6563])
+- time: use sharding for timer implementation ([#6534])
+
+### Fixed
+
+- taskdump: allow building taskdump docs on non-unix machines ([#6564])
+- time: check for overflow in `Interval::poll_tick` ([#6487])
+
+### Documented
+
+- fs: rewrite file system docs ([#6467])
+- io: fix `stdin` documentation ([#6581])
+- io: fix obsolete reference in `ReadHalf::unsplit()` documentation ([#6498])
+- macros: render more comprehensible documentation for `select!` ([#6468])
+- net: add missing types to module docs ([#6482])
+- net: fix misleading `NamedPipeServer` example ([#6590])
+- sync: add examples for `SemaphorePermit`, `OwnedSemaphorePermit` ([#6477])
+- sync: document that `Barrier::wait` is not cancel safe ([#6494])
+- sync: explain relation between `watch::Sender::{subscribe,closed}` ([#6490])
+- task: clarify that you can't abort `spawn_blocking` tasks ([#6571])
+- task: fix a typo in doc of `LocalSet::run_until` ([#6599])
+- time: fix test-util requirement for pause and resume in docs ([#6503])
+
+[#6421]: https://github.com/tokio-rs/tokio/pull/6421
+[#6433]: https://github.com/tokio-rs/tokio/pull/6433
+[#6445]: https://github.com/tokio-rs/tokio/pull/6445
+[#6449]: https://github.com/tokio-rs/tokio/pull/6449
+[#6465]: https://github.com/tokio-rs/tokio/pull/6465
+[#6467]: https://github.com/tokio-rs/tokio/pull/6467
+[#6468]: https://github.com/tokio-rs/tokio/pull/6468
+[#6472]: https://github.com/tokio-rs/tokio/pull/6472
+[#6477]: https://github.com/tokio-rs/tokio/pull/6477
+[#6478]: https://github.com/tokio-rs/tokio/pull/6478
+[#6482]: https://github.com/tokio-rs/tokio/pull/6482
+[#6487]: https://github.com/tokio-rs/tokio/pull/6487
+[#6490]: https://github.com/tokio-rs/tokio/pull/6490
+[#6494]: https://github.com/tokio-rs/tokio/pull/6494
+[#6497]: https://github.com/tokio-rs/tokio/pull/6497
+[#6498]: https://github.com/tokio-rs/tokio/pull/6498
+[#6499]: https://github.com/tokio-rs/tokio/pull/6499
+[#6500]: https://github.com/tokio-rs/tokio/pull/6500
+[#6503]: https://github.com/tokio-rs/tokio/pull/6503
+[#6510]: https://github.com/tokio-rs/tokio/pull/6510
+[#6511]: https://github.com/tokio-rs/tokio/pull/6511
+[#6512]: https://github.com/tokio-rs/tokio/pull/6512
+[#6517]: https://github.com/tokio-rs/tokio/pull/6517
+[#6520]: https://github.com/tokio-rs/tokio/pull/6520
+[#6521]: https://github.com/tokio-rs/tokio/pull/6521
+[#6534]: https://github.com/tokio-rs/tokio/pull/6534
+[#6551]: https://github.com/tokio-rs/tokio/pull/6551
+[#6552]: https://github.com/tokio-rs/tokio/pull/6552
+[#6556]: https://github.com/tokio-rs/tokio/pull/6556
+[#6558]: https://github.com/tokio-rs/tokio/pull/6558
+[#6563]: https://github.com/tokio-rs/tokio/pull/6563
+[#6564]: https://github.com/tokio-rs/tokio/pull/6564
+[#6571]: https://github.com/tokio-rs/tokio/pull/6571
+[#6573]: https://github.com/tokio-rs/tokio/pull/6573
+[#6578]: https://github.com/tokio-rs/tokio/pull/6578
+[#6581]: https://github.com/tokio-rs/tokio/pull/6581
+[#6586]: https://github.com/tokio-rs/tokio/pull/6586
+[#6590]: https://github.com/tokio-rs/tokio/pull/6590
+[#6596]: https://github.com/tokio-rs/tokio/pull/6596
+[#6599]: https://github.com/tokio-rs/tokio/pull/6599
+
 # 1.37.0 (March 28th, 2024)
 
 ### Added

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -39,6 +39,7 @@ stabilize more metrics.
 
 - taskdump: allow building taskdump docs on non-unix machines ([#6564])
 - time: check for overflow in `Interval::poll_tick` ([#6487])
+- sync: fix incorrect `is_empty` on mpsc block boundaries ([#6603])
 
 ### Documented
 
@@ -95,6 +96,7 @@ stabilize more metrics.
 [#6590]: https://github.com/tokio-rs/tokio/pull/6590
 [#6596]: https://github.com/tokio-rs/tokio/pull/6596
 [#6599]: https://github.com/tokio-rs/tokio/pull/6599
+[#6603]: https://github.com/tokio-rs/tokio/pull/6603
 
 # 1.37.0 (March 28th, 2024)
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.37.0"
+version = "1.38.0"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.37.0", features = ["full"] }
+tokio = { version = "1.38.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.38.0 (May 30th, 2024)

This release marks the beginning of stabilization for runtime metrics. It
stabilizes `RuntimeMetrics::worker_count`. Future releases will continue to
stabilize more metrics.

### Added

- fs: add `File::create_new` ([#6573])
- io: add `copy_bidirectional_with_sizes` ([#6500])
- io: implement `AsyncBufRead` for `Join` ([#6449])
- net: add Apple visionOS support ([#6465])
- net: implement `Clone` for `NamedPipeInfo` ([#6586])
- net: support QNX OS ([#6421])
- sync: add `Notify::notify_last` ([#6520])
- sync: add `mpsc::Receiver::{capacity,max_capacity}` ([#6511])
- sync: add `split` method to the semaphore permit ([#6472], [#6478])
- task: add `tokio::task::join_set::Builder::spawn_blocking` ([#6578])
- wasm: support rt-multi-thread with wasm32-wasi-preview1-threads ([#6510])

### Changed

- macros: make `#[tokio::test]` append `#[test]` at the end of the attribute list ([#6497])
- metrics: fix `blocking_threads` count ([#6551])
- metrics: stabilize `RuntimeMetrics::worker_count` ([#6556])
- runtime: move task out of the `lifo_slot` in `block_in_place` ([#6596])
- runtime: panic if `global_queue_interval` is zero ([#6445])
- sync: always drop message in destructor for oneshot receiver ([#6558])
- sync: instrument `Semaphore` for task dumps ([#6499])
- sync: use FIFO ordering when waking batches of wakers ([#6521])
- task: make `LocalKey::get` work with Clone types ([#6433])
- tests: update nix and mio-aio dev-dependencies ([#6552])
- time: clean up implementation ([#6517])
- time: lazily init timers on first poll ([#6512])
- time: remove the `true_when` field in `TimerShared` ([#6563])
- time: use sharding for timer implementation ([#6534])

### Fixed

- taskdump: allow building taskdump docs on non-unix machines ([#6564])
- time: check for overflow in `Interval::poll_tick` ([#6487])
- sync: fix incorrect `is_empty` on mpsc block boundaries ([#6603])

### Documented

- fs: rewrite file system docs ([#6467])
- io: fix `stdin` documentation ([#6581])
- io: fix obsolete reference in `ReadHalf::unsplit()` documentation ([#6498])
- macros: render more comprehensible documentation for `select!` ([#6468])
- net: add missing types to module docs ([#6482])
- net: fix misleading `NamedPipeServer` example ([#6590])
- sync: add examples for `SemaphorePermit`, `OwnedSemaphorePermit` ([#6477])
- sync: document that `Barrier::wait` is not cancel safe ([#6494])
- sync: explain relation between `watch::Sender::{subscribe,closed}` ([#6490])
- task: clarify that you can't abort `spawn_blocking` tasks ([#6571])
- task: fix a typo in doc of `LocalSet::run_until` ([#6599])
- time: fix test-util requirement for pause and resume in docs ([#6503])

[#6421]: https://github.com/tokio-rs/tokio/pull/6421
[#6433]: https://github.com/tokio-rs/tokio/pull/6433
[#6445]: https://github.com/tokio-rs/tokio/pull/6445
[#6449]: https://github.com/tokio-rs/tokio/pull/6449
[#6465]: https://github.com/tokio-rs/tokio/pull/6465
[#6467]: https://github.com/tokio-rs/tokio/pull/6467
[#6468]: https://github.com/tokio-rs/tokio/pull/6468
[#6472]: https://github.com/tokio-rs/tokio/pull/6472
[#6477]: https://github.com/tokio-rs/tokio/pull/6477
[#6478]: https://github.com/tokio-rs/tokio/pull/6478
[#6482]: https://github.com/tokio-rs/tokio/pull/6482
[#6487]: https://github.com/tokio-rs/tokio/pull/6487
[#6490]: https://github.com/tokio-rs/tokio/pull/6490
[#6494]: https://github.com/tokio-rs/tokio/pull/6494
[#6497]: https://github.com/tokio-rs/tokio/pull/6497
[#6498]: https://github.com/tokio-rs/tokio/pull/6498
[#6499]: https://github.com/tokio-rs/tokio/pull/6499
[#6500]: https://github.com/tokio-rs/tokio/pull/6500
[#6503]: https://github.com/tokio-rs/tokio/pull/6503
[#6510]: https://github.com/tokio-rs/tokio/pull/6510
[#6511]: https://github.com/tokio-rs/tokio/pull/6511
[#6512]: https://github.com/tokio-rs/tokio/pull/6512
[#6517]: https://github.com/tokio-rs/tokio/pull/6517
[#6520]: https://github.com/tokio-rs/tokio/pull/6520
[#6521]: https://github.com/tokio-rs/tokio/pull/6521
[#6534]: https://github.com/tokio-rs/tokio/pull/6534
[#6551]: https://github.com/tokio-rs/tokio/pull/6551
[#6552]: https://github.com/tokio-rs/tokio/pull/6552
[#6556]: https://github.com/tokio-rs/tokio/pull/6556
[#6558]: https://github.com/tokio-rs/tokio/pull/6558
[#6563]: https://github.com/tokio-rs/tokio/pull/6563
[#6564]: https://github.com/tokio-rs/tokio/pull/6564
[#6571]: https://github.com/tokio-rs/tokio/pull/6571
[#6573]: https://github.com/tokio-rs/tokio/pull/6573
[#6578]: https://github.com/tokio-rs/tokio/pull/6578
[#6581]: https://github.com/tokio-rs/tokio/pull/6581
[#6586]: https://github.com/tokio-rs/tokio/pull/6586
[#6590]: https://github.com/tokio-rs/tokio/pull/6590
[#6596]: https://github.com/tokio-rs/tokio/pull/6596
[#6599]: https://github.com/tokio-rs/tokio/pull/6599
[#6603]: https://github.com/tokio-rs/tokio/pull/6603