### PR TITLE
sync: fix sync::broadcast::Sender<T>::closed() doctest

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -825,17 +825,14 @@ impl<T> Sender<T> {
     ///     let (tx, mut rx1) = broadcast::channel::<u32>(16);
     ///     let mut rx2 = tx.subscribe();
     ///
-    ///     tokio::spawn(async move {
-    ///         assert_eq!(rx1.recv().await.unwrap(), 10);
-    ///     });
-    ///
     ///     let _ = tx.send(10);
+    ///
+    ///     assert_eq!(rx1.recv().await.unwrap(), 10);
+    ///     drop(rx1);
     ///     assert!(tx.closed().now_or_never().is_none());
     ///
-    ///     let _ = tokio::spawn(async move {
-    ///         assert_eq!(rx2.recv().await.unwrap(), 10);
-    ///     }).await;
-    ///
+    ///     assert_eq!(rx2.recv().await.unwrap(), 10);
+    ///     drop(rx2);
     ///     assert!(tx.closed().now_or_never().is_some());
     /// }
     /// ```


### PR DESCRIPTION
The test's previous iteration could sometimes flake since we didn't await the completion of the first task. Since the tasks only existed to `move` the relevant `rx`'s in, to force a drop, we can omit them entirely and drop the `rx`s via `drop()`. This prevents any scheduling-related flakes.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
