### PR TITLE
net: fix handling of leading zero byte in `from_abstract_name`

### DIFF
--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -81,7 +81,7 @@ impl UnixListener {
         let addr = {
             let os_str_bytes = path.as_ref().as_os_str().as_bytes();
             if os_str_bytes.starts_with(b"\0") {
-                StdSocketAddr::from_abstract_name(os_str_bytes)?
+                StdSocketAddr::from_abstract_name(&os_str_bytes[1..])?
             } else {
                 StdSocketAddr::from_pathname(path)?
             }

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -77,7 +77,7 @@ impl UnixStream {
         let addr = {
             let os_str_bytes = path.as_ref().as_os_str().as_bytes();
             if os_str_bytes.starts_with(b"\0") {
-                StdSocketAddr::from_abstract_name(os_str_bytes)?
+                StdSocketAddr::from_abstract_name(&os_str_bytes[1..])?
             } else {
                 StdSocketAddr::from_pathname(path)?
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
Closes https://github.com/tokio-rs/tokio/issues/6837.

The `from_abstract_name` function from std assumes the name in parameter doesn't have a prefix `\0` (see also the [implementation](https://github.com/rust-lang/rust/blob/5a2dd7d4f3210629e65879aeecbe643ba3b86bb4/library/std/src/os/unix/net/addr.rs#L269-L293) or [a test](https://github.com/rust-lang/rust/blob/16beabe1e17fa1f35a1964609ee589b999386690/library/std/src/os/unix/net/tests.rs#L425) for this function), so we need to trim the leading zero byte from the path provided by the user.



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
