### PR TITLE
codec: fix incorrect handling of invalid utf-8 in `LinesCodec::decode_eof`

### DIFF
--- a/tokio-util/src/codec/lines_codec.rs
+++ b/tokio-util/src/codec/lines_codec.rs
@@ -169,6 +169,7 @@ impl Decoder for LinesCodec {
         Ok(match self.decode(buf)? {
             Some(frame) => Some(frame),
             None => {
+                self.next_index = 0;
                 // No terminating newline - return remaining data, if any
                 if buf.is_empty() || buf == &b"\r"[..] {
                     None
@@ -176,7 +177,6 @@ impl Decoder for LinesCodec {
                     let line = buf.split_to(buf.len());
                     let line = without_carriage_return(&line);
                     let line = utf8(line)?;
-                    self.next_index = 0;
                     Some(line.to_string())
                 }
             }

--- a/tokio-util/tests/codecs.rs
+++ b/tokio-util/tests/codecs.rs
@@ -63,6 +63,19 @@ fn lines_decoder() {
 }
 
 #[test]
+fn lines_decoder_invalid_utf8() {
+    let mut codec = LinesCodec::new();
+    let buf = &mut BytesMut::new();
+    buf.reserve(200);
+    buf.put_slice(b"line 1\xc3\x28");
+    assert_eq!(None, codec.decode(buf).unwrap());
+    assert!(codec.decode_eof(buf).is_err());
+    assert_eq!(None, codec.decode_eof(buf).unwrap());
+    buf.put_slice(b"line 22222222222222\n");
+    assert_eq!("line 22222222222222", codec.decode(buf).unwrap().unwrap());
+}
+
+#[test]
 fn lines_decoder_max_length() {
     const MAX_LENGTH: usize = 6;
 


### PR DESCRIPTION
## Motivation
LinesCodec is not resetting internal state in `decode_eof` in case there is utf8 decoding error.
This causes the following panic in subsequent `decode` calls: `slice index starts at 8 but ends at 0`

## Solution
Reset `next_index` at the start of `decode_eof`.
