### PR TITLE
Fix thread parking on WebAssembly

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -65,12 +65,7 @@ impl ParkThread {
     pub(crate) fn park_timeout(&mut self, duration: Duration) {
         #[cfg(loom)]
         CURRENT_THREAD_PARK_COUNT.with(|count| count.fetch_add(1, SeqCst));
-
-        // Wasm doesn't have threads, so just sleep.
-        #[cfg(not(target_family = "wasm"))]
         self.inner.park_timeout(duration);
-        #[cfg(target_family = "wasm")]
-        std::thread::sleep(duration);
     }
 
     pub(crate) fn shutdown(&mut self) {
@@ -158,11 +153,19 @@ impl Inner {
             Err(actual) => panic!("inconsistent park_timeout state; actual = {actual}"),
         }
 
+        #[cfg(not(all(target_family = "wasm", not(target_feature = "atomics"))))]
         // Wait with a timeout, and if we spuriously wake up or otherwise wake up
         // from a notification, we just want to unconditionally set the state back to
         // empty, either consuming a notification or un-flagging ourselves as
         // parked.
         let (_m, _result) = self.condvar.wait_timeout(m, dur).unwrap();
+
+        #[cfg(all(target_family = "wasm", not(target_feature = "atomics")))]
+        // Wasm without atomics doesn't have threads, so just sleep.
+        {
+            let _m = m;
+            std::thread::sleep(dur);
+        }
 
         match self.state.swap(EMPTY, SeqCst) {
             NOTIFIED => {} // got a notification, hurray!


### PR DESCRIPTION
On WebAssembly the notification state was not checked before sleeping and thus wrongfully ignored.
    
Additionally this refines the check whether threads are available on a particular WebAssembly target.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Bug #7036

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Fixes #7036
