### PR TITLE
docs: fix warnings when building the docs

### DIFF
--- a/tokio/src/doc/mod.rs
+++ b/tokio/src/doc/mod.rs
@@ -24,21 +24,21 @@ pub enum NotDefinedHere {}
 impl mio::event::Source for NotDefinedHere {
     fn register(
         &mut self,
-        registry: &mio::Registry,
-        token: mio::Token,
-        interests: mio::Interest,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+        _interests: mio::Interest,
     ) -> std::io::Result<()> {
         Ok(())
     }
     fn reregister(
         &mut self,
-        registry: &mio::Registry,
-        token: mio::Token,
-        interests: mio::Interest,
+        _registry: &mio::Registry,
+        _token: mio::Token,
+        _interests: mio::Interest,
     ) -> std::io::Result<()> {
         Ok(())
     }
-    fn deregister(&mut self, registry: &mio::Registry) -> std::io::Result<()> {
+    fn deregister(&mut self, _registry: &mio::Registry) -> std::io::Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
This PR fixes the warnings that happen when building the docs.