### PR TITLE
Add try_block_on method to allow calling sync functions from threads

### DIFF
--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -14,9 +14,9 @@ cfg_rt! {
         e.block_on(f).unwrap()
     }
 
-    pub(crate) fn try_blocking_on<F: Future>(f: F) -> Result<BlockingRegionGuard, Box<dyn Error>> {
+    pub(crate) fn try_blocking_on<F: Future>(f: F) -> Result<F::Output, Box<dyn Error>> {
         match crate::runtime::context::try_enter_blocking_region(){
-            Some(x) => Ok(x),
+            Some(mut e) => Ok(e.block_on(f).unwrap()),
             None => Err("Cannot block the current thread from within a runtime. This \
             happens because a function attempted to block the current \
             thread while the thread is being used to drive asynchronous \

--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -14,7 +14,7 @@ cfg_rt! {
         e.block_on(f).unwrap()
     }
 
-    pub(crate) fn try_blocking_on<F: Future>(f: F) -> Result<F::Output, Box<dyn Error>> {
+    pub(crate) fn try_block_on<F: Future>(f: F) -> Result<F::Output, Box<dyn Error>> {
         match crate::runtime::context::try_enter_blocking_region(){
             Some(mut e) => Ok(e.block_on(f).unwrap()),
             None => Err("Cannot block the current thread from within a runtime. This \


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The existing `block_on` function panics when used within a runtime context, preventing users from handling the situation appropriately. Specifically, it uses `expect` to panic, which does not allow users to take alternative actions, such as spawning a task when already in a runtime thread.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

A new method, `try_block_on`, has been added. This method returns a `Result` instead of panicking, allowing users to handle the error case. The implementation checks whether the current thread can enter a blocking region. If it can, it runs the provided future; otherwise, it returns an error.

```rust
pub(crate) fn try_block_on<F: Future>(f: F) -> Result<F::Output, Box<dyn Error>> {
    match crate::runtime::context::try_enter_blocking_region() {
        Some(mut e) => Ok(e.block_on(f).unwrap()),
        None => Err("Cannot block the current thread from within a runtime. This \
        happens because a function attempted to block the current \
        thread while the thread is being used to drive asynchronous \
        tasks.".into())
    }
}
```

Idea is, users can handle this with a match or an if let and trigger spawn if needed.