### PR TITLE
ci: run ci with 1.81 rustc beta release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     resource_class: arm.medium
     environment:
       # Change to pin rust version
-      RUST_STABLE: stable
+      RUST_STABLE: beta
     steps:
       - checkout
       - run:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
   image_family: freebsd-14-1
 env:
-  RUST_STABLE: stable
+  RUST_STABLE: beta
   RUST_NIGHTLY: nightly-2024-05-05
   RUSTFLAGS: -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_WINDOWS_PATH_ADD_BIN: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: beta
   rust_nightly: nightly-2024-05-05
   rust_clippy: '1.77'
   # When updating this, also update:


### PR DESCRIPTION
To catch new warnings breaking the build before they happen, make a CI run with the beta compiler.