### PR TITLE
7707 updated Tx struct and UnboundedSender to return message length

### DIFF
--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -1,6 +1,6 @@
 use crate::loom::cell::UnsafeCell;
 use crate::loom::future::AtomicWaker;
-use crate::loom::sync::atomic::AtomicUsize;
+use crate::loom::sync::atomic::{AtomicUsize, Ordering};
 use crate::loom::sync::Arc;
 use crate::runtime::park::CachedParkThread;
 use crate::sync::mpsc::error::TryRecvError;
@@ -207,6 +207,10 @@ impl<T, S: Semaphore> Tx<T, S> {
             return;
         }
         notified.await;
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.inner.tx_count.load(Ordering::SeqCst)
     }
 }
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -208,10 +208,6 @@ impl<T, S: Semaphore> Tx<T, S> {
         }
         notified.await;
     }
-
-    pub(crate) fn len(&self) -> usize {
-        self.inner.tx_count.load(Ordering::SeqCst)
-    }
 }
 
 impl<T, S> Clone for Tx<T, S> {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -675,6 +675,11 @@ impl<T> UnboundedSender<T> {
     pub fn weak_count(&self) -> usize {
         self.chan.weak_count()
     }
+
+    //Returns length of [`UnboundedSender`] semaphores /2, supposidly the number of messages.
+    pub fn len(&self) -> usize{
+        self.chan.len()
+    }
 }
 
 impl<T> Clone for WeakUnboundedSender<T> {

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -676,9 +676,10 @@ impl<T> UnboundedSender<T> {
         self.chan.weak_count()
     }
 
-    //Returns length of [`UnboundedSender`] semaphores /2, supposidly the number of messages.
+    ///Returns length of [`UnboundedSender`] semaphores /2, the number of messages.
     pub fn len(&self) -> usize{
-        self.chan.len()
+        (self.strong_count() + self.weak_count()) / 2
+        
     }
 }
 


### PR DESCRIPTION
update recommended by https://github.com/tokio-rs/tokio/issues/7077
simply they requested that we produce a len method that returns the length of messages in que for UnboundedSender struct

This should return the length of messages in que, though it will get it at an instance, thus as a threaded application may be inaccurate when the instance is updated simultaneously, though should be approximately correct for the time/instance of the method call.

no tests for this as there is not a test class for this file and associated structs (which needs to be rectified), same tests pass/ & fail as the regular master branch.

I've been looking for something to help contribute to this repo, though I'm new to rust, this repo, and my ide, so let me know what's wrong, what can be better, and what I'm missing.

hope this works for you and I hope to be a more useful contributor in the future.
