### PR TITLE
ci: Test AArch64 Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,9 @@ jobs:
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
             rustflags: --cfg tokio_taskdump
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
+            rustflags: --cfg tokio_taskdump
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable
@@ -597,6 +600,9 @@ jobs:
             os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+            rustflags: --cfg tokio_taskdump
+          - target: aarch64-pc-windows-msvc
+            os: windows-11-arm
             rustflags: --cfg tokio_taskdump
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,7 +556,6 @@ jobs:
             rustflags: --cfg tokio_taskdump
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
-            rustflags: --cfg tokio_taskdump
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable
@@ -603,7 +602,6 @@ jobs:
             rustflags: --cfg tokio_taskdump
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
-            rustflags: --cfg tokio_taskdump
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

GitHub Actions now supports AArch64 Windows runner (`windows-11-arm`) as public preview
https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/
https://github.com/actions/partner-runner-images

Closes #2985