### PR TITLE
io: fix trait bounds on `impl Sink for StreamReader`

### DIFF
--- a/tokio-util/src/io/stream_reader.rs
+++ b/tokio-util/src/io/stream_reader.rs
@@ -326,7 +326,7 @@ impl<S, B> StreamReader<S, B> {
     }
 }
 
-impl<S: Sink<T, Error = E>, E, T> Sink<T> for StreamReader<S, E> {
+impl<S: Sink<T, Error = E>, B, E, T> Sink<T> for StreamReader<S, B> {
     type Error = E;
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
         self.project().inner.poll_ready(cx)


### PR DESCRIPTION
This impl had a bound on `StreamReader<S, E>`; this is incorrect because the second generic parameter to `StreamReader` is not an error type; it's a buffer type.

## Motivation

This "passthrough" `Sink` impl is currently unusable because it requires the `Sink` error type be the same as the `StreamReader` buffer type. This seems like it must have been a typo, because that constraint is not useful.

See the example program in #6642 for more details.

## Solution

Resolve this by removing the constraint on `StreamReader`'s buffer type `B`. It's irrelevant to a `Sink` impl anyway.

Fixes #6642.