### PR TITLE
Update backtrace

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -106,7 +106,7 @@ tracing = { version = "0.1.29", default-features = false, features = ["std"], op
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_taskdump)'.dependencies]
-backtrace = { version = "0.3.58" }
+backtrace = { version = "0.3.74" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.168", optional = true }


### PR DESCRIPTION
This is needed as the old version of backtrace uses an old version of object, duplicating deps in my project.

This version of backtrace has a MSRV of 1.65, which is lower than tokio.