### PR TITLE
time: doc a missing panic scenario of `time::advance`

### DIFF
--- a/tokio/src/time/clock.rs
+++ b/tokio/src/time/clock.rs
@@ -185,8 +185,18 @@ cfg_test_util! {
     ///
     /// # Panics
     ///
-    /// Panics if time is not frozen or if called from outside of the Tokio
-    /// runtime.
+    /// Panics if any of the following conditions are met:
+    ///
+    /// - The clock is not frozen, which means that you must
+    ///   call [`pause`] before calling this method.
+    /// - If called outside of the Tokio runtime.
+    /// - If the input `duration` is too large (such as [`Duration::MAX`])
+    ///   to be safely added to the current time without causing an overflow.
+    ///
+    /// # Caveats
+    ///
+    /// Using a very large `duration` is not recommended,
+    /// as it may cause panicking due to overflow.
     ///
     /// # Auto-advance
     ///


### PR DESCRIPTION
## Motivation

close #7380, supersede #7381

#7381 tried to solve the panic issue by `checked_add` and `far_future`, however, it still panics after many times of advance.

Having asked the author of the question, I think adding documentation explicitly describing this behavior would suffice. After all, this is just a test utility.

## Solution

* Doc this panic scenario.
* Add a caveat section stating that large durations are discouraged.
