### PR TITLE
task: stabilize `consume_budget`

### DIFF
--- a/tokio/src/task/consume_budget.rs
+++ b/tokio/src/task/consume_budget.rs
@@ -8,10 +8,6 @@ use std::task::Poll;
 /// computations that do not use Tokio resources like sockets or semaphores,
 /// without redundantly yielding to the runtime each time.
 ///
-/// **Note**: This is an [unstable API][unstable]. The public API of this type
-/// may break in 1.x releases. See [the documentation on unstable
-/// features][unstable] for details.
-///
 /// # Examples
 ///
 /// Make sure that a function which returns a sum of (potentially lots of)
@@ -27,8 +23,7 @@ use std::task::Poll;
 ///     sum
 /// }
 /// ```
-/// [unstable]: crate#unstable-features
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub async fn consume_budget() {
     let mut status = Poll::Pending;
 

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -337,10 +337,8 @@ cfg_rt! {
     mod yield_now;
     pub use yield_now::yield_now;
 
-    cfg_unstable! {
-        mod consume_budget;
-        pub use consume_budget::consume_budget;
-    }
+    mod consume_budget;
+    pub use consume_budget::consume_budget;
 
     mod local;
     pub use local::{spawn_local, LocalSet, LocalEnterGuard};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This utility seems simple and complete. Stabilizing it avoids the need for workarounds to consuming/reading Tokio's task budgets such as abusing `io::Empty`.

## Solution

Stabilize `task::consume_budget()`.