### PR TITLE
added: `broadcast::Receiver::receiver_count()`

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -997,31 +997,30 @@ impl<T> Receiver<T> {
         (next_send_pos - self.next) as usize
     }
 
-    
     /// Returns the number of active receivers.
-    /// 
+    ///
     /// # Note
     ///
     /// It is not guaranteed that a sent message will reach this number of
     /// receivers. Active receivers may never call [`recv`] again before
     /// dropping.
-    /// 
+    ///
     /// [`recv`]: crate::sync::broadcast::Receiver::recv
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```
     /// use tokio::sync::broadcast;
-    /// 
+    ///
     /// #[tokio::main]
     /// async fn main() {
     ///     let (tx, rx) = broadcast::channel(16);
-    /// 
+    ///
     ///     assert_eq!(1, rx.receiver_count());
-    /// 
+    ///
     ///     let mut _rx2 = rx.resubscribe();
     ///     assert_eq!(2, _rx2.receiver_count());
-    /// 
+    ///
     ///     tx.send(10).unwrap();
     /// }
     /// ```

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -997,6 +997,38 @@ impl<T> Receiver<T> {
         (next_send_pos - self.next) as usize
     }
 
+    
+    /// Returns the number of active receivers.
+    /// 
+    /// # Note
+    ///
+    /// It is not guaranteed that a sent message will reach this number of
+    /// receivers. Active receivers may never call [`recv`] again before
+    /// dropping.
+    /// 
+    /// [`recv`]: crate::sync::broadcast::Receiver::recv
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use tokio::sync::broadcast;
+    /// 
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = broadcast::channel(16);
+    /// 
+    ///     assert_eq!(1, rx.receiver_count());
+    /// 
+    ///     let mut _rx2 = rx.resubscribe();
+    ///     assert_eq!(2, _rx2.receiver_count());
+    /// 
+    ///     tx.send(10).unwrap();
+    /// }
+    /// ```
+    pub fn receiver_count(&self) -> usize {
+        self.shared.tail.lock().rx_cnt
+    }
+
     /// Returns true if there aren't any messages in the channel that the [`Receiver`]
     /// has yet to receive.
     ///


### PR DESCRIPTION
This can be useful in many scenarios.

In my use case, I need to execute some code when all `broadcast::Receiver` instances are dropped.