### PR TITLE
[WIP] add a basic illumos test job

### DIFF
--- a/.github/buildomat/README.md
+++ b/.github/buildomat/README.md
@@ -1,0 +1,1 @@
+# tokio illumos CI

--- a/.github/buildomat/README.md
+++ b/.github/buildomat/README.md
@@ -1,1 +1,20 @@
-# tokio illumos CI
+# Buildomat illumos CI
+
+This directory contains CI configurations for the [illumos] operating system.
+Tokio's illumos CI jobs are run using [Buildomat], a CI system developed by
+Oxide Computer, which supports illumos. See [the Buildomat README] for more
+details.
+
+## illumos-Specific CI Failures
+
+If your pull request's CI build fails on illumos, and you aren't able to easily
+reproduce the failure on other operating systems, don't worry! The
+[tokio-rs/illumos] team is responsible for maintaining Tokio's illumos support,
+and can be called on to assist contributors with illumos-specific issues. Please
+feel free to tag @tokio-rs/illumos to ask for help resolving build failures on
+illumos 
+
+[illumos]: https://www.illumos.org/
+[Buildomat]: https://github.com/oxidecomputer/buildomat
+[the Buildomat README]: https://github.com/oxidecomputer/buildomat
+[tokio-rs/illumos]: https://github.com/orgs/tokio-rs/teams/illumos

--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -1,3 +1,6 @@
+# Repository-level Buildomat configuration.
+# See: https://github.com/oxidecomputer/buildomat#per-repository-configuration
+
 # Enable buildomat. This one should be self-explanatory.
 enable = true
 # Allow CI runs for PRs from users outside the `tokio-rs` organization. Our

--- a/.github/buildomat/config.toml
+++ b/.github/buildomat/config.toml
@@ -1,0 +1,5 @@
+# Enable buildomat. This one should be self-explanatory.
+enable = true
+# Allow CI runs for PRs from users outside the `tokio-rs` organization. Our
+# buildomat jobs don't touch any secrets/keys, so this should be fine.
+org_only = false

--- a/.github/buildomat/jobs/test-full.sh
+++ b/.github/buildomat/jobs/test-full.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#:
+#: name = "illumos-test-full"
+#: variety = "basic"
+#: target = "omnios-r151038"
+#: rust_toolchain = "stable"
+
+# basic illumos test job with --features full.
+# TODO(eliza): consider splitting the "build" and "test" jobs into separate
+# buildomat jobs, so that the build and test jobs can fail independently.
+
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+
+# These are the same env vars that are set for all GitHub Actions CI jobs.
+export RUSTFLAGS="-Dwarnings"
+export RUST_BACKTRACE=1
+# We're building once, so there's no need to incur the overhead of an
+# incremental build.
+export CARGO_INCREMENTAL=0
+
+# NOTE: Currently we use the latest cargo-nextest release, since this is what
+# the Linux CI jobs do. If we ever start pinning our nextest version, this
+# should be changed to match that.
+NEXTEST_VERSION='latest'
+
+
+curl -sSfL --retry 10 "https://get.nexte.st/$NEXTEST_VERSION/illumos" | gunzip | tar -xvf - -C ~/.cargo/bin
+
+# Print the current test execution environment
+uname -a
+cargo --version
+rustc --version
+
+banner build
+ptime -m cargo test --no-run --all --verbose --features full
+
+banner tests
+ptime -m cargo nextest run --features full
+
+banner doctests
+ptime -m cargo test --doc --verbose --features full


### PR DESCRIPTION
## Motivation

As described in #6763, Tokio compiles for the illumos operating system, but we don't presently have automated tests on illumos. We'd like to fix that.

## Solution

This branch adds a basic illumos CI setup using [buildomat](https://github.com/oxidecomputer/buildomat), an illumos-compatible CI system developed by Oxide. These CI jobs run on infrastructure contributed by Oxide.