### PR TITLE
metrics: rename `injection_queue_depth` to `global_queue_depth`

### DIFF
--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -681,29 +681,8 @@ impl RuntimeMetrics {
             }
         }
 
-        /// Returns the number of tasks currently scheduled in the runtime's
-        /// injection queue.
-        ///
-        /// Tasks that are spawned or notified from a non-runtime thread are
-        /// scheduled using the runtime's injection queue. This metric returns the
-        /// **current** number of tasks pending in the injection queue. As such, the
-        /// returned value may increase or decrease as new tasks are scheduled and
-        /// processed.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use tokio::runtime::Handle;
-        ///
-        /// #[tokio::main]
-        /// async fn main() {
-        ///     let metrics = Handle::current().metrics();
-        ///
-        ///     let n = metrics.injection_queue_depth();
-        ///     println!("{} tasks currently pending in the runtime's injection queue", n);
-        /// }
-        /// ```
         #[deprecated = "Renamed to global_queue_depth"]
+        /// Renamed to [`RuntimeMetrics::global_queue_depth`]
         pub fn injection_queue_depth(&self) -> usize {
             self.handle.inner.injection_queue_depth()
         }

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -71,11 +71,11 @@ impl RuntimeMetrics {
     }
 
     /// Returns the number of tasks currently scheduled in the runtime's
-    /// injection queue.
+    /// global queue.
     ///
     /// Tasks that are spawned or notified from a non-runtime thread are
-    /// scheduled using the runtime's injection queue. This metric returns the
-    /// **current** number of tasks pending in the injection queue. As such, the
+    /// scheduled using the runtime's global queue. This metric returns the
+    /// **current** number of tasks pending in the global queue. As such, the
     /// returned value may increase or decrease as new tasks are scheduled and
     /// processed.
     ///
@@ -88,11 +88,11 @@ impl RuntimeMetrics {
     /// async fn main() {
     ///     let metrics = Handle::current().metrics();
     ///
-    ///     let n = metrics.injection_queue_depth();
-    ///     println!("{} tasks currently pending in the runtime's injection queue", n);
+    ///     let n = metrics.global_queue_depth();
+    ///     println!("{} tasks currently pending in the runtime's global queue", n);
     /// }
     /// ```
-    pub fn injection_queue_depth(&self) -> usize {
+    pub fn global_queue_depth(&self) -> usize {
         self.handle.inner.injection_queue_depth()
     }
 
@@ -679,6 +679,33 @@ impl RuntimeMetrics {
                     .overflow_count
                     .load(Relaxed)
             }
+        }
+
+        /// Returns the number of tasks currently scheduled in the runtime's
+        /// injection queue.
+        ///
+        /// Tasks that are spawned or notified from a non-runtime thread are
+        /// scheduled using the runtime's injection queue. This metric returns the
+        /// **current** number of tasks pending in the injection queue. As such, the
+        /// returned value may increase or decrease as new tasks are scheduled and
+        /// processed.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime::Handle;
+        ///
+        /// #[tokio::main]
+        /// async fn main() {
+        ///     let metrics = Handle::current().metrics();
+        ///
+        ///     let n = metrics.injection_queue_depth();
+        ///     println!("{} tasks currently pending in the runtime's injection queue", n);
+        /// }
+        /// ```
+        #[deprecated = "Renamed to global_queue_depth"]
+        pub fn injection_queue_depth(&self) -> usize {
+            self.handle.inner.injection_queue_depth()
         }
 
         /// Returns the number of tasks currently scheduled in the given worker's

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -681,8 +681,9 @@ impl RuntimeMetrics {
             }
         }
 
-        #[deprecated = "Renamed to global_queue_depth"]
         /// Renamed to [`RuntimeMetrics::global_queue_depth`]
+        #[deprecated = "Renamed to global_queue_depth"]
+        #[doc(hidden)]
         pub fn injection_queue_depth(&self) -> usize {
             self.handle.inner.injection_queue_depth()
         }

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -47,7 +47,7 @@ fn num_alive_tasks() {
 }
 
 #[test]
-fn injection_queue_depth_current_thread() {
+fn global_queue_depth_current_thread() {
     use std::thread;
 
     let rt = current_thread();
@@ -60,11 +60,11 @@ fn injection_queue_depth_current_thread() {
     .join()
     .unwrap();
 
-    assert_eq!(1, metrics.injection_queue_depth());
+    assert_eq!(1, metrics.global_queue_depth());
 }
 
 #[test]
-fn injection_queue_depth_multi_thread() {
+fn global_queue_depth_multi_thread() {
     let rt = threaded();
     let metrics = rt.metrics();
 
@@ -85,7 +85,7 @@ fn injection_queue_depth_multi_thread() {
 
     let mut fail: Option<String> = None;
     for i in 0..10 {
-        let depth = metrics.injection_queue_depth();
+        let depth = metrics.global_queue_depth();
         if i != depth {
             fail = Some(format!("{i} is not equal to {depth}"));
             break;


### PR DESCRIPTION
This changes the metric name of `injection_queue_depth` to `global_queue_depth`. Note that this only changes the public facing apis, not all internal codes or comments.

Also, I left the `injection_queue_depth` as a deprecated api.

ref: https://github.com/tokio-rs/tokio/issues/6915