### PR TITLE
runtime: move is_join_waker_set assertion in unset_waker

### DIFF
--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -446,11 +446,14 @@ impl State {
     pub(super) fn unset_waker(&self) -> UpdateResult {
         self.fetch_update(|curr| {
             assert!(curr.is_join_interested());
-            assert!(curr.is_join_waker_set());
 
             if curr.is_complete() {
                 return None;
             }
+
+            // If the task is completed, this bit may have been unset by
+            // `unset_waker_after_complete`.
+            assert!(curr.is_join_waker_set());
 
             let mut next = curr;
             next.unset_join_waker();


### PR DESCRIPTION
This was detected in the test_combinations test. It seems that the test doesn't fail every time.

Follow-up to #6986

cc @tglane for review