### PR TITLE
chore: prepare Tokio v1.45.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,30 @@
+# 1.45.0 (May 5th, 2025)
+
+### Added
+
+- metrics: stabilize `worker_total_busy_duration`, `worker_park_count`, and
+  `worker_unpark_count` ([#6899], [#7276])
+- process: add `Command::spawn_with` ([#7249])
+
+### Changed
+
+- io: do not require `Unpin` for some trait impls ([#7204])
+- rt: mark `runtime::Handle` as unwind safe ([#7230])
+- time: revert internal sharding implementation ([#7226])
+
+### Unstable
+
+- rt: remove alt multi-threaded runtime ([#7275])
+
+[#6899]: https://github.com/tokio-rs/tokio/pull/6899
+[#7276]: https://github.com/tokio-rs/tokio/pull/7276
+[#7249]: https://github.com/tokio-rs/tokio/pull/7249
+[#7204]: https://github.com/tokio-rs/tokio/pull/7204
+[#7230]: https://github.com/tokio-rs/tokio/pull/7230
+[#7226]: https://github.com/tokio-rs/tokio/pull/7226
+[#7275]: https://github.com/tokio-rs/tokio/pull/7275
+
+
 # 1.44.2 (April 5th, 2025)
 
 This release fixes a soundness issue in the broadcast channel. The channel

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.44.2"
+version = "1.45.0"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.45.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
### Added

- metrics: stabilize `worker_total_busy_duration`, `worker_park_count`, and
  `worker_unpark_count` ([#6899], [#7276])
- process: add `Command::spawn_with` ([#7249])

### Changed

- io: do not require `Unpin` for some trait impls ([#7204])
- rt: mark `runtime::Handle` as unwind safe ([#7230])
- time: revert internal sharding implementation ([#7226])

### Unstable

- rt: remove alt multi-threaded runtime ([#7275])

[#6899]: https://github.com/tokio-rs/tokio/pull/6899
[#7276]: https://github.com/tokio-rs/tokio/pull/7276
[#7249]: https://github.com/tokio-rs/tokio/pull/7249
[#7204]: https://github.com/tokio-rs/tokio/pull/7204
[#7230]: https://github.com/tokio-rs/tokio/pull/7230
[#7226]: https://github.com/tokio-rs/tokio/pull/7226
[#7275]: https://github.com/tokio-rs/tokio/pull/7275