### PR TITLE
readme: update miri test flags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ run loom tests that test unstable features.
 
 You can run miri tests with
 ```
-MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-tag-raw-pointers" \
+MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-strict-provenance -Zmiri-retag-fields" \
     cargo +nightly miri test --features full --lib
 ```
 


### PR DESCRIPTION
Remove the `-Zmiri-tag-raw-pointers` flag that does not exist anymore, and make docs content consistent with the current ci settings.