### PR TITLE
Implement Clone for AbortHandle

### DIFF
--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -102,3 +102,11 @@ impl Drop for AbortHandle {
         self.raw.drop_abort_handle();
     }
 }
+
+impl Clone for AbortHandle {
+    /// Returns a cloned `AbortHandle` that can be used to remotely abort this task.
+    fn clone(&self) -> Self {
+        self.raw.ref_inc();
+        Self::new(self.raw)
+    }
+}

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -119,6 +119,29 @@ fn drop_abort_handle2() {
     handle.assert_dropped();
 }
 
+#[test]
+fn drop_abort_handle_clone() {
+    let (ad, handle) = AssertDrop::new();
+    let (notified, join) = unowned(
+        async {
+            drop(ad);
+            unreachable!()
+        },
+        NoopSchedule,
+        Id::next(),
+    );
+    let abort = join.abort_handle();
+    let abort_clone = abort.clone();
+    drop(join);
+    handle.assert_not_dropped();
+    drop(notified);
+    handle.assert_not_dropped();
+    drop(abort);
+    handle.assert_not_dropped();
+    drop(abort_clone);
+    handle.assert_dropped();
+}
+
 // Shutting down through Notified works
 #[test]
 fn create_shutdown1() {


### PR DESCRIPTION

This is a small change so that AbortHandle implements Clone.

## Motivation

The [the module level docs](https://docs.rs/tokio/latest/tokio/task/index.html#cancellation) indicate

> Each task can only have one [JoinHandle](https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html), but it can have more than one [AbortHandle](https://docs.rs/tokio/latest/tokio/task/struct.AbortHandle.html).

Cloning is convenient for `AbortHandle`s given there can be more than one.

## Solution

The proposed solution is similar to JoinHandle's [`abort_handle`](https://github.com/tokio-rs/tokio/blob/8e15c234c60cf8132c490ccf03dd31738cfeaca8/tokio/src/runtime/task/join.rs#L299) method:
```
impl Clone for AbortHandle {
    /// Returns a cloned `AbortHandle` that can be used to remotely abort this task.
    fn clone(&self) -> Self {
        self.raw.ref_inc();
        Self::new(self.raw)
    }
}
```

