### PR TITLE
Update rand crate to latest version

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -11,8 +11,8 @@ test-util = ["tokio/test-util"]
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 criterion = "0.5.1"
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.9"
+rand_chacha = "0.9"
 
 [dev-dependencies]
 tokio-util = { version = "0.7.0", path = "../tokio-util", features = ["full"] }

--- a/benches/copy.rs
+++ b/benches/copy.rs
@@ -77,7 +77,7 @@ impl SlowHddWriter {
     ) -> std::task::Poll<Result<usize, std::io::Error>> {
         let service_res = self.as_mut().service_write(cx);
 
-        if service_res.is_pending() && self.blocking_rng.gen_bool(PROBABILITY_FLUSH_WAIT) {
+        if service_res.is_pending() && self.blocking_rng.random_bool(PROBABILITY_FLUSH_WAIT) {
             return Poll::Pending;
         }
         let available = self.buffer_size - self.buffer_used;

--- a/benches/sync_broadcast.rs
+++ b/benches/sync_broadcast.rs
@@ -17,7 +17,7 @@ fn do_work(rng: &mut impl RngCore) -> u32 {
     use std::fmt::Write;
     let mut message = String::new();
     for i in 1..=10 {
-        let _ = write!(&mut message, " {i}={}", rng.gen::<f64>());
+        let _ = write!(&mut message, " {i}={}", rng.random::<f64>());
     }
     message
         .as_bytes()

--- a/benches/sync_watch.rs
+++ b/benches/sync_watch.rs
@@ -17,7 +17,7 @@ fn do_work(rng: &mut impl RngCore) -> u32 {
     use std::fmt::Write;
     let mut message = String::new();
     for i in 1..=10 {
-        let _ = write!(&mut message, " {i}={}", rng.gen::<f64>());
+        let _ = write!(&mut message, " {i}={}", rng.random::<f64>());
     }
     message
         .as_bytes()

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -23,7 +23,6 @@ serde_json = "1.0"
 httparse = "1.0"
 httpdate = "1.0"
 once_cell = "1.5.2"
-rand = "0.8.3"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.52"

--- a/stress-test/Cargo.toml
+++ b/stress-test/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 tokio = { version = "1.0.0", path = "../tokio/", features = ["full"] }
 
 [dev-dependencies]
-rand = "0.8"
+rand = "0.9"
 
 [lints]
 workspace = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -147,7 +147,7 @@ tempfile = "3.1.0"
 proptest = "1"
 
 [target.'cfg(not(all(target_family = "wasm", target_os = "unknown")))'.dev-dependencies]
-rand = "0.8.0"
+rand = "0.9"
 
 [target.'cfg(all(target_family = "wasm", not(target_os = "wasi")))'.dev-dependencies]
 wasm-bindgen-test = "0.3.0"

--- a/tokio/tests/sync_broadcast.rs
+++ b/tokio/tests/sync_broadcast.rs
@@ -565,13 +565,11 @@ fn sender_len() {
 #[test]
 #[cfg(not(all(target_family = "wasm", not(target_os = "wasi"))))]
 fn sender_len_random() {
-    use rand::Rng;
-
     let (tx, mut rx1) = broadcast::channel(16);
     let mut rx2 = tx.subscribe();
 
     for _ in 0..1000 {
-        match rand::thread_rng().gen_range(0..4) {
+        match rand::random_range(0..4) {
             0 => {
                 let _ = rx1.try_recv();
             }

--- a/tokio/tests/time_pause.rs
+++ b/tokio/tests/time_pause.rs
@@ -63,7 +63,7 @@ async fn paused_time_stress_run() -> Vec<Duration> {
     let mut times = vec![];
     let start = Instant::now();
     for _ in 0..10_000 {
-        let sleep = rng.gen_range(Duration::from_secs(0)..Duration::from_secs(1));
+        let sleep = rng.random_range(Duration::from_secs(0)..Duration::from_secs(1));
         time::sleep(sleep).await;
         times.push(start.elapsed());
     }


### PR DESCRIPTION
Migrate from 0.8.5 to 0.9.1, fix resulting build warnings.
