### PR TITLE
metrics: add worker thread id

### DIFF
--- a/tokio/src/runtime/metrics/mock.rs
+++ b/tokio/src/runtime/metrics/mock.rs
@@ -1,5 +1,7 @@
 //! This file contains mocks of the types in src/runtime/metrics
 
+use std::thread::ThreadId;
+
 pub(crate) struct SchedulerMetrics {}
 
 pub(crate) struct WorkerMetrics {}
@@ -30,6 +32,7 @@ impl WorkerMetrics {
     }
 
     pub(crate) fn set_queue_depth(&self, _len: usize) {}
+    pub(crate) fn set_thread_id(&self, _thread_id: ThreadId) {}
 }
 
 impl MetricsBatch {

--- a/tokio/src/runtime/metrics/worker.rs
+++ b/tokio/src/runtime/metrics/worker.rs
@@ -2,6 +2,8 @@ use crate::runtime::metrics::Histogram;
 use crate::runtime::Config;
 use crate::util::metric_atomics::{MetricAtomicU64, MetricAtomicUsize};
 use std::sync::atomic::Ordering::Relaxed;
+use std::sync::Mutex;
+use std::thread::ThreadId;
 
 /// Retrieve runtime worker metrics.
 ///
@@ -46,6 +48,9 @@ pub(crate) struct WorkerMetrics {
 
     /// If `Some`, tracks the number of polls by duration range.
     pub(super) poll_count_histogram: Option<Histogram>,
+
+    /// Thread id of worker thread.
+    thread_id: Mutex<Option<ThreadId>>,
 }
 
 impl WorkerMetrics {
@@ -68,5 +73,13 @@ impl WorkerMetrics {
 
     pub(crate) fn set_queue_depth(&self, len: usize) {
         self.queue_depth.store(len, Relaxed);
+    }
+
+    pub(crate) fn thread_id(&self) -> Option<ThreadId> {
+        *self.thread_id.lock().unwrap()
+    }
+
+    pub(crate) fn set_thread_id(&self, thread_id: ThreadId) {
+        *self.thread_id.lock().unwrap() = Some(thread_id);
     }
 }

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -11,12 +11,12 @@ use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::{fmt, thread};
 use std::future::Future;
 use std::sync::atomic::Ordering::{AcqRel, Release};
 use std::task::Poll::{Pending, Ready};
 use std::task::Waker;
 use std::time::Duration;
+use std::{fmt, thread};
 
 /// Executes tasks on the current thread
 pub(crate) struct CurrentThread {

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -11,7 +11,7 @@ use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
-use std::fmt;
+use std::{fmt, thread};
 use std::future::Future;
 use std::sync::atomic::Ordering::{AcqRel, Release};
 use std::task::Poll::{Pending, Ready};
@@ -123,6 +123,7 @@ impl CurrentThread {
         config: Config,
     ) -> (CurrentThread, Arc<Handle>) {
         let worker_metrics = WorkerMetrics::from_config(&config);
+        worker_metrics.set_thread_id(thread::current().id());
 
         // Get the configured global queue interval, or use the default.
         let global_queue_interval = config

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -173,6 +173,10 @@ impl CurrentThread {
             // available or the future is complete.
             loop {
                 if let Some(core) = self.take_core(handle) {
+                    handle
+                        .shared
+                        .worker_metrics
+                        .set_thread_id(thread::current().id());
                     return core.block_on(future);
                 } else {
                     let notified = self.notify.notified();

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -72,6 +72,7 @@ use crate::util::rand::{FastRand, RngSeedGenerator};
 
 use std::cell::RefCell;
 use std::task::Waker;
+use std::thread;
 use std::time::Duration;
 
 cfg_unstable_metrics! {
@@ -481,6 +482,8 @@ fn run(worker: Arc<Worker>) {
         Some(core) => core,
         None => return,
     };
+
+    worker.handle.shared.worker_metrics[worker.index].set_thread_id(thread::current().id());
 
     let handle = scheduler::Handle::MultiThread(worker.handle.clone());
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -335,6 +335,12 @@ where
                 if let Some(cx) = maybe_cx {
                     if self.take_core {
                         let core = cx.worker.core.take();
+
+                        if core.is_some() {
+                            cx.worker.handle.shared.worker_metrics[cx.worker.index]
+                                .set_thread_id(thread::current().id());
+                        }
+
                         let mut cx_core = cx.core.borrow_mut();
                         assert!(cx_core.is_none());
                         *cx_core = core;

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -70,9 +70,9 @@ use crate::util::atomic_cell::AtomicCell;
 use crate::util::rand::{FastRand, RngSeedGenerator};
 
 use std::cell::{Cell, RefCell};
-use std::cmp;
 use std::task::Waker;
 use std::time::Duration;
+use std::{cmp, thread};
 
 cfg_unstable_metrics! {
     mod metrics;
@@ -569,6 +569,7 @@ impl Worker {
             }
         };
 
+        cx.shared().worker_metrics[core.index].set_thread_id(thread::current().id());
         core.stats.start_processing_scheduled_tasks(&mut self.stats);
 
         if let Some(task) = maybe_task {

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -179,13 +179,38 @@ fn worker_thread_id_threaded() {
     let rt = threaded();
     let metrics = rt.metrics();
 
-    rt.block_on(async {});
-    drop(rt);
+    rt.block_on(rt.spawn(async move {
+        // Check that we are running on a worker thread and determine
+        // the index of our worker.
+        let thread_id = std::thread::current().id();
+        let this_worker = (0..2)
+            .position(|w| metrics.worker_thread_id(w) == Some(thread_id))
+            .expect("task not running on any worker thread");
 
-    assert!(metrics.worker_thread_id(0).is_some());
-    assert!(metrics.worker_thread_id(1).is_some());
-    assert_ne!(Some(thread::current().id()), metrics.worker_thread_id(0));
-    assert_ne!(Some(thread::current().id()), metrics.worker_thread_id(1));
+        // Force worker to another thread.
+        let moved_thread_id = tokio::task::block_in_place(|| {
+            assert_eq!(thread_id, std::thread::current().id());
+
+            // Wait for worker to move to another thread.
+            for _ in 0..100 {
+                let new_id = metrics.worker_thread_id(this_worker).unwrap();
+                if thread_id != new_id {
+                    return new_id;
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+
+            panic!("worker did not move to new thread");
+        });
+
+        // After blocking task worker either stays on new thread or
+        // is moved back to current thread.
+        assert!(
+            metrics.worker_thread_id(this_worker) == Some(moved_thread_id)
+                || metrics.worker_thread_id(this_worker) == Some(thread_id)
+        );
+    }))
+    .unwrap()
 }
 
 #[test]

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -169,8 +169,8 @@ fn worker_thread_id() {
     drop(rt);
     assert!(metrics.worker_thread_id(0).is_some());
     assert!(metrics.worker_thread_id(1).is_some());
-    assert_ne!(metrics.worker_thread_id(0), metrics.worker_thread_id(1));
     assert_ne!(Some(thread::current().id()), metrics.worker_thread_id(0));
+    assert_ne!(Some(thread::current().id()), metrics.worker_thread_id(1));
 }
 
 #[test]


### PR DESCRIPTION
This allows querying the thread id of each worker thread.

Additional information, such as native thread id, can be collected using `runtime::Builder::on_thread_start()` and correlated using the thread id.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

See #6353 and discussion in #6370.

## Solution

Provides thread ids of workers, so that a stuck worker can be correlated to a thread.
