### PR TITLE
Merge 1.42.1 into 1.43.x

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -66,6 +66,20 @@ reporting the issue).
 [#7073]: https://github.com/tokio-rs/tokio/pull/7073
 [#7074]: https://github.com/tokio-rs/tokio/pull/7074
 
+# 1.42.1 (April 8th, 2025)
+
+This release fixes a soundness issue in the broadcast channel. The channel
+accepts values that are `Send` but `!Sync`. Previously, the channel called
+`clone()` on these values without synchronizing. This release fixes the channel
+by synchronizing calls to `.clone()` (Thanks Austin Bonander for finding and
+reporting the issue).
+
+### Fixed
+
+- sync: synchronize `clone()` call in broadcast channel ([#7232])
+
+[#7232]: https://github.com/tokio-rs/tokio/pull/7232
+
 # 1.42.0 (Dec 3rd, 2024)
 
 ### Added


### PR DESCRIPTION
This merges the history of tokio-1.42.x with the release of v1.42.1 into tokio-1.43.x.

This must be merged with the command-line, and must be merged after #7244.