### PR TITLE
[semaphore] add try_acquire_timeout impl

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -18,6 +18,7 @@
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::{AtomicBool, AtomicUsize};
 use crate::loom::sync::{Arc, Mutex, MutexGuard};
+#[cfg(feature = "time")]
 use crate::time::timeout;
 use crate::util::linked_list::{self, LinkedList};
 #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -295,6 +296,7 @@ impl Semaphore {
         }
     }
 
+    #[cfg(feature = "time")]
     pub(crate) async fn try_acquire_timeout(
         &self,
         num_permits: usize,

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -16,23 +16,25 @@
 //! use-case like tokio's read-write lock, writers will not be starved by
 //! readers.
 use crate::loom::cell::UnsafeCell;
-use crate::loom::sync::atomic::{AtomicBool, AtomicUsize};
-use crate::loom::sync::{Arc, Mutex, MutexGuard};
-#[cfg(feature = "time")]
-use crate::time::timeout;
+use crate::loom::sync::atomic::AtomicUsize;
+use crate::loom::sync::{Mutex, MutexGuard};
 use crate::util::linked_list::{self, LinkedList};
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;
 use crate::util::WakeList;
-
 use std::future::Future;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::*;
 use std::task::{Context, Poll, Waker};
-use std::time::Duration;
 use std::{cmp, fmt};
+#[cfg(feature = "time")]
+use {
+    crate::loom::sync::{atomic::AtomicBool, Arc},
+    crate::time::timeout,
+    std::time::Duration,
+};
 
 /// An asynchronous counting semaphore which permits waiting on multiple permits at once.
 pub(crate) struct Semaphore {

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -3,6 +3,7 @@ use super::{AcquireError, TryAcquireError};
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;
 use std::sync::Arc;
+#[cfg(feature = "time")]
 use std::time::Duration;
 
 /// Counting semaphore performing asynchronous permit acquisition.

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -675,6 +675,7 @@ impl Semaphore {
     /// [`TryAcquireError::Closed`]: crate::sync::TryAcquireError::Closed
     /// [`TryAcquireError::NoPermits`]: crate::sync::TryAcquireError::NoPermits
     /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
+    #[cfg(feature = "time")]
     pub async fn try_acquire_timeout(
         &self,
         dur: Duration,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

It is difficult for users to simulate timeout semaphore functions through existing semaphore apis

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Provides an api with timeout functionality. example:

```rust
use tokio::sync::{Semaphore, TryAcquireError};
use std::time::Duration;

#[tokio::main]
async fn main() {
    let semaphore = Semaphore::new(2);

    let permit_1 = semaphore.try_acquire_timeout(Duration::from_millis(1)).await.unwrap();
    assert_eq!(semaphore.available_permits(), 1);

    let permit_2 = semaphore.try_acquire_timeout(Duration::from_millis(1)).await.unwrap();
    assert_eq!(semaphore.available_permits(), 0);

    let permit_3 = semaphore.try_acquire_timeout(Duration::from_millis(1)).await;
    assert_eq!(permit_3.err(), Some(TryAcquireError::NoPermits));
}
```
