### PR TITLE
Tokio-util: Enable the full feature when compiled for the playground

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -65,3 +65,6 @@ rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
 # it's necessary to _also_ pass `--cfg tokio_unstable` to rustc, or else
 # dependencies will not be enabled, and the docs build will fail.
 rustc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
+
+[package.metadata.playground]
+features = ["full"]


### PR DESCRIPTION
Like https://github.com/tokio-rs/tokio/pull/1960, but for tokio-util. Makes tokio-util usable in the Playground.

See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=14e34737f9747022fcfaff8428e4eb53 for what happens currently.
