### PR TITLE
runtime: eliminate unnecessary lfence in fn `len`

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -394,7 +394,7 @@ impl<T> Steal<T> {
     /// Returns the number of entries in the queue
     pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.0.head.load(Acquire));
-        let tail = self.0.tail.load(Acquire);
+        let tail = self.0.tail.load(Relaxed);
         len(head, tail)
     }
 


### PR DESCRIPTION
## Motivation

Inspired by #7340. Explained in #7385.
> As value returned from Steal<T>::len and Local<T>::len can not be used for indexing, the loads of head and tail in these functions can be marked Relaxed (but not unsync_load for Steal<T>). After all, no matter whice memory order we use, the value returned is an approximate size, not actual size.

## Solution

### Relaxed load for `tail`
As explained in #7385, mark the loading of `head` to `Relaxed` will need an additional comparison. Therefore, I only mark the loading of `tail` to `Relaxed`.
> If we mark the loads of both head and tail to Relaxed, it's possible to see head larger than tail (for Steal<T>::len), but only mark the load of tail to Relaxed is safe.

### Merge implementations of `Local<T>::len` and `Steal<T>::len`
I cannot see any deference between using directly pointer deref and atomic relaxed loading, since the atomic acquire loading prevent compiler optimization already. Therefore, I merge these two implementations together.

If I misunderstood something, please let me know.
