### PR TITLE
tests: pdfd-reaper: fix tests when '-' is absent from kernel version

### DIFF
--- a/tokio/src/process/unix/pidfd_reaper.rs
+++ b/tokio/src/process/unix/pidfd_reaper.rs
@@ -245,7 +245,12 @@ mod test {
         assert!(status.success());
         let stdout = String::from_utf8_lossy(&stdout);
 
-        let mut kernel_version_iter = stdout.split_once('-').unwrap().0.split('.');
+        let mut kernel_version_iter = match stdout.split_once('-') {
+            Some((version, _)) => version,
+            _ => &stdout,
+        }
+        .split('.');
+
         let major: u32 = kernel_version_iter.next().unwrap().parse().unwrap();
         let minor: u32 = kernel_version_iter.next().unwrap().parse().unwrap();
 


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

On my machine, any pidfd reaper test that calls `is_pidfd_available` fails as my kernel version string does not contain a '-'; the code expects there to be one.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Fix the test so that is works regardless on whether the kernel string contains a '-'.