### PR TITLE
sync: handle panic during mpsc drop

### DIFF
--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -490,10 +490,34 @@ impl<T, S: Semaphore> Drop for Rx<T, S> {
 
         self.inner.rx_fields.with_mut(|rx_fields_ptr| {
             let rx_fields = unsafe { &mut *rx_fields_ptr };
-
-            while let Some(Value(_)) = rx_fields.list.pop(&self.inner.tx) {
-                self.inner.semaphore.add_permit();
+            struct Guard<'a, T, S: Semaphore> {
+                list: &'a mut list::Rx<T>,
+                tx: &'a CachePadded<crate::sync::mpsc::list::Tx<T>>,
+                sem: &'a S,
             }
+
+            impl<'a, T, S: Semaphore> Guard<'a, T, S> {
+                fn drain(&mut self) {
+                    // call T's destructor.
+                    while let Some(Value(_)) = self.list.pop(self.tx) {
+                        self.sem.add_permit();
+                    }
+                }
+            }
+
+            impl<'a, T, S: Semaphore> Drop for Guard<'a, T, S> {
+                fn drop(&mut self) {
+                    self.drain();
+                }
+            }
+
+            let mut guard = Guard {
+                list: &mut rx_fields.list,
+                tx: &self.inner.tx,
+                sem: &self.inner.semaphore,
+            };
+
+            guard.drain();
         });
     }
 }

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -492,7 +492,7 @@ impl<T, S: Semaphore> Drop for Rx<T, S> {
             let rx_fields = unsafe { &mut *rx_fields_ptr };
             struct Guard<'a, T, S: Semaphore> {
                 list: &'a mut list::Rx<T>,
-                tx: &'a CachePadded<crate::sync::mpsc::list::Tx<T>>,
+                tx: &'a list::Tx<T>,
                 sem: &'a S,
             }
 


### PR DESCRIPTION
This PR updates the `mpsc` to handle panics during the `drop`. Specifically, the `chan::Rx` will continue executing its `drop` even if a panic occurs during the `drop`.

Although this scenario is expected to be rare, there could be edge cases, for example:

* On thread1, [`chan::Rx`](https://github.com/tokio-rs/tokio/blob/435e39001b04f5846d1e9db1b243e6b81982f654/tokio/src/sync/mpsc/chan.rs#L485-L499) is dropped
* On thread1, panic occurs in the middle of the drop
* On thread2, [`chan::Chan`](https://github.com/tokio-rs/tokio/blob/435e39001b04f5846d1e9db1b243e6b81982f654/tokio/src/sync/mpsc/chan.rs#L529-L542) is dropped (resuming from the interrupted element)
* On thread2, panic occurs in the middle of the drop (no double panic since it's in a different thread)
* The program continues with elements still remaining in the `chan::Chan`

This PR prevents such cases by enforcing a double panic on thread1.