### PR TITLE
docs: Improved docs & examples for ` tokio_util::compat`

### DIFF
--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -17,7 +17,7 @@
 //!
 //! | Inner Type Implements...                                                                 | `Compat<T>` Implements...                                                           |
 //! |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-//! | [`tokio::io::AsyncRead`])     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
+//! | [`tokio::io::AsyncRead`]     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
 //! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`]     |
 //! | [`tokio::io::AsyncWrite`]   | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
 //! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`]   |
@@ -99,8 +99,8 @@
 //! - [`Compat`] type
 //! - [`TokioAsyncReadCompatExt`]
 //! - [`FuturesAsyncReadCompatExt`]
-//! - [`tokio::io` module](https://docs.rs/tokio/latest/tokio/io/)
-//! - [`futures::io` module](https://docs.rs/futures/latest/futures/io/)
+//! - [`tokio::io`]
+//! - [`futures::io`](https://docs.rs/futures/latest/futures/io/)
 
 use pin_project_lite::pin_project;
 use std::io;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,3 +1,5 @@
+//! Compatibility between the `tokio::io` and `futures-io` versions of the
+//! `AsyncRead` and `AsyncWrite` traits.
 //! ## Bridging Tokio and Futures I/O with `compat()`
 //!
 //! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,23 +1,24 @@
-//! Compatibility between the `tokio::io` and `futures-io` versions of the
-//! `AsyncRead` and `AsyncWrite` traits.
-
 //! ## Bridging Tokio and Futures I/O with `compat()`
 //!
 //! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
 //! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
-//! to be used as their [`futures::io::AsyncRead`] or [`futures::io::AsyncWrite`] counterparts — and vice versa.
+//! to be used as their
+//! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
+//! or
+//! [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html)
+//! counterparts — and vice versa.
 //!
 //! This is especially useful when working with libraries that expect I/O types from one ecosystem
 //! (usually `futures`) but you’re using types from the other (usually `tokio`).
 //!
 //! ## Compatibility Overview
 //!
-//! | If the inner type implements...       | Then `Compat<T>` implements...            |
-//! |--------------------------------------|-------------------------------------------|
-//! | [`tokio::io::AsyncRead`]             | [`futures::io::AsyncRead`]                |
-//! | [`futures::io::AsyncRead`]           | [`tokio::io::AsyncRead`]                  |
-//! | [`tokio::io::AsyncWrite`]            | [`futures::io::AsyncWrite`]               |
-//! | [`futures::io::AsyncWrite`]          | [`tokio::io::AsyncWrite`]                 |
+//! | If the inner type implements...                                     | Then `Compat<T>` implements...                          |
+//! |----------------------------------------------------------------------|----------------------------------------------------------|
+//! | [`tokio::io::AsyncRead`]                                            | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
+//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`]                                 |
+//! | [`tokio::io::AsyncWrite`]                                           | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
+//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`]                                 |
 //!
 //! ## Feature Flag
 //!
@@ -30,7 +31,8 @@
 //! ## Example 1: Tokio → Futures (`AsyncRead`)
 //!
 //! This example demonstrates sending data over a [`tokio::net::TcpStream`] and using
-//! [`futures::io::AsyncReadExt::read`] to read it after adapting the stream via `compat()`.
+//! [`read`](https://docs.rs/futures/latest/futures/io/trait.AsyncReadExt.html#method.read)
+//! from the `futures` crate to read it after adapting the stream via `compat()`.
 //!
 //! ```no_run
 //! use tokio::net::{TcpListener, TcpStream};
@@ -61,22 +63,27 @@
 //!
 //! ## Example 2: Futures → Tokio (`AsyncRead`)
 //!
-//! The reverse is also possible: you can take a [`futures::io::AsyncRead`] (e.g. a cursor)
-//! and adapt it to be used with [`tokio::io::AsyncReadExt::read_to_end`].
+//! The reverse is also possible: you can take a
+//! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
+//! (e.g. a cursor) and adapt it to be used with
+//! [`tokio::io::AsyncReadExt::read_to_end`].
 //!
-//! ```no_run
+//! ```
 //! use futures::io::Cursor;
 //! use tokio_util::compat::FuturesAsyncReadCompatExt;
 //! use tokio::io::AsyncReadExt;
 //!
-//! #[tokio::main]
-//! async fn main() -> std::io::Result<()> {
-//!     let reader = Cursor::new(b"Hello from futures");
-//!     let mut compat_reader = reader.compat();
-//!     let mut buf = Vec::new();
-//!     compat_reader.read_to_end(&mut buf).await?;
-//!     println!("Received: {}", String::from_utf8_lossy(&buf));
-//!     Ok(())
+//! fn main() {
+//!     let future = async {
+//!         let reader = Cursor::new(b"Hello from futures");
+//!         let mut compat_reader = reader.compat();
+//!         let mut buf = Vec::new();
+//!         compat_reader.read_to_end(&mut buf).await.unwrap();
+//!         assert_eq!(&buf, b"Hello from futures");
+//!     };
+//!
+//!     // Run the future inside a Tokio runtime
+//!     tokio::runtime::Runtime::new().unwrap().block_on(future);
 //! }
 //! ```
 //!
@@ -88,11 +95,12 @@
 //!
 //! ## See Also
 //!
-//! - [`Compat`](Compat) type
-//! - [`TokioAsyncReadCompatExt`](TokioAsyncReadCompatExt)
-//! - [`FuturesAsyncReadCompatExt`](FuturesAsyncReadCompatExt)
-//! - [`tokio::io` module](tokio::io)
-//! - [`futures::io` module](futures::io)
+//! - [`Compat`] type
+//! - [`TokioAsyncReadCompatExt`]
+//! - [`FuturesAsyncReadCompatExt`]
+//! - [`tokio::io` module](https://docs.rs/tokio/latest/tokio/io/)
+//! - [`futures::io` module](https://docs.rs/futures/latest/futures/io/)
+
 
 use pin_project_lite::pin_project;
 use std::io;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,7 +1,7 @@
 //! ## Bridging Tokio and Futures I/O with `compat()`
 //!
 //! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
-//! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
+//! that allows types implementing [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) or [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)
 //! to be used as their
 //! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
 //! or
@@ -13,13 +13,12 @@
 //!
 //! ## Compatibility Overview
 //!
-//! | If the inner type implements...                                     | Then `Compat<T>` implements...                          |
-//! |----------------------------------------------------------------------|----------------------------------------------------------|
-//! | [`tokio::io::AsyncRead`]                                            | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
-//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`]                                 |
-//! | [`tokio::io::AsyncWrite`]                                           | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
-//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`]                                 |
-//!
+//! | Inner Type Implements...                                                                 | `Compat<T>` Implements...                                                           |
+//! |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+//! | [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html)     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
+//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html)     |
+//! | [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)   | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
+//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)   |
 //! ## Feature Flag
 //!
 //! This functionality is available through the `compat` feature flag:
@@ -66,7 +65,7 @@
 //! The reverse is also possible: you can take a
 //! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
 //! (e.g. a cursor) and adapt it to be used with
-//! [`tokio::io::AsyncReadExt::read_to_end`].
+//! [`tokio::io::AsyncReadExt::read_to_end`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_to_end).
 //!
 //! ```
 //! use futures::io::Cursor;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -9,7 +9,7 @@
 //! counterparts — and vice versa.
 //!
 //! This is especially useful when working with libraries that expect I/O types from one ecosystem
-//! (usually `futures`) but you’re using types from the other (usually `tokio`).
+//! (usually `futures`) but you are using types from the other (usually `tokio`).
 //!
 //! ## Compatibility Overview
 //!
@@ -28,7 +28,7 @@
 //! tokio-util = { version = "...", features = ["compat"] }
 //! ```
 //!
-//! ## Example 1: Tokio → Futures (`AsyncRead`)
+//! ## Example 1: Tokio -> Futures (`AsyncRead`)
 //!
 //! This example demonstrates sending data over a [`tokio::net::TcpStream`] and using
 //! [`read`](https://docs.rs/futures/latest/futures/io/trait.AsyncReadExt.html#method.read)
@@ -61,7 +61,7 @@
 //! }
 //! ```
 //!
-//! ## Example 2: Futures → Tokio (`AsyncRead`)
+//! ## Example 2: Futures -> Tokio (`AsyncRead`)
 //!
 //! The reverse is also possible: you can take a
 //! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -101,7 +101,6 @@
 //! - [`tokio::io` module](https://docs.rs/tokio/latest/tokio/io/)
 //! - [`futures::io` module](https://docs.rs/futures/latest/futures/io/)
 
-
 use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,26 +1,24 @@
 //! Compatibility between the `tokio::io` and `futures-io` versions of the
 //! `AsyncRead` and `AsyncWrite` traits.
+//!
 //! ## Bridging Tokio and Futures I/O with `compat()`
 //!
-//! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
-//! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
-//! to be used as their
-//! [`futures::io::AsyncRead`]
-//! or
-//! [`futures::io::AsyncWrite`]
-//! counterparts — and vice versa.
+//! The [`compat()`] function provides a compatibility layer that allows types implementing
+//! [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`] to be used as their
+//! [`futures::io::AsyncRead`] or [`futures::io::AsyncWrite`] counterparts — and vice versa.
 //!
 //! This is especially useful when working with libraries that expect I/O types from one ecosystem
 //! (usually `futures`) but you are using types from the other (usually `tokio`).
 //!
 //! ## Compatibility Overview
 //!
-//! | Inner Type Implements...                                                                 | `Compat<T>` Implements...                                                           |
-//! |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-//! | [`tokio::io::AsyncRead`]     | [`futures::io::AsyncRead`] |
-//! | [`futures::io::AsyncRead`] | [`tokio::io::AsyncRead`]     |
+//! | Inner Type Implements...    | `Compat<T>` Implements...   |
+//! |-----------------------------|-----------------------------|
+//! | [`tokio::io::AsyncRead`]    | [`futures::io::AsyncRead`]  |
+//! | [`futures::io::AsyncRead`]  | [`tokio::io::AsyncRead`]    |
 //! | [`tokio::io::AsyncWrite`]   | [`futures::io::AsyncWrite`] |
 //! | [`futures::io::AsyncWrite`] | [`tokio::io::AsyncWrite`]   |
+//!
 //! ## Feature Flag
 //!
 //! This functionality is available through the `compat` feature flag:
@@ -32,8 +30,8 @@
 //! ## Example 1: Tokio -> Futures (`AsyncRead`)
 //!
 //! This example demonstrates sending data over a [`tokio::net::TcpStream`] and using
-//! [`futures_util::io::AsyncReadExt::read`]
-//! from the `futures` crate to read it after adapting the stream via `compat()`.
+//! [`futures::io::AsyncReadExt::read`] from the `futures` crate to read it after adapting the
+//! stream via [`compat()`].
 //!
 //! ```no_run
 //! use tokio::net::{TcpListener, TcpStream};
@@ -64,10 +62,8 @@
 //!
 //! ## Example 2: Futures -> Tokio (`AsyncRead`)
 //!
-//! The reverse is also possible: you can take a
-//! [`futures::io::AsyncRead`]
-//! (e.g. a cursor) and adapt it to be used with
-//! [`tokio::io::AsyncReadExt::read_to_end`]
+//! The reverse is also possible: you can take a [`futures::io::AsyncRead`] (e.g. a cursor) and
+//! adapt it to be used with [`tokio::io::AsyncReadExt::read_to_end`]
 //!
 //! ```
 //! use futures::io::Cursor;
@@ -90,9 +86,10 @@
 //!
 //! ## Common Use Cases
 //!
-//! - Using `tokio` sockets with `async-tungstenite`, `async-compression`, or `futures-rs`-based libraries
-//! - Bridging I/O interfaces between mixed-ecosystem libraries
-//! - Avoiding rewrites or duplication of I/O code in async environments
+//! - Using `tokio` sockets with `async-tungstenite`, `async-compression`, or `futures-rs`-based
+//!   libraries.
+//! - Bridging I/O interfaces between mixed-ecosystem libraries.
+//! - Avoiding rewrites or duplication of I/O code in async environments.
 //!
 //! ## See Also
 //!
@@ -102,10 +99,11 @@
 //! - [`tokio::io`]
 //! - [`futures::io`]
 //!
-//! [`futures::io`]: (https://docs.rs/futures/latest/futures/io/)
+//! [`futures::io`]: https://docs.rs/futures/latest/futures/io/
 //! [`futures::io::AsyncRead`]: https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html
 //! [`futures::io::AsyncWrite`]: https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html
-//! [`futures_util::io::AsyncReadExt::read`]: (https://docs.rs/futures-util/latest/futures_util/io/trait.AsyncReadExt.html#method.read)
+//! [`futures::io::AsyncReadExt::read`]: https://docs.rs/futures/latest/futures/io/trait.AsyncReadExt.html#method.read
+//! [`compat()`]: TokioAsyncReadCompatExt::compat
 
 use pin_project_lite::pin_project;
 use std::io;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -1,5 +1,99 @@
 //! Compatibility between the `tokio::io` and `futures-io` versions of the
 //! `AsyncRead` and `AsyncWrite` traits.
+
+//! ## Bridging Tokio and Futures I/O with `compat()`
+//!
+//! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
+//! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
+//! to be used as their [`futures::io::AsyncRead`] or [`futures::io::AsyncWrite`] counterparts — and vice versa.
+//!
+//! This is especially useful when working with libraries that expect I/O types from one ecosystem
+//! (usually `futures`) but you’re using types from the other (usually `tokio`).
+//!
+//! ## Compatibility Overview
+//!
+//! | If the inner type implements...       | Then `Compat<T>` implements...            |
+//! |--------------------------------------|-------------------------------------------|
+//! | [`tokio::io::AsyncRead`]             | [`futures::io::AsyncRead`]                |
+//! | [`futures::io::AsyncRead`]           | [`tokio::io::AsyncRead`]                  |
+//! | [`tokio::io::AsyncWrite`]            | [`futures::io::AsyncWrite`]               |
+//! | [`futures::io::AsyncWrite`]          | [`tokio::io::AsyncWrite`]                 |
+//!
+//! ## Feature Flag
+//!
+//! This functionality is available through the `compat` feature flag:
+//!
+//! ```toml
+//! tokio-util = { version = "...", features = ["compat"] }
+//! ```
+//!
+//! ## Example 1: Tokio → Futures (`AsyncRead`)
+//!
+//! This example demonstrates sending data over a [`tokio::net::TcpStream`] and using
+//! [`futures::io::AsyncReadExt::read`] to read it after adapting the stream via `compat()`.
+//!
+//! ```no_run
+//! use tokio::net::{TcpListener, TcpStream};
+//! use tokio::io::AsyncWriteExt;
+//! use tokio_util::compat::TokioAsyncReadCompatExt;
+//! use futures::io::AsyncReadExt;
+//!
+//! #[tokio::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let listener = TcpListener::bind("127.0.0.1:8081").await?;
+//!
+//!     tokio::spawn(async {
+//!         let mut client = TcpStream::connect("127.0.0.1:8081").await.unwrap();
+//!         client.write_all(b"Hello World").await.unwrap();
+//!     });
+//!
+//!     let (stream, _) = listener.accept().await?;
+//!
+//!     // Adapt `tokio::TcpStream` to be used with `futures::io::AsyncReadExt`
+//!     let mut compat_stream = stream.compat();
+//!     let mut buffer = [0; 20];
+//!     let n = compat_stream.read(&mut buffer).await?;
+//!     println!("Received: {}", String::from_utf8_lossy(&buffer[..n]));
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Example 2: Futures → Tokio (`AsyncRead`)
+//!
+//! The reverse is also possible: you can take a [`futures::io::AsyncRead`] (e.g. a cursor)
+//! and adapt it to be used with [`tokio::io::AsyncReadExt::read_to_end`].
+//!
+//! ```no_run
+//! use futures::io::Cursor;
+//! use tokio_util::compat::FuturesAsyncReadCompatExt;
+//! use tokio::io::AsyncReadExt;
+//!
+//! #[tokio::main]
+//! async fn main() -> std::io::Result<()> {
+//!     let reader = Cursor::new(b"Hello from futures");
+//!     let mut compat_reader = reader.compat();
+//!     let mut buf = Vec::new();
+//!     compat_reader.read_to_end(&mut buf).await?;
+//!     println!("Received: {}", String::from_utf8_lossy(&buf));
+//!     Ok(())
+//! }
+//! ```
+//!
+//! ## Common Use Cases
+//!
+//! - Using `tokio` sockets with `async-tungstenite`, `async-compression`, or `futures-rs`-based libraries
+//! - Bridging I/O interfaces between mixed-ecosystem libraries
+//! - Avoiding rewrites or duplication of I/O code in async environments
+//!
+//! ## See Also
+//!
+//! - [`Compat`](Compat) type
+//! - [`TokioAsyncReadCompatExt`](TokioAsyncReadCompatExt)
+//! - [`FuturesAsyncReadCompatExt`](FuturesAsyncReadCompatExt)
+//! - [`tokio::io` module](tokio::io)
+//! - [`futures::io` module](futures::io)
+
 use pin_project_lite::pin_project;
 use std::io;
 use std::pin::Pin;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -3,7 +3,7 @@
 //! ## Bridging Tokio and Futures I/O with `compat()`
 //!
 //! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
-//! that allows types implementing [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html) or [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)
+//! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
 //! to be used as their
 //! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
 //! or
@@ -17,10 +17,10 @@
 //!
 //! | Inner Type Implements...                                                                 | `Compat<T>` Implements...                                                           |
 //! |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-//! | [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html)     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
-//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncRead.html)     |
-//! | [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)   | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
-//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncWrite.html)   |
+//! | [`tokio::io::AsyncRead`])     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
+//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`]     |
+//! | [`tokio::io::AsyncWrite`]   | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
+//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`]   |
 //! ## Feature Flag
 //!
 //! This functionality is available through the `compat` feature flag:
@@ -67,7 +67,7 @@
 //! The reverse is also possible: you can take a
 //! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
 //! (e.g. a cursor) and adapt it to be used with
-//! [`tokio::io::AsyncReadExt::read_to_end`](https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_to_end).
+//! [`tokio::io::AsyncReadExt::read_to_end`]
 //!
 //! ```
 //! use futures::io::Cursor;

--- a/tokio-util/src/compat.rs
+++ b/tokio-util/src/compat.rs
@@ -5,9 +5,9 @@
 //! The [`compat()`](TokioAsyncReadCompatExt::compat) function provides a compatibility layer
 //! that allows types implementing [`tokio::io::AsyncRead`] or [`tokio::io::AsyncWrite`]
 //! to be used as their
-//! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
+//! [`futures::io::AsyncRead`]
 //! or
-//! [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html)
+//! [`futures::io::AsyncWrite`]
 //! counterparts — and vice versa.
 //!
 //! This is especially useful when working with libraries that expect I/O types from one ecosystem
@@ -17,10 +17,10 @@
 //!
 //! | Inner Type Implements...                                                                 | `Compat<T>` Implements...                                                           |
 //! |------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-//! | [`tokio::io::AsyncRead`]     | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) |
-//! | [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html) | [`tokio::io::AsyncRead`]     |
-//! | [`tokio::io::AsyncWrite`]   | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) |
-//! | [`futures::io::AsyncWrite`](https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html) | [`tokio::io::AsyncWrite`]   |
+//! | [`tokio::io::AsyncRead`]     | [`futures::io::AsyncRead`] |
+//! | [`futures::io::AsyncRead`] | [`tokio::io::AsyncRead`]     |
+//! | [`tokio::io::AsyncWrite`]   | [`futures::io::AsyncWrite`] |
+//! | [`futures::io::AsyncWrite`] | [`tokio::io::AsyncWrite`]   |
 //! ## Feature Flag
 //!
 //! This functionality is available through the `compat` feature flag:
@@ -32,7 +32,7 @@
 //! ## Example 1: Tokio -> Futures (`AsyncRead`)
 //!
 //! This example demonstrates sending data over a [`tokio::net::TcpStream`] and using
-//! [`read`](https://docs.rs/futures/latest/futures/io/trait.AsyncReadExt.html#method.read)
+//! [`futures_util::io::AsyncReadExt::read`]
 //! from the `futures` crate to read it after adapting the stream via `compat()`.
 //!
 //! ```no_run
@@ -65,7 +65,7 @@
 //! ## Example 2: Futures -> Tokio (`AsyncRead`)
 //!
 //! The reverse is also possible: you can take a
-//! [`futures::io::AsyncRead`](https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html)
+//! [`futures::io::AsyncRead`]
 //! (e.g. a cursor) and adapt it to be used with
 //! [`tokio::io::AsyncReadExt::read_to_end`]
 //!
@@ -100,7 +100,12 @@
 //! - [`TokioAsyncReadCompatExt`]
 //! - [`FuturesAsyncReadCompatExt`]
 //! - [`tokio::io`]
-//! - [`futures::io`](https://docs.rs/futures/latest/futures/io/)
+//! - [`futures::io`]
+//!
+//! [`futures::io`]: (https://docs.rs/futures/latest/futures/io/)
+//! [`futures::io::AsyncRead`]: https://docs.rs/futures/latest/futures/io/trait.AsyncRead.html
+//! [`futures::io::AsyncWrite`]: https://docs.rs/futures/latest/futures/io/trait.AsyncWrite.html
+//! [`futures_util::io::AsyncReadExt::read`]: (https://docs.rs/futures-util/latest/futures_util/io/trait.AsyncReadExt.html#method.read)
 
 use pin_project_lite::pin_project;
 use std::io;

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -17,14 +17,11 @@
 //! [`tokio`] crate. However, `tokio-util` _will_ respect Rust's
 //! semantic versioning policy, especially with regard to breaking changes.
 //!
-//! [`tokio`]: https://docs.rs/tokio
-//!
 //! Useful modules:
 //!
 //! - [`compat`]: Inter-convertibility between [`tokio::io`] and [`futures::io`] traits.
 //!
 //! [`compat`]: crate::compat
-//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
 //! [`futures::io`]: https://docs.rs/futures/latest/futures/io/index.html
 
 #[macro_use]

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! Useful modules:
 //!
-//! - [`compat`]: Interoperability between [`tokio::io`] and [`futures::io`] traits.
+//! - [`compat`]: Inter-convertibility between [`tokio::io`] and [`futures::io`] traits.
 //!
 //! [`compat`]: crate::compat
 //! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -16,13 +16,6 @@
 //! This crate is not versioned in lockstep with the core
 //! [`tokio`] crate. However, `tokio-util` _will_ respect Rust's
 //! semantic versioning policy, especially with regard to breaking changes.
-//!
-//! Useful modules:
-//!
-//! - [`compat`]: Inter-convertibility between [`tokio::io`] and [`futures::io`] traits.
-//!
-//! [`compat`]: crate::compat
-//! [`futures::io`]: https://docs.rs/futures/latest/futures/io/index.html
 
 #[macro_use]
 mod cfg;

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -23,7 +23,6 @@
 //!
 //! - [`compat`]: Interoperability between [`tokio::io`] and [`futures::io`] traits.
 //!
-//! [`tokio`]: https://docs.rs/tokio
 //! [`compat`]: crate::compat
 //! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
 //! [`futures::io`]: https://docs.rs/futures/latest/futures/io/index.html

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -27,7 +27,6 @@
 //! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
 //! [`futures::io`]: https://docs.rs/futures/latest/futures/io/index.html
 
-
 #[macro_use]
 mod cfg;
 

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -18,6 +18,11 @@
 //! semantic versioning policy, especially with regard to breaking changes.
 //!
 //! [`tokio`]: https://docs.rs/tokio
+//!
+//! See the [`compat`](crate::compat::Compat) module for interoperability between
+//! [`tokio::io`] and [`futures::io`] traits.
+//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/
+//! [`futures::io`]: https://docs.rs/futures/latest/futures/io/
 
 #[macro_use]
 mod cfg;

--- a/tokio-util/src/lib.rs
+++ b/tokio-util/src/lib.rs
@@ -19,10 +19,15 @@
 //!
 //! [`tokio`]: https://docs.rs/tokio
 //!
-//! See the [`compat`](crate::compat::Compat) module for interoperability between
-//! [`tokio::io`] and [`futures::io`] traits.
-//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/
-//! [`futures::io`]: https://docs.rs/futures/latest/futures/io/
+//! Useful modules:
+//!
+//! - [`compat`]: Interoperability between [`tokio::io`] and [`futures::io`] traits.
+//!
+//! [`tokio`]: https://docs.rs/tokio
+//! [`compat`]: crate::compat
+//! [`tokio::io`]: https://docs.rs/tokio/latest/tokio/io/index.html
+//! [`futures::io`]: https://docs.rs/futures/latest/futures/io/index.html
+
 
 #[macro_use]
 mod cfg;


### PR DESCRIPTION
[Click to view rendered documentation](https://deploy-preview-7279--tokio-rs.netlify.app/tokio_util/compat/index.html)

### **Motivation**

This PR addresses [tokio-rs/tokio#2775](https://github.com/tokio-rs/tokio/issues/2775), which requested improved documentation and discoverability for the compat I/O layer in tokio-util.

### **Solution**  
Add and enhance documentation for the `compat` module:

- In `tokio-util/src/lib.rs`  
  Add a brief summary and a direct link to the `compat` module docs.

- In `tokio-util/src/compat.rs`  
  - Add a detailed explanation of the compatibility layer.  
  - Include a compatibility trait matrix.  

Included practical examples:
- Tokio → Futures: Using TcpStream with futures::io::AsyncReadExt.
- Futures → Tokio: Using Cursor with tokio::io::AsyncReadExt.

This is a documentation-only update.

### **Post Review testing?**  

- [X]  tested with link - https://deploy-preview-7279--tokio-rs.netlify.app 
Latest:
<img width="605" alt="image" src="https://github.com/user-attachments/assets/79cf615c-8d61-45ba-ae78-01366777b644" />

### **Closes**
Closes #2775

automerge=true