### PR TITLE
chore: prepare tokio-macros v2.5.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.5.0 (Jan 8th, 2025)
+
+- macros: suppress `clippy::needless_return` in `#[tokio::main]` ([#6874])
+
+[#6874]: https://github.com/tokio-rs/tokio/pull/6874
+
 # 2.4.0 (July 22nd, 2024)
 
 - msrv: increase MSRV to 1.70 ([#6645])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-1.x.y" git tag.
-version = "2.4.0"
+version = "2.5.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -86,7 +86,7 @@ test-util = ["rt", "sync", "time"]
 time = []
 
 [dependencies]
-tokio-macros = { version = "~2.4.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.5.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
 


### PR DESCRIPTION
# 2.5.0 (Jan 8th, 2025)

- macros: suppress `clippy::needless_return` in `#[tokio::main]` ([#6874])

[#6874]: https://github.com/tokio-rs/tokio/pull/6874