### PR TITLE
Mark runtime::Handle as unwind-safe

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -443,6 +443,10 @@ impl Handle {
     }
 }
 
+impl std::panic::UnwindSafe for Handle {}
+
+impl std::panic::RefUnwindSafe for Handle {}
+
 cfg_taskdump! {
     impl Handle {
         /// Captures a snapshot of the runtime's state.


### PR DESCRIPTION
This type is used internally by the `Runtime`, which is already marked unwind-safe. This allows using types that contain one or more `Handle`s with the `catch_unwind` function without resorting to `AssertUnwindSafe`.

Related to #4657