### PR TITLE
sync: add `len` and `is_empty` methods to mpsc senders

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -515,7 +515,6 @@ impl<T> Receiver<T> {
     ///     tx.send(0).await.unwrap();
     ///     assert!(!rx.is_empty());
     /// }
-    ///
     /// ```
     pub fn is_empty(&self) -> bool {
         self.chan.is_empty()
@@ -1058,6 +1057,46 @@ impl<T> Sender<T> {
     /// ```
     pub fn is_closed(&self) -> bool {
         self.chan.is_closed()
+    }
+
+    /// Checks if a channel is empty.
+    ///
+    /// This method returns `true` if the channel has no messages.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::unbounded_channel();
+    ///     assert!(rx.is_empty());
+    ///
+    ///     tx.send(0).await.unwrap();
+    ///     assert!(!rx.is_empty());
+    /// }
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.chan.semaphore().bound - self.chan.semaphore().semaphore.available_permits() == 0
+    }
+
+    /// Returns the number of messages in the channel.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::unbounded_channel();
+    ///     assert_eq!(0, rx.len());
+    ///
+    ///     tx.send(0).await.unwrap();
+    ///     assert_eq!(1, rx.len());
+    /// }
+    /// ```
+    pub fn len(&self) -> usize {
+        self.chan.semaphore().bound - self.chan.semaphore().semaphore.available_permits()
     }
 
     /// Waits for channel capacity. Once capacity to send one message is

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -382,7 +382,6 @@ impl<T> UnboundedReceiver<T> {
     ///     tx.send(0).unwrap();
     ///     assert!(!rx.is_empty());
     /// }
-    ///
     /// ```
     pub fn is_empty(&self) -> bool {
         self.chan.is_empty()
@@ -575,6 +574,46 @@ impl<T> UnboundedSender<T> {
                 }
             }
         }
+    }
+
+    /// Checks if a channel is empty.
+    ///
+    /// This method returns `true` if the channel has no messages.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::unbounded_channel();
+    ///     assert!(tx.is_empty());
+    ///
+    ///     tx.send(0).unwrap();
+    ///     assert!(!tx.is_empty());
+    /// }
+    /// ```
+    pub fn is_empty(&self) -> bool {
+        self.chan.is_empty()
+    }
+
+    /// Returns the number of messages in the channel.
+    ///
+    /// # Examples
+    /// ```
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, rx) = mpsc::unbounded_channel();
+    ///     assert_eq!(0, tx.len());
+    ///
+    ///     tx.send(0).unwrap();
+    ///     assert_eq!(1, tx.len());
+    /// }
+    /// ```
+    pub fn len(&self) -> usize {
+        self.chan.len()
     }
 
     /// Completes when the receiver has dropped.

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -1040,6 +1040,64 @@ async fn test_tx_capacity() {
 }
 
 #[tokio::test]
+async fn test_bounded_tx_len() {
+    let (tx, mut rx) = mpsc::channel::<()>(10);
+
+    // initially len should be 0
+    assert_eq!(tx.len(), 0);
+    assert!(tx.is_empty());
+
+    // queue one message, and len should be 1
+    tx.send(()).await.unwrap();
+    assert_eq!(tx.len(), 1);
+    assert!(!tx.is_empty());
+
+    // queue a second message, and len should be 2
+    tx.send(()).await.unwrap();
+    assert_eq!(tx.len(), 2);
+    assert!(!tx.is_empty());
+
+    // consume a message, and len should be 1
+    let _ = rx.recv().await;
+    assert_eq!(tx.len(), 1);
+    assert!(!tx.is_empty());
+
+    // consume a final message, and len should be 0
+    let _ = rx.recv().await;
+    assert_eq!(tx.len(), 0);
+    assert!(tx.is_empty());
+}
+
+#[tokio::test]
+async fn test_unbounded_tx_len() {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+
+    // initially len should be 0
+    assert_eq!(tx.len(), 0);
+    assert!(tx.is_empty());
+
+    // queue one message, and len should be 1
+    tx.send(()).unwrap();
+    assert_eq!(tx.len(), 1);
+    assert!(!tx.is_empty());
+
+    // queue a second message, and len should be 2
+    tx.send(()).unwrap();
+    assert_eq!(tx.len(), 2);
+    assert!(!tx.is_empty());
+
+    // consume a message, and len should be 1
+    let _ = rx.recv().await;
+    assert_eq!(tx.len(), 1);
+    assert!(!tx.is_empty());
+
+    // consume a final message, and len should be 0
+    let _ = rx.recv().await;
+    assert_eq!(tx.len(), 0);
+    assert!(tx.is_empty());
+}
+
+#[tokio::test]
 async fn test_rx_is_closed_when_calling_close_with_sender() {
     // is_closed should return true after calling close but still has a sender
     let (_tx, mut rx) = mpsc::channel::<()>(10);


### PR DESCRIPTION
## Motivation

Closes https://github.com/tokio-rs/tokio/issues/7077

See https://github.com/tokio-rs/tokio/issues/7077#issue-2774583585

Tldr; adds `len` method to both bounded and unbounded Sender's.

## Solution

@conradludgate mentioned in the issue in a [comment](https://github.com/tokio-rs/tokio/issues/7077#issuecomment-2577091067) that the unbounded len can be derived from the seamphore's available permits / 2. However it seems like I didn't need to divide the semaphore available permits based on tests.

The implementation of `len` for **bounded** `Sender` did not use the semaphore's available permits directly, and instead used the semaphore's `bound - available_permits`.

I've added tests for these new methods which are passing.

---

Related PR https://github.com/tokio-rs/tokio/pull/7092
