### PR TITLE
time: eliminate timer wheel allocations

### DIFF
--- a/tokio/src/loom/mocked.rs
+++ b/tokio/src/loom/mocked.rs
@@ -24,6 +24,11 @@ pub(crate) mod sync {
         pub(crate) fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
             self.0.try_lock().ok()
         }
+
+        #[inline]
+        pub(crate) fn get_mut(&mut self) -> &mut T {
+            self.0.get_mut().unwrap()
+        }
     }
     pub(crate) use loom::sync::*;
 

--- a/tokio/src/loom/std/mutex.rs
+++ b/tokio/src/loom/std/mutex.rs
@@ -33,4 +33,12 @@ impl<T> Mutex<T> {
             Err(TryLockError::WouldBlock) => None,
         }
     }
+
+    #[inline]
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        match self.0.get_mut() {
+            Ok(val) => val,
+            Err(p_err) => p_err.into_inner(),
+        }
+    }
 }


### PR DESCRIPTION
## Motivation
#6683 introduced additional allocations to keep the locks of the timer wheel shards alive. #6757 is a request to get rid of those additional allocations. This PR should address this issue.

## Solution
I wrapped the timer wheel shards in an `RwLock`. With that we can get a `write`-lock in `park_internal` to prevent other threads from accessing the shards. In all other places the `read`-lock can be used for simultaneous access.

Closes #6757 