### PR TITLE
Update the mockall dev dependency to 0.13.0

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -131,7 +131,7 @@ features = [
 tokio-test = { version = "0.4.0", path = "../tokio-test" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 futures = { version = "0.3.0", features = ["async-await"] }
-mockall = "0.11.1"
+mockall = "0.13.0"
 async-stream = "0.3"
 futures-concurrency = "7.6.3"
 

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -62,6 +62,13 @@ impl Read for MockFile {
 
 impl Read for &'_ MockFile {
     fn read(&mut self, dst: &mut [u8]) -> io::Result<usize> {
+        // Placate Miri.  Tokio will call this method with an uninitialized
+        // buffer, which is ok because std::io::Read::read implementations don't usually read
+        // from their input buffers.  But Mockall 0.12-0.13 will try to Debug::fmt the
+        // buffer, even if there is no failure, triggering an uninitialized data access alert from
+        // Miri.  Initialize the data here just to prevent those Miri alerts.
+        // This can be removed after upgrading to Mockall 0.14.
+        dst.fill(0);
         self.inner_read(dst)
     }
 }


### PR DESCRIPTION
This eliminates a duplicate dependency on syn

## Motivation

Building mockall-0.11 required tokio to build both syn-1 and syn-2

## Solution

Update the mockall dev dependency to the latest version.