### PR TITLE
Docs: Fix swapped examples for `TcpSocket::set_nodelay` and `TcpSocket::nodelay`

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -425,7 +425,7 @@ impl TcpSocket {
     /// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
     /// let socket = TcpSocket::new_v4()?;
     ///
-    /// println!("{:?}", socket.nodelay()?);
+    /// socket.set_nodelay(true)?;
     /// # Ok(())
     /// # }
     /// ```
@@ -445,9 +445,9 @@ impl TcpSocket {
     /// use tokio::net::TcpSocket;
     ///
     /// # async fn dox() -> Result<(), Box<dyn std::error::Error>> {
-    /// let stream = TcpSocket::new_v4()?;
+    /// let socket = TcpSocket::new_v4()?;
     ///
-    /// stream.set_nodelay(true)?;
+    /// println!("{:?}", socket.nodelay()?);
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
The examples were swapped, I also renamed the variable `stream` to `socket` since all the other examples only call it `stream` after a successful `connect` call.

Situation before:

![Screenshot_20240912_143052](https://github.com/user-attachments/assets/3afb20aa-662a-4b65-8f69-6a6fe6f3f8b8)

---

Situation after:

![Screenshot_20240912_143108](https://github.com/user-attachments/assets/bbd910ee-a446-46df-bf4e-f93f28fbbb6a)


