### PR TITLE
sync: add `CancellationToken::run_until_cancelled_owned`

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -287,6 +287,22 @@ impl CancellationToken {
         }
         .await
     }
+
+    /// Runs a future to completion and returns its result wrapped inside of an `Option`
+    /// unless the `CancellationToken` is cancelled. In that case the function returns
+    /// `None` and the future gets dropped.
+    ///
+    /// The function takes self by value and returns a future that owns the token.
+    ///
+    /// # Cancel safety
+    ///
+    /// This method is only cancel safe if `fut` is cancel safe.
+    pub async fn run_until_cancelled_owned<F>(self, fut: F) -> Option<F::Output>
+    where
+        F: Future,
+    {
+        self.run_until_cancelled(fut).await
+    }
 }
 
 // ===== impl WaitForCancellationFuture =====


### PR DESCRIPTION
Pretty natural addition to match the `cancelled_owned` fn.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

```rust
let token = CancellationToken::new();
tokio::spawn(token.run_until_cancelled(my_async_fn())); // doesn't compile
tokio::spawn(async move { // current workaround
    token.run_until_cancelled(my_async_fn())).await
});
tokio::spawn(token.run_until_cancelled_owned(my_async_fn())); // compiles, looks nicer
```

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Just a carbon copy of the existing fn switching to the appropriate cancellation future.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
