### PR TITLE
Spelling and Date Format Corrections

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -34,7 +34,7 @@ adaptor
 adaptors
 Adaptors
 AIO
-ambiant
+ambient
 amongst
 api
 APIs

--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -135,7 +135,7 @@ This release contains one performance improvement:
 [#5630]: https://github.com/tokio-rs/tokio/pull/5630
 [#5632]: https://github.com/tokio-rs/tokio/pull/5632
 
-# 0.7.7 (February 12, 2023)
+# 0.7.7 (February 12th, 2023)
 
 This release reverts the removal of the `Encoder` bound on the `FramedParts`
 constructor from [#5280] since it turned out to be a breaking change. ([#5450])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -37,7 +37,7 @@
 [#6938]: https://github.com/tokio-rs/tokio/pull/6938
 [#6944]: https://github.com/tokio-rs/tokio/pull/6944
 
-# 1.41.0 (Oct 22th, 2024)
+# 1.41.0 (Oct 22nd, 2024)
 
 ### Added
 

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -24,7 +24,7 @@ use super::{Notified, OwnedTasks, Schedule};
 type Backtrace = Vec<BacktraceFrame>;
 type SymbolTrace = Vec<Symbol>;
 
-/// The ambiant backtracing context.
+/// The ambient backtracing context.
 pub(crate) struct Context {
     /// The address of [`Trace::root`] establishes an upper unwinding bound on
     /// the backtraces in `Trace`.


### PR DESCRIPTION
File: spellcheck.dic
Added:
ambient (correct spelling)
Removed:
ambiant (incorrect spelling)
Reason: Corrected the spelling of "ambient" to ensure consistency and accuracy in documentation and code comments.

File: tokio-util/CHANGELOG.md
Changed:
Date format for version 0.7.7 from "February 12, 2023" to "February 12th, 2023" for consistency.
Date format for version 1.41.0 from "Oct 22th, 2024" to "Oct 22nd, 2024" for consistency.
Reason: Standardized date formatting across the changelog to improve readability and maintain consistency.