### PR TITLE
sync: add mpsc::Receiver::blocking_recv_many

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -419,6 +419,16 @@ impl<T> Receiver<T> {
         crate::future::block_on(self.recv())
     }
 
+    /// Variant of [`Self::recv_many`] for blocking contexts.
+    ///
+    /// The same conditions as in [`Self::blocking_recv`] apply.
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    #[cfg_attr(docsrs, doc(alias = "recv_many_blocking"))]
+    pub fn blocking_recv_many(&mut self, buffer: &mut Vec<T>, limit: usize) -> usize {
+        crate::future::block_on(self.recv_many(buffer, limit))
+    }
+
     /// Closes the receiving half of a channel without dropping it.
     ///
     /// This prevents any further messages from being sent on the channel while

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -319,6 +319,16 @@ impl<T> UnboundedReceiver<T> {
         crate::future::block_on(self.recv())
     }
 
+    /// Variant of [`Self::recv_many`] for blocking contexts.
+    ///
+    /// The same conditions as in [`Self::blocking_recv`] apply.
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    #[cfg_attr(docsrs, doc(alias = "recv_many_blocking"))]
+    pub fn blocking_recv_many(&mut self, buffer: &mut Vec<T>, limit: usize) -> usize {
+        crate::future::block_on(self.recv_many(buffer, limit))
+    }
+
     /// Closes the receiving half of a channel, without dropping it.
     ///
     /// This prevents any further messages from being sent on the channel while

--- a/tokio/tests/sync_panic.rs
+++ b/tokio/tests/sync_panic.rs
@@ -130,6 +130,22 @@ fn mpsc_bounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Erro
 }
 
 #[test]
+fn mpsc_bounded_receiver_blocking_recv_many_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let rt = current_thread();
+        let (_tx, mut rx) = mpsc::channel::<u8>(1);
+        rt.block_on(async {
+            let _ = rx.blocking_recv();
+        });
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
 fn mpsc_bounded_sender_blocking_send_panic_caller() -> Result<(), Box<dyn Error>> {
     let panic_location_file = test_panic(|| {
         let rt = current_thread();
@@ -152,6 +168,23 @@ fn mpsc_unbounded_receiver_blocking_recv_panic_caller() -> Result<(), Box<dyn Er
         let (_tx, mut rx) = mpsc::unbounded_channel::<u8>();
         rt.block_on(async {
             let _ = rx.blocking_recv();
+        });
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
+fn mpsc_unbounded_receiver_blocking_recv_many_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let rt = current_thread();
+        let (_tx, mut rx) = mpsc::unbounded_channel::<u8>();
+        let mut vec = vec![];
+        rt.block_on(async {
+            let _ = rx.blocking_recv_many(&mut vec, 1);
         });
     });
 


### PR DESCRIPTION
Fixes: #6865

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I would like to use an API like `recv_many`, but from a blocking context.

## Solution

Use crate::future::block_on in a similar fashion to how blocking_recv does it to call the async `recv_many` function.

## What's missing

Tests and docs. I'll complete them once it's clear if this entire change makes sense. Do you think referring to `blocking_recv` and `recv_many` from the docs is fine or should there be more specific docs?