### PR TITLE
Enable some tests to test with miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-01-25
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2025-01-25
+  rust_miri_nightly: nightly-2025-06-02
   rust_clippy: '1.77'
   # When updating this, also update:
   # - README.md

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -148,7 +148,6 @@ fn drain(mut fd: &FileDescriptor, mut amt: usize) {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn initially_writable() {
     let (a, b) = socketpair();
 
@@ -167,7 +166,6 @@ async fn initially_writable() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn reset_readable() {
     let (a, mut b) = socketpair();
 
@@ -212,7 +210,6 @@ async fn reset_readable() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn reset_writable() {
     let (a, b) = socketpair();
 
@@ -250,7 +247,6 @@ impl<T: AsRawFd> AsRawFd for ArcFd<T> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn drop_closes() {
     let (a, mut b) = socketpair();
 
@@ -291,7 +287,6 @@ async fn drop_closes() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn reregister() {
     let (a, _b) = socketpair();
 
@@ -301,7 +296,6 @@ async fn reregister() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn guard_try_io() {
     let (a, mut b) = socketpair();
 
@@ -337,7 +331,6 @@ async fn guard_try_io() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn try_io_readable() {
     let (a, mut b) = socketpair();
     let mut afd_a = AsyncFd::new(a).unwrap();
@@ -397,7 +390,6 @@ async fn try_io_readable() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn try_io_writable() {
     let (a, _b) = socketpair();
     let afd_a = AsyncFd::new(a).unwrap();
@@ -439,7 +431,6 @@ async fn try_io_writable() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn multiple_waiters() {
     let (a, mut b) = socketpair();
     let afd_a = Arc::new(AsyncFd::new(a).unwrap());
@@ -488,7 +479,7 @@ async fn multiple_waiters() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
+#[cfg_attr(miri, ignore)] // FIXME: miri hit unreachable.
 async fn poll_fns() {
     let (a, b) = socketpair();
     let afd_a = Arc::new(AsyncFd::new(a).unwrap());
@@ -582,7 +573,6 @@ fn rt() -> tokio::runtime::Runtime {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_currently_pending() {
     let rt = rt();
 
@@ -604,7 +594,6 @@ fn driver_shutdown_wakes_currently_pending() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_future_pending() {
     let rt = rt();
 
@@ -620,7 +609,6 @@ fn driver_shutdown_wakes_future_pending() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_pending_race() {
     // TODO: make this a loom test
     for _ in 0..100 {
@@ -651,7 +639,6 @@ async fn poll_writable<T: AsRawFd>(fd: &AsyncFd<T>) -> std::io::Result<AsyncFdRe
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_currently_pending_polls() {
     let rt = rt();
 
@@ -674,7 +661,6 @@ fn driver_shutdown_wakes_currently_pending_polls() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_poll() {
     let rt = rt();
 
@@ -691,7 +677,6 @@ fn driver_shutdown_wakes_poll() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_then_clear_readiness() {
     let rt = rt();
 
@@ -709,7 +694,6 @@ fn driver_shutdown_then_clear_readiness() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 fn driver_shutdown_wakes_poll_race() {
     // TODO: make this a loom test
     for _ in 0..100 {
@@ -773,7 +757,6 @@ fn send_oob_data<S: AsRawFd>(stream: &S, data: &[u8]) -> io::Result<usize> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn clear_ready_matching_clears_ready() {
     use tokio::io::{Interest, Ready};
 
@@ -797,7 +780,6 @@ async fn clear_ready_matching_clears_ready() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn clear_ready_matching_clears_ready_mut() {
     use tokio::io::{Interest, Ready};
 
@@ -878,7 +860,7 @@ fn configure_timestamping_socket(udp_socket: &std::net::UdpSocket) -> std::io::R
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
+#[cfg_attr(miri, ignore)] // No socket in miri.
 #[cfg(target_os = "linux")]
 async fn await_error_readiness_invalid_address() {
     use std::net::{Ipv4Addr, SocketAddr};

--- a/tokio/tests/io_async_fd.rs
+++ b/tokio/tests/io_async_fd.rs
@@ -479,7 +479,8 @@ async fn multiple_waiters() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // FIXME: miri hit unreachable.
+// Block on https://github.com/rust-lang/miri/issues/4374
+#[cfg_attr(miri, ignore)]
 async fn poll_fns() {
     let (a, b) = socketpair();
     let afd_a = Arc::new(AsyncFd::new(a).unwrap());

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -469,7 +469,7 @@ async fn anon_pipe_simple_send() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
+#[cfg_attr(miri, ignore)] // No `pidfd_spawnp` in miri.
 async fn anon_pipe_spawn_echo() -> std::io::Result<()> {
     use tokio::process::Command;
 
@@ -520,7 +520,6 @@ async fn anon_pipe_from_owned_fd() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn anon_pipe_into_nonblocking_fd() -> std::io::Result<()> {
     let (tx, rx) = pipe::pipe()?;
 
@@ -534,7 +533,6 @@ async fn anon_pipe_into_nonblocking_fd() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No F_GETFL for fcntl in miri.
 async fn anon_pipe_into_blocking_fd() -> std::io::Result<()> {
     let (tx, rx) = pipe::pipe()?;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Miri supported ``fcntl`` in https://github.com/rust-lang/miri/issues/4119.

## Solution
This PR enables tests that use ``fcntl``, and update the rustc version needed for miri to run the tests in CI. 
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
