### PR TITLE
metrics: rename `num_active_tasks` to `num_alive_tasks`

### DIFF
--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -83,7 +83,7 @@ impl RuntimeMetrics {
 
         /// Returns the current number of alive tasks in the runtime.
         ///
-        /// This counter increses when a task is spawned and decreases when a
+        /// This counter increases when a task is spawned and decreases when a
         /// task exits.
         ///
         /// # Examples

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -75,15 +75,16 @@ impl RuntimeMetrics {
             self.handle.inner.num_blocking_threads()
         }
 
-        #[deprecated = "Renamed to num_active_tasks"]
-        /// Renamed to [`RuntimeMetrics::num_active_tasks`]
+        #[deprecated = "Renamed to num_alive_tasks"]
+        /// Renamed to [`RuntimeMetrics::num_alive_tasks`]
         pub fn active_tasks_count(&self) -> usize {
-            self.num_active_tasks()
+            self.num_alive_tasks()
         }
 
-        /// Returns the current number of active tasks in the runtime.
+        /// Returns the current number of alive tasks in the runtime.
         ///
-        /// This value increases and decreases over time as tasks are spawned and as they are completed or cancelled.
+        /// This counter increses when a task is spawned and decreases when a
+        /// task exits.
         ///
         /// # Examples
         ///
@@ -94,12 +95,12 @@ impl RuntimeMetrics {
         /// async fn main() {
         ///    let metrics = Handle::current().metrics();
         ///
-        ///     let n = metrics.num_active_tasks();
-        ///     println!("Runtime has {} active tasks", n);
+        ///     let n = metrics.num_alive_tasks();
+        ///     println!("Runtime has {} alive tasks", n);
         /// }
         /// ```
-        pub fn num_active_tasks(&self) -> usize {
-            self.handle.inner.active_tasks_count()
+        pub fn num_alive_tasks(&self) -> usize {
+            self.handle.inner.alive_tasks_count()
         }
 
         /// Returns the number of idle threads, which have spawned by the runtime

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -533,8 +533,8 @@ cfg_unstable_metrics! {
             self.blocking_spawner.queue_depth()
         }
 
-        pub(crate) fn active_tasks_count(&self) -> usize {
-            self.shared.owned.active_tasks_count()
+        pub(crate) fn alive_tasks_count(&self) -> usize {
+            self.shared.owned.alive_tasks_count()
         }
 
         cfg_64bit_metrics! {

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -193,8 +193,8 @@ cfg_rt! {
                 match_flavor!(self, Handle(handle) => handle.num_idle_blocking_threads())
             }
 
-            pub(crate) fn active_tasks_count(&self) -> usize {
-                match_flavor!(self, Handle(handle) => handle.active_tasks_count())
+            pub(crate) fn alive_tasks_count(&self) -> usize {
+                match_flavor!(self, Handle(handle) => handle.alive_tasks_count())
             }
 
             pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -27,8 +27,8 @@ impl Handle {
             self.blocking_spawner.num_idle_threads()
         }
 
-        pub(crate) fn active_tasks_count(&self) -> usize {
-            self.shared.owned.active_tasks_count()
+        pub(crate) fn alive_tasks_count(&self) -> usize {
+            self.shared.owned.alive_tasks_count()
         }
 
         pub(crate) fn scheduler_metrics(&self) -> &SchedulerMetrics {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle/metrics.rs
@@ -18,8 +18,8 @@ impl Handle {
         self.blocking_spawner.num_idle_threads()
     }
 
-    pub(crate) fn active_tasks_count(&self) -> usize {
-        self.shared.owned.active_tasks_count()
+    pub(crate) fn alive_tasks_count(&self) -> usize {
+        self.shared.owned.alive_tasks_count()
     }
 
     cfg_64bit_metrics! {

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -166,7 +166,7 @@ impl<S: 'static> OwnedTasks<S> {
         self.list.shard_size()
     }
 
-    pub(crate) fn active_tasks_count(&self) -> usize {
+    pub(crate) fn alive_tasks_count(&self) -> usize {
         self.list.len()
     }
 

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -93,22 +93,22 @@ fn blocking_queue_depth() {
 }
 
 #[test]
-fn num_active_tasks() {
+fn num_alive_tasks() {
     let rt = current_thread();
     let metrics = rt.metrics();
-    assert_eq!(0, metrics.num_active_tasks());
+    assert_eq!(0, metrics.num_alive_tasks());
     rt.block_on(rt.spawn(async move {
-        assert_eq!(1, metrics.num_active_tasks());
+        assert_eq!(1, metrics.num_alive_tasks());
     }))
     .unwrap();
 
-    assert_eq!(0, rt.metrics().num_active_tasks());
+    assert_eq!(0, rt.metrics().num_alive_tasks());
 
     let rt = threaded();
     let metrics = rt.metrics();
-    assert_eq!(0, metrics.num_active_tasks());
+    assert_eq!(0, metrics.num_alive_tasks());
     rt.block_on(rt.spawn(async move {
-        assert_eq!(1, metrics.num_active_tasks());
+        assert_eq!(1, metrics.num_alive_tasks());
     }))
     .unwrap();
 
@@ -116,12 +116,12 @@ fn num_active_tasks() {
     // wake_join() is called before the task is released, so in multithreaded
     // code, this means we sometimes exit the block_on before the counter decrements.
     for _ in 0..100 {
-        if rt.metrics().num_active_tasks() == 0 {
+        if rt.metrics().num_alive_tasks() == 0 {
             break;
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    assert_eq!(0, rt.metrics().num_active_tasks());
+    assert_eq!(0, rt.metrics().num_alive_tasks());
 }
 
 #[test]


### PR DESCRIPTION
The word "active" is the opposite of "idle", but an "idle task" normally refers to a task that is alive but not currently able to make progress. However, idle tasks are included in this counter.

Instead of "active", I propose the name "alive".