### PR TITLE
tokio/interval: Fix overflow for interval tick

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -340,10 +340,12 @@ impl MissedTickBehavior {
     /// If a tick is missed, this method is called to determine when the next tick should happen.
     fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
         match self {
-            Self::Burst => timeout + period,
-            Self::Delay => now + period,
+            Self::Burst => timeout
+                .checked_add(period)
+                .unwrap_or_else(Instant::far_future),
+            Self::Delay => now.checked_add(period).unwrap_or_else(Instant::far_future),
             Self::Skip => {
-                now + period
+                now.checked_add(period).unwrap_or_else(Instant::far_future)
                     - Duration::from_nanos(
                         ((now - timeout).as_nanos() % period.as_nanos())
                             .try_into()

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -475,7 +475,12 @@ impl Interval {
         // However, if a tick took excessively long and we are now behind,
         // schedule the next tick according to how the user specified with
         // `MissedTickBehavior`
-        let next = if now > timeout + Duration::from_millis(5) {
+
+        let next = if now
+            > timeout
+                .checked_add(Duration::from_millis(5))
+                .unwrap_or_else(Instant::far_future)
+        {
             self.missed_tick_behavior
                 .next_timeout(timeout, now, self.period)
         } else {

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -476,11 +476,7 @@ impl Interval {
         // schedule the next tick according to how the user specified with
         // `MissedTickBehavior`
 
-        let next = if now
-            > timeout
-                .checked_add(Duration::from_millis(5))
-                .unwrap_or_else(Instant::far_future)
-        {
+        let next = if now.saturating_duration_since(timeout) > Duration::from_millis(5) {
             self.missed_tick_behavior
                 .next_timeout(timeout, now, self.period)
         } else {


### PR DESCRIPTION
This PR fixes an overflow produced by the `Instant::poll_tick` function when called for an instant set with a period from `u64::MAX`. 

For example, timers initiated like the following would panic because there's no room to add the 5 ms duration:

```rust
let mut timer = tokio::time::interval(std::time::Duration::from_secs(u64::MAX));
```

cc https://github.com/paritytech/polkadot-sdk/pull/7793 