### PR TITLE
runtime: fixed yield_now lost wakeup

### DIFF
--- a/tokio/tests/task_yield_now.rs
+++ b/tokio/tests/task_yield_now.rs
@@ -1,5 +1,5 @@
 #![allow(unknown_lints, unexpected_cfgs)]
-#![cfg(all(feature = "full", tokio_unstable))]
+#![cfg(all(feature = "full", not(target_os = "wasi"), tokio_unstable))]
 
 use tokio::task;
 use tokio_test::task::spawn;
@@ -14,4 +14,12 @@ fn yield_now_outside_of_runtime() {
     assert!(task.poll().is_pending());
     assert!(task.is_woken());
     assert!(task.poll().is_ready());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn yield_now_external_executor_and_block_in_place() {
+    let j = tokio::spawn(async {
+        task::block_in_place(|| futures::executor::block_on(task::yield_now()));
+    });
+    j.await.unwrap();
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fixes https://github.com/tokio-rs/tokio/issues/6996

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The PR makes wake defer only occur in the enter runtime state. this avoid lost wakeup due to defer during exit runtime.