### PR TITLE
io: implement `is_terminal` for stdio types

### DIFF
--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -50,6 +50,12 @@ cfg_io_blocking! {
     }
 }
 
+impl<T> Blocking<T> {
+    pub(crate) fn inner(&self) -> Option<&T> {
+        self.inner.as_ref()
+    }
+}
+
 impl<T> AsyncRead for Blocking<T>
 where
     T: Read + Unpin + Send + 'static,

--- a/tokio/src/io/stderr.rs
+++ b/tokio/src/io/stderr.rs
@@ -3,6 +3,7 @@ use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
 
 use std::io;
+use std::io::IsTerminal;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -130,5 +131,16 @@ impl AsyncWrite for Stderr {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.std).poll_shutdown(cx)
+    }
+}
+
+impl Stderr {
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.std
+            .inner()
+            .inner()
+            .map(|stderr| stderr.is_terminal())
+            .unwrap_or_default()
     }
 }

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -1,7 +1,7 @@
 use crate::io::blocking::Blocking;
 use crate::io::{AsyncRead, ReadBuf};
 
-use std::io;
+use std::io::{self, IsTerminal};
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -94,5 +94,15 @@ impl AsyncRead for Stdin {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         Pin::new(&mut self.std).poll_read(cx, buf)
+    }
+}
+
+impl Stdin {
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.std
+            .inner()
+            .map(|stdin| stdin.is_terminal())
+            .unwrap_or_default()
     }
 }

--- a/tokio/src/io/stdio_common.rs
+++ b/tokio/src/io/stdio_common.rs
@@ -17,6 +17,10 @@ impl<W> SplitByUtf8BoundaryIfWindows<W> {
     pub(crate) fn new(inner: W) -> Self {
         Self { inner }
     }
+
+    pub(crate) fn inner(&self) -> &W {
+        &self.inner
+    }
 }
 
 // this constant is defined by Unicode standard.

--- a/tokio/src/io/stdout.rs
+++ b/tokio/src/io/stdout.rs
@@ -2,6 +2,7 @@ use crate::io::blocking::Blocking;
 use crate::io::stdio_common::SplitByUtf8BoundaryIfWindows;
 use crate::io::AsyncWrite;
 use std::io;
+use std::io::IsTerminal;
 use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
@@ -179,5 +180,16 @@ impl AsyncWrite for Stdout {
         cx: &mut Context<'_>,
     ) -> Poll<Result<(), io::Error>> {
         Pin::new(&mut self.std).poll_shutdown(cx)
+    }
+}
+
+impl Stdout {
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.std
+            .inner()
+            .inner()
+            .map(|stdout| stdout.is_terminal())
+            .unwrap_or_default()
     }
 }

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1381,6 +1381,11 @@ impl ChildStdin {
             inner: imp::stdio(inner)?,
         })
     }
+
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.inner.is_terminal()
+    }
 }
 
 impl ChildStdout {
@@ -1396,6 +1401,11 @@ impl ChildStdout {
             inner: imp::stdio(inner)?,
         })
     }
+
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.inner.is_terminal()
+    }
 }
 
 impl ChildStderr {
@@ -1410,6 +1420,11 @@ impl ChildStderr {
         Ok(Self {
             inner: imp::stdio(inner)?,
         })
+    }
+
+    /// Returns true if the descriptor/handle refers to a terminal/tty.
+    pub fn is_terminal(&self) -> bool {
+        self.inner.is_terminal()
     }
 }
 

--- a/tokio/src/process/unix/mod.rs
+++ b/tokio/src/process/unix/mod.rs
@@ -41,7 +41,7 @@ use mio::unix::SourceFd;
 use std::fmt;
 use std::fs::File;
 use std::future::Future;
-use std::io;
+use std::io::{self, IsTerminal};
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, OwnedFd, RawFd};
 use std::pin::Pin;
 use std::process::{Child as StdChild, ExitStatus, Stdio};
@@ -278,6 +278,10 @@ pub(crate) struct ChildStdio {
 impl ChildStdio {
     pub(super) fn into_owned_fd(self) -> io::Result<OwnedFd> {
         convert_to_blocking_file(self).map(OwnedFd::from)
+    }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.as_fd().is_terminal()
     }
 }
 

--- a/tokio/src/process/windows.rs
+++ b/tokio/src/process/windows.rs
@@ -24,7 +24,9 @@ use std::fmt;
 use std::fs::File as StdFile;
 use std::future::Future;
 use std::io;
-use std::os::windows::prelude::{AsRawHandle, IntoRawHandle, OwnedHandle, RawHandle};
+use std::os::windows::prelude::{
+    AsHandle, AsRawHandle, BorrowedHandle, IntoRawHandle, OwnedHandle, RawHandle,
+};
 use std::pin::Pin;
 use std::process::Stdio;
 use std::process::{Child as StdChild, Command as StdCommand, ExitStatus};
@@ -199,11 +201,21 @@ impl ChildStdio {
     pub(super) fn into_owned_handle(self) -> io::Result<OwnedHandle> {
         convert_to_file(self).map(OwnedHandle::from)
     }
+
+    pub(crate) fn is_terminal(&self) -> bool {
+        self.as_handle().is_terminal()
+    }
 }
 
 impl AsRawHandle for ChildStdio {
     fn as_raw_handle(&self) -> RawHandle {
         self.raw.as_raw_handle()
+    }
+}
+
+impl AsHandle for ChildStdio {
+    fn as_handle(&self) -> BorrowedHandle<'_> {
+        self.raw.as_handle()
     }
 }
 


### PR DESCRIPTION
This PR adds the `is_terminal` function to different stdio types by delegating to the `IsTerminal::is_terminal` implementation of the standard library. Note that since this trait is sealed, we cannot implement it directly.

Resolves #6407.