### PR TITLE
docs: socket.rs document of method recv_buffer_size

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -368,7 +368,7 @@ impl TcpSocket {
     ///
     /// Note that if [`set_recv_buffer_size`] has been called on this socket
     /// previously, the value returned by this function may not be the same as
-    /// the argument provided to `set_send_buffer_size`. This is for the
+    /// the argument provided to `set_recv_buffer_size`. This is for the
     /// following reasons:
     ///
     /// * Most operating systems have minimum and maximum allowed sizes for the


### PR DESCRIPTION
## Motivation

When I read the document of method "recv_buffer_size" I found this issue that this method shoud associate to "set_recv_buffer_size" not "set_send_buffer_size", so I think there is a describtion problem.

## Solution
change "set_send_buffer_size" -> "set_recv_buffer_size" description that in recv_buffer_size method document

