### PR TITLE
Doc: JoinSet::try_join_next() returns None when no tasks are completed

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -308,7 +308,7 @@ impl<T: 'static> JoinSet<T> {
 
     /// Tries to join one of the tasks in the set that has completed and return its output.
     ///
-    /// Returns `None` if the set is empty.
+    /// Returns `None` if there are no completed tasks, or if the set is empty.
     pub fn try_join_next(&mut self) -> Option<Result<T, JoinError>> {
         // Loop over all notified `JoinHandle`s to find one that's ready, or until none are left.
         loop {
@@ -331,7 +331,7 @@ impl<T: 'static> JoinSet<T> {
     /// Tries to join one of the tasks in the set that has completed and return its output,
     /// along with the [task ID] of the completed task.
     ///
-    /// Returns `None` if the set is empty.
+    /// Returns `None` if there are no completed tasks, or if the set is empty.
     ///
     /// When this method returns an error, then the id of the task that failed can be accessed
     /// using the [`JoinError::id`] method.


### PR DESCRIPTION
## Motivation

The documentation of `JoinSet`'s `try_join_next()` and `try_join_next_with_id()` doesn't say what happens if there are no completed tasks.

`join_next()` waits, but `try_join_next()` appears to return `None` immediately.

## Solution

Update the docs for both methods.