### PR TITLE
Added method as_std_mut to tokio::process::Command

### DIFF
--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -120,7 +120,7 @@ pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
 /// [`File`]: tokio::fs::File
 /// [vectored writes]: tokio::io::AsyncWrite::poll_write_vectored
 #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
-pub fn poll_write_buf<T: AsyncWrite, B: Buf>(
+pub fn poll_write_buf<T: AsyncWrite + ?Sized, B: Buf>(
     io: Pin<&mut T>,
     cx: &mut Context<'_>,
     buf: &mut B,

--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -46,7 +46,7 @@ use std::task::{Context, Poll};
 /// # }
 /// ```
 #[cfg_attr(not(feature = "io"), allow(unreachable_pub))]
-pub fn poll_read_buf<T: AsyncRead, B: BufMut>(
+pub fn poll_read_buf<T: AsyncRead + ?Sized, B: BufMut>(
     io: Pin<&mut T>,
     cx: &mut Context<'_>,
     buf: &mut B,

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -325,6 +325,12 @@ impl Command {
         &self.std
     }
 
+    /// Cheaply convert to a `&mut std::process::Command` for places where the type from the
+    /// standard library is expected.
+    pub fn as_std_mut(&mut self) -> &mut StdCommand {
+        &mut self.std
+    }
+
     /// Adds an argument to pass to the program.
     ///
     /// Only one argument can be passed per use. So instead of:


### PR DESCRIPTION
## Motivation
Citing from #6523:
> Sometimes I want to access a mutable reference of std::process::Command out of the tokio counterpart, so I can access some unstable functions in std to update Command, but tokio only provides an as_std method returning a shared reference.

## Solution
I added a method `as_std_mut(&mut self) -> &mut std::process::Command` to `tokio::process::Command` to get mutable access to the inner std command structure.

This closes #6523 