### PR TITLE
task: use `NonZeroU64` for `task::Id`

### DIFF
--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -78,26 +78,16 @@ impl Id {
         use crate::loom::sync::atomic::StaticAtomicU64;
 
         #[cfg(all(test, loom))]
-        {
-            crate::loom::lazy_static! {
-                static ref NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
-            }
-            loop {
-                let id = NEXT_ID.fetch_add(1, Relaxed);
-                if let Some(id) = NonZeroU64::new(u64::from(id)) {
-                    return Self(id);
-                }
-            }
+        crate::loom::lazy_static! {
+            static ref NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
         }
-
         #[cfg(not(all(test, loom)))]
-        {
-            static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
-            loop {
-                let id = NEXT_ID.fetch_add(1, Relaxed);
-                if let Some(id) = NonZeroU64::new(u64::from(id)) {
-                    return Self(id);
-                }
+        static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
+
+        loop {
+            let id = NEXT_ID.fetch_add(1, Relaxed);
+            if let Some(id) = NonZeroU64::new(u64::from(id)) {
+                return Self(id);
             }
         }
     }

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -81,6 +81,7 @@ impl Id {
         crate::loom::lazy_static! {
             static ref NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
         }
+
         #[cfg(not(all(test, loom)))]
         static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
 

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -1,6 +1,6 @@
 use crate::runtime::context;
 
-use std::fmt;
+use std::{fmt, num::NonZeroU64};
 
 /// An opaque ID that uniquely identifies a task relative to all other currently
 /// running tasks.
@@ -24,7 +24,7 @@ use std::fmt;
 #[cfg_attr(docsrs, doc(cfg(all(feature = "rt", tokio_unstable))))]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
-pub struct Id(pub(crate) u64);
+pub struct Id(pub(crate) NonZeroU64);
 
 /// Returns the [`Id`] of the currently running task.
 ///
@@ -82,17 +82,23 @@ impl Id {
             crate::loom::lazy_static! {
                 static ref NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
             }
-            Self(NEXT_ID.fetch_add(1, Relaxed))
+            let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Relaxed))
+                .unwrap_or_else(|| NonZeroU64::new(1).unwrap());
+
+            Self(id)
         }
 
         #[cfg(not(all(test, loom)))]
         {
             static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
-            Self(NEXT_ID.fetch_add(1, Relaxed))
+            let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Relaxed))
+                .unwrap_or_else(|| NonZeroU64::new(1).unwrap());
+
+            Self(id)
         }
     }
 
     pub(crate) fn as_u64(&self) -> u64 {
-        self.0
+        self.0.get()
     }
 }

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -82,19 +82,23 @@ impl Id {
             crate::loom::lazy_static! {
                 static ref NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
             }
-            let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Relaxed))
-                .unwrap_or_else(|| NonZeroU64::new(1).unwrap());
-
-            Self(id)
+            loop {
+                let id = NEXT_ID.fetch_add(1, Relaxed);
+                if let Some(id) = NonZeroU64::new(u64::from(id)) {
+                    return Self(id);
+                }
+            }
         }
 
         #[cfg(not(all(test, loom)))]
         {
             static NEXT_ID: StaticAtomicU64 = StaticAtomicU64::new(1);
-            let id = NonZeroU64::new(NEXT_ID.fetch_add(1, Relaxed))
-                .unwrap_or_else(|| NonZeroU64::new(1).unwrap());
-
-            Self(id)
+            loop {
+                let id = NEXT_ID.fetch_add(1, Relaxed);
+                if let Some(id) = NonZeroU64::new(u64::from(id)) {
+                    return Self(id);
+                }
+            }
         }
     }
 

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -87,7 +87,7 @@ impl Id {
 
         loop {
             let id = NEXT_ID.fetch_add(1, Relaxed);
-            if let Some(id) = NonZeroU64::new(u64::from(id)) {
+            if let Some(id) = NonZeroU64::new(id) {
                 return Self(id);
             }
         }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -532,6 +532,6 @@ unsafe impl<S> sharded_list::ShardedListItem for Task<S> {
     unsafe fn get_shard_id(target: NonNull<Self::Target>) -> usize {
         // SAFETY: The caller guarantees that `target` points at a valid task.
         let task_id = unsafe { Header::get_id(target) };
-        task_id.0 as usize
+        task_id.0.get() as usize
     }
 }


### PR DESCRIPTION
This should make the size slightly smaller when `Id` is wrapped in Option.

It seems that [ThreadId](https://github.com/tokio-rs/tokio/blob/0cbf1a5adae81e8ff86ca6d040aeee67cf888262/tokio/src/runtime/thread_id.rs) does the same thing already. (However, unlike threadId, when it overflows it wraps around without panic to keep the current behavior.)