### PR TITLE
rt: fix race in yield_defers_until_park test

### DIFF
--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -785,9 +785,9 @@ rt_test! {
             barrier.wait();
 
             let (fail_test, fail_test_recv) = oneshot::channel::<()>();
-
+            let flag_clone = flag.clone();
             let jh = tokio::spawn(async move {
-                // Create a TCP litener
+                // Create a TCP listener
                 let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
                 let addr = listener.local_addr().unwrap();
 
@@ -798,7 +798,7 @@ rt_test! {
 
                         // Yield until connected
                         let mut cnt = 0;
-                        while !flag.load(SeqCst){
+                        while !flag_clone.load(SeqCst){
                             tokio::task::yield_now().await;
                             cnt += 1;
 
@@ -814,7 +814,7 @@ rt_test! {
                     },
                     async {
                         let _ = listener.accept().await.unwrap();
-                        flag.store(true, SeqCst);
+                        flag_clone.store(true, SeqCst);
                     }
                 );
             });
@@ -824,6 +824,11 @@ rt_test! {
             let success = fail_test_recv.await.is_err();
 
             if success {
+                // Setting flag to true ensures that the tasks we spawned at
+                // the beginning of the test will exit.
+                // If we don't do this, the test will hang since the runtime waits
+                // for all spawned tasks to finish when dropping.
+                flag.store(true, SeqCst);
                 // Check for panics in spawned task.
                 jh.abort();
                 jh.await.unwrap();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes #6765 where the yield_defers_until_park test was hanging on failures.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The test hanged while trying to `drop` the Runtime on failures since:
1. The tasks we spawn at the beginning of the test will never terminate on failures since we never set the `flag` they loop on to `true`, and
2. The tokio Runtime waits till all of the spawned tasks terminate / yield before dropping them on [shutdown](https://docs.rs/tokio/1.39.3/tokio/runtime/struct.Runtime.html#shutdown).

To fix, we set the flag to true on failure cases to guarantee all tasks terminate before returning.

To verify the fix, I looped the test 100k times. Whereas before I always got a hang, afterwards, I never
saw it hang and got the appropriate test failure.