### PR TITLE
io: clarify behavior of seeking when `start_seek` is not used

### DIFF
--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -34,11 +34,17 @@ pub trait AsyncSeek {
 
     /// Waits for a seek operation to complete.
     ///
-    /// If the seek operation completed successfully,
-    /// this method returns the new position from the start of the stream.
-    /// That position can be used later with [`SeekFrom::Start`]. Repeatedly
-    /// calling this function without calling `start_seek` might return the
-    /// same result.
+    /// If the seek operation completed successfully, this method returns the
+    /// new position from the start of the stream. That position can be used
+    /// later with [`SeekFrom::Start`].
+    ///
+    /// The position returned by calling this method can only be relied on right
+    /// after `start_seek`. If you have changed the position by e.g. reading or
+    /// writing since calling `start_seek`, then it is unspecified whether the
+    /// returned position takes that position change into account. Similarly, if
+    /// `start_seek` has never been called, then it is unspecified whether
+    /// `poll_complete` returns the actual position or some other placeholder
+    /// value (such as 0).
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Issue #6374 reports that `AsyncSeek::poll_complete` could return the wrong value if `start_seek` was never called on a `File`. However, you are required to call `start_seek` first if you want to use the position returned by `poll_complete`. Update the documentation to reflect this.

Closes: #6374