### PR TITLE
net: debug_assert on creating a tokio socket from a blocking one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(fuzzing)',
   'cfg(loom)',
   'cfg(mio_unsupported_force_poll_poll)',
+  'cfg(tokio_allow_from_blocking_fd)',
   'cfg(tokio_internal_mt_counters)',
   'cfg(tokio_no_parking_lot)',
   'cfg(tokio_no_tuning_tests)',

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -210,7 +210,7 @@ impl TcpListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking
     ///

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -210,7 +210,9 @@ impl TcpListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking
     ///

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -1,11 +1,11 @@
 use crate::io::{Interest, PollEvented};
 use crate::net::tcp::TcpStream;
+use crate::util::check_socket_for_blocking;
 
 cfg_not_wasi! {
     use crate::net::{to_socket_addrs, ToSocketAddrs};
 }
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
@@ -210,7 +210,7 @@ impl TcpListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking
     ///

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -5,11 +5,11 @@ cfg_not_wasi! {
     use crate::net::{to_socket_addrs, ToSocketAddrs};
 }
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{self, SocketAddr};
 use std::task::{ready, Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_net! {
     /// A TCP socket server, listening for connections.
@@ -209,7 +209,7 @@ impl TcpListener {
     /// non-blocking mode. Otherwise all I/O operations on the listener
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
-    /// 
+    ///
     /// Tokio's handling of blocking sockets may change in the future.
     ///
     /// [`set_nonblocking`]: std::net::TcpListener::set_nonblocking
@@ -240,7 +240,7 @@ impl TcpListener {
     #[track_caller]
     pub fn from_std(listener: net::TcpListener) -> io::Result<TcpListener> {
         check_socket_for_blocking(&listener)?;
-        
+
         let io = mio::net::TcpListener::from_std(listener);
         let io = PollEvented::new(io)?;
         Ok(TcpListener { io })

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -174,7 +174,7 @@ impl TcpStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -7,8 +7,8 @@ cfg_not_wasi! {
 use crate::io::{AsyncRead, AsyncWrite, Interest, PollEvented, ReadBuf, Ready};
 use crate::net::tcp::split::{split, ReadHalf, WriteHalf};
 use crate::net::tcp::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};
+use crate::util::check_socket_for_blocking;
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{Shutdown, SocketAddr};
@@ -174,7 +174,7 @@ impl TcpStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -174,7 +174,9 @@ impl TcpStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::TcpStream::set_nonblocking
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -8,12 +8,12 @@ use crate::io::{AsyncRead, AsyncWrite, Interest, PollEvented, ReadBuf, Ready};
 use crate::net::tcp::split::{split, ReadHalf, WriteHalf};
 use crate::net::tcp::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{Shutdown, SocketAddr};
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -204,7 +204,7 @@ impl TcpStream {
     #[track_caller]
     pub fn from_std(stream: std::net::TcpStream) -> io::Result<TcpStream> {
         check_socket_for_blocking(&stream)?;
-        
+
         let io = mio::net::TcpStream::from_std(stream);
         let io = PollEvented::new(io)?;
         Ok(TcpStream { io })

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1,7 +1,7 @@
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::{to_socket_addrs, ToSocketAddrs};
+use crate::util::check_socket_for_blocking;
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
@@ -193,7 +193,7 @@ impl UdpSocket {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -193,7 +193,9 @@ impl UdpSocket {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -193,7 +193,7 @@ impl UdpSocket {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1,11 +1,11 @@
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::{to_socket_addrs, ToSocketAddrs};
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::task::{ready, Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -194,7 +194,7 @@ impl UdpSocket {
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// Tokio's handling of blocking sockets may change in the future.
-    /// 
+    ///
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///
     /// # Panics
@@ -224,7 +224,7 @@ impl UdpSocket {
     #[track_caller]
     pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
         check_socket_for_blocking(&socket)?;
-        
+
         let io = mio::net::UdpSocket::from_std(socket);
         UdpSocket::new(io)
     }

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::io;
 use std::net::{self, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::task::{ready, Context, Poll};
+use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -192,6 +193,8 @@ impl UdpSocket {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
+    /// Tokio's handling of blocking sockets may change in the future.
+    /// 
     /// [`set_nonblocking`]: std::net::UdpSocket::set_nonblocking
     ///
     /// # Panics
@@ -220,6 +223,8 @@ impl UdpSocket {
     /// ```
     #[track_caller]
     pub fn from_std(socket: net::UdpSocket) -> io::Result<UdpSocket> {
+        check_socket_for_blocking(&socket)?;
+        
         let io = mio::net::UdpSocket::from_std(socket);
         UdpSocket::new(io)
     }

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1,6 +1,7 @@
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::unix::SocketAddr;
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::Shutdown;
@@ -8,7 +9,6 @@ use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::task::{ready, Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -451,7 +451,7 @@ impl UnixDatagram {
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
     /// Tokio's handling of blocking sockets may change in the future.
-    /// 
+    ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///
     /// # Panics

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -1,7 +1,7 @@
 use crate::io::{Interest, PollEvented, ReadBuf, Ready};
 use crate::net::unix::SocketAddr;
+use crate::util::check_socket_for_blocking;
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 use std::net::Shutdown;
@@ -450,7 +450,7 @@ impl UnixDatagram {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -8,6 +8,7 @@ use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net;
 use std::path::Path;
 use std::task::{ready, Context, Poll};
+use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -449,6 +450,8 @@ impl UnixDatagram {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
+    /// Tokio's handling of blocking sockets may change in the future.
+    /// 
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///
     /// # Panics
@@ -484,6 +487,8 @@ impl UnixDatagram {
     /// ```
     #[track_caller]
     pub fn from_std(datagram: net::UnixDatagram) -> io::Result<UnixDatagram> {
+        check_socket_for_blocking(&datagram)?;
+
         let socket = mio::net::UnixDatagram::from_std(datagram);
         let io = PollEvented::new(socket)?;
         Ok(UnixDatagram { io })

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -450,7 +450,7 @@ impl UnixDatagram {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -450,7 +450,9 @@ impl UnixDatagram {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixDatagram::set_nonblocking
     ///

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -1,7 +1,7 @@
 use crate::io::{Interest, PollEvented};
 use crate::net::unix::{SocketAddr, UnixStream};
+use crate::util::check_socket_for_blocking;
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 #[cfg(target_os = "android")]
@@ -107,7 +107,7 @@ impl UnixListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking
     ///

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -107,7 +107,9 @@ impl UnixListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking
     ///

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -1,6 +1,7 @@
 use crate::io::{Interest, PollEvented};
 use crate::net::unix::{SocketAddr, UnixStream};
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::io;
 #[cfg(target_os = "android")]
@@ -13,7 +14,6 @@ use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
 use std::path::Path;
 use std::task::{ready, Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_net_unix! {
     /// A Unix socket which can accept connections from other Unix sockets.
@@ -137,7 +137,7 @@ impl UnixListener {
     #[track_caller]
     pub fn from_std(listener: net::UnixListener) -> io::Result<UnixListener> {
         check_socket_for_blocking(&listener)?;
-        
+
         let listener = mio::net::UnixListener::from_std(listener);
         let io = PollEvented::new(listener)?;
         Ok(UnixListener { io })

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -107,7 +107,7 @@ impl UnixListener {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixListener::set_nonblocking
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -792,7 +792,9 @@ impl UnixStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous,
+    /// and the behavior in that case may change in the future.
+    /// For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -4,6 +4,7 @@ use crate::net::unix::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};
 use crate::net::unix::ucred::{self, UCred};
 use crate::net::unix::SocketAddr;
 
+use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::future::poll_fn;
 use std::io::{self, Read, Write};
@@ -19,7 +20,6 @@ use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -822,7 +822,7 @@ impl UnixStream {
     #[track_caller]
     pub fn from_std(stream: net::UnixStream) -> io::Result<UnixStream> {
         check_socket_for_blocking(&stream)?;
-        
+
         let stream = mio::net::UnixStream::from_std(stream);
         let io = PollEvented::new(stream)?;
 

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -792,7 +792,7 @@ impl UnixStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
+    /// Passing a listener in blocking mode is always erroneous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -3,8 +3,8 @@ use crate::net::unix::split::{split, ReadHalf, WriteHalf};
 use crate::net::unix::split_owned::{split_owned, OwnedReadHalf, OwnedWriteHalf};
 use crate::net::unix::ucred::{self, UCred};
 use crate::net::unix::SocketAddr;
+use crate::util::check_socket_for_blocking;
 
-use crate::util::blocking_check::check_socket_for_blocking;
 use std::fmt;
 use std::future::poll_fn;
 use std::io::{self, Read, Write};
@@ -792,7 +792,7 @@ impl UnixStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
-    /// Tokio's handling of blocking sockets may change in the future.
+    /// Passing a listener in blocking mode is always errornous, and the behavior in that case may change in the future. For example, it could panic.
     ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -19,6 +19,7 @@ use std::os::unix::net::{self, SocketAddr as StdSocketAddr};
 use std::path::Path;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use crate::util::blocking_check::check_socket_for_blocking;
 
 cfg_io_util! {
     use bytes::BufMut;
@@ -791,6 +792,8 @@ impl UnixStream {
     /// will block the thread, which will cause unexpected behavior.
     /// Non-blocking mode can be set using [`set_nonblocking`].
     ///
+    /// Tokio's handling of blocking sockets may change in the future.
+    ///
     /// [`set_nonblocking`]: std::os::unix::net::UnixStream::set_nonblocking
     ///
     /// # Examples
@@ -818,6 +821,8 @@ impl UnixStream {
     /// explicitly with [`Runtime::enter`](crate::runtime::Runtime::enter) function.
     #[track_caller]
     pub fn from_std(stream: net::UnixStream) -> io::Result<UnixStream> {
+        check_socket_for_blocking(&stream)?;
+        
         let stream = mio::net::UnixStream::from_std(stream);
         let io = PollEvented::new(stream)?;
 

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -1,7 +1,26 @@
+#[cfg(unix)]
 use std::os::fd::AsFd;
+#[cfg(windows)]
+use std::os::windows::io::AsHandle;
 
+#[cfg(unix)]
 #[allow(unused_variables)]
 pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()> {
+    #[cfg(debug_assertions)]
+    {
+        let sock = socket2::SockRef::from(s);
+
+        if !sock.nonblocking()? {
+            eprintln!("Warning: binding a nonblocking socket, this may be a bug!");
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+#[allow(unused_variables)]
+pub(crate) fn check_socket_for_blocking<S: AsHandle>(s: &S) -> crate::io::Result<()> {
     #[cfg(debug_assertions)]
     {
         let sock = socket2::SockRef::from(s);

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -21,14 +21,6 @@ pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()>
 #[cfg(windows)]
 #[allow(unused_variables)]
 pub(crate) fn check_socket_for_blocking<S: AsSocket>(s: &S) -> crate::io::Result<()> {
-    #[cfg(debug_assertions)]
-    {
-        let sock = socket2::SockRef::from(s);
-
-        if !sock.nonblocking()? {
-            eprintln!("Warning: binding a nonblocking socket, this may be a bug!");
-        }
-    }
-
+    // we cannot retrieve the nonblocking status on windows
     Ok(())
 }

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -1,7 +1,7 @@
 #[cfg(unix)]
 use std::os::fd::AsFd;
 #[cfg(windows)]
-use std::os::windows::io::AsHandle;
+use std::os::windows::io::AsSocket;
 
 #[cfg(unix)]
 #[allow(unused_variables)]
@@ -20,7 +20,7 @@ pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()>
 
 #[cfg(windows)]
 #[allow(unused_variables)]
-pub(crate) fn check_socket_for_blocking<S: AsHandle>(s: &S) -> crate::io::Result<()> {
+pub(crate) fn check_socket_for_blocking<S: AsSocket>(s: &S) -> crate::io::Result<()> {
     #[cfg(debug_assertions)]
     {
         let sock = socket2::SockRef::from(s);

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -13,7 +13,7 @@ pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()>
             sock.nonblocking()?,
             "Registering a blocking socket with the tokio runtime is unsupported. \
             If you wish to do anyways, please add `--cfg tokio_allow_from_blocking_fd` to your \
-            RUSTFLAGS. See 7172 for more details."
+            RUSTFLAGS. See github.com/tokio-rs/tokio/issues/7172 for details."
         );
     }
 

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -1,0 +1,15 @@
+use std::os::fd::AsFd;
+
+#[allow(unused_variables)]
+pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()> {
+    #[cfg(debug_assertions)]
+    {
+        let sock = socket2::SockRef::from(s);
+
+        if !sock.nonblocking()? {
+            eprintln!("Warning: binding a nonblocking socket, this may be a bug!");
+        }
+    }
+
+    Ok(())
+}

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -9,7 +9,7 @@ pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()>
         let sock = socket2::SockRef::from(s);
 
         if !sock.nonblocking()? {
-            eprintln!("Warning: binding a nonblocking socket, this may be a bug!");
+            eprintln!("Warning: registering a blocking socket, this may be a bug!");
         }
     }
 

--- a/tokio/src/util/blocking_check.rs
+++ b/tokio/src/util/blocking_check.rs
@@ -1,7 +1,5 @@
 #[cfg(unix)]
 use std::os::fd::AsFd;
-#[cfg(windows)]
-use std::os::windows::io::AsSocket;
 
 #[cfg(unix)]
 #[allow(unused_variables)]
@@ -18,9 +16,10 @@ pub(crate) fn check_socket_for_blocking<S: AsFd>(s: &S) -> crate::io::Result<()>
     Ok(())
 }
 
-#[cfg(windows)]
+#[cfg(not(unix))]
 #[allow(unused_variables)]
-pub(crate) fn check_socket_for_blocking<S: AsSocket>(s: &S) -> crate::io::Result<()> {
+pub(crate) fn check_socket_for_blocking<S>(s: &S) -> crate::io::Result<()> {
     // we cannot retrieve the nonblocking status on windows
+    // and i dont know how to support wasi yet
     Ok(())
 }

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -5,6 +5,11 @@ cfg_io_driver! {
 #[cfg(feature = "rt")]
 pub(crate) mod atomic_cell;
 
+#[cfg(feature = "net")]
+mod blocking_check;
+#[cfg(feature = "net")]
+pub(crate) use blocking_check::check_socket_for_blocking;
+
 pub(crate) mod metric_atomics;
 
 #[cfg(any(feature = "rt", feature = "signal", feature = "process"))]
@@ -53,11 +58,6 @@ cfg_rt! {
 
 #[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
 pub(crate) mod rand;
-
-cfg_net! {
-    mod blocking_check;
-    pub(crate) use blocking_check::check_socket_for_blocking;
-}
 
 cfg_rt! {
     mod idle_notified_set;

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -10,9 +10,6 @@ pub(crate) mod metric_atomics;
 #[cfg(any(feature = "rt", feature = "signal", feature = "process"))]
 pub(crate) mod once_cell;
 
-#[cfg(feature = "net")]
-pub(crate) mod blocking_check;
-
 #[cfg(any(
     // io driver uses `WakeList` directly
     feature = "net",
@@ -56,6 +53,11 @@ cfg_rt! {
 
 #[cfg(any(feature = "rt", feature = "macros", feature = "time"))]
 pub(crate) mod rand;
+
+cfg_net! {
+    mod blocking_check;
+    pub(crate) use blocking_check::check_socket_for_blocking;
+}
 
 cfg_rt! {
     mod idle_notified_set;

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -10,6 +10,9 @@ pub(crate) mod metric_atomics;
 #[cfg(any(feature = "rt", feature = "signal", feature = "process"))]
 pub(crate) mod once_cell;
 
+#[cfg(feature = "net")]
+pub(crate) mod blocking_check;
+
 #[cfg(any(
     // io driver uses `WakeList` directly
     feature = "net",

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod atomic_cell;
 #[cfg(feature = "net")]
 mod blocking_check;
 #[cfg(feature = "net")]
+#[allow(unused_imports)]
 pub(crate) use blocking_check::check_socket_for_blocking;
 
 pub(crate) mod metric_atomics;

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -96,7 +96,10 @@ fn panics_when_io_disabled() {
     let rt = runtime::Builder::new_current_thread().build().unwrap();
 
     rt.block_on(async {
-        let _ =
-            tokio::net::TcpListener::from_std(std::net::TcpListener::bind("127.0.0.1:0").unwrap());
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+        listener.set_nonblocking(true).unwrap();
+
+        let _ = tokio::net::TcpListener::from_std(listener);
     });
 }

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -13,6 +13,9 @@ fn tcp_doesnt_block() {
     let listener = {
         let _enter = rt.enter();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+        listener.set_nonblocking(true).unwrap();
+
         TcpListener::from_std(listener).unwrap()
     };
 
@@ -33,6 +36,9 @@ fn drop_wakes() {
     let listener = {
         let _enter = rt.enter();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+        listener.set_nonblocking(true).unwrap();
+
         TcpListener::from_std(listener).unwrap()
     };
 

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -39,5 +39,7 @@ async fn timeout_value() {
 )]
 #[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn io_panics_when_no_tokio_context() {
-    let _ = tokio::net::TcpListener::from_std(std::net::TcpListener::bind("127.0.0.1:0").unwrap());
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+    let _ = tokio::net::TcpListener::from_std(listener);
 }

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -41,5 +41,7 @@ async fn timeout_value() {
 fn io_panics_when_no_tokio_context() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
 
+    listener.set_nonblocking(true).unwrap();
+
     let _ = tokio::net::TcpListener::from_std(listener);
 }

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -13,6 +13,9 @@ use std::{io::Write, net};
 #[tokio::test]
 async fn peek() {
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+    listener.set_nonblocking(true).unwrap();
+
     let addr = listener.local_addr().unwrap();
     let t = thread::spawn(move || assert_ok!(listener.accept()).0);
 

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -14,8 +14,6 @@ use std::{io::Write, net};
 async fn peek() {
     let listener = net::TcpListener::bind("127.0.0.1:0").unwrap();
 
-    listener.set_nonblocking(true).unwrap();
-
     let addr = listener.local_addr().unwrap();
     let t = thread::spawn(move || assert_ok!(listener.accept()).0);
 

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -24,6 +24,9 @@ async fn peek() {
     left.set_nonblocking(true).unwrap();
 
     let mut right = t.join().unwrap();
+
+    right.set_nonblocking(true).unwrap();
+
     let _ = right.write(&[1, 2, 3, 4]).unwrap();
 
     let mut left: TcpStream = left.try_into().unwrap();

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -20,6 +20,9 @@ async fn peek() {
     let t = thread::spawn(move || assert_ok!(listener.accept()).0);
 
     let left = net::TcpStream::connect(addr).unwrap();
+
+    left.set_nonblocking(true).unwrap();
+
     let mut right = t.join().unwrap();
     let _ = right.write(&[1, 2, 3, 4]).unwrap();
 


### PR DESCRIPTION
See #5595 and #7172.

This adds a debug assertion that checks that a supplied underlying std socket is set to nonblocking mode when constructing a tokio socket object from such an object.

This only works on unix.