### PR TITLE
chore: prepare Tokio v1.39.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.39.0", features = ["full"] }
+tokio = { version = "1.39.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,13 @@
+# 1.39.1 (July 23rd, 2024)
+
+This release reverts "time: avoid traversing entries in the time wheel twice"
+because it contains a bug. ([#6715])
+
+[#6715]: https://github.com/tokio-rs/tokio/pull/6715
+
 # 1.39.0 (July 23rd, 2024)
+
+Yanked. Please use 1.39.1 instead.
 
 - This release bumps the MSRV to 1.70. ([#6645])
 - This release upgrades to mio v1. ([#6635])

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.39.0"
+version = "1.39.1"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.39.0", features = ["full"] }
+tokio = { version = "1.39.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.39.1 (July 23rd, 2024)

This release reverts "time: avoid traversing entries in the time wheel twice" because it contains a bug. ([#6715])

[#6715]: https://github.com/tokio-rs/tokio/pull/6715