### PR TITLE
Make cooperative and poll_proceed public

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -137,8 +137,6 @@ features = [
 tokio-test = { version = "0.4.0", path = "../tokio-test" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 futures = { version = "0.3.0", features = ["async-await"] }
-futures-channel = "0.3.0"
-futures-util = "0.3.0"
 mockall = "0.13.0"
 async-stream = "0.3"
 futures-concurrency = "7.6.3"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -137,6 +137,8 @@ features = [
 tokio-test = { version = "0.4.0", path = "../tokio-test" }
 tokio-stream = { version = "0.1", path = "../tokio-stream" }
 futures = { version = "0.3.0", features = ["async-await"] }
+futures-channel = "0.3.0"
+futures-util = "0.3.0"
 mockall = "0.13.0"
 async-stream = "0.3"
 futures-concurrency = "7.6.3"

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -508,8 +508,8 @@ cfg_coop! {
     ///
     /// ```
     /// use tokio::task::coop::cooperative;
-    /// use futures_channel::mpsc::Receiver;
-    /// use futures_util::stream::StreamExt;
+    /// use futures::channel::mpsc::Receiver;
+    /// use futures::stream::StreamExt;
     ///
     /// async fn receive_next<T>(receiver: &mut Receiver<T>) -> Option<T>
     /// where

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -502,9 +502,10 @@ cfg_coop! {
     /// channel, task budget will automatically be consumed when the next value is returned.
     /// This makes tasks that use Tokio mpsc channels automatically cooperative.
     ///
-    /// If you're using `futures::channel::mpsc` instead, automatic task budget consumption will
-    /// not happen. This example shows how can use `cooperative` to make `futures::channel::mpsc`
-    /// channels cooperate with the scheduler in the same way Tokio channels do.
+    /// If you're using [`futures::channel::mpsc`](https://docs.rs/futures/latest/futures/channel/mpsc/index.html)
+    /// instead, automatic task budget consumption will not happen. This example shows how can use
+    /// `cooperative` to make `futures::channel::mpsc` channels cooperate with the scheduler in the
+    /// same way Tokio channels do.
     ///
     /// ```
     /// use tokio::task::coop::cooperative;

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -514,8 +514,7 @@ cfg_coop! {
     /// use futures::channel::mpsc::Receiver;
     /// use futures::stream::StreamExt;
     ///
-    /// async fn receive_next<T>(receiver: &mut Receiver<T>) -> Option<T>
-    /// {
+    /// async fn receive_next<T>(receiver: &mut Receiver<T>) -> Option<T> {
     ///     // Use `StreamExt::next` to obtain a `Future` that resolves to the next value
     ///     let recv_future = receiver.next();
     ///     // Wrap it a cooperative wrapper

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -343,35 +343,37 @@ cfg_coop! {
     ///     }
     /// }
     ///
-    /// impl<T> Future for CountdownLatch<T> where T: Unpin {
-    ///       type Output = T;
+    /// impl<T> Future for CountdownLatch<T> {
+    ///     type Output = T;
     ///
-    ///       fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-    ///           // `poll_proceed` checks with the runtime if this task is still allowed to proceed
-    ///           // with performing work.
-    ///           // If not, `Pending` is returned and `ready!` ensures this function returns.
-    ///           // If we are allowed to proceed, coop now represents the budget consumption
-    ///           let coop = ready!(coop::poll_proceed(cx));
+    ///     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+    ///         // `poll_proceed` checks with the runtime if this task is still allowed to proceed
+    ///         // with performing work.
+    ///         // If not, `Pending` is returned and `ready!` ensures this function returns.
+    ///         // If we are allowed to proceed, coop now represents the budget consumption
+    ///         let coop = ready!(coop::poll_proceed(cx));
     ///
-    ///           // Get a mutable reference to the unpinned CountdownLatch
-    ///           let this = Pin::get_mut(self);
+    ///         // Get a mutable reference to the CountdownLatch
+    ///         let this = Pin::get_mut(self);
     ///
-    ///           // Next we check if the latch is ready to release its value
-    ///           if this.counter == 0 {
-    ///                let t = this.value.take();
-    ///                // The latch made progress so call `made_progress` to ensure the budget
-    ///                // is not reverted.
-    ///                coop.made_progress();
-    ///                Poll::Ready(t.unwrap())
-    ///           } else {
-    ///                // If the latch is not ready so return pending and simply drop `coop`.
-    ///                // This will restore the budget making it available again to perform any
-    ///                // other work.
-    ///                this.waker = Some(cx.waker().clone());
-    ///                Poll::Pending
-    ///           }
-    ///        }
-    ///    }
+    ///         // Next we check if the latch is ready to release its value
+    ///         if this.counter == 0 {
+    ///             let t = this.value.take();
+    ///             // The latch made progress so call `made_progress` to ensure the budget
+    ///             // is not reverted.
+    ///             coop.made_progress();
+    ///             Poll::Ready(t.unwrap())
+    ///         } else {
+    ///             // If the latch is not ready so return pending and simply drop `coop`.
+    ///             // This will restore the budget making it available again to perform any
+    ///             // other work.
+    ///             this.waker = Some(cx.waker().clone());
+    ///             Poll::Pending
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// impl<T> Unpin for CountdownLatch<T> {}
     /// ```
     #[inline]
     pub fn poll_proceed(cx: &mut Context<'_>) -> Poll<RestoreOnPending> {

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -90,7 +90,6 @@ cfg_rt! {
 // the outer future against the cooperating budget.
 
 use crate::runtime::context;
-use std::marker::PhantomData;
 
 /// Opaque type tracking the amount of "work" a task may still do before
 /// yielding back to the scheduler.
@@ -251,6 +250,7 @@ cfg_coop! {
     use pin_project_lite::pin_project;
     use std::cell::Cell;
     use std::future::Future;
+    use std::marker::PhantomData;
     use std::pin::Pin;
     use std::task::{ready, Context, Poll};
 

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -521,7 +521,6 @@ cfg_coop! {
     ///     // And await
     ///     coop_future.await
     /// }
-
     #[inline]
     pub fn cooperative<F: Future>(fut: F) -> Coop<F> {
         Coop { fut }

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -513,12 +513,10 @@ cfg_coop! {
     /// use futures::stream::StreamExt;
     ///
     /// async fn receive_next<T>(receiver: &mut Receiver<T>) -> Option<T>
-    /// where
-    ///     T: Unpin,
     /// {
     ///     // Use `StreamExt::next` to obtain a `Future` that resolves to the next value
     ///     let recv_future = receiver.next();
-    ///     // Wrap it an a cooperative wrapper
+    ///     // Wrap it a cooperative wrapper
     ///     let coop_future = cooperative(recv_future);
     ///     // And await
     ///     coop_future.await

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -454,7 +454,7 @@ assert_value!(tokio::task::JoinSet<NN>: !Send & !Sync & Unpin);
 assert_value!(tokio::task::JoinSet<YN>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinSet<YY>: Send & Sync & Unpin);
 assert_value!(tokio::task::LocalSet: !Send & !Sync & Unpin);
-assert_value!(tokio::task::coop::RestoreOnPending: Send & !Sync & Unpin);
+assert_value!(tokio::task::coop::RestoreOnPending: !Send & !Sync & Unpin);
 async_assert_fn!(tokio::sync::Barrier::wait(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::sync::Mutex<NN>::lock(_): !Send & !Sync & !Unpin);
 async_assert_fn!(tokio::sync::Mutex<NN>::lock_owned(_): !Send & !Sync & !Unpin);

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -454,6 +454,7 @@ assert_value!(tokio::task::JoinSet<NN>: !Send & !Sync & Unpin);
 assert_value!(tokio::task::JoinSet<YN>: Send & Sync & Unpin);
 assert_value!(tokio::task::JoinSet<YY>: Send & Sync & Unpin);
 assert_value!(tokio::task::LocalSet: !Send & !Sync & Unpin);
+assert_value!(tokio::task::coop::RestoreOnPending: Send & !Sync & Unpin);
 async_assert_fn!(tokio::sync::Barrier::wait(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::sync::Mutex<NN>::lock(_): !Send & !Sync & !Unpin);
 async_assert_fn!(tokio::sync::Mutex<NN>::lock_owned(_): !Send & !Sync & !Unpin);


### PR DESCRIPTION
## Motivation

In systems that use the Tokio runtime, it can be useful to integrate non-Tokio resources with the Tokio task budget. This makes it easier to ensure all tasks yield sufficiently. Currently only `consume_budget` is available, but this is impractical when trying to make certain types like `Future` or `Stream` participate in cooperative scheduling.

Closes #7403

## Solution

Make the existing `cooperative` and `poll_proceed` methods public.
Clarify the documentation of `poll_proceed`.