### PR TITLE
benches: properly gate unix benches

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -71,12 +71,12 @@ name = "sync_semaphore"
 path = "sync_semaphore.rs"
 harness = false
 
-[[bench]]
+[[target.'cfg(unix)'.bench]]
 name = "signal"
 path = "signal.rs"
 harness = false
 
-[[bench]]
+[[target.'cfg(unix)'.bench]]
 name = "fs"
 path = "fs.rs"
 harness = false

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -1,5 +1,3 @@
-#![cfg(unix)]
-
 use tokio_stream::StreamExt;
 
 use tokio::fs::File;

--- a/benches/signal.rs
+++ b/benches/signal.rs
@@ -1,5 +1,4 @@
 //! Benchmark the delay in propagating OS signals to any listeners.
-#![cfg(unix)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::future::Future;


### PR DESCRIPTION
`#![cfg(unix)]` creates an empty files for non-unix targets, causing rust to complain about a missing `fn main`, but now these benches are instead disabled.