### PR TITLE
6536 - fix yield_calls_park_before_scheduling_again test

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -35,7 +35,7 @@ tokio_thread_local! {
 // Bit of a hack, but it is only for loom
 #[cfg(loom)]
 tokio_thread_local! {
-    static CURRENT_THREAD_PARK_COUNT: AtomicUsize = AtomicUsize::new(0);
+    pub(crate) static CURRENT_THREAD_PARK_COUNT: AtomicUsize = AtomicUsize::new(0);
 }
 
 // ==== impl ParkThread ====

--- a/tokio/src/runtime/tests/loom_multi_thread/yield_now.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/yield_now.rs
@@ -3,7 +3,6 @@ use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
 
 #[test]
-#[ignore]
 fn yield_calls_park_before_scheduling_again() {
     // Don't need to check all permutations
     let mut loom = loom::model::Builder::default();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->
closes https://github.com/tokio-rs/tokio/issues/6536.

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Fixes the failing test outlined in https://github.com/tokio-rs/tokio/issues/6536

## Solution
Since this is just a Loom-related change, I felt it fine to simply increment the counter if the lock call fails. If a more robust change is desired, please let me know and I will happily do so. It feels like such a change would probably involve attaching the conditionally-compiled Loom counter to some struct, but I haven't looked too deeply into it.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
