### PR TITLE
metrics: Fix bug where num_buckets became inconsistent

### DIFF
--- a/tokio/src/runtime/metrics/histogram.rs
+++ b/tokio/src/runtime/metrics/histogram.rs
@@ -264,14 +264,14 @@ impl HistogramBuilder {
             }
             None => self.histogram_type,
         };
-        let num_buckets = self.histogram_type.num_buckets();
+        let num_buckets = histogram_type.num_buckets();
 
         Histogram {
             buckets: (0..num_buckets)
                 .map(|_| MetricAtomicU64::new(0))
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
-            histogram_type: histogram_type,
+            histogram_type,
         }
     }
 }
@@ -301,6 +301,13 @@ mod test {
             legacy: None,
         }
         .build()
+    }
+
+    #[test]
+    fn test_legacy_builder() {
+        let mut builder = HistogramBuilder::new();
+        builder.legacy_mut(|b| b.num_buckets = 20);
+        assert_eq!(builder.build().num_buckets(), 20);
     }
 
     #[test]
@@ -355,6 +362,9 @@ mod test {
 
         b.measure(4096, 1);
         assert_bucket_eq!(b, 9, 1);
+
+        b.measure(u64::MAX, 1);
+        assert_bucket_eq!(b, 9, 2);
     }
 
     #[test]

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -13,7 +13,7 @@ use std::task::Poll;
 use std::thread;
 use tokio::macros::support::poll_fn;
 
-use tokio::runtime::{HistogramConfiguration, LogHistogram, Runtime};
+use tokio::runtime::{HistogramConfiguration, HistogramScale, LogHistogram, Runtime};
 use tokio::task::consume_budget;
 use tokio::time::{self, Duration};
 
@@ -422,6 +422,21 @@ fn log_histogram() {
         .map(|(worker, bucket)| metrics.poll_time_histogram_bucket_count(worker, bucket))
         .sum();
     assert_eq!(N, n);
+}
+
+#[test]
+#[allow(deprecated)]
+fn legacy_log_histogram() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .enable_metrics_poll_time_histogram()
+        .metrics_poll_count_histogram_scale(HistogramScale::Log)
+        .metrics_poll_count_histogram_resolution(Duration::from_micros(50))
+        .metrics_poll_count_histogram_buckets(20)
+        .build()
+        .unwrap();
+    let num_buckets = rt.metrics().poll_time_histogram_num_buckets();
+    assert_eq!(num_buckets, 20);
 }
 
 #[test]


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

In Tokio 1.41, #6897 refactored histograms and their construction. Unfortunately, this change included a bug where `num_buckets` was not properly preserved when the legacy builder methods were used. This could cause an inconsistency where even if the customer set max buckets, we would still use the default.

**This can result in a runtime panic because the histogram thinks it has `N` buckets, but in reality, it only has 10.**
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Fix the bug.
