### PR TITLE
chore: prepare tokio-util v0.7.15

### DIFF
--- a/tokio-util/CHANGELOG.md
+++ b/tokio-util/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 0.7.15 (April 23rd, 2025)
+
+### Fixed
+
+- task: properly handle removed entries in `JoinMap` ([#7264])
+
+### Updated
+
+- deps: update hashbrown to 0.15 ([#7219])
+
+### Documented
+
+- task: explicitly state that `TaskTracker` does not abort tasks on Drop ([#7223])
+
+[#7219]: https://github.com/tokio-rs/tokio/pull/7219
+[#7223]: https://github.com/tokio-rs/tokio/pull/7223
+[#7264]: https://github.com/tokio-rs/tokio/pull/7264
+
 # 0.7.14 (March 12th, 2025)
 
 ### Added

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-util"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
-version = "0.7.14"
+version = "0.7.15"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.7.15 (April 23rd, 2025)

### Fixed

- task: properly handle removed entries in `JoinMap` ([#7264])

### Updated

- deps: update hashbrown to 0.15 ([#7219])

### Documented

- task: explicitly state that `TaskTracker` does not abort tasks on Drop ([#7223])

[#7219]: https://github.com/tokio-rs/tokio/pull/7219
[#7223]: https://github.com/tokio-rs/tokio/pull/7223
[#7264]: https://github.com/tokio-rs/tokio/pull/7264
