### PR TITLE
stream: change the visibility of stream adaptor structures to public

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -2,61 +2,61 @@ use core::future::Future;
 use futures_core::Stream;
 
 mod all;
-use all::AllFuture;
+pub use all::AllFuture;
 
 mod any;
-use any::AnyFuture;
+pub use any::AnyFuture;
 
 mod chain;
-use chain::Chain;
+pub use chain::Chain;
 
 pub(crate) mod collect;
 use collect::{Collect, FromStream};
 
 mod filter;
-use filter::Filter;
+pub use filter::Filter;
 
 mod filter_map;
-use filter_map::FilterMap;
+pub use filter_map::FilterMap;
 
 mod fold;
-use fold::FoldFuture;
+pub use fold::FoldFuture;
 
 mod fuse;
-use fuse::Fuse;
+pub use fuse::Fuse;
 
 mod map;
-use map::Map;
+pub use map::Map;
 
 mod map_while;
-use map_while::MapWhile;
+pub use map_while::MapWhile;
 
 mod merge;
-use merge::Merge;
+pub use merge::Merge;
 
 mod next;
-use next::Next;
+pub use next::Next;
 
 mod skip;
-use skip::Skip;
+pub use skip::Skip;
 
 mod skip_while;
-use skip_while::SkipWhile;
+pub use skip_while::SkipWhile;
 
 mod take;
-use take::Take;
+pub use take::Take;
 
 mod take_while;
-use take_while::TakeWhile;
+pub use take_while::TakeWhile;
 
 mod then;
-use then::Then;
+pub use then::Then;
 
 mod try_next;
-use try_next::TryNext;
+pub use try_next::TryNext;
 
 mod peekable;
-use peekable::Peekable;
+pub use peekable::Peekable;
 
 cfg_time! {
     pub(crate) mod timeout;


### PR DESCRIPTION
Added pub to all use declarations in stream_ext.rs, except for Collect as it should stay private, as stated in its doc.

Fixes: #6656

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The `StreamExt` trait provides the helpful method `take`, `map`, and the like on `Stream`s. But the structures themselves (`Take`, `Map`, etc.) are not visible outside the crate, as they are not `pub use` in `stream_ext.rs`.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added pub to all use declarations in stream_ext.rs, except for Collect as it should stay private, as stated in its doc.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
