### PR TITLE
macros: fix doc format issue

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -410,7 +410,7 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// ### Set number of worker threads
 ///
 /// ```no_run
-/// #[tokio::test(flavor ="multi_thread", worker_threads = 2)]
+/// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 /// async fn my_test() {
 ///     assert!(true);
 /// }


### PR DESCRIPTION
## Motivation

Docs for `#[tokio::test]` contained a formatting issue for one of the examples

## Solution

Fixes it by using the same format as the other examples