### PR TITLE
fs: avoid `contents` copy for `Vec<u8>`, `String`, `Bytes` write

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -94,6 +94,7 @@ pin-project-lite = "0.2.11"
 bytes = { version = "1.2.1", optional = true }
 mio = { version = "1.0.1", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
+unty = "0.0.3"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 socket2 = { version = "0.5.5", optional = true, features = ["all"] }

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -25,7 +25,7 @@ use std::{io, path::Path};
 /// ```
 pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Result<()> {
     let path = path.as_ref().to_owned();
-    let contents = contents.as_ref().to_owned();
+    let contents = crate::util::as_ref::upgrade(contents);
 
     asyncify(move || std::fs::write(path, contents)).await
 }

--- a/tokio/src/util/as_ref.rs
+++ b/tokio/src/util/as_ref.rs
@@ -1,0 +1,36 @@
+#[derive(Debug)]
+pub(crate) enum OwnedBuf {
+    Vec(Vec<u8>),
+    #[cfg(feature = "io-util")]
+    Bytes(bytes::Bytes),
+}
+
+impl AsRef<[u8]> for OwnedBuf {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Self::Vec(vec) => vec,
+            #[cfg(feature = "io-util")]
+            Self::Bytes(bytes) => bytes,
+        }
+    }
+}
+
+pub(crate) fn upgrade<B: AsRef<[u8]>>(buf: B) -> OwnedBuf {
+    let buf = match unsafe { unty::unty::<B, Vec<u8>>(buf) } {
+        Ok(vec) => return OwnedBuf::Vec(vec),
+        Err(original_buf) => original_buf,
+    };
+
+    let buf = match unsafe { unty::unty::<B, String>(buf) } {
+        Ok(string) => return OwnedBuf::Vec(string.into_bytes()),
+        Err(original_buf) => original_buf,
+    };
+
+    #[cfg(feature = "io-util")]
+    let buf = match unsafe { unty::unty::<B, bytes::Bytes>(buf) } {
+        Ok(bytes) => return OwnedBuf::Bytes(bytes),
+        Err(original_buf) => original_buf,
+    };
+
+    OwnedBuf::Vec(buf.as_ref().to_owned())
+}

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -2,6 +2,9 @@ cfg_io_driver! {
     pub(crate) mod bit;
 }
 
+#[cfg(feature = "fs")]
+pub(crate) mod as_ref;
+
 #[cfg(feature = "rt")]
 pub(crate) mod atomic_cell;
 


### PR DESCRIPTION
## Motivation

As discovered by #7183 `tokio::fs::write` always copies the whole buffer, even when it's not necessary (the buffer is `Send + 'static`).

## Solution

This issue could have been fixed if we had proper specialization, but without it and with references involved we can't directly use `Any` from std. However, the `bincode` folks made the [`unty`](https://docs.rs/unty/0.0.3/unty/) crate, which would at least allow us to do poor's man specialization (and not copy) for `Vec<u8>`, `String` and `Bytes`.

Compiler explorer shows good enough output and correct proper functioning https://rust.godbolt.org/z/ef5GaooxW.

---

I was too thinking about this idea when thinking of this problem and finding the `unty` crate. We should made an extra check to make sure our usage is always safe.
Before merging I can inline the `unty` sources into tokio.