### PR TITLE
runtime: simplify thread parking and remove CachedParkThread

### DIFF
--- a/tokio/src/future/block_on.rs
+++ b/tokio/src/future/block_on.rs
@@ -9,14 +9,13 @@ cfg_rt! {
             thread while the thread is being used to drive asynchronous \
             tasks."
         );
-        e.block_on(f).unwrap()
+        e.block_on(f)
     }
 }
 
 cfg_not_rt! {
     #[track_caller]
     pub(crate) fn block_on<F: Future>(f: F) -> F::Output {
-        let mut park = crate::runtime::park::CachedParkThread::new();
-        park.block_on(f).unwrap()
+        crate::runtime::park::block_on(f)
     }
 }

--- a/tokio/src/loom/mocked.rs
+++ b/tokio/src/loom/mocked.rs
@@ -80,6 +80,11 @@ pub(crate) mod sys {
 }
 
 pub(crate) mod thread {
+    use crate::time::Duration;
     pub use loom::lazy_static::AccessError;
     pub use loom::thread::*;
+    pub fn park_timeout(_dur: Duration) {
+        // TODO: timeout
+        park();
+    }
 }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -323,9 +323,7 @@ impl Handle {
 
         // Enter the runtime context. This sets the current driver handles and
         // prevents blocking an existing runtime.
-        context::enter_runtime(&self.inner, true, |blocking| {
-            blocking.block_on(future).expect("failed to park thread")
-        })
+        context::enter_runtime(&self.inner, true, |blocking| blocking.block_on(future))
     }
 
     #[track_caller]

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -202,20 +202,17 @@ impl CurrentThread {
                     let notified = self.notify.notified();
                     pin!(notified);
 
-                    if let Some(out) = blocking
-                        .block_on(poll_fn(|cx| {
-                            if notified.as_mut().poll(cx).is_ready() {
-                                return Ready(None);
-                            }
+                    if let Some(out) = blocking.block_on(poll_fn(|cx| {
+                        if notified.as_mut().poll(cx).is_ready() {
+                            return Ready(None);
+                        }
 
-                            if let Ready(out) = future.as_mut().poll(cx) {
-                                return Ready(Some(out));
-                            }
+                        if let Ready(out) = future.as_mut().poll(cx) {
+                            return Ready(Some(out));
+                        }
 
-                            Pending
-                        }))
-                        .expect("Failed to `Enter::block_on`")
-                    {
+                        Pending
+                    })) {
                         return out;
                     }
                 }

--- a/tokio/src/runtime/scheduler/multi_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/mod.rs
@@ -83,9 +83,7 @@ impl MultiThread {
     where
         F: Future,
     {
-        crate::runtime::context::enter_runtime(handle, true, |blocking| {
-            blocking.block_on(future).expect("failed to park thread")
-        })
+        crate::runtime::context::enter_runtime(handle, true, |blocking| blocking.block_on(future))
     }
 
     pub(crate) fn shutdown(&mut self, handle: &scheduler::Handle) {

--- a/tokio/src/util/mod.rs
+++ b/tokio/src/util/mod.rs
@@ -17,7 +17,7 @@ pub(crate) use blocking_check::check_socket_for_blocking;
 pub(crate) mod metric_atomics;
 
 mod wake;
-pub(crate) use wake::{waker, Wake};
+pub(crate) use wake::waker;
 
 #[cfg(any(
     // io driver uses `WakeList` directly
@@ -69,7 +69,7 @@ cfg_rt! {
 
     pub(crate) use self::rand::RngSeedGenerator;
 
-    pub(crate) use wake::{waker_ref, WakerRef};
+    pub(crate) use wake::{waker_ref, Wake, WakerRef};
 
     mod sync_wrapper;
     pub(crate) use sync_wrapper::SyncWrapper;

--- a/tokio/src/util/wake.rs
+++ b/tokio/src/util/wake.rs
@@ -1,4 +1,5 @@
 use crate::loom::sync::Arc;
+use crate::loom::thread;
 
 use std::mem::ManuallyDrop;
 use std::task::{RawWaker, RawWakerVTable, Waker};
@@ -82,4 +83,14 @@ unsafe fn wake_by_ref_arc_raw<T: Wake>(data: *const ()) {
 
 unsafe fn drop_arc_raw<T: Wake>(data: *const ()) {
     drop(Arc::<T>::from_raw(data.cast()));
+}
+
+impl Wake for thread::Thread {
+    fn wake(arc_self: Arc<Self>) {
+        arc_self.unpark();
+    }
+
+    fn wake_by_ref(arc_self: &Arc<Self>) {
+        arc_self.unpark();
+    }
 }


### PR DESCRIPTION
Removes the CachedParkThread struct and related thread-local storage, replacing it by a block_on function. Calls thread::park and Thread::unpark for current-thread parking instead of dispatching to ParkThread and UnparkThread.

ParkThread and UnparkThread are kept since the multi-threaded runtime does not support thread::park & Thread::unpark.