### PR TITLE
Clarify ReadBuf::uninit allows initialized buffers as well

### DIFF
--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -39,7 +39,7 @@ impl<'a> ReadBuf<'a> {
         }
     }
 
-    /// Creates a new `ReadBuf` from a fully uninitialized buffer.
+    /// Creates a new `ReadBuf` from a buffer that may be fully uninitialized.
     ///
     /// Use `assume_init` if part of the buffer is known to be already initialized.
     #[inline]

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -39,7 +39,7 @@ impl<'a> ReadBuf<'a> {
         }
     }
 
-    /// Creates a new `ReadBuf` from a buffer that may be fully uninitialized.
+    /// Creates a new `ReadBuf` from a buffer that may be uninitialized.
     ///
     /// Use `assume_init` if part of the buffer is known to be already initialized.
     #[inline]

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -41,7 +41,9 @@ impl<'a> ReadBuf<'a> {
 
     /// Creates a new `ReadBuf` from a buffer that may be uninitialized.
     ///
-    /// Use `assume_init` if part of the buffer is known to be already initialized.
+    /// The internal cursor will mark the entire buffer as uninitialized. If
+    /// the buffer is known to be partially initialized, then use `assume_init`
+    /// to move the internal cursor.
     #[inline]
     pub fn uninit(buf: &'a mut [MaybeUninit<u8>]) -> ReadBuf<'a> {
         ReadBuf {


### PR DESCRIPTION
## Motivation

The documentation for `ReadBuf::uninit` makes it seem as though the passed buffer _must_ be fully uninitialized; however it allows _any_ buffer, a subset of which is fully uninitialized memory.

Note this is more for people like me who are deficient in `unsafe` code; thus the original documentation is likely obvious for those who are well acquainted with `unsafe` code.

## Solution

State the buffer _may_ be fully uninitialized.