### PR TITLE
docs: reiterate that `[build]` doesn't go in Cargo.toml

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -367,6 +367,12 @@
 //! rustflags = ["--cfg", "tokio_unstable"]
 //! ```
 //!
+//! <div class="warning">
+//! The <code>[build]</code> section does <strong>not</strong> go in a
+//! <code>Cargo.toml</code> file. Instead it must be placed in the Cargo config
+//! file <code>.cargo/config.toml</code>.
+//! </div>
+//!
 //! Alternatively, you can specify it with an environment variable:
 //!
 //! ```sh


### PR DESCRIPTION
This may seem like overkill, but we get this problem a lot on Discord.

## Motivation

To enable unstable features in Tokio, passing `--cfg tokio_unstable` to
the compiler is necessary. We document how to do this in a variety of
ways in the main Tokio (lib.rs) documentation.

One way is to add a `[build]` section to the file `.cargo/config.toml`.
Even though this filename is stated in the documentation, it is quite
common that first time users (including this author, some time ago) put
it in their `Cargo.toml` file instead.

## Solution

This change adds a "warning" section to the documentation to reiterate
the point that this section doesn't go in the cargo manifest
(`Cargo.toml`).