### PR TITLE
Add copy_with_size

### DIFF
--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -266,7 +266,7 @@ cfg_io_util! {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn copy<'a, R, W>(reader: &'a mut R, writer: &'a mut W) -> io::Result<u64>
+    pub async fn copy<'a, R, W>(reader: &'a mut R, writer: &'a mut W, buf_size: Option<usize>) -> io::Result<u64>
     where
         R: AsyncRead + Unpin + ?Sized,
         W: AsyncWrite + Unpin + ?Sized,
@@ -274,7 +274,7 @@ cfg_io_util! {
         Copy {
             reader,
             writer,
-            buf: CopyBuffer::new(super::DEFAULT_BUF_SIZE)
+            buf: CopyBuffer::new(buf_size.unwrap_or(super::DEFAULT_BUF_SIZE))
         }.await
     }
 }

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -266,7 +266,7 @@ cfg_io_util! {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn copy<'a, R, W>(reader: &'a mut R, writer: &'a mut W, buf_size: Option<usize>) -> io::Result<u64>
+    pub async fn copy<'a, R, W>(reader: &'a mut R, writer: &'a mut W) -> io::Result<u64>
     where
         R: AsyncRead + Unpin + ?Sized,
         W: AsyncWrite + Unpin + ?Sized,
@@ -274,7 +274,19 @@ cfg_io_util! {
         Copy {
             reader,
             writer,
-            buf: CopyBuffer::new(buf_size.unwrap_or(super::DEFAULT_BUF_SIZE))
+            buf: CopyBuffer::new(super::DEFAULT_BUF_SIZE)
+        }.await
+    }
+
+    pub async fn copy_with_size<'a, R, W>(reader: &'a mut R, writer: &'a mut W, buf_size: usize) -> io::Result<u64>
+    where
+        R: AsyncRead + Unpin + ?Sized,
+        W: AsyncWrite + Unpin + ?Sized,
+    {
+        Copy {
+            reader,
+            writer,
+            buf: CopyBuffer::new(buf_size)
         }.await
     }
 }


### PR DESCRIPTION
Add `copy_with_size` to support custom buffer sizes in `io::copy`

## Motivation

The `io::copy` function is invaluable for networking and general I/O operations. However, its default 8KB buffer size can be limiting when handling large file transfers. For instance, copying a 1GB file on my system took **11 seconds** using `io::copy`, whereas increasing the buffer size to **128KB** reduced the time to just **1 second**.

While `io::copy_bidirectional_with_sizes` offers buffer size customization, it is bidirectional. In cases where only **unidirectional** copying is required, a dedicated function is more suitable.

I did not add tests since `copy_with_size` follows the same logic as `io::copy`. Additionally, modifying `io::copy` itself would require extensive changes to both the source code and tests.

## Solution

This new function works similarly to `io::copy` but allows specifying a custom buffer size, making it more efficient for large data transfers.
