### PR TITLE
feat: Add find method to StreamExt

### DIFF
--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -834,7 +834,7 @@ pub trait StreamExt: Stream {
     ///
     /// Basic usage:
     ///
-    /// ```
+    /// ```rust
     /// # #[tokio::main]
     /// # async fn main() {
     /// use tokio_stream::{self as stream, StreamExt};
@@ -850,9 +850,27 @@ pub trait StreamExt: Stream {
     ///     .await;
     /// assert!(result.is_some());
     /// assert_eq!(Some(&2), result)
-    ///
     /// # }
     /// ```
+    ///
+    /// When it can't find, it returns `None`
+    ///
+    /// /// ```rust
+    /// # #[tokio::main]
+    /// # async fn main() {
+    /// use tokio_stream::{self as stream, StreamExt};
+    ///
+    /// let a = [1, 2, 3];
+    /// let result = stream::iter(&a)
+    ///     .find(|x| {
+    ///         if x > &3 {
+    ///             return Some(x);
+    ///         }
+    ///         return None;
+    ///     })
+    ///     .await;
+    /// assert!(result.is_none());
+    /// # }
     /// ```
     fn find<F>(&mut self, f: F) -> FindFuture<'_, Self, F>
     where

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -833,7 +833,6 @@ pub trait StreamExt: Stream {
     /// An empty stream returns `None`.
     ///
     /// Basic usage:
-    ///
     /// ```rust
     /// # #[tokio::main]
     /// # async fn main() {
@@ -854,8 +853,7 @@ pub trait StreamExt: Stream {
     /// ```
     ///
     /// When it can't find, it returns `None`
-    ///
-    /// /// ```rust
+    /// ```rust
     /// # #[tokio::main]
     /// # async fn main() {
     /// use tokio_stream::{self as stream, StreamExt};

--- a/tokio-stream/src/stream_ext.rs
+++ b/tokio-stream/src/stream_ext.rs
@@ -849,7 +849,7 @@ pub trait StreamExt: Stream {
     ///     })
     ///     .await;
     /// assert!(result.is_some());
-    /// assert_eq!(Some(&3), result)
+    /// assert_eq!(Some(&2), result)
     ///
     /// # }
     /// ```

--- a/tokio-stream/src/stream_ext/find.rs
+++ b/tokio-stream/src/stream_ext/find.rs
@@ -1,0 +1,54 @@
+use crate::Stream;
+
+use core::future::Future;
+use core::marker::PhantomPinned;
+use core::pin::Pin;
+use core::task::{ready, Context, Poll};
+use pin_project_lite::pin_project;
+
+pin_project! {
+    /// Future for the [`find`](super::StreamExt::find) method.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct FindFuture<'a, St: ?Sized, F> {
+        stream: &'a mut St,
+        f: F,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+impl<'a, St: ?Sized, F> FindFuture<'a, St, F> {
+    pub(super) fn new(stream: &'a mut St, f: F) -> Self {
+        Self {
+            stream,
+            f,
+            _pin: PhantomPinned,
+        }
+    }
+}
+
+impl<St, F> Future for FindFuture<'_, St, F>
+where
+    St: ?Sized + Stream + Unpin,
+    F: FnMut(St::Item) -> Option<St::Item>,
+{
+    type Output = Option<St::Item>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
+        let me = self.project();
+        let mut stream = Pin::new(me.stream);
+
+        loop {
+            match ready!(stream.as_mut().poll_next(cx)) {
+                Some(v) => {
+                    if let Some(v) = (me.f)(v) {
+                        return Poll::Ready(Some(v));
+                    }
+                }
+                None => return Poll::Ready(None),
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Add `find` method to `StreamExt` in order to be feature comparable to iterators as described in #7255 .

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

`find` implementation based on `any` and `filter` implementations.
