### PR TITLE
make tracing a task public so self-tracing is possible

### DIFF
--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -227,10 +227,9 @@ impl Trace {
     ///
     /// Example usage:
     /// ```
-    /// # use std::future::Future;
-    /// # use std::task::Poll;
-    ///
-    /// # use tokio::runtime::dump::Trace;
+    /// use std::future::Future;
+    /// use std::task::Poll;
+    /// use tokio::runtime::dump::Trace;
     ///
     /// # async fn test_fn() {
     /// // some future

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -227,6 +227,12 @@ impl Trace {
     ///
     /// Example usage:
     /// ```
+    /// # use std::future::Future;
+    /// # use std::task::Poll;
+    ///
+    /// # use tokio::runtime::dump::Trace;
+    ///
+    /// # async fn test_fn() {
     /// // some future
     /// let mut test_future = std::pin::pin!(async move { tokio::task::yield_now().await; 0 });
     ///
@@ -242,6 +248,7 @@ impl Trace {
     /// };
     ///
     /// println!("{trace}");
+    /// # }
     /// ```
     ///
     /// ### Nested calls

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -447,6 +447,9 @@ cfg_taskdump! {
     impl Handle {
         /// Captures a snapshot of the runtime's state.
         ///
+        /// If you only want to capture a snapshot of a single future's state, you can use
+        /// [`Trace::capture`][crate::runtime::dump::Trace].
+        ///
         /// This functionality is experimental, and comes with a number of
         /// requirements and limitations.
         ///

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -56,7 +56,8 @@ pub(crate) struct Trace {
 pin_project_lite::pin_project! {
     #[derive(Debug, Clone)]
     #[must_use = "futures do nothing unless you `.await` or poll them"]
-    pub(crate) struct Root<T> {
+    /// A future wrapper that roots traces (captured with [`Trace::capture`]).
+    pub struct Root<T> {
         #[pin]
         future: T,
     }

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -6,22 +6,21 @@
     any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]
 
-use std::{
-    future::Future,
-    pin::Pin,
-    sync::{Arc, Mutex},
-    task::{Context, Poll},
-    time::{Duration, Instant},
-};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
 use tokio::runtime::dump::{Root, Trace};
 
-pin_project_lite::pin_project! { pub struct PrettyFuture<F: Future> {
-    #[pin]
-    f: Root<F>,
-    t_last: State,
-    logs: Arc<Mutex<Vec<Trace>>>,
-}
+pin_project_lite::pin_project! {
+    pub struct PrettyFuture<F: Future> {
+        #[pin]
+        f: Root<F>,
+        t_last: State,
+        logs: Arc<Mutex<Vec<Trace>>>,
+    }
 }
 
 enum State {

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -1,0 +1,108 @@
+#![allow(unknown_lints, unexpected_cfgs)]
+#![cfg(all(
+    tokio_unstable,
+    tokio_taskdump,
+    target_os = "linux",
+    any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+))]
+
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use tokio::runtime::dump::{Root, Trace};
+
+pin_project_lite::pin_project! { pub struct PrettyFuture<F: Future> {
+    #[pin]
+    f: Root<F>,
+    t_last: State,
+    logs: Arc<Mutex<Vec<Trace>>>,
+}
+}
+
+enum State {
+    NotStarted,
+    Running { since: Instant },
+    Alerted,
+}
+
+impl<F: Future> PrettyFuture<F> {
+    pub fn pretty(f: F, logs: Arc<Mutex<Vec<Trace>>>) -> Self {
+        PrettyFuture {
+            f: Trace::root(f),
+            t_last: State::NotStarted,
+            logs,
+        }
+    }
+}
+
+impl<F: Future> Future for PrettyFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
+        let mut this = self.project();
+        let now = Instant::now();
+        let t_last = match this.t_last {
+            State::Running { since } => Some(*since),
+            State::NotStarted => {
+                *this.t_last = State::Running { since: now };
+                None
+            }
+            State::Alerted => {
+                // don't double-alert for the same future
+                None
+            }
+        };
+        if t_last.is_some_and(|t_last| now.duration_since(t_last) > Duration::from_millis(500)) {
+            let (res, trace) = tokio::runtime::dump::Trace::capture(|| this.f.as_mut().poll(cx));
+            this.logs.lock().unwrap().push(trace);
+            *this.t_last = State::Alerted;
+            return res;
+        }
+        this.f.poll(cx)
+    }
+}
+
+#[tokio::test]
+async fn task_trace_self() {
+    let log = Arc::new(Mutex::new(vec![]));
+    let log2 = Arc::new(Mutex::new(vec![]));
+    let mut good_line = vec![];
+    let mut bad_line = vec![];
+    PrettyFuture::pretty(
+        PrettyFuture::pretty(
+            async {
+                bad_line.push(line!() + 1);
+                tokio::task::yield_now().await;
+                bad_line.push(line!() + 1);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                for _ in 0..100 {
+                    good_line.push(line!() + 1);
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            },
+            log.clone(),
+        ),
+        log2.clone(),
+    )
+    .await;
+    for line in good_line {
+        let s = format!("{}:{}:", file!(), line);
+        assert!(log.lock().unwrap().iter().any(|x| {
+            eprintln!("{}", x);
+            format!("{}", x).contains(&s)
+        }));
+    }
+    for line in bad_line {
+        let s = format!("{}:{}:", file!(), line);
+        assert!(!log
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|x| format!("{}", x).contains(&s)));
+    }
+}


### PR DESCRIPTION
There is some desire to make it possible for tasks to trace themselves to discover slow wakeups, something similar to the test I added.

This PR makes some functions public (but unstable) to make that easier.

I currently shared it with someone I'm working with to see whether it helps them debug their "slow task" problems. I'll make this PR less WIP after I get feedback from them.

WIP: actually add docs.