### PR TITLE
io: implement `AsyncSeek` for `Empty`

### DIFF
--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -1,8 +1,8 @@
 use crate::io::util::poll_proceed_and_make_progress;
-use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
+use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 
 use std::fmt;
-use std::io;
+use std::io::{self, SeekFrom};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -130,6 +130,18 @@ impl AsyncWrite for Empty {
         ready!(poll_proceed_and_make_progress(cx));
         let num_bytes = bufs.iter().map(|b| b.len()).sum();
         Poll::Ready(Ok(num_bytes))
+    }
+}
+
+impl AsyncSeek for Empty {
+    fn start_seek(self: Pin<&mut Self>, _position: SeekFrom) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        ready!(crate::trace::trace_leaf(cx));
+        ready!(poll_proceed_and_make_progress(cx));
+        Poll::Ready(Ok(0))
     }
 }
 

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -134,10 +134,12 @@ impl AsyncWrite for Empty {
 }
 
 impl AsyncSeek for Empty {
+    #[inline]
     fn start_seek(self: Pin<&mut Self>, _position: SeekFrom) -> io::Result<()> {
         Ok(())
     }
 
+    #[inline]
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
         ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));

--- a/tokio/tests/io_util_empty.rs
+++ b/tokio/tests/io_util_empty.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "full")]
-use tokio::io::{AsyncBufReadExt, AsyncReadExt};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt};
+use tokio_test::assert_ok;
 
 #[tokio::test]
 async fn empty_read_is_cooperative() {
@@ -29,4 +30,17 @@ async fn empty_buf_reads_are_cooperative() {
         } => {},
         _ = tokio::task::yield_now() => {}
     }
+}
+
+#[tokio::test]
+async fn empty_seek() {
+    use std::io::SeekFrom;
+
+    let mut empty = tokio::io::empty();
+
+    let pos = assert_ok!(empty.seek(SeekFrom::Start(0)).await);
+    assert_eq!(pos, 0);
+
+    let pos = assert_ok!(empty.seek(SeekFrom::Start(8)).await);
+    assert_eq!(pos, 0);
 }

--- a/tokio/tests/io_util_empty.rs
+++ b/tokio/tests/io_util_empty.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "full")]
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt};
-use tokio_test::assert_ok;
 
 #[tokio::test]
 async fn empty_read_is_cooperative() {
@@ -38,9 +37,25 @@ async fn empty_seek() {
 
     let mut empty = tokio::io::empty();
 
-    let pos = assert_ok!(empty.seek(SeekFrom::Start(0)).await);
-    assert_eq!(pos, 0);
+    assert!(matches!(empty.seek(SeekFrom::Start(0)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::Start(1)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::Start(u64::MAX)).await, Ok(0)));
 
-    let pos = assert_ok!(empty.seek(SeekFrom::Start(8)).await);
-    assert_eq!(pos, 0);
+    assert!(matches!(empty.seek(SeekFrom::End(i64::MIN)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::End(-1)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::End(0)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::End(1)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::End(i64::MAX)).await, Ok(0)));
+
+    assert!(matches!(
+        empty.seek(SeekFrom::Current(i64::MIN)).await,
+        Ok(0)
+    ));
+    assert!(matches!(empty.seek(SeekFrom::Current(-1)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::Current(0)).await, Ok(0)));
+    assert!(matches!(empty.seek(SeekFrom::Current(1)).await, Ok(0)));
+    assert!(matches!(
+        empty.seek(SeekFrom::Current(i64::MAX)).await,
+        Ok(0)
+    ));
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

While porting a test from `std:io` to `tokio::io`, I discovered `AsyncSeek` is not implemented for `tokio::io::Empty`. This was unexpected, as [`std::io::Seek` was implemented for `std::io::Empty` in Rust 1.51.0](https://doc.rust-lang.org/stable/std/io/struct.Empty.html#impl-Seek-for-Empty) (2021-03-25).

## Solution

This implementation mimics the behavior of [the `Seek` implementation for `std::io::Empty`](https://github.com/rust-lang/rust/blob/036b38ced36b0ed16579f95b4647ba7424f6b1bc/library/std/src/io/util.rs#L81-L94).
