### PR TITLE
Update the default version of signal-hook-registry to accommodate AIX support

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -110,7 +110,7 @@ backtrace = { version = "0.3.58" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.168", optional = true }
-signal-hook-registry = { version = "1.1.1", optional = true }
+signal-hook-registry = { version = "1.4.5", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.168" }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

(WIP - draft for now)

The tokio crate has an optional dependency on signal-hook-registry, which has a default version requirement of 1.1.1, however this version of signal-hook-registry cannot be built on AIX without the necessary AIX fixes in signal-hook-registry, which has since been added in a newer version of signal-hook-registry.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update the default version for signal-hook-registry to be version 1.4.5, which is the newest version at the time of this patch, and also contains the necessary fixes for AIX.