### PR TITLE
Use web-time for tokio::time::Instant on wasm32-unknown-unknown 

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -83,7 +83,7 @@ signal = [
 ]
 sync = []
 test-util = ["rt", "sync", "time"]
-time = []
+time = ["web-time"]
 
 [dependencies]
 tokio-macros = { version = "~2.4.0", path = "../tokio-macros", optional = true }
@@ -97,6 +97,9 @@ parking_lot = { version = "0.12.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 socket2 = { version = "0.5.5", optional = true, features = [ "all" ] }
+
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+web-time = { version = "1", optional = true }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -603,3 +603,21 @@ macro_rules! cfg_is_wasm_not_wasi {
         )*
     }
 }
+
+macro_rules! cfg_wasm_unknown {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(target_family = "wasm", target_os = "unknown"))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_wasm_unknown {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(all(target_family = "wasm", target_os = "unknown")))]
+            $item
+        )*
+    }
+}

--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -4,6 +4,14 @@ use std::fmt;
 use std::ops;
 use std::time::Duration;
 
+cfg_wasm_unknown! {
+    pub(crate) type InstantInner = web_time::Instant;
+}
+
+cfg_not_wasm_unknown! {
+    pub(crate) type InstantInner = std::time::Instant;
+}
+
 /// A measurement of a monotonically nondecreasing clock.
 /// Opaque and useful only with `Duration`.
 ///
@@ -32,7 +40,7 @@ use std::time::Duration;
 /// take advantage of `time::pause()` and `time::advance()`.
 #[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct Instant {
-    std: std::time::Instant,
+    std: InstantInner,
 }
 
 impl Instant {
@@ -50,7 +58,7 @@ impl Instant {
     }
 
     /// Create a `tokio::time::Instant` from a `std::time::Instant`.
-    pub fn from_std(std: std::time::Instant) -> Instant {
+    pub fn from_std(std: InstantInner) -> Instant {
         Instant { std }
     }
 
@@ -63,7 +71,7 @@ impl Instant {
     }
 
     /// Convert the value into a `std::time::Instant`.
-    pub fn into_std(self) -> std::time::Instant {
+    pub fn into_std(self) -> InstantInner {
         self.std
     }
 
@@ -150,14 +158,14 @@ impl Instant {
     }
 }
 
-impl From<std::time::Instant> for Instant {
-    fn from(time: std::time::Instant) -> Instant {
+impl From<InstantInner> for Instant {
+    fn from(time: InstantInner) -> Instant {
         Instant::from_std(time)
     }
 }
 
-impl From<Instant> for std::time::Instant {
-    fn from(time: Instant) -> std::time::Instant {
+impl From<Instant> for InstantInner {
+    fn from(time: Instant) -> InstantInner {
         time.into_std()
     }
 }
@@ -188,7 +196,7 @@ impl ops::Sub<Duration> for Instant {
     type Output = Instant;
 
     fn sub(self, rhs: Duration) -> Instant {
-        Instant::from_std(std::time::Instant::sub(self.std, rhs))
+        Instant::from_std(InstantInner::sub(self.std, rhs))
     }
 }
 
@@ -206,10 +214,10 @@ impl fmt::Debug for Instant {
 
 #[cfg(not(feature = "test-util"))]
 mod variant {
-    use super::Instant;
+    use super::{Instant, InstantInner};
 
     pub(super) fn now() -> Instant {
-        Instant::from_std(std::time::Instant::now())
+        Instant::from_std(InstantInner::now())
     }
 }
 

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -96,6 +96,7 @@ mod instant;
 pub use self::instant::Instant;
 
 mod interval;
+pub(crate) use instant::InstantInner;
 pub use interval::{interval, interval_at, Interval, MissedTickBehavior};
 
 mod sleep;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`tokio::time::Instant` and such dependencies compile for wasm32-unknown-unknown however [when `std::time::Instant::now()` is called, it panics](https://github.com/rust-lang/rust/issues/48564). This more or less renders, `tokio::time::*` useless as they rely on `tokio::time::Instant::now()` (which then panics in the stdlib):
* [`tokio::time::timeout`](https://github.com/tokio-rs/tokio/blob/338e13b04baa3cf8db3feb1ba2266c0070a9efdf/tokio/src/time/timeout.rs#L92)
* [`tokio::time::sleep`](https://github.com/tokio-rs/tokio/blob/338e13b04baa3cf8db3feb1ba2266c0070a9efdf/tokio/src/time/sleep.rs#L128)
* [`tokio::time::Instant`](https://github.com/tokio-rs/tokio/blob/338e13b04baa3cf8db3feb1ba2266c0070a9efdf/tokio/src/time/interval.rs#L470)


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

I've done my best to try and research the various PRs. This is related to https://github.com/tokio-rs/tokio/issues/6178 and tangentially related to https://github.com/tokio-rs/tokio/issues/4827.

The [`web-time` crate](https://github.com/daxpedda/web-time) is referenced in a few issues and is a "Complete drop-in replacement for [std::time](https://doc.rust-lang.org/stable/std/time/) that works in browsers." 

Tokio is a pretty critical crate in the rust ecosystem and I don't take adding a new dependency lightly. When looking the [other top level tokio dependencies](https://crates.io/crates/tokio/1.39.2/dependencies), there are just two crates of even remotely similar popularity ([`pin-project-lite`](https://github.com/taiki-e/pin-project-lite) and [`signal-hook`](https://github.com/vorner/signal-hook)) so this dependency is definitely on the lesser-popularity side. The author/maintainer ([`daxpedda`](https://github.com/daxpedda/)) is a pretty common contributor to winit (where I first recognized the handle) and a bunch of wasm related projects so I think they're pretty responsible (we've not met, we just contribute to the same repos from time to time.)

This is a sibling PR to https://github.com/tokio-rs/tracing/pull/2758.

cc: @daxpedda (hope you don't mind the tag)

There's still the issue that [`std::thread::sleep` is unsupported for wasm](https://github.com/rust-lang/rust/blob/a886938671e1fde9d7271dce8ca3d6938bae9d2e/library/std/src/sys/pal/wasm/mod.rs#L47-L48) which is the next problem. I figure it's good to see the interest level of these changes before getting too far into the weeds.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
