### PR TITLE
I propose exposing the pidfd instance for Tokio-spawned child processes on Linux

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1104,7 +1104,7 @@ pub struct Child {
 
 impl Child {
     /// Return the file descriptor associated with the child process.
-    /// May return None if process file descriptor is not supported
+    /// May return None if process file descriptors are not supported
     ///
     /// # Safety
     ///

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1112,9 +1112,8 @@ impl Child {
     /// while working with this file descriptor -- specifically, they must not close it
     /// or reseat it with system calls such as ```dup2()``` or ```dup3()```
     #[cfg(all(target_os = "linux", feature = "rt"))]
-    #[cfg_attr(docsrs, doc(cfg(linux, rt)))]
-    pub unsafe fn get_pidfd(&self) -> Option<ProcessHandle>
-    {
+    #[cfg_attr(docsrs, doc(cfg(all(linux, rt))))]
+    pub unsafe fn get_pidfd(&self) -> Option<ProcessHandle> {
         self.os_handle
     }
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1103,14 +1103,14 @@ pub struct Child {
 }
 
 impl Child {
-    /// Return the pidfd instance associated with the child process.
-    /// May return None if pidfd is not supported
+    /// Return the file descriptor associated with the child process.
+    /// May return None if process file descriptor is not supported
     ///
     /// # Safety
     ///
     /// The caller must respect [the I/O safety requirements](https://doc.rust-lang.org/std/io/index.html#io-safety)
     /// while working with this file descriptor -- specifically, they must not close it
-    /// or reseat it with system calls such as ```dup2()``` or ```dup3()```
+    /// or re-seat it with system calls such as ```dup2()``` or ```dup3()```
     #[cfg(all(target_os = "linux", feature = "rt"))]
     #[cfg_attr(docsrs, doc(cfg(all(linux, rt))))]
     pub unsafe fn get_pidfd(&self) -> Option<ProcessHandle> {

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -131,7 +131,7 @@ pub(crate) fn spawn_child(cmd: &mut std::process::Command) -> io::Result<Spawned
                 stdin,
                 stdout,
                 stderr,
-            })
+            });
         }
         Err((Some(err), _child)) => return Err(err),
         Err((None, child_returned)) => child = child_returned,

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -124,8 +124,10 @@ pub(crate) fn spawn_child(cmd: &mut std::process::Command) -> io::Result<Spawned
     #[cfg(all(target_os = "linux", feature = "rt"))]
     match pidfd_reaper::PidfdReaper::new(child, GlobalOrphanQueue) {
         Ok(pidfd_reaper) => {
+            let saved_fd = pidfd_reaper.as_raw_fd();
             return Ok(SpawnedChild {
                 child: Child::PidfdReaper(pidfd_reaper),
+                os_handle: Option::Some(saved_fd),
                 stdin,
                 stdout,
                 stderr,
@@ -139,6 +141,8 @@ pub(crate) fn spawn_child(cmd: &mut std::process::Command) -> io::Result<Spawned
 
     Ok(SpawnedChild {
         child: Child::SignalReaper(Reaper::new(child, GlobalOrphanQueue, signal)),
+        #[cfg(all(target_os = "linux", feature = "rt"))]
+        os_handle: None,
         stdin,
         stdout,
         stderr,

--- a/tokio/src/process/unix/pidfd_reaper.rs
+++ b/tokio/src/process/unix/pidfd_reaper.rs
@@ -191,8 +191,7 @@ where
     W: Wait + Unpin,
     Q: OrphanQueue<W> + Unpin,
 {
-    fn as_raw_fd(&self) -> std::os::fd::RawFd
-    {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
         self.os_handle
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Hello, everyone! I propose giving the ```tokio::process::Child``` client code access to the underlying pidfd instance on Linux.

## Motivation

Pidfd instances on Linux are file descriptors referring to a process (either running or terminated). Tokio uses these file descriptors internally to receive notifications when Tokio-spawned child process has terminated. If pidfd is not supported, Tokio falls back to checking all watched child processes on receiving the ```SIGCHLD``` signal. However, watching and waiting for child processes is not the only use-case for pidfd, it can be used to send arbitrary signals to a child (```pidfd_send_signal()```) if you have signalling rights, intervene with its operation (```process_madvise()```, ```pidfd_getfd()```) if you have ptrace rights, entering child's namespace (```setns()```). Future versions of Linux may add other use-cases for the pidfd instances.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I propose adding a new ```unsafe``` method on ```tokio::process::Child``` structure -- the ```get_pidfd()``` that returns a pidfd instance as long as it's supported by the operating system (this is obviously a Linux-only feature). It's ```unsafe``` because closing it may break the ```tokio::process::Child``` operation, therefore, the client code should probably use something like ```std::os::fd::BorrowedFd``` to wrap it.
