### PR TITLE
runtime: eliminate unnecessary lfence while operating on `queue::Local<T>`

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -107,12 +107,19 @@ pub(crate) fn local<T: 'static>() -> (Steal<T>, Local<T>) {
 impl<T> Local<T> {
     /// Returns the number of entries in the queue
     pub(crate) fn len(&self) -> usize {
-        self.inner.len() as usize
+        let (_, head) = unpack(self.inner.head.load(Acquire));
+        // safety: this is the **only** thread that updates this cell.
+        let tail = unsafe { self.inner.tail.unsync_load() };
+        len(head, tail)
     }
 
     /// How many tasks can be pushed into the queue
     pub(crate) fn remaining_slots(&self) -> usize {
-        self.inner.remaining_slots()
+        let (steal, _) = unpack(self.inner.head.load(Acquire));
+        // safety: this is the **only** thread that updates this cell.
+        let tail = unsafe { self.inner.tail.unsync_load() };
+
+        LOCAL_QUEUE_CAPACITY - len(steal, tail)
     }
 
     pub(crate) fn max_capacity(&self) -> usize {
@@ -124,7 +131,7 @@ impl<T> Local<T> {
     /// Separate to `is_stealable` so that refactors of `is_stealable` to "protect"
     /// some tasks from stealing won't affect this
     pub(crate) fn has_tasks(&self) -> bool {
-        !self.inner.is_empty()
+        self.len() != 0
     }
 
     /// Pushes a batch of tasks to the back of the queue. All tasks must fit in
@@ -384,8 +391,14 @@ impl<T> Local<T> {
 }
 
 impl<T> Steal<T> {
+    fn len(&self) -> usize {
+        let (_, head) = unpack(self.0.head.load(Acquire));
+        let tail = self.0.tail.load(Acquire);
+        len(head, tail)
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     /// Steals half the tasks from self and place them into `dst`.
@@ -565,24 +578,10 @@ impl<T> Drop for Local<T> {
     }
 }
 
-impl<T> Inner<T> {
-    fn remaining_slots(&self) -> usize {
-        let (steal, _) = unpack(self.head.load(Acquire));
-        let tail = self.tail.load(Acquire);
-
-        LOCAL_QUEUE_CAPACITY - (tail.wrapping_sub(steal) as usize)
-    }
-
-    fn len(&self) -> UnsignedShort {
-        let (_, head) = unpack(self.head.load(Acquire));
-        let tail = self.tail.load(Acquire);
-
-        tail.wrapping_sub(head)
-    }
-
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
+/// Calculate the length of the queue using the head and tail.
+/// The `head` can be the `steal` or `real` head.
+fn len(head: UnsignedShort, tail: UnsignedShort) -> usize {
+    tail.wrapping_sub(head) as usize
 }
 
 /// Split the head value into the real head and the index a stealer is working

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -391,12 +391,15 @@ impl<T> Local<T> {
 }
 
 impl<T> Steal<T> {
-    fn len(&self) -> usize {
+    /// Returns the number of entries in the queue
+    pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.0.head.load(Acquire));
         let tail = self.0.tail.load(Acquire);
         len(head, tail)
     }
 
+    /// Return true if the queue is empty,
+    /// false if there are any entries in the queue
     pub(crate) fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -552,14 +555,6 @@ impl<T> Steal<T> {
                     prev_packed = actual;
                 }
             }
-        }
-    }
-}
-
-cfg_unstable_metrics! {
-    impl<T> Steal<T> {
-        pub(crate) fn len(&self) -> usize {
-            self.0.len() as _
         }
     }
 }


### PR DESCRIPTION
<del>*Blocked by #7339 which fixes the CI failures caused by the new compilation error message of the new stable toolchain.*</del>

## Motivation

`queue::Local<T>` is never been send to another thread (except while shutting down), the `tail` is only updated by the worker thread who owned this local queue, so any change to `tail` is immediately visible to the current thread.

This means the `Acquire` ordering is not required for loading `tail` while operating on the local queue.

## Solution

### Unsync load

Since the lfence is not required for this scenario, the atomic loading was replaced by simple pointer deref.

### Remove all methods of the `queue::Inner<T>`

Because of the following reasons:

* All method on the `Inner<T>` can be implemented in differently way for `Local<T>` and `Steal<T>`
* Adding method like `len_local` or `unsync_len` creates possibilities for incorrect usage in the future which causes ABA problems in critical path.

I removed all methods on the `Inner<T>` and re-implement it for both `Local<T>` and `Steal<T>`.

### Remove the feature gate of `Steal<T>::len()`

The feature gate `cfg_unstable_metrics` is removed for `Steal<T>::len()` to avoid duplicating the same code.

This doesn't seem to break anything, but if it does please let me know and I'll switch to something else.

## Anything else?

Ideally, the `queue::Local<T>` should be marked as `!Send` to lower the risk that unintentionally send it to another thread, but it required the changes of the starting and shutdown logic, I will try to open another PR for this improvement.
