### PR TITLE
ci: pin valgrind on 1.82

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: ${{ env.rust_stable }}
+            toolchain: 1.82
 
       - name: Install Valgrind
         uses: taiki-e/install-action@valgrind

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -13,7 +13,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: 1.82
 
 permissions:
   contents: read


### PR DESCRIPTION
Needed due to https://github.com/rust-lang/rust/issues/133574.