### PR TITLE
io: mandate stdio operations

### DIFF
--- a/tokio/src/blocking.rs
+++ b/tokio/src/blocking.rs
@@ -1,7 +1,7 @@
 cfg_rt! {
     pub(crate) use crate::runtime::spawn_blocking;
 
-    cfg_fs! {
+    cfg_io_blocking! {
         #[allow(unused_imports)]
         pub(crate) use crate::runtime::spawn_mandatory_blocking;
     }
@@ -24,7 +24,7 @@ cfg_not_rt! {
         panic!("requires the `rt` Tokio feature flag")
     }
 
-    cfg_fs! {
+    cfg_io_blocking! {
         pub(crate) fn spawn_mandatory_blocking<F, R>(_f: F) -> Option<JoinHandle<R>>
         where
             F: FnOnce() -> R + Send + 'static,

--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -289,7 +289,7 @@ cfg_io_blocking! {
     /// Types in this module can be mocked out in tests.
     mod sys {
         // TODO: don't rename
-        pub(crate) use crate::blocking::spawn_blocking as run;
+        pub(crate) use crate::blocking::spawn_mandatory_blocking as run;
         pub(crate) use crate::blocking::JoinHandle as Blocking;
     }
 }

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -185,7 +185,7 @@ where
     rt.spawn_blocking(func)
 }
 
-cfg_fs! {
+cfg_io_blocking! {
     #[cfg_attr(any(
         all(loom, not(test)), // the function is covered by loom tests
         test
@@ -327,7 +327,7 @@ impl Spawner {
         }
     }
 
-    cfg_fs! {
+    cfg_io_blocking! {
         #[track_caller]
         #[cfg_attr(any(
             all(loom, not(test)), // the function is covered by loom tests


### PR DESCRIPTION
Previously stdio operations were not mandatory to run, so these operations could be shutdown even if they were scheduled before runtime shutdown. This PR replaces the use of `spawn_blocking` with `spawn_mandatory_blocking` in order to mandate the execution of stdio operations.

Resolves #7174.