### PR TITLE
Implement Stream::size_hint for BroadcastStream

### DIFF
--- a/tokio-stream/src/wrappers/broadcast.rs
+++ b/tokio-stream/src/wrappers/broadcast.rs
@@ -92,6 +92,10 @@ impl<T: 'static + Clone + Send> Stream for BroadcastStream<T> {
         }
     }
 
+    /// Returns the estimated number of items ready to be received.
+    ///
+    /// The returned lower bound is updated on each poll of the stream.  
+    /// Before the first `poll_next()` call, it reflects the channel state at construction time.
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.len, None)
     }

--- a/tokio-stream/tests/broadcast_stream.rs
+++ b/tokio-stream/tests/broadcast_stream.rs
@@ -1,0 +1,41 @@
+use futures_core::Stream;
+use tokio::sync::broadcast;
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+
+#[tokio::test]
+async fn size_hint_with_alive_sender() {
+    let (tx, rx) = broadcast::channel(16);
+    tx.send(1).unwrap();
+    tx.send(2).unwrap();
+
+    let mut stream = BroadcastStream::new(rx);
+    assert_eq!(stream.size_hint().0, 2);
+    stream.next().await;
+    assert_eq!(stream.size_hint().0, 1);
+}
+
+#[tokio::test]
+async fn size_hint_no_sender_but_retained_values() {
+    let (tx, rx) = broadcast::channel(16);
+    tx.send(10).unwrap();
+    tx.send(20).unwrap();
+    drop(tx); // close all senders
+
+    let mut stream = BroadcastStream::new(rx);
+    assert_eq!(stream.size_hint().0, 2);
+    stream.next().await;
+    assert_eq!(stream.size_hint().0, 1);
+    stream.next().await;
+    assert_eq!(stream.size_hint().0, 0);
+}
+
+#[tokio::test]
+async fn size_hint_no_sender_and_empty_channel() {
+    let (_tx, rx) = broadcast::channel::<i32>(16);
+    drop(_tx); // drop sender before sending anything
+
+    let mut stream = BroadcastStream::new(rx);
+    assert_eq!(stream.size_hint().0, 0);
+    assert_eq!(stream.next().await, None);
+    assert_eq!(stream.size_hint().0, 0);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This PR fixes issue #7296 .

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
