### PR TITLE
test: make `Spawn` forward `size_hint`

### DIFF
--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -148,6 +148,10 @@ impl<T: Stream> Stream for Spawn<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.future.as_mut().poll_next(cx)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.future.size_hint()
+    }
 }
 
 impl MockTask {

--- a/tokio-test/tests/task.rs
+++ b/tokio-test/tests/task.rs
@@ -1,0 +1,25 @@
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio_stream::Stream;
+use tokio_test::task;
+
+/// A [`Stream`] that has a stub size hint.
+struct SizedStream;
+
+impl Stream for SizedStream {
+    type Item = ();
+
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        Poll::Pending
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (100, Some(200))
+    }
+}
+
+#[test]
+fn test_spawn_stream_size_hint() {
+    let spawn = task::spawn(SizedStream);
+    assert_eq!(spawn.size_hint(), (100, Some(200)));
+}


### PR DESCRIPTION
## Motivation

I have a need to use `Spawn` in conjunction with a `Stream` impl that has a custom `size_hint`, and need to assert on this size hint.

Currently the size hint of the wrapped stream can be accessed via `Deref`, but not by accessing the `Stream` impl on `Spawn` itself (it instead returns the default value of `(0, None)`), which is confusing.

## Solution

To reduce confusion this pull request adds a `size_hint` override in the `Stream` impl for `Spawn`. This override forwards the `size_hint` invocation to the wrapped stream, allowing its size hint to be accessed directly instead of having it replaced with the default value. A test was added to validate the behavior.