### PR TITLE
Making `net` feature flag show in documentation for net::UdpSocket

### DIFF
--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -46,6 +46,7 @@ cfg_net! {
         pub use tcp::socket::TcpSocket;
 
         mod udp;
+        #[doc(inline)]
         pub use udp::UdpSocket;
     }
 }


### PR DESCRIPTION
Fixes #6935. I nudged rustdoc to show the `net` feature on the re-export by `cfg(inline)`ing the documentation of `UdpSocket`. This works because `net::udp::UdpSocket` is already wrapped in a `cfg_net!`, which is seemingly stripped by rustdoc from the re-exported item.

Here are screenshots from my branch built with

```
RUSTDOCFLAGS="--cfg docsrs --cfg tokio_unstable" RUSTFLAGS="--cfg docsrs --cfg tokio_unstable" cargo +nightly doc --all-features
```

![image](https://github.com/user-attachments/assets/11573324-468f-4f22-9d9f-ac3403e342c4)

![image](https://github.com/user-attachments/assets/4add9830-c26d-483d-94e9-81ff324a3501)
