### PR TITLE
fix: update the broken link for the timer paper

### DIFF
--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -99,7 +99,7 @@ impl AtomicOptionNonZeroU64 {
 /// either be canceled (dropped) or their associated entries will reach level
 /// zero and be notified.
 ///
-/// [paper]: http://www.cs.columbia.edu/~nahum/w6998/papers/ton97-timing-wheels.pdf
+/// [paper]: https://ieeexplore.ieee.org/document/650142
 /// [sleep]: crate::time::Sleep
 /// [timeout]: crate::time::Timeout
 /// [interval]: crate::time::Interval


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I found this broken link when I read the code.

## Solution

Updated it to a new link.

I know it is not free, but at least we can see the title of the paper. 😆