### PR TITLE
ci: enable printing in multi thread loom tests

### DIFF
--- a/.github/workflows/loom.yml
+++ b/.github/workflows/loom.yml
@@ -91,7 +91,7 @@ jobs:
             toolchain: ${{ env.rust_stable }}
       - uses: Swatinem/rust-cache@v2
       - name: loom ${{ matrix.scope }}
-        run: cargo test --lib --release --features full -- $SCOPE
+        run: cargo test --lib --release --features full -- --nocapture $SCOPE
         working-directory: tokio
         env:
           SCOPE: ${{ matrix.scope }}
@@ -116,7 +116,7 @@ jobs:
             toolchain: ${{ env.rust_stable }}
       - uses: Swatinem/rust-cache@v2
       - name: loom ${{ matrix.scope }}
-        run: cargo test --lib --release --features full -- $SCOPE
+        run: cargo test --lib --release --features full -- --nocapture $SCOPE
         working-directory: tokio
         env:
           SCOPE: ${{ matrix.scope }}


### PR DESCRIPTION
Enable printing in multi-threaded loom tests, as [other tests do](https://github.com/tokio-rs/tokio/blob/e076d21f679a35ae2697165d46d111285d09e3b4/.github/workflows/loom.yml#L71).