### PR TITLE
chore: release v1.38.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.38.0", features = ["full"] }
+tokio = { version = "1.38.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -7,6 +7,9 @@ to fire when they should.
 
 - time: update `wake_up` while holding all the locks of sharded time wheels ([#6683])
 
+[#6682]: https://github.com/tokio-rs/tokio/pull/6682
+[#6683]: https://github.com/tokio-rs/tokio/pull/6683
+
 # 1.38.0 (May 30th, 2024)
 
 This release marks the beginning of stabilization for runtime metrics. It

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.38.1 (July 16th, 2024)
+
+This release fixes the bug identified as ([#6682]), which caused timers not
+to fire when they should.
+
+### Fixed
+
+- time: update `wake_up` while holding all the locks of sharded time wheels ([#6683])
+
 # 1.38.0 (May 30th, 2024)
 
 This release marks the beginning of stabilization for runtime metrics. It

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.38.0"
+version = "1.38.1"
 edition = "2021"
 rust-version = "1.63"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.38.0", features = ["full"] }
+tokio = { version = "1.38.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
This release fixes the bug identified as #6682, which caused timers not to fire when they should.