### PR TITLE
rt: implement initial set of task hooks

### DIFF
--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "test-util")]
 use crate::runtime::scheduler;
-use crate::runtime::task::{self, Task};
+use crate::runtime::task::{self, Task, TaskHarnessScheduleHooks};
 use crate::runtime::Handle;
 
 /// `task::Schedule` implementation that does nothing (except some bookkeeping
@@ -12,6 +12,7 @@ use crate::runtime::Handle;
 pub(crate) struct BlockingSchedule {
     #[cfg(feature = "test-util")]
     handle: Handle,
+    hooks: TaskHarnessScheduleHooks,
 }
 
 impl BlockingSchedule {
@@ -32,6 +33,9 @@ impl BlockingSchedule {
         BlockingSchedule {
             #[cfg(feature = "test-util")]
             handle: handle.clone(),
+            hooks: TaskHarnessScheduleHooks {
+                task_terminate_callback: handle.inner.hooks().task_terminate_callback.clone(),
+            },
         }
     }
 }
@@ -56,5 +60,11 @@ impl task::Schedule for BlockingSchedule {
 
     fn schedule(&self, _task: task::Notified<Self>) {
         unreachable!();
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: self.hooks.task_terminate_callback.clone(),
+        }
     }
 }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
 use crate::runtime::handle::Handle;
-#[cfg!(tokio_unstable)]
+#[cfg(tokio_unstable)]
 use crate::runtime::TaskMeta;
 use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback};
 use crate::util::rand::{RngSeed, RngSeedGenerator};

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,5 +1,9 @@
+#![cfg_attr(loom, allow(unused_imports))]
+
 use crate::runtime::handle::Handle;
-use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime};
+use crate::runtime::{
+    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TaskMeta,
+};
 use crate::util::rand::{RngSeed, RngSeedGenerator};
 
 use std::fmt;
@@ -77,6 +81,12 @@ pub struct Builder {
 
     /// To run after each thread is unparked.
     pub(super) after_unpark: Option<Callback>,
+
+    /// To run before each task is spawned.
+    pub(super) before_spawn: Option<TaskCallback>,
+
+    /// To run after each task is terminated.
+    pub(super) after_termination: Option<TaskCallback>,
 
     /// Customizable keep alive timeout for `BlockingPool`
     pub(super) keep_alive: Option<Duration>,
@@ -289,6 +299,9 @@ impl Builder {
             before_stop: None,
             before_park: None,
             after_unpark: None,
+
+            before_spawn: None,
+            after_termination: None,
 
             keep_alive: None,
 
@@ -674,6 +687,91 @@ impl Builder {
         F: Fn() + Send + Sync + 'static,
     {
         self.after_unpark = Some(std::sync::Arc::new(f));
+        self
+    }
+
+    /// Executes function `f` just before a task is spawned.
+    ///
+    /// `f` is called within the Tokio context, so functions like
+    /// [`tokio::spawn`](crate::spawn) can be called, and may result in this callback being
+    /// invoked immediately.
+    ///
+    /// This can be used for bookkeeping or monitoring purposes.
+    ///
+    /// Note: There can only be one spawn callback for a runtime; calling this function more
+    /// than once replaces the last callback defined, rather than adding to it.
+    ///
+    /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tokio::runtime;
+    /// # pub fn main() {
+    /// let runtime = runtime::Builder::new_current_thread()
+    ///     .on_task_spawn(|_| {
+    ///         println!("spawning task");
+    ///     })
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// runtime.block_on(async {
+    ///     tokio::task::spawn(std::future::ready(()));
+    ///
+    ///     for _ in 0..64 {
+    ///         tokio::task::yield_now().await;
+    ///     }
+    /// })
+    /// # }
+    /// ```
+    #[cfg(not(loom))]
+    pub fn on_task_spawn<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+    {
+        self.before_spawn = Some(std::sync::Arc::new(f));
+        self
+    }
+
+    /// Executes function `f` just after a task is terminated.
+    ///
+    /// `f` is called within the Tokio context, so functions like
+    /// [`tokio::spawn`](crate::spawn) can be called.
+    ///
+    /// This can be used for bookkeeping or monitoring purposes.
+    ///
+    /// Note: There can only be one task termination callback for a runtime; calling this
+    /// function more than once replaces the last callback defined, rather than adding to it.
+    ///
+    /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use tokio::runtime;
+    /// # pub fn main() {
+    /// let runtime = runtime::Builder::new_current_thread()
+    ///     .on_task_terminate(|_| {
+    ///         println!("killing task");
+    ///     })
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// runtime.block_on(async {
+    ///     tokio::task::spawn(std::future::ready(()));
+    ///
+    ///     for _ in 0..64 {
+    ///         tokio::task::yield_now().await;
+    ///     }
+    /// })
+    /// # }
+    /// ```
+    #[cfg(not(loom))]
+    pub fn on_task_terminate<F>(&mut self, f: F) -> &mut Self
+    where
+        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+    {
+        self.after_termination = Some(std::sync::Arc::new(f));
         self
     }
 
@@ -1118,6 +1216,8 @@ impl Builder {
             Config {
                 before_park: self.before_park.clone(),
                 after_unpark: self.after_unpark.clone(),
+                before_spawn: self.before_spawn.clone(),
+                after_termination: self.after_termination.clone(),
                 global_queue_interval: self.global_queue_interval,
                 event_interval: self.event_interval,
                 local_queue_capacity: self.local_queue_capacity,
@@ -1269,6 +1369,8 @@ cfg_rt_multi_thread! {
                 Config {
                     before_park: self.before_park.clone(),
                     after_unpark: self.after_unpark.clone(),
+                    before_spawn: self.before_spawn.clone(),
+                    after_termination: self.after_termination.clone(),
                     global_queue_interval: self.global_queue_interval,
                     event_interval: self.event_interval,
                     local_queue_capacity: self.local_queue_capacity,
@@ -1316,6 +1418,8 @@ cfg_rt_multi_thread! {
                     Config {
                         before_park: self.before_park.clone(),
                         after_unpark: self.after_unpark.clone(),
+                        before_spawn: self.before_spawn.clone(),
+                        after_termination: self.after_termination.clone(),
                         global_queue_interval: self.global_queue_interval,
                         event_interval: self.event_interval,
                         local_queue_capacity: self.local_queue_capacity,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
 use crate::runtime::handle::Handle;
-use crate::runtime::{
-    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TaskMeta,
-};
+#[cfg!(tokio_unstable)]
+use crate::runtime::TaskMeta;
+use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback};
 use crate::util::rand::{RngSeed, RngSeedGenerator};
 
 use std::fmt;

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
 use crate::runtime::handle::Handle;
-use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime};
 #[cfg(all(not(loom), tokio_unstable))]
-use crate::runtime::{TaskCallback, TaskMeta};
+use crate::runtime::TaskMeta;
+use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback};
 use crate::util::rand::{RngSeed, RngSeedGenerator};
 
 use std::fmt;

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
 use crate::runtime::handle::Handle;
-use crate::runtime::{
-    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TaskMeta,
-};
+use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime};
+#[cfg(all(not(loom), tokio_unstable))]
+use crate::runtime::{TaskCallback, TaskMeta};
 use crate::util::rand::{RngSeed, RngSeedGenerator};
 
 use std::fmt;
@@ -724,7 +724,7 @@ impl Builder {
     /// })
     /// # }
     /// ```
-    #[cfg(not(loom))]
+    #[cfg(all(not(loom), tokio_unstable))]
     pub fn on_task_spawn<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
@@ -766,7 +766,7 @@ impl Builder {
     /// })
     /// # }
     /// ```
-    #[cfg(not(loom))]
+    #[cfg(all(not(loom), tokio_unstable))]
     pub fn on_task_terminate<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,9 +1,9 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
 use crate::runtime::handle::Handle;
-#[cfg(all(not(loom), tokio_unstable))]
-use crate::runtime::TaskMeta;
-use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback};
+use crate::runtime::{
+    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TaskMeta,
+};
 use crate::util::rand::{RngSeed, RngSeedGenerator};
 
 use std::fmt;

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -2,7 +2,7 @@
     any(not(all(tokio_unstable, feature = "full")), target_family = "wasm"),
     allow(dead_code)
 )]
-use crate::runtime::Callback;
+use crate::runtime::{Callback, TaskCallback};
 use crate::util::RngSeedGenerator;
 
 pub(crate) struct Config {
@@ -20,6 +20,12 @@ pub(crate) struct Config {
 
     /// Callback for a worker unparking itself
     pub(crate) after_unpark: Option<Callback>,
+
+    /// To run before each task is spawned.
+    pub(crate) before_spawn: Option<TaskCallback>,
+
+    /// To run after each task is terminated.
+    pub(crate) after_termination: Option<TaskCallback>,
 
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -381,6 +381,7 @@ cfg_rt! {
 
     mod task_hooks;
     pub (crate) use task_hooks::{TaskHooks, TaskCallback};
+    #[cfg(all(not(loom), tokio_unstable))]
     pub use task_hooks::TaskMeta;
 
     mod handle;

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -380,7 +380,7 @@ cfg_rt! {
     }
 
     mod task_hooks;
-    pub (crate) use task_hooks::{TaskHooks, TaskCallback};
+    pub(crate) use task_hooks::{TaskHooks, TaskCallback};
     #[cfg(tokio_unstable)]
     pub use task_hooks::TaskMeta;
     #[cfg(not(tokio_unstable))]

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -381,8 +381,10 @@ cfg_rt! {
 
     mod task_hooks;
     pub (crate) use task_hooks::{TaskHooks, TaskCallback};
-    #[cfg(all(not(loom), tokio_unstable))]
+    #[cfg(tokio_unstable)]
     pub use task_hooks::TaskMeta;
+    #[cfg(not(tokio_unstable))]
+    pub(crate) use task_hooks::TaskMeta;
 
     mod handle;
     pub use handle::{EnterGuard, Handle, TryCurrentError};

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -379,6 +379,10 @@ cfg_rt! {
         pub use dump::Dump;
     }
 
+    mod task_hooks;
+    pub (crate) use task_hooks::{TaskHooks, TaskCallback};
+    pub use task_hooks::TaskMeta;
+
     mod handle;
     pub use handle::{EnterGuard, Handle, TryCurrentError};
 

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -47,7 +47,7 @@ pub(crate) struct Handle {
     pub(crate) seed_generator: RngSeedGenerator,
 
     /// User-supplied hooks to invoke for things
-    pub(crate) scheduler_hooks: TaskHooks,
+    pub(crate) task_hooks: TaskHooks,
 }
 
 /// Data required for executing the scheduler. The struct is passed around to
@@ -138,7 +138,7 @@ impl CurrentThread {
             .unwrap_or(DEFAULT_GLOBAL_QUEUE_INTERVAL);
 
         let handle = Arc::new(Handle {
-            scheduler_hooks: TaskHooks {
+            task_hooks: TaskHooks {
                 task_spawn_callback: config.before_spawn.clone(),
                 task_terminate_callback: config.after_termination.clone(),
             },
@@ -447,7 +447,7 @@ impl Handle {
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
-        me.scheduler_hooks.spawn(&TaskMeta {
+        me.task_hooks.spawn(&TaskMeta {
             #[cfg(tokio_unstable)]
             id,
             _phantom: Default::default(),
@@ -619,7 +619,7 @@ impl Schedule for Arc<Handle> {
 
     fn hooks(&self) -> TaskHarnessScheduleHooks {
         TaskHarnessScheduleHooks {
-            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+            task_terminate_callback: self.task_hooks.task_terminate_callback.clone(),
         }
     }
 

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -3,8 +3,12 @@ use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
-use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, Task};
-use crate::runtime::{blocking, context, Config, MetricsBatch, SchedulerMetrics, WorkerMetrics};
+use crate::runtime::task::{
+    self, JoinHandle, OwnedTasks, Schedule, Task, TaskHarnessScheduleHooks,
+};
+use crate::runtime::{
+    blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, TaskMeta, WorkerMetrics,
+};
 use crate::sync::notify::Notify;
 use crate::util::atomic_cell::AtomicCell;
 use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};
@@ -41,6 +45,9 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
+
+    /// User-supplied hooks to invoke for things
+    pub(crate) scheduler_hooks: TaskHooks,
 }
 
 /// Data required for executing the scheduler. The struct is passed around to
@@ -131,6 +138,10 @@ impl CurrentThread {
             .unwrap_or(DEFAULT_GLOBAL_QUEUE_INTERVAL);
 
         let handle = Arc::new(Handle {
+            scheduler_hooks: TaskHooks {
+                task_spawn_callback: config.before_spawn.clone(),
+                task_terminate_callback: config.after_termination.clone(),
+            },
             shared: Shared {
                 inject: Inject::new(),
                 owned: OwnedTasks::new(1),
@@ -436,6 +447,12 @@ impl Handle {
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
+        me.scheduler_hooks.spawn(&TaskMeta {
+            #[cfg(tokio_unstable)]
+            id,
+            _phantom: Default::default(),
+        });
+
         if let Some(notified) = notified {
             me.schedule(notified);
         }
@@ -598,6 +615,12 @@ impl Schedule for Arc<Handle> {
                 self.driver.unpark();
             }
         });
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+        }
     }
 
     cfg_unstable! {

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -7,6 +7,8 @@ cfg_rt! {
 
     pub(crate) mod inject;
     pub(crate) use inject::Inject;
+
+    use crate::runtime::TaskHooks;
 }
 
 cfg_rt_multi_thread! {
@@ -148,6 +150,16 @@ cfg_rt! {
                 Handle::CurrentThread(handle) => handle,
                 #[cfg(feature = "rt-multi-thread")]
                 _ => panic!("not a CurrentThread handle"),
+            }
+        }
+
+        pub(crate) fn hooks(&self) -> &TaskHooks {
+            match self {
+                Handle::CurrentThread(h) => &h.scheduler_hooks,
+                #[cfg(feature = "rt-multi-thread")]
+                Handle::MultiThread(h) => &h.scheduler_hooks,
+                #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+                Handle::MultiThreadAlt(h) => &h.scheduler_hooks,
             }
         }
 

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -155,11 +155,11 @@ cfg_rt! {
 
         pub(crate) fn hooks(&self) -> &TaskHooks {
             match self {
-                Handle::CurrentThread(h) => &h.scheduler_hooks,
+                Handle::CurrentThread(h) => &h.task_hooks,
                 #[cfg(feature = "rt-multi-thread")]
-                Handle::MultiThread(h) => &h.scheduler_hooks,
+                Handle::MultiThread(h) => &h.task_hooks,
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-                Handle::MultiThreadAlt(h) => &h.scheduler_hooks,
+                Handle::MultiThreadAlt(h) => &h.task_hooks,
             }
         }
 

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -31,7 +31,7 @@ pub(crate) struct Handle {
     pub(crate) seed_generator: RngSeedGenerator,
 
     /// User-supplied hooks to invoke for things
-    pub(crate) scheduler_hooks: TaskHooks,
+    pub(crate) task_hooks: TaskHooks,
 }
 
 impl Handle {
@@ -55,7 +55,7 @@ impl Handle {
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
-        me.scheduler_hooks.spawn(&TaskMeta {
+        me.task_hooks.spawn(&TaskMeta {
             #[cfg(tokio_unstable)]
             id,
             _phantom: Default::default(),

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -4,6 +4,7 @@ use crate::runtime::scheduler::multi_thread::worker;
 use crate::runtime::{
     blocking, driver,
     task::{self, JoinHandle},
+    TaskHooks, TaskMeta,
 };
 use crate::util::RngSeedGenerator;
 
@@ -28,6 +29,9 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
+
+    /// User-supplied hooks to invoke for things
+    pub(crate) scheduler_hooks: TaskHooks,
 }
 
 impl Handle {
@@ -50,6 +54,12 @@ impl Handle {
         T::Output: Send + 'static,
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+
+        me.scheduler_hooks.spawn(&TaskMeta {
+            #[cfg(tokio_unstable)]
+            id,
+            _phantom: Default::default(),
+        });
 
         me.schedule_option_task_without_yield(notified);
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -284,7 +284,7 @@ pub(super) fn create(
 
     let remotes_len = remotes.len();
     let handle = Arc::new(Handle {
-        scheduler_hooks: TaskHooks {
+        task_hooks: TaskHooks {
             task_spawn_callback: config.before_spawn.clone(),
             task_terminate_callback: config.after_termination.clone(),
         },
@@ -1043,7 +1043,7 @@ impl task::Schedule for Arc<Handle> {
 
     fn hooks(&self) -> TaskHarnessScheduleHooks {
         TaskHarnessScheduleHooks {
-            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+            task_terminate_callback: self.task_hooks.task_terminate_callback.clone(),
         }
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -58,15 +58,15 @@
 
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime;
-use crate::runtime::context;
 use crate::runtime::scheduler::multi_thread::{
     idle, queue, Counters, Handle, Idle, Overflow, Parker, Stats, TraceStatus, Unparker,
 };
 use crate::runtime::scheduler::{inject, Defer, Lock};
-use crate::runtime::task::OwnedTasks;
+use crate::runtime::task::{OwnedTasks, TaskHarnessScheduleHooks};
 use crate::runtime::{
     blocking, coop, driver, scheduler, task, Config, SchedulerMetrics, WorkerMetrics,
 };
+use crate::runtime::{context, TaskHooks};
 use crate::util::atomic_cell::AtomicCell;
 use crate::util::rand::{FastRand, RngSeedGenerator};
 
@@ -284,6 +284,10 @@ pub(super) fn create(
 
     let remotes_len = remotes.len();
     let handle = Arc::new(Handle {
+        scheduler_hooks: TaskHooks {
+            task_spawn_callback: config.before_spawn.clone(),
+            task_terminate_callback: config.after_termination.clone(),
+        },
         shared: Shared {
             remotes: remotes.into_boxed_slice(),
             inject,
@@ -1035,6 +1039,12 @@ impl task::Schedule for Arc<Handle> {
 
     fn schedule(&self, task: Notified) {
         self.schedule_task(task, false);
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+        }
     }
 
     fn yield_now(&self, task: Notified) {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
@@ -4,6 +4,7 @@ use crate::runtime::scheduler::multi_thread_alt::worker;
 use crate::runtime::{
     blocking, driver,
     task::{self, JoinHandle},
+    TaskHooks, TaskMeta,
 };
 use crate::util::RngSeedGenerator;
 
@@ -26,6 +27,9 @@ pub(crate) struct Handle {
 
     /// Current random number generator seed
     pub(crate) seed_generator: RngSeedGenerator,
+
+    /// User-supplied hooks to invoke for things
+    pub(crate) scheduler_hooks: TaskHooks,
 }
 
 impl Handle {
@@ -49,6 +53,12 @@ impl Handle {
         T::Output: Send + 'static,
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+
+        me.scheduler_hooks.spawn(&TaskMeta {
+            #[cfg(tokio_unstable)]
+            id,
+            _phantom: Default::default(),
+        });
 
         if let Some(notified) = notified {
             me.shared.schedule_task(notified, false);

--- a/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/handle.rs
@@ -29,7 +29,7 @@ pub(crate) struct Handle {
     pub(crate) seed_generator: RngSeedGenerator,
 
     /// User-supplied hooks to invoke for things
-    pub(crate) scheduler_hooks: TaskHooks,
+    pub(crate) task_hooks: TaskHooks,
 }
 
 impl Handle {
@@ -54,7 +54,7 @@ impl Handle {
     {
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
 
-        me.scheduler_hooks.spawn(&TaskMeta {
+        me.task_hooks.spawn(&TaskMeta {
             #[cfg(tokio_unstable)]
             id,
             _phantom: Default::default(),

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -1441,7 +1441,7 @@ impl Shared {
 
     fn push_remote_task_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item=task::Notified<Arc<Handle>>>,
+        I: Iterator<Item = task::Notified<Arc<Handle>>>,
     {
         unsafe {
             self.inject.push_batch(self, iter);
@@ -1450,7 +1450,7 @@ impl Shared {
 
     fn push_remote_task_batch_synced<I>(&self, synced: &mut Synced, iter: I)
     where
-        I: Iterator<Item=task::Notified<Arc<Handle>>>,
+        I: Iterator<Item = task::Notified<Arc<Handle>>>,
     {
         unsafe {
             self.inject.push_batch(&mut synced.inject, iter);
@@ -1525,7 +1525,7 @@ impl Overflow<Arc<Handle>> for Shared {
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item=task::Notified<Arc<Handle>>>,
+        I: Iterator<Item = task::Notified<Arc<Handle>>>,
     {
         self.push_remote_task_batch(iter)
     }

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -58,14 +58,14 @@
 
 use crate::loom::sync::{Arc, Condvar, Mutex, MutexGuard};
 use crate::runtime;
-use crate::runtime::context;
 use crate::runtime::driver::Driver;
 use crate::runtime::scheduler::multi_thread_alt::{
     idle, queue, stats, Counters, Handle, Idle, Overflow, Stats, TraceStatus,
 };
 use crate::runtime::scheduler::{self, inject, Lock};
-use crate::runtime::task::OwnedTasks;
+use crate::runtime::task::{OwnedTasks, TaskHarnessScheduleHooks};
 use crate::runtime::{blocking, coop, driver, task, Config, SchedulerMetrics, WorkerMetrics};
+use crate::runtime::{context, TaskHooks};
 use crate::util::atomic_cell::AtomicCell;
 use crate::util::rand::{FastRand, RngSeedGenerator};
 
@@ -303,6 +303,10 @@ pub(super) fn create(
     let (inject, inject_synced) = inject::Shared::new();
 
     let handle = Arc::new(Handle {
+        scheduler_hooks: TaskHooks {
+            task_spawn_callback: config.before_spawn.clone(),
+            task_terminate_callback: config.after_termination.clone(),
+        },
         shared: Shared {
             remotes: remotes.into_boxed_slice(),
             inject,
@@ -1554,6 +1558,12 @@ impl task::Schedule for Arc<Handle> {
 
     fn schedule(&self, task: Notified) {
         self.shared.schedule_task(task, false);
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+        }
     }
 
     fn yield_now(&self, task: Notified) {

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -303,7 +303,7 @@ pub(super) fn create(
     let (inject, inject_synced) = inject::Shared::new();
 
     let handle = Arc::new(Handle {
-        scheduler_hooks: TaskHooks {
+        task_hooks: TaskHooks {
             task_spawn_callback: config.before_spawn.clone(),
             task_terminate_callback: config.after_termination.clone(),
         },
@@ -1441,7 +1441,7 @@ impl Shared {
 
     fn push_remote_task_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<Arc<Handle>>>,
+        I: Iterator<Item=task::Notified<Arc<Handle>>>,
     {
         unsafe {
             self.inject.push_batch(self, iter);
@@ -1450,7 +1450,7 @@ impl Shared {
 
     fn push_remote_task_batch_synced<I>(&self, synced: &mut Synced, iter: I)
     where
-        I: Iterator<Item = task::Notified<Arc<Handle>>>,
+        I: Iterator<Item=task::Notified<Arc<Handle>>>,
     {
         unsafe {
             self.inject.push_batch(&mut synced.inject, iter);
@@ -1525,7 +1525,7 @@ impl Overflow<Arc<Handle>> for Shared {
 
     fn push_batch<I>(&self, iter: I)
     where
-        I: Iterator<Item = task::Notified<Arc<Handle>>>,
+        I: Iterator<Item=task::Notified<Arc<Handle>>>,
     {
         self.push_remote_task_batch(iter)
     }
@@ -1562,7 +1562,7 @@ impl task::Schedule for Arc<Handle> {
 
     fn hooks(&self) -> TaskHarnessScheduleHooks {
         TaskHarnessScheduleHooks {
-            task_terminate_callback: self.scheduler_hooks.task_terminate_callback.clone(),
+            task_terminate_callback: self.task_hooks.task_terminate_callback.clone(),
         }
     }
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -14,7 +14,7 @@ use crate::loom::cell::UnsafeCell;
 use crate::runtime::context;
 use crate::runtime::task::raw::{self, Vtable};
 use crate::runtime::task::state::State;
-use crate::runtime::task::{Id, Schedule};
+use crate::runtime::task::{Id, Schedule, TaskHarnessScheduleHooks};
 use crate::util::linked_list;
 
 use std::num::NonZeroU64;
@@ -185,6 +185,8 @@ pub(super) struct Trailer {
     pub(super) owned: linked_list::Pointers<Header>,
     /// Consumer task waiting on completion of this task.
     pub(super) waker: UnsafeCell<Option<Waker>>,
+    /// Optional hooks needed in the harness.
+    pub(super) hooks: TaskHarnessScheduleHooks,
 }
 
 generate_addr_of_methods! {
@@ -226,6 +228,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         let tracing_id = future.id();
         let vtable = raw::vtable::<T, S>();
         let result = Box::new(Cell {
+            trailer: Trailer::new(scheduler.hooks()),
             header: new_header(
                 state,
                 vtable,
@@ -239,7 +242,6 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                 },
                 task_id,
             },
-            trailer: Trailer::new(),
         });
 
         #[cfg(debug_assertions)]
@@ -459,10 +461,11 @@ impl Header {
 }
 
 impl Trailer {
-    fn new() -> Self {
+    fn new(hooks: TaskHarnessScheduleHooks) -> Self {
         Trailer {
             waker: UnsafeCell::new(None),
             owned: linked_list::Pointers::new(),
+            hooks,
         }
     }
 

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -334,15 +334,15 @@ where
         //
         // We call this in a separate block so that it runs after the task appears to have
         // completed and will still run if the destructor panics.
-        let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-            if let Some(f) = self.trailer().hooks.task_terminate_callback.as_ref() {
+        if let Some(f) = self.trailer().hooks.task_terminate_callback.as_ref() {
+            let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 f(&TaskMeta {
                     #[cfg(tokio_unstable)]
                     id: self.core().task_id,
                     _phantom: Default::default(),
                 })
-            }
-        }));
+            }));
+        }
 
         // The task has completed execution and will no longer be scheduled.
         let num_release = self.release();

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,0 +1,35 @@
+use std::marker::PhantomData;
+
+impl TaskHooks {
+    pub(crate) fn spawn(&self, meta: &TaskMeta<'_>) {
+        if let Some(f) = self.task_spawn_callback.as_ref() {
+            f(meta)
+        }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct TaskHooks {
+    pub(crate) task_spawn_callback: Option<TaskCallback>,
+    pub(crate) task_terminate_callback: Option<TaskCallback>,
+}
+
+/// Task metadata supplied to user-provided hooks for task events.
+#[allow(missing_debug_implementations)]
+pub struct TaskMeta<'a> {
+    /// The opaque ID of the task.
+    #[cfg(tokio_unstable)]
+    pub(crate) id: super::task::Id,
+    pub(crate) _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> TaskMeta<'a> {
+    /// Return the opaque ID of the task.
+    #[cfg(tokio_unstable)]
+    pub fn id(&self) -> super::task::Id {
+        self.id
+    }
+}
+
+/// Runs on specific task-related events
+pub(crate) type TaskCallback = std::sync::Arc<dyn Fn(&TaskMeta<'_>) + Send + Sync>;

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -16,6 +16,7 @@ pub(crate) struct TaskHooks {
 
 /// Task metadata supplied to user-provided hooks for task events.
 #[allow(missing_debug_implementations)]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 pub struct TaskMeta<'a> {
     /// The opaque ID of the task.
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -6,7 +6,7 @@ use self::noop_scheduler::NoopSchedule;
 use self::unowned_wrapper::unowned;
 
 mod noop_scheduler {
-    use crate::runtime::task::{self, Task};
+    use crate::runtime::task::{self, Task, TaskHarnessScheduleHooks};
 
     /// `task::Schedule` implementation that does nothing, for testing.
     pub(crate) struct NoopSchedule;
@@ -18,6 +18,12 @@ mod noop_scheduler {
 
         fn schedule(&self, _task: task::Notified<Self>) {
             unreachable!();
+        }
+
+        fn hooks(&self) -> TaskHarnessScheduleHooks {
+            TaskHarnessScheduleHooks {
+                task_terminate_callback: None,
+            }
         }
     }
 }

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -1,5 +1,5 @@
 use crate::runtime::scheduler::multi_thread::{queue, Stats};
-use crate::runtime::task::{self, Schedule, Task};
+use crate::runtime::task::{self, Schedule, Task, TaskHarnessScheduleHooks};
 
 use std::cell::RefCell;
 use std::thread;
@@ -283,5 +283,11 @@ impl Schedule for Runtime {
 
     fn schedule(&self, _task: task::Notified<Self>) {
         unreachable!();
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: None,
+        }
     }
 }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -1,4 +1,6 @@
-use crate::runtime::task::{self, unowned, Id, JoinHandle, OwnedTasks, Schedule, Task};
+use crate::runtime::task::{
+    self, unowned, Id, JoinHandle, OwnedTasks, Schedule, Task, TaskHarnessScheduleHooks,
+};
 use crate::runtime::tests::NoopSchedule;
 
 use std::collections::VecDeque;
@@ -349,5 +351,11 @@ impl Schedule for Runtime {
 
     fn schedule(&self, task: task::Notified<Self>) {
         self.0.core.try_lock().unwrap().queue.push_back(task);
+    }
+
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: None,
+        }
     }
 }

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -3,7 +3,7 @@ use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::{Arc, Mutex};
 #[cfg(tokio_unstable)]
 use crate::runtime;
-use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, Task};
+use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, Task, TaskHarnessScheduleHooks};
 use crate::runtime::{context, ThreadId, BOX_FUTURE_THRESHOLD};
 use crate::sync::AtomicWaker;
 use crate::util::RcCell;
@@ -1069,6 +1069,13 @@ impl task::Schedule for Arc<Shared> {
 
     fn schedule(&self, task: task::Notified<Self>) {
         Shared::schedule(self, task);
+    }
+
+    // localset does not currently support task hooks
+    fn hooks(&self) -> TaskHarnessScheduleHooks {
+        TaskHarnessScheduleHooks {
+            task_terminate_callback: None,
+        }
     }
 
     cfg_unstable! {

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -1,0 +1,76 @@
+#![allow(unknown_lints, unexpected_cfgs)]
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", tokio_unstable, target_has_atomic = "64"))]
+
+use std::collections::HashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use tokio::runtime::Builder;
+
+const TASKS: usize = 8;
+const ITERATIONS: usize = 64;
+/// Assert that the spawn task hook always fires when set.
+#[test]
+fn spawn_task_hook_fires() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let count2 = Arc::clone(&count);
+
+    let ids = Arc::new(Mutex::new(HashSet::new()));
+    let ids2 = Arc::clone(&ids);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(move |data| {
+            ids2.lock().unwrap().insert(data.id());
+
+            count2.fetch_add(1, Ordering::SeqCst);
+        })
+        .build()
+        .unwrap();
+
+    for _ in 0..TASKS {
+        runtime.spawn(std::future::pending::<()>());
+    }
+
+    let count_realized = count.load(Ordering::SeqCst);
+    assert_eq!(
+        TASKS, count_realized,
+        "Total number of spawned task hook invocations was incorrect, expected {TASKS}, got {}",
+        count_realized
+    );
+
+    let count_ids_realized = ids.lock().unwrap().len();
+
+    assert_eq!(
+        TASKS, count_ids_realized,
+        "Total number of spawned task hook invocations was incorrect, expected {TASKS}, got {}",
+        count_realized
+    );
+}
+
+/// Assert that the terminate task hook always fires when set.
+#[test]
+fn terminate_task_hook_fires() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let count2 = Arc::clone(&count);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_terminate(move |_data| {
+            count2.fetch_add(1, Ordering::SeqCst);
+        })
+        .build()
+        .unwrap();
+
+    for _ in 0..TASKS {
+        runtime.spawn(std::future::ready(()));
+    }
+
+    runtime.block_on(async {
+        // tick the runtime a bunch to close out tasks
+        for _ in 0..ITERATIONS {
+            tokio::task::yield_now().await;
+        }
+    });
+
+    assert_eq!(TASKS, count.load(Ordering::SeqCst));
+}


### PR DESCRIPTION
This change implements two hooks for per-task actions, one which is invoked on task spawn, and one which is invoked during task termination.

These hooks initially are only supplied with the task ID (on unstable only), but more information can be added in the future, as the struct used to supply parameters is opaque.

Fixes #3181.