### PR TITLE
Update FreeBSD CI environment

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 only_if: $CIRRUS_TAG == '' && ($CIRRUS_PR != '' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH =~ 'tokio-.*')
 auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
-  image_family: freebsd-14-0
+  image_family: freebsd-14-1
 env:
   RUST_STABLE: stable
   RUST_NIGHTLY: nightly-2024-05-05


### PR DESCRIPTION
Use the newly released FreeBSD 14.1.

## Motivation

FreeBSD 14.0 will soon be EoL.

## Solution

Use 14.1 in CI.