### PR TITLE
runtime: fix typo in unhandled_panic

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -816,7 +816,7 @@ impl Builder {
         ///
         /// By default, an unhandled panic (i.e. a panic not caught by
         /// [`std::panic::catch_unwind`]) has no impact on the runtime's
-        /// execution. The panic is error value is forwarded to the task's
+        /// execution. The panic's error value is forwarded to the task's
         /// [`JoinHandle`] and all other spawned tasks continue running.
         ///
         /// The `unhandled_panic` option enables configuring this behavior.


### PR DESCRIPTION
Fix the grammar in this paragraph, assuming this was supposed to refer to the "panic's error value".