### PR TITLE
test: remove unused dependencies

### DIFF
--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -19,9 +19,6 @@ categories = ["asynchronous", "development-tools::testing"]
 [dependencies]
 tokio = { version = "1.2.0", path = "../tokio", features = ["rt", "sync", "time", "test-util"] }
 tokio-stream = { version = "0.1.1", path = "../tokio-stream" }
-async-stream = "0.3.3"
-
-bytes = "1.0.0"
 futures-core = "0.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I think these dependencies are no longer used in `tokio-test`.