### PR TITLE
docs(io): swap reader/writer in simplex doc test

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -197,8 +197,8 @@ impl Drop for DuplexStream {
 /// ```
 /// # async fn ex() -> std::io::Result<()> {
 /// # use tokio::io::{AsyncReadExt, AsyncWriteExt};
-/// let (writer, reader) = tokio::io::simplex(64);
-/// let mut simplex_stream = writer.unsplit(reader);
+/// let (reader, writer) = tokio::io::simplex(64);
+/// let mut simplex_stream = reader.unsplit(writer);
 /// simplex_stream.write_all(b"hello").await?;
 ///
 /// let mut buf = [0u8; 5];


### PR DESCRIPTION
Swap the `reader` and `writer` in the `simplex` documentation test to match the API.

Fixes: #7175

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Fixes the [doctest for simplex](https://github.com/tokio-rs/tokio/blob/master/tokio/src/io/util/mem.rs#L185-L209) as discussed in #7175 i.e. the `reader` and `writer` being swapped.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Simple fix for this one - just swap the variables names to match their type in the destructuring.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
