### PR TITLE
Ok on Child::start_kill after wait

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1158,10 +1158,7 @@ impl Child {
     pub fn start_kill(&mut self) -> io::Result<()> {
         match &mut self.child {
             FusedChild::Child(child) => child.kill(),
-            FusedChild::Done(_) => Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                "invalid argument: can't kill an exited process",
-            )),
+            FusedChild::Done(_) => Ok(()),
         }
     }
 


### PR DESCRIPTION
- there's no good reason to my knowledge to return error in kill of killed process
- `start_kill` is often used in cleanup, which may happen after wait, so better not error there
- this matches behavior of std `Child::kill`
  - [decision by libs team](https://github.com/rust-lang/rust/issues/112423#issuecomment-1589851902)