### PR TITLE
Prepare tokio-macros v2.4.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.4.0 (July 22nd, 2024)
+
+- msrv: increase MSRV to 1.70 ([#6645])
+- macros: allow `unhandled_panic` behavior for `#[tokio::main]` and `#[tokio::test]` ([#6593])
+
+[#6593]: https://github.com/tokio-rs/tokio/pull/6593
+[#6645]: https://github.com/tokio-rs/tokio/pull/6645
+
 # 2.3.0 (May 30th, 2024)
 
 - macros: make `#[tokio::test]` append `#[test]` at the end of the attribute list ([#6497])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.x.y" git tag.
-version = "2.3.0"
+version = "2.4.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -89,7 +89,7 @@ test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]
-tokio-macros = { version = "~2.3.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.4.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
 


### PR DESCRIPTION
# 2.4.0 (July 22nd, 2024)

- msrv: increase MSRV to 1.70 ([#6645])
- macros: allow `unhandled_panic` behavior for `#[tokio::main]` and `#[tokio::test]` ([#6593])

[#6593]: https://github.com/tokio-rs/tokio/pull/6593
[#6645]: https://github.com/tokio-rs/tokio/pull/6645