### PR TITLE
sync: Add into_inner method on TrySendErrors

### DIFF
--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -36,6 +36,16 @@ pub enum TrySendError<T> {
     Closed(T),
 }
 
+impl<T> TrySendError<T> {
+    /// Consume the `TrySendError`, returning the unsent value
+    pub fn into_inner(self) -> T {
+        match self {
+            TrySendError::Full(val) => val,
+            TrySendError::Closed(val) => val,
+        }
+    }
+}
+
 impl<T> fmt::Debug for TrySendError<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
@@ -121,6 +131,16 @@ cfg_time! {
         /// The receive half of the channel was explicitly closed or has been
         /// dropped.
         Closed(T),
+    }
+
+    impl<T> SendTimeoutError<T> {
+        /// Consume the `SendTimeoutError`, returning the unsent value
+        pub fn into_inner(self) -> T {
+            match self {
+                SendTimeoutError::Timeout(val) => val,
+                SendTimeoutError::Closed(val) => val,
+            }
+        }
     }
 
     impl<T> fmt::Debug for SendTimeoutError<T> {

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -37,7 +37,7 @@ pub enum TrySendError<T> {
 }
 
 impl<T> TrySendError<T> {
-    /// Consume the `TrySendError`, returning the unsent value
+    /// Consume the `TrySendError`, returning the unsent value.
     pub fn into_inner(self) -> T {
         match self {
             TrySendError::Full(val) => val,
@@ -134,7 +134,7 @@ cfg_time! {
     }
 
     impl<T> SendTimeoutError<T> {
-        /// Consume the `SendTimeoutError`, returning the unsent value
+        /// Consume the `SendTimeoutError`, returning the unsent value.
         pub fn into_inner(self) -> T {
             match self {
                 SendTimeoutError::Timeout(val) => val,


### PR DESCRIPTION
## Motivation

In the case where you might not care about the specific error produced (or you just want to log it) but want to retrieve the value you sent, these provide a simple way to do that.

These are just convenience methods to retrieve the inner value from these error types. These enums aren't `non_exhaustive`  so I don't think there's a risk of the API changing and invalidating these methods.

## Solution

Straight forward into_inner method.
