### PR TITLE
Update to Mio v1

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,7 @@ pin-project-lite = "0.2.11"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
-mio = { version = "1.0.0", optional = true, default-features = false }
+mio = { version = "1.0.1", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,7 @@ pin-project-lite = "0.2.11"
 
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
-mio = { version = "0.8.9", optional = true, default-features = false }
+mio = { version = "1.0.0", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::path::Path;
 
 /// An address associated with a Tokio Unix socket.
-pub struct SocketAddr(pub(super) mio::net::SocketAddr);
+pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 
 impl SocketAddr {
     /// Returns `true` if the address is unnamed.


### PR DESCRIPTION
Bumps the MSRV to 1.70.

One breaking changes is the removal of mio::net::SocketAddr, replacing it with std::os::unix::net::SocketAddr. The methods on the type should be the same.

For some smaller OS, such as ESP-IDF and Hermit, it can now be compiled without RUSTFLAGS.