### PR TITLE
(tokio-util JoinMap) Remove raw-entry feature in favour of HashTable API.

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -45,7 +45,7 @@ slab = { version = "0.4.4", optional = true } # Backs `DelayQueue`
 tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true }
 
 [target.'cfg(tokio_unstable)'.dependencies]
-hashbrown = { version = "0.15.0", default-features = false, features = ["raw-entry"], optional = true }
+hashbrown = { version = "0.15.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", path = "../tokio", features = ["full"] }

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -1,6 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(feature = "rt", tokio_unstable))]
 
+use std::panic::AssertUnwindSafe;
+
 use tokio::sync::oneshot;
 use tokio::time::Duration;
 use tokio_util::task::JoinMap;
@@ -340,6 +342,37 @@ async fn duplicate_keys2() {
     let (key, res) = map.join_next().await.unwrap();
     assert_eq!(key, 1);
     assert_eq!(res.unwrap(), 2);
+
+    assert!(map.join_next().await.is_none());
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::test]
+async fn duplicate_keys_drop() {
+    #[derive(Hash, Debug, PartialEq, Eq)]
+    struct Key;
+    impl Drop for Key {
+        fn drop(&mut self) {
+            panic!("drop called for key");
+        }
+    }
+
+    let (send, recv) = oneshot::channel::<()>();
+
+    let mut map = JoinMap::new();
+
+    map.spawn(Key, async { recv.await.unwrap() });
+
+    // replace the task, force it to drop the key and abort the task
+    // we should expect it to panic when dropping the key.
+    let _ = std::panic::catch_unwind(AssertUnwindSafe(|| map.spawn(Key, async {}))).unwrap_err();
+
+    // don't panic when this key drops.
+    let (key, _) = map.join_next().await.unwrap();
+    std::mem::forget(key);
+
+    // original task should have been aborted, so the sender should be dangling.
+    assert!(send.is_closed());
 
     assert!(map.join_next().await.is_none());
 }

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -346,7 +346,7 @@ async fn duplicate_keys2() {
     assert!(map.join_next().await.is_none());
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg_attr(not(panic = "unwind"), ignore)]
 #[tokio::test]
 async fn duplicate_keys_drop() {
     #[derive(Hash, Debug, PartialEq, Eq)]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

While rebasing #7075, I noticed the change from #7219 which updates hashbrown, requiring the addition of the `raw-entry` feature. That inspired me to take a look at the actual JoinMap impl and I thought it could be improved by using `HashTable` instead.

## Solution

Replacing the `tasks_by_key` map with a `HashTable`, we unlock a few benefits:
1. When searching by ID, we don't need to store the id in `tasks_by_key`, since we can fetch the ID from the `AbortHandle`.
2. We don't need to duplicate the `S: BuildHasher`, as we are in-control over the hash-function, we can fetch the existing hasher from `hashes_by_task`.

However, removing the ID from `tasks_by_key` will slow down those lookups (only in `join_next()`), as they now need a vtable lookup, rather than comparing against the id already in the current cache line.

---

I don't feel strongly about this PR, I'm just quite fond of the HashTable API and thought I'd try it here.