### PR TITLE
sync, coop: apply cooperative scheduling to `sync::watch`

### DIFF
--- a/tokio/src/runtime/coop.rs
+++ b/tokio/src/runtime/coop.rs
@@ -135,8 +135,11 @@ cfg_rt! {
 }
 
 cfg_coop! {
+    use pin_project_lite::pin_project;
     use std::cell::Cell;
-    use std::task::{Context, Poll};
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{ready, Context, Poll};
 
     #[must_use]
     pub(crate) struct RestoreOnPending(Cell<Budget>);
@@ -239,6 +242,42 @@ cfg_coop! {
         fn is_unconstrained(self) -> bool {
             self.0.is_none()
         }
+    }
+
+    pin_project! {
+        /// A future type that calls `poll_proceed` before polling the inner future to check if the
+        /// inner future has exceeded its budget. If the inner future resolves, this will
+        /// automatically call `RestoreOnPending::made_progress` before resolving this future with
+        /// the result of the inner one. If polling the inner future is pending, polling this future
+        /// type will also return a `Poll::Pending`.
+        #[must_use = "futures do nothing unless polled"]
+        pub(crate) struct BudgetConstraintFuture<F: Future> {
+            #[pin]
+            pub(crate) fut: F,
+        }
+    }
+
+    impl<F: Future> Future for BudgetConstraintFuture<F> {
+        type Output = F::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let coop = ready!(poll_proceed(cx));
+            let me = self.project();
+            if let Poll::Ready(ret) = me.fut.poll(cx) {
+                coop.made_progress();
+                Poll::Ready(ret)
+            } else {
+                Poll::Pending
+            }
+        }
+    }
+
+    /// Run a future with a budget constraint for cooperative scheduling.
+    /// If the future exceeds its budget while being polled, control is yielded back to the
+    /// runtime.
+    #[inline]
+    pub(crate) async fn budget_constraint<F: Future>(fut: F) -> F::Output {
+        BudgetConstraintFuture { fut }.await
     }
 }
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -111,6 +111,7 @@
 //! [`Sender::closed`]: crate::sync::watch::Sender::closed
 //! [`Sender::subscribe()`]: crate::sync::watch::Sender::subscribe
 
+use crate::runtime::coop::cooperative;
 use crate::sync::notify::Notify;
 
 use crate::loom::sync::atomic::AtomicUsize;
@@ -743,7 +744,7 @@ impl<T> Receiver<T> {
     /// }
     /// ```
     pub async fn changed(&mut self) -> Result<(), error::RecvError> {
-        crate::runtime::coop::budget_constraint(changed_impl(&self.shared, &mut self.version)).await
+        cooperative(changed_impl(&self.shared, &mut self.version)).await
     }
 
     /// Waits for a value that satisfies the provided condition.
@@ -844,7 +845,9 @@ impl<T> Receiver<T> {
             }
 
             // Wait for the value to change.
-            closed = changed_impl(&self.shared, &mut self.version).await.is_err();
+            closed = cooperative(changed_impl(&self.shared, &mut self.version))
+                .await
+                .is_err();
         }
     }
 
@@ -1224,19 +1227,22 @@ impl<T> Sender<T> {
     /// }
     /// ```
     pub async fn closed(&self) {
-        crate::trace::async_trace_leaf().await;
+        cooperative(async {
+            crate::trace::async_trace_leaf().await;
 
-        while self.receiver_count() > 0 {
-            let notified = self.shared.notify_tx.notified();
+            while self.receiver_count() > 0 {
+                let notified = self.shared.notify_tx.notified();
 
-            if self.receiver_count() == 0 {
-                return;
+                if self.receiver_count() == 0 {
+                    return;
+                }
+
+                notified.await;
+                // The channel could have been reopened in the meantime by calling
+                // `subscribe`, so we loop again.
             }
-
-            notified.await;
-            // The channel could have been reopened in the meantime by calling
-            // `subscribe`, so we loop again.
-        }
+        })
+        .await;
     }
 
     /// Creates a new [`Receiver`] connected to this `Sender`.

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -743,7 +743,7 @@ impl<T> Receiver<T> {
     /// }
     /// ```
     pub async fn changed(&mut self) -> Result<(), error::RecvError> {
-        changed_impl(&self.shared, &mut self.version).await
+        crate::runtime::coop::budget_constraint(changed_impl(&self.shared, &mut self.version)).await
     }
 
     /// Waits for a value that satisfies the provided condition.

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -368,3 +368,52 @@ async fn receiver_is_notified_when_last_sender_is_dropped() {
 
     assert!(t.is_woken());
 }
+
+#[tokio::test]
+async fn receiver_changed_is_cooperative() {
+    let (tx, mut rx) = watch::channel(());
+
+    drop(tx);
+
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                let _ = rx.changed().await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {},
+    }
+}
+
+#[tokio::test]
+async fn receiver_wait_for_is_cooperative() {
+    let (tx, mut rx) = watch::channel(0);
+
+    drop(tx);
+
+    tokio::select! {
+        biased;
+        _ = async {
+            loop {
+                let _ = rx.wait_for(|val| *val == 1).await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {},
+    }
+}
+
+#[tokio::test]
+async fn sender_closed_is_cooperative() {
+    let (tx, rx) = watch::channel(());
+
+    drop(rx);
+    tokio::select! {
+        _ = async {
+            loop {
+                let _ = tx.closed().await;
+            }
+        } => {},
+        _ = tokio::task::yield_now() => {},
+    }
+}


### PR DESCRIPTION
## Motivation
#6839 showed that `sync::watch::Receiver::changed` will not cooperatively yield control back to the runtime which led to it blocking the thread it was running on.
Edit: This is also true for `sync::watch::Receiver::wait_for` and `sync::watch::Sender::closed`

## Solution
Added cooperative scheduling to `sync::watch::Receiver::changed` by utilizing the `runtime::coop` module.
More specifically I added a new future type that wraps the implementation of `sync::watch::Receiver::changed` and checks if the current task has exceeded its budget before polling the wrapped future.

Closes #6839.