### PR TITLE
Fix ambiguity in `TcpStream::try_write_vectored` docs

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -920,7 +920,7 @@ impl TcpStream {
     /// were written.
     ///
     /// Data is written from each buffer in order, with the final buffer read
-    /// from possible being only partially consumed. This method behaves
+    /// from possibly being only partially consumed. This method behaves
     /// equivalently to a single call to [`try_write()`] with concatenated
     /// buffers.
     ///


### PR DESCRIPTION
## Motivation

The buffer cannot be possible.

## Solution

Make it clear that the last buffer that is read from by the method, may have only been partially read.

As a side note, does the method override the buffers' contents? If not, then "consumed" should be replaced with "written".