### PR TITLE
ci: use cargo deny

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,18 +13,12 @@ permissions:
   contents: read
 
 jobs:
-  security-audit:
+  cargo-deny:
     permissions:
-      checks: write  # for rustsec/audit-check to create check
-      contents: read  # for actions/checkout to fetch code
-      issues: write  # for rustsec/audit-check to create issues
+      checks: write
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Audit Check
-        # https://github.com/rustsec/audit-check/issues/2
-        uses: rustsec/audit-check@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -20,5 +20,5 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2

--- a/.github/workflows/pr-audit.yml
+++ b/.github/workflows/pr-audit.yml
@@ -16,17 +16,8 @@ permissions:
   contents: read
 
 jobs:
-  security-audit:
+  cargo-deny:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.head_commit.message, 'ci skip')"
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-
-      - name: Generate lockfile
-        run: cargo generate-lockfile
-
-      - name: Audit dependencies
-        run: cargo audit
+    - uses: actions/checkout@v4
+    - uses: EmbarkStudios/cargo-deny-action@v2

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -3,6 +3,7 @@ name = "benches"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT"
 
 [features]
 test-util = ["tokio/test-util"]
@@ -15,7 +16,7 @@ rand_chacha = "0.3"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }
-tokio-stream = { path = "../tokio-stream" }
+tokio-stream = { version = "0.1", path = "../tokio-stream" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.42"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,21 @@
+# https://embarkstudios.github.io/cargo-deny/cli/init.html
+
+[graph]
+all-features = true
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+]
+exceptions = [
+    { allow = ["Unicode-DFS-2016"], crate = "unicode-ident" },
+]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -3,6 +3,7 @@ name = "examples"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "MIT"
 
 # If you copy one of the examples into a new project, you should be using
 # [dependencies] instead, and delete the **path**.

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -3,12 +3,13 @@ name = "stress-test"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2021"
+license = "MIT"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { path = "../tokio/", features = ["full"] }
+tokio = { version = "1.0.0", path = "../tokio/", features = ["full"] }
 
 [dev-dependencies]
 rand = "0.8"

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -3,6 +3,7 @@ name = "tests-build"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2021"
+license = "MIT"
 publish = false
 
 [features]
@@ -10,7 +11,7 @@ full = ["tokio/full"]
 rt = ["tokio/rt", "tokio/macros"]
 
 [dependencies]
-tokio = { path = "../tokio", optional = true }
+tokio = { version = "1.0.0", path = "../tokio", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -3,6 +3,7 @@ name = "tests-integration"
 version = "0.1.0"
 authors = ["Tokio Contributors <team@tokio.rs>"]
 edition = "2021"
+license = "MIT"
 publish = false
 
 [[bin]]
@@ -55,8 +56,8 @@ rt = ["tokio/rt"]
 rt-multi-thread = ["rt", "tokio/rt-multi-thread"]
 
 [dependencies]
-tokio = { path = "../tokio" }
-tokio-test = { path = "../tokio-test", optional = true }
+tokio = { version = "1.0.0", path = "../tokio" }
+tokio-test = { version = "0.4", path = "../tokio-test", optional = true }
 doc-comment = "0.3.1"
 futures = { version = "0.3.0", features = ["async-await"] }
 bytes = "1.0.0"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -45,7 +45,7 @@ tokio-util = { version = "0.7.0", path = "../tokio-util", optional = true }
 tokio = { version = "1.2.0", path = "../tokio", features = ["full", "test-util"] }
 async-stream = "0.3"
 parking_lot = "0.12.0"
-tokio-test = { path = "../tokio-test" }
+tokio-test = { version = "0.4", path = "../tokio-test" }
 futures = { version = "0.3", default-features = false }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The rustsec audit check is not working anymore due to a `Cargo.lock` requirement. Update to cargo deny instead.

I'm not completely sure about this configuration. Ideally, we want advisories to result in an issue being opened, rather than in failing CI on random PRs. Thoughts?