### PR TITLE
fix #7257 by ignoring tasks with missing map keys

### DIFF
--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -297,3 +297,16 @@ async fn abort_all() {
         assert!(was_seen);
     }
 }
+
+#[tokio::test]
+async fn duplicate_keys() {
+    let mut map = JoinMap::new();
+    map.spawn(1, async { 1 });
+    map.spawn(1, async { 2 });
+
+    assert_eq!(map.len(), 1);
+
+    let (key, res) = map.join_next().await.unwrap();
+    assert_eq!(key, 1);
+    assert_eq!(res.unwrap(), 2);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

#7257. Duplicate map keys abort the original task, but no special handling was taken during `join_next`, such that these aborted tasks would return `None`, even though the join map wasn't empty.

## Solution

Loop if the task ID is not being tracked in this `JoinMap`.
