### PR TITLE
allow getting task dump backtraces in a programmatic format

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -80,6 +80,7 @@ debuginfo
 decrementing
 demangled
 dequeued
+dereferenced
 deregister
 deregistered
 deregistering

--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-297
+298
 &
 +
 <
@@ -31,6 +31,7 @@
 50ms
 8MB
 ABI
+accessors
 adaptor
 adaptors
 Adaptors

--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-292
+297
 &
 +
 <
@@ -296,4 +296,3 @@ Wakers
 wakeup
 wakeups
 workstealing
-

--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -45,9 +45,7 @@ awaitable
 backend
 backpressure
 backtrace
-BacktraceFrame
 backtraces
-BacktraceSymbol
 backtracing
 binded
 bitfield

--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -30,6 +30,7 @@
 450ms
 50ms
 8MB
+ABI
 adaptor
 adaptors
 Adaptors
@@ -44,7 +45,9 @@ awaitable
 backend
 backpressure
 backtrace
+BacktraceFrame
 backtraces
+BacktraceSymbol
 backtracing
 binded
 bitfield
@@ -75,7 +78,9 @@ datagrams
 deallocate
 deallocated
 Deallocates
+debuginfo
 decrementing
+demangled
 dequeued
 deregister
 deregistered
@@ -133,6 +138,7 @@ implementers
 implementor
 implementors
 incrementing
+inlining
 interoperate
 invariants
 Invariants

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -30,7 +30,7 @@ pub struct Task {
     trace: Trace,
 }
 
-/// A backtrace symbol. This is similar to [backtrace::BacktraceSymbol],
+/// A backtrace symbol. This is similar to [`backtrace::BacktraceSymbol`],
 /// but is a separate struct to avoid public dependency issues.
 ///
 /// This struct is guaranteed to be pure data and operations involving
@@ -93,7 +93,7 @@ impl BacktraceSymbol {
     }
 }
 
-/// A backtrace frame. This is similar to [backtrace::BacktraceFrame],
+/// A backtrace frame. This is similar to [`backtrace::BacktraceFrame`],
 /// but is a separate struct to avoid public dependency issues.
 ///
 /// This struct is guaranteed to be pure data and operations involving
@@ -105,6 +105,10 @@ pub struct BacktraceFrame {
     symbol_address: *mut std::ffi::c_void,
     symbols: Vec<BacktraceSymbol>,
 }
+
+// Raw pointers are not actually used as pointers.
+unsafe impl Send for BacktraceFrame {}
+unsafe impl Sync for BacktraceFrame {}
 
 impl BacktraceFrame {
     pub(crate) fn from_resolved_backtrace_frame(frame: &backtrace::BacktraceFrame) -> Self {
@@ -133,7 +137,7 @@ impl BacktraceFrame {
 
     /// Return an iterator over the symbols of this backtrace frame.
     ///
-    /// Due to inlining, it is possible for there to be multiple [BacktraceSymbol] items relating
+    /// Due to inlining, it is possible for there to be multiple [`BacktraceSymbol`] items relating
     /// to a single frame. The first symbol listed is the "innermost function",
     /// whereas the last symbol is the outermost (last caller).
     pub fn symbols(&self) -> impl Iterator<Item = &BacktraceSymbol> {

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -164,7 +164,16 @@ pub struct Trace {
 }
 
 impl Trace {
-    /// Resolve and return a list of backtraces that are involved in polls in this task.
+    /// Resolve and return a list of backtraces that are involved in polls in this trace.
+    ///
+    /// The exact backtraces included here are unstable and might change in the future,
+    /// but you can expect one backtrace (one [`Vec<BacktraceFrame>`]) for every call to
+    /// [`poll`] to a bottom-level Tokio future - so if something like [`join!`] is
+    /// used, there will be a backtrace for each future in the join.
+    ///
+
+    /// [`poll`]: std::future::Future::poll
+    /// [`join!`]: macro@join
     pub fn resolve_backtraces(&self) -> Vec<Vec<BacktraceFrame>> {
         self.inner
             .backtraces()

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -41,12 +41,9 @@ struct Address(*mut std::ffi::c_void);
 unsafe impl Send for Address {}
 unsafe impl Sync for Address {}
 
-/// A backtrace symbol. This is similar to [`backtrace::BacktraceSymbol`],
-/// but is a separate struct to avoid public dependency issues.
+/// A backtrace symbol.
 ///
-/// This struct is guaranteed to be pure data and operations involving
-/// it will not call platform functions that take an unpredictable amount
-/// of time to finish.
+/// This struct provides accessors for backtrace symbols, similar to [`backtrace::BacktraceSymbol`].
 #[derive(Clone, Debug)]
 pub struct BacktraceSymbol {
     name: Option<Box<[u8]>>,
@@ -106,12 +103,9 @@ impl BacktraceSymbol {
     }
 }
 
-/// A backtrace frame. This is similar to [`backtrace::BacktraceFrame`],
-/// but is a separate struct to avoid public dependency issues.
+/// A backtrace frame.
 ///
-/// This struct is guaranteed to be pure data and operations involving
-/// it will not call platform functions that take an unpredictable amount
-/// of time to finish.
+/// This struct represents one stack frame in a captured backtrace, similar to [`backtrace::BacktraceFrame`].
 #[derive(Clone, Debug)]
 pub struct BacktraceFrame {
     ip: Address,
@@ -154,12 +148,9 @@ impl BacktraceFrame {
     }
 }
 
-/// A backtrace. This is similar to [`backtrace::Backtrace`],
-/// but is a separate struct to avoid public dependency issues.
+/// A captured backtrace.
 ///
-/// This struct is guaranteed to be pure data and operations involving
-/// it will not call platform functions that take an unpredictable amount
-/// of time to finish.
+/// This struct provides access to each backtrace frame, similar to [`backtrace::Backtrace`].
 #[derive(Clone, Debug)]
 pub struct Backtrace {
     frames: Box<[BacktraceFrame]>,
@@ -176,6 +167,7 @@ impl Backtrace {
 /// An execution trace of a task's last poll.
 ///
 /// <div class="warning">
+///
 /// Resolving a backtrace, either via the [`Display`][std::fmt::Display] impl or via
 /// [`resolve_backtraces`][Trace::resolve_backtraces], parses debuginfo, which is
 /// possibly a CPU-expensive operation that can take a platform-specific but

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -116,7 +116,7 @@ impl BacktraceSymbol {
 pub struct BacktraceFrame {
     ip: Address,
     symbol_address: Address,
-    symbols: Vec<BacktraceSymbol>,
+    symbols: Box<[BacktraceSymbol]>,
 }
 
 impl BacktraceFrame {

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -1,13 +1,13 @@
 //! Snapshots of runtime state.
 //!
-//! See [Handle::dump][crate::runtime::Handle::dump].
+//! See [`Handle::dump`][crate::runtime::Handle::dump].
 
 use crate::task::Id;
 use std::{fmt, path::Path};
 
 /// A snapshot of a runtime's state.
 ///
-/// See [Handle::dump][crate::runtime::Handle::dump].
+/// See [`Handle::dump`][crate::runtime::Handle::dump].
 #[derive(Debug)]
 pub struct Dump {
     tasks: Tasks,
@@ -15,7 +15,7 @@ pub struct Dump {
 
 /// Snapshots of tasks.
 ///
-/// See [Handle::dump][crate::runtime::Handle::dump].
+/// See [`Handle::dump`][crate::runtime::Handle::dump].
 #[derive(Debug)]
 pub struct Tasks {
     tasks: Vec<Task>,
@@ -23,7 +23,7 @@ pub struct Tasks {
 
 /// A snapshot of a task.
 ///
-/// See [Handle::dump][crate::runtime::Handle::dump].
+/// See [`Handle::dump`][crate::runtime::Handle::dump].
 #[derive(Debug)]
 pub struct Task {
     id: Id,
@@ -154,7 +154,7 @@ impl BacktraceFrame {
     }
 }
 
-/// A backtrace. This is similar to [backtrace::Backtrace],
+/// A backtrace. This is similar to [`backtrace::Backtrace`],
 /// but is a separate struct to avoid public dependency issues.
 ///
 /// This struct is guaranteed to be pure data and operations involving
@@ -185,11 +185,11 @@ impl Backtrace {
 /// the first call, but all guarantees are platform-dependent.
 ///
 /// To avoid blocking the runtime, it is recommended
-/// that you resolve backtraces inside of a [spawn_blocking()][crate::task::spawn_blocking]
+/// that you resolve backtraces inside of a [`spawn_blocking()`][crate::task::spawn_blocking]
 /// and to have some concurrency-limiting mechanism to avoid unexpected performance impact.
 /// </div>
 ///
-/// See [Handle::dump][crate::runtime::Handle::dump].
+/// See [`Handle::dump`][crate::runtime::Handle::dump].
 #[derive(Debug)]
 pub struct Trace {
     inner: super::task::trace::Trace,

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -138,6 +138,10 @@ impl Trace {
     pub(crate) fn root<F>(future: F) -> Root<F> {
         Root { future }
     }
+
+    pub(crate) fn backtraces(&self) -> &[Backtrace] {
+        &self.backtraces
+    }
 }
 
 /// If this is a sub-invocation of [`Trace::capture`], capture a backtrace.


### PR DESCRIPTION
This PR creates structs that allow dumping backtraces in a programmatic format, for example JSON. A JSON serializer is not natively included to avoid creating a Tokio dependency on one, but serialization can be done by customers.

Fixes #6309.
