### PR TITLE
io: document cancellation safety of AsyncWriteExt::flush

### DIFF
--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -1231,6 +1231,13 @@ cfg_io_util! {
         /// It is considered an error if not all bytes could be written due to
         /// I/O errors or EOF being reached.
         ///
+        /// # Cancel safety
+        ///
+        /// This method is cancellation safe in the sense that if it is used as
+        /// the event in a [`tokio::select!`](crate::select) statement and some
+        /// other branch completes first, then it is guaranteed that no intermediately
+        /// buffered content got flushed.
+        ///
         /// # Examples
         ///
         /// ```no_run


### PR DESCRIPTION
This PR documents cancellation safety of `AsyncWriteExt::flush`.

## Motivation

As cancellation of futures are common it is useful to know which methods are cancel safe in order to not get confused about the consequences of retrying them. This PR explains that `AsyncWriteExt::flush` must be cancel safe. 

## Solution

This PR updates the documentation to give the user more relevant information.