### PR TITLE
docs: fix nesting of next sections under examples

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -302,7 +302,7 @@
 //! }
 //! ```
 //!
-//! ## Feature flags
+//! # Feature flags
 //!
 //! Tokio uses a set of [feature flags] to reduce the amount of compiled code. It
 //! is possible to just enable certain features over others. By default, Tokio
@@ -340,7 +340,7 @@
 //! _Note: `AsyncRead` and `AsyncWrite` traits do not require any features and are
 //! always available._
 //!
-//! ### Unstable features
+//! ## Unstable features
 //!
 //! Some feature flags are only available when specifying the `tokio_unstable` flag:
 //!
@@ -392,7 +392,7 @@
 //! [unstable features]: https://internals.rust-lang.org/t/feature-request-unstable-opt-in-non-transitive-crate-features/16193#why-not-a-crate-feature-2
 //! [feature flags]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section
 //!
-//! ## Supported platforms
+//! # Supported platforms
 //!
 //! Tokio currently guarantees support for the following platforms:
 //!
@@ -418,7 +418,7 @@
 //!
 //! [mio-supported]: https://crates.io/crates/mio#platforms
 //!
-//! ### `WASM` support
+//! ## `WASM` support
 //!
 //! Tokio has some limited support for the `WASM` platform. Without the
 //! `tokio_unstable` flag, the following features are supported:
@@ -440,7 +440,7 @@
 //! immediately instead of blocking forever. On platforms that don't support
 //! time, this means that the runtime can never be idle in any way.
 //!
-//! ### Unstable `WASM` support
+//! ## Unstable `WASM` support
 //!
 //! Tokio also has unstable support for some additional `WASM` features. This
 //! requires the use of the `tokio_unstable` flag.


### PR DESCRIPTION
Promote the "Feature flags" and "Supported platforms" sections out from under "Examples", as they are not examples. Adjust their subsections accordingly. Expose these subsections via navigation sidebar.

## Motivation

I believe the documentation subheadings under "Examples" might have been nested by mistake. It seems like they were meant to follow "Examples", and I suspect that no one noticed this mistake because the default page styling makes the nesting structure hard to see.

This matters for at least two reasons:
1. Accessibility, e.g. to users of screen readers.
2. The "Sections" navigation menu in the sidebar only renders `#` and `##` headings. The headings "Unstable features", "`WASM` support", and "Unstable `WASM` support" are absent from this menu, and I believe they were meant to be present.

## Solution

Promote each subsection under `Examples` by one level.