### PR TITLE
Update tokio::time::sleep documentation to reflect maximum sleep

### DIFF
--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -76,8 +76,6 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 ///
 /// To run something regularly on a schedule, see [`interval`].
 ///
-/// The maximum duration for a sleep is 68719476734 milliseconds (approximately 2.2 years).
-///
 /// # Cancellation
 ///
 /// Canceling a sleep instance is done by dropping the returned future. No additional

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -259,13 +259,10 @@ async fn reset_after_firing() {
         .poll(&mut Context::from_waker(noop_waker_ref())));
 }
 
-const NUM_LEVELS: usize = 6;
-const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
-
 #[tokio::test]
 async fn exactly_max() {
     time::pause();
-    time::sleep(ms(MAX_DURATION)).await;
+    time::sleep(Duration::MAX).await;
 }
 
 #[tokio::test]
@@ -285,7 +282,7 @@ async fn issue_5183() {
 #[tokio::test]
 async fn no_out_of_bounds_close_to_max() {
     time::pause();
-    time::sleep(ms(MAX_DURATION - 1)).await;
+    time::sleep(Duration::MAX - Duration::from_millis(1)).await;
 }
 
 fn ms(n: u64) -> Duration {


### PR DESCRIPTION
This commit updates the tokio::time::sleep documentation to remove the outdated maximum sleep duration.

This fixes #7301.
