### PR TITLE
ci: detect trailing whitespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1        
+version: 2.1
 jobs:
   test-arm:
     machine:

--- a/.github/buildomat/README.md
+++ b/.github/buildomat/README.md
@@ -12,7 +12,7 @@ reproduce the failure on other operating systems, don't worry! The
 [tokio-rs/illumos] team is responsible for maintaining Tokio's illumos support,
 and can be called on to assist contributors with illumos-specific issues. Please
 feel free to tag @tokio-rs/illumos to ask for help resolving build failures on
-illumos 
+illumos.
 
 [illumos]: https://www.illumos.org/
 [Buildomat]: https://github.com/oxidecomputer/buildomat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1103,4 +1103,5 @@ jobs:
           }
       - name: Run cargo-spellcheck
         run: cargo spellcheck --code 1
-
+      - name: Detect trailing whitespace
+        run: if grep --exclude-dir=.git --exclude-dir=target -re '\s$' . ; then exit 1; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,7 +196,7 @@ LOOM_MAX_PREEMPTIONS=1 LOOM_MAX_BRANCHES=10000 RUSTFLAGS="--cfg loom -C debug_as
     cargo test --lib --release --features full -- --test-threads=1 --nocapture
 ```
 Additionally, you can also add `--cfg tokio_unstable` to the `RUSTFLAGS` environment variable to
-run loom tests that test unstable features. 
+run loom tests that test unstable features.
 
 You can run miri tests with
 ```
@@ -216,8 +216,8 @@ cargo install --locked cargo-spellcheck
 cargo spellcheck check
 ```
 
-if the command rejects a word, you should backtick the rejected word if it's code related. If not, the 
-rejected word should be put into `spellcheck.dic` file. 
+if the command rejects a word, you should backtick the rejected word if it's code related. If not, the
+rejected word should be put into `spellcheck.dic` file.
 
 Note that when you add a word into the file, you should also update the first line which tells the spellcheck tool
 the total number of words included in the file

--- a/tokio-util/src/task/spawn_pinned.rs
+++ b/tokio-util/src/task/spawn_pinned.rs
@@ -39,9 +39,9 @@ use tokio::task::{spawn_local, JoinHandle, LocalSet};
 ///             task::spawn_local(async move {
 ///                 println!("{}", data_clone);
 ///             });
-///     
+///
 ///             data.to_string()
-///         }   
+///         }
 ///     }).await.unwrap();
 ///     println!("output: {}", output);
 /// }

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -142,7 +142,7 @@ impl UnixStream {
     ///             // if the readiness event is a false positive.
     ///             match stream.try_read(&mut data) {
     ///                 Ok(n) => {
-    ///                     println!("read {} bytes", n);        
+    ///                     println!("read {} bytes", n);
     ///                 }
     ///                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
     ///                     continue;

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -706,11 +706,11 @@ impl Builder {
     ///
     /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
     ///
-    /// **Note**: This is an [unstable API][unstable]. The public API of this type  
-    /// may break in 1.x releases. See [the documentation on unstable  
-    /// features][unstable] for details.  
-    ///  
-    /// [unstable]: crate#unstable-features  
+    /// **Note**: This is an [unstable API][unstable]. The public API of this type
+    /// may break in 1.x releases. See [the documentation on unstable
+    /// features][unstable] for details.
+    ///
+    /// [unstable]: crate#unstable-features
     ///
     /// # Examples
     ///
@@ -755,11 +755,11 @@ impl Builder {
     ///
     /// This *does not* support [`LocalSet`](crate::task::LocalSet) at this time.
     ///
-    /// **Note**: This is an [unstable API][unstable]. The public API of this type  
-    /// may break in 1.x releases. See [the documentation on unstable  
-    /// features][unstable] for details.  
-    ///  
-    /// [unstable]: crate#unstable-features  
+    /// **Note**: This is an [unstable API][unstable]. The public API of this type
+    /// may break in 1.x releases. See [the documentation on unstable
+    /// features][unstable] for details.
+    ///
+    /// [unstable]: crate#unstable-features
     ///
     /// # Examples
     ///

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -16,11 +16,11 @@ pub(crate) struct TaskHooks {
 
 /// Task metadata supplied to user-provided hooks for task events.
 ///
-/// **Note**: This is an [unstable API][unstable]. The public API of this type  
-/// may break in 1.x releases. See [the documentation on unstable  
-/// features][unstable] for details.  
-///  
-/// [unstable]: crate#unstable-features  
+/// **Note**: This is an [unstable API][unstable]. The public API of this type
+/// may break in 1.x releases. See [the documentation on unstable
+/// features][unstable] for details.
+///
+/// [unstable]: crate#unstable-features
 #[allow(missing_debug_implementations)]
 #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 pub struct TaskMeta<'a> {

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -395,9 +395,9 @@ impl<T: 'static> JoinSet<T> {
     ///            tokio::time::sleep(Duration::from_secs(3 - i)).await;
     ///            i
     ///        });
-    ///     }   
+    ///     }
     ///
-    ///     let output = set.join_all().await;  
+    ///     let output = set.join_all().await;
     ///     assert_eq!(output, vec![2, 1, 0]);
     /// }
     /// ```
@@ -414,8 +414,8 @@ impl<T: 'static> JoinSet<T> {
     ///
     ///     for i in 0..3 {
     ///        set.spawn(async move {i});
-    ///     }   
-    ///     
+    ///     }
+    ///
     ///     let mut output = Vec::new();
     ///     while let Some(res) = set.join_next().await{
     ///         match res {


### PR DESCRIPTION
Trailing whitespace is generally always wrong. There are a few instances of it in the Tokio repository.