### PR TITLE
docs: clarify documentation of sync module

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -9,6 +9,13 @@
 //!
 //! [tasks]: crate::task
 //!
+//! **Note**: All functionality provided in this module is runtime agnostic. It is safe
+//! and correct to use these primitives without also using Tokio. Some types may provide additional
+//! functionality when used with Tokio runtime (e.g. cooperation with [Task Dumps]), but all
+//! documented functionality is runtime-agnostic.
+//!
+//! [Task Dumps]: crate::runtime::Handle::dump
+//!
 //! # Message passing
 //!
 //! The most common form of synchronization in a Tokio program is message


### PR DESCRIPTION
Based on feedback from customers, adding a clearer and top-line comment about runtime-agnosticism for the sync module.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Builders were unsure if they could use these primitives outside of Tokio. It is in the docs, but it's near the bottom.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Added more docs.
