### PR TITLE
socketaddr: implement conversions for tokio and std unix `SocketAddr`

### DIFF
--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -32,13 +32,12 @@ impl fmt::Debug for SocketAddr {
 
 impl From<std::os::unix::net::SocketAddr> for SocketAddr {
     fn from(value: std::os::unix::net::SocketAddr) -> Self {
-	SocketAddr(value)
+        SocketAddr(value)
     }
 }
 
 impl From<SocketAddr> for std::os::unix::net::SocketAddr {
     fn from(value: SocketAddr) -> Self {
-	value.0
+        value.0
     }
 }
-

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -3,10 +3,9 @@ use std::path::Path;
 
 /// An address associated with a Tokio Unix socket.
 ///
-/// This type is a think wrapper around
-/// [`std::os::unix::net::SocketAddr`];
-/// you can use [`From`] to wrap and unwrap
-/// instances of [`std::os::unix::net::SocketAddr`] as this type.
+/// This type is a thin wrapper around [`std::os::unix::net::SocketAddr`]. You
+/// can convert to and from the standard library `SocketAddr` type using the
+/// [`From`] trait.
 pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 
 impl SocketAddr {

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -29,3 +29,16 @@ impl fmt::Debug for SocketAddr {
         self.0.fmt(fmt)
     }
 }
+
+impl From<std::os::unix::net::SocketAddr> for SocketAddr {
+    fn from(value: std::os::unix::net::SocketAddr) -> Self {
+	SocketAddr(value)
+    }
+}
+
+impl From<SocketAddr> for std::os::unix::net::SocketAddr {
+    fn from(value: SocketAddr) -> Self {
+	value.0
+    }
+}
+

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -2,6 +2,11 @@ use std::fmt;
 use std::path::Path;
 
 /// An address associated with a Tokio Unix socket.
+///
+/// This type is a think wrapper around
+/// [`std::os::unix::net::SocketAddr`];
+/// you can use [`From`](std::convert::From) to wrap and unwrap
+/// instances of [`std::os::unix::net::SocketAddr`] as this type.
 pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 
 impl SocketAddr {

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 ///
 /// This type is a think wrapper around
 /// [`std::os::unix::net::SocketAddr`];
-/// you can use [`From`](std::convert::From) to wrap and unwrap
+/// you can use [`From`] to wrap and unwrap
 /// instances of [`std::os::unix::net::SocketAddr`] as this type.
 pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 


### PR DESCRIPTION
Implement `From` to convert `tokio::unix::SocketAddr` to and from Rust's `std::os::unix::net::SocketAddr`.

These types were (I'm told) originally separate because `mio` had a distinct `SocketAddr` type.  This patch makes it possible to convert between them more easily.

Fixes: #6864