### PR TITLE
sync: add `#[must_use]` to `Notified`

### DIFF
--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -379,6 +379,7 @@ impl Drop for NotifyWaitersList<'_> {
 /// This future is fused, so once it has completed, any future calls to poll
 /// will immediately return `Poll::Ready`.
 #[derive(Debug)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct Notified<'a> {
     /// The `Notify` being received on.
     notify: &'a Notify,


### PR DESCRIPTION
## Motivation

To prevent situation as in these "bug" report: https://github.com/tokio-rs/tokio/issues/6827

## Solution

Add #[must_use] to print warning while compiling or checking 
