### PR TITLE
io: document default `ReaderStream` capacity

### DIFF
--- a/tokio-util/src/io/reader_stream.rs
+++ b/tokio-util/src/io/reader_stream.rs
@@ -58,6 +58,8 @@ impl<R: AsyncRead> ReaderStream<R> {
     /// Convert an [`AsyncRead`] into a [`Stream`] with item type
     /// `Result<Bytes, std::io::Error>`.
     ///
+    /// The default capacity of this stream is 4096 bytes (4KiB).
+    ///
     /// [`AsyncRead`]: tokio::io::AsyncRead
     /// [`Stream`]: futures_core::Stream
     pub fn new(reader: R) -> Self {


### PR DESCRIPTION
## Motivation

I had to read the source to figure out the default ReaderStream capacity

## Solution

Add a little docstring line to the typical `::new()` for ReaderStream to document. DEFAULT_CAPACITY is private, we could alternatively publicise it and link in the docstring to it? 
