### PR TITLE
ci: freeze FreeBSD on rustc 1.81

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -3,7 +3,7 @@ auto_cancellation: $CIRRUS_BRANCH != 'master' && $CIRRUS_BRANCH !=~ 'tokio-.*'
 freebsd_instance:
   image_family: freebsd-14-1
 env:
-  RUST_STABLE: stable
+  RUST_STABLE: 1.81
   RUST_NIGHTLY: nightly-2024-05-05
   RUSTFLAGS: -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -952,10 +952,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ env.rust_stable }}
+      - name: Install Rust 1.81
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.rust_stable }}
+          toolchain: 1.81
       - name: Install wasm-pack
         uses: taiki-e/install-action@wasm-pack
 


### PR DESCRIPTION
Workaround for https://github.com/rust-lang/rust/issues/130677 which has landed in rustc 1.82.0.