### PR TITLE
chore: prepare tokio-util v0.7.13

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.7.13 (December 4th, 2024)
+
+### Fixed
+
+- codec: fix incorrect handling of invalid utf-8 in `LinesCodec::decode_eof` ([#7011])
+
+[#7011]: https://github.com/tokio-rs/tokio/pull/7011
+
 # 0.7.12 (September 5th, 2024)
 
 This release bumps the MSRV to 1.70. ([#6645])

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.12"
+version = "0.7.13"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.7.13 (December 4th, 2024)

### Fixed

- codec: fix incorrect handling of invalid utf-8 in `LinesCodec::decode_eof` ([#7011])

[#7011]: https://github.com/tokio-rs/tokio/pull/7011