### PR TITLE
Rough implementation of task poll callbacks

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -89,8 +89,11 @@ pub struct Builder {
     pub(super) before_spawn: Option<TaskCallback>,
 
     /// To run before each poll
+    #[cfg(tokio_unstable)]
     pub(super) before_poll: Option<TaskCallback>,
 
+    /// To run after each poll
+    #[cfg(tokio_unstable)]
     pub(super) after_poll: Option<TaskCallback>,
 
     /// To run after each task is terminated.
@@ -311,7 +314,9 @@ impl Builder {
             before_spawn: None,
             after_termination: None,
 
+            #[cfg(tokio_unstable)]
             before_poll: None,
+            #[cfg(tokio_unstable)]
             after_poll: None,
 
             keep_alive: None,
@@ -1436,7 +1441,9 @@ impl Builder {
                 before_park: self.before_park.clone(),
                 after_unpark: self.after_unpark.clone(),
                 before_spawn: self.before_spawn.clone(),
+                #[cfg(tokio_unstable)]
                 before_poll: self.before_poll.clone(),
+                #[cfg(tokio_unstable)]
                 after_poll: self.after_poll.clone(),
                 after_termination: self.after_termination.clone(),
                 global_queue_interval: self.global_queue_interval,
@@ -1588,7 +1595,9 @@ cfg_rt_multi_thread! {
                     before_park: self.before_park.clone(),
                     after_unpark: self.after_unpark.clone(),
                     before_spawn: self.before_spawn.clone(),
+                    #[cfg(tokio_unstable)]
                     before_poll: self.before_poll.clone(),
+                    #[cfg(tokio_unstable)]
                     after_poll: self.after_poll.clone(),
                     after_termination: self.after_termination.clone(),
                     global_queue_interval: self.global_queue_interval,
@@ -1640,7 +1649,9 @@ cfg_rt_multi_thread! {
                         after_unpark: self.after_unpark.clone(),
                         before_spawn: self.before_spawn.clone(),
                         after_termination: self.after_termination.clone(),
+                        #[cfg(tokio_unstable)]
                         before_poll: self.before_poll.clone(),
+                        #[cfg(tokio_unstable)]
                         after_poll: self.after_poll.clone(),
                         global_queue_interval: self.global_queue_interval,
                         event_interval: self.event_interval,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -778,8 +778,8 @@ impl Builder {
     /// let poll_start = poll_start_counter.clone();
     /// let rt = tokio::runtime::Builder::new_multi_thread()
     ///     .enable_all()
-    ///     .on_before_task_poll(move |_meta| {
-    ///         poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    ///     .on_before_task_poll(move |meta| {
+    ///         println!("task {} is about to be polled", meta.id())
     ///     })
     ///     .build()
     ///     .unwrap();
@@ -787,7 +787,6 @@ impl Builder {
     ///     yield_now().await;
     /// });
     /// let _ = rt.block_on(task);
-    /// assert_eq!(poll_start.load(std::sync::atomic::Ordering::SeqCst), 2);
     ///
     /// # }
     /// ```
@@ -822,8 +821,8 @@ impl Builder {
     /// let poll_stop = poll_stop_counter.clone();
     /// let rt = tokio::runtime::Builder::new_multi_thread()
     ///     .enable_all()
-    ///     .on_after_task_poll(move |_meta| {
-    ///         poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    ///     .on_after_task_poll(move |meta| {
+    ///         println!("task {} completed polling", meta.id());
     ///     })
     ///     .build()
     ///     .unwrap();
@@ -831,7 +830,6 @@ impl Builder {
     ///     yield_now().await;
     /// });
     /// let _ = rt.block_on(task);
-    /// assert_eq!(poll_stop.load(std::sync::atomic::Ordering::SeqCst), 2);
     ///
     /// # }
     /// ```

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -27,6 +27,12 @@ pub(crate) struct Config {
     /// To run after each task is terminated.
     pub(crate) after_termination: Option<TaskCallback>,
 
+    /// To run before each poll
+    pub(crate) before_poll: Option<TaskCallback>,
+
+    /// To run after each poll
+    pub(crate) after_poll: Option<TaskCallback>,
+
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,
     /// especially message passing between tasks. However, this LIFO slot is not

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -28,9 +28,11 @@ pub(crate) struct Config {
     pub(crate) after_termination: Option<TaskCallback>,
 
     /// To run before each poll
+    #[cfg(tokio_unstable)]
     pub(crate) before_poll: Option<TaskCallback>,
 
     /// To run after each poll
+    #[cfg(tokio_unstable)]
     pub(crate) after_poll: Option<TaskCallback>,
 
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -145,6 +145,8 @@ impl CurrentThread {
             task_hooks: TaskHooks {
                 task_spawn_callback: config.before_spawn.clone(),
                 task_terminate_callback: config.after_termination.clone(),
+                before_poll_callback: config.before_poll.clone(),
+                after_poll_callback: config.after_poll.clone(),
             },
             shared: Shared {
                 inject: Inject::new(),

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -145,7 +145,9 @@ impl CurrentThread {
             task_hooks: TaskHooks {
                 task_spawn_callback: config.before_spawn.clone(),
                 task_terminate_callback: config.after_termination.clone(),
+                #[cfg(tokio_unstable)]
                 before_poll_callback: config.before_poll.clone(),
+                #[cfg(tokio_unstable)]
                 after_poll_callback: config.after_poll.clone(),
             },
             shared: Shared {

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -768,8 +768,17 @@ impl CoreGuard<'_> {
 
                     let task = context.handle.shared.owned.assert_owner(task);
 
+                    #[cfg(tokio_unstable)]
+                    let task_id = task.task_id();
+
                     let (c, ()) = context.run_task(core, || {
+                        #[cfg(tokio_unstable)]
+                        context.handle.task_hooks.poll_start_callback(task_id);
+
                         task.run();
+
+                        #[cfg(tokio_unstable)]
+                        context.handle.task_hooks.poll_stop_callback(task_id);
                     });
 
                     core = c;

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -600,6 +600,9 @@ impl Context {
 
             task.run();
 
+            // <we pause here for infinity>
+            // thread.sleep(60 seconds)
+
             #[cfg(tokio_unstable)]
             self.worker.handle.task_hooks.poll_stop_callback(task_id);
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -588,16 +588,16 @@ impl Context {
         // purposes. These tasks inherent the "parent"'s limits.
         core.stats.start_poll();
 
-        // Unlike the poll time above, poll start callback is attached to the task id,
-        // so it is tightly associated with the actual poll invocation.
-        #[cfg(tokio_unstable)]
-        self.worker.handle.task_hooks.poll_start_callback(task_id);
-
         // Make the core available to the runtime context
         *self.core.borrow_mut() = Some(core);
 
         // Run the task
         coop::budget(|| {
+            // Unlike the poll time above, poll start callback is attached to the task id,
+            // so it is tightly associated with the actual poll invocation.
+            #[cfg(tokio_unstable)]
+            self.worker.handle.task_hooks.poll_start_callback(task_id);
+
             task.run();
 
             #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread_alt/worker.rs
@@ -303,10 +303,7 @@ pub(super) fn create(
     let (inject, inject_synced) = inject::Shared::new();
 
     let handle = Arc::new(Handle {
-        task_hooks: TaskHooks {
-            task_spawn_callback: config.before_spawn.clone(),
-            task_terminate_callback: config.after_termination.clone(),
-        },
+        task_hooks: TaskHooks::from_config(&config),
         shared: Shared {
             remotes: remotes.into_boxed_slice(),
             inject,

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -426,6 +426,7 @@ impl<S: 'static> Notified<S> {
     }
 
     #[cfg(tokio_unstable)]
+    #[allow(dead_code)]
     pub(crate) fn task_id(&self) -> crate::task::Id {
         self.0.id()
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -256,6 +256,13 @@ pub(crate) struct LocalNotified<S: 'static> {
     _not_send: PhantomData<*const ()>,
 }
 
+impl<S> LocalNotified<S> {
+    #[cfg(tokio_unstable)]
+    pub(crate) fn task_id(&self) -> Id {
+        self.task.id()
+    }
+}
+
 /// A task that is not owned by any `OwnedTasks`. Used for blocking tasks.
 /// This type holds two ref-counts.
 pub(crate) struct UnownedTask<S: 'static> {
@@ -386,6 +393,16 @@ impl<S: 'static> Task<S> {
         self.raw.header_ptr()
     }
 
+    /// Returns a [task ID] that uniquely identifies this task relative to other
+    /// currently spawned tasks.
+    ///
+    /// [task ID]: crate::task::Id
+    #[cfg(tokio_unstable)]
+    pub(crate) fn id(&self) -> crate::task::Id {
+        // Safety: The header pointer is valid.
+        unsafe { Header::get_id(self.raw.header_ptr()) }
+    }
+
     cfg_taskdump! {
         /// Notify the task for task dumping.
         ///
@@ -400,21 +417,17 @@ impl<S: 'static> Task<S> {
             }
         }
 
-        /// Returns a [task ID] that uniquely identifies this task relative to other
-        /// currently spawned tasks.
-        ///
-        /// [task ID]: crate::task::Id
-        #[cfg(tokio_unstable)]
-        pub(crate) fn id(&self) -> crate::task::Id {
-            // Safety: The header pointer is valid.
-            unsafe { Header::get_id(self.raw.header_ptr()) }
-        }
     }
 }
 
 impl<S: 'static> Notified<S> {
     fn header(&self) -> &Header {
         self.0.header()
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn task_id(&self) -> crate::task::Id {
+        self.0.id()
     }
 }
 

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -13,7 +13,9 @@ impl TaskHooks {
         Self {
             task_spawn_callback: config.before_spawn.clone(),
             task_terminate_callback: config.after_termination.clone(),
+            #[cfg(tokio_unstable)]
             before_poll_callback: config.before_poll.clone(),
+            #[cfg(tokio_unstable)]
             after_poll_callback: config.after_poll.clone(),
         }
     }
@@ -45,7 +47,9 @@ impl TaskHooks {
 pub(crate) struct TaskHooks {
     pub(crate) task_spawn_callback: Option<TaskCallback>,
     pub(crate) task_terminate_callback: Option<TaskCallback>,
+    #[cfg(tokio_unstable)]
     pub(crate) before_poll_callback: Option<TaskCallback>,
+    #[cfg(tokio_unstable)]
     pub(crate) after_poll_callback: Option<TaskCallback>,
 }
 

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,9 +1,20 @@
 use std::marker::PhantomData;
 
+use super::Config;
+
 impl TaskHooks {
     pub(crate) fn spawn(&self, meta: &TaskMeta<'_>) {
         if let Some(f) = self.task_spawn_callback.as_ref() {
             f(meta)
+        }
+    }
+
+    pub(crate) fn from_config(config: &Config) -> Self {
+        Self {
+            task_spawn_callback: config.before_spawn.clone(),
+            task_terminate_callback: config.after_termination.clone(),
+            before_poll_callback: config.before_poll.clone(),
+            after_poll_callback: config.after_poll.clone(),
         }
     }
 }
@@ -12,6 +23,8 @@ impl TaskHooks {
 pub(crate) struct TaskHooks {
     pub(crate) task_spawn_callback: Option<TaskCallback>,
     pub(crate) task_terminate_callback: Option<TaskCallback>,
+    pub(crate) before_poll_callback: Option<TaskCallback>,
+    pub(crate) after_poll_callback: Option<TaskCallback>,
 }
 
 /// Task metadata supplied to user-provided hooks for task events.

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -9,6 +9,7 @@ impl TaskHooks {
         }
     }
 
+    #[allow(dead_code)]
     pub(crate) fn from_config(config: &Config) -> Self {
         Self {
             task_spawn_callback: config.before_spawn.clone(),

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -17,6 +17,28 @@ impl TaskHooks {
             after_poll_callback: config.after_poll.clone(),
         }
     }
+
+    #[cfg(tokio_unstable)]
+    #[inline]
+    pub(crate) fn poll_start_callback(&self, id: super::task::Id) {
+        if let Some(poll_start) = &self.before_poll_callback {
+            (poll_start)(&TaskMeta {
+                id,
+                _phantom: std::marker::PhantomData,
+            })
+        }
+    }
+
+    #[cfg(tokio_unstable)]
+    #[inline]
+    pub(crate) fn poll_stop_callback(&self, id: super::task::Id) {
+        if let Some(poll_stop) = &self.after_poll_callback {
+            (poll_stop)(&TaskMeta {
+                id,
+                _phantom: std::marker::PhantomData,
+            })
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -81,12 +81,15 @@ mod unstable {
             yield_now().await;
             yield_now().await;
             yield_now().await;
+            5
         });
         let task = rt.spawn(task);
 
         let spawned_task_id = task.id();
 
-        rt.block_on(task).expect("task should succeed");
+        assert_eq!(rt.block_on(task).expect("task should succeed"), 5);
+        // We need to drop the runtime to force the workers to cleanly exit
+        drop(rt);
 
         assert_eq!(
             before_task_poll_callback_task_id.lock().unwrap().unwrap(),

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -86,7 +86,7 @@ mod unstable {
 
         let spawned_task_id = task.id();
 
-        let _ = rt.block_on(task);
+        rt.block_on(task).expect("task should succeed");
 
         assert_eq!(
             before_task_poll_callback_task_id.lock().unwrap().unwrap(),
@@ -99,11 +99,13 @@ mod unstable {
         let actual_count = count.load(std::sync::atomic::Ordering::SeqCst);
         assert_eq!(
             poll_start.load(std::sync::atomic::Ordering::SeqCst),
-            actual_count
+            actual_count,
+            "unexpected number of poll starts"
         );
         assert_eq!(
             poll_stop.load(std::sync::atomic::Ordering::SeqCst),
-            actual_count
+            actual_count,
+            "unexpected number of poll stops"
         );
     }
 

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -1,13 +1,12 @@
-use std::{
-    sync::{atomic::AtomicUsize, Arc},
-    time::Duration,
-};
+#![allow(unknown_lints, unexpected_cfgs)]
+use std::sync::{atomic::AtomicUsize, Arc};
 
-use tokio::time::sleep;
+use tokio::task::yield_now;
 
-//#[cfg(tokio_unstable)]
+#[cfg(tokio_unstable)]
+#[cfg(not(target_os = "wasi"))]
 #[test]
-fn callbacks_fire() {
+fn callbacks_fire_multi_thread() {
     let poll_start_counter = Arc::new(AtomicUsize::new(0));
     let poll_stop_counter = Arc::new(AtomicUsize::new(0));
     let poll_start = poll_start_counter.clone();
@@ -15,19 +14,19 @@ fn callbacks_fire() {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .on_before_task_poll(move |_meta| {
-            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         })
         .on_after_task_poll(move |_meta| {
-            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         })
         .build()
         .unwrap();
     let task = rt.spawn(async {
-        sleep(Duration::from_millis(100)).await;
-        sleep(Duration::from_millis(100)).await;
-        sleep(Duration::from_millis(100)).await;
+        yield_now().await;
+        yield_now().await;
+        yield_now().await;
     });
-    rt.block_on(task);
-    assert_eq!(poll_start.load(std::sync::atomic::Ordering::Relaxed), 4);
-    assert_eq!(poll_stop.load(std::sync::atomic::Ordering::Relaxed), 4);
+    let _ = rt.block_on(task);
+    assert_eq!(poll_start.load(std::sync::atomic::Ordering::SeqCst), 4);
+    assert_eq!(poll_stop.load(std::sync::atomic::Ordering::SeqCst), 4);
 }

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -1,0 +1,33 @@
+use std::{
+    sync::{atomic::AtomicUsize, Arc},
+    time::Duration,
+};
+
+use tokio::time::sleep;
+
+//#[cfg(tokio_unstable)]
+#[test]
+fn callbacks_fire() {
+    let poll_start_counter = Arc::new(AtomicUsize::new(0));
+    let poll_stop_counter = Arc::new(AtomicUsize::new(0));
+    let poll_start = poll_start_counter.clone();
+    let poll_stop = poll_stop_counter.clone();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .on_before_task_poll(move |_meta| {
+            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .on_after_task_poll(move |_meta| {
+            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .build()
+        .unwrap();
+    let task = rt.spawn(async {
+        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
+    });
+    rt.block_on(task);
+    assert_eq!(poll_start.load(std::sync::atomic::Ordering::Relaxed), 4);
+    assert_eq!(poll_stop.load(std::sync::atomic::Ordering::Relaxed), 4);
+}

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -1,32 +1,64 @@
 #![allow(unknown_lints, unexpected_cfgs)]
-use std::sync::{atomic::AtomicUsize, Arc};
-
-use tokio::task::yield_now;
 
 #[cfg(tokio_unstable)]
-#[cfg(not(target_os = "wasi"))]
-#[test]
-fn callbacks_fire_multi_thread() {
-    let poll_start_counter = Arc::new(AtomicUsize::new(0));
-    let poll_stop_counter = Arc::new(AtomicUsize::new(0));
-    let poll_start = poll_start_counter.clone();
-    let poll_stop = poll_stop_counter.clone();
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .on_before_task_poll(move |_meta| {
-            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        })
-        .on_after_task_poll(move |_meta| {
-            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        })
-        .build()
-        .unwrap();
-    let task = rt.spawn(async {
-        yield_now().await;
-        yield_now().await;
-        yield_now().await;
-    });
-    let _ = rt.block_on(task);
-    assert_eq!(poll_start.load(std::sync::atomic::Ordering::SeqCst), 4);
-    assert_eq!(poll_stop.load(std::sync::atomic::Ordering::SeqCst), 4);
+mod unstable {
+    use std::sync::{atomic::AtomicUsize, Arc};
+
+    use tokio::task::yield_now;
+
+    #[cfg(not(target_os = "wasi"))]
+    #[test]
+    fn callbacks_fire_multi_thread() {
+        let poll_start_counter = Arc::new(AtomicUsize::new(0));
+        let poll_stop_counter = Arc::new(AtomicUsize::new(0));
+        let poll_start = poll_start_counter.clone();
+        let poll_stop = poll_stop_counter.clone();
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .on_before_task_poll(move |_meta| {
+                poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .on_after_task_poll(move |_meta| {
+                poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            })
+            .build()
+            .unwrap();
+        let task = rt.spawn(async {
+            yield_now().await;
+            yield_now().await;
+            yield_now().await;
+        });
+        let _ = rt.block_on(task);
+        assert_eq!(poll_start.load(std::sync::atomic::Ordering::SeqCst), 4);
+        assert_eq!(poll_stop.load(std::sync::atomic::Ordering::SeqCst), 4);
+    }
+
+    #[test]
+    fn callbacks_fire_current_thread() {
+        let poll_start_counter = Arc::new(AtomicUsize::new(0));
+        let poll_stop_counter = Arc::new(AtomicUsize::new(0));
+        let poll_start = poll_start_counter.clone();
+        let poll_stop = poll_stop_counter.clone();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .on_before_task_poll(move |_meta| {
+                poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            })
+            .on_after_task_poll(move |_meta| {
+                poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            })
+            .build()
+            .unwrap();
+
+        let task = rt.spawn(async {
+            yield_now().await;
+            yield_now().await;
+            yield_now().await;
+        });
+        let _ = rt.block_on(task);
+
+        assert_eq!(poll_start.load(std::sync::atomic::Ordering::Relaxed), 4);
+        assert_eq!(poll_stop.load(std::sync::atomic::Ordering::Relaxed), 4);
+    }
 }

--- a/tokio/tests/rt_poll_callbacks.rs
+++ b/tokio/tests/rt_poll_callbacks.rs
@@ -1,169 +1,128 @@
 #![allow(unknown_lints, unexpected_cfgs)]
+#![cfg(tokio_unstable)]
 
-#[cfg(tokio_unstable)]
-mod unstable {
-    use std::{
-        future::Future,
-        sync::{atomic::AtomicUsize, Arc, Mutex},
-    };
+use std::sync::{atomic::AtomicUsize, Arc, Mutex};
 
-    use tokio::task::yield_now;
+use tokio::task::yield_now;
 
-    pin_project_lite::pin_project! {
-        struct PollCounter<F> {
-            #[pin]
-            inner: F,
-            counter: Arc<AtomicUsize>,
-        }
-    }
+#[cfg(not(target_os = "wasi"))]
+#[test]
+fn callbacks_fire_multi_thread() {
+    let poll_start_counter = Arc::new(AtomicUsize::new(0));
+    let poll_stop_counter = Arc::new(AtomicUsize::new(0));
+    let poll_start = poll_start_counter.clone();
+    let poll_stop = poll_stop_counter.clone();
 
-    impl<F: Future> Future for PollCounter<F> {
-        type Output = F::Output;
+    let before_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
+        Arc::new(Mutex::new(None));
+    let after_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
+        Arc::new(Mutex::new(None));
 
-        fn poll(
-            self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Self::Output> {
-            let this = self.project();
-            this.counter
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            this.inner.poll(cx)
-        }
-    }
+    let before_task_poll_callback_task_id_ref = Arc::clone(&before_task_poll_callback_task_id);
+    let after_task_poll_callback_task_id_ref = Arc::clone(&after_task_poll_callback_task_id);
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .on_before_task_poll(move |task_meta| {
+            before_task_poll_callback_task_id_ref
+                .lock()
+                .unwrap()
+                .replace(task_meta.id());
+            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .on_after_task_poll(move |task_meta| {
+            after_task_poll_callback_task_id_ref
+                .lock()
+                .unwrap()
+                .replace(task_meta.id());
+            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .build()
+        .unwrap();
+    let task = rt.spawn(async {
+        yield_now().await;
+        yield_now().await;
+        yield_now().await;
+    });
 
-    impl PollCounter<()> {
-        fn new<F: Future>(future: F) -> (PollCounter<F>, Arc<AtomicUsize>) {
-            let counter = Arc::new(AtomicUsize::new(0));
-            (
-                PollCounter {
-                    inner: future,
-                    counter: counter.clone(),
-                },
-                counter,
-            )
-        }
-    }
+    let spawned_task_id = task.id();
 
-    #[cfg(not(target_os = "wasi"))]
-    #[test]
-    fn callbacks_fire_multi_thread() {
-        let poll_start_counter = Arc::new(AtomicUsize::new(0));
-        let poll_stop_counter = Arc::new(AtomicUsize::new(0));
-        let poll_start = poll_start_counter.clone();
-        let poll_stop = poll_stop_counter.clone();
+    rt.block_on(task).expect("task should succeed");
+    // We need to drop the runtime to guarantee the workers have exited (and thus called the callback)
+    drop(rt);
 
-        let before_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
-            Arc::new(Mutex::new(None));
-        let after_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
-            Arc::new(Mutex::new(None));
+    assert_eq!(
+        before_task_poll_callback_task_id.lock().unwrap().unwrap(),
+        spawned_task_id
+    );
+    assert_eq!(
+        after_task_poll_callback_task_id.lock().unwrap().unwrap(),
+        spawned_task_id
+    );
+    let actual_count = 4;
+    assert_eq!(
+        poll_start.load(std::sync::atomic::Ordering::Relaxed),
+        actual_count,
+        "unexpected number of poll starts"
+    );
+    assert_eq!(
+        poll_stop.load(std::sync::atomic::Ordering::Relaxed),
+        actual_count,
+        "unexpected number of poll stops"
+    );
+}
 
-        let before_task_poll_callback_task_id_ref = Arc::clone(&before_task_poll_callback_task_id);
-        let after_task_poll_callback_task_id_ref = Arc::clone(&after_task_poll_callback_task_id);
-        let rt = tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .on_before_task_poll(move |task_meta| {
-                before_task_poll_callback_task_id_ref
-                    .lock()
-                    .unwrap()
-                    .replace(task_meta.id());
-                poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            })
-            .on_after_task_poll(move |task_meta| {
-                after_task_poll_callback_task_id_ref
-                    .lock()
-                    .unwrap()
-                    .replace(task_meta.id());
-                poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            })
-            .build()
-            .unwrap();
-        let (task, count) = PollCounter::new(async {
-            yield_now().await;
-            yield_now().await;
-            yield_now().await;
-            5
-        });
-        let task = rt.spawn(task);
+#[test]
+fn callbacks_fire_current_thread() {
+    let poll_start_counter = Arc::new(AtomicUsize::new(0));
+    let poll_stop_counter = Arc::new(AtomicUsize::new(0));
+    let poll_start = poll_start_counter.clone();
+    let poll_stop = poll_stop_counter.clone();
 
-        let spawned_task_id = task.id();
+    let before_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
+        Arc::new(Mutex::new(None));
+    let after_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
+        Arc::new(Mutex::new(None));
 
-        assert_eq!(rt.block_on(task).expect("task should succeed"), 5);
-        // We need to drop the runtime to force the workers to cleanly exit
-        drop(rt);
+    let before_task_poll_callback_task_id_ref = Arc::clone(&before_task_poll_callback_task_id);
+    let after_task_poll_callback_task_id_ref = Arc::clone(&after_task_poll_callback_task_id);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .on_before_task_poll(move |task_meta| {
+            before_task_poll_callback_task_id_ref
+                .lock()
+                .unwrap()
+                .replace(task_meta.id());
+            poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .on_after_task_poll(move |task_meta| {
+            after_task_poll_callback_task_id_ref
+                .lock()
+                .unwrap()
+                .replace(task_meta.id());
+            poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        })
+        .build()
+        .unwrap();
 
-        assert_eq!(
-            before_task_poll_callback_task_id.lock().unwrap().unwrap(),
-            spawned_task_id
-        );
-        assert_eq!(
-            after_task_poll_callback_task_id.lock().unwrap().unwrap(),
-            spawned_task_id
-        );
-        let actual_count = count.load(std::sync::atomic::Ordering::SeqCst);
-        assert_eq!(
-            poll_start.load(std::sync::atomic::Ordering::SeqCst),
-            actual_count,
-            "unexpected number of poll starts"
-        );
-        assert_eq!(
-            poll_stop.load(std::sync::atomic::Ordering::SeqCst),
-            actual_count,
-            "unexpected number of poll stops"
-        );
-    }
+    let task = rt.spawn(async {
+        yield_now().await;
+        yield_now().await;
+        yield_now().await;
+    });
 
-    #[test]
-    fn callbacks_fire_current_thread() {
-        let poll_start_counter = Arc::new(AtomicUsize::new(0));
-        let poll_stop_counter = Arc::new(AtomicUsize::new(0));
-        let poll_start = poll_start_counter.clone();
-        let poll_stop = poll_stop_counter.clone();
+    let spawned_task_id = task.id();
 
-        let before_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
-            Arc::new(Mutex::new(None));
-        let after_task_poll_callback_task_id: Arc<Mutex<Option<tokio::task::Id>>> =
-            Arc::new(Mutex::new(None));
+    let _ = rt.block_on(task);
+    drop(rt);
 
-        let before_task_poll_callback_task_id_ref = Arc::clone(&before_task_poll_callback_task_id);
-        let after_task_poll_callback_task_id_ref = Arc::clone(&after_task_poll_callback_task_id);
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .on_before_task_poll(move |task_meta| {
-                before_task_poll_callback_task_id_ref
-                    .lock()
-                    .unwrap()
-                    .replace(task_meta.id());
-                poll_start_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            })
-            .on_after_task_poll(move |task_meta| {
-                after_task_poll_callback_task_id_ref
-                    .lock()
-                    .unwrap()
-                    .replace(task_meta.id());
-                poll_stop_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-            })
-            .build()
-            .unwrap();
-
-        let task = rt.spawn(async {
-            yield_now().await;
-            yield_now().await;
-            yield_now().await;
-        });
-
-        let spawned_task_id = task.id();
-
-        let _ = rt.block_on(task);
-
-        assert_eq!(
-            before_task_poll_callback_task_id.lock().unwrap().unwrap(),
-            spawned_task_id
-        );
-        assert_eq!(
-            after_task_poll_callback_task_id.lock().unwrap().unwrap(),
-            spawned_task_id
-        );
-        assert_eq!(poll_start.load(std::sync::atomic::Ordering::Relaxed), 4);
-        assert_eq!(poll_stop.load(std::sync::atomic::Ordering::Relaxed), 4);
-    }
+    assert_eq!(
+        before_task_poll_callback_task_id.lock().unwrap().unwrap(),
+        spawned_task_id
+    );
+    assert_eq!(
+        after_task_poll_callback_task_id.lock().unwrap().unwrap(),
+        spawned_task_id
+    );
+    assert_eq!(poll_start.load(std::sync::atomic::Ordering::Relaxed), 4);
+    assert_eq!(poll_stop.load(std::sync::atomic::Ordering::Relaxed), 4);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

_Just throwing this up for initial discussion, I need to do work to clean up internal names & get all the right `tokio_unstable` gating.

- [ ] Implement on current thread worker
- [ ] Implement on alt runtime
- [ ] fix unstable
- [ ] more tests and docs

## Motivation

We would like to be able to store metadata before polls start and stop to allow us to instrument all polls, not just polls where you have spawned the task.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add callbacks for poll start and stop
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
