### PR TITLE
chore: replace ready! with std::task::ready

### DIFF
--- a/tests-integration/tests/process_stdio.rs
+++ b/tests-integration/tests/process_stdio.rs
@@ -10,6 +10,7 @@ use futures::future::{self, FutureExt};
 use std::env;
 use std::io;
 use std::process::{ExitStatus, Stdio};
+use std::task::ready;
 
 fn cat() -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_test-cat"));
@@ -211,7 +212,7 @@ async fn vectored_writes() {
             if vectored == 0 {
                 return std::task::Poll::Ready(std::io::Result::Ok(()));
             }
-            let n = futures::ready!(Pin::new(&mut stdin).poll_write_vectored(cx, &slices))?;
+            let n = ready!(Pin::new(&mut stdin).poll_write_vectored(cx, &slices))?;
             writes_completed += 1;
             input.advance(n);
         })

--- a/tokio-stream/src/macros.rs
+++ b/tokio-stream/src/macros.rs
@@ -57,12 +57,3 @@ macro_rules! cfg_signal {
         )*
     }
 }
-
-macro_rules! ready {
-    ($e:expr $(,)?) => {
-        match $e {
-            std::task::Poll::Ready(t) => t,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-        }
-    };
-}

--- a/tokio-stream/src/stream_ext/all.rs
+++ b/tokio-stream/src/stream_ext/all.rs
@@ -3,7 +3,7 @@ use crate::Stream;
 use core::future::Future;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -42,7 +42,7 @@ where
 
         // Take a maximum of 32 items from the stream before yielding.
         for _ in 0..32 {
-            match futures_core::ready!(stream.as_mut().poll_next(cx)) {
+            match ready!(stream.as_mut().poll_next(cx)) {
                 Some(v) => {
                     if !(me.f)(v) {
                         return Poll::Ready(false);

--- a/tokio-stream/src/stream_ext/any.rs
+++ b/tokio-stream/src/stream_ext/any.rs
@@ -3,7 +3,7 @@ use crate::Stream;
 use core::future::Future;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -42,7 +42,7 @@ where
 
         // Take a maximum of 32 items from the stream before yielding.
         for _ in 0..32 {
-            match futures_core::ready!(stream.as_mut().poll_next(cx)) {
+            match ready!(stream.as_mut().poll_next(cx)) {
                 Some(v) => {
                     if (me.f)(v) {
                         return Poll::Ready(true);

--- a/tokio-stream/src/stream_ext/chain.rs
+++ b/tokio-stream/src/stream_ext/chain.rs
@@ -2,7 +2,7 @@ use crate::stream_ext::Fuse;
 use crate::Stream;
 
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/chunks_timeout.rs
+++ b/tokio-stream/src/stream_ext/chunks_timeout.rs
@@ -4,7 +4,7 @@ use tokio::time::{sleep, Sleep};
 
 use core::future::Future;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 use std::time::Duration;
 

--- a/tokio-stream/src/stream_ext/collect.rs
+++ b/tokio-stream/src/stream_ext/collect.rs
@@ -4,7 +4,7 @@ use core::future::Future;
 use core::marker::PhantomPinned;
 use core::mem;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 // Do not export this struct until `FromStream` can be unsealed.

--- a/tokio-stream/src/stream_ext/filter.rs
+++ b/tokio-stream/src/stream_ext/filter.rs
@@ -2,7 +2,7 @@ use crate::Stream;
 
 use core::fmt;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/filter_map.rs
+++ b/tokio-stream/src/stream_ext/filter_map.rs
@@ -2,7 +2,7 @@ use crate::Stream;
 
 use core::fmt;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/fold.rs
+++ b/tokio-stream/src/stream_ext/fold.rs
@@ -3,7 +3,7 @@ use crate::Stream;
 use core::future::Future;
 use core::marker::PhantomPinned;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/fuse.rs
+++ b/tokio-stream/src/stream_ext/fuse.rs
@@ -2,7 +2,7 @@ use crate::Stream;
 
 use pin_project_lite::pin_project;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Stream returned by [`fuse()`][super::StreamExt::fuse].

--- a/tokio-stream/src/stream_ext/skip.rs
+++ b/tokio-stream/src/stream_ext/skip.rs
@@ -2,7 +2,7 @@ use crate::Stream;
 
 use core::fmt;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/skip_while.rs
+++ b/tokio-stream/src/stream_ext/skip_while.rs
@@ -2,7 +2,7 @@ use crate::Stream;
 
 use core::fmt;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_ext/throttle.rs
+++ b/tokio-stream/src/stream_ext/throttle.rs
@@ -5,7 +5,7 @@ use tokio::time::{Duration, Instant, Sleep};
 
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{self, Poll};
+use std::task::{self, ready, Poll};
 
 use pin_project_lite::pin_project;
 

--- a/tokio-stream/src/stream_ext/timeout.rs
+++ b/tokio-stream/src/stream_ext/timeout.rs
@@ -4,7 +4,7 @@ use tokio::time::{Instant, Sleep};
 
 use core::future::Future;
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 use std::fmt;
 use std::time::Duration;

--- a/tokio-stream/src/stream_ext/timeout_repeating.rs
+++ b/tokio-stream/src/stream_ext/timeout_repeating.rs
@@ -3,7 +3,7 @@ use crate::{Elapsed, Stream};
 use tokio::time::Interval;
 
 use core::pin::Pin;
-use core::task::{Context, Poll};
+use core::task::{ready, Context, Poll};
 use pin_project_lite::pin_project;
 
 pin_project! {

--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -3,7 +3,7 @@ use crate::{poll_fn, Stream};
 use std::borrow::Borrow;
 use std::hash::Hash;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Combine many streams into one, indexing each source stream with a unique
 /// key.

--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -6,7 +6,7 @@ use futures_core::Stream;
 use tokio_util::sync::ReusableBoxFuture;
 
 use std::fmt;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// A wrapper around [`tokio::sync::broadcast::Receiver`] that implements [`Stream`].
 ///

--- a/tokio-stream/src/wrappers/watch.rs
+++ b/tokio-stream/src/wrappers/watch.rs
@@ -5,7 +5,7 @@ use futures_core::Stream;
 use tokio_util::sync::ReusableBoxFuture;
 
 use std::fmt;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tokio::sync::watch::error::RecvError;
 
 /// A wrapper around [`tokio::sync::watch::Receiver`] that implements [`Stream`].

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -23,13 +23,13 @@ use tokio::sync::mpsc;
 use tokio::time::{self, Duration, Instant, Sleep};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use futures_core::{ready, Stream};
+use futures_core::Stream;
 use std::collections::VecDeque;
 use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{self, Poll, Waker};
+use std::task::{self, ready, Poll, Waker};
 use std::{cmp, io};
 
 /// An I/O object that follows a predefined script.

--- a/tokio-test/src/stream_mock.rs
+++ b/tokio-test/src/stream_mock.rs
@@ -36,10 +36,10 @@
 
 use std::collections::VecDeque;
 use std::pin::Pin;
-use std::task::Poll;
+use std::task::{ready, Poll};
 use std::time::Duration;
 
-use futures_core::{ready, Stream};
+use futures_core::Stream;
 use std::future::Future;
 use tokio::time::{sleep_until, Instant, Sleep};
 

--- a/tokio-util/src/codec/framed_impl.rs
+++ b/tokio-util/src/codec/framed_impl.rs
@@ -5,13 +5,12 @@ use futures_core::Stream;
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use bytes::BytesMut;
-use futures_core::ready;
 use futures_sink::Sink;
 use pin_project_lite::pin_project;
 use std::borrow::{Borrow, BorrowMut};
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     #[derive(Debug)]

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,10 +1,9 @@
 //! Compatibility between the `tokio::io` and `futures-io` versions of the
 //! `AsyncRead` and `AsyncWrite` traits.
-use futures_core::ready;
 use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// A compatibility layer that allows conversion between the

--- a/tokio-util/src/io/inspect.rs
+++ b/tokio-util/src/io/inspect.rs
@@ -1,8 +1,7 @@
-use futures_core::ready;
 use pin_project_lite::pin_project;
 use std::io::{IoSlice, Result};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 

--- a/tokio-util/src/io/sink_writer.rs
+++ b/tokio-util/src/io/sink_writer.rs
@@ -1,11 +1,10 @@
-use futures_core::ready;
 use futures_sink::Sink;
 
 use futures_core::stream::Stream;
 use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 
 pin_project! {

--- a/tokio-util/src/sync/poll_semaphore.rs
+++ b/tokio-util/src/sync/poll_semaphore.rs
@@ -1,8 +1,8 @@
-use futures_core::{ready, Stream};
+use futures_core::Stream;
 use std::fmt;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use tokio::sync::{AcquireError, OwnedSemaphorePermit, Semaphore, TryAcquireError};
 
 use super::ReusableBoxFuture;

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -6,7 +6,6 @@
 
 use crate::time::wheel::{self, Wheel};
 
-use futures_core::ready;
 use tokio::time::{sleep_until, Duration, Instant, Sleep};
 
 use core::ops::{Index, IndexMut};
@@ -19,7 +18,7 @@ use std::fmt::Debug;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::task::{self, Poll, Waker};
+use std::task::{self, ready, Poll, Waker};
 
 /// A queue of delayed elements.
 ///
@@ -74,9 +73,8 @@ use std::task::{self, Poll, Waker};
 /// ```rust,no_run
 /// use tokio_util::time::{DelayQueue, delay_queue};
 ///
-/// use futures::ready;
 /// use std::collections::HashMap;
-/// use std::task::{Context, Poll};
+/// use std::task::{ready, Context, Poll};
 /// use std::time::Duration;
 /// # type CacheKey = String;
 /// # type Value = String;

--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -4,10 +4,9 @@ use futures_core::Stream;
 use tokio::{io::ReadBuf, net::UdpSocket};
 
 use bytes::{BufMut, BytesMut};
-use futures_core::ready;
 use futures_sink::Sink;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{
     borrow::Borrow,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},

--- a/tokio-util/src/util/poll_buf.rs
+++ b/tokio-util/src/util/poll_buf.rs
@@ -1,11 +1,10 @@
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use bytes::{Buf, BufMut};
-use futures_core::ready;
 use std::io::{self, IoSlice};
 use std::mem::MaybeUninit;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Try to read data from an `AsyncRead` into an implementer of the [`BufMut`] trait.
 ///

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -14,8 +14,7 @@ use std::io::{self, Seek, SeekFrom};
 use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
+use std::task::{ready, Context, Poll};
 
 #[cfg(test)]
 use super::mocks::JoinHandle;

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -8,8 +8,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
-use std::task::Context;
-use std::task::Poll;
+use std::task::{ready, Context, Poll};
 
 #[cfg(test)]
 use super::mocks::spawn_blocking;

--- a/tokio/src/future/maybe_done.rs
+++ b/tokio/src/future/maybe_done.rs
@@ -3,7 +3,7 @@
 use pin_project_lite::pin_project;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// A future that may have completed.

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::fmt;
 use std::io;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::{task::Context, task::Poll};
+use std::task::{ready, Context, Poll};
 
 /// Associates an IO object backed by a Unix file descriptor with the tokio
 /// reactor, allowing for readiness to be polled. The file descriptor must be of

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -71,11 +71,10 @@ use std::task::{ready, Context, Poll};
 /// and using the IO traits [`AsyncRead`] and [`AsyncWrite`].
 ///
 /// ```no_run
-/// use futures::ready;
 /// use std::io::{self, Read, Write};
 /// use std::net::TcpStream;
 /// use std::pin::Pin;
-/// use std::task::{Context, Poll};
+/// use std::task::{ready, Context, Poll};
 /// use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 /// use tokio::io::unix::AsyncFd;
 ///

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::io;
 use std::io::prelude::*;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// `T` should not implement _both_ Read and Write.
 #[derive(Debug)]

--- a/tokio/src/io/bsd/poll_aio.rs
+++ b/tokio/src/io/bsd/poll_aio.rs
@@ -11,7 +11,7 @@ use std::io;
 use std::ops::{Deref, DerefMut};
 use std::os::unix::io::AsRawFd;
 use std::os::unix::prelude::RawFd;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Like [`mio::event::Source`], but for POSIX AIO only.
 ///

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::io;
 use std::ops::Deref;
 use std::panic::{RefUnwindSafe, UnwindSafe};
+use std::task::ready;
 
 cfg_io_driver! {
     /// Associates an I/O resource that implements the [`std::io::Read`] and/or

--- a/tokio/src/io/seek.rs
+++ b/tokio/src/io/seek.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::io::{self, SeekFrom};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Future for the [`seek`](crate::io::AsyncSeekExt::seek) method.

--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -4,7 +4,7 @@ use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 use pin_project_lite::pin_project;
 use std::io::{self, IoSlice, SeekFrom};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{cmp, fmt, mem};
 
 pin_project! {

--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -5,7 +5,7 @@ use pin_project_lite::pin_project;
 use std::fmt;
 use std::io::{self, IoSlice, SeekFrom, Write};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Wraps a writer and buffers its output.

--- a/tokio/src/io/util/chain.rs
+++ b/tokio/src/io/util/chain.rs
@@ -4,7 +4,7 @@ use pin_project_lite::pin_project;
 use std::fmt;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Stream for the [`chain`](super::AsyncReadExt::chain) method.

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -3,7 +3,7 @@ use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 #[derive(Debug)]
 pub(super) struct CopyBuffer {

--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -5,7 +5,7 @@ use crate::io::{AsyncRead, AsyncWrite};
 
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 enum TransferState {
     Running(CopyBuffer),

--- a/tokio/src/io/util/copy_buf.rs
+++ b/tokio/src/io/util/copy_buf.rs
@@ -2,7 +2,7 @@ use crate::io::{AsyncBufRead, AsyncWrite};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     /// A future that asynchronously copies the entire contents of a reader into a

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -4,7 +4,7 @@ use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 use std::fmt;
 use std::io::{self, SeekFrom};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     /// `Empty` ignores any data written via [`AsyncWrite`], and will always be empty

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -5,7 +5,7 @@ use pin_project_lite::pin_project;
 use std::io;
 use std::mem;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Reads lines from an [`AsyncBufRead`].

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -7,7 +7,7 @@ use bytes::{Buf, BytesMut};
 use std::{
     pin::Pin,
     sync::Arc,
-    task::{self, Poll, Waker},
+    task::{self, ready, Poll, Waker},
 };
 
 /// A bidirectional pipe to read and write bytes in memory.

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -88,7 +88,7 @@ cfg_io_util! {
 
     cfg_coop! {
         fn poll_proceed_and_make_progress(cx: &mut std::task::Context<'_>) -> std::task::Poll<()> {
-            let coop = ready!(crate::runtime::coop::poll_proceed(cx));
+            let coop = std::task::ready!(crate::runtime::coop::poll_proceed(cx));
             coop.made_progress();
             std::task::Poll::Ready(())
         }

--- a/tokio/src/io/util/read.rs
+++ b/tokio/src/io/util/read.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::marker::PhantomPinned;
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Tries to read some bytes directly into the given `buf` in asynchronous
 /// manner, returning a future type.

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::io;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pub(crate) fn read_buf<'a, R, B>(reader: &'a mut R, buf: &'a mut B) -> ReadBuf<'a, R, B>
 where

--- a/tokio/src/io/util/read_exact.rs
+++ b/tokio/src/io/util/read_exact.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::marker::PhantomPinned;
 use std::marker::Unpin;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// A future which can be used to easily read exactly enough bytes to fill
 /// a buffer.

--- a/tokio/src/io/util/read_line.rs
+++ b/tokio/src/io/util/read_line.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
 use std::string::FromUtf8Error;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Future for the [`read_line`](crate::io::AsyncBufReadExt::read_line) method.

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::marker::PhantomPinned;
 use std::mem::{self, MaybeUninit};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     #[derive(Debug)]

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -7,7 +7,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{io, mem};
 
 pin_project! {

--- a/tokio/src/io/util/read_until.rs
+++ b/tokio/src/io/util/read_until.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Future for the [`read_until`](crate::io::AsyncBufReadExt::read_until) method.

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -3,7 +3,7 @@ use crate::io::{AsyncRead, ReadBuf};
 
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     /// An async reader which yields one byte over and over and over and over and

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -4,7 +4,7 @@ use crate::io::AsyncWrite;
 use std::fmt;
 use std::io;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     /// An async writer which will move data into the void.

--- a/tokio/src/io/util/split.rs
+++ b/tokio/src/io/util/split.rs
@@ -5,7 +5,7 @@ use pin_project_lite::pin_project;
 use std::io;
 use std::mem;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// Splitter for the [`split`](crate::io::AsyncBufReadExt::split) method.

--- a/tokio/src/io/util/take.rs
+++ b/tokio/src/io/util/take.rs
@@ -3,7 +3,7 @@ use crate::io::{AsyncBufRead, AsyncRead, ReadBuf};
 use pin_project_lite::pin_project;
 use std::convert::TryFrom;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 use std::{cmp, io};
 
 pin_project! {

--- a/tokio/src/io/util/write_all.rs
+++ b/tokio/src/io/util/write_all.rs
@@ -6,7 +6,7 @@ use std::io;
 use std::marker::PhantomPinned;
 use std::mem;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     #[derive(Debug)]

--- a/tokio/src/io/util/write_all_buf.rs
+++ b/tokio/src/io/util/write_all_buf.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::io::{self, IoSlice};
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// A future to write some of the buffer to an `AsyncWrite`.

--- a/tokio/src/io/util/write_buf.rs
+++ b/tokio/src/io/util/write_buf.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 use std::io;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 pin_project! {
     /// A future to write some of the buffer to an `AsyncWrite`.

--- a/tokio/src/macros/mod.rs
+++ b/tokio/src/macros/mod.rs
@@ -10,9 +10,6 @@ mod loom;
 mod pin;
 
 #[macro_use]
-mod ready;
-
-#[macro_use]
 mod thread_local;
 
 #[macro_use]

--- a/tokio/src/macros/ready.rs
+++ b/tokio/src/macros/ready.rs
@@ -1,8 +1,0 @@
-macro_rules! ready {
-    ($e:expr $(,)?) => {
-        match $e {
-            std::task::Poll::Ready(t) => t,
-            std::task::Poll::Pending => return std::task::Poll::Pending,
-        }
-    };
-}

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -257,6 +257,7 @@ pub(crate) mod sealed {
     use std::future::Future;
     use std::io;
     use std::net::SocketAddr;
+    use std::task::ready;
 
     #[doc(hidden)]
     pub trait ToSocketAddrsPriv {

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -257,7 +257,6 @@ pub(crate) mod sealed {
     use std::future::Future;
     use std::io;
     use std::net::SocketAddr;
-    use std::task::ready;
 
     #[doc(hidden)]
     pub trait ToSocketAddrsPriv {
@@ -275,7 +274,7 @@ pub(crate) mod sealed {
 
         use std::option;
         use std::pin::Pin;
-        use std::task::{Context, Poll};
+        use std::task::{ready,Context, Poll};
         use std::vec;
 
         #[doc(hidden)]

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -8,7 +8,7 @@ cfg_not_wasi! {
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_net! {
     /// A TCP socket server, listening for connections.

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::io;
 use std::net::{Shutdown, SocketAddr};
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     use bytes::BufMut;

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -4,7 +4,7 @@ use crate::net::{to_socket_addrs, ToSocketAddrs};
 use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     use bytes::BufMut;

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -7,7 +7,7 @@ use std::net::Shutdown;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_util! {
     use bytes::BufMut;

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -12,7 +12,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
 use std::path::Path;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_net_unix! {
     /// A Unix socket which can accept connections from other Unix sockets.

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -250,8 +250,7 @@ use std::io;
 use std::path::Path;
 use std::pin::Pin;
 use std::process::{Command as StdCommand, ExitStatus, Output, Stdio};
-use std::task::Context;
-use std::task::Poll;
+use std::task::{ready, Context, Poll};
 
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;

--- a/tokio/src/process/unix/pidfd_reaper.rs
+++ b/tokio/src/process/unix/pidfd_reaper.rs
@@ -19,7 +19,7 @@ use std::{
     pin::Pin,
     process::ExitStatus,
     sync::atomic::{AtomicBool, Ordering::Relaxed},
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 
 #[derive(Debug)]

--- a/tokio/src/runtime/coop.rs
+++ b/tokio/src/runtime/coop.rs
@@ -312,7 +312,7 @@ mod test {
             }
 
             let mut task = task::spawn(poll_fn(|cx| {
-                let coop = ready!(poll_proceed(cx));
+                let coop = std::task::ready!(poll_proceed(cx));
                 coop.made_progress();
                 Poll::Ready(())
             }));

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -7,7 +7,7 @@ use crate::runtime::scheduler;
 use mio::event::Source;
 use std::io;
 use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 cfg_io_driver! {
     /// Associates an I/O resource with the reactor instance that drives it.

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::marker::PhantomData;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
-use std::task::{Context, Poll, Waker};
+use std::task::{ready, Context, Poll, Waker};
 
 cfg_rt! {
     /// An owned permission to join on a task (await its termination).

--- a/tokio/src/runtime/tests/loom_multi_thread.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread.rs
@@ -11,7 +11,7 @@ mod yield_now;
 use crate::future::poll_fn;
 use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
-use crate::{ready, spawn, task};
+use crate::{spawn, task};
 use tokio_test::assert_ok;
 
 use loom::sync::atomic::{AtomicBool, AtomicUsize};
@@ -21,7 +21,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 mod atomic_take {
     use loom::sync::atomic::AtomicBool;

--- a/tokio/src/runtime/tests/loom_multi_thread.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread.rs
@@ -11,7 +11,7 @@ mod yield_now;
 use crate::future::poll_fn;
 use crate::runtime::tests::loom_oneshot as oneshot;
 use crate::runtime::{self, Runtime};
-use crate::{spawn, task};
+use crate::{ready, spawn, task};
 use tokio_test::assert_ok;
 
 use loom::sync::atomic::{AtomicBool, AtomicUsize};

--- a/tokio/src/runtime/tests/loom_multi_thread_alt.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread_alt.rs
@@ -23,7 +23,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 mod atomic_take {
     use loom::sync::atomic::AtomicBool;

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -28,7 +28,7 @@ use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::*;
-use std::task::{Context, Poll, Waker};
+use std::task::{ready, Context, Poll, Waker};
 use std::{cmp, fmt};
 
 /// An asynchronous counting semaphore which permits waiting on multiple permits at once.

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -128,7 +128,7 @@ use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::{Acquire, Relaxed, Release, SeqCst};
-use std::task::{Context, Poll, Waker};
+use std::task::{ready, Context, Poll, Waker};
 
 /// Sending-half of the [`broadcast`] channel.
 ///

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -13,7 +13,7 @@ use std::panic;
 use std::process;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 use std::task::Poll::{Pending, Ready};
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Channel sender.
 pub(crate) struct Tx<T, S> {

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1041,7 +1041,7 @@ impl Notified<'_> {
                     #[cfg(tokio_taskdump)]
                     if let Some(waker) = waker {
                         let mut ctx = Context::from_waker(waker);
-                        ready!(crate::trace::trace_leaf(&mut ctx));
+                        std::task::ready!(crate::trace::trace_leaf(&mut ctx));
                     }
 
                     if waiter.notification.load(Acquire).is_some() {
@@ -1135,7 +1135,7 @@ impl Notified<'_> {
                     #[cfg(tokio_taskdump)]
                     if let Some(waker) = waker {
                         let mut ctx = Context::from_waker(waker);
-                        ready!(crate::trace::trace_leaf(&mut ctx));
+                        std::task::ready!(crate::trace::trace_leaf(&mut ctx));
                     }
                     return Poll::Ready(());
                 }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -135,7 +135,7 @@ use std::mem::MaybeUninit;
 use std::pin::Pin;
 use std::sync::atomic::Ordering::{self, AcqRel, Acquire};
 use std::task::Poll::{Pending, Ready};
-use std::task::{Context, Poll, Waker};
+use std::task::{ready, Context, Poll, Waker};
 
 /// Sends a value to the associated [`Receiver`].
 ///

--- a/tokio/src/task/consume_budget.rs
+++ b/tokio/src/task/consume_budget.rs
@@ -1,4 +1,4 @@
-use std::task::Poll;
+use std::task::{ready, Poll};
 
 /// Consumes a unit of budget and returns the execution back to the Tokio
 /// runtime *if* the task's coop budget was exhausted.

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -2,7 +2,7 @@ use crate::runtime::context;
 
 use std::future::Future;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Yields execution back to the Tokio runtime.
 ///

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -5,7 +5,7 @@ use crate::util::trace;
 use std::future::Future;
 use std::panic::Location;
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Creates new [`Interval`] that yields with interval of `period`. The first
 /// tick completes immediately. The default [`MissedTickBehavior`] is

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -6,7 +6,7 @@ use pin_project_lite::pin_project;
 use std::future::Future;
 use std::panic::Location;
 use std::pin::Pin;
-use std::task::{self, Poll};
+use std::task::{self, ready, Poll};
 
 /// Waits until `deadline` is reached.
 ///

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -2,12 +2,11 @@
 #![cfg(feature = "full")]
 
 use bytes::BytesMut;
-use futures::ready;
 use tokio::io::{self, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio_test::assert_ok;
 
 use std::pin::Pin;
-use std::task::{Context, Poll};
+use std::task::{ready, Context, Poll};
 
 #[tokio::test]
 async fn copy() {


### PR DESCRIPTION
Tokio's MSRV now supports the std::task:ready macro. So the tokio ready! macro can be replaced with that.

## Motivation
Tokio's MSRV is 1.70.0. std::task::ready! was introduced in 1.64.0 and has identical implementation to tokio's ready! macro.
std::task::ready! can be used instead.
Thanks @mox692 for suggesting this change!


## Solution
This PR removes the tokio ready! and replaces it with std::task:ready!

