### PR TITLE
time: update wake_up while holding all the locks of sharded time wheels

### DIFF
--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -190,11 +190,13 @@ impl Driver {
         assert!(!handle.is_shutdown());
 
         // Finds out the min expiration time to park.
-        let expiration_time = (0..rt_handle.time().inner.get_shard_size())
-            .filter_map(|id| {
-                let lock = rt_handle.time().inner.lock_sharded_wheel(id);
-                lock.next_expiration_time()
-            })
+        let locks = (0..rt_handle.time().inner.get_shard_size())
+            .map(|id| rt_handle.time().inner.lock_sharded_wheel(id))
+            .collect::<Vec<_>>();
+
+        let expiration_time = locks
+            .iter()
+            .filter_map(|lock| lock.next_expiration_time())
             .min();
 
         rt_handle
@@ -202,7 +204,10 @@ impl Driver {
             .inner
             .next_wake
             .store(next_wake_time(expiration_time));
-
+        
+        // Safety: After updating the `next_wake`, we drop all the locks.
+        drop(locks);
+        
         match expiration_time {
             Some(when) => {
                 let now = handle.time_source.now(rt_handle.clock());

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -204,10 +204,10 @@ impl Driver {
             .inner
             .next_wake
             .store(next_wake_time(expiration_time));
-        
+
         // Safety: After updating the `next_wake`, we drop all the locks.
         drop(locks);
-        
+
         match expiration_time {
             Some(when) => {
                 let now = handle.time_source.now(rt_handle.clock());


### PR DESCRIPTION
## Motivation

fixes https://github.com/tokio-rs/tokio/issues/6682

We may encounter the following issue:

- After we calculated that `expiration_time` is `None`, we did not update the `next_wake` immediately. The `next_wake` is now the old value of the previous round of `park_internal` (the value is not `None`). Then we droped the locks.
- When other threads poll a `Sleep`, they find that `when > next_wake` (here `next_wake` is not `None`), so they will not execute `unpark.unpark()`.

## Solution

While we hold the locks, we calculate and update the `next_wake`.
