### PR TITLE
task: add join_all method to JoinSet

### DIFF
--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -375,8 +375,8 @@ impl<T: 'static> JoinSet<T> {
     }
 
     /// Awaits the completion of all tasks in this `JoinSet`, returning a vector of their results.
-    /// The results will be stored in the order they completed not the order they were spawned.
     ///
+    /// The results will be stored in the order they completed not the order they were spawned.
     /// This is a convenience method that is equivalent to calling [`join_next`] in
     /// a loop. If any tasks on the `JoinSet` fail with an [`JoinError`], then this call
     /// to `join_all` will panic and all remaining tasks on the `JoinSet` are

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -377,7 +377,7 @@ impl<T: 'static> JoinSet<T> {
     /// Awaits the completion of all tasks in this `JoinSet`, returning a vector of their results.
     /// The results will be stored in the order they completed not the order they were spawned.
     ///
-    /// This a convenience method that is equivalent to calling [`join_next`] in
+    /// This is a convenience method that is equivalent to calling [`join_next`] in
     /// a loop. If any tasks on the `JoinSet` fail with an [`JoinError`], then this call
     /// to `join_all` will panic and all remaining tasks on the `JoinSet` are
     /// cancelled. To handle errors in any other way, manually call [`join_next`]

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -378,9 +378,9 @@ impl<T: 'static> JoinSet<T> {
     /// The results will be stored in the order they completed not the order they were spawned.
     ///
     /// This a convenience method that is equivalent to calling [`join_next`] in
-    /// a loop. If any tasks on the `JoinSet` fail with an `JoinError`, then this call
+    /// a loop. If any tasks on the `JoinSet` fail with an [`JoinError`], then this call
     /// to `join_all` will panic and all remaining tasks on the `JoinSet` are
-    /// [cancelled]. To handle errors in any other way, manually call `join_next`
+    /// cancelled. To handle errors in any other way, manually call [`join_next`]
     /// in a loop.
     ///
     /// # Examples
@@ -389,6 +389,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// ```
     /// use tokio::task::JoinSet;
+    /// use std::time::Duration;
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -398,18 +399,19 @@ impl<T: 'static> JoinSet<T> {
     ///        set.spawn(async move {
     ///            tokio::time::sleep(Duration::from_secs(3 - i)).await;
     ///            i
-    //         });
+    ///        });
     ///     }   
     ///
-    ///     let res = set.join_all.await;  
-    ///     assert_eq!(vec, vec![2, 1, 0]);
+    ///     let output = set.join_all().await;  
+    ///     assert_eq!(output, vec![2, 1, 0]);
     /// }
     /// ```
     ///
-    /// Equivalent of `join_all` using `join_next` and loop.
+    /// Equivalent implementation of `join_all`, using [`join_next`] and loop.
     ///
     /// ```
     /// use tokio::task::JoinSet;
+    /// use std::panic;
     ///
     /// #[tokio::main]
     /// async fn main() {
@@ -419,17 +421,19 @@ impl<T: 'static> JoinSet<T> {
     ///        set.spawn(async move {i});
     ///     }   
     ///     
-    ///     let res = Vec::new();
+    ///     let mut output = Vec::new();
     ///     while let Some(res) = set.join_next().await{
     ///         match res {
-    ///         Ok(t) => res.push(t),
-    ///         Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
-    ///         Err(err) => panic!("{err}"),
+    ///             Ok(t) => output.push(t),
+    ///             Err(err) if err.is_panic() => panic::resume_unwind(err.into_panic()),
+    ///             Err(err) => panic!("{err}"),
     ///         }
     ///     }
-    ///     assert_eq!(res.len(),3);
+    ///     assert_eq!(output.len(),3);
     /// }
     /// ```
+    /// [`join_next`]: fn@Self::join_next
+    /// [`JoinError::id`]: fn@crate::task::JoinError::id
     pub async fn join_all(mut self) -> Vec<T> {
         let mut output = Vec::with_capacity(self.len());
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -171,6 +171,7 @@ async fn join_all() {
     }
 }
 
+#[cfg(panic = "unwind")]
 #[tokio::test]
 async fn task_panics() {
     let mut set: JoinSet<()> = JoinSet::new();

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -156,6 +156,45 @@ fn runtime_gone() {
         .is_cancelled());
 }
 
+#[tokio::test]
+async fn join_all() {
+    let mut set: JoinSet<i32> = JoinSet::new();
+
+    for _ in 0..5 {
+        set.spawn(async { 1 });
+    }
+    let res: Vec<i32> = set.join_all().await;
+
+    assert_eq!(res.len(), 5);
+    for itm in res.into_iter() {
+        assert_eq!(itm, 1)
+    }
+}
+
+#[tokio::test]
+async fn task_panics() {
+    let mut set: JoinSet<()> = JoinSet::new();
+
+    let (tx, mut rx) = oneshot::channel();
+    assert_eq!(set.len(), 0);
+
+    set.spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        tx.send(()).unwrap();
+    });
+    assert_eq!(set.len(), 1);
+
+    set.spawn(async {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        panic!();
+    });
+    assert_eq!(set.len(), 2);
+
+    let panic = tokio::spawn(set.join_all()).await.unwrap_err();
+    assert!(rx.try_recv().is_err());
+    assert!(panic.is_panic());
+}
+
 #[tokio::test(start_paused = true)]
 async fn abort_all() {
     let mut set: JoinSet<()> = JoinSet::new();

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -172,7 +172,7 @@ async fn join_all() {
 }
 
 #[cfg(panic = "unwind")]
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn task_panics() {
     let mut set: JoinSet<()> = JoinSet::new();
 


### PR DESCRIPTION
Adds join_all method to JoinSet. join_all consumes JoinSet and awaits the completion of all tasks on it, returning the results of the tasks in a vector. An error or panic in the task will cause join_all to panic, canceling all other tasks.

Fixes: #6664

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
The goal of this PR is to add the method join_all to JoinSet in line with the discussion in Fixes: #6664.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
join_all method is added, as well as tests for:
1. Success scenario returning tasks in a vector.
2. Failure scenario resulting in a panic and cancelation of other tasks.