### PR TITLE
time: remove outdated explicit `drop` call of `Mutex`

### DIFF
--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -251,7 +251,6 @@ cfg_test_util! {
             let mut inner = self.inner.lock();
 
             if !inner.enable_pausing {
-                drop(inner); // avoid poisoning the lock
                 return Err("`time::pause()` requires the `current_thread` Tokio runtime. \
                         This is the default Runtime used by `#[tokio::test].");
             }


### PR DESCRIPTION
## Summary

This PR just basically removes a dead code, it should not change any functionality, and also no actual performance impact.

https://github.com/tokio-rs/tokio/blob/bdd64cc9d3561115d125584484404e9d1f7d7cca/tokio/src/time/clock.rs#L253-L257

This drop is no longer necessary.

This drop was firstly introduced by #3289 and the next line invokes `panic!`.

In #5434, the original `panic!` was replaced with `return Err`, so dropping it explicitly is no longer necessary.

## Background

I didn't face any real issue of this dead code, it just confused me while reading the source.

