### PR TITLE
Always send large futures to heap

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -299,12 +299,11 @@ impl Spawner {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        let (join_handle, spawn_result) =
-            if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-                self.spawn_blocking_inner(Box::new(func), Mandatory::NonMandatory, None, rt)
-            } else {
-                self.spawn_blocking_inner(func, Mandatory::NonMandatory, None, rt)
-            };
+        let (join_handle, spawn_result) = if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+            self.spawn_blocking_inner(Box::new(func), Mandatory::NonMandatory, None, rt)
+        } else {
+            self.spawn_blocking_inner(func, Mandatory::NonMandatory, None, rt)
+        };
 
         match spawn_result {
             Ok(()) => join_handle,
@@ -327,7 +326,7 @@ impl Spawner {
             F: FnOnce() -> R + Send + 'static,
             R: Send + 'static,
         {
-            let (join_handle, spawn_result) = if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+            let (join_handle, spawn_result) = if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
                 self.spawn_blocking_inner(
                     Box::new(func),
                     Mandatory::Mandatory,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -189,7 +189,7 @@ impl Handle {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             self.spawn_named(Box::pin(future), None)
         } else {
             self.spawn_named(future, None)
@@ -296,7 +296,7 @@ impl Handle {
     /// [`tokio::time`]: crate::time
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             self.block_on_inner(Box::pin(future))
         } else {
             self.block_on_inner(future)

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -394,7 +394,11 @@ cfg_rt! {
 
     /// Boundary value to prevent stack overflow caused by a large-sized
     /// Future being placed in the stack.
-    pub(crate) const BOX_FUTURE_THRESHOLD: usize = 2048;
+    pub(crate) const BOX_FUTURE_THRESHOLD: usize = if cfg!(debug_assertions)  {
+        2048
+    } else {
+        16384
+    };
 
     mod thread_id;
     pub(crate) use thread_id::ThreadId;

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -241,7 +241,7 @@ impl Runtime {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             self.handle.spawn_named(Box::pin(future), None)
         } else {
             self.handle.spawn_named(future, None)
@@ -329,7 +329,7 @@ impl Runtime {
     /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             self.block_on_inner(Box::pin(future))
         } else {
             self.block_on_inner(future)

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -88,13 +88,11 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
-        Ok(
-            if cfg!(debug_assertions) && std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-                super::spawn::spawn_inner(Box::pin(future), self.name)
-            } else {
-                super::spawn::spawn_inner(future, self.name)
-            },
-        )
+        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
+            super::spawn::spawn_inner(Box::pin(future), self.name)
+        } else {
+            super::spawn::spawn_inner(future, self.name)
+        })
     }
 
     /// Spawn a task with this builder's settings on the provided [runtime
@@ -110,13 +108,11 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
-        Ok(
-            if cfg!(debug_assertions) && std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-                handle.spawn_named(Box::pin(future), self.name)
-            } else {
-                handle.spawn_named(future, self.name)
-            },
-        )
+        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
+            handle.spawn_named(Box::pin(future), self.name)
+        } else {
+            handle.spawn_named(future, self.name)
+        })
     }
 
     /// Spawns `!Send` a task on the current [`LocalSet`] with this builder's
@@ -139,13 +135,11 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
-        Ok(
-            if cfg!(debug_assertions) && std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-                super::local::spawn_local_inner(Box::pin(future), self.name)
-            } else {
-                super::local::spawn_local_inner(future, self.name)
-            },
-        )
+        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
+            super::local::spawn_local_inner(Box::pin(future), self.name)
+        } else {
+            super::local::spawn_local_inner(future, self.name)
+        })
     }
 
     /// Spawns `!Send` a task on the provided [`LocalSet`] with this builder's
@@ -206,22 +200,22 @@ impl<'a> Builder<'a> {
         Output: Send + 'static,
     {
         use crate::runtime::Mandatory;
-        let (join_handle, spawn_result) =
-            if cfg!(debug_assertions) && std::mem::size_of::<Function>() > BOX_FUTURE_THRESHOLD {
-                handle.inner.blocking_spawner().spawn_blocking_inner(
-                    Box::new(function),
-                    Mandatory::NonMandatory,
-                    self.name,
-                    handle,
-                )
-            } else {
-                handle.inner.blocking_spawner().spawn_blocking_inner(
-                    function,
-                    Mandatory::NonMandatory,
-                    self.name,
-                    handle,
-                )
-            };
+        let (join_handle, spawn_result) = if std::mem::size_of::<Function>() > BOX_FUTURE_THRESHOLD
+        {
+            handle.inner.blocking_spawner().spawn_blocking_inner(
+                Box::new(function),
+                Mandatory::NonMandatory,
+                self.name,
+                handle,
+            )
+        } else {
+            handle.inner.blocking_spawner().spawn_blocking_inner(
+                function,
+                Mandatory::NonMandatory,
+                self.name,
+                handle,
+            )
+        };
 
         spawn_result?;
         Ok(join_handle)

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -367,7 +367,7 @@ cfg_rt! {
         F: Future + 'static,
         F::Output: 'static,
     {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             spawn_local_inner(Box::pin(future), None)
         } else {
             spawn_local_inner(future, None)
@@ -649,7 +649,7 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             self.spawn_named_inner(Box::pin(future), name)
         } else {
             self.spawn_named_inner(future, name)

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -169,7 +169,7 @@ cfg_rt! {
     {
         // preventing stack overflows on debug mode, by quickly sending the
         // task to the heap.
-        if cfg!(debug_assertions) && std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
             spawn_inner(Box::pin(future), None)
         } else {
             spawn_inner(future, None)


### PR DESCRIPTION
## Motivation

In #4009, `task::spawn` was changed to send tasks to the heap to prevent stack overflows in debug mode.
The initial proposal was to do this unconditionally in debug mode:
```rust
if cfg!(debug_assertions) {
```
but based on a suggestion from @Darksonn this was then changed to
```rust
if cfg!(debug_assertions) && std::mem::size_of::<T>() > BOX_FUTURE_THRESHOLD {
```

As detailed in #6057, this creates a bit of a footgun where code works great in debug builds but then fails in release mode. This can be surprisingly hard to track down (https://github.com/tokio-rs/tokio/issues/6057#issuecomment-2331098720).

## Solution

Instead of only doing this for debug builds only, I propose we change the condition to
```rust
if std::mem::size_of::<T>() > BOX_FUTURE_THRESHOLD {
```
only so that debug and release builds work the same way.

@Darksonn mentioned that there may be other - better - ways to fix this in https://github.com/tokio-rs/tokio/issues/6057#issuecomment-1751708310. I don't know what the alternative would be, but until that is tackled I think this here could be better than the current implementation. :)