### PR TITLE
macros: make select budget-aware

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -524,6 +524,10 @@ doc! {macro_rules! select {
                 // supplied.
                 let start = $start;
 
+                // Return `Pending` when the task budget is depleted since budget-aware futures
+                // are going to yield anyway and other futures will not cooperate.
+                ::std::task::ready!($crate::task::poll_budget_available(cx));
+
                 for i in 0..BRANCHES {
                     let branch;
                     #[allow(clippy::modulo_one)]

--- a/tokio/src/task/budget.rs
+++ b/tokio/src/task/budget.rs
@@ -1,4 +1,4 @@
-use std::task::{ready, Poll};
+use std::task::{ready, Context, Poll};
 
 /// Consumes a unit of budget and returns the execution back to the Tokio
 /// runtime *if* the task's coop budget was exhausted.
@@ -38,4 +38,22 @@ pub async fn consume_budget() {
         status
     })
     .await
+}
+
+/// Polls to see if any budget is available or not.
+///
+/// See also the usage example in the [task module](index.html#poll_budget_available).
+///
+/// This method returns:
+/// - `Poll::Pending` if the budget is depleted
+/// - `Poll::Ready(())` if there is still budget left
+#[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+pub fn poll_budget_available(cx: &mut Context<'_>) -> Poll<()> {
+    ready!(crate::trace::trace_leaf(cx));
+    if crate::runtime::coop::has_budget_remaining() {
+        Poll::Ready(())
+    } else {
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
 }

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -8,7 +8,7 @@ use wasm_bindgen_test::wasm_bindgen_test as maybe_tokio_test;
 #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 use tokio::test as maybe_tokio_test;
 
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio_test::{assert_ok, assert_pending, assert_ready};
 
 use std::future::poll_fn;
@@ -628,6 +628,42 @@ async fn mut_ref_patterns() {
             assert_eq!(*foo, "2");
         },
     };
+}
+
+#[maybe_tokio_test]
+async fn select_is_budget_aware() {
+    const BUDGET: usize = 128;
+
+    let message_sent = BUDGET + 1;
+    let (sender, mut receiver) = mpsc::channel(message_sent);
+
+    let jh = tokio::spawn(async move {
+        for n in 0usize..message_sent {
+            sender.send(n).await.unwrap();
+        }
+    });
+
+    // Wait for all messages to be sent
+    jh.await.unwrap();
+
+    let mut message_received = 0;
+    loop {
+        tokio::select! {
+            // Poll the `receiver` first in order to deplete the budget
+            biased;
+
+            msg = receiver.recv() => {
+                if msg.is_some() {
+                    message_received += 1
+                } else {
+                    break;
+                }
+            },
+            () = std::future::ready(()) => {}
+        }
+    }
+
+    assert_eq!(message_sent, message_received);
 }
 
 #[cfg(tokio_unstable)]


### PR DESCRIPTION
This PR introduces a new function called `poll_budget_available` which can be called in order to poll for budget availability. This is then used in `select!`, before polling the branches, in order to make select budget-aware.

Resolves #7108.