### PR TITLE
net: rename the argument for `send_to`

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1164,8 +1164,8 @@ impl UdpSocket {
     ///     Ok(())
     /// }
     /// ```
-    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> io::Result<usize> {
-        let mut addrs = to_socket_addrs(target).await?;
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], addr: A) -> io::Result<usize> {
+        let mut addrs = to_socket_addrs(addr).await?;
 
         match addrs.next() {
             Some(target) => self.send_to_addr(buf, target).await,


### PR DESCRIPTION
Resolves https://github.com/tokio-rs/tokio/issues/7145.

For consistency with std's [`send_to`](https://doc.rust-lang.org/std/net/struct.UdpSocket.html#method.send_to), this PR renames the argument from `target` to `addr` instead of updating the docs.