### PR TITLE
codec: docs: fix length_delimited doc description and make examples testable

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -75,7 +75,7 @@
 //!
 //! ## Example 1
 //!
-//! The following will parse a `u16` length field at offset 0, including the
+//! The following will parse a `u16` length field at offset 0, omitting the
 //! frame head in the yielded `BytesMut`.
 //!
 //! ```
@@ -111,7 +111,7 @@
 //!
 //! ## Example 2
 //!
-//! The following will parse a `u16` length field at offset 0, omitting the
+//! The following will parse a `u16` length field at offset 0, including the
 //! frame head in the yielded `BytesMut`.
 //!
 //! ```
@@ -147,7 +147,7 @@
 //!
 //! ## Example 3
 //!
-//! The following will parse a `u16` length field at offset 0, including the
+//! The following will parse a `u16` length field at offset 0, omitting the
 //! frame head in the yielded `BytesMut`. In this case, the length field
 //! **includes** the frame head length.
 //!

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -141,8 +141,8 @@
 //! ```
 //!
 //! This is similar to the first example, the only difference is that the
-//! frame head is **included** in the yielded `BytesMut` value. To archive
-//! this, we need to add header size to the length with `length_adjustment`,
+//! frame head is **included** in the yielded `BytesMut` value. To achieve
+//! this, we need to add the header size to the length with `length_adjustment`,
 //! and set `num_skip` to `0` to prevent skipping the head.
 //!
 //! ## Example 3


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

According to [comment](https://github.com/tokio-rs/tokio/issues/6604#issuecomment-2150408931) in #6604, some examples for `length_delimited` do not fit the real behavior. This PR fix the document and add tests to the examples.

Close #6604

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Fix the docs.

Swap the order of example 1 and 2 to make it more easier to understand.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
