### PR TITLE
chore: prepare Tokio v1.44.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.44.0", features = ["full"] }
+tokio = { version = "1.44.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- rt: skip defer queue in `block_in_place` context (#7216)
+- rt: skip defer queue in `block_in_place` context ([#7216])
 
 [#7216]: https://github.com/tokio-rs/tokio/pull/7216
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.44.1 (March 13th, 2025)
+
+### Fixed
+
+- rt: skip defer queue in `block_in_place` context (#7216)
+
+[#7216]: https://github.com/tokio-rs/tokio/pull/7216
+
 # 1.44.0 (March 7th, 2025)
 
 This release changes the `from_std` method on sockets to panic if a blocking

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.44.0"
+version = "1.44.1"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.44.0", features = ["full"] }
+tokio = { version = "1.44.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.44.1 (March 13th, 2025)

### Fixed

- rt: skip defer queue in `block_in_place` context ([#7216])

[#7216]: https://github.com/tokio-rs/tokio/pull/7216