### PR TITLE
sync: add `DropGuardRef` for `CancellationToken`

### DIFF
--- a/tokio-util/src/sync/cancellation_token.rs
+++ b/tokio-util/src/sync/cancellation_token.rs
@@ -1,6 +1,7 @@
 //! An asynchronously awaitable `CancellationToken`.
 //! The token allows to signal a cancellation request to one or more tasks.
 pub(crate) mod guard;
+pub(crate) mod guard_ref;
 mod tree_node;
 
 use crate::loom::sync::Arc;
@@ -10,6 +11,7 @@ use core::pin::Pin;
 use core::task::{Context, Poll};
 
 use guard::DropGuard;
+use guard_ref::DropGuardRef;
 use pin_project_lite::pin_project;
 
 /// A token which can be used to signal a cancellation request to one or more
@@ -240,6 +242,14 @@ impl CancellationToken {
     /// unless disarmed.
     pub fn drop_guard(self) -> DropGuard {
         DropGuard { inner: Some(self) }
+    }
+
+    /// Creates a `DropGuardRef` for this token.
+    ///
+    /// Returned guard will cancel this token (and all its children) on drop
+    /// unless disarmed.
+    pub fn drop_guard_ref(&self) -> DropGuardRef<'_> {
+        DropGuardRef { inner: Some(self) }
     }
 
     /// Runs a future to completion and returns its result wrapped inside of an `Option`

--- a/tokio-util/src/sync/cancellation_token/guard_ref.rs
+++ b/tokio-util/src/sync/cancellation_token/guard_ref.rs
@@ -1,0 +1,29 @@
+use crate::sync::CancellationToken;
+
+/// A wrapper for cancellation token which automatically cancels
+/// it on drop. It is created using `drop_guard_ref` method on the `CancellationToken`.
+///
+/// This is a `ref` version of `DropGuard`
+#[derive(Debug)]
+pub struct DropGuardRef<'a> {
+    pub(super) inner: Option<&'a CancellationToken>,
+}
+
+impl<'a> DropGuardRef<'a> {
+    /// Returns stored cancellation token and removes this drop guard instance
+    /// (i.e. it will no longer cancel token). Other guards for this token
+    /// are not affected.
+    pub fn disarm(mut self) -> &'a CancellationToken {
+        self.inner
+            .take()
+            .expect("`inner` can be only None in a destructor")
+    }
+}
+
+impl Drop for DropGuardRef<'_> {
+    fn drop(&mut self) {
+        if let Some(inner) = self.inner {
+            inner.cancel();
+        }
+    }
+}

--- a/tokio-util/src/sync/mod.rs
+++ b/tokio-util/src/sync/mod.rs
@@ -2,7 +2,8 @@
 
 mod cancellation_token;
 pub use cancellation_token::{
-    guard::DropGuard, CancellationToken, WaitForCancellationFuture, WaitForCancellationFutureOwned,
+    guard::DropGuard, guard_ref::DropGuardRef, CancellationToken, WaitForCancellationFuture,
+    WaitForCancellationFutureOwned,
 };
 
 mod mpsc;


### PR DESCRIPTION
Closes #7406

## Motivation

`CancellationToken::drop_guard()` requires cloning a new `CancellationToken` in most scenarios, which is actually unnecessary. Within the same scope, we can reference the `CancellationToken` in the scope and continue using it in subsequent code. This PR adds a `DropGuardRef` type that contains a borrow of the CancellationToken, thereby avoiding the clone action

## Solution

like `DropGuard` but contains a reference of `CancellationToken`
```rust
#[derive(Debug)]
pub struct DropGuardRef<'a> {
    pub(super) inner: Option<&'a CancellationToken>,
}
```

use `DropGuard`:
```rust
async fn do_some_work(cancel: CancellationToken) {
    let _cancel = cancel.clone().drop_guard(); // <=== HERE
    loop {
        let Some(result) = cancel.run_until_cancelled(some_async_work()).await else {
            break;
        };
        // do something with result
    }
}
```

use `DropGuardRef`:
```rust
async fn do_some_work(cancel: CancellationToken) {
    let _cancel = cancel.drop_guard_ref(); // <=== HERE
    loop {
        let Some(result) = cancel.run_until_cancelled(some_async_work()).await else {
            break;
        };
        // do something with result
    }
}
```
