### PR TITLE
signal: remove oneshot channels from tests

### DIFF
--- a/tokio/tests/signal_ctrl_c.rs
+++ b/tokio/tests/signal_ctrl_c.rs
@@ -9,23 +9,15 @@ mod support {
 use support::signal::send_signal;
 
 use tokio::signal;
-use tokio::sync::oneshot;
 use tokio_test::assert_ok;
 
 #[tokio::test]
 async fn ctrl_c() {
     let ctrl_c = signal::ctrl_c();
 
-    let (fire, wait) = oneshot::channel();
-
-    // NB: simulate a signal coming in by exercising our signal handler
-    // to avoid complications with sending SIGINT to the test process
     tokio::spawn(async {
-        wait.await.expect("wait failed");
         send_signal(libc::SIGINT);
     });
-
-    let _ = fire.send(());
 
     assert_ok!(ctrl_c.await);
 }

--- a/tokio/tests/signal_info.rs
+++ b/tokio/tests/signal_info.rs
@@ -17,23 +17,15 @@ use support::signal::send_signal;
 
 use tokio::signal;
 use tokio::signal::unix::SignalKind;
-use tokio::sync::oneshot;
 use tokio::time::{timeout, Duration};
 
 #[tokio::test]
 async fn siginfo() {
     let mut sig = signal::unix::signal(SignalKind::info()).expect("installed signal handler");
 
-    let (fire, wait) = oneshot::channel();
-
-    // NB: simulate a signal coming in by exercising our signal handler
-    // to avoid complications with sending SIGINFO to the test process
     tokio::spawn(async {
-        wait.await.expect("wait failed");
         send_signal(libc::SIGINFO);
     });
-
-    let _ = fire.send(());
 
     // Add a timeout to ensure the test doesn't hang.
     timeout(Duration::from_secs(5), sig.recv())


### PR DESCRIPTION
The oneshot channels don't make any sense here. Tasks in a current-thread runtime will run once the main task yields, which is always after the `fire.send(())` call. Thus, clean up and simplify the tests.