### PR TITLE
tests: fix typo in build test instructions

### DIFF
--- a/tests-build/README.md
+++ b/tests-build/README.md
@@ -6,5 +6,5 @@ To run all of the tests in this directory, run the following commands:
 cargo test --features full
 cargo test --features rt
 ```
-If one of the tests fail, you can pass `TRYBUILD=overwrite` to the `cargo test`
+If one of the tests fails, you can pass `TRYBUILD=overwrite` to the `cargo test`
 command that failed to have it regenerate the test output.

--- a/tests-build/README.md
+++ b/tests-build/README.md
@@ -6,5 +6,5 @@ To run all of the tests in this directory, run the following commands:
 cargo test --features full
 cargo test --features rt
 ```
-If one of the tests fails, you can pass `TRYBUILD=overwrite` to the `cargo test`
+If any of the tests fail, you can pass `TRYBUILD=overwrite` to the `cargo test`
 command that failed to have it regenerate the test output.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "fail" to "fails".

Please review the changes and let me know if any additional changes are needed.

