### PR TITLE
runtime: fix stability feature flags for docs

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -351,8 +351,10 @@
 //! - [`task::Builder`]
 //! - Some methods on [`task::JoinSet`]
 //! - [`runtime::RuntimeMetrics`]
+//! - [`runtime::Builder::on_task_spawn`]
+//! - [`runtime::Builder::on_task_terminate`]
 //! - [`runtime::Builder::unhandled_panic`]
-//! - [`task::Id`]
+//! - [`runtime::TaskMeta`]
 //!
 //! This flag enables **unstable** features. The public API of these features
 //! may break in 1.x releases. To enable these features, the `--cfg

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -706,6 +706,12 @@ impl Builder {
     ///
     /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
     ///
+    /// **Note**: This is an [unstable API][unstable]. The public API of this type  
+    /// may break in 1.x releases. See [the documentation on unstable  
+    /// features][unstable] for details.  
+    ///  
+    /// [unstable]: crate#unstable-features  
+    ///
     /// # Examples
     ///
     /// ```
@@ -748,6 +754,12 @@ impl Builder {
     /// function more than once replaces the last callback defined, rather than adding to it.
     ///
     /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
+    ///
+    /// **Note**: This is an [unstable API][unstable]. The public API of this type  
+    /// may break in 1.x releases. See [the documentation on unstable  
+    /// features][unstable] for details.  
+    ///  
+    /// [unstable]: crate#unstable-features  
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -728,7 +728,7 @@ impl Builder {
     /// # }
     /// ```
     #[cfg(all(not(loom), tokio_unstable))]
-    #[cfg_attr(docsrs, doc(cfg(all(not(loom), tokio_unstable))))]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_task_spawn<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -728,6 +728,7 @@ impl Builder {
     /// # }
     /// ```
     #[cfg(all(not(loom), tokio_unstable))]
+    #[cfg_attr(docsrs, doc(cfg(all(not(loom), tokio_unstable))))]
     pub fn on_task_spawn<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
@@ -770,6 +771,7 @@ impl Builder {
     /// # }
     /// ```
     #[cfg(all(not(loom), tokio_unstable))]
+    #[cfg_attr(docsrs, doc(cfg(all(not(loom), tokio_unstable))))]
     pub fn on_task_terminate<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -783,7 +783,7 @@ impl Builder {
     /// # }
     /// ```
     #[cfg(all(not(loom), tokio_unstable))]
-    #[cfg_attr(docsrs, doc(cfg(all(not(loom), tokio_unstable))))]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_task_terminate<F>(&mut self, f: F) -> &mut Self
     where
         F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -384,8 +384,9 @@ cfg_rt! {
 
     mod task_hooks;
     pub(crate) use task_hooks::{TaskHooks, TaskCallback};
-    #[cfg(tokio_unstable)]
-    pub use task_hooks::TaskMeta;
+    cfg_unstable! {
+        pub use task_hooks::TaskMeta;
+    }
     #[cfg(not(tokio_unstable))]
     pub(crate) use task_hooks::TaskMeta;
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -119,6 +119,7 @@ pub enum RuntimeFlavor {
     MultiThread,
     /// The flavor that executes tasks across multiple threads.
     #[cfg(tokio_unstable)]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     MultiThreadAlt,
 }
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -391,7 +391,6 @@ impl<S: 'static> Task<S> {
         ///
         /// [task ID]: crate::task::Id
         #[cfg(tokio_unstable)]
-        #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
         pub(crate) fn id(&self) -> crate::task::Id {
             // Safety: The header pointer is valid.
             unsafe { Header::get_id(self.raw.header_ptr()) }

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -15,6 +15,12 @@ pub(crate) struct TaskHooks {
 }
 
 /// Task metadata supplied to user-provided hooks for task events.
+///
+/// **Note**: This is an [unstable API][unstable]. The public API of this type  
+/// may break in 1.x releases. See [the documentation on unstable  
+/// features][unstable] for details.  
+///  
+/// [unstable]: crate#unstable-features  
 #[allow(missing_debug_implementations)]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 pub struct TaskMeta<'a> {


### PR DESCRIPTION
## Motivation

Fixes: #6907

## Solution

Adds doc attribute noting the tokio_unstable requirements for various items