### PR TITLE
DRAFT RFC: limited `no-std` I/O support using `portable-io`

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -75,7 +75,7 @@ process = [
   "windows-sys/Win32_System_WindowsProgramming",
 ]
 # Includes basic task execution capabilities
-rt = []
+rt = ["std"]
 rt-multi-thread = ["rt"]
 signal = [
   "libc",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -24,6 +24,8 @@ keywords = ["io", "async", "non-blocking", "futures"]
 [features]
 # Include nothing by default
 default = []
+# XXX TODO:
+# default = ["std"]
 
 # enable everything
 full = [
@@ -37,14 +39,17 @@ full = [
   "rt",
   "rt-multi-thread",
   "signal",
+  "std",
   "sync",
   "time",
 ]
 
+# XXX TODO other features will likely require "std" to work
 fs = []
-io-util = ["bytes"]
+# XXX TBD io-util no-std WITH portable-io
+io-util = ["std", "bytes"]
 # stdin, stdout, stderr
-io-std = []
+io-std = ["std"]
 macros = ["tokio-macros"]
 net = [
   "libc",
@@ -81,6 +86,7 @@ signal = [
   "windows-sys/Win32_Foundation",
   "windows-sys/Win32_System_Console",
 ]
+std = []
 sync = []
 test-util = ["rt", "sync", "time"]
 time = []

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -87,7 +87,7 @@ signal = [
   "windows-sys/Win32_System_Console",
 ]
 std = []
-sync = []
+sync = ["std"]
 test-util = ["rt", "sync", "time"]
 time = []
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -49,7 +49,7 @@ fs = ["std"]
 io-util = ["bytes"]
 # stdin, stdout, stderr
 io-std = ["std"]
-macros = ["tokio-macros"]
+macros = ["std", "tokio-macros"]
 net = [
   "libc",
   "mio/os-poll",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -80,6 +80,7 @@ process = [
 rt = ["std"]
 rt-multi-thread = ["rt"]
 signal = [
+  "std",
   "libc",
   "mio/os-poll",
   "mio/net",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -51,6 +51,7 @@ io-util = ["bytes"]
 io-std = ["std"]
 macros = ["std", "tokio-macros"]
 net = [
+  "std",
   "libc",
   "mio/os-poll",
   "mio/os-ext",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -92,7 +92,7 @@ signal = [
 std = []
 sync = ["std"]
 test-util = ["rt", "sync", "time"]
-time = []
+time = ["std"]
 
 [dependencies]
 tokio-macros = { version = "~2.5.0", path = "../tokio-macros", optional = true }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -65,6 +65,7 @@ net = [
 ]
 portable-io = ["dep:portable-io"]
 process = [
+  "std",
   "bytes",
   "libc",
   "mio/os-poll",

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -47,7 +47,7 @@ full = [
 # XXX TODO other features will likely require "std" to work
 fs = []
 # XXX TBD io-util no-std WITH portable-io
-io-util = ["std", "bytes"]
+io-util = ["bytes"]
 # stdin, stdout, stderr
 io-std = ["std"]
 macros = ["tokio-macros"]
@@ -63,6 +63,7 @@ net = [
   "windows-sys/Win32_System_Pipes",
   "windows-sys/Win32_System_SystemServices",
 ]
+portable-io = ["dep:portable-io"]
 process = [
   "bytes",
   "libc",
@@ -100,6 +101,7 @@ pin-project-lite = "0.2.11"
 bytes = { version = "1.1.0", optional = true }
 mio = { version = "1.0.1", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
+portable-io = { version = "0.0.4", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 socket2 = { version = "0.5.5", optional = true, features = ["all"] }

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -44,8 +44,7 @@ full = [
   "time",
 ]
 
-# XXX TODO other features will likely require "std" to work
-fs = []
+fs = ["std"]
 # XXX TBD io-util no-std WITH portable-io
 io-util = ["bytes"]
 # stdin, stdout, stderr

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -22,10 +22,7 @@ categories = ["asynchronous", "network-programming"]
 keywords = ["io", "async", "non-blocking", "futures"]
 
 [features]
-# Include nothing by default
-default = []
-# XXX TODO:
-# default = ["std"]
+default = ["std"]
 
 # enable everything
 full = [

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -42,7 +42,6 @@ full = [
 ]
 
 fs = ["std"]
-# XXX TBD io-util no-std WITH portable-io
 io-util = ["bytes"]
 # stdin, stdout, stderr
 io-std = ["std"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -59,7 +59,7 @@ net = [
   "windows-sys/Win32_System_Pipes",
   "windows-sys/Win32_System_SystemServices",
 ]
-portable-io = ["dep:portable-io"]
+portable-io = ["parking_lot", "dep:portable-io"]
 process = [
   "std",
   "bytes",

--- a/tokio/src/blocking.rs
+++ b/tokio/src/blocking.rs
@@ -10,6 +10,8 @@ cfg_rt! {
 }
 
 cfg_not_rt! {
+    use crate::alias::std;
+
     use std::fmt;
     use std::future::Future;
     use std::pin::Pin;

--- a/tokio/src/fs/canonicalize.rs
+++ b/tokio/src/fs/canonicalize.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/copy.rs
+++ b/tokio/src/fs/copy.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 use std::path::Path;
 

--- a/tokio/src/fs/create_dir.rs
+++ b/tokio/src/fs/create_dir.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/create_dir_all.rs
+++ b/tokio/src/fs/create_dir_all.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/dir_builder.rs
+++ b/tokio/src/fs/dir_builder.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -2,6 +2,7 @@
 //!
 //! [`File`]: File
 
+use crate::alias::std::{self, prelude::*};
 use crate::fs::{asyncify, OpenOptions};
 use crate::io::blocking::{Buf, DEFAULT_MAX_BUF_SIZE};
 use crate::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};

--- a/tokio/src/fs/hard_link.rs
+++ b/tokio/src/fs/hard_link.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/metadata.rs
+++ b/tokio/src/fs/metadata.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::fs::Metadata;

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -295,7 +295,7 @@ cfg_windows! {
     pub use self::symlink_file::symlink_file;
 }
 
-use std::io;
+use crate::alias::std::io;
 
 #[cfg(not(test))]
 use crate::blocking::spawn_blocking;

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::{asyncify, File};
 
 use std::io;

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -1,5 +1,7 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
+// XXX XXX portable io / fs - XXX
 use std::{io, path::Path};
 
 /// Reads the entire contents of a file into a bytes vector.

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -1,7 +1,6 @@
 use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
-// XXX XXX portable io / fs - XXX
 use std::{io, path::Path};
 
 /// Reads the entire contents of a file into a bytes vector.

--- a/tokio/src/fs/read_dir.rs
+++ b/tokio/src/fs/read_dir.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::collections::VecDeque;

--- a/tokio/src/fs/read_link.rs
+++ b/tokio/src/fs/read_link.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/read_to_string.rs
+++ b/tokio/src/fs/read_to_string.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::{io, path::Path};

--- a/tokio/src/fs/remove_dir.rs
+++ b/tokio/src/fs/remove_dir.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/remove_dir_all.rs
+++ b/tokio/src/fs/remove_dir_all.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/remove_file.rs
+++ b/tokio/src/fs/remove_file.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/set_permissions.rs
+++ b/tokio/src/fs/set_permissions.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::fs::Permissions;

--- a/tokio/src/fs/symlink.rs
+++ b/tokio/src/fs/symlink.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/symlink_metadata.rs
+++ b/tokio/src/fs/symlink_metadata.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::fs::Metadata;

--- a/tokio/src/fs/try_exists.rs
+++ b/tokio/src/fs/try_exists.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::io;

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::fs::asyncify;
 
 use std::{io, path::Path};

--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::future::Future;
 
 cfg_rt! {

--- a/tokio/src/future/maybe_done.rs
+++ b/tokio/src/future/maybe_done.rs
@@ -76,11 +76,15 @@ impl<Fut: Future> Future for MaybeDone<Fut> {
 // Test for https://github.com/tokio-rs/tokio/issues/6729
 #[cfg(test)]
 mod miri_tests {
+    extern crate std;
+    use std::borrow::ToOwned;
+
     use super::maybe_done;
 
     use std::{
         future::Future,
         pin::Pin,
+        string::String,
         sync::Arc,
         task::{Context, Poll, Wake},
     };

--- a/tokio/src/future/maybe_done.rs
+++ b/tokio/src/future/maybe_done.rs
@@ -1,5 +1,7 @@
 //! Definition of the [`MaybeDone`] combinator.
 
+use crate::alias::std;
+
 use pin_project_lite::pin_project;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;

--- a/tokio/src/future/mod.rs
+++ b/tokio/src/future/mod.rs
@@ -23,6 +23,6 @@ cfg_trace! {
 
 cfg_not_trace! {
     cfg_rt! {
-        pub(crate) use std::future::Future;
+        pub(crate) use crate::alias::std::future::Future;
     }
 }

--- a/tokio/src/future/try_join.rs
+++ b/tokio/src/future/try_join.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::future::maybe_done::{maybe_done, MaybeDone};
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/async_buf_read.rs
+++ b/tokio/src/io/async_buf_read.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use crate::io::AsyncRead;
 
 use std::io;

--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{Interest, Ready};
 use crate::runtime::io::{ReadyEvent, Registration};
 use crate::runtime::scheduler;

--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -1,4 +1,8 @@
 use super::ReadBuf;
+
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use std::io;
 use std::ops::DerefMut;
 use std::pin::Pin;

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use std::io::{self, SeekFrom};
 use std::ops::DerefMut;
 use std::pin::Pin;

--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use std::io::{self, IoSlice};
 use std::ops::DerefMut;
 use std::pin::Pin;

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use crate::io::sys;
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 

--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "net"), allow(dead_code, unreachable_pub))]
 
+use crate::alias::std;
 use crate::io::ready::Ready;
 
 use std::fmt;

--- a/tokio/src/io/join.rs
+++ b/tokio/src/io/join.rs
@@ -1,5 +1,6 @@
 //! Join two values implementing `AsyncRead` and `AsyncWrite` into a single one.
 
+use crate::alias::std;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 use std::io;

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -194,6 +194,8 @@ cfg_io_blocking! {
     pub(crate) mod blocking;
 }
 
+use crate::alias::std;
+
 mod async_buf_read;
 pub use self::async_buf_read::AsyncBufRead;
 

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::interest::Interest;
 use crate::runtime::io::Registration;
 use crate::runtime::scheduler;

--- a/tokio/src/io/read_buf.rs
+++ b/tokio/src/io/read_buf.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::fmt;
 use std::mem::MaybeUninit;
 

--- a/tokio/src/io/ready.rs
+++ b/tokio/src/io/ready.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "net"), allow(unreachable_pub))]
 
+use crate::alias::std;
 use crate::io::interest::Interest;
 
 use std::fmt;

--- a/tokio/src/io/seek.rs
+++ b/tokio/src/io/seek.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncSeek;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/split.rs
+++ b/tokio/src/io/split.rs
@@ -4,6 +4,7 @@
 //! To restore this read/write object from its `split::ReadHalf` and
 //! `split::WriteHalf` use `unsplit`.
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use std::fmt;

--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::blocking::Blocking;
 use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
@@ -79,6 +80,8 @@ cfg_io_std! {
 
 #[cfg(unix)]
 mod sys {
+    use crate::alias::std;
+
     use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
     use super::Stderr;

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use crate::io::blocking::Blocking;
 use crate::io::{AsyncRead, ReadBuf};
 
@@ -54,6 +56,8 @@ cfg_io_std! {
 
 #[cfg(unix)]
 mod sys {
+    use crate::alias::std;
+
     use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
     use super::Stdin;

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -112,12 +112,14 @@ where
 #[cfg(test)]
 #[cfg(not(loom))]
 mod tests {
+    extern crate std;
     use crate::io::blocking::DEFAULT_MAX_BUF_SIZE;
     use crate::io::AsyncWriteExt;
     use std::io;
     use std::pin::Pin;
     use std::task::Context;
     use std::task::Poll;
+    use std::vec::Vec;
 
     struct TextMockWriter;
 

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -1,5 +1,8 @@
 //! Contains utilities for stdout and stderr.
+
+use crate::alias::std;
 use crate::io::AsyncWrite;
+
 use std::pin::Pin;
 use std::task::{Context, Poll};
 /// # Windows

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -1,6 +1,9 @@
+use crate::alias::std;
+
 use crate::io::blocking::Blocking;
 use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
+
 use std::io;
 use std::pin::Pin;
 use std::task::Context;
@@ -128,6 +131,8 @@ cfg_io_std! {
 
 #[cfg(unix)]
 mod sys {
+    use crate::alias::std;
+
     use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
     use super::Stdout;

--- a/tokio/src/io/util/async_buf_read_ext.rs
+++ b/tokio/src/io/util/async_buf_read_ext.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::fill_buf::{fill_buf, FillBuf};
 use crate::io::util::lines::{lines, Lines};
 use crate::io::util::read_line::{read_line, ReadLine};

--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -1,3 +1,5 @@
+use crate::alias::std::prelude::*;
+
 use crate::io::util::chain::{chain, Chain};
 use crate::io::util::read::{read, Read};
 use crate::io::util::read_buf::{read_buf, ReadBuf};

--- a/tokio/src/io/util/async_seek_ext.rs
+++ b/tokio/src/io/util/async_seek_ext.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::seek::{seek, Seek};
 use crate::io::AsyncSeek;
 use std::io::SeekFrom;

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -3,6 +3,8 @@ use crate::io::util::flush::{flush, Flush};
 use crate::io::util::shutdown::{shutdown, Shutdown};
 use crate::io::util::write::{write, Write};
 use crate::io::util::write_all::{write_all, WriteAll};
+// XXX TBD XXX XXX
+#[cfg(not(feature = "portable-io"))]
 use crate::io::util::write_all_buf::{write_all_buf, WriteAllBuf};
 use crate::io::util::write_buf::{write_buf, WriteBuf};
 use crate::io::util::write_int::{WriteF32, WriteF32Le, WriteF64, WriteF64Le};
@@ -317,6 +319,8 @@ cfg_io_util! {
         /// ```
         ///
         /// [`write`]: AsyncWriteExt::write
+        // XXX TBD XXX XXX
+        #[cfg(not(feature = "portable-io"))]
         fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B>
         where
             Self: Sized + Unpin,

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::util::flush::{flush, Flush};
 use crate::io::util::shutdown::{shutdown, Shutdown};
 use crate::io::util::write::{write, Write};

--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -3,8 +3,6 @@ use crate::io::util::flush::{flush, Flush};
 use crate::io::util::shutdown::{shutdown, Shutdown};
 use crate::io::util::write::{write, Write};
 use crate::io::util::write_all::{write_all, WriteAll};
-// XXX TBD XXX XXX
-#[cfg(not(feature = "portable-io"))]
 use crate::io::util::write_all_buf::{write_all_buf, WriteAllBuf};
 use crate::io::util::write_buf::{write_buf, WriteBuf};
 use crate::io::util::write_int::{WriteF32, WriteF32Le, WriteF64, WriteF64Le};
@@ -319,8 +317,6 @@ cfg_io_util! {
         /// ```
         ///
         /// [`write`]: AsyncWriteExt::write
-        // XXX TBD XXX XXX
-        #[cfg(not(feature = "portable-io"))]
         fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B>
         where
             Self: Sized + Unpin,

--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::DEFAULT_BUF_SIZE;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 

--- a/tokio/src/io/util/buf_stream.rs
+++ b/tokio/src/io/util/buf_stream.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::util::{BufReader, BufWriter};
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 

--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::DEFAULT_BUF_SIZE;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 

--- a/tokio/src/io/util/chain.rs
+++ b/tokio/src/io/util/chain.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{AsyncBufRead, AsyncRead, ReadBuf};
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use std::future::Future;

--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -1,5 +1,6 @@
 use super::copy::CopyBuffer;
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite};
 
 use std::future::poll_fn;

--- a/tokio/src/io/util/copy_buf.rs
+++ b/tokio/src/io/util/copy_buf.rs
@@ -1,4 +1,6 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::{AsyncBufRead, AsyncWrite};
+
 use std::future::Future;
 use std::io;
 use std::pin::Pin;

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 

--- a/tokio/src/io/util/fill_buf.rs
+++ b/tokio/src/io/util/fill_buf.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncBufRead;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/flush.rs
+++ b/tokio/src/io/util/flush.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::read_line::read_line_internal;
 use crate::io::AsyncBufRead;
 

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -2,6 +2,12 @@
 
 use crate::alias::std;
 use crate::io::{split, AsyncRead, AsyncWrite, ReadBuf, ReadHalf, WriteHalf};
+#[cfg(all(
+    feature = "parking_lot",
+    not(feature = "std"),
+))]
+use parking_lot::Mutex;
+#[cfg(feature = "std")]
 use crate::loom::sync::Mutex;
 
 use bytes::{Buf, BytesMut};

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -1,5 +1,6 @@
 //! In-process memory IO types.
 
+use crate::alias::std;
 use crate::io::{split, AsyncRead, AsyncWrite, ReadBuf, ReadHalf, WriteHalf};
 use crate::loom::sync::Mutex;
 

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -1,6 +1,8 @@
 #![allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
 
 cfg_io_util! {
+    use crate::alias::std;
+
     mod async_buf_read_ext;
     pub use async_buf_read_ext::AsyncBufReadExt;
 

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -80,6 +80,8 @@ cfg_io_util! {
     mod write_vectored;
     mod write_all;
     mod write_buf;
+    // XXX TBD XXX XXX
+    #[cfg(not(feature = "portable-io"))]
     mod write_all_buf;
     mod write_int;
 

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -80,8 +80,6 @@ cfg_io_util! {
     mod write_vectored;
     mod write_all;
     mod write_buf;
-    // XXX TBD XXX XXX
-    #[cfg(not(feature = "portable-io"))]
     mod write_all_buf;
     mod write_int;
 

--- a/tokio/src/io/util/read.rs
+++ b/tokio/src/io/util/read.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{AsyncRead, ReadBuf};
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/read_buf.rs
+++ b/tokio/src/io/util/read_buf.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncRead;
 
 use bytes::BufMut;

--- a/tokio/src/io/util/read_exact.rs
+++ b/tokio/src/io/util/read_exact.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{AsyncRead, ReadBuf};
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/read_int.rs
+++ b/tokio/src/io/util/read_int.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::{AsyncRead, ReadBuf};
 
 use bytes::Buf;

--- a/tokio/src/io/util/read_line.rs
+++ b/tokio/src/io/util/read_line.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::read_until::read_until_internal;
 use crate::io::AsyncBufRead;
 

--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::io::util::vec_with_initialized::{into_read_buf_parts, VecU8, VecWithInitialized};
 use crate::io::{AsyncRead, ReadBuf};
 

--- a/tokio/src/io/util/read_to_string.rs
+++ b/tokio/src/io/util/read_to_string.rs
@@ -1,3 +1,5 @@
+use crate::alias::{std, std::prelude::*};
+
 use crate::io::util::read_line::finish_string_read;
 use crate::io::util::read_to_end::read_to_end_internal;
 use crate::io::util::vec_with_initialized::VecWithInitialized;

--- a/tokio/src/io/util/read_until.rs
+++ b/tokio/src/io/util/read_until.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use crate::io::AsyncBufRead;
 use crate::util::memchr;
 

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -1,5 +1,6 @@
 use bytes::BufMut;
 
+use crate::alias::std;
 use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::{AsyncRead, ReadBuf};
 

--- a/tokio/src/io/util/shutdown.rs
+++ b/tokio/src/io/util/shutdown.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::util::poll_proceed_and_make_progress;
 use crate::io::AsyncWrite;
 

--- a/tokio/src/io/util/split.rs
+++ b/tokio/src/io/util/split.rs
@@ -1,3 +1,6 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use crate::io::util::read_until::read_until_internal;
 use crate::io::AsyncBufRead;
 

--- a/tokio/src/io/util/take.rs
+++ b/tokio/src/io/util/take.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{AsyncBufRead, AsyncRead, ReadBuf};
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/vec_with_initialized.rs
+++ b/tokio/src/io/util/vec_with_initialized.rs
@@ -1,4 +1,8 @@
+use crate::alias::std;
+use crate::alias::std::prelude::*;
+
 use crate::io::ReadBuf;
+
 use std::mem::MaybeUninit;
 
 /// Something that looks like a `Vec<u8>`.

--- a/tokio/src/io/util/write.rs
+++ b/tokio/src/io/util/write.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/write_all.rs
+++ b/tokio/src/io/util/write_all.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/io/util/write_all_buf.rs
+++ b/tokio/src/io/util/write_all_buf.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use bytes::Buf;

--- a/tokio/src/io/util/write_buf.rs
+++ b/tokio/src/io/util/write_buf.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use bytes::Buf;

--- a/tokio/src/io/util/write_int.rs
+++ b/tokio/src/io/util/write_int.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use crate::io::AsyncWrite;
 
 use bytes::BufMut;

--- a/tokio/src/io/util/write_vectored.rs
+++ b/tokio/src/io/util/write_vectored.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::AsyncWrite;
 
 use pin_project_lite::pin_project;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -506,7 +506,10 @@ cfg_fs! {
 mod future;
 
 pub mod io;
-pub mod net;
+
+cfg_net! {
+    pub mod net;
+}
 
 mod loom;
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -673,6 +673,8 @@ pub(crate) mod alias {
         pub(crate) mod prelude {
             pub(crate) use super::borrow::ToOwned;
             pub(crate) use super::boxed::Box;
+            #[cfg(feature = "std")]
+            pub(crate) use super::eprintln;
             pub(crate) use super::string::String;
             pub(crate) use super::vec;
             pub(crate) use super::vec::Vec;
@@ -695,7 +697,7 @@ pub(crate) mod alias {
         pub(crate) use std::io;
 
         #[cfg(feature = "std")]
-        pub(crate) use std::{alloc, collections, env, error, ffi, fs, hash, net, os, panic, path, process, result, thread, thread_local};
+        pub(crate) use std::{alloc, collections, env, eprintln, error, ffi, fs, hash, net, os, panic, path, process, result, thread, thread_local};
 
         pub(crate) mod sync {
             pub(crate) use core::sync::atomic;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -669,16 +669,17 @@ pub(crate) use alias::std::os;
 pub(crate) mod alias {
     pub(crate) mod std {
         pub(crate) mod prelude {
+            pub(crate) use super::borrow::ToOwned;
             pub(crate) use super::boxed::Box;
             pub(crate) use super::string::String;
             pub(crate) use super::vec;
             pub(crate) use super::vec::Vec;
         }
 
-        pub(crate) use core::{cell, convert, cmp, fmt, future, hint, marker, mem, num, ops, pin, slice, task};
+        pub(crate) use core::{cell, convert, cmp, fmt, future, hint, marker, mem, num, ops, pin, ptr, slice, task};
 
         extern crate alloc;
-        pub(crate) use alloc::{boxed, rc, str, string, vec};
+        pub(crate) use alloc::{borrow, boxed, rc, str, string, vec};
 
         #[cfg(feature = "portable-io")]
         pub(crate) use portable_io as io;
@@ -693,7 +694,7 @@ pub(crate) mod alias {
         pub(crate) use std::io;
 
         #[cfg(feature = "std")]
-        pub(crate) use std::{collections, env, hash, os, panic, thread, thread_local};
+        pub(crate) use std::{collections, env, error, ffi, fs, hash, os, panic, path, thread, thread_local};
 
         pub(crate) mod sync {
             extern crate alloc;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -507,9 +507,15 @@ cfg_fs! {
 
 mod future;
 
-// XXX TODO SUPPORT no-std with portable-io
-#[cfg(feature = "std")]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+// XXX TBD XXX XXX
+#[cfg(any(
+    feature = "std",
+    feature = "portable-io",
+))]
+#[cfg_attr(docsrs, doc(cfg(any(
+    feature = "std",
+    feature = "portable-io",
+))))]
 pub mod io;
 
 cfg_net! {
@@ -674,11 +680,18 @@ pub(crate) mod alias {
         extern crate alloc;
         pub(crate) use alloc::{boxed, rc, str, string, vec};
 
+        #[cfg(feature = "portable-io")]
+        pub(crate) use portable_io as io;
+
         #[cfg(feature = "std")]
         extern crate std;
 
-        #[cfg(feature = "std")]
+        #[cfg(all(
+            feature = "std",
+            not(feature = "portable-io"),
+        ))]
         pub(crate) use std::io;
+
         #[cfg(feature = "std")]
         pub(crate) use std::{collections, env, hash, os, panic, thread, thread_local};
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -678,7 +678,7 @@ pub(crate) mod alias {
             pub(crate) use super::vec::Vec;
         }
 
-        pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, pin, ptr, slice, task};
+        pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, option, pin, ptr, slice, task};
 
         pub(crate) use crate::alloc::{borrow, boxed, rc, str, string, vec};
 
@@ -695,7 +695,7 @@ pub(crate) mod alias {
         pub(crate) use std::io;
 
         #[cfg(feature = "std")]
-        pub(crate) use std::{alloc, collections, env, error, ffi, fs, hash, os, panic, path, process, result, thread, thread_local};
+        pub(crate) use std::{alloc, collections, env, error, ffi, fs, hash, net, os, panic, path, process, result, thread, thread_local};
 
         pub(crate) mod sync {
             pub(crate) use core::sync::atomic;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -675,6 +675,7 @@ pub(crate) mod alias {
             pub(crate) use super::boxed::Box;
             #[cfg(feature = "std")]
             pub(crate) use super::eprintln;
+            pub(crate) use super::format;
             pub(crate) use super::string::String;
             pub(crate) use super::vec;
             pub(crate) use super::vec::Vec;
@@ -682,7 +683,7 @@ pub(crate) mod alias {
 
         pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, option, pin, ptr, slice, task};
 
-        pub(crate) use crate::alloc::{borrow, boxed, rc, str, string, vec};
+        pub(crate) use crate::alloc::{borrow, boxed, format, rc, str, string, vec};
 
         #[cfg(feature = "portable-io")]
         pub(crate) use portable_io as io;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -666,6 +666,8 @@ pub(crate) use self::doc::os;
 #[allow(unused)]
 pub(crate) use alias::std::os;
 
+extern crate alloc;
+
 pub(crate) mod alias {
     pub(crate) mod std {
         pub(crate) mod prelude {
@@ -678,8 +680,7 @@ pub(crate) mod alias {
 
         pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, pin, ptr, slice, task};
 
-        extern crate alloc;
-        pub(crate) use alloc::{borrow, boxed, rc, str, string, vec};
+        pub(crate) use crate::alloc::{borrow, boxed, rc, str, string, vec};
 
         #[cfg(feature = "portable-io")]
         pub(crate) use portable_io as io;
@@ -694,17 +695,13 @@ pub(crate) mod alias {
         pub(crate) use std::io;
 
         #[cfg(feature = "std")]
-        pub(crate) use std::{collections, env, error, ffi, fs, hash, os, panic, path, process, result, thread, thread_local};
+        pub(crate) use std::{alloc, collections, env, error, ffi, fs, hash, os, panic, path, process, result, thread, thread_local};
 
         pub(crate) mod sync {
-            extern crate alloc;
-            #[cfg(feature = "std")]
-            extern crate std;
-
             pub(crate) use core::sync::atomic;
-            pub(crate) use alloc::sync::*;
+            pub(crate) use crate::alloc::sync::*;
             #[cfg(feature = "std")]
-            pub(crate) use std::sync::*;
+            pub(crate) use super::std::sync::*;
         }
 
         pub(crate) mod time {

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -676,7 +676,7 @@ pub(crate) mod alias {
             pub(crate) use super::vec::Vec;
         }
 
-        pub(crate) use core::{cell, convert, cmp, fmt, future, hint, marker, mem, num, ops, pin, ptr, slice, task};
+        pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, pin, ptr, slice, task};
 
         extern crate alloc;
         pub(crate) use alloc::{borrow, boxed, rc, str, string, vec};
@@ -694,7 +694,7 @@ pub(crate) mod alias {
         pub(crate) use std::io;
 
         #[cfg(feature = "std")]
-        pub(crate) use std::{collections, env, error, ffi, fs, hash, os, panic, path, thread, thread_local};
+        pub(crate) use std::{collections, env, error, ffi, fs, hash, os, panic, path, process, result, thread, thread_local};
 
         pub(crate) mod sync {
             extern crate alloc;

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -681,7 +681,7 @@ pub(crate) mod alias {
             pub(crate) use super::vec::Vec;
         }
 
-        pub(crate) use core::{any, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, option, pin, ptr, slice, task};
+        pub(crate) use core::{any, array, cell, convert, cmp, fmt, future, hint, iter, marker, mem, num, ops, option, pin, ptr, slice, task};
 
         pub(crate) use crate::alloc::{borrow, boxed, format, rc, str, string, vec};
 
@@ -714,7 +714,7 @@ pub(crate) mod alias {
             extern crate std;
 
             #[cfg(feature = "std")]
-            pub(crate) use std::time::*;
+            pub use std::time::*;
         }
     }
 }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -493,6 +493,16 @@ compile_error!(
 linux, on `aarch64`, `x86` and `x86_64`."
 );
 
+#[cfg(not(any(feature = "std", feature = "portable-io")))]
+compile_error!("std or portable-io feature is required (may use both)");
+
+#[cfg(all(
+    feature = "io-util",
+    not(feature = "std"),
+    not(feature = "parking_lot"),
+))]
+compile_error!("io-util requires parking_lot to compile with no-std");
+
 // Includes re-exports used by macros.
 //
 // This module is not intended to be part of the public API. In general, any
@@ -507,15 +517,6 @@ cfg_fs! {
 
 mod future;
 
-// XXX TBD XXX XXX
-#[cfg(any(
-    feature = "std",
-    feature = "portable-io",
-))]
-#[cfg_attr(docsrs, doc(cfg(any(
-    feature = "std",
-    feature = "portable-io",
-))))]
 pub mod io;
 
 cfg_net! {

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -503,6 +503,15 @@ compile_error!("std or portable-io feature is required (may use both)");
 ))]
 compile_error!("io-util requires parking_lot to compile with no-std");
 
+#[cfg(all(feature = "portable-io", any(
+    feature = "fs",
+    feature = "net",
+    feature = "process",
+    feature = "rt",
+    feature = "signal",
+)))]
+compile_error!("cannot use portable-io with fs, net, process, rt or signal");
+
 // Includes re-exports used by macros.
 //
 // This module is not intended to be part of the public API. In general, any

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -23,6 +23,8 @@
 
 #![no_std]
 
+// XXX TODO UPDATE DOCUMENTATION FOR NEW FEATURES ADDED
+
 //! A runtime for writing reliable network applications without compromising speed.
 //!
 //! Tokio is an event-driven, non-blocking I/O platform for writing asynchronous

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -521,6 +521,8 @@ compile_error!("cannot use portable-io with fs, net, process, rt or signal");
 pub mod macros;
 
 cfg_fs! {
+    // XXX SKIP TEST in fs for now - XXX TODO INVESTIGATE & RESOLVE ISSUES with fs test mocks
+    #[cfg(not(test))]
     pub mod fs;
 }
 

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -498,13 +498,6 @@ linux, on `aarch64`, `x86` and `x86_64`."
 #[cfg(not(any(feature = "std", feature = "portable-io")))]
 compile_error!("std or portable-io feature is required (may use both)");
 
-#[cfg(all(
-    feature = "io-util",
-    not(feature = "std"),
-    not(feature = "parking_lot"),
-))]
-compile_error!("io-util requires parking_lot to compile with no-std");
-
 #[cfg(all(feature = "portable-io", any(
     feature = "fs",
     feature = "net",

--- a/tokio/src/loom/std/atomic_u16.rs
+++ b/tokio/src/loom/std/atomic_u16.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::ops::Deref;

--- a/tokio/src/loom/std/atomic_u32.rs
+++ b/tokio/src/loom/std/atomic_u32.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::ops::Deref;

--- a/tokio/src/loom/std/atomic_u64_native.rs
+++ b/tokio/src/loom/std/atomic_u64_native.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 pub(crate) use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Alias `AtomicU64` to `StaticAtomicU64`

--- a/tokio/src/loom/std/atomic_usize.rs
+++ b/tokio/src/loom/std/atomic_usize.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::cell::UnsafeCell;
 use std::fmt;
 use std::ops;

--- a/tokio/src/loom/std/barrier.rs
+++ b/tokio/src/loom/std/barrier.rs
@@ -2,6 +2,8 @@
 //!
 //! This implementation mirrors that of the Rust standard library.
 
+use crate::alias::std;
+
 use crate::loom::sync::{Condvar, Mutex};
 use std::fmt;
 use std::time::{Duration, Instant};

--- a/tokio/src/loom/std/mod.rs
+++ b/tokio/src/loom/std/mod.rs
@@ -26,10 +26,13 @@ pub(crate) mod future {
 }
 
 pub(crate) mod hint {
+    use crate::alias::std;
     pub(crate) use std::hint::spin_loop;
 }
 
 pub(crate) mod rand {
+    use crate::alias::std;
+
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hash, Hasher};
     use std::sync::atomic::AtomicU32;
@@ -51,6 +54,8 @@ pub(crate) mod rand {
 }
 
 pub(crate) mod sync {
+    use crate::alias::std;
+
     pub(crate) use std::sync::{Arc, Weak};
 
     // Below, make sure all the feature-influenced types are exported for
@@ -74,6 +79,8 @@ pub(crate) mod sync {
     pub(crate) use crate::loom::std::rwlock::RwLock;
 
     pub(crate) mod atomic {
+        use crate::alias::std;
+
         pub(crate) use crate::loom::std::atomic_u16::AtomicU16;
         pub(crate) use crate::loom::std::atomic_u32::AtomicU32;
         pub(crate) use crate::loom::std::atomic_u64::{AtomicU64, StaticAtomicU64};
@@ -86,6 +93,8 @@ pub(crate) mod sync {
 }
 
 pub(crate) mod sys {
+    use crate::alias::std;
+
     #[cfg(feature = "rt-multi-thread")]
     pub(crate) fn num_cpus() -> usize {
         use std::num::NonZeroUsize;
@@ -116,6 +125,7 @@ pub(crate) mod sys {
 }
 
 pub(crate) mod thread {
+    use crate::alias::std;
     #[inline]
     pub(crate) fn yield_now() {
         std::hint::spin_loop();

--- a/tokio/src/loom/std/mutex.rs
+++ b/tokio/src/loom/std/mutex.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::sync::{self, MutexGuard, TryLockError};
 
 /// Adapter for `std::Mutex` that removes the poisoning aspects

--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -3,6 +3,8 @@
 //!
 //! This can be extended to additional types/methods as required.
 
+use crate::alias::std;
+
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};

--- a/tokio/src/loom/std/rwlock.rs
+++ b/tokio/src/loom/std/rwlock.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::sync::{self, RwLockReadGuard, RwLockWriteGuard, TryLockError};
 
 /// Adapter for `std::sync::RwLock` that removes the poisoning aspects

--- a/tokio/src/loom/std/unsafe_cell.rs
+++ b/tokio/src/loom/std/unsafe_cell.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 #[derive(Debug)]
 pub(crate) struct UnsafeCell<T>(std::cell::UnsafeCell<T>);
 

--- a/tokio/src/macros/addr_of.rs
+++ b/tokio/src/macros/addr_of.rs
@@ -14,7 +14,7 @@ macro_rules! generate_addr_of_methods {
             $(#[$attrs])*
             $vis unsafe fn $fn_name(me: ::core::ptr::NonNull<Self>) -> ::core::ptr::NonNull<$field_type> {
                 let me = me.as_ptr();
-                let field = ::std::ptr::addr_of_mut!((*me) $(.$field_name)+ );
+                let field = ::core::ptr::addr_of_mut!((*me) $(.$field_name)+ );
                 ::core::ptr::NonNull::new_unchecked(field)
             }
         )*}

--- a/tokio/src/macros/support.rs
+++ b/tokio/src/macros/support.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 cfg_macros! {
     pub use crate::future::maybe_done::maybe_done;
 

--- a/tokio/src/macros/thread_local.rs
+++ b/tokio/src/macros/thread_local.rs
@@ -13,6 +13,6 @@ macro_rules! tokio_thread_local {
 #[cfg(not(all(loom, test)))]
 macro_rules! tokio_thread_local {
     ($($tts:tt)+) => {
-        ::std::thread_local!{ $($tts)+ }
+        crate::alias::std::thread_local!{ $($tts)+ }
     }
 }

--- a/tokio/src/net/addr.rs
+++ b/tokio/src/net/addr.rs
@@ -1,3 +1,5 @@
+use crate::alias::std::{self, prelude::*};
+
 use std::future;
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
@@ -253,6 +255,8 @@ pub(crate) mod sealed {
     //! The contents of this trait are intended to remain private and __not__
     //! part of the `ToSocketAddrs` public API. The details will change over
     //! time.
+
+    use crate::alias::std;
 
     use std::future::Future;
     use std::io;

--- a/tokio/src/net/lookup_host.rs
+++ b/tokio/src/net/lookup_host.rs
@@ -1,4 +1,5 @@
 cfg_net! {
+    use crate::alias::std;
     use crate::net::addr::{self, ToSocketAddrs};
 
     use std::io;

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -35,20 +35,18 @@ cfg_not_wasi! {
 }
 pub use addr::ToSocketAddrs;
 
-cfg_net! {
-    mod lookup_host;
-    pub use lookup_host::lookup_host;
+mod lookup_host;
+pub use lookup_host::lookup_host;
 
-    pub mod tcp;
-    pub use tcp::listener::TcpListener;
-    pub use tcp::stream::TcpStream;
-    cfg_not_wasi! {
-        pub use tcp::socket::TcpSocket;
+pub mod tcp;
+pub use tcp::listener::TcpListener;
+pub use tcp::stream::TcpStream;
+cfg_not_wasi! {
+    pub use tcp::socket::TcpSocket;
 
-        mod udp;
-        #[doc(inline)]
-        pub use udp::UdpSocket;
-    }
+    mod udp;
+    #[doc(inline)]
+    pub use udp::UdpSocket;
 }
 
 cfg_net_unix! {

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{Interest, PollEvented};
 use crate::net::tcp::TcpStream;
 
@@ -400,6 +401,7 @@ impl fmt::Debug for TcpListener {
 #[cfg(unix)]
 mod sys {
     use super::TcpListener;
+    use crate::alias::std;
     use std::os::unix::prelude::*;
 
     impl AsRawFd for TcpListener {

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::net::{TcpListener, TcpStream};
 
 use std::fmt;

--- a/tokio/src/net/tcp/split.rs
+++ b/tokio/src/net/tcp/split.rs
@@ -8,6 +8,7 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::TcpStream;
 

--- a/tokio/src/net/tcp/split_owned.rs
+++ b/tokio/src/net/tcp/split_owned.rs
@@ -8,6 +8,7 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::TcpStream;
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 cfg_not_wasi! {
     use crate::net::{to_socket_addrs, ToSocketAddrs};
     use std::future::poll_fn;
@@ -1375,6 +1377,7 @@ impl fmt::Debug for TcpStream {
 #[cfg(unix)]
 mod sys {
     use super::TcpStream;
+    use crate::alias::std;
     use std::os::unix::prelude::*;
 
     impl AsRawFd for TcpStream {

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::{to_socket_addrs, ToSocketAddrs};
 
@@ -2165,6 +2166,7 @@ impl fmt::Debug for UdpSocket {
 #[cfg(unix)]
 mod sys {
     use super::UdpSocket;
+    use crate::alias::std;
     use std::os::unix::prelude::*;
 
     impl AsRawFd for UdpSocket {

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::unix::SocketAddr;
 

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{Interest, PollEvented};
 use crate::net::unix::{SocketAddr, UnixStream};
 

--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -1,5 +1,6 @@
 //! Unix pipe types.
 
+use crate::alias::std;
 use crate::io::interest::Interest;
 use crate::io::{AsyncRead, AsyncWrite, PollEvented, ReadBuf, Ready};
 

--- a/tokio/src/net/unix/socket.rs
+++ b/tokio/src/net/unix/socket.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::io;
 use std::path::Path;
 

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::fmt;
 use std::path::Path;
 

--- a/tokio/src/net/unix/split.rs
+++ b/tokio/src/net/unix/split.rs
@@ -8,6 +8,7 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::UnixStream;
 

--- a/tokio/src/net/unix/split_owned.rs
+++ b/tokio/src/net/unix/split_owned.rs
@@ -8,10 +8,12 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::UnixStream;
 
 use crate::net::unix::SocketAddr;
+
 use std::error::Error;
 use std::net::Shutdown;
 use std::pin::Pin;

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, Interest, PollEvented, ReadBuf, Ready};
 use crate::net::unix::split::{split, ReadHalf, WriteHalf};
 use crate::net::unix::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::net::unix;
 
 /// Credentials of a process.
@@ -208,6 +209,7 @@ pub(crate) mod impl_bsd {
     target_os = "visionos"
 ))]
 pub(crate) mod impl_macos {
+    use crate::alias::std;
     use crate::net::unix::{self, UnixStream};
 
     use libc::{c_void, getpeereid, getsockopt, pid_t, LOCAL_PEEREPID, SOL_LOCAL};

--- a/tokio/src/process/kill.rs
+++ b/tokio/src/process/kill.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::io;
 
 /// An interface for killing a running process.

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1591,6 +1591,8 @@ mod test {
     use super::kill::Kill;
     use super::ChildDropGuard;
 
+    extern crate std;
+
     use futures::future::FutureExt;
     use std::future::Future;
     use std::io;

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -241,6 +241,7 @@ mod imp;
 
 mod kill;
 
+use crate::alias::std::{self, prelude::*};
 use crate::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::process::kill::Kill;
 
@@ -1490,6 +1491,7 @@ impl TryInto<Stdio> for ChildStderr {
 #[cfg(unix)]
 #[cfg_attr(docsrs, doc(cfg(unix)))]
 mod sys {
+    use crate::alias::std;
     use std::{
         io,
         os::unix::io::{AsFd, AsRawFd, BorrowedFd, OwnedFd, RawFd},

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -30,6 +30,7 @@ use reap::Reaper;
 #[cfg(all(target_os = "linux", feature = "rt"))]
 mod pidfd_reaper;
 
+use crate::alias::std;
 use crate::io::{AsyncRead, AsyncWrite, PollEvented, ReadBuf};
 use crate::process::kill::Kill;
 use crate::process::SpawnedChild;

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -1,7 +1,9 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::{Mutex, MutexGuard};
 use crate::runtime::signal::Handle as SignalHandle;
 use crate::signal::unix::{signal_with_handle, SignalKind};
 use crate::sync::watch;
+
 use std::io;
 use std::process::ExitStatus;
 

--- a/tokio/src/process/unix/reap.rs
+++ b/tokio/src/process/unix/reap.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::process::imp::orphan::{OrphanQueue, Wait};
 use crate::process::kill::Kill;
 use crate::signal::unix::InternalStream;

--- a/tokio/src/process/unix/reap.rs
+++ b/tokio/src/process/unix/reap.rs
@@ -140,6 +140,8 @@ mod test {
     use std::process::ExitStatus;
     use std::task::Context;
     use std::task::Poll;
+    use std::vec;
+    use std::vec::Vec;
 
     #[derive(Debug)]
     struct MockWait {

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -1,5 +1,6 @@
 //! Thread pool for blocking operations
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::{Arc, Condvar, Mutex};
 use crate::loom::thread;
 use crate::runtime::blocking::schedule::BlockingSchedule;

--- a/tokio/src/runtime/blocking/shutdown.rs
+++ b/tokio/src/runtime/blocking/shutdown.rs
@@ -3,6 +3,7 @@
 //! Each worker holds the `Sender` half. When all the `Sender` halves are
 //! dropped, the `Receiver` receives a notification.
 
+use crate::alias::std;
 use crate::loom::sync::Arc;
 use crate::sync::oneshot;
 

--- a/tokio/src/runtime/blocking/task.rs
+++ b/tokio/src/runtime/blocking/task.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(loom, allow(unused_imports))]
 
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::handle::Handle;
 use crate::runtime::{blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback};
 #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use crate::loom::thread::AccessError;
 use crate::runtime::coop;
 

--- a/tokio/src/runtime/context/blocking.rs
+++ b/tokio/src/runtime/context/blocking.rs
@@ -1,5 +1,6 @@
 use super::{EnterRuntime, CONTEXT};
 
+use crate::alias::std;
 use crate::loom::thread::AccessError;
 use crate::util::markers::NotSendOrSync;
 

--- a/tokio/src/runtime/context/current.rs
+++ b/tokio/src/runtime/context/current.rs
@@ -1,5 +1,6 @@
 use super::{Context, CONTEXT};
 
+use crate::alias::std;
 use crate::runtime::{scheduler, TryCurrentError};
 use crate::util::markers::SyncNotSend;
 

--- a/tokio/src/runtime/context/runtime.rs
+++ b/tokio/src/runtime/context/runtime.rs
@@ -1,5 +1,6 @@
 use super::{BlockingRegionGuard, SetCurrentGuard, CONTEXT};
 
+use crate::alias::std;
 use crate::runtime::scheduler;
 use crate::util::rand::{FastRand, RngSeed};
 

--- a/tokio/src/runtime/context/scoped.rs
+++ b/tokio/src/runtime/context/scoped.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::cell::Cell;
 use std::ptr;
 

--- a/tokio/src/runtime/coop.rs
+++ b/tokio/src/runtime/coop.rs
@@ -135,6 +135,8 @@ cfg_rt! {
 }
 
 cfg_coop! {
+    use crate::alias::std;
+
     use pin_project_lite::pin_project;
     use std::cell::Cell;
     use std::future::Future;

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -7,6 +7,8 @@
     allow(dead_code)
 )]
 
+use crate::alias::std;
+
 use crate::runtime::park::{ParkThread, UnparkThread};
 
 use std::io;

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -15,6 +15,7 @@ pub struct Handle {
     pub(crate) inner: scheduler::Handle,
 }
 
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::task::JoinHandle;
 use crate::runtime::BOX_FUTURE_THRESHOLD;
 use crate::util::error::{CONTEXT_MISSING_ERROR, THREAD_LOCAL_DESTROYED_ERROR};

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -3,6 +3,7 @@ cfg_signal_internal_and_unix! {
     mod signal;
 }
 
+use crate::alias::std;
 use crate::io::interest::Interest;
 use crate::io::ready::Ready;
 use crate::loom::sync::Mutex;

--- a/tokio/src/runtime/io/driver/signal.rs
+++ b/tokio/src/runtime/io/driver/signal.rs
@@ -1,5 +1,7 @@
 use super::{Driver, Handle, TOKEN_SIGNAL};
 
+use crate::alias::std;
+
 use std::io;
 
 impl Handle {

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "net"), allow(dead_code))]
 
+use crate::alias::std;
 use crate::io::interest::Interest;
 use crate::runtime::io::{Direction, Handle, ReadyEvent, ScheduledIo};
 use crate::runtime::scheduler;

--- a/tokio/src/runtime/io/registration_set.rs
+++ b/tokio/src/runtime/io/registration_set.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::runtime::io::ScheduledIo;
 use crate::util::linked_list::{self, LinkedList};

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::io::interest::Interest;
 use crate::io::ready::Ready;
 use crate::loom::sync::atomic::AtomicUsize;

--- a/tokio/src/runtime/metrics/mock.rs
+++ b/tokio/src/runtime/metrics/mock.rs
@@ -1,5 +1,7 @@
 //! This file contains mocks of the types in src/runtime/metrics
 
+use crate::alias::std;
+
 use std::thread::ThreadId;
 
 pub(crate) struct SchedulerMetrics {}

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -319,6 +319,8 @@
 #[macro_use]
 mod tests;
 
+use crate::alias::std;
+
 pub(crate) mod context;
 
 pub(crate) mod coop;

--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "full"), allow(dead_code))]
 
+use crate::alias::std;
+
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::{Arc, Condvar, Mutex};
 

--- a/tokio/src/runtime/process.rs
+++ b/tokio/src/runtime/process.rs
@@ -2,6 +2,7 @@
 
 //! Process driver.
 
+use crate::alias::std;
 use crate::process::unix::GlobalOrphanQueue;
 use crate::runtime::driver;
 use crate::runtime::signal::{Driver as SignalDriver, Handle as SignalHandle};

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -1,4 +1,6 @@
 use super::BOX_FUTURE_THRESHOLD;
+
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
 use crate::runtime::{context, EnterGuard, Handle};

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};

--- a/tokio/src/runtime/scheduler/defer.rs
+++ b/tokio/src/runtime/scheduler/defer.rs
@@ -1,3 +1,5 @@
+use crate::alias::std::{self, prelude::*};
+
 use std::cell::RefCell;
 use std::task::Waker;
 

--- a/tokio/src/runtime/scheduler/inject/pop.rs
+++ b/tokio/src/runtime/scheduler/inject/pop.rs
@@ -1,5 +1,6 @@
 use super::Synced;
 
+use crate::alias::std;
 use crate::runtime::task;
 
 use std::marker::PhantomData;

--- a/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
+++ b/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
@@ -1,5 +1,6 @@
 use super::{Shared, Synced};
 
+use crate::alias::std;
 use crate::runtime::scheduler::Lock;
 use crate::runtime::task;
 

--- a/tokio/src/runtime/scheduler/inject/shared.rs
+++ b/tokio/src/runtime/scheduler/inject/shared.rs
@@ -1,5 +1,6 @@
 use super::{Pop, Synced};
 
+use crate::alias::std;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::runtime::task;
 

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -78,6 +78,7 @@ impl Handle {
 }
 
 cfg_rt! {
+    use crate::alias::std;
     use crate::future::Future;
     use crate::loom::sync::Arc;
     use crate::runtime::{blocking, task::Id};

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::future::Future;
 use crate::loom::sync::Arc;
 use crate::runtime::scheduler::multi_thread::worker;

--- a/tokio/src/runtime/scheduler/multi_thread/idle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/idle.rs
@@ -1,5 +1,6 @@
 //! Coordinates idling workers
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::runtime::scheduler::multi_thread::Shared;
 

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -37,6 +37,7 @@ cfg_not_taskdump! {
 
 pub(crate) use worker::block_in_place;
 
+use crate::alias::std;
 use crate::loom::sync::Arc;
 use crate::runtime::{
     blocking,

--- a/tokio/src/runtime/scheduler/multi_thread/overflow.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/overflow.rs
@@ -1,7 +1,7 @@
 use crate::runtime::task;
 
 #[cfg(test)]
-use std::cell::RefCell;
+use crate::alias::std::{cell::RefCell, vec::Vec};
 
 pub(crate) trait Overflow<T: 'static> {
     fn push(&self, task: task::Notified<T>);

--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -2,6 +2,7 @@
 //!
 //! A combination of the various resource driver park handles.
 
+use crate::alias::std;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::{Arc, Condvar, Mutex};
 use crate::runtime::driver::{self, Driver};

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -1,5 +1,6 @@
 //! Run-queue structures to support a work-stealing scheduler
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::Arc;
 use crate::runtime::scheduler::multi_thread::{Overflow, Stats};

--- a/tokio/src/runtime/scheduler/multi_thread/stats.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/stats.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::{Config, MetricsBatch, WorkerMetrics};
 
 use std::time::{Duration, Instant};

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -56,6 +56,7 @@
 //! the inject queue indefinitely. This would be a ref-count cycle and a memory
 //! leak.
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime;
 use crate::runtime::scheduler::multi_thread::{

--- a/tokio/src/runtime/scheduler/multi_thread/worker/taskdump_mock.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker/taskdump_mock.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::prelude::*;
 use super::{Core, Handle};
 
 impl Handle {

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -2,6 +2,7 @@
 
 //! Signal driver
 
+use crate::alias::std;
 use crate::runtime::{driver, io};
 use crate::signal::registry::globals;
 

--- a/tokio/src/runtime/task/abort.rs
+++ b/tokio/src/runtime/task/abort.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::runtime::task::{Header, RawTask};
+
 use std::fmt;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -9,6 +9,7 @@
 //! Make sure to consult the relevant safety section of each function before
 //! use.
 
+use crate::alias::std::{self, prelude::*};
 use crate::future::Future;
 use crate::loom::cell::UnsafeCell;
 use crate::runtime::context;

--- a/tokio/src/runtime/task/error.rs
+++ b/tokio/src/runtime/task/error.rs
@@ -1,3 +1,5 @@
+use crate::alias::std::{self, prelude::*};
+
 use std::any::Any;
 use std::fmt;
 use std::io;

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::future::Future;
 use crate::runtime::task::core::{Cell, Core, Header, Trailer};
 use crate::runtime::task::state::{Snapshot, State};

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::context;
 
 use std::{fmt, num::NonZeroU64};

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::task::{Header, RawTask};
 
 use std::fmt;

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -6,6 +6,7 @@
 //! The collections can be closed to prevent adding new tasks during shutdown of
 //! the scheduler with the collection.
 
+use crate::alias::std;
 use crate::future::Future;
 use crate::loom::cell::UnsafeCell;
 use crate::runtime::task::{JoinHandle, LocalNotified, Notified, Schedule, Task};

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -220,6 +220,7 @@ cfg_taskdump! {
     pub(crate) mod trace;
 }
 
+use crate::alias::std;
 use crate::future::Future;
 use crate::util::linked_list;
 use crate::util::sharded_list;

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::future::Future;
 use crate::runtime::task::core::{Core, Trailer};
 use crate::runtime::task::{Cell, Harness, Header, Id, Schedule, State};

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::loom::sync::atomic::AtomicUsize;
 
 use std::fmt;

--- a/tokio/src/runtime/task/waker.rs
+++ b/tokio/src/runtime/task/waker.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::task::{Header, RawTask, Schedule};
 
 use std::marker::PhantomData;

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::marker::PhantomData;
 
 impl TaskHooks {

--- a/tokio/src/runtime/tests/inject.rs
+++ b/tokio/src/runtime/tests/inject.rs
@@ -1,4 +1,8 @@
+extern crate std;
+
 use crate::runtime::scheduler::inject;
+
+use std::println;
 
 #[test]
 fn push_and_pop() {

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -29,6 +29,7 @@ mod noop_scheduler {
 }
 
 mod unowned_wrapper {
+    extern crate std;
     use crate::runtime::task::{Id, JoinHandle, Notified};
     use crate::runtime::tests::NoopSchedule;
 

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -1,9 +1,14 @@
 use crate::runtime::scheduler::multi_thread::{queue, Stats};
 use crate::runtime::task::{self, Schedule, Task, TaskHarnessScheduleHooks};
 
+extern crate std;
+
 use std::cell::RefCell;
 use std::thread;
 use std::time::Duration;
+// XXX TBD TEST ???
+use std::vec;
+use std::vec::Vec;
 
 #[allow(unused)]
 macro_rules! assert_metrics {

--- a/tokio/src/runtime/tests/task_combinations.rs
+++ b/tokio/src/runtime/tests/task_combinations.rs
@@ -1,3 +1,4 @@
+extern crate std;
 use std::fmt;
 use std::future::Future;
 use std::panic;

--- a/tokio/src/runtime/thread_id.rs
+++ b/tokio/src/runtime/thread_id.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::num::NonZeroU64;
 
 #[derive(Eq, PartialEq, Clone, Copy, Hash, Debug)]

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -54,6 +54,8 @@
 //!
 //! [mark_pending]: TimerHandle::mark_pending
 
+use crate::alias::std;
+
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicU64;
 use crate::loom::sync::atomic::Ordering;

--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::runtime::time::TimeSource;
+
 use std::fmt;
 
 /// Handle to time driver instance.

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -19,6 +19,7 @@ pub(crate) use source::TimeSource;
 
 mod wheel;
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::{AtomicBool, Ordering};
 use crate::loom::sync::{Mutex, RwLock};
 use crate::runtime::driver::{self, IoHandle, IoStack};

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -1,6 +1,12 @@
 #![cfg(not(target_os = "wasi"))]
 
+extern crate std;
+
 use std::{task::Context, time::Duration};
+use std::boxed::Box;
+
+// XXX TODO TEST ONLY
+use std::vec;
 
 #[cfg(not(loom))]
 use futures::task::noop_waker_ref;

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::time::{EntryList, TimerHandle, TimerShared};
 
 use std::{array, fmt, ptr::NonNull};

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::time::{TimerHandle, TimerShared};
 use crate::time::error::InsertError;
 

--- a/tokio/src/signal/ctrl_c.rs
+++ b/tokio/src/signal/ctrl_c.rs
@@ -3,6 +3,8 @@ use super::unix::{self as os_impl};
 #[cfg(windows)]
 use super::windows::{self as os_impl};
 
+use crate::alias::std;
+
 use std::io;
 
 /// Completes when a "ctrl-c" notification is sent to the process.

--- a/tokio/src/signal/mod.rs
+++ b/tokio/src/signal/mod.rs
@@ -42,7 +42,10 @@
 //! }
 //! # }
 //! ```
+
+use crate::alias::std;
 use crate::sync::watch::Receiver;
+
 use std::task::{Context, Poll};
 
 #[cfg(feature = "signal")]

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::signal::os::{OsExtraData, OsStorage};
 use crate::sync::watch;
 use crate::util::once_cell::OnceCell;

--- a/tokio/src/signal/reusable_box.rs
+++ b/tokio/src/signal/reusable_box.rs
@@ -1,3 +1,5 @@
+use crate::alias::std::{self, prelude::*};
+
 use std::alloc::Layout;
 use std::future::Future;
 use std::panic::AssertUnwindSafe;

--- a/tokio/src/signal/reusable_box.rs
+++ b/tokio/src/signal/reusable_box.rs
@@ -154,6 +154,7 @@ impl<T> fmt::Debug for ReusableBoxFuture<T> {
 
 #[cfg(test)]
 mod test {
+    extern crate std;
     use super::ReusableBoxFuture;
     use futures::future::FutureExt;
     use std::alloc::Layout;

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -6,6 +6,7 @@
 #![cfg(unix)]
 #![cfg_attr(docsrs, doc(cfg(all(unix, feature = "signal"))))]
 
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::scheduler;
 use crate::runtime::signal::Handle;
 use crate::signal::registry::{globals, EventId, EventInfo, Globals, Init, Storage};

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -15,6 +15,7 @@
 //! tasks are acquiring smaller numbers of permits. This means that in a
 //! use-case like tokio's read-write lock, writers will not be starved by
 //! readers.
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::{Mutex, MutexGuard};

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -116,6 +116,7 @@
 //! }
 //! ```
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::{AtomicBool, AtomicUsize};
 use crate::loom::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard};
@@ -212,6 +213,8 @@ pub struct Receiver<T> {
 
 pub mod error {
     //! Broadcast error types
+
+    use crate::alias::std;
 
     use std::fmt;
 

--- a/tokio/src/sync/mpsc/block.rs
+++ b/tokio/src/sync/mpsc/block.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
 

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::Arc;
 use crate::sync::batch_semaphore::{self as semaphore, TryAcquireError};
 use crate::sync::mpsc::chan;

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::cell::UnsafeCell;
 use crate::loom::future::AtomicWaker;
 use crate::loom::sync::atomic::AtomicUsize;

--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -1,5 +1,7 @@
 //! Channel error types.
 
+use crate::alias::std;
+
 use std::error::Error;
 use std::fmt;
 

--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -1,5 +1,6 @@
 //! A concurrent, lock-free, FIFO list.
 
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::{AtomicPtr, AtomicUsize};
 use crate::loom::thread;
 use crate::sync::mpsc::block::{self, Block};

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::{atomic::AtomicUsize, Arc};
 use crate::sync::mpsc::chan;
 use crate::sync::mpsc::error::{SendError, TryRecvError};

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "sync"), allow(unreachable_pub, dead_code))]
 
+use crate::alias::std;
 use crate::sync::batch_semaphore as semaphore;
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -5,6 +5,7 @@
 // triggers this warning but it is safe to ignore in this case.
 #![cfg_attr(not(feature = "sync"), allow(unreachable_pub, dead_code))]
 
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Mutex;

--- a/tokio/src/sync/once_cell.rs
+++ b/tokio/src/sync/once_cell.rs
@@ -1,5 +1,8 @@
 use super::{Semaphore, SemaphorePermit, TryAcquireError};
+
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
+
 use std::error::Error;
 use std::fmt;
 use std::future::Future;

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -123,6 +123,7 @@
 //! }
 //! ```
 
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Arc;
@@ -331,6 +332,8 @@ pub struct Receiver<T> {
 
 pub mod error {
     //! `Oneshot` error types.
+
+    use crate::alias::std;
 
     use std::fmt;
 

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -1,7 +1,9 @@
+use crate::alias::std;
 use crate::sync::batch_semaphore::{Semaphore, TryAcquireError};
 use crate::sync::mutex::TryLockError;
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;
+
 use std::cell::UnsafeCell;
 use std::marker;
 use std::marker::PhantomData;

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::sync::rwlock::RwLock;
+
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{fmt, mem, ops, ptr};

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -1,6 +1,8 @@
+use crate::alias::std;
 use crate::sync::rwlock::owned_read_guard::OwnedRwLockReadGuard;
 use crate::sync::rwlock::owned_write_guard_mapped::OwnedRwLockMappedWriteGuard;
 use crate::sync::rwlock::RwLock;
+
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{fmt, mem, ops, ptr};

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::sync::rwlock::RwLock;
+
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::{fmt, mem, ops, ptr};

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::sync::batch_semaphore::Semaphore;
+
 use std::marker::PhantomData;
 use std::{fmt, mem, ops};
 

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -1,6 +1,8 @@
+use crate::alias::std;
 use crate::sync::batch_semaphore::Semaphore;
 use crate::sync::rwlock::read_guard::RwLockReadGuard;
 use crate::sync::rwlock::write_guard_mapped::RwLockMappedWriteGuard;
+
 use std::marker::PhantomData;
 use std::{fmt, mem, ops};
 

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -1,4 +1,6 @@
+use crate::alias::std;
 use crate::sync::batch_semaphore::Semaphore;
+
 use std::marker::PhantomData;
 use std::{fmt, mem, ops};
 

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1,7 +1,10 @@
 use super::batch_semaphore as ll; // low level implementation
 use super::{AcquireError, TryAcquireError};
+
+use crate::alias::std;
 #[cfg(all(tokio_unstable, feature = "tracing"))]
 use crate::util::trace;
+
 use std::sync::Arc;
 
 /// Counting semaphore performing asynchronous permit acquisition.

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(any(loom, not(feature = "sync")), allow(dead_code, unreachable_pub))]
 
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
 use crate::loom::hint;
 use crate::loom::sync::atomic::AtomicUsize;

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -1,6 +1,8 @@
 use crate::sync::AtomicWaker;
 use tokio_test::task;
 
+extern crate std;
+
 use std::task::Waker;
 
 #[allow(unused)]

--- a/tokio/src/sync/tests/notify.rs
+++ b/tokio/src/sync/tests/notify.rs
@@ -1,7 +1,10 @@
+extern crate std;
 use crate::sync::Notify;
+
 use std::future::Future;
 use std::sync::Arc;
 use std::task::{Context, RawWaker, RawWakerVTable, Waker};
+use std::vec::Vec;
 
 #[cfg(all(target_family = "wasm", not(target_os = "wasi")))]
 use wasm_bindgen_test::wasm_bindgen_test as test;

--- a/tokio/src/sync/tests/semaphore_batch.rs
+++ b/tokio/src/sync/tests/semaphore_batch.rs
@@ -1,5 +1,8 @@
+extern crate std;
 use crate::sync::batch_semaphore::Semaphore;
 use tokio_test::*;
+
+use std::boxed::Box;
 
 const MAX_PERMITS: usize = crate::sync::Semaphore::MAX_PERMITS;
 

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -111,12 +111,15 @@
 //! [`Sender::closed`]: crate::sync::watch::Sender::closed
 //! [`Sender::subscribe()`]: crate::sync::watch::Sender::subscribe
 
+use crate::alias::std;
+
 use crate::runtime::coop::cooperative;
 use crate::sync::notify::Notify;
 
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::atomic::Ordering::{AcqRel, Relaxed};
 use crate::loom::sync::{Arc, RwLock, RwLockReadGuard};
+
 use std::fmt;
 use std::mem;
 use std::ops;
@@ -280,6 +283,8 @@ impl<T: fmt::Debug> fmt::Debug for Shared<T> {
 pub mod error {
     //! Watch error types.
 
+    use crate::alias::std;
+
     use std::error::Error;
     use std::fmt;
 
@@ -320,6 +325,7 @@ pub mod error {
 
 mod big_notify {
     use super::Notify;
+    use crate::alias::std;
     use crate::sync::notify::Notified;
 
     // To avoid contention on the lock inside the `Notify`, we store multiple

--- a/tokio/src/task/consume_budget.rs
+++ b/tokio/src/task/consume_budget.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::task::{ready, Poll};
 
 /// Consumes a unit of budget and returns the execution back to the Tokio

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -4,6 +4,9 @@
 //! of spawned tasks and allows asynchronously awaiting the output of those
 //! tasks as they complete. See the documentation for the [`JoinSet`] type for
 //! details.
+
+use crate::alias::std::{self, prelude::*};
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -1,4 +1,6 @@
 //! Runs `!Send` futures on the current thread.
+
+use crate::alias::std::{self, prelude::*};
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::{Arc, Mutex};
 #[cfg(tokio_unstable)]

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::runtime::BOX_FUTURE_THRESHOLD;
 use crate::task::JoinHandle;
 use crate::util::trace::SpawnMeta;

--- a/tokio/src/task/task_local.rs
+++ b/tokio/src/task/task_local.rs
@@ -1,4 +1,7 @@
+use crate::alias::std;
+
 use pin_project_lite::pin_project;
+
 use std::cell::RefCell;
 use std::error::Error;
 use std::future::Future;

--- a/tokio/src/task/unconstrained.rs
+++ b/tokio/src/task/unconstrained.rs
@@ -1,4 +1,7 @@
+use crate::alias::std;
+
 use pin_project_lite::pin_project;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::context;
 
 use std::future::Future;

--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -7,6 +7,7 @@
 //! configurable.
 
 cfg_not_test_util! {
+    use crate::alias::std;
     use crate::time::{Instant};
 
     #[derive(Debug, Clone)]
@@ -28,6 +29,7 @@ cfg_not_test_util! {
 }
 
 cfg_test_util! {
+    use crate::alias::std;
     use crate::time::{Duration, Instant};
     use crate::loom::sync::Mutex;
     use crate::loom::sync::atomic::Ordering;

--- a/tokio/src/time/error.rs
+++ b/tokio/src/time/error.rs
@@ -1,5 +1,7 @@
 //! Time error types.
 
+use crate::alias::std;
+
 use std::error;
 use std::fmt;
 

--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::trivially_copy_pass_by_ref)]
 
+use crate::alias::std;
+
 use std::fmt;
 use std::ops;
 use std::time::Duration;
@@ -207,6 +209,7 @@ impl fmt::Debug for Instant {
 #[cfg(not(feature = "test-util"))]
 mod variant {
     use super::Instant;
+    use crate::alias::std;
 
     pub(super) fn now() -> Instant {
         Instant::from_std(std::time::Instant::now())

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::time::{sleep_until, Duration, Instant, Sleep};
 use crate::util::trace;
 

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -84,6 +84,8 @@
 //! [`interval`]: crate::time::interval()
 //! [`sleep`]: sleep()
 
+use crate::alias::std;
+
 mod clock;
 pub(crate) use self::clock::Clock;
 cfg_test_util! {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::runtime::time::TimerEntry;
 use crate::time::{error::Error, Duration, Instant};
 use crate::util::trace;

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -5,6 +5,7 @@
 //! [`Timeout`]: struct@Timeout
 
 use crate::{
+    alias::std,
     runtime::coop,
     time::{error::Elapsed, sleep_until, Duration, Instant, Sleep},
     util::trace,

--- a/tokio/src/util/atomic_cell.rs
+++ b/tokio/src/util/atomic_cell.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use crate::loom::sync::atomic::AtomicPtr;
 
 use std::ptr;

--- a/tokio/src/util/bit.rs
+++ b/tokio/src/util/bit.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::fmt;
 
 #[derive(Clone, Copy, PartialEq)]

--- a/tokio/src/util/cacheline.rs
+++ b/tokio/src/util/cacheline.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(feature = "sync"), allow(dead_code, unreachable_pub))]
-use std::ops::{Deref, DerefMut};
+
+use core::ops::{Deref, DerefMut};
 
 /// Pads and aligns a value to the length of a cache line.
 #[derive(Clone, Copy, Default, Hash, PartialEq, Eq)]

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -6,6 +6,8 @@
 //! specified using the `T` parameter. It will usually be a `JoinHandle` or
 //! similar.
 
+use crate::alias::std::{self, prelude::*};
+
 use std::marker::PhantomPinned;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -469,7 +469,11 @@ impl<T> fmt::Debug for Pointers<T> {
 pub(crate) mod tests {
     use super::*;
 
+    extern crate std;
+    use std::boxed::Box;
     use std::pin::Pin;
+    use std::vec;
+    use std::vec::Vec;
 
     #[derive(Debug)]
     #[repr(C)]

--- a/tokio/src/util/memchr.rs
+++ b/tokio/src/util/memchr.rs
@@ -25,6 +25,8 @@ pub(crate) fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::memchr;
+    extern crate std;
+    use std::vec::Vec;
 
     #[test]
     fn memchr_test() {

--- a/tokio/src/util/metric_atomics.rs
+++ b/tokio/src/util/metric_atomics.rs
@@ -1,3 +1,5 @@
+use crate::alias::std;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 cfg_64bit_metrics! {

--- a/tokio/src/util/once_cell.rs
+++ b/tokio/src/util/once_cell.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+
+use crate::alias::std;
+
 use std::cell::UnsafeCell;
 use std::mem::MaybeUninit;
 use std::sync::Once;

--- a/tokio/src/util/ptr_expose.rs
+++ b/tokio/src/util/ptr_expose.rs
@@ -4,7 +4,10 @@
 //! under miri, pointer casts are replaced with lookups in a hash map. This makes Tokio compatible
 //! with strict provenance when running under miri (which comes with a performance cost).
 
+use crate::alias::std;
+
 use std::marker::PhantomData;
+
 #[cfg(miri)]
 use {crate::loom::sync::Mutex, std::collections::BTreeMap};
 

--- a/tokio/src/util/rand/rt.rs
+++ b/tokio/src/util/rand/rt.rs
@@ -1,5 +1,7 @@
 use super::{FastRand, RngSeed};
 
+use crate::alias::std;
+
 use std::sync::Mutex;
 
 /// A deterministic generator for seeds (and other generators).

--- a/tokio/src/util/rc_cell.rs
+++ b/tokio/src/util/rc_cell.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::loom::cell::UnsafeCell;
 
 use std::rc::Rc;

--- a/tokio/src/util/sharded_list.rs
+++ b/tokio/src/util/sharded_list.rs
@@ -1,3 +1,4 @@
+use crate::alias::std::{self, prelude::*};
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering;
 

--- a/tokio/src/util/sync_wrapper.rs
+++ b/tokio/src/util/sync_wrapper.rs
@@ -3,6 +3,8 @@
 //!
 //! A similar primitive is provided in the `sync_wrapper` crate.
 
+use crate::alias::std::{self, prelude::*};
+
 use std::any::Any;
 
 pub(crate) struct SyncWrapper<T> {

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,4 +1,6 @@
 cfg_rt! {
+    use crate::alias::std;
+
     use std::marker::PhantomData;
 
     #[derive(Copy, Clone)]

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -1,6 +1,6 @@
-cfg_rt! {
-    use crate::alias::std;
+use crate::alias::std;
 
+cfg_rt! {
     use std::marker::PhantomData;
 
     #[derive(Copy, Clone)]

--- a/tokio/src/util/try_lock.rs
+++ b/tokio/src/util/try_lock.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::loom::sync::atomic::AtomicBool;
 
 use std::cell::UnsafeCell;

--- a/tokio/src/util/wake.rs
+++ b/tokio/src/util/wake.rs
@@ -1,3 +1,4 @@
+use crate::alias::std;
 use crate::loom::sync::Arc;
 
 use std::marker::PhantomData;

--- a/tokio/src/util/wake_list.rs
+++ b/tokio/src/util/wake_list.rs
@@ -1,6 +1,6 @@
 use core::mem::MaybeUninit;
 use core::ptr;
-use std::task::Waker;
+use crate::alias::std::task::Waker;
 
 const NUM_WAKERS: usize = 32;
 


### PR DESCRIPTION
## Motivation

I have been very interested in getting some more widely-used Rust libraries working with `no-std` for embedded devices.

`no-std` support was requested in #3544 /cc @surechen

My initial idea is to start achieving this kind of support with help from [`portable-io`](https://crates.io/crates/portable-io) crate that I recently published.

NOTE that my primary intention is to start discussion on supporting `no-std`, with a working demo, and would be very happy to discuss any possible alternative solutions.

## Possible alternative solutions

- split the core I/O out to another crate, say `tokio-io`, maybe like it was done in the past, and *only* support `no-std` in that crate
- keep these `no-std` I/O updates in a separate fork
- move the optional Tokio features into one or more separate Tokio packages to keep the core Tokio more simplified & focused
- Update Tokio to vendor some of the `std::io` traits & classes, working with `no-std`
- It would be ideal if they could move most or all of the Rust `std::io` functionality into `core`, as discussed in RFC: https://github.com/rust-lang/rfcs/issues/2262

## Solution

### Proposed solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

This is a proposal to get the core IO & optional `io-util` features working with `no-std` using some of the Rust I/O traits & types that I extracted in [`portable-io`](https://crates.io/crates/portable-io) crate.

__Features added:__

- `std` - proposed to be enabled by default
- `portable-io` - option to use `portable-io` instead of `std::io` for the standard I/O traits & types

__with some feature requirements & restrictions:__

- at least one of `std` or `portable-io` features must be enabled (both can be enabled)
- cannot use `portable-io` with `fs`, `net`, `process`, `rt` or `signal` features

__other implementation notes:__

- using Mutex from `parking_lot` with slight API variation to support `no-std` in `tokio/src/io/split.rs` - I think it would be ideal to use a more portable mutex API
- I made a quick adaptation in `tokio/src/io/util/write_all_buf.rs` to simplify logic as needed for `portable-io` option - I think this logic should be simplified in a separate PR for normal `std::io` usage as well

__Major drawbacks:__

- feature configuration slightly more complex
- use of `no-std` directive requires updates throughout the Tokio codebase to explicitly import `std` crate features that would otherwise have been implicit, adding some complexity to the existing imports
- `portable-io` crate is new & unproven - it is yet another alternative for https://github.com/rust-lang/rfcs/issues/2262 (looks like some other alternatives had stopped development)

---

__Testing done:__

- `cargo test -F full -p tokio` ✅

__Build testing done:__

- `cargo build --no-default-features -F portable-io -p tokio`
- `cargo build -F portable-io -p tokio`
- `cargo build --no-default-features -F portable-io,io-util -p tokio`
- `cargo build -F portable-io,io-util -p tokio`
- `cargo build --no-default-features -F portable-io,io-util,macros,time -p tokio`
- `cargo build -F full -p tokio` # (same as before; includes std; DOES NOT include portable-io)

---

__Deferred for now:__

- `no-std` support for runtime tasks - I would like to see this, would likely require major rework of context state maintained in `thread_local!`
- use `portable-atomic` to enable building for targets with no atomic ptr (etc.)
- update `tokio-stream` & `tokio-util` to support `no-std` (I have started this in my workarea)

---

__Loose ends & major TODO items:__

- [ ] update documentation
- [ ] check & resolve any CI build issues
- [ ] update build testing in CI
- [ ] update CI testing to try building for embedded `no-std` target (with no std library available)
- [ ] `fs` test mock not working with these updates - seems to be an issue between these updates & `mockall` in `tokio/src/fs/mocks.rs` - testing with `fs` disabled for now - needs further investigation
- [ ] cargo test with `portable-io` feature
- [ ] resolve lint & clippy issues
- [ ] resolve or defer any other XXX todo items in these updates