### PR TITLE
chore: increase MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ env:
   # - tokio-util/Cargo.toml
   # - tokio-test/Cargo.toml
   # - tokio-stream/Cargo.toml
-  rust_min: '1.63'
+  rust_min: '1.70'
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+released at least six months ago. The current MSRV is 1.70.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
+ * 1.39 to now  - Rust 1.70
+ * 1.30 to 1.38 - Rust 1.63
  * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-macros"
 # - Create "tokio-macros-1.x.y" git tag.
 version = "2.3.0"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-stream"
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.15"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-test"
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.4"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio-util"
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.11"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 repository = "https://github.com/tokio-rs/tokio"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -8,7 +8,7 @@ name = "tokio"
 # - Create "v1.x.y" git tag.
 version = "1.38.1"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 license = "MIT"
 readme = "README.md"

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -186,12 +186,13 @@ When updating this, also update:
 
 Tokio will keep a rolling MSRV (minimum supported rust version) policy of **at
 least** 6 months. When increasing the MSRV, the new Rust version must have been
-released at least six months ago. The current MSRV is 1.63.
+released at least six months ago. The current MSRV is 1.70.
 
 Note that the MSRV is not increased automatically, and only as part of a minor
 release. The MSRV history for past minor releases can be found below:
 
- * 1.30 to now - Rust 1.63
+ * 1.39 to now  - Rust 1.70
+ * 1.30 to 1.38 - Rust 1.63
  * 1.27 to 1.29 - Rust 1.56
  * 1.17 to 1.26 - Rust 1.49
  * 1.15 to 1.16 - Rust 1.46


### PR DESCRIPTION
Mio v1 was recently released, and it requires an MSRV of 1.70.0 for various changes that mio is using to get rid of its `SocketAddr` type and instead use the std version. This PR proposes to bump the MSRV of Tokio to 1.70.

The main disadvantage is that debian stable is still at rustc 1.63.

Refs: #6635