### PR TITLE
macros: characterization tests for ? operator fail

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.rs
+++ b/tests-build/tests/fail/macros_type_mismatch.rs
@@ -23,6 +23,40 @@ async fn extra_semicolon() -> Result<(), ()> {
     Ok(());
 }
 
+/// This test is a characterization test for the `?` operator.
+///
+/// See <https://github.com/tokio-rs/tokio/issues/6930#issuecomment-2572502517> for more details.
+///
+/// It should fail with a single error message about the return type of the function, but instead
+/// if fails with an extra error message due to the `?` operator being used within the async block
+/// rather than the original function.
+///
+/// ```text
+/// 28 |     None?;
+///    |         ^ cannot use the `?` operator in an async block that returns `()`
+/// ```
+#[tokio::main]
+async fn question_mark_operator_with_invalid_option() -> Option<()> {
+    None?;
+}
+
+/// This test is a characterization test for the `?` operator.
+///
+/// See <https://github.com/tokio-rs/tokio/issues/6930#issuecomment-2572502517> for more details.
+///
+/// It should fail with a single error message about the return type of the function, but instead
+/// if fails with an extra error message due to the `?` operator being used within the async block
+/// rather than the original function.
+///
+/// ```text
+/// 33 |     Ok(())?;
+///    |           ^ cannot use the `?` operator in an async block that returns `()`
+/// ```
+#[tokio::main]
+async fn question_mark_operator_with_invalid_result() -> Result<(), ()> {
+    Ok(())?;
+}
+
 // https://github.com/tokio-rs/tokio/issues/4635
 #[allow(redundant_semicolons)]
 #[rustfmt::skip]

--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -49,11 +49,68 @@ help: try adding an expression at the end of the block
 24 +     Ok(())
    |
 
-error[E0308]: mismatched types
-  --> tests/fail/macros_type_mismatch.rs:32:5
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> tests/fail/macros_type_mismatch.rs:40:9
    |
-30 | async fn issue_4635() {
+38 | #[tokio::main]
+   | -------------- this function should return `Result` or `Option` to accept `?`
+39 | async fn question_mark_operator_with_invalid_option() -> Option<()> {
+40 |     None?;
+   |         ^ cannot use the `?` operator in an async block that returns `()`
+   |
+   = help: the trait `FromResidual<Option<Infallible>>` is not implemented for `()`
+
+error[E0308]: mismatched types
+  --> tests/fail/macros_type_mismatch.rs:40:5
+   |
+39 | async fn question_mark_operator_with_invalid_option() -> Option<()> {
+   |                                                          ---------- expected `Option<()>` because of return type
+40 |     None?;
+   |     ^^^^^^ expected `Option<()>`, found `()`
+   |
+   = note:   expected enum `Option<()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+40 ~     None?;;
+41 +     None
+   |
+40 ~     None?;;
+41 +     Some(())
+   |
+
+error[E0277]: the `?` operator can only be used in an async block that returns `Result` or `Option` (or another type that implements `FromResidual`)
+  --> tests/fail/macros_type_mismatch.rs:57:11
+   |
+55 | #[tokio::main]
+   | -------------- this function should return `Result` or `Option` to accept `?`
+56 | async fn question_mark_operator_with_invalid_result() -> Result<(), ()> {
+57 |     Ok(())?;
+   |           ^ cannot use the `?` operator in an async block that returns `()`
+   |
+   = help: the trait `FromResidual<Result<Infallible, _>>` is not implemented for `()`
+
+error[E0308]: mismatched types
+  --> tests/fail/macros_type_mismatch.rs:57:5
+   |
+56 | async fn question_mark_operator_with_invalid_result() -> Result<(), ()> {
+   |                                                          -------------- expected `Result<(), ()>` because of return type
+57 |     Ok(())?;
+   |     ^^^^^^^^ expected `Result<(), ()>`, found `()`
+   |
+   = note:   expected enum `Result<(), ()>`
+           found unit type `()`
+help: try adding an expression at the end of the block
+   |
+57 ~     Ok(())?;;
+58 +     Ok(())
+   |
+
+error[E0308]: mismatched types
+  --> tests/fail/macros_type_mismatch.rs:66:5
+   |
+64 | async fn issue_4635() {
    |                      - help: try adding a return type: `-> i32`
-31 |     return 1;
-32 |     ;
+65 |     return 1;
+66 |     ;
    |     ^ expected `()`, found integer


### PR DESCRIPTION
When a `?` operator is used in a tokio entry point function (wrapped in
`#[tokio::main]`), which has a Option or Result return type, but where
the function does not actually return that type correctly, currently the
compiler returns two errors instead of just one. The first of which is
incorrect and only exists due to the macro expanding to an async block.

```
cannot use the `?` operator in an async block that returns `()`
```

This commit is a characterization test for this behavior to help show
when it's fixed (or even changed for better / worse)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Annoyed by incorrect error message. "cannot use the `?` operator in an async block that returns `()`". More specifically, when editing code in ways that break the code (by changing return values, or changing the order of things, seeing error messages that aren't actually relevant to fixes can be annoying, particularly in situations where these errors are reported inline to the code. There's a small amount of time where the brain leaves the problem at hand and moves into solve the bug mode, which is unnecessary (and hence worth addressing)

More details at https://github.com/tokio-rs/tokio/issues/6930#issuecomment-2572502517

## Solution

This PR is about just identifying and capturing the problem. It can be merged as-is, or can be left open while considering the options to fix this.