### PR TITLE
Removed race condition from global_queue_depth_multi_thread test

### DIFF
--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -66,10 +66,10 @@ fn global_queue_depth_current_thread() {
 
 #[test]
 fn global_queue_depth_multi_thread() {
-    let rt = threaded();
-    let metrics = rt.metrics();
-
     for _ in 0..10 {
+        let rt = threaded();
+        let metrics = rt.metrics();
+
         if let Ok(_blocking_tasks) = try_block_threaded(&rt) {
             for i in 0..10 {
                 assert_eq!(i, metrics.global_queue_depth());
@@ -93,7 +93,7 @@ fn try_block_threaded(rt: &Runtime) -> Result<Vec<mpsc::Sender<()>>, mpsc::RecvT
 
             // Spawn a task per runtime worker to block it.
             rt.spawn(async move {
-                tx.send(()).unwrap();
+                tx.send(()).ok();
                 barrier.recv().ok();
             });
 


### PR DESCRIPTION
@Darksonn and @mox692 [discovered a race condition](https://github.com/tokio-rs/tokio/pull/6932#discussion_r1812507881) in the retry logic introduced in #6916 that this PR aims to fix.

In the `global_queue_depth_multi_thread` test, we try to block the two worker threads before spawning more tasks onto the global queue. This allows us to measure the [`RuntimeMetrics::global_queue_depth`](https://docs.rs/tokio/latest/tokio/runtime/struct.RuntimeMetrics.html#method.global_queue_depth) deterministically, as the two worker threads are blocked and therefore unable to pull any tasks from the global queue. Blocking the two worker threads [might fail](https://github.com/tokio-rs/tokio/pull/6876), in which case one of the tasks from the previous try to block the runtime would remain in the global queue. If the task remains in the global queue after the second try to block the runtime succeeds, it would add an unexpected task to the `global_queue_depth`, making the test fail. 

The solution this PR provides is to just create a new runtime on each try to block it. So if the first try to block the runtime fails, we drop the runtime and create a new one (with an empty global queue) that we then try to block again. We proceed until we succeed in blocking one runtime or run out of tries.