### PR TITLE
stream: prepare 0.1.16 release

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This release bumps the MSRV of tokio-stream to 1.70.
 
-- stream: add `next_many` and `poll_next_many` to `StreamMap` (#6409)
-- stream: make stream adapters public (#6658)
-- readme: add readme for tokio-stream (#6456)
+- stream: add `next_many` and `poll_next_many` to `StreamMap` ([#6409])
+- stream: make stream adapters public ([#6658])
+- readme: add readme for tokio-stream ([#6456])
 
 [#6409]: https://github.com/tokio-rs/tokio/pull/6409
 [#6658]: https://github.com/tokio-rs/tokio/pull/6658

--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,14 +1,14 @@
 # 0.1.16 (September 5th, 2024)
 
+This release bumps the MSRV of tokio-stream to 1.70.
+
 - stream: add `next_many` and `poll_next_many` to `StreamMap` (#6409)
 - stream: make stream adapters public (#6658)
 - readme: add readme for tokio-stream (#6456)
-- chore: increase MSRV to 1.70 (#6645)
 
 [#6409]: https://github.com/tokio-rs/tokio/pull/6409
 [#6658]: https://github.com/tokio-rs/tokio/pull/6658
 [#6456]: https://github.com/tokio-rs/tokio/pull/6456
-[#6645]: https://github.com/tokio-rs/tokio/pull/6645
 
 # 0.1.15 (March 14th, 2024)
 

--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.1.16 (September 5th, 2024)
+
+- stream: add `next_many` and `poll_next_many` to `StreamMap` (#6409)
+- stream: make stream adapters public (#6658)
+- readme: add readme for tokio-stream (#6456)
+- chore: increase MSRV to 1.70 (#6645)
+
+[#6409]: https://github.com/tokio-rs/tokio/pull/6409
+[#6658]: https://github.com/tokio-rs/tokio/pull/6658
+[#6456]: https://github.com/tokio-rs/tokio/pull/6456
+[#6645]: https://github.com/tokio-rs/tokio/pull/6645
+
 # 0.1.15 (March 14th, 2024)
 
 This release bumps the MSRV of tokio-stream to 1.63.

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
As discussed on Discord. Full changelog (I skipped most of the chores for the changelog):

```
djc-2021 stream-0.1.16-prep tokio-stream $ git log --oneline -20 . 
a9fd3b94 (HEAD -> stream-0.1.16-prep, origin/stream-0.1.16-prep) stream: prepare 0.1.16 release
12b2567b (origin/master, origin/HEAD, master) chore: use `poll_fn` from std (#6810)
11f66f43 chore: replace `ready!` with `std::task::ready!` (#6804)
15cd5146 chore: increase MSRV to 1.70 (#6645)
c8f3539b stream: make stream adapters public (#6658)
3a6fdc05 license: fix formatting and remove year in licenses (#6451)
daa89017 ci: fix new clippy warnings (#6569)
2a0df5fb ci: bump nightly to nightly-2024-05-05 (#6538)
be9328da chore: fix clippy warnings (#6466)
a1acfd8c readme: add readme for tokio-stream (#6456)
4601c847 stream: add `next_many` and `poll_next_many` to `StreamMap` (#6409)
7cfb1007 (tag: tokio-stream-0.1.15) chore: prepare tokio-stream v0.1.15 (#6401)
```

# 0.1.16 (September 5th, 2024)

This release bumps the MSRV of tokio-stream to 1.70.

- stream: add `next_many` and `poll_next_many` to `StreamMap` ([#6409])
- stream: make stream adapters public ([#6658])
- readme: add readme for tokio-stream ([#6456])

[#6409]: https://github.com/tokio-rs/tokio/pull/6409
[#6658]: https://github.com/tokio-rs/tokio/pull/6658
[#6456]: https://github.com/tokio-rs/tokio/pull/6456