### PR TITLE
chore: replace num_cpus with available_parallelism

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -12,7 +12,6 @@ tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 criterion = "0.5.1"
 rand = "0.8"
 rand_chacha = "0.3"
-num_cpus = "1.16.0"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -71,10 +71,7 @@ process = [
 ]
 # Includes basic task execution capabilities
 rt = []
-rt-multi-thread = [
-  "num_cpus",
-  "rt",
-]
+rt-multi-thread = ["rt"]
 signal = [
   "libc",
   "mio/os-poll",
@@ -96,7 +93,6 @@ pin-project-lite = "0.2.11"
 # Everything else is optional...
 bytes = { version = "1.0.0", optional = true }
 mio = { version = "0.8.9", optional = true, default-features = false }
-num_cpus = { version = "1.8.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]


### PR DESCRIPTION
Unblocked now that tokio's MSRV is 1.70. I could also update the internal `::loom` function name if you want too.

Closes: #6432