### PR TITLE
macros: suppress clippy::needless_return and add docs

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -438,8 +438,9 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
     };
 
     let body_ident = quote! { body };
+    // This explicit `return` is intentional. See tokio-rs/tokio#4636
     let last_block = quote_spanned! {last_stmt_end_span=>
-        #[allow(clippy::expect_used, clippy::diverging_sub_expression)]
+        #[allow(clippy::expect_used, clippy::diverging_sub_expression, clippy::needless_return)]
         {
             return #rt
                 .enable_all()


### PR DESCRIPTION
## Motivation

Fixes #6869: nightly clippy warns on any `#[tokio::{main,test}]`.

## Solution

`#[allow(clippy::needless_return)]` to suppress that clippy warning. Ideally clippy should allow it for macro generated code, but we have no idea how long it would take to do that.

Also document the reason why we are using a `return` instead of a tail expression.

Tested to work for `1.83.0-nightly (2bd1e894e 2024-09-26)`