### PR TITLE
style: simplify statements for readability

### DIFF
--- a/benches/sync_mpsc.rs
+++ b/benches/sync_mpsc.rs
@@ -37,7 +37,7 @@ fn create_medium<const SIZE: usize>(g: &mut BenchmarkGroup<WallTime>) {
 fn send_data<T: Default, const SIZE: usize>(g: &mut BenchmarkGroup<WallTime>, prefix: &str) {
     let rt = rt();
 
-    g.bench_function(format!("{}_{}", prefix, SIZE), |b| {
+    g.bench_function(format!("{prefix}_{SIZE}"), |b| {
         b.iter(|| {
             let (tx, mut rx) = mpsc::channel::<T>(SIZE);
 

--- a/examples/chat.rs
+++ b/examples/chat.rs
@@ -193,7 +193,7 @@ async fn process(
     // A client has connected, let's let everyone know.
     {
         let mut state = state.lock().await;
-        let msg = format!("{} has joined the chat", username);
+        let msg = format!("{username} has joined the chat");
         tracing::info!("{}", msg);
         state.broadcast(addr, &msg).await;
     }
@@ -210,7 +210,7 @@ async fn process(
                 // broadcast this message to the other users.
                 Some(Ok(msg)) => {
                     let mut state = state.lock().await;
-                    let msg = format!("{}: {}", username, msg);
+                    let msg = format!("{username}: {msg}");
 
                     state.broadcast(addr, &msg).await;
                 }
@@ -234,7 +234,7 @@ async fn process(
         let mut state = state.lock().await;
         state.peers.remove(&addr);
 
-        let msg = format!("{} has left the chat", username);
+        let msg = format!("{username} has left the chat");
         tracing::info!("{}", msg);
         state.broadcast(addr, &msg).await;
     }

--- a/examples/connect.rs
+++ b/examples/connect.rs
@@ -77,7 +77,7 @@ mod tcp {
                 //BytesMut into Bytes
                 Ok(i) => future::ready(Some(i.freeze())),
                 Err(e) => {
-                    println!("failed to read from socket; error={}", e);
+                    println!("failed to read from socket; error={e}");
                     future::ready(None)
                 }
             })

--- a/examples/echo-udp.rs
+++ b/examples/echo-udp.rs
@@ -38,7 +38,7 @@ impl Server {
             if let Some((size, peer)) = to_send {
                 let amt = socket.send_to(&buf[..size], &peer).await?;
 
-                println!("Echoed {}/{} bytes to {}", amt, size, peer);
+                println!("Echoed {amt}/{size} bytes to {peer}");
             }
 
             // If we're here then `to_send` is `None`, so we take a look for the

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // connections. This TCP listener is bound to the address we determined
     // above and must be associated with an event loop.
     let listener = TcpListener::bind(&addr).await?;
-    println!("Listening on: {}", addr);
+    println!("Listening on: {addr}");
 
     loop {
         // Asynchronously wait for an inbound socket.

--- a/examples/print_each_packet.rs
+++ b/examples/print_each_packet.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // to our event loop. After the socket's created we inform that we're ready
     // to go and start accepting connections.
     let listener = TcpListener::bind(&addr).await?;
-    println!("Listening on: {}", addr);
+    println!("Listening on: {addr}");
 
     loop {
         // Asynchronously wait for an inbound socket.
@@ -96,8 +96,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // The stream will return None once the client disconnects.
             while let Some(message) = framed.next().await {
                 match message {
-                    Ok(bytes) => println!("bytes: {:?}", bytes),
-                    Err(err) => println!("Socket closed with error: {:?}", err),
+                    Ok(bytes) => println!("bytes: {bytes:?}"),
+                    Err(err) => println!("Socket closed with error: {err:?}"),
                 }
             }
             println!("Socket received FIN packet and closed connection");

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -38,8 +38,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .nth(2)
         .unwrap_or_else(|| "127.0.0.1:8080".to_string());
 
-    println!("Listening on: {}", listen_addr);
-    println!("Proxying to: {}", server_addr);
+    println!("Listening on: {listen_addr}");
+    println!("Proxying to: {server_addr}");
 
     let listener = TcpListener::bind(listen_addr).await?;
 
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             copy_bidirectional(&mut inbound, &mut outbound)
                 .map(|r| {
                     if let Err(e) = r {
-                        println!("Failed to transfer; error={}", e);
+                        println!("Failed to transfer; error={e}");
                     }
                 })
                 .await

--- a/examples/tinydb.rs
+++ b/examples/tinydb.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .unwrap_or_else(|| "127.0.0.1:8080".to_string());
 
     let listener = TcpListener::bind(&addr).await?;
-    println!("Listening on: {}", addr);
+    println!("Listening on: {addr}");
 
     // Create the shared state of this server that will be shared amongst all
     // clients. We populate the initial database and then create the `Database`
@@ -131,11 +131,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 let response = response.serialize();
 
                                 if let Err(e) = lines.send(response.as_str()).await {
-                                    println!("error on sending response; error = {:?}", e);
+                                    println!("error on sending response; error = {e:?}");
                                 }
                             }
                             Err(e) => {
-                                println!("error on decoding from socket; error = {:?}", e);
+                                println!("error on decoding from socket; error = {e:?}");
                             }
                         }
                     }
@@ -143,7 +143,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     // The connection will be closed at this point as `lines.next()` has returned `None`.
                 });
             }
-            Err(e) => println!("error accepting socket; error = {:?}", e),
+            Err(e) => println!("error accepting socket; error = {e:?}"),
         }
     }
 }
@@ -162,7 +162,7 @@ fn handle_request(line: &str, db: &Arc<Database>) -> Response {
                 value: value.clone(),
             },
             None => Response::Error {
-                msg: format!("no key {}", key),
+                msg: format!("no key {key}"),
             },
         },
         Request::Set { key, value } => {
@@ -203,7 +203,7 @@ impl Request {
                     value: value.to_string(),
                 })
             }
-            Some(cmd) => Err(format!("unknown command: {}", cmd)),
+            Some(cmd) => Err(format!("unknown command: {cmd}")),
             None => Err("empty input".into()),
         }
     }
@@ -212,13 +212,13 @@ impl Request {
 impl Response {
     fn serialize(&self) -> String {
         match *self {
-            Response::Value { ref key, ref value } => format!("{} = {}", key, value),
+            Response::Value { ref key, ref value } => format!("{key} = {value}"),
             Response::Set {
                 ref key,
                 ref value,
                 ref previous,
-            } => format!("set {} = `{}`, previous: {:?}", key, value, previous),
-            Response::Error { ref msg } => format!("error: {}", msg),
+            } => format!("set {key} = `{value}`, previous: {previous:?}"),
+            Response::Error { ref msg } => format!("error: {msg}"),
         }
     }
 }

--- a/examples/tinyhttp.rs
+++ b/examples/tinyhttp.rs
@@ -31,13 +31,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .nth(1)
         .unwrap_or_else(|| "127.0.0.1:8080".to_string());
     let server = TcpListener::bind(&addr).await?;
-    println!("Listening on: {}", addr);
+    println!("Listening on: {addr}");
 
     loop {
         let (stream, _) = server.accept().await?;
         tokio::spawn(async move {
             if let Err(e) = process(stream).await {
-                println!("failed to process connection; error = {}", e);
+                println!("failed to process connection; error = {e}");
             }
         });
     }
@@ -159,7 +159,7 @@ impl Decoder for Http {
             let mut parsed_headers = [httparse::EMPTY_HEADER; 16];
             let mut r = httparse::Request::new(&mut parsed_headers);
             let status = r.parse(src).map_err(|e| {
-                let msg = format!("failed to parse http request: {:?}", e);
+                let msg = format!("failed to parse http request: {e:?}");
                 io::Error::new(io::ErrorKind::Other, msg)
             })?;
 

--- a/examples/udp-codec.rs
+++ b/examples/udp-codec.rs
@@ -46,7 +46,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Run both futures simultaneously of `a` and `b` sending messages back and forth.
     match tokio::try_join!(a, b) {
-        Err(e) => println!("an error occurred; error = {:?}", e),
+        Err(e) => println!("an error occurred; error = {e:?}"),
         _ => println!("done!"),
     }
 

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -20,7 +20,7 @@ impl RuntimeFlavor {
             "single_thread" => Err("The single threaded runtime flavor is called `current_thread`.".to_string()),
             "basic_scheduler" => Err("The `basic_scheduler` runtime flavor has been renamed to `current_thread`.".to_string()),
             "threaded_scheduler" => Err("The `threaded_scheduler` runtime flavor has been renamed to `multi_thread`.".to_string()),
-            _ => Err(format!("No such runtime flavor `{}`. The runtime flavors are `current_thread` and `multi_thread`.", s)),
+            _ => Err(format!("No such runtime flavor `{s}`. The runtime flavors are `current_thread` and `multi_thread`.")),
         }
     }
 }
@@ -36,7 +36,7 @@ impl UnhandledPanic {
         match s {
             "ignore" => Ok(UnhandledPanic::Ignore),
             "shutdown_runtime" => Ok(UnhandledPanic::ShutdownRuntime),
-            _ => Err(format!("No such unhandled panic behavior `{}`. The unhandled panic behaviors are `ignore` and `shutdown_runtime`.", s)),
+            _ => Err(format!("No such unhandled panic behavior `{s}`. The unhandled panic behaviors are `ignore` and `shutdown_runtime`.")),
         }
     }
 
@@ -239,12 +239,12 @@ fn parse_int(int: syn::Lit, span: Span, field: &str) -> Result<usize, syn::Error
             Ok(value) => Ok(value),
             Err(e) => Err(syn::Error::new(
                 span,
-                format!("Failed to parse value of `{}` as integer: {}", field, e),
+                format!("Failed to parse value of `{field}` as integer: {e}"),
             )),
         },
         _ => Err(syn::Error::new(
             span,
-            format!("Failed to parse value of `{}` as integer.", field),
+            format!("Failed to parse value of `{field}` as integer."),
         )),
     }
 }
@@ -255,7 +255,7 @@ fn parse_string(int: syn::Lit, span: Span, field: &str) -> Result<String, syn::E
         syn::Lit::Verbatim(s) => Ok(s.to_string()),
         _ => Err(syn::Error::new(
             span,
-            format!("Failed to parse value of `{}` as string.", field),
+            format!("Failed to parse value of `{field}` as string."),
         )),
     }
 }
@@ -275,7 +275,7 @@ fn parse_path(lit: syn::Lit, span: Span, field: &str) -> Result<Path, syn::Error
         }
         _ => Err(syn::Error::new(
             span,
-            format!("Failed to parse value of `{}` as path.", field),
+            format!("Failed to parse value of `{field}` as path."),
         )),
     }
 }
@@ -285,7 +285,7 @@ fn parse_bool(bool: syn::Lit, span: Span, field: &str) -> Result<bool, syn::Erro
         syn::Lit::Bool(b) => Ok(b.value),
         _ => Err(syn::Error::new(
             span,
-            format!("Failed to parse value of `{}` as bool.", field),
+            format!("Failed to parse value of `{field}` as bool."),
         )),
     }
 }
@@ -342,8 +342,7 @@ fn build_config(
                     }
                     name => {
                         let msg = format!(
-                            "Unknown attribute {} is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `unhandled_panic`",
-                            name,
+                            "Unknown attribute {name} is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `unhandled_panic`",
                         );
                         return Err(syn::Error::new_spanned(namevalue, msg));
                     }
@@ -358,21 +357,19 @@ fn build_config(
                 let msg = match name.as_str() {
                     "threaded_scheduler" | "multi_thread" => {
                         format!(
-                            "Set the runtime flavor with #[{}(flavor = \"multi_thread\")].",
-                            macro_name
+                            "Set the runtime flavor with #[{macro_name}(flavor = \"multi_thread\")]."
                         )
                     }
                     "basic_scheduler" | "current_thread" | "single_threaded" => {
                         format!(
-                            "Set the runtime flavor with #[{}(flavor = \"current_thread\")].",
-                            macro_name
+                            "Set the runtime flavor with #[{macro_name}(flavor = \"current_thread\")]."
                         )
                     }
                     "flavor" | "worker_threads" | "start_paused" | "crate" | "unhandled_panic" => {
-                        format!("The `{}` attribute requires an argument.", name)
+                        format!("The `{name}` attribute requires an argument.")
                     }
                     name => {
-                        format!("Unknown attribute {} is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `unhandled_panic`.", name)
+                        format!("Unknown attribute {name} is specified; expected one of: `flavor`, `worker_threads`, `start_paused`, `crate`, `unhandled_panic`.")
                     }
                 };
                 return Err(syn::Error::new_spanned(path, msg));

--- a/tokio-macros/src/select.rs
+++ b/tokio-macros/src/select.rs
@@ -11,7 +11,7 @@ pub(crate) fn declare_output_enum(input: TokenStream) -> TokenStream {
     };
 
     let variants = (0..branches)
-        .map(|num| Ident::new(&format!("_{}", num), Span::call_site()))
+        .map(|num| Ident::new(&format!("_{num}"), Span::call_site()))
         .collect::<Vec<_>>();
 
     // Use a bitfield to track which futures completed

--- a/tokio-test/src/stream_mock.rs
+++ b/tokio-test/src/stream_mock.rs
@@ -161,8 +161,7 @@ impl<T: Unpin> Drop for StreamMock<T> {
 
         assert!(
             undropped_count == 0,
-            "StreamMock was dropped before all actions were consumed, {} actions were not consumed",
-            undropped_count
+            "StreamMock was dropped before all actions were consumed, {undropped_count} actions were not consumed"
         );
     }
 }

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -34,7 +34,7 @@ async fn read_error() {
     match mock.read(&mut buf).await {
         Err(error) => {
             assert_eq!(error.kind(), io::ErrorKind::Other);
-            assert_eq!("cruel", format!("{}", error));
+            assert_eq!("cruel", format!("{error}"));
         }
         Ok(_) => panic!("error not received"),
     }
@@ -87,7 +87,7 @@ async fn write_error() {
     match mock.write_all(b"whoa").await {
         Err(error) => {
             assert_eq!(error.kind(), io::ErrorKind::Other);
-            assert_eq!("cruel", format!("{}", error));
+            assert_eq!("cruel", format!("{error}"));
         }
         Ok(_) => panic!("error not received"),
     }

--- a/tokio-util/src/codec/any_delimiter_codec.rs
+++ b/tokio-util/src/codec/any_delimiter_codec.rs
@@ -249,7 +249,7 @@ impl fmt::Display for AnyDelimiterCodecError {
             AnyDelimiterCodecError::MaxChunkLengthExceeded => {
                 write!(f, "max chunk length exceeded")
             }
-            AnyDelimiterCodecError::Io(e) => write!(f, "{}", e),
+            AnyDelimiterCodecError::Io(e) => write!(f, "{e}"),
         }
     }
 }

--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -218,7 +218,7 @@ impl fmt::Display for LinesCodecError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LinesCodecError::MaxLineLengthExceeded => write!(f, "max line length exceeded"),
-            LinesCodecError::Io(e) => write!(f, "{}", e),
+            LinesCodecError::Io(e) => write!(f, "{e}"),
         }
     }
 }

--- a/tokio-util/src/task/spawn_pinned.rs
+++ b/tokio-util/src/task/spawn_pinned.rs
@@ -249,7 +249,7 @@ impl LocalPool {
             // Send the callback to the LocalSet task
             if let Err(e) = worker_spawner.send(spawn_task) {
                 // Propagate the error as a panic in the join handle.
-                panic!("Failed to send job to worker: {}", e);
+                panic!("Failed to send job to worker: {e}");
             }
 
             // Wait for the task's join handle
@@ -260,7 +260,7 @@ impl LocalPool {
                     // join handle... We assume something happened to the worker
                     // and the task was not spawned. Propagate the error as a
                     // panic in the join handle.
-                    panic!("Worker failed to send join handle: {}", e);
+                    panic!("Worker failed to send join handle: {e}");
                 }
             };
 
@@ -284,12 +284,12 @@ impl LocalPool {
                         // No one else should have the join handle, so this is
                         // unexpected. Forward this error as a panic in the join
                         // handle.
-                        panic!("spawn_pinned task was canceled: {}", e);
+                        panic!("spawn_pinned task was canceled: {e}");
                     } else {
                         // Something unknown happened (not a panic or
                         // cancellation). Forward this error as a panic in the
                         // join handle.
-                        panic!("spawn_pinned task failed: {}", e);
+                        panic!("spawn_pinned task failed: {e}");
                     }
                 }
             }

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -665,7 +665,7 @@ impl<T> DelayQueue<T> {
                 // The delay is already expired, store it in the expired queue
                 self.expired.push(key, &mut self.slab);
             }
-            Err((_, err)) => panic!("invalid deadline; err={:?}", err),
+            Err((_, err)) => panic!("invalid deadline; err={err:?}"),
         }
     }
 

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -283,9 +283,7 @@ mod test {
             assert_eq!(
                 0,
                 level_for(0, pos),
-                "level_for({}) -- binary = {:b}",
-                pos,
-                pos
+                "level_for({pos}) -- binary = {pos:b}"
             );
         }
 
@@ -295,9 +293,7 @@ mod test {
                 assert_eq!(
                     level,
                     level_for(0, a as u64),
-                    "level_for({}) -- binary = {:b}",
-                    a,
-                    a
+                    "level_for({a}) -- binary = {a:b}"
                 );
 
                 if pos > level {
@@ -305,9 +301,7 @@ mod test {
                     assert_eq!(
                         level,
                         level_for(0, a as u64),
-                        "level_for({}) -- binary = {:b}",
-                        a,
-                        a
+                        "level_for({a}) -- binary = {a:b}"
                     );
                 }
 
@@ -316,9 +310,7 @@ mod test {
                     assert_eq!(
                         level,
                         level_for(0, a as u64),
-                        "level_for({}) -- binary = {:b}",
-                        a,
-                        a
+                        "level_for({a}) -- binary = {a:b}"
                     );
                 }
             }

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -280,11 +280,7 @@ mod test {
     #[test]
     fn test_level_for() {
         for pos in 0..64 {
-            assert_eq!(
-                0,
-                level_for(0, pos),
-                "level_for({pos}) -- binary = {pos:b}"
-            );
+            assert_eq!(0, level_for(0, pos), "level_for({pos}) -- binary = {pos:b}");
         }
 
         for level in 1..5 {

--- a/tokio-util/tests/codecs.rs
+++ b/tokio-util/tests/codecs.rs
@@ -75,26 +75,17 @@ fn lines_decoder_max_length() {
     assert!(codec.decode(buf).is_err());
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(
-        line.len() <= MAX_LENGTH,
-        "{line:?}.len() <= {MAX_LENGTH:?}"
-    );
+    assert!(line.len() <= MAX_LENGTH, "{line:?}.len() <= {MAX_LENGTH:?}");
     assert_eq!("line 2", line);
 
     assert!(codec.decode(buf).is_err());
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(
-        line.len() <= MAX_LENGTH,
-        "{line:?}.len() <= {MAX_LENGTH:?}"
-    );
+    assert!(line.len() <= MAX_LENGTH, "{line:?}.len() <= {MAX_LENGTH:?}");
     assert_eq!("line 4", line);
 
     let line = codec.decode(buf).unwrap().unwrap();
-    assert!(
-        line.len() <= MAX_LENGTH,
-        "{line:?}.len() <= {MAX_LENGTH:?}"
-    );
+    assert!(line.len() <= MAX_LENGTH, "{line:?}.len() <= {MAX_LENGTH:?}");
     assert_eq!("", line);
 
     assert_eq!(None, codec.decode(buf).unwrap());
@@ -103,10 +94,7 @@ fn lines_decoder_max_length() {
     assert_eq!(None, codec.decode(buf).unwrap());
 
     let line = codec.decode_eof(buf).unwrap().unwrap();
-    assert!(
-        line.len() <= MAX_LENGTH,
-        "{line:?}.len() <= {MAX_LENGTH:?}"
-    );
+    assert!(line.len() <= MAX_LENGTH, "{line:?}.len() <= {MAX_LENGTH:?}");
     assert_eq!("\rk", line);
 
     assert_eq!(None, codec.decode(buf).unwrap());

--- a/tokio-util/tests/codecs.rs
+++ b/tokio-util/tests/codecs.rs
@@ -77,9 +77,7 @@ fn lines_decoder_max_length() {
     let line = codec.decode(buf).unwrap().unwrap();
     assert!(
         line.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        line,
-        MAX_LENGTH
+        "{line:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("line 2", line);
 
@@ -88,18 +86,14 @@ fn lines_decoder_max_length() {
     let line = codec.decode(buf).unwrap().unwrap();
     assert!(
         line.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        line,
-        MAX_LENGTH
+        "{line:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("line 4", line);
 
     let line = codec.decode(buf).unwrap().unwrap();
     assert!(
         line.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        line,
-        MAX_LENGTH
+        "{line:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("", line);
 
@@ -111,9 +105,7 @@ fn lines_decoder_max_length() {
     let line = codec.decode_eof(buf).unwrap().unwrap();
     assert!(
         line.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        line,
-        MAX_LENGTH
+        "{line:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("\rk", line);
 
@@ -273,18 +265,14 @@ fn any_delimiters_decoder_max_length() {
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("chunk 2", chunk);
 
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("chunk 3", chunk);
 
@@ -292,36 +280,28 @@ fn any_delimiters_decoder_max_length() {
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("", chunk);
 
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("chunk 4", chunk);
 
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("", chunk);
 
     let chunk = codec.decode(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("", chunk);
 
@@ -333,9 +313,7 @@ fn any_delimiters_decoder_max_length() {
     let chunk = codec.decode_eof(buf).unwrap().unwrap();
     assert!(
         chunk.len() <= MAX_LENGTH,
-        "{:?}.len() <= {:?}",
-        chunk,
-        MAX_LENGTH
+        "{chunk:?}.len() <= {MAX_LENGTH:?}"
     );
     assert_eq!("k", chunk);
 

--- a/tokio-util/tests/framed_write.rs
+++ b/tokio-util/tests/framed_write.rs
@@ -180,7 +180,7 @@ impl Write for Mock {
                 Ok(data.len())
             }
             Some(Err(e)) => Err(e),
-            None => panic!("unexpected write; {:?}", src),
+            None => panic!("unexpected write; {src:?}"),
         }
     }
 

--- a/tokio-util/tests/io_reader_stream.rs
+++ b/tokio-util/tests/io_reader_stream.rs
@@ -42,7 +42,7 @@ async fn correct_behavior_on_errors() {
     let mut had_error = false;
     loop {
         let item = stream.next().await.unwrap();
-        println!("{:?}", item);
+        println!("{item:?}");
         match item {
             Ok(bytes) => {
                 let bytes = &*bytes;

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -789,7 +789,7 @@ impl AsyncWrite for Mock {
         match self.calls.pop_front() {
             Some(Poll::Ready(Ok(Op::Data(data)))) => {
                 let len = data.len();
-                assert!(src.len() >= len, "expect={:?}; actual={:?}", data, src);
+                assert!(src.len() >= len, "expect={data:?}; actual={src:?}");
                 assert_eq!(&data[..], &src[..len]);
                 Poll::Ready(Ok(len))
             }

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -111,7 +111,7 @@ async fn multi_delay_at_start() {
 
     let start = Instant::now();
     for elapsed in 0..1200 {
-        println!("elapsed: {:?}", elapsed);
+        println!("elapsed: {elapsed:?}");
         let elapsed = elapsed + 1;
         tokio::time::sleep_until(start + ms(elapsed)).await;
 
@@ -328,7 +328,7 @@ async fn remove_at_timer_wheel_threshold() {
             let entry = queue.remove(&key1).into_inner();
             assert_eq!(entry, "foo");
         }
-        other => panic!("other: {:?}", other),
+        other => panic!("other: {other:?}"),
     }
 }
 

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -129,7 +129,7 @@ impl<T> Future for JoinHandle<T> {
 
         match Pin::new(&mut self.rx).poll(cx) {
             Poll::Ready(Ok(v)) => Poll::Ready(Ok(v)),
-            Poll::Ready(Err(e)) => panic!("error = {:?}", e),
+            Poll::Ready(Err(e)) => panic!("error = {e:?}"),
             Poll::Pending => Poll::Pending,
         }
     }

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -95,9 +95,7 @@ pub(crate) mod sys {
         match std::env::var(ENV_WORKER_THREADS) {
             Ok(s) => {
                 let n = s.parse().unwrap_or_else(|e| {
-                    panic!(
-                        "\"{ENV_WORKER_THREADS}\" must be usize, error: {e}, value: {s}"
-                    )
+                    panic!("\"{ENV_WORKER_THREADS}\" must be usize, error: {e}, value: {s}")
                 });
                 assert!(n > 0, "\"{ENV_WORKER_THREADS}\" cannot be set to 0");
                 n
@@ -106,9 +104,7 @@ pub(crate) mod sys {
                 std::thread::available_parallelism().map_or(1, NonZeroUsize::get)
             }
             Err(std::env::VarError::NotUnicode(e)) => {
-                panic!(
-                    "\"{ENV_WORKER_THREADS}\" must be valid unicode, error: {e:?}"
-                )
+                panic!("\"{ENV_WORKER_THREADS}\" must be valid unicode, error: {e:?}")
             }
         }
     }

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -96,11 +96,10 @@ pub(crate) mod sys {
             Ok(s) => {
                 let n = s.parse().unwrap_or_else(|e| {
                     panic!(
-                        "\"{}\" must be usize, error: {}, value: {}",
-                        ENV_WORKER_THREADS, e, s
+                        "\"{ENV_WORKER_THREADS}\" must be usize, error: {e}, value: {s}"
                     )
                 });
-                assert!(n > 0, "\"{}\" cannot be set to 0", ENV_WORKER_THREADS);
+                assert!(n > 0, "\"{ENV_WORKER_THREADS}\" cannot be set to 0");
                 n
             }
             Err(std::env::VarError::NotPresent) => {
@@ -108,8 +107,7 @@ pub(crate) mod sys {
             }
             Err(std::env::VarError::NotUnicode(e)) => {
                 panic!(
-                    "\"{}\" must be valid unicode, error: {:?}",
-                    ENV_WORKER_THREADS, e
+                    "\"{ENV_WORKER_THREADS}\" must be valid unicode, error: {e:?}"
                 )
             }
         }

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -322,7 +322,7 @@ impl Spawner {
             // Compat: do not panic here, return the join_handle even though it will never resolve
             Err(SpawnError::ShuttingDown) => join_handle,
             Err(SpawnError::NoThreads(e)) => {
-                panic!("OS can't spawn worker thread: {}", e)
+                panic!("OS can't spawn worker thread: {e}")
             }
         }
     }

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -154,7 +154,7 @@ impl Driver {
                 // In case of wasm32_wasi this error happens, when trying to poll without subscriptions
                 // just return from the park, as there would be nothing, which wakes us up.
             }
-            Err(e) => panic!("unexpected error when polling the I/O driver: {:?}", e),
+            Err(e) => panic!("unexpected error when polling the I/O driver: {e:?}"),
         }
 
         // Process all the events that came in, dispatching appropriately

--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -109,7 +109,7 @@ impl Inner {
 
                 return;
             }
-            Err(actual) => panic!("inconsistent park state; actual = {}", actual),
+            Err(actual) => panic!("inconsistent park state; actual = {actual}"),
         }
 
         loop {
@@ -155,7 +155,7 @@ impl Inner {
 
                 return;
             }
-            Err(actual) => panic!("inconsistent park_timeout state; actual = {}", actual),
+            Err(actual) => panic!("inconsistent park_timeout state; actual = {actual}"),
         }
 
         // Wait with a timeout, and if we spuriously wake up or otherwise wake up
@@ -167,7 +167,7 @@ impl Inner {
         match self.state.swap(EMPTY, SeqCst) {
             NOTIFIED => {} // got a notification, hurray!
             PARKED => {}   // no notification, alas
-            n => panic!("inconsistent park_timeout state: {}", n),
+            n => panic!("inconsistent park_timeout state: {n}"),
         }
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -151,7 +151,7 @@ impl Inner {
 
                 return;
             }
-            Err(actual) => panic!("inconsistent park state; actual = {}", actual),
+            Err(actual) => panic!("inconsistent park state; actual = {actual}"),
         }
 
         loop {
@@ -188,7 +188,7 @@ impl Inner {
 
                 return;
             }
-            Err(actual) => panic!("inconsistent park state; actual = {}", actual),
+            Err(actual) => panic!("inconsistent park state; actual = {actual}"),
         }
 
         driver.park(handle);
@@ -196,7 +196,7 @@ impl Inner {
         match self.state.swap(EMPTY, SeqCst) {
             NOTIFIED => {}      // got a notification, hurray!
             PARKED_DRIVER => {} // no notification, alas
-            n => panic!("inconsistent park_timeout state: {}", n),
+            n => panic!("inconsistent park_timeout state: {n}"),
         }
     }
 
@@ -211,7 +211,7 @@ impl Inner {
             NOTIFIED => {} // already unparked
             PARKED_CONDVAR => self.unpark_condvar(),
             PARKED_DRIVER => driver.unpark(),
-            actual => panic!("inconsistent state in unpark; actual = {}", actual),
+            actual => panic!("inconsistent state in unpark; actual = {actual}"),
         }
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -264,9 +264,7 @@ impl<T> Local<T> {
         assert_eq!(
             tail.wrapping_sub(head) as usize,
             LOCAL_QUEUE_CAPACITY,
-            "queue is not full; tail = {}; head = {}",
-            tail,
-            head
+            "queue is not full; tail = {tail}; head = {head}"
         );
 
         let prev = pack(head, head);
@@ -490,8 +488,7 @@ impl<T> Steal<T> {
 
         assert!(
             n <= LOCAL_QUEUE_CAPACITY as UnsignedShort / 2,
-            "actual = {}",
-            n
+            "actual = {n}"
         );
 
         let (first, _) = unpack(next_packed);

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -118,7 +118,7 @@ impl Driver {
                 Ok(0) => panic!("EOF on self-pipe"),
                 Ok(_) => continue, // Keep reading
                 Err(e) if e.kind() == std_io::ErrorKind::WouldBlock => break,
-                Err(e) => panic!("Bad read on self-pipe: {}", e),
+                Err(e) => panic!("Bad read on self-pipe: {e}"),
             }
         }
 

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -301,9 +301,7 @@ mod test {
             assert_eq!(
                 0,
                 level_for(0, pos),
-                "level_for({}) -- binary = {:b}",
-                pos,
-                pos
+                "level_for({pos}) -- binary = {pos:b}"
             );
         }
 
@@ -313,9 +311,7 @@ mod test {
                 assert_eq!(
                     level,
                     level_for(0, a as u64),
-                    "level_for({}) -- binary = {:b}",
-                    a,
-                    a
+                    "level_for({a}) -- binary = {a:b}"
                 );
 
                 if pos > level {
@@ -323,9 +319,7 @@ mod test {
                     assert_eq!(
                         level,
                         level_for(0, a as u64),
-                        "level_for({}) -- binary = {:b}",
-                        a,
-                        a
+                        "level_for({a}) -- binary = {a:b}"
                     );
                 }
 
@@ -334,9 +328,7 @@ mod test {
                     assert_eq!(
                         level,
                         level_for(0, a as u64),
-                        "level_for({}) -- binary = {:b}",
-                        a,
-                        a
+                        "level_for({a}) -- binary = {a:b}"
                     );
                 }
             }

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -298,11 +298,7 @@ mod test {
     #[test]
     fn test_level_for() {
         for pos in 0..64 {
-            assert_eq!(
-                0,
-                level_for(0, pos),
-                "level_for({pos}) -- binary = {pos:b}"
-            );
+            assert_eq!(0, level_for(0, pos), "level_for({pos}) -- binary = {pos:b}");
         }
 
         for level in 1..5 {

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -76,7 +76,7 @@ impl<S: Storage> Registry<S> {
     fn register_listener(&self, event_id: EventId) -> watch::Receiver<()> {
         self.storage
             .event_info(event_id)
-            .unwrap_or_else(|| panic!("invalid event_id: {}", event_id))
+            .unwrap_or_else(|| panic!("invalid event_id: {event_id}"))
             .tx
             .subscribe()
     }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -258,7 +258,7 @@ fn signal_enable(signal: SignalKind, handle: &Handle) -> io::Result<()> {
     if signal < 0 || signal_hook_registry::FORBIDDEN.contains(&signal) {
         return Err(Error::new(
             ErrorKind::Other,
-            format!("Refusing to register signal {}", signal),
+            format!("Refusing to register signal {signal}"),
         ));
     }
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -255,7 +255,7 @@ pub mod error {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             match self {
                 RecvError::Closed => write!(f, "channel closed"),
-                RecvError::Lagged(amt) => write!(f, "channel lagged by {}", amt),
+                RecvError::Lagged(amt) => write!(f, "channel lagged by {amt}"),
             }
         }
     }
@@ -291,7 +291,7 @@ pub mod error {
             match self {
                 TryRecvError::Empty => write!(f, "channel empty"),
                 TryRecvError::Closed => write!(f, "channel closed"),
-                TryRecvError::Lagged(amt) => write!(f, "channel lagged by {}", amt),
+                TryRecvError::Lagged(amt) => write!(f, "channel lagged by {amt}"),
             }
         }
     }

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -274,8 +274,7 @@ impl<T: ?Sized> RwLock<T> {
     {
         assert!(
             max_reads <= MAX_READS,
-            "a RwLock may not be created with more than {} readers",
-            MAX_READS
+            "a RwLock may not be created with more than {MAX_READS} readers"
         );
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -96,7 +96,7 @@ impl fmt::Display for Error {
             Kind::AtCapacity => "timer is at capacity and cannot create a new entry",
             Kind::Invalid => "timer duration exceeds maximum duration",
         };
-        write!(fmt, "{}", descr)
+        write!(fmt, "{descr}")
     }
 }
 

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -447,7 +447,7 @@ impl Future for Sleep {
         let _ao_poll_span = self.inner.ctx.async_op_poll_span.clone().entered();
         match ready!(self.as_mut().poll_elapsed(cx)) {
             Ok(()) => Poll::Ready(()),
-            Err(e) => panic!("timer error: {}", e),
+            Err(e) => panic!("timer error: {e}"),
         }
     }
 }

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -211,7 +211,7 @@ async fn file_debug_fmt() {
     let file = File::open(tempfile.path()).await.unwrap();
 
     assert_eq!(
-        &format!("{:?}", file)[0..33],
+        &format!("{file:?}")[0..33],
         "tokio::fs::File { std: File { fd:"
     );
 }

--- a/tokio/tests/fs_open_options.rs
+++ b/tokio/tests/fs_open_options.rs
@@ -59,8 +59,7 @@ async fn open_options_mode() {
     // TESTING HACK: use Debug output to check the stored data
     assert!(
         mode.contains("mode: 420 ") || mode.contains("mode: 0o000644 "),
-        "mode is: {}",
-        mode
+        "mode is: {mode}"
     );
 }
 

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -141,7 +141,7 @@ fn drain(mut fd: &FileDescriptor, mut amt: usize) {
         match fd.read(&mut buf[..]) {
             Err(e) if e.kind() == ErrorKind::WouldBlock => {}
             Ok(0) => panic!("unexpected EOF"),
-            Err(e) => panic!("unexpected error: {:?}", e),
+            Err(e) => panic!("unexpected error: {e:?}"),
             Ok(x) => amt -= x,
         }
     }

--- a/tokio/tests/io_read_to_string.rs
+++ b/tokio/tests/io_read_to_string.rs
@@ -23,9 +23,9 @@ async fn to_string_does_not_truncate_on_utf8_error() {
     let mut s = "abc".to_string();
 
     match AsyncReadExt::read_to_string(&mut data.as_slice(), &mut s).await {
-        Ok(len) => panic!("Should fail: {} bytes.", len),
+        Ok(len) => panic!("Should fail: {len} bytes."),
         Err(err) if err.to_string() == "stream did not contain valid UTF-8" => {}
-        Err(err) => panic!("Fail: {}.", err),
+        Err(err) => panic!("Fail: {err}."),
     }
 
     assert_eq!(s, "abc");
@@ -40,9 +40,9 @@ async fn to_string_does_not_truncate_on_io_error() {
     let mut s = "abc".to_string();
 
     match AsyncReadExt::read_to_string(&mut mock, &mut s).await {
-        Ok(len) => panic!("Should fail: {} bytes.", len),
+        Ok(len) => panic!("Should fail: {len} bytes."),
         Err(err) if err.to_string() == "whoops" => {}
-        Err(err) => panic!("Fail: {}.", err),
+        Err(err) => panic!("Fail: {err}."),
     }
 
     assert_eq!(s, "abc");

--- a/tokio/tests/process_issue_42.rs
+++ b/tokio/tests/process_issue_42.rs
@@ -20,7 +20,7 @@ async fn issue_42() {
         task::spawn(async {
             let processes = (0..10usize).map(|i| {
                 let mut child = Command::new("echo")
-                    .arg(format!("I am spawned process #{}", i))
+                    .arg(format!("I am spawned process #{i}"))
                     .stdin(Stdio::null())
                     .stdout(Stdio::null())
                     .stderr(Stdio::null())

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -165,14 +165,14 @@ fn try_lock() {
 async fn debug_format() {
     let s = "debug";
     let m = Mutex::new(s.to_string());
-    assert_eq!(format!("{:?}", s), format!("{:?}", m.lock().await));
+    assert_eq!(format!("{s:?}"), format!("{:?}", m.lock().await));
 }
 
 #[maybe_tokio_test]
 async fn mutex_debug() {
     let s = "data";
     let m = Mutex::new(s.to_string());
-    assert_eq!(format!("{:?}", m), r#"Mutex { data: "data" }"#);
+    assert_eq!(format!("{m:?}"), r#"Mutex { data: "data" }"#);
     let _guard = m.lock().await;
-    assert_eq!(format!("{:?}", m), r#"Mutex { data: <locked> }"#)
+    assert_eq!(format!("{m:?}"), r#"Mutex { data: <locked> }"#)
 }

--- a/tokio/tests/sync_mutex_owned.rs
+++ b/tokio/tests/sync_mutex_owned.rs
@@ -133,5 +133,5 @@ fn try_lock_owned() {
 async fn debug_format() {
     let s = "debug";
     let m = Arc::new(Mutex::new(s.to_string()));
-    assert_eq!(format!("{:?}", s), format!("{:?}", m.lock_owned().await));
+    assert_eq!(format!("{s:?}"), format!("{:?}", m.lock_owned().await));
 }

--- a/tokio/tests/task_abort.rs
+++ b/tokio/tests/task_abort.rs
@@ -233,7 +233,7 @@ fn test_join_error_display() {
         // `String` payload
         let join_err = tokio::spawn(async move {
             let value = 1234;
-            panic!("Format-args payload: {}", value)
+            panic!("Format-args payload: {value}")
         })
         .await
         .unwrap_err();
@@ -244,8 +244,7 @@ fn test_join_error_display() {
         assert!(
             join_err_str.starts_with("task ")
                 && join_err_str.ends_with(" panicked with message \"Format-args payload: 1234\""),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
 
         // `&'static str` payload
@@ -258,8 +257,7 @@ fn test_join_error_display() {
         assert!(
             join_err_str.starts_with("task ")
                 && join_err_str.ends_with(" panicked with message \"Const payload\""),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
 
         // Non-string payload
@@ -271,8 +269,7 @@ fn test_join_error_display() {
 
         assert!(
             join_err_str.starts_with("task ") && join_err_str.ends_with(" panicked"),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
     });
 }
@@ -287,19 +284,18 @@ fn test_join_error_debug() {
         // `String` payload
         let join_err = tokio::spawn(async move {
             let value = 1234;
-            panic!("Format-args payload: {}", value)
+            panic!("Format-args payload: {value}")
         })
         .await
         .unwrap_err();
 
         // We can't assert the full output because the task ID can change.
-        let join_err_str = format!("{:?}", join_err);
+        let join_err_str = format!("{join_err:?}");
 
         assert!(
             join_err_str.starts_with("JoinError::Panic(Id(")
                 && join_err_str.ends_with("), \"Format-args payload: 1234\", ...)"),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
 
         // `&'static str` payload
@@ -307,13 +303,12 @@ fn test_join_error_debug() {
             .await
             .unwrap_err();
 
-        let join_err_str = format!("{:?}", join_err);
+        let join_err_str = format!("{join_err:?}");
 
         assert!(
             join_err_str.starts_with("JoinError::Panic(Id(")
                 && join_err_str.ends_with("), \"Const payload\", ...)"),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
 
         // Non-string payload
@@ -321,12 +316,11 @@ fn test_join_error_debug() {
             .await
             .unwrap_err();
 
-        let join_err_str = format!("{:?}", join_err);
+        let join_err_str = format!("{join_err:?}");
 
         assert!(
             join_err_str.starts_with("JoinError::Panic(Id(") && join_err_str.ends_with("), ...)"),
-            "Unexpected join_err_str {:?}",
-            join_err_str
+            "Unexpected join_err_str {join_err_str:?}"
         );
     });
 }

--- a/tokio/tests/task_blocking.rs
+++ b/tokio/tests/task_blocking.rs
@@ -134,8 +134,7 @@ fn useful_panic_message_when_dropping_rt_in_rt() {
 
     assert!(
         err.contains("Cannot drop a runtime"),
-        "Wrong panic message: {:?}",
-        err
+        "Wrong panic message: {err:?}"
     );
 }
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -254,7 +254,7 @@ async fn join_set_coop() {
     loop {
         match set.join_next().now_or_never() {
             Some(Some(Ok(()))) => {}
-            Some(Some(Err(err))) => panic!("failed: {}", err),
+            Some(Some(Err(err))) => panic!("failed: {err}"),
             None => {
                 coop_count += 1;
                 tokio::task::yield_now().await;
@@ -294,7 +294,7 @@ async fn try_join_next() {
             Some(Ok(())) => {
                 count += 1;
             }
-            Some(Err(err)) => panic!("failed: {}", err),
+            Some(Err(err)) => panic!("failed: {err}"),
             None => {
                 break;
             }

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -385,9 +385,8 @@ fn with_timeout(timeout: Duration, f: impl FnOnce() + Send + 'static) {
     // in case CI is slow, we'll give it a long timeout.
     match done_rx.recv_timeout(timeout) {
         Err(RecvTimeoutError::Timeout) => panic!(
-            "test did not complete within {:?} seconds, \
+            "test did not complete within {timeout:?} seconds, \
              we have (probably) entered an infinite loop!",
-            timeout,
         ),
         // Did the test thread panic? We'll find out for sure when we `join`
         // with it.

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -97,7 +97,7 @@ async fn drop_write() -> Result<()> {
             Ok(0) => Ok(()),
             Ok(len) => Err(Error::new(
                 ErrorKind::Other,
-                format!("Unexpected read: {} bytes.", len),
+                format!("Unexpected read: {len} bytes."),
             )),
             Err(err) => Err(err),
         };
@@ -122,8 +122,8 @@ async fn drop_write() -> Result<()> {
 
     match read_half.read(&mut read_buf[..]).await {
         Ok(0) => {}
-        Ok(len) => panic!("Unexpected read: {} bytes.", len),
-        Err(err) => panic!("Unexpected error: {}.", err),
+        Ok(len) => panic!("Unexpected read: {len} bytes."),
+        Err(err) => panic!("Unexpected error: {err}."),
     }
 
     handle.join().unwrap().unwrap();

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -65,7 +65,7 @@ async fn try_read_write() {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -84,7 +84,7 @@ async fn try_read_write() {
             match server.try_read(&mut read[i..]) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 
@@ -106,7 +106,7 @@ async fn try_read_write() {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -129,7 +129,7 @@ async fn try_read_write() {
             match server.try_read_vectored(&mut bufs) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 
@@ -321,7 +321,7 @@ async fn try_read_buf() {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -340,7 +340,7 @@ async fn try_read_buf() {
             match server.try_read_buf(&mut read) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -415,7 +415,7 @@ async fn try_send_recv() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -431,7 +431,7 @@ async fn try_send_recv() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -457,7 +457,7 @@ async fn try_send_to_recv_from() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -474,7 +474,7 @@ async fn try_send_to_recv_from() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -502,7 +502,7 @@ async fn try_recv_buf() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -518,7 +518,7 @@ async fn try_recv_buf() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -561,7 +561,7 @@ async fn try_recv_buf_from() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -578,7 +578,7 @@ async fn try_recv_buf_from() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -621,7 +621,7 @@ async fn poll_ready() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -638,7 +638,7 @@ async fn poll_ready() {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -88,7 +88,7 @@ async fn try_send_recv_never_block() -> io::Result<()> {
                 (io::ErrorKind::WouldBlock, _) => break,
                 (_, Some(libc::ENOBUFS)) => break,
                 _ => {
-                    panic!("unexpected error {:?}", err);
+                    panic!("unexpected error {err:?}");
                 }
             },
             Ok(len) => {
@@ -206,7 +206,7 @@ async fn try_send_to_recv_from() -> std::io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -223,7 +223,7 @@ async fn try_send_to_recv_from() -> std::io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -253,7 +253,7 @@ async fn try_recv_buf_from() -> std::io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -270,7 +270,7 @@ async fn try_recv_buf_from() -> std::io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }
@@ -317,7 +317,7 @@ async fn try_recv_buf_never_block() -> io::Result<()> {
                 (io::ErrorKind::WouldBlock, _) => break,
                 (_, Some(libc::ENOBUFS)) => break,
                 _ => {
-                    panic!("unexpected error {:?}", err);
+                    panic!("unexpected error {err:?}");
                 }
             },
             Ok(len) => {
@@ -388,7 +388,7 @@ async fn poll_ready() -> io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
 
@@ -405,7 +405,7 @@ async fn poll_ready() -> io::Result<()> {
                     break;
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("{:?}", e),
+                Err(e) => panic!("{e:?}"),
             }
         }
     }

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -106,7 +106,7 @@ async fn try_read_write() -> std::io::Result<()> {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -125,7 +125,7 @@ async fn try_read_write() -> std::io::Result<()> {
             match server.try_read(&mut read[i..]) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 
@@ -147,7 +147,7 @@ async fn try_read_write() -> std::io::Result<()> {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -170,7 +170,7 @@ async fn try_read_write() -> std::io::Result<()> {
             match server.try_read_vectored(&mut bufs) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 
@@ -343,7 +343,7 @@ async fn try_read_buf() -> std::io::Result<()> {
             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                 break;
             }
-            Err(e) => panic!("error = {:?}", e),
+            Err(e) => panic!("error = {e:?}"),
         }
     }
 
@@ -362,7 +362,7 @@ async fn try_read_buf() -> std::io::Result<()> {
             match server.try_read_buf(&mut read) {
                 Ok(n) => i += n,
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                Err(e) => panic!("error = {:?}", e),
+                Err(e) => panic!("error = {e:?}"),
             }
         }
 


### PR DESCRIPTION
Closes #6977

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Some lines like

```rust
format!("The `{}` attribute requires an argument.", name)
```

aren't as readable as they could be.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

We can replace lines like

```rust
format!("The `{}` attribute requires an argument.", name)
```

with

```rust
format!("The `{name}` attribute requires an argument.")
```

to improve code readability and maintainability.
