### PR TITLE
process: stabilize `Command::process_group`

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -751,29 +751,34 @@ impl Command {
     ///
     /// Process groups determine which processes receive signals.
     ///
-    /// **Note**: This is an [unstable API][unstable] but will be stabilised once
-    /// tokio's `MSRV` is sufficiently new. See [the documentation on
-    /// unstable features][unstable] for details about using unstable features.
+    /// # Examples
     ///
-    /// If you want similar behavior without using this unstable feature you can
-    /// create a [`std::process::Command`] and convert that into a
-    /// [`tokio::process::Command`] using the `From` trait.
+    /// Pressing Ctrl-C in a terminal will send `SIGINT` to all processes
+    /// in the current foreground process group. By spawning the `sleep`
+    /// subprocess in a new process group, it will not receive `SIGINT`
+    /// from the terminal.
     ///
-    /// [unstable]: crate#unstable-features
-    /// [`tokio::process::Command`]: crate::process::Command
+    /// The parent process could install a [signal handler] and manage the
+    /// process on its own terms.
+    ///
+    /// A process group ID of 0 will use the process ID as the PGID.
     ///
     /// ```no_run
     /// # async fn test() { // allow using await
     /// use tokio::process::Command;
     ///
-    /// let output = Command::new("ls")
-    ///         .process_group(0)
-    ///         .output().await.unwrap();
+    /// let output = Command::new("sleep")
+    ///     .arg("10")
+    ///     .process_group(0)
+    ///     .output()
+    ///     .await
+    ///     .unwrap();
     /// # }
     /// ```
+    ///
+    /// [signal handler]: crate::signal
     #[cfg(unix)]
-    #[cfg(tokio_unstable)]
-    #[cfg_attr(docsrs, doc(cfg(all(unix, tokio_unstable))))]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub fn process_group(&mut self, pgroup: i32) -> &mut Command {
         self.std.process_group(pgroup);
         self


### PR DESCRIPTION
With the recent MSRV bump from 1.63 to 1.70, this can now be stabilized.

The underlying [`std::os::unix::process::CommandExt::process_group()`](https://doc.rust-lang.org/stable/std/os/unix/process/trait.CommandExt.html#tymethod.process_group) was added in Rust 1.64.0.

Also adjust the documentation to match std, explaining why setting process groups may be useful.