### PR TITLE
Tokio 1.43.1 fix release date

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.43.1 (April 2nd, 2025)
+# 1.43.1 (April 5th, 2025)
 
 This release fixes a soundness issue in the broadcast channel. The channel
 accepts values that are `Send` but `!Sync`. Previously, the channel called


### PR DESCRIPTION
The release date is april 5th, not 2nd.

This must be merged with the command-line, and must be merged after https://github.com/tokio-rs/tokio/pull/7245.