### PR TITLE
Correctly handle duplicate keys in JoinMap

### DIFF
--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -133,6 +133,24 @@ async fn test_keys() {
     assert!(keys.is_empty());
 }
 
+#[tokio::test]
+async fn test_duplicated_keys() {
+    let mut map = JoinMap::new();
+    map.spawn("1", async { 1 });
+    map.spawn("2", async { 2 });
+    map.spawn("1", async { 11 });
+    map.spawn("3", async { 3 });
+
+    let (key, res) = map.join_next().await.unwrap();
+    assert_eq!((key, res.unwrap()), ("2", 2));
+
+    let (key, res) = map.join_next().await.unwrap();
+    assert_eq!((key, res.unwrap()), ("1", 11));
+
+    let (key, res) = map.join_next().await.unwrap();
+    assert_eq!((key, res.unwrap()), ("3", 3));
+}
+
 #[tokio::test(start_paused = true)]
 async fn abort_by_key() {
     let mut map = JoinMap::new();


### PR DESCRIPTION
## Motivation

This PR fixes an issue with how duplicate keys are handled when spawned on a `JoinMap`. See https://github.com/tokio-rs/tokio/issues/7257 for more details.

## Solution

In prior implementations, duplicate tasks were removed from both `self.hashes_by_task` and `self.tasks_by_key` respectively, but not from `self.tasks`. This resulted in a case where `None` was returned when trying to find metadata about the task from the underlying key->handle mapping. This PR ensures that if no map entry for the task was found, it's safe to assume that the just-resolved task from the `JoinSet` is a duplicate that got replaced for the new. 

The decision to go this direction in contrast to evicting from the `JoinSet` in `.spawn*(..)` is due to the limitation of `IdleNotifiedSet`, which is backed by a linked list. So searching would be considerably less efficient compared to evicting in `.join_next(..)`.

Fixes #7257