### PR TITLE
Making the Stream adaptor structures public in tokio-stream

### DIFF
--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -82,7 +82,7 @@ pub mod wrappers;
 mod stream_ext;
 pub use stream_ext::{collect::FromStream, StreamExt};
 /// Adapters for types that implement the `Stream` trait.
-/// Created through the tokio [`StreamExt`](crate::stream_ext::StreamExt) methods.
+/// Created through the tokio [`StreamExt`] methods.
 pub mod adapters {
     pub use crate::stream_ext::{
         AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -93,6 +93,7 @@ pub mod adapters {
 }
 
 cfg_time! {
+    #[deprecated = "Import those symbols from adapters instead"]
     #[doc(hidden)]
     pub use stream_ext::timeout::{Elapsed, Timeout};
 }

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -89,11 +89,12 @@ pub mod adapters {
         Next, Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
     };
     cfg_time! {
-        pub use crate::stream_ext::{ChunksTimeout, Timeout, TimeoutRepeating};
+        pub use crate::stream_ext::{ChunksTimeout, timeout::Elapsed, Timeout, TimeoutRepeating};
     }
 }
 
 cfg_time! {
+    #[doc(hidden)]
     pub use stream_ext::timeout::{Elapsed, Timeout};
 }
 

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -81,8 +81,7 @@ pub mod wrappers;
 
 mod stream_ext;
 pub use stream_ext::{collect::FromStream, StreamExt};
-/// Adapters for types that implement the `Stream` trait.
-/// Created through the tokio [`StreamExt`] methods.
+/// Adapters for [`Stream`]s created by methods in [`StreamExt`].
 pub mod adapters {
     pub use crate::stream_ext::{
         AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -81,10 +81,15 @@ pub mod wrappers;
 
 mod stream_ext;
 pub use stream_ext::{collect::FromStream, StreamExt};
-pub use stream_ext::{
-    AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge, Next,
-    Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
-};
+/// Adapters for types that implement the `Stream` trait.
+/// Created through the tokio [`StreamExt`](crate::stream_ext::StreamExt) methods.
+pub mod adapters {
+    pub use crate::stream_ext::{
+        AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,
+        Next, Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
+    };
+}
+
 cfg_time! {
     pub use stream_ext::timeout::{Elapsed, Timeout};
 }

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -81,6 +81,10 @@ pub mod wrappers;
 
 mod stream_ext;
 pub use stream_ext::{collect::FromStream, StreamExt};
+pub use stream_ext::{
+    AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge, Next,
+    Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
+};
 cfg_time! {
     pub use stream_ext::timeout::{Elapsed, Timeout};
 }

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -88,6 +88,9 @@ pub mod adapters {
         AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,
         Next, Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
     };
+    cfg_time! {
+        pub use crate::stream_ext::{ChunksTimeout, Timeout, TimeoutRepeating};
+    }
 }
 
 cfg_time! {

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -84,11 +84,11 @@ pub use stream_ext::{collect::FromStream, StreamExt};
 /// Adapters for [`Stream`]s created by methods in [`StreamExt`].
 pub mod adapters {
     pub use crate::stream_ext::{
-        AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,
-        Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
+        Chain, Filter, FilterMap, Fuse, Map, MapWhile, Merge, Peekable, Skip, SkipWhile, Take,
+        TakeWhile, Then,
     };
     cfg_time! {
-        pub use crate::stream_ext::{ChunksTimeout, timeout::Elapsed, Timeout, TimeoutRepeating};
+        pub use crate::stream_ext::{ChunksTimeout, Timeout, TimeoutRepeating};
     }
 }
 

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -95,7 +95,8 @@ pub mod adapters {
 cfg_time! {
     #[deprecated = "Import those symbols from adapters instead"]
     #[doc(hidden)]
-    pub use stream_ext::timeout::{Elapsed, Timeout};
+    pub use stream_ext::timeout::Timeout;
+    pub use stream_ext::timeout::Elapsed;
 }
 
 mod empty;

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -85,7 +85,7 @@ pub use stream_ext::{collect::FromStream, StreamExt};
 pub mod adapters {
     pub use crate::stream_ext::{
         AllFuture, AnyFuture, Chain, Filter, FilterMap, FoldFuture, Fuse, Map, MapWhile, Merge,
-        Next, Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
+        Peekable, Skip, SkipWhile, Take, TakeWhile, Then, TryNext,
     };
     cfg_time! {
         pub use crate::stream_ext::{ChunksTimeout, timeout::Elapsed, Timeout, TimeoutRepeating};

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -61,13 +61,13 @@ pub use peekable::Peekable;
 cfg_time! {
     pub(crate) mod timeout;
     pub(crate) mod timeout_repeating;
-    use timeout::Timeout;
-    use timeout_repeating::TimeoutRepeating;
+    pub use timeout::Timeout;
+    pub use timeout_repeating::TimeoutRepeating;
     use tokio::time::{Duration, Interval};
     mod throttle;
     use throttle::{throttle, Throttle};
     mod chunks_timeout;
-    use chunks_timeout::ChunksTimeout;
+    pub use chunks_timeout::ChunksTimeout;
 }
 
 /// An extension trait for the [`Stream`] trait that provides a variety of

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -2,61 +2,61 @@ use core::future::Future;
 use futures_core::Stream;
 
 mod all;
-use all::AllFuture;
+pub use all::AllFuture;
 
 mod any;
-use any::AnyFuture;
+pub use any::AnyFuture;
 
 mod chain;
-use chain::Chain;
+pub use chain::Chain;
 
 pub(crate) mod collect;
 use collect::{Collect, FromStream};
 
 mod filter;
-use filter::Filter;
+pub use filter::Filter;
 
 mod filter_map;
-use filter_map::FilterMap;
+pub use filter_map::FilterMap;
 
 mod fold;
-use fold::FoldFuture;
+pub use fold::FoldFuture;
 
 mod fuse;
-use fuse::Fuse;
+pub use fuse::Fuse;
 
 mod map;
-use map::Map;
+pub use map::Map;
 
 mod map_while;
-use map_while::MapWhile;
+pub use map_while::MapWhile;
 
 mod merge;
-use merge::Merge;
+pub use merge::Merge;
 
 mod next;
-use next::Next;
+pub use next::Next;
 
 mod skip;
-use skip::Skip;
+pub use skip::Skip;
 
 mod skip_while;
-use skip_while::SkipWhile;
+pub use skip_while::SkipWhile;
 
 mod take;
-use take::Take;
+pub use take::Take;
 
 mod take_while;
-use take_while::TakeWhile;
+pub use take_while::TakeWhile;
 
 mod then;
-use then::Then;
+pub use then::Then;
 
 mod try_next;
-use try_next::TryNext;
+pub use try_next::TryNext;
 
 mod peekable;
-use peekable::Peekable;
+pub use peekable::Peekable;
 
 cfg_time! {
     pub(crate) mod timeout;

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -2,10 +2,10 @@ use core::future::Future;
 use futures_core::Stream;
 
 mod all;
-pub use all::AllFuture;
+use all::AllFuture;
 
 mod any;
-pub use any::AnyFuture;
+use any::AnyFuture;
 
 mod chain;
 pub use chain::Chain;
@@ -20,7 +20,7 @@ mod filter_map;
 pub use filter_map::FilterMap;
 
 mod fold;
-pub use fold::FoldFuture;
+use fold::FoldFuture;
 
 mod fuse;
 pub use fuse::Fuse;
@@ -53,7 +53,7 @@ mod then;
 pub use then::Then;
 
 mod try_next;
-pub use try_next::TryNext;
+use try_next::TryNext;
 
 mod peekable;
 pub use peekable::Peekable;

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -35,7 +35,7 @@ mod merge;
 pub use merge::Merge;
 
 mod next;
-pub use next::Next;
+use next::Next;
 
 mod skip;
 pub use skip::Skip;

--- a/tokio-stream/tests/stream_chain.rs
+++ b/tokio-stream/tests/stream_chain.rs
@@ -41,10 +41,10 @@ async fn basic_usage() {
 
 fn visibility_test<I, S1, S2>(s1: S1, s2: S2) -> Chain<S1, S2>
 where
-	S1: Stream<Item=I>,
-	S2: Stream<Item=I>,
+    S1: Stream<Item = I>,
+    S2: Stream<Item = I>,
 {
-	s1.chain(s2)
+    s1.chain(s2)
 }
 
 #[tokio::test]

--- a/tokio-stream/tests/stream_chain.rs
+++ b/tokio-stream/tests/stream_chain.rs
@@ -1,4 +1,4 @@
-use tokio_stream::{self as stream, Chain, Stream, StreamExt};
+use tokio_stream::{self as stream, Stream, StreamExt};
 use tokio_test::{assert_pending, assert_ready, task};
 
 mod support {
@@ -6,6 +6,7 @@ mod support {
 }
 
 use support::mpsc;
+use tokio_stream::adapters::Chain;
 
 #[tokio::test]
 async fn basic_usage() {

--- a/tokio-stream/tests/stream_chain.rs
+++ b/tokio-stream/tests/stream_chain.rs
@@ -1,4 +1,4 @@
-use tokio_stream::{self as stream, Stream, StreamExt};
+use tokio_stream::{self as stream, Chain, Stream, StreamExt};
 use tokio_test::{assert_pending, assert_ready, task};
 
 mod support {
@@ -12,7 +12,7 @@ async fn basic_usage() {
     let one = stream::iter(vec![1, 2, 3]);
     let two = stream::iter(vec![4, 5, 6]);
 
-    let mut stream = one.chain(two);
+    let mut stream = visibility_test(one, two);
 
     assert_eq!(stream.size_hint(), (6, Some(6)));
     assert_eq!(stream.next().await, Some(1));
@@ -37,6 +37,14 @@ async fn basic_usage() {
 
     assert_eq!(stream.size_hint(), (0, Some(0)));
     assert_eq!(stream.next().await, None);
+}
+
+fn visibility_test<I, S1, S2>(s1: S1, s2: S2) -> Chain<S1, S2>
+where
+	S1: Stream<Item=I>,
+	S2: Stream<Item=I>,
+{
+	s1.chain(s2)
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The StreamExt trait provides the helpful method take, map, and the like on Streams. But the structures themselves (Take, Map, etc.) are not visible outside the crate, as they are not pub use in stream_ext.rs.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Re-exported `pub`licly all the structures in stream_ext.rs except for `Collect`, which is different and should not be exported as stated in its documentation. Re-exported them `pub`licly again in lib.rs.

Added a function in a test with return type `Chain` to show that it can be part of an external function signature.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Closes: #6656