### PR TITLE
must use macro annotation for abort_handle of JoinHandle

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -296,7 +296,7 @@ impl<T> JoinHandle<T> {
     /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
-    #[must_use]
+    #[must_use = "abort handles do nothing unless `.abort` is called"]
     pub fn abort_handle(&self) -> super::AbortHandle {
         self.raw.ref_inc();
         super::AbortHandle::new(self.raw)

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -296,6 +296,7 @@ impl<T> JoinHandle<T> {
     /// # }
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
+    #[must_use]
     pub fn abort_handle(&self) -> super::AbortHandle {
         self.raw.ref_inc();
         super::AbortHandle::new(self.raw)


### PR DESCRIPTION
if the return value of abort_handle is unused then abort will never be called for that JoinHandle

Fixes: #6761
