### PR TITLE
time,sync: make Sleep and BatchSemaphore instrumentation explicit roots

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -147,6 +147,7 @@ impl Semaphore {
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let resource_span = {
             let resource_span = tracing::trace_span!(
+                parent: None,
                 "runtime.resource",
                 concrete_type = "Semaphore",
                 kind = "Sync",

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -267,6 +267,7 @@ impl Sleep {
 
             let location = location.expect("should have location if tracing");
             let resource_span = tracing::trace_span!(
+                parent: None,
                 "runtime.resource",
                 concrete_type = "Sleep",
                 kind = "timer",

--- a/tokio/tests/tracing-instrumentation/tests/sync.rs
+++ b/tokio/tests/tracing-instrumentation/tests/sync.rs
@@ -60,7 +60,7 @@ async fn test_mutex_creates_span() {
         .new_span(mutex_span.clone().with_explicit_parent(None))
         .enter(mutex_span.clone())
         .event(locked_event)
-        .new_span(batch_semaphore_span.clone())
+        .new_span(batch_semaphore_span.clone().with_explicit_parent(None))
         .enter(batch_semaphore_span.clone())
         .event(batch_semaphore_permits_event)
         .exit(batch_semaphore_span.clone())

--- a/tokio/tests/tracing-instrumentation/tests/time.rs
+++ b/tokio/tests/tracing-instrumentation/tests/time.rs
@@ -1,0 +1,61 @@
+//! Tests for time resource instrumentation.
+//!
+//! These tests ensure that the instrumentation for tokio
+//! synchronization primitives is correct.
+use std::time::Duration;
+
+use tracing_mock::{expect, subscriber};
+
+#[tokio::test]
+async fn test_sleep_creates_span() {
+    let sleep_span = expect::span()
+        .named("runtime.resource")
+        .with_target("tokio::time::sleep");
+
+    let state_update = expect::event()
+        .with_target("runtime::resource::state_update")
+        .with_fields(
+            expect::field("duration")
+                .with_value(&(7_u64 + 1))
+                .and(expect::field("duration.op").with_value(&"override")),
+        );
+
+    let async_op_span = expect::span()
+        .named("runtime.resource.async_op")
+        .with_target("tokio::time::sleep");
+
+    let async_op_poll_span = expect::span()
+        .named("runtime.resource.async_op.poll")
+        .with_target("tokio::time::sleep");
+
+    let (subscriber, handle) = subscriber::mock()
+        .new_span(sleep_span.clone().with_explicit_parent(None))
+        .enter(sleep_span.clone())
+        .event(state_update)
+        .new_span(
+            async_op_span
+                .clone()
+                .with_contextual_parent(Some("runtime.resource"))
+                .with_field(expect::field("source").with_value(&"Sleep::new_timeout")),
+        )
+        .exit(sleep_span.clone())
+        .enter(async_op_span.clone())
+        .new_span(
+            async_op_poll_span
+                .clone()
+                .with_contextual_parent(Some("runtime.resource.async_op")),
+        )
+        .exit(async_op_span.clone())
+        .drop_span(async_op_span)
+        .drop_span(async_op_poll_span)
+        .drop_span(sleep_span)
+        .run_with_handle();
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        _ = tokio::time::sleep(Duration::from_millis(7));
+    }
+
+    handle.assert_finished();
+}


### PR DESCRIPTION
## Motivation

When instrumenting resources in Tokio, a span is created for each
resource. Previously, all resources inherited the currently active span
as their parent (tracing default). However, this would keep that parent
span alive until the resource (and its span) were dropped. This is often
not correct, as a resource may be created in a task and then sent
elsewhere, while the originating task ends.

This artificial extension of the parent span's lifetime would make it
look like that task was still alive (but idle) in any system reading the
tracing instrumentation in Tokio, for example Tokio Console as reported
in tokio-rs/console#345.

## Solution

In #6107, most of the existing resource spans were updated to
make them explicit roots, so they have no contextual parent. However,
2. were missed:
- `Sleep`
- `BatchSemaphore`

This change alters the resource spans for those 2 resources to also make
them explicit roots.