### PR TITLE
sync: `oneshot::Receiver::is_empty()`

### DIFF
--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -403,6 +403,20 @@ fn receiver_is_empty_send() {
 }
 
 #[test]
+fn receiver_is_empty_try_recv() {
+    let (tx, mut rx) = oneshot::channel::<i32>();
+
+    assert!(rx.is_empty(), "channel IS empty before value is sent");
+    tx.send(17).unwrap();
+    assert!(!rx.is_empty(), "channel is NOT empty after value is sent");
+
+    let value = rx.try_recv().expect("value is waiting");
+    assert_eq!(value, 17);
+
+    assert!(rx.is_empty(), "channel IS empty after value is read");
+}
+
+#[test]
 fn receiver_is_empty_drop() {
     let (tx, mut rx) = oneshot::channel::<i32>();
 

--- a/tokio/tests/sync_oneshot.rs
+++ b/tokio/tests/sync_oneshot.rs
@@ -386,3 +386,41 @@ fn receiver_is_terminated_rx_close() {
         "channel IS terminated after value is read"
     );
 }
+
+#[test]
+fn receiver_is_empty_send() {
+    let (tx, mut rx) = oneshot::channel::<i32>();
+
+    assert!(rx.is_empty(), "channel IS empty before value is sent");
+    tx.send(17).unwrap();
+    assert!(!rx.is_empty(), "channel is NOT empty after value is sent");
+
+    let mut task = task::spawn(());
+    let poll = task.enter(|cx, _| Pin::new(&mut rx).poll(cx));
+    assert_ready_eq!(poll, Ok(17));
+
+    assert!(rx.is_empty(), "channel IS empty after value is read");
+}
+
+#[test]
+fn receiver_is_empty_drop() {
+    let (tx, mut rx) = oneshot::channel::<i32>();
+
+    assert!(rx.is_empty(), "channel IS empty before sender is dropped");
+    drop(tx);
+    assert!(rx.is_empty(), "channel IS empty after sender is dropped");
+
+    let mut task = task::spawn(());
+    let poll = task.enter(|cx, _| Pin::new(&mut rx).poll(cx));
+    assert_ready_err!(poll);
+
+    assert!(rx.is_empty(), "channel IS empty after value is read");
+}
+
+#[test]
+fn receiver_is_empty_rx_close() {
+    let (_tx, mut rx) = oneshot::channel::<i32>();
+    assert!(rx.is_empty());
+    rx.close();
+    assert!(rx.is_empty());
+}


### PR DESCRIPTION
this commit introduces a new method to `tokio::sync::oneshot::Receiver<T>`.

this method returns true if the channel has no messages waiting to be received. this is similar to the existing `tokio::sync::mpsc::Receiver::is_empty()` and `tokio::sync::broadcast::Receiver::is_empty()` methods.

see:
* https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Receiver.html#method.is_empty
* https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html#method.is_empty
* https://github.com/tokio-rs/tokio/pull/7137#discussion_r1940242052