### PR TITLE
docs: fix mismatched backticks in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,7 +269,7 @@ To list the available fuzzing harnesses you can run;
 $ cd tokio
 $ cargo fuzz list
 fuzz_linked_list
-````
+```
 
 Running a fuzz test is as simple as;
 


### PR DESCRIPTION
## Motivation

A code block in CONTRIBUTING.md has mismatched backticks.

The document is rendered correctly at least on GitHub, but syntax highlighting fails after that point.

## Solution

Adjust the backticks.