### PR TITLE
ci: fix ci error about wasm32-wasip1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1009,7 +1009,7 @@ jobs:
       - name: Install cargo-hack, wasmtime, and cargo-wasi
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,wasmtime,cargo-wasi
+          tool: cargo-hack,wasmtime
 
       - uses: Swatinem/rust-cache@v2
       - name: WASI test tokio full
@@ -1035,9 +1035,12 @@ jobs:
 
       - name: test tests-integration --features wasi-rt
         # TODO: this should become: `cargo hack wasi test --each-feature`
-        run: cargo wasi test --target ${{ matrix.target }} --test rt_yield --features wasi-rt
+        run: cargo test --target ${{ matrix.target }} --test rt_yield --features wasi-rt
         if: matrix.target == 'wasm32-wasip1'
         working-directory: tests-integration
+        env:
+          CARGO_TARGET_WASM32_WASIP1_RUNNER: "wasmtime run --"
+          RUSTFLAGS: -Dwarnings -C target-feature=+atomics,+bulk-memory -C link-args=--max-memory=67108864
 
       - name: test tests-integration --features wasi-threads-rt
         run: cargo test --target ${{ matrix.target }} --features wasi-threads-rt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1035,7 +1035,7 @@ jobs:
 
       - name: test tests-integration --features wasi-rt
         # TODO: this should become: `cargo hack wasi test --each-feature`
-        run: cargo wasi test --test rt_yield --features wasi-rt
+        run: cargo wasi test --target ${{ matrix.target }} --test rt_yield --features wasi-rt
         if: matrix.target == 'wasm32-wasip1'
         working-directory: tests-integration
 


### PR DESCRIPTION
CI is failing:

```
Run cargo wasi test --test rt_yield --features wasi-rt
error: toolchain 'stable-x86_64-unknown-linux-gnu' does not support target 'wasm32-wasi'; did you mean 'wasm32-wasip1'?
note: you can see a list of supported targets with `rustc --print=target-list`
note: if you are adding support for a new target to rustc itself, see https://rustc-dev-guide.rust-lang.org/building/new-target.html

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: rustup::toolchain::distributable::DistributableToolchain::add_component
   2: rustup::cli::rustup_mode::target_add
   3: rustup::cli::rustup_mode::main
   4: rustup_init::main
   5: std::sys_common::backtrace::__rust_begin_short_backtrace
   6: main
   7: <unknown>
   8: __libc_start_main
   9: <unknown>
error: failed to execute "rustup" "target" "add" "wasm[32](https://github.com/tokio-rs/tokio/actions/runs/12696581327/job/35391033832?pr=7081#step:9:33)-wasi"
    status: exit status: 1
```