### PR TITLE
ci: update cargo-check-external-types to 0.1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1046,10 +1046,7 @@ jobs:
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v1
         with:
-          tool: cargo-check-external-types
-          # TODO: install from crates.io once https://github.com/awslabs/cargo-check-external-types/pull/183 merged and released.
-          git: https://github.com/taiki-e/cargo-check-external-types.git
-          rev: 83a8d29
+          tool: cargo-check-external-types@0.1.13
       - name: check-external-types
         run: cargo check-external-types --all-features
         working-directory: tokio


### PR DESCRIPTION

## Motivation

cargo-check-external-types bug has been fixed and released in 0.1.13.

Context: https://github.com/tokio-rs/tokio/pull/6937