### PR TITLE
Consistently use worker_threads instead of core_threads

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1640,13 +1640,13 @@ cfg_rt_multi_thread! {
             use crate::runtime::{Config, runtime::Scheduler};
             use crate::runtime::scheduler::{self, MultiThread};
 
-            let core_threads = self.worker_threads.unwrap_or_else(num_cpus);
+            let worker_threads = self.worker_threads.unwrap_or_else(num_cpus);
 
-            let (driver, driver_handle) = driver::Driver::new(self.get_cfg(core_threads))?;
+            let (driver, driver_handle) = driver::Driver::new(self.get_cfg(worker_threads))?;
 
             // Create the blocking pool
             let blocking_pool =
-                blocking::create_blocking_pool(self, self.max_blocking_threads + core_threads);
+                blocking::create_blocking_pool(self, self.max_blocking_threads + worker_threads);
             let blocking_spawner = blocking_pool.spawner().clone();
 
             // Generate a rng seed for this runtime.
@@ -1654,7 +1654,7 @@ cfg_rt_multi_thread! {
             let seed_generator_2 = self.seed_generator.next_generator();
 
             let (scheduler, handle, launch) = MultiThread::new(
-                core_threads,
+                worker_threads,
                 driver,
                 driver_handle,
                 blocking_spawner,
@@ -1694,12 +1694,12 @@ cfg_rt_multi_thread! {
                 use crate::runtime::{Config, runtime::Scheduler};
                 use crate::runtime::scheduler::MultiThreadAlt;
 
-                let core_threads = self.worker_threads.unwrap_or_else(num_cpus);
-                let (driver, driver_handle) = driver::Driver::new(self.get_cfg(core_threads))?;
+                let worker_threads = self.worker_threads.unwrap_or_else(num_cpus);
+                let (driver, driver_handle) = driver::Driver::new(self.get_cfg(worker_threads))?;
 
                 // Create the blocking pool
                 let blocking_pool =
-                    blocking::create_blocking_pool(self, self.max_blocking_threads + core_threads);
+                    blocking::create_blocking_pool(self, self.max_blocking_threads + worker_threads);
                 let blocking_spawner = blocking_pool.spawner().clone();
 
                 // Generate a rng seed for this runtime.
@@ -1707,7 +1707,7 @@ cfg_rt_multi_thread! {
                 let seed_generator_2 = self.seed_generator.next_generator();
 
                 let (scheduler, handle) = MultiThreadAlt::new(
-                    core_threads,
+                    worker_threads,
                     driver,
                     driver_handle,
                     blocking_spawner,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The builder parameter `core_threads` was renamed to `worker_threads` but it wasn't consistently renamed inside the code, what might be confusing.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Renamed `core_threads` local variables to `worker_threads` in `builder.rs`. 
