### PR TITLE
task: add task size to tracing instrumentation

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -42,7 +42,7 @@ futures-io = { version = "0.3.0", optional = true }
 futures-util = { version = "0.3.0", optional = true }
 pin-project-lite = "0.2.11"
 slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
-tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true }
+tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true }
 
 [target.'cfg(tokio_unstable)'.dependencies]
 hashbrown = { version = "0.14.0", default-features = false, optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -101,7 +101,7 @@ socket2 = { version = "0.5.5", optional = true, features = [ "all" ] }
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_unstable)'.dependencies]
-tracing = { version = "0.1.25", default-features = false, features = ["std"], optional = true } # Not in full
+tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true } # Not in full
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -375,6 +375,7 @@ impl Spawner {
                 task.name = %name.unwrap_or_default(),
                 task.id = id.as_u64(),
                 "fn" = %std::any::type_name::<F>(),
+                size.bytes = std::mem::size_of::<F>(),
                 loc.file = location.file(),
                 loc.line = location.line(),
                 loc.col = location.column(),

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -302,9 +302,19 @@ impl Spawner {
     {
         let fn_size = std::mem::size_of::<F>();
         let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
-            self.spawn_blocking_inner(Box::new(func), Mandatory::NonMandatory, SpawnMeta::new_unnamed(fn_size), rt)
+            self.spawn_blocking_inner(
+                Box::new(func),
+                Mandatory::NonMandatory,
+                SpawnMeta::new_unnamed(fn_size),
+                rt,
+            )
         } else {
-            self.spawn_blocking_inner(func, Mandatory::NonMandatory, SpawnMeta::new_unnamed(fn_size), rt)
+            self.spawn_blocking_inner(
+                func,
+                Mandatory::NonMandatory,
+                SpawnMeta::new_unnamed(fn_size),
+                rt,
+            )
         };
 
         match spawn_result {

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -3,8 +3,10 @@ use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
 use crate::runtime::{context, EnterGuard, Handle};
 use crate::task::JoinHandle;
+use crate::util::trace::SpawnMeta;
 
 use std::future::Future;
+use std::mem;
 use std::time::Duration;
 
 cfg_rt_multi_thread! {
@@ -241,10 +243,11 @@ impl Runtime {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-            self.handle.spawn_named(Box::pin(future), None)
+        let fut_size = mem::size_of::<F>();
+        if fut_size > BOX_FUTURE_THRESHOLD {
+            self.handle.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
-            self.handle.spawn_named(future, None)
+            self.handle.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         }
     }
 
@@ -329,15 +332,16 @@ impl Runtime {
     /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-            self.block_on_inner(Box::pin(future))
+        let fut_size = mem::size_of::<F>();
+        if fut_size > BOX_FUTURE_THRESHOLD {
+            self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
-            self.block_on_inner(future)
+            self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
         }
     }
 
     #[track_caller]
-    fn block_on_inner<F: Future>(&self, future: F) -> F::Output {
+    fn block_on_inner<F: Future>(&self, future: F, _meta: SpawnMeta<'_>) -> F::Output {
         #[cfg(all(
             tokio_unstable,
             tokio_taskdump,
@@ -351,7 +355,7 @@ impl Runtime {
         let future = crate::util::trace::task(
             future,
             "block_on",
-            None,
+            _meta,
             crate::runtime::task::Id::next().as_u64(),
         );
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -245,9 +245,11 @@ impl Runtime {
     {
         let fut_size = mem::size_of::<F>();
         if fut_size > BOX_FUTURE_THRESHOLD {
-            self.handle.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            self.handle
+                .spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
-            self.handle.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
+            self.handle
+                .spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         }
     }
 

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -1,7 +1,8 @@
 #![allow(unreachable_pub)]
 use crate::{
     runtime::{Handle, BOX_FUTURE_THRESHOLD},
-    task::{JoinHandle, LocalSet}, util::trace::SpawnMeta,
+    task::{JoinHandle, LocalSet},
+    util::trace::SpawnMeta,
 };
 use std::{future::Future, io, mem};
 
@@ -137,7 +138,6 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
-
         let fut_size = mem::size_of::<Fut>();
         Ok(if fut_size > BOX_FUTURE_THRESHOLD {
             super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
@@ -169,7 +169,6 @@ impl<'a> Builder<'a> {
         } else {
             local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         })
-            
     }
 
     /// Spawns blocking code on the blocking threadpool.
@@ -211,8 +210,7 @@ impl<'a> Builder<'a> {
     {
         use crate::runtime::Mandatory;
         let fn_size = mem::size_of::<Function>();
-        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD
-        {
+        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 Box::new(function),
                 Mandatory::NonMandatory,

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -1,9 +1,9 @@
 #![allow(unreachable_pub)]
 use crate::{
     runtime::{Handle, BOX_FUTURE_THRESHOLD},
-    task::{JoinHandle, LocalSet},
+    task::{JoinHandle, LocalSet}, util::trace::SpawnMeta,
 };
-use std::{future::Future, io};
+use std::{future::Future, io, mem};
 
 /// Factory which is used to configure the properties of a new task.
 ///
@@ -88,10 +88,11 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
-        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-            super::spawn::spawn_inner(Box::pin(future), self.name)
+        let fut_size = mem::size_of::<Fut>();
+        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+            super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
-            super::spawn::spawn_inner(future, self.name)
+            super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
         })
     }
 
@@ -108,10 +109,11 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
-        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-            handle.spawn_named(Box::pin(future), self.name)
+        let fut_size = mem::size_of::<Fut>();
+        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+            handle.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
-            handle.spawn_named(future, self.name)
+            handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         })
     }
 
@@ -135,10 +137,12 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
-        Ok(if std::mem::size_of::<Fut>() > BOX_FUTURE_THRESHOLD {
-            super::local::spawn_local_inner(Box::pin(future), self.name)
+
+        let fut_size = mem::size_of::<Fut>();
+        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+            super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
-            super::local::spawn_local_inner(future, self.name)
+            super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
         })
     }
 
@@ -159,7 +163,13 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
-        Ok(local_set.spawn_named(future, self.name))
+        let fut_size = mem::size_of::<Fut>();
+        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+            local_set.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+        } else {
+            local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
+        })
+            
     }
 
     /// Spawns blocking code on the blocking threadpool.
@@ -200,19 +210,20 @@ impl<'a> Builder<'a> {
         Output: Send + 'static,
     {
         use crate::runtime::Mandatory;
-        let (join_handle, spawn_result) = if std::mem::size_of::<Function>() > BOX_FUTURE_THRESHOLD
+        let fn_size = mem::size_of::<Function>();
+        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD
         {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 Box::new(function),
                 Mandatory::NonMandatory,
-                self.name,
+                SpawnMeta::new(self.name, fn_size),
                 handle,
             )
         } else {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 function,
                 Mandatory::NonMandatory,
-                self.name,
+                SpawnMeta::new(self.name, fn_size),
                 handle,
             )
         };

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -6,11 +6,12 @@ use crate::runtime;
 use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, Task, TaskHarnessScheduleHooks};
 use crate::runtime::{context, ThreadId, BOX_FUTURE_THRESHOLD};
 use crate::sync::AtomicWaker;
+use crate::util::trace::SpawnMeta;
 use crate::util::RcCell;
 
 use std::cell::Cell;
 use std::collections::VecDeque;
-use std::fmt;
+use std::{fmt, mem};
 use std::future::Future;
 use std::marker::PhantomData;
 use std::pin::Pin;
@@ -367,22 +368,23 @@ cfg_rt! {
         F: Future + 'static,
         F::Output: 'static,
     {
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-            spawn_local_inner(Box::pin(future), None)
+        let fut_size = std::mem::size_of::<F>();
+        if fut_size > BOX_FUTURE_THRESHOLD {
+            spawn_local_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
-            spawn_local_inner(future, None)
+            spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
         }
     }
 
 
     #[track_caller]
-    pub(super) fn spawn_local_inner<F>(future: F, name: Option<&str>) -> JoinHandle<F::Output>
+    pub(super) fn spawn_local_inner<F>(future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
     where F: Future + 'static,
           F::Output: 'static
     {
         match CURRENT.with(|LocalData { ctx, .. }| ctx.get()) {
             None => panic!("`spawn_local` called from outside of a `task::LocalSet`"),
-            Some(cx) => cx.spawn(future, name)
+            Some(cx) => cx.spawn(future, meta)
        }
     }
 }
@@ -521,7 +523,12 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
-        self.spawn_named(future, None)
+        let fut_size = mem::size_of::<F>();
+        if fut_size > BOX_FUTURE_THRESHOLD {
+            self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+        } else {
+            self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
+        }
     }
 
     /// Runs a future to completion on the provided runtime, driving any local
@@ -643,26 +650,22 @@ impl LocalSet {
     pub(in crate::task) fn spawn_named<F>(
         &self,
         future: F,
-        name: Option<&str>,
+        meta: SpawnMeta<'_>,
     ) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
         F::Output: 'static,
     {
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-            self.spawn_named_inner(Box::pin(future), name)
-        } else {
-            self.spawn_named_inner(future, name)
-        }
+        self.spawn_named_inner(future, meta)
     }
 
     #[track_caller]
-    fn spawn_named_inner<F>(&self, future: F, name: Option<&str>) -> JoinHandle<F::Output>
+    fn spawn_named_inner<F>(&self, future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
         F::Output: 'static,
     {
-        let handle = self.context.spawn(future, name);
+        let handle = self.context.spawn(future, meta);
 
         // Because a task was spawned from *outside* the `LocalSet`, wake the
         // `LocalSet` future to execute the new task, if it hasn't been woken.
@@ -949,13 +952,13 @@ impl Drop for LocalSet {
 
 impl Context {
     #[track_caller]
-    fn spawn<F>(&self, future: F, name: Option<&str>) -> JoinHandle<F::Output>
+    fn spawn<F>(&self, future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
         F::Output: 'static,
     {
         let id = crate::runtime::task::Id::next();
-        let future = crate::util::trace::task(future, "local", name, id.as_u64());
+        let future = crate::util::trace::task(future, "local", meta, id.as_u64());
 
         // Safety: called from the thread that owns the `LocalSet`
         let (handle, notified) = {

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -11,9 +11,10 @@ use crate::util::RcCell;
 
 use std::cell::Cell;
 use std::collections::VecDeque;
-use std::{fmt, mem};
+use std::fmt;
 use std::future::Future;
 use std::marker::PhantomData;
+use std::mem;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::task::Poll;

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -1,5 +1,6 @@
 use crate::runtime::BOX_FUTURE_THRESHOLD;
 use crate::task::JoinHandle;
+use crate::util::trace::SpawnMeta;
 
 use std::future::Future;
 
@@ -167,17 +168,16 @@ cfg_rt! {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        // preventing stack overflows on debug mode, by quickly sending the
-        // task to the heap.
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
-            spawn_inner(Box::pin(future), None)
+        let fut_size = std::mem::size_of::<F>();
+        if fut_size > BOX_FUTURE_THRESHOLD {
+            spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
-            spawn_inner(future, None)
+            spawn_inner(future, SpawnMeta::new_unnamed(fut_size))
         }
     }
 
     #[track_caller]
-    pub(super) fn spawn_inner<T>(future: T, name: Option<&str>) -> JoinHandle<T::Output>
+    pub(super) fn spawn_inner<T>(future: T, meta: SpawnMeta<'_>) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,
@@ -197,7 +197,7 @@ cfg_rt! {
         ))]
         let future = task::trace::Trace::root(future);
         let id = task::Id::next();
-        let task = crate::util::trace::task(future, "task", name, id.as_u64());
+        let task = crate::util::trace::task(future, "task", meta, id.as_u64());
 
         match context::with_current(|handle| handle.spawn(task, id)) {
             Ok(join_handle) => join_handle,

--- a/tokio/tests/tracing-instrumentation/tests/task.rs
+++ b/tokio/tests/tracing-instrumentation/tests/task.rs
@@ -3,6 +3,8 @@
 //! These tests ensure that the instrumentation for task spawning and task
 //! lifecycles is correct.
 
+use std::{mem, time::Duration};
+
 use tokio::task;
 use tracing_mock::{expect, span::NewSpan, subscriber};
 
@@ -85,6 +87,83 @@ async fn task_builder_loc_file_recorded() {
 
         task::Builder::new()
             .spawn(futures::future::ready(()))
+            .unwrap()
+            .await
+            .expect("failed to await join handle");
+    }
+
+    handle.assert_finished();
+}
+
+#[tokio::test]
+async fn task_spawn_sizes_recorded() {
+    let future = futures::future::ready(());
+    let size = mem::size_of_val(&future) as u64;
+
+    let task_span = expect::span()
+        .named("runtime.spawn")
+        .with_target("tokio::task")
+        .with_field(
+            expect::field("size.bytes")
+                .with_value(&size)
+                .and(expect::field("original_size.bytes").with_value(&size)),
+        );
+
+    let (subscriber, handle) = subscriber::mock().new_span(task_span).run_with_handle();
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        task::Builder::new()
+            .spawn(future)
+            .unwrap()
+            .await
+            .expect("failed to await join handle");
+    }
+
+    handle.assert_finished();
+}
+
+#[tokio::test]
+async fn task_big_spawn_sizes_recorded() {
+    let future = {
+        async fn big<const N: usize>() {
+            let mut a = [0_u8; N];
+            for idx in 0..N {
+                a[idx] = (idx % 256) as u8;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            for idx in 0..N {
+                assert_eq!(a[idx], (idx % 256) as u8);
+            }
+        }
+
+        // This is larger than the release auto-boxing threshold
+        big::<20_000>()
+    };
+
+    fn boxed_size<T>(_: &T) -> usize {
+        mem::size_of::<Box<T>>()
+    }
+    let size = mem::size_of_val(&future) as u64;
+    let boxed_size = boxed_size(&future);
+
+    let task_span = expect::span()
+        .named("runtime.spawn")
+        .with_target("tokio::task")
+        .with_field(
+            expect::field("size.bytes")
+                .with_value(&boxed_size)
+                .and(expect::field("original_size.bytes").with_value(&size)),
+        );
+
+    let (subscriber, handle) = subscriber::mock().new_span(task_span).run_with_handle();
+
+    {
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        task::Builder::new()
+            .spawn(future)
             .unwrap()
             .await
             .expect("failed to await join handle");


### PR DESCRIPTION
## Motivation

In Tokio, the futures for tasks are stored on the stack unless they are
explicitly boxed, either by the user or auto-boxed by Tokio when they
are especially large. Auto-boxing now also occurs in release mode
(since #6826).

Having very large futures can be problematic as it can cause a stack
overflow. In some cases it might be desireable to have smaller futures,
even if they are placed on the heap.

## Solution

This change adds the size of the future driving an async task or the
function driving a blocking task to the tracing instrumentation. In the
case of a future that is auto-boxed by Tokio, both the final size as well
the original size before boxing is included.

To do this, a new struct `SpawnMeta` gets passed down from where a
future might get boxed to where the instrumentation is added. This
contains the task name (optionally) and the original future or function
size. If the `tokio_unstable` cfg flag and the `tracing` feature aren't both
enabled, then this struct will be zero sized, which is a small improvement
on the previous behavior of unconditionally passing down an `Option<&str>`
for the name.

This will make this information immediately available in Tokio Console,
and will enable new lints which will warn users if they have large futures
(just for async tasks).

We have some tests under the `tracing-instrumentation` crate which test
that the `size.bytes` and `original_size.bytes` fields are set correctly.

The minimal version of `tracing` required for Tokio has been bumped from
0.1.25 to 0.1.29 to get the `Value` impl on `Option<T>`. Given that the current
version is 0.1.40, this seems reasonable, especially given that Tracing's MSRV
is still lower than Tokio's in the latest version.

## PR Notes

Here's a preview of Tokio Console using this new instrumentation
(purple arrows are my addition).

<img width="1201" alt="tasks_screen" src="https://github.com/user-attachments/assets/c8de1407-23c8-4508-aae1-8176e343ff2e">

<img width="1201" alt="blocking_task_detail_screen" src="https://github.com/user-attachments/assets/a7ab5ed5-5238-4ab4-b580-a11567cd331c">
