### PR TITLE
Clarify Child::kill behavior

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1164,7 +1164,12 @@ impl Child {
 
     /// Forces the child to exit.
     ///
-    /// This is equivalent to sending a `SIGKILL` on unix platforms.
+    /// This is equivalent to sending a `SIGKILL` on unix platforms
+    /// followed by [`wait`](Child::wait).
+    ///
+    /// Note: std version of [`Child::kill`](std::process::Child::kill) does not `wait`.
+    /// For an equivalent of `Child::kill` in the standard library,
+    /// use [`start_kill`](Child::start_kill).
     ///
     /// # Examples
     ///


### PR DESCRIPTION
```
Child::kill       == std Child::kill + Child::wait
Child::start_kill == std Child::kill
```

As a side note, kill that also waits, is convenient, but also
dangerous, because `wait` may hang in certain cases (NFS, ptrace,
etc).  And different behavior between std and tokio may leads to
bugs when code is mechanically converted from one to another.  Better
name name of this function might be `kill_and_wait`.

CC @maminrayej 