### PR TITLE
util: explicitly state that TaskTracker does not abort tasks on Drop

### DIFF
--- a/tokio-util/src/task/task_tracker.rs
+++ b/tokio-util/src/task/task_tracker.rs
@@ -53,6 +53,9 @@ use tokio::{
 /// `TaskTracker`, this does not happen. Once tasks exit, they are immediately removed from the
 /// `TaskTracker`.
 ///
+/// Note that unlike [`JoinSet`], when a `TaskTracker` is dropped its tasks are not immediately
+/// aborted.
+///
 /// # Examples
 ///
 /// For more examples, please see the topic page on [graceful shutdown].

--- a/tokio-util/src/task/task_tracker.rs
+++ b/tokio-util/src/task/task_tracker.rs
@@ -53,8 +53,7 @@ use tokio::{
 /// `TaskTracker`, this does not happen. Once tasks exit, they are immediately removed from the
 /// `TaskTracker`.
 ///
-/// Note that unlike [`JoinSet`], when a `TaskTracker` is dropped its tasks are not immediately
-/// aborted.
+/// Note that unlike [`JoinSet`], dropping a `TaskTracker` does not abort the tasks.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Makes clear that TaskTracker doesn't abort its tasks on Drop

Fixes: #7222