### PR TITLE
Stabilize `runtime::id::Id`

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -404,36 +404,27 @@ impl Handle {
         }
     }
 
-    cfg_unstable! {
-        /// Returns the [`Id`] of the current `Runtime`.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use tokio::runtime::Handle;
-        ///
-        /// #[tokio::main(flavor = "current_thread")]
-        /// async fn main() {
-        ///   println!("Current runtime id: {}", Handle::current().id());
-        /// }
-        /// ```
-        ///
-        /// **Note**: This is an [unstable API][unstable]. The public API of this type
-        /// may break in 1.x releases. See [the documentation on unstable
-        /// features][unstable] for details.
-        ///
-        /// [unstable]: crate#unstable-features
-        /// [`Id`]: struct@crate::runtime::Id
-        pub fn id(&self) -> runtime::Id {
-            let owned_id = match &self.inner {
-                scheduler::Handle::CurrentThread(handle) => handle.owned_id(),
-                #[cfg(feature = "rt-multi-thread")]
-                scheduler::Handle::MultiThread(handle) => handle.owned_id(),
-                #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-                scheduler::Handle::MultiThreadAlt(handle) => handle.owned_id(),
-            };
-            owned_id.into()
-        }
+    /// Returns the [`Id`] of the current `Runtime`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime::Handle;
+    ///
+    /// #[tokio::main(flavor = "current_thread")]
+    /// async fn main() {
+    ///   println!("Current runtime id: {}", Handle::current().id());
+    /// }
+    /// ```
+    pub fn id(&self) -> crate::runtime::Id {
+        let owned_id = match &self.inner {
+            scheduler::Handle::CurrentThread(handle) => handle.owned_id(),
+            #[cfg(feature = "rt-multi-thread")]
+            scheduler::Handle::MultiThread(handle) => handle.owned_id(),
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            scheduler::Handle::MultiThreadAlt(handle) => handle.owned_id(),
+        };
+        crate::runtime::Id::new(owned_id)
     }
 
     /// Returns a view that lets you get information about how the runtime

--- a/tokio/src/runtime/id.rs
+++ b/tokio/src/runtime/id.rs
@@ -1,5 +1,5 @@
 use std::fmt;
-use std::num::{NonZeroU32, NonZeroU64};
+use std::num::NonZeroU64;
 
 /// An opaque ID that uniquely identifies a runtime relative to all other currently
 /// running runtimes.
@@ -23,25 +23,12 @@ use std::num::{NonZeroU32, NonZeroU64};
 ///   println!("Current runtime id: {}", Handle::current().id());
 /// }
 /// ```
-///
-/// **Note**: This is an [unstable API][unstable]. The public API of this type
-/// may break in 1.x releases. See [the documentation on unstable
-/// features][unstable] for details.
-///
-/// [unstable]: crate#unstable-features
-#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct Id(NonZeroU64);
 
-impl From<NonZeroU64> for Id {
-    fn from(value: NonZeroU64) -> Self {
-        Id(value)
-    }
-}
-
-impl From<NonZeroU32> for Id {
-    fn from(value: NonZeroU32) -> Self {
-        Id(value.into())
+impl Id {
+    pub(crate) fn new(integer: impl Into<NonZeroU64>) -> Self {
+        Self(integer.into())
     }
 }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -366,10 +366,6 @@ cfg_rt! {
     mod builder;
     pub use self::builder::Builder;
     cfg_unstable! {
-        mod id;
-        #[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
-        pub use id::Id;
-
         pub use self::builder::UnhandledPanic;
         pub use crate::util::rand::RngSeed;
 
@@ -395,6 +391,10 @@ cfg_rt! {
 
     mod runtime;
     pub use runtime::{Runtime, RuntimeFlavor};
+
+    mod id;
+    pub use id::Id;
+
 
     /// Boundary value to prevent stack overflow caused by a large-sized
     /// Future being placed in the stack.

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -603,13 +603,11 @@ cfg_unstable_metrics! {
     }
 }
 
-cfg_unstable! {
-    use std::num::NonZeroU64;
+use std::num::NonZeroU64;
 
-    impl Handle {
-        pub(crate) fn owned_id(&self) -> NonZeroU64 {
-            self.shared.owned.id
-        }
+impl Handle {
+    pub(crate) fn owned_id(&self) -> NonZeroU64 {
+        self.shared.owned.id
     }
 }
 

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -66,13 +66,11 @@ impl Handle {
     }
 }
 
-cfg_unstable! {
-    use std::num::NonZeroU64;
+use std::num::NonZeroU64;
 
-    impl Handle {
-        pub(crate) fn owned_id(&self) -> NonZeroU64 {
-            self.shared.owned.id
-        }
+impl Handle {
+    pub(crate) fn owned_id(&self) -> NonZeroU64 {
+        self.shared.owned.id
     }
 }
 

--- a/tokio/tests/rt_handle.rs
+++ b/tokio/tests/rt_handle.rs
@@ -100,27 +100,22 @@ fn drop_tasks_with_reference_cycle() {
     });
 }
 
-#[cfg(tokio_unstable)]
-mod unstable {
-    use super::*;
+#[test]
+fn runtime_id_is_same() {
+    let rt = rt();
 
-    #[test]
-    fn runtime_id_is_same() {
-        let rt = rt();
+    let handle1 = rt.handle();
+    let handle2 = rt.handle();
 
-        let handle1 = rt.handle();
-        let handle2 = rt.handle();
+    assert_eq!(handle1.id(), handle2.id());
+}
 
-        assert_eq!(handle1.id(), handle2.id());
-    }
+#[test]
+fn runtime_ids_different() {
+    let rt1 = rt();
+    let rt2 = rt();
 
-    #[test]
-    fn runtime_ids_different() {
-        let rt1 = rt();
-        let rt2 = rt();
-
-        assert_ne!(rt1.handle().id(), rt2.handle().id());
-    }
+    assert_ne!(rt1.handle().id(), rt2.handle().id());
 }
 
 fn rt() -> Runtime {


### PR DESCRIPTION
This commit stabilizes the `runtime::id::Id`.

`runtime::id::Id` uniquely identifies a runtime relative to the parent process' other currently running runtimes.

It was introduced in July 2023 and has only received one modification since, where `impl From<NonZeroU32> for Id` was added in December 2023 in 3a4aef17b2c70d255affa51eb473efcf703896e4 .

## `std::from::From` implementations

This commit removes the runtime `Id`'s `From` implementations.

Removing unnecessary publc APIs makes stabilizing the `Id` less risky. Instead, a crate private `Id::new` method has been introduced.

This means that as of this commit, users can no longer safely construct
 an `Id`.
Instead, they must get a runtime `Id` from a method such as `Handle::current().id()`.

The `Id`'s documentation explains that it is intended to be an opaque handle. Therefore, we should not expose a way to construct one.