### PR TITLE
io: implemented `get_ref` and `get_mut` for `SyncIoBridge`

### DIFF
--- a/tokio-util/src/io/sync_bridge.rs
+++ b/tokio-util/src/io/sync_bridge.rs
@@ -153,4 +153,18 @@ impl<T: Unpin> SyncIoBridge<T> {
     pub fn into_inner(self) -> T {
         self.src
     }
+
+    /// Returns a shared reference to the inner resource.
+    ///
+    /// It is inadvisable to directly read/write from the underlying resource.
+    pub fn get_ref(&self) -> &T {
+        &self.src
+    }
+
+    /// Returns a mutable reference to the inner resource.
+    ///
+    /// It is inadvisable to directly read/write from the underlying resource.
+    pub fn get_mut(&mut self) -> &T {
+        &mut self.src
+    }
 }

--- a/tokio-util/src/io/sync_bridge.rs
+++ b/tokio-util/src/io/sync_bridge.rs
@@ -153,18 +153,16 @@ impl<T: Unpin> SyncIoBridge<T> {
     pub fn into_inner(self) -> T {
         self.src
     }
+}
 
-    /// Returns a shared reference to the inner resource.
-    ///
-    /// It is inadvisable to directly read/write from the underlying resource.
-    pub fn get_ref(&self) -> &T {
-        &self.src
-    }
-
-    /// Returns a mutable reference to the inner resource.
-    ///
-    /// It is inadvisable to directly read/write from the underlying resource.
-    pub fn get_mut(&mut self) -> &mut T {
+impl<T> AsMut<T> for SyncIoBridge<T> {
+    fn as_mut(&mut self) -> &mut T {
         &mut self.src
+    }
+}
+
+impl<T> AsRef<T> for SyncIoBridge<T> {
+    fn as_ref(&self) -> &T {
+        &self.src
     }
 }

--- a/tokio-util/src/io/sync_bridge.rs
+++ b/tokio-util/src/io/sync_bridge.rs
@@ -164,7 +164,7 @@ impl<T: Unpin> SyncIoBridge<T> {
     /// Returns a mutable reference to the inner resource.
     ///
     /// It is inadvisable to directly read/write from the underlying resource.
-    pub fn get_mut(&mut self) -> &T {
+    pub fn get_mut(&mut self) -> &mut T {
         &mut self.src
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

When interacting with resources wrapped in a `SyncIoBridge`, it might be handy to interact with the inner resource.

## Solution

Implement `get_ref` and `get_mut` on `SyncIoBridge`.