### PR TITLE
build: upgrade `windows-sys` 0.52 → 0.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,10 @@ members = [
 
 [workspace.metadata.spellcheck]
 config = "spellcheck.toml"
+
+
+[patch.crates-io]
+# TODO: Consume a release of `mio` that contains <https://github.com/tokio-rs/mio/pull/1857>.
+mio = { git = "https://github.com/erichdongubler-contrib/mio", rev = "1ef9c035f9c147621a6aa1d7b80a14d7acb09555" }
+# TODO: Consume a release of `socket2` that contains <https://github.com/rust-lang/socket2/pull/545>.
+socket2 = { git = "https://github.com/erichdongubler-contrib/socket2", rev = "d4ed5f73ddb051ac700e1b7ee66a72905a86a05e" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1.5.2"
 rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.52"
+version = "0.59"
 
 [[example]]
 name = "chat"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -117,7 +117,7 @@ libc = { version = "0.2.168" }
 nix = { version = "0.29.0", default-features = false, features = ["aio", "fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.52"
+version = "0.59"
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]

--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -7,6 +7,7 @@ use std::ffi::OsStr;
 use std::io::{self, Read, Write};
 use std::pin::Pin;
 use std::ptr;
+use std::ptr::null_mut;
 use std::task::{Context, Poll};
 
 use crate::io::{AsyncRead, AsyncWrite, Interest, PollEvented, ReadBuf, Ready};
@@ -2556,7 +2557,7 @@ impl ClientOptions {
             attrs as *mut _,
             windows_sys::OPEN_EXISTING,
             self.get_flags(),
-            0,
+            null_mut(),
         );
 
         if h == windows_sys::INVALID_HANDLE_VALUE {

--- a/tokio/src/process/windows.rs
+++ b/tokio/src/process/windows.rs
@@ -28,6 +28,7 @@ use std::os::windows::prelude::{AsRawHandle, IntoRawHandle, OwnedHandle, RawHand
 use std::pin::Pin;
 use std::process::Stdio;
 use std::process::{Child as StdChild, Command as StdCommand, ExitStatus};
+use std::ptr::null_mut;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
@@ -120,7 +121,7 @@ impl Future for Child {
             }
             let (tx, rx) = oneshot::channel();
             let ptr = Box::into_raw(Box::new(Some(tx)));
-            let mut wait_object = 0;
+            let mut wait_object = null_mut();
             let rc = unsafe {
                 RegisterWaitForSingleObject(
                     &mut wait_object,


### PR DESCRIPTION
## Motivation

We at Mozilla would like to upgrade WGPU and crates we otherwise use in `mozilla-central` to `windows` 0.59. 😀 This will let us handle breaking changes, and stay in sync. with the current ecosystem for Windows targets.

## Solution

Migrate `tokio` to `windows` 0.59.

## Remaining work

- [ ] Figure out why other stuff is failing to compile (hit a timebox).