### PR TITLE
Update mio-aio dev dependency to 1.0

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -147,7 +147,7 @@ rand = "0.8.0"
 wasm-bindgen-test = "0.3.0"
 
 [target.'cfg(target_os = "freebsd")'.dev-dependencies]
-mio-aio = { version = "0.9.0", features = ["tokio"] }
+mio-aio = { version = "1", features = ["tokio"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }


### PR DESCRIPTION
This eliminates a duplicate dependency on mio

## Motivation

To develop tokio without building two versions of mio

## Solution

Use the latest version of mio-aio