### PR TITLE
chore: prepare tokio-util v0.7.14

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,41 @@
+# 0.7.14 (March 12th, 2025)
+
+### Added
+
+- io: add `get_ref` and `get_mut` for `SyncIoBridge` ([#7128])
+- io: add `read_exact_arc` ([#7165])
+- sync: add `CancellationToken::run_until_cancelled_owned` ([#7081])
+
+### Changed
+
+- codec: optimize buffer reserve for `AnyDelimiterCodec::encode` ([#7188])
+- either: enable `Either` to use underlying `AsyncWrite` implementation ([#7025])
+
+### Fixed
+
+- codec: fix typo in API docs ([#7044])
+- util: fix example in `StreamReader` docs ([#7167])
+
+### Documented
+
+- io: add docs for `SyncIoBridge` with examples and alternatives ([#6815])
+
+### Internal
+
+- io: clean up buffer casts ([#7142])
+- task: run `spawn_pinned` tests with miri ([#7023])
+
+[#6815]: https://github.com/tokio-rs/tokio/pull/6815
+[#7023]: https://github.com/tokio-rs/tokio/pull/7023
+[#7025]: https://github.com/tokio-rs/tokio/pull/7025
+[#7044]: https://github.com/tokio-rs/tokio/pull/7044
+[#7081]: https://github.com/tokio-rs/tokio/pull/7081
+[#7128]: https://github.com/tokio-rs/tokio/pull/7128
+[#7142]: https://github.com/tokio-rs/tokio/pull/7142
+[#7165]: https://github.com/tokio-rs/tokio/pull/7165
+[#7167]: https://github.com/tokio-rs/tokio/pull/7167
+[#7188]: https://github.com/tokio-rs/tokio/pull/7188
+
 # 0.7.13 (December 4th, 2024)
 
 ### Fixed


### PR DESCRIPTION
# 0.7.14 (March 12th, 2025)

### Added

- io: add `get_ref` and `get_mut` for `SyncIoBridge` ([#7128])
- io: add `read_exact_arc` ([#7165])
- sync: add `CancellationToken::run_until_cancelled_owned` ([#7081])

### Changed

- codec: optimize buffer reserve for `AnyDelimiterCodec::encode` ([#7188])
- either: enable `Either` to use underlying `AsyncWrite` implementation ([#7025])

### Fixed

- codec: fix typo in API docs ([#7044])
- util: fix example in `StreamReader` docs ([#7167])

### Documented

- io: add docs for `SyncIoBridge` with examples and alternatives ([#6815])

### Internal

- io: clean up buffer casts ([#7142])
- task: run `spawn_pinned` tests with miri ([#7023])

[#6815]: https://github.com/tokio-rs/tokio/pull/6815
[#7023]: https://github.com/tokio-rs/tokio/pull/7023
[#7025]: https://github.com/tokio-rs/tokio/pull/7025
[#7044]: https://github.com/tokio-rs/tokio/pull/7044
[#7081]: https://github.com/tokio-rs/tokio/pull/7081
[#7128]: https://github.com/tokio-rs/tokio/pull/7128
[#7142]: https://github.com/tokio-rs/tokio/pull/7142
[#7165]: https://github.com/tokio-rs/tokio/pull/7165
[#7167]: https://github.com/tokio-rs/tokio/pull/7167
[#7188]: https://github.com/tokio-rs/tokio/pull/7188