### PR TITLE
fix: A couple of typos in `once_cell.rs`

### DIFF
--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -9,7 +9,7 @@ use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 // This file contains an implementation of an OnceCell. The principle
-// behind the safety the of the cell is that any thread with an `&OnceCell` may
+// behind the safety of the cell is that any thread with an `&OnceCell` may
 // access the `value` field according the following rules:
 //
 //  1. When `value_set` is false, the `value` field may be modified by the
@@ -179,8 +179,8 @@ impl<T> OnceCell<T> {
     ///
     /// [`OnceCell::new`]: crate::sync::OnceCell::new
     // Once https://github.com/rust-lang/rust/issues/73255 lands
-    // and tokio MSRV is bumped to the rustc version with it stablised,
-    // we can made this function available in const context,
+    // and tokio MSRV is bumped to the rustc version with it stabilised,
+    // we can make this function available in const context,
     // by creating `Semaphore::const_new_closed`.
     pub fn new_with(value: Option<T>) -> Self {
         if let Some(v) = value {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Just fixing a couple of typos in `OnceCell`

## Solution

N/A