### PR TITLE
Change `AsyncReadExt::read` docs formatting to clarify requirements

### DIFF
--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -124,7 +124,7 @@ cfg_io_util! {
         ///
         /// No guarantees are provided about the contents of `buf` when this
         /// function is called, implementations cannot rely on any property of the
-        /// contents of `buf` being `true`. It is recommended that *implementations*
+        /// contents of `buf` being true. It is recommended that *implementations*
         /// only write data to `buf` instead of reading its contents.
         ///
         /// Correspondingly, however, *callers* of this method may not assume


### PR DESCRIPTION
## Motivation

I was reading the docs for the method, and in its current state, it read to me as:
> No guarantees are provided about the contents of `buf` when this function is called, implementations cannot rely on [any] ~property~ [of] the contents of `buf` being `true`.

With the inline block formatting on *true*, it makes it seem that you must not rely on `buf` containing the value `true`.

## Solution

Remove the inline block formatting on *true*, as we are not talking about the boolean value `true` in code.