### PR TITLE
Unbury the lede on tokio::sync::mutex docs

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -23,8 +23,11 @@ use std::{fmt, mem, ptr};
 ///
 /// # Which kind of mutex should you use?
 ///
-/// Contrary to popular belief, it is ok and often preferred to use the ordinary
-/// [`Mutex`][std] from the standard library in asynchronous code.
+/// The ordinary std [`Mutex`][std] cannot be held across an `.await` point -
+/// your program will deadlock if you do this. Use the async mutex instead in
+/// such cases. However, it is ok and often preferred to use the std mutex in
+/// asynchronous tasks when it does not need to be held across an `.await`
+/// point.
 ///
 /// The feature that the async mutex offers over the blocking mutex is the
 /// ability to keep it locked across an `.await` point. This makes the async


### PR DESCRIPTION
Fixes #5024

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

https://turso.tech/blog/how-to-deadlock-tokio-application-in-rust-with-just-a-single-mutex

## Solution

Writing