### PR TITLE
chore: prepare Tokio v1.39.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.39.1", features = ["full"] }
+tokio = { version = "1.39.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.39.2 (July 27th, 2024)
+
+This release fixes a regression where the `select!` macro stopped accepting
+expressions that make use of temporary lifetime extension. ([#6722])
+
+[#6722]: https://github.com/tokio-rs/tokio/pull/6722
+
 # 1.39.1 (July 23rd, 2024)
 
 This release reverts "time: avoid traversing entries in the time wheel twice"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.39.1"
+version = "1.39.2"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.39.1", features = ["full"] }
+tokio = { version = "1.39.2", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.39.2 (July 27th, 2024)

This release fixes a regression where the `select!` macro stopped accepting expressions that make use of temporary lifetime extension. ([#6722])

[#6722]: https://github.com/tokio-rs/tokio/pull/6722