### PR TITLE
chore: use [lints] to address unexpected_cfgs lint

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ freebsd_instance:
   image_family: freebsd-14-1
 env:
   RUST_STABLE: stable
-  RUST_NIGHTLY: nightly-2024-05-05
+  RUST_NIGHTLY: nightly-2025-01-25
   RUSTFLAGS: -D warnings
 
 # Test FreeBSD in a full VM on cirrus-ci.com.  Test the i686 target too, in the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ env:
   RUSTUP_WINDOWS_PATH_ADD_BIN: 1
   # Change to specific Rust release to pin
   rust_stable: stable
-  rust_nightly: nightly-2024-05-05
+  rust_nightly: nightly-2025-01-25
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2024-10-21
+  rust_miri_nightly: nightly-2025-01-25
   rust_clippy: '1.77'
   # When updating this, also update:
   # - README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1086,23 +1086,6 @@ jobs:
         run: cargo check-external-types --all-features
         working-directory: tokio
 
-  check-unexpected-lints-cfgs:
-    name: check unexpected lints and cfgs
-    needs: basics
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust ${{ env.rust_nightly }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.rust_nightly }}
-      - name: don't allow warnings
-        run: sed -i '/#!\[allow(unknown_lints, unexpected_cfgs)\]/d' */src/lib.rs */tests/*.rs
-      - name: check for unknown lints and cfgs
-        run: cargo check --all-features --tests
-        env:
-          RUSTFLAGS: -Dwarnings --check-cfg=cfg(loom,tokio_unstable,tokio_taskdump,fuzzing,mio_unsupported_force_poll_poll,tokio_internal_mt_counters,fs,tokio_no_parking_lot,tokio_no_tuning_tests) -Funexpected_cfgs -Funknown_lints
-
   check-fuzzing:
     name: check-fuzzing
     needs: basics

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ config = "spellcheck.toml"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
-  'cfg(fs)',
   'cfg(fuzzing)',
   'cfg(loom)',
   'cfg(mio_unsupported_force_poll_poll)',

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,16 @@ members = [
 
 [workspace.metadata.spellcheck]
 config = "spellcheck.toml"
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(fs)',
+  'cfg(fuzzing)',
+  'cfg(loom)',
+  'cfg(mio_unsupported_force_poll_poll)',
+  'cfg(tokio_internal_mt_counters)',
+  'cfg(tokio_no_parking_lot)',
+  'cfg(tokio_no_tuning_tests)',
+  'cfg(tokio_taskdump)',
+  'cfg(tokio_unstable)',
+] }

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -95,3 +95,6 @@ harness = false
 name = "time_timeout"
 path = "time_timeout.rs"
 harness = false
+
+[lints]
+workspace = true

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -95,3 +95,6 @@ path = "named-pipe-multi-client.rs"
 [[example]]
 name = "dump"
 path = "dump.rs"
+
+[lints]
+workspace = true

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
-
 //! This example demonstrates tokio's experimental task dumping functionality.
 //! This application deadlocks. Input CTRL+C to display traces of each task, or
 //! input CTRL+C twice within 1 second to quit.

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -13,3 +13,6 @@ tokio = { version = "1.0.0", path = "../tokio/", features = ["full"] }
 
 [dev-dependencies]
 rand = "0.8"
+
+[lints]
+workspace = true

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -15,3 +15,6 @@ tokio = { version = "1.0.0", path = "../tokio", optional = true }
 
 [dev-dependencies]
 trybuild = "1.0"
+
+[lints]
+workspace = true

--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -61,3 +61,6 @@ tokio-test = { version = "0.4", path = "../tokio-test", optional = true }
 doc-comment = "0.3.1"
 futures = { version = "0.3.0", features = ["async-await"] }
 bytes = "1.0.0"
+
+[lints]
+workspace = true

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -31,3 +31,6 @@ tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,
@@ -211,7 +210,6 @@ use proc_macro::TokenStream;
 /// This option is only compatible with the `current_thread` runtime.
 ///
 /// ```no_run
-/// # #![allow(unknown_lints, unexpected_cfgs)]
 /// #[cfg(tokio_unstable)]
 /// #[tokio::main(flavor = "current_thread", unhandled_panic = "shutdown_runtime")]
 /// async fn main() {
@@ -226,7 +224,6 @@ use proc_macro::TokenStream;
 /// Equivalent code not using `#[tokio::main]`
 ///
 /// ```no_run
-/// # #![allow(unknown_lints, unexpected_cfgs)]
 /// #[cfg(tokio_unstable)]
 /// fn main() {
 ///     tokio::runtime::Builder::new_current_thread()
@@ -480,7 +477,6 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// This option is only compatible with the `current_thread` runtime.
 ///
 /// ```no_run
-/// # #![allow(unknown_lints, unexpected_cfgs)]
 /// #[cfg(tokio_unstable)]
 /// #[tokio::test(flavor = "current_thread", unhandled_panic = "shutdown_runtime")]
 /// async fn my_test() {
@@ -495,7 +491,6 @@ pub fn main_rt(args: TokenStream, item: TokenStream) -> TokenStream {
 /// Equivalent code not using `#[tokio::test]`
 ///
 /// ```no_run
-/// # #![allow(unknown_lints, unexpected_cfgs)]
 /// #[cfg(tokio_unstable)]
 /// #[test]
 /// fn my_test() {

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -56,3 +56,6 @@ rustdoc-args = ["--cfg", "docsrs"]
 # This should allow `docsrs` to be read across projects, so that `tokio-stream`
 # can pick up stubbed types exported by `tokio`.
 rustc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/tokio-stream/src/lib.rs
+++ b/tokio-stream/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -30,3 +30,6 @@ futures-util = "0.3.0"
 
 [package.metadata.docs.rs]
 all-features = true
+
+[lints]
+workspace = true

--- a/tokio-test/src/lib.rs
+++ b/tokio-test/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -68,3 +68,6 @@ rustc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
 
 [package.metadata.playground]
 features = ["full"]
+
+[lints]
+workspace = true

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_doctest_main)]
 #![warn(
     missing_debug_implementations,

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "rt", tokio_unstable))]
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -173,3 +173,6 @@ allowed_external_types = [
   "bytes::buf::buf_mut::BufMut",
   "tokio_macros::*",
 ]
+
+[lints]
+workspace = true

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(
     clippy::cognitive_complexity,
     clippy::large_enum_variant,

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -128,7 +128,7 @@ pub(crate) struct Task {
 
 #[derive(PartialEq, Eq)]
 pub(crate) enum Mandatory {
-    #[cfg_attr(not(fs), allow(dead_code))]
+    #[cfg_attr(not(feature = "fs"), allow(dead_code))]
     Mandatory,
     NonMandatory,
 }

--- a/tokio/tests/_require_full.rs
+++ b/tokio/tests/_require_full.rs
@@ -1,5 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
-
 #[cfg(not(any(feature = "full", target_family = "wasm")))]
 compile_error!("run main Tokio tests with `--features full`");
 

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(
     tokio_unstable,
     tokio_taskdump,

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(feature = "macros")]
 #![allow(clippy::disallowed_names)]
 

--- a/tokio/tests/macros_test.rs
+++ b/tokio/tests/macros_test.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support threading
 
 use tokio::test;

--- a/tokio/tests/rt_basic.rs
+++ b/tokio/tests/rt_basic.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(not(miri))] // Possible bug on Miri.

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/rt_local.rs
+++ b/tokio/tests/rt_local.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable))]
 

--- a/tokio/tests/rt_metrics.rs
+++ b/tokio/tests/rt_metrics.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi"), target_has_atomic = "64"))]
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 // Too slow on miri.
 #![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))]

--- a/tokio/tests/rt_threaded_alt.rs
+++ b/tokio/tests/rt_threaded_alt.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", not(target_os = "wasi")))]
 #![cfg(tokio_unstable)]

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(
     feature = "full",

--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(tokio_unstable, feature = "tracing"))]
 
 use std::rc::Rc;

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "full", tokio_unstable, target_has_atomic = "64"))]
 

--- a/tokio/tests/task_id.rs
+++ b/tokio/tests/task_id.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_local_set.rs
+++ b/tokio/tests/task_local_set.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 

--- a/tokio/tests/task_yield_now.rs
+++ b/tokio/tests/task_yield_now.rs
@@ -1,4 +1,3 @@
-#![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(feature = "full", not(target_os = "wasi"), tokio_unstable))]
 
 use tokio::task;

--- a/tokio/tests/tracing_sync.rs
+++ b/tokio/tests/tracing_sync.rs
@@ -2,7 +2,6 @@
 //!
 //! These tests ensure that the instrumentation for tokio
 //! synchronization primitives is correct.
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
 

--- a/tokio/tests/tracing_task.rs
+++ b/tokio/tests/tracing_task.rs
@@ -2,7 +2,6 @@
 //!
 //! These tests ensure that the instrumentation for task spawning and task
 //! lifecycles is correct.
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
 

--- a/tokio/tests/tracing_time.rs
+++ b/tokio/tests/tracing_time.rs
@@ -2,7 +2,6 @@
 //!
 //! These tests ensure that the instrumentation for tokio
 //! synchronization primitives is correct.
-#![allow(unknown_lints, unexpected_cfgs)]
 #![warn(rust_2018_idioms)]
 #![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #6583


## Solution

This uses `[lints.rust.unexpected_cfgs.check-cfg]` as suggested in #6583.

This also bumps nightly toolchain to the latest (nightly-2025-01-25) because the above config is not recognized in old nightly.

```
warning: /home/runner/work/tokio/tokio/Cargo.toml: unused manifest key: workspace.lints.rust.unexpected_cfgs.check-cfg
```