### PR TITLE
time&runtime: cumulative minor improvements

### DIFF
--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -376,7 +376,6 @@ impl LocalRuntime {
     }
 }
 
-#[allow(clippy::single_match)] // there are comments in the error branch, so we don't want if-let
 impl Drop for LocalRuntime {
     fn drop(&mut self) {
         if let LocalRuntimeScheduler::CurrentThread(current_thread) = &mut self.scheduler {

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -471,7 +471,6 @@ impl Runtime {
     }
 }
 
-#[allow(clippy::single_match)] // there are comments in the error branch, so we don't want if-let
 impl Drop for Runtime {
     fn drop(&mut self) {
         match &mut self.scheduler {

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -63,6 +63,7 @@ use crate::sync::AtomicWaker;
 use crate::time::Instant;
 use crate::util::linked_list;
 
+use pin_project_lite::pin_project;
 use std::task::{Context, Poll, Waker};
 use std::{marker::PhantomPinned, pin::Pin, ptr::NonNull};
 
@@ -276,29 +277,36 @@ impl StateCell {
     }
 }
 
-/// A timer entry.
-///
-/// This is the handle to a timer that is controlled by the requester of the
-/// timer. As this participates in intrusive data structures, it must be pinned
-/// before polling.
-#[derive(Debug)]
-pub(crate) struct TimerEntry {
-    /// Arc reference to the runtime handle. We can only free the driver after
-    /// deregistering everything from their respective timer wheels.
-    driver: scheduler::Handle,
-    /// Shared inner structure; this is part of an intrusive linked list, and
-    /// therefore other references can exist to it while mutable references to
-    /// Entry exist.
-    ///
-    /// This is manipulated only under the inner mutex.
-    inner: Option<TimerShared>,
-    /// Deadline for the timer. This is used to register on the first
-    /// poll, as we can't register prior to being pinned.
-    deadline: Instant,
-    /// Whether the deadline has been registered.
-    registered: bool,
-    /// Ensure the type is !Unpin
-    _m: std::marker::PhantomPinned,
+pin_project! {
+    // A timer entry.
+    //
+    // This is the handle to a timer that is controlled by the requester of the
+    // timer. As this participates in intrusive data structures, it must be pinned
+    // before polling.
+    #[derive(Debug)]
+    pub(crate) struct TimerEntry {
+        // Arc reference to the runtime handle. We can only free the driver after
+        // deregistering everything from their respective timer wheels.
+        driver: scheduler::Handle,
+        // Shared inner structure; this is part of an intrusive linked list, and
+        // therefore other references can exist to it while mutable references to
+        // Entry exist.
+        //
+        // This is manipulated only under the inner mutex.
+        #[pin]
+        inner: Option<TimerShared>,
+        // Deadline for the timer. This is used to register on the first
+        // poll, as we can't register prior to being pinned.
+        deadline: Instant,
+        // Whether the deadline has been registered.
+        registered: bool,
+    }
+
+    impl PinnedDrop for TimerEntry {
+        fn drop(this: Pin<&mut Self>) {
+            this.cancel();
+        }
+    }
 }
 
 unsafe impl Send for TimerEntry {}
@@ -480,7 +488,6 @@ impl TimerEntry {
             inner: None,
             deadline,
             registered: false,
-            _m: std::marker::PhantomPinned,
         }
     }
 
@@ -488,10 +495,10 @@ impl TimerEntry {
         self.inner.as_ref()
     }
 
-    fn init_inner(&mut self) {
+    fn init_inner(self: Pin<&mut Self>) {
         match self.inner {
             Some(_) => {}
-            None => self.inner = Some(TimerShared::new()),
+            None => self.project().inner.set(Some(TimerShared::new())),
         }
     }
 
@@ -540,16 +547,16 @@ impl TimerEntry {
     }
 
     pub(crate) fn reset(mut self: Pin<&mut Self>, new_time: Instant, reregister: bool) {
-        let this = unsafe { self.as_mut().get_unchecked_mut() };
-        this.deadline = new_time;
-        this.registered = reregister;
+        let this = self.as_mut().project();
+        *this.deadline = new_time;
+        *this.registered = reregister;
 
-        let tick = this.driver().time_source().deadline_to_tick(new_time);
-        let inner = match this.inner() {
+        let tick = self.driver().time_source().deadline_to_tick(new_time);
+        let inner = match self.inner() {
             Some(inner) => inner,
             None => {
-                this.init_inner();
-                this.inner()
+                self.as_mut().init_inner();
+                self.inner()
                     .expect("inner should already be initialized by `this.init_inner()`")
             }
         };
@@ -560,8 +567,8 @@ impl TimerEntry {
 
         if reregister {
             unsafe {
-                this.driver()
-                    .reregister(&this.driver.driver().io, tick, inner.into());
+                self.driver()
+                    .reregister(&self.driver.driver().io, tick, inner.into());
             }
         }
     }
@@ -654,11 +661,5 @@ impl TimerHandle {
     /// the entry must not be in any wheel linked lists.
     pub(super) unsafe fn fire(self, completed_state: TimerResult) -> Option<Waker> {
         self.inner.as_ref().state.fire(completed_state)
-    }
-}
-
-impl Drop for TimerEntry {
-    fn drop(&mut self) {
-        unsafe { Pin::new_unchecked(self) }.as_mut().cancel();
     }
 }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -246,7 +246,6 @@ impl Driver {
 }
 
 impl Handle {
-    /// Runs timer related logic, and returns the next wakeup time
     pub(self) fn process(&self, clock: &Clock) {
         let now = self.time_source().now(clock);
 

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -62,9 +62,7 @@ fn single_timer() {
         let time = handle.inner.driver().time();
         let clock = handle.inner.driver().clock();
 
-        // This may or may not return Some (depending on how it races with the
-        // thread). If it does return None, however, the timer should complete
-        // synchronously.
+        // advance 2s
         time.process_at_time(time.time_source().now(clock) + 2_000_000_000);
 
         jh.join().unwrap();
@@ -170,7 +168,6 @@ fn reset_future() {
 
         let handle = handle.inner.driver().time();
 
-        // This may or may not return a wakeup time.
         handle.process_at_time(
             handle
                 .time_source()

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -225,10 +225,8 @@ fn poll_process_levels() {
             let mut context = Context::from_waker(noop_waker_ref());
             if deadline <= t {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_ready());
-                assert!(future.is_elapsed());
             } else {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_pending());
-                assert!(!future.is_elapsed())
             }
         }
     }

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -225,8 +225,10 @@ fn poll_process_levels() {
             let mut context = Context::from_waker(noop_waker_ref());
             if deadline <= t {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_ready());
+                assert!(future.is_elapsed());
             } else {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_pending());
+                assert!(!future.is_elapsed())
             }
         }
     }


### PR DESCRIPTION
## Summary

Just a few minor improvements while reading the source.

*It would be convenient to enable the 'Hide whitespace' in diff view.*

## Full changes per-commit

### runtime: remove outdated clippy attributes

These `clippy` attributes were introduced by #6808 and it looks like they were forgotten to be removed before merging into master.

***

### time: eliminate unsafe blocks using `pin_project`

Follow-up of #7329.

Usually, the `Pin::get_unchecked_mut` can be replaced with `pin_project`, this reduce the unsafe area without sacrificing readability and performance.

*Note: The `#[doc = "..."]` attributes have been replaced with `//` due to the limitation of `pin_project_lite` (ref: https://github.com/taiki-e/pin-project-lite/issues/41).*


***

### time: remove outdated comments

These comments were introduced by the [initial commit](https://github.com/tokio-rs/tokio/commit/f052f85315936a685f36c99dbceae0de541e0e4e) of #3080, but not be removed in the final version before merging it into the master.


***

### time: add comment to `TimerEntry::is_elapsed` for better readability

https://github.com/tokio-rs/tokio/blob/d7d4f7d08bf75daf23bec676b03cb4c88993e5d0/tokio/src/runtime/time/entry.rs#L502-L508

The logic here doesn't seem very intuitive, and I paused for a while while reading to understand it, so I've added some comments to make try to make it a bit more obvious.
