### PR TITLE
Show data as text when an tokio_test::io assert fails

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -23,6 +23,7 @@ async-stream = "0.3.3"
 
 bytes = "1.0.0"
 futures-core = "0.3.0"
+bstr = "1.6.2"
 
 [dev-dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["full"] }

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -18,6 +18,7 @@
 //! [`AsyncRead`]: tokio::io::AsyncRead
 //! [`AsyncWrite`]: tokio::io::AsyncWrite
 
+use bstr::BStr;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio::sync::mpsc;
 use tokio::time::{self, Duration, Instant, Sleep};
@@ -256,7 +257,7 @@ impl Inner {
                 Action::Write(ref mut expect) => {
                     let n = cmp::min(src.len(), expect.len());
 
-                    assert_eq!(&src[..n], &expect[..n]);
+                    assert_eq!(ShowBytes(src, n), ShowBytes(expect, n));
 
                     // Drop data that was matched
                     expect.drain(..n);
@@ -475,8 +476,8 @@ impl Drop for Mock {
         }
 
         self.inner.actions.iter().for_each(|a| match a {
-            Action::Read(data) => assert!(data.is_empty(), "There is still data left to read."),
-            Action::Write(data) => assert!(data.is_empty(), "There is still data left to write."),
+            Action::Read(data) => assert!(data.is_empty(), "There is still data left to read: {:?}", ShowBytes(data, 10)),
+            Action::Write(data) => assert!(data.is_empty(), "There is still data left to write: {:?}", ShowBytes(data, 10)),
             _ => (),
         });
     }
@@ -506,5 +507,26 @@ fn is_task_ctx() -> bool {
 impl fmt::Debug for Inner {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Inner {{...}}")
+    }
+}
+
+struct ShowBytes<'a>(&'a[u8], usize);
+
+impl<'a> fmt::Debug for ShowBytes<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let n = self.0.len();
+        let limit = self.1;
+        if self.0.len() <= limit {
+            write!(f, "{:?}", BStr::new(self.0))
+        } else {
+            let bytes = BStr::new(&self.0[..limit]);
+            write!(f, "{bytes:?} plus {} more bytes", n - limit)
+        }
+    }
+}
+
+impl<'a> PartialEq for ShowBytes<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0[..self.1] == other.0[..other.1]
     }
 }


### PR DESCRIPTION
## Motivation

The mock object mimics a reader or writer. If the code under test performs different reads or writes than expected, an assertion fails. Currently, the assertion shows the expected and actual data as a series of numbers representing bytes. If the protocol is textual, the numbers are quite hard to read.

## Solution

Essentially wrap the data in a [BStr](https://docs.rs/bstr/latest/bstr/struct.BStr.html). This shows text as-is and shows non-text bytes as \xAA\xBB etc.

The newly added struct `ShowBytes` contains a byte slice and a length limit. It has a PartialEq implementation and a fmt::Debug implementation. The Debug implementation shows only the given number of bytes, possibly followed by "plus N more bytes".
The PartialEq implementation compares only the given number of bytes.

This is sufficient for the existing three `assert!` statements in the code.