### PR TITLE
unix/socketaddr: add as_abstract_name

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -163,6 +163,7 @@ mut
 mutex
 Mutex
 Nagle
+namespace
 nonblocking
 nondecreasing
 noop

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -22,6 +22,16 @@ impl SocketAddr {
     pub fn as_pathname(&self) -> Option<&Path> {
         self.0.as_pathname()
     }
+
+    /// Returns the contents of this address without the leading null byte
+    /// if it is an abstract namespace.
+    ///
+    /// Documentation reflected in [`SocketAddr`]
+    ///
+    /// [`SocketAddr`]: std::os::unix::net::SocketAddr
+    pub fn as_abstract_name(&self) -> Option<&[u8]> {
+        self.0.as_abstract_namespace()
+    }
 }
 
 impl fmt::Debug for SocketAddr {


### PR DESCRIPTION
## Motivation

Both std and mio provide API to fetch underlying path from an abstract uds. This is
missing in tokio's wrapper type.

## Solution

Add the missing API. std names it as as_abstract_name, mio names it as
as_abstract_namespace, this pr chooses the former.