### PR TITLE
signal: add SignalKind::info on illumos

### DIFF
--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -34,11 +34,11 @@ impl Init for OsStorage {
         // hasn't changed since 2013. See
         // https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/iso/signal_iso.h.
         //
-        // illumos also has real-time signals, but (a) the number of real-time
-        // signals is actually configurable at runtime and (b) this capability
-        // isn't exposed by libc as of 0.2.167, so we don't support them at the
-        // moment. If support for real-time signals on illumos is desired, this
-        // code would have to be changed to accommodate that.
+        // illumos also has real-time signals, but this capability isn't exposed
+        // by libc as of 0.2.167, so we don't support them at the moment. Once
+        // https://github.com/rust-lang/libc/pull/4171 is merged and released in
+        // upstream libc, we should switch the illumos impl to do what Linux
+        // does.
         #[cfg(target_os = "illumos")]
         let possible = 0..=41;
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -23,12 +23,24 @@ pub(crate) type OsStorage = Box<[SignalInfo]>;
 impl Init for OsStorage {
     fn init() -> Self {
         // There are reliable signals ranging from 1 to 33 available on every Unix platform.
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
         let possible = 0..=33;
 
         // On Linux, there are additional real-time signals available.
         #[cfg(target_os = "linux")]
         let possible = 0..=libc::SIGRTMAX();
+
+        // On illumos, signal numbers go up to 41 (SIGINFO). The list of signals
+        // hasn't changed since 2013. See
+        // https://github.com/illumos/illumos-gate/blob/master/usr/src/uts/common/sys/iso/signal_iso.h.
+        //
+        // illumos also has real-time signals, but (a) the number of real-time
+        // signals is actually configurable at runtime and (b) this capability
+        // isn't exposed by libc as of 0.2.167, so we don't support them at the
+        // moment. If support for real-time signals on illumos is desired, this
+        // code would have to be changed to accommodate that.
+        #[cfg(target_os = "illumos")]
+        let possible = 0..=41;
 
         possible.map(|_| SignalInfo::default()).collect()
     }
@@ -130,7 +142,8 @@ impl SignalKind {
         target_os = "freebsd",
         target_os = "macos",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "illumos"
     ))]
     pub const fn info() -> Self {
         Self(libc::SIGINFO)

--- a/tokio/tests/signal_info.rs
+++ b/tokio/tests/signal_info.rs
@@ -1,0 +1,38 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "illumos"
+))]
+#![cfg(not(miri))] // No `sigaction` on Miri
+
+mod support {
+    pub mod signal;
+}
+use support::signal::send_signal;
+
+use tokio::signal;
+use tokio::signal::unix::SignalKind;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+async fn siginfo() {
+    let mut sig = signal::unix::signal(SignalKind::info()).expect("installed signal handler");
+
+    let (fire, wait) = oneshot::channel();
+
+    // NB: simulate a signal coming in by exercising our signal handler
+    // to avoid complications with sending SIGINFO to the test process
+    tokio::spawn(async {
+        wait.await.expect("wait failed");
+        send_signal(libc::SIGINFO);
+    });
+
+    let _ = fire.send(());
+
+    sig.recv().await.expect("received SIGINFO signal");
+}

--- a/tokio/tests/signal_info.rs
+++ b/tokio/tests/signal_info.rs
@@ -18,6 +18,7 @@ use support::signal::send_signal;
 use tokio::signal;
 use tokio::signal::unix::SignalKind;
 use tokio::sync::oneshot;
+use tokio::time::{timeout, Duration};
 
 #[tokio::test]
 async fn siginfo() {
@@ -34,5 +35,9 @@ async fn siginfo() {
 
     let _ = fire.send(());
 
-    sig.recv().await.expect("received SIGINFO signal");
+    // Add a timeout to ensure the test doesn't hang.
+    timeout(Duration::from_secs(5), sig.recv())
+        .await
+        .expect("received SIGINFO signal in time")
+        .expect("received SIGINFO signal");
 }


### PR DESCRIPTION
## Motivation

illumos has supported SIGINFO for a long time; see https://github.com/illumos/illumos-gate/commit/19d32b9ab53d17ac6605971e14c45a5281f8d9bb. It is possible to create a signal handler from the constant by hand, but having `SignalKind::info` work is more convenient.

## Solution

Add `target_os = "illumos"` to the `cfg` for `SignalKind::info`.