### PR TITLE
chore: use boxed slice if possible

### DIFF
--- a/tokio-util/src/task/spawn_pinned.rs
+++ b/tokio-util/src/task/spawn_pinned.rs
@@ -14,7 +14,7 @@ use tokio::task::{spawn_local, JoinHandle, LocalSet};
 /// Internally the local pool uses a [`tokio::task::LocalSet`] for each worker thread
 /// in the pool. Consequently you can also use [`tokio::task::spawn_local`] (which will
 /// execute on the same thread) inside the Future you supply to the various spawn methods
-/// of `LocalPoolHandle`,
+/// of `LocalPoolHandle`.
 ///
 /// [`tokio::task::LocalSet`]: tokio::task::LocalSet
 /// [`tokio::task::spawn_local`]: tokio::task::spawn_local
@@ -194,7 +194,7 @@ enum WorkerChoice {
 }
 
 struct LocalPool {
-    workers: Vec<LocalWorkerHandle>,
+    workers: Box<[LocalWorkerHandle]>,
 }
 
 impl LocalPool {

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -34,7 +34,7 @@ pub(crate) struct Wheel<T> {
     /// * ~ 4 min slots / ~ 4 hr range
     /// * ~ 4 hr slots / ~ 12 day range
     /// * ~ 12 day slots / ~ 2 yr range
-    levels: Vec<Level<T>>,
+    levels: Box<[Level<T>]>,
 }
 
 /// Number of levels. Each level has 64 slots. By using 6 levels with 64 slots

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::task::{Context, Poll};
 
-pub(crate) type OsStorage = Vec<SignalInfo>;
+pub(crate) type OsStorage = Box<[SignalInfo]>;
 
 impl Init for OsStorage {
     fn init() -> Self {


### PR DESCRIPTION
There are some places where using a boxed slice instead of Vec is sufficient, allowing for minor space optimization.