### PR TITLE
net: add handling for abstract socket name

### DIFF
--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -3,9 +3,9 @@ use crate::net::unix::{SocketAddr, UnixStream};
 
 use std::fmt;
 use std::io;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::linux::net::SocketAddrExt;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
@@ -75,7 +75,7 @@ impl UnixListener {
         P: AsRef<Path>,
     {
         // For now, we handle abstract socket paths on linux here.
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let addr = {
             let os_str_bytes = path.as_ref().as_os_str().as_bytes();
             if os_str_bytes.starts_with(b"\0") {
@@ -84,7 +84,7 @@ impl UnixListener {
                 StdSocketAddr::from_pathname(path)?
             }
         };
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let addr = StdSocketAddr::from_pathname(path)?;
 
         let listener = mio::net::UnixListener::bind_addr(&addr)?;

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -3,10 +3,10 @@ use crate::net::unix::{SocketAddr, UnixStream};
 
 use std::fmt;
 use std::io;
-#[cfg(target_os = "linux")]
-use std::os::linux::net::SocketAddrExt;
 #[cfg(target_os = "android")]
 use std::os::android::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -3,8 +3,10 @@ use crate::net::unix::{SocketAddr, UnixStream};
 
 use std::fmt;
 use std::io;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -8,9 +8,9 @@ use crate::net::unix::SocketAddr;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::linux::net::SocketAddrExt;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
@@ -71,7 +71,7 @@ impl UnixStream {
         P: AsRef<Path>,
     {
         // On linux, abstract socket paths need to be considered.
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         let addr = {
             let os_str_bytes = path.as_ref().as_os_str().as_bytes();
             if os_str_bytes.starts_with(b"\0") {
@@ -80,7 +80,7 @@ impl UnixStream {
                 StdSocketAddr::from_pathname(path)?
             }
         };
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "android")))]
         let addr = StdSocketAddr::from_pathname(path)?;
 
         let stream = mio::net::UnixStream::connect_addr(&addr)?;

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -8,8 +8,10 @@ use crate::net::unix::SocketAddr;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
-#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg(target_os = "linux")]
 use std::os::linux::net::SocketAddrExt;
+#[cfg(target_os = "android")]
+use std::os::android::net::SocketAddrExt;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -8,8 +8,12 @@ use crate::net::unix::SocketAddr;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
-use std::os::unix::net;
+use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -66,7 +70,20 @@ impl UnixStream {
     where
         P: AsRef<Path>,
     {
-        let stream = mio::net::UnixStream::connect(path)?;
+        // On linux, abstract socket paths need to be considered.
+        #[cfg(target_os = "linux")]
+        let addr = {
+            let os_str_bytes = path.as_ref().as_os_str().as_bytes();
+            if os_str_bytes.starts_with(b"\0") {
+                StdSocketAddr::from_abstract_name(os_str_bytes)?
+            } else {
+                StdSocketAddr::from_pathname(path)?
+            }
+        };
+        #[cfg(not(target_os = "linux"))]
+        let addr = StdSocketAddr::from_pathname(path)?;
+
+        let stream = mio::net::UnixStream::connect_addr(&addr)?;
         let stream = UnixStream::new(stream)?;
 
         poll_fn(|cx| stream.io.registration().poll_write_ready(cx)).await?;

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -8,10 +8,10 @@ use crate::net::unix::SocketAddr;
 use std::fmt;
 use std::io::{self, Read, Write};
 use std::net::Shutdown;
-#[cfg(target_os = "linux")]
-use std::os::linux::net::SocketAddrExt;
 #[cfg(target_os = "android")]
 use std::os::android::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -409,3 +409,16 @@ async fn epollhup() -> io::Result<()> {
     assert_eq!(err.kind(), io::ErrorKind::ConnectionReset);
     Ok(())
 }
+
+// test for https://github.com/tokio-rs/tokio/issues/6767
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn abstract_socket_name() {
+    let socket_path = "\0aaa";
+    let listener = UnixListener::bind(socket_path).unwrap();
+
+    let accept = listener.accept();
+    let connect = UnixStream::connect(&socket_path);
+
+    try_join(accept, connect).await.unwrap();
+}

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -412,7 +412,7 @@ async fn epollhup() -> io::Result<()> {
 
 // test for https://github.com/tokio-rs/tokio/issues/6767
 #[tokio::test]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 async fn abstract_socket_name() {
     let socket_path = "\0aaa";
     let listener = UnixListener::bind(socket_path).unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Closes https://github.com/tokio-rs/tokio/issues/6767.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
If the beginning of the path is `\0`, we fallback to std's `from_abstract_name`.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
