### PR TITLE
Run spawn_pinned test on miri

### DIFF
--- a/tokio-util/tests/spawn_pinned.rs
+++ b/tokio-util/tests/spawn_pinned.rs
@@ -1,7 +1,5 @@
 #![warn(rust_2018_idioms)]
 #![cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
-// Blocked on https://github.com/rust-lang/miri/issues/3911
-#![cfg(not(miri))]
 
 use std::rc::Rc;
 use std::sync::Arc;


### PR DESCRIPTION
This test previously blocked on a miri bug, but now it can run successfully. :tada:

Tracking issue #6812 