### PR TITLE
rt(unstable): add spawn `Location` to `TaskMeta`

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -379,7 +379,12 @@ impl Spawner {
         let fut =
             blocking_task::<F, BlockingTask<F>>(BlockingTask::new(func), spawn_meta, id.as_u64());
 
-        let (task, handle) = task::unowned(fut, BlockingSchedule::new(rt), id);
+        let (task, handle) = task::unowned(
+            fut,
+            BlockingSchedule::new(rt),
+            id,
+            std::panic::Location::caller(),
+        );
 
         let spawned = self.spawn_task(Task::new(task, is_mandatory), rt);
         (handle, spawned)

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -15,6 +15,7 @@ use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::future::{poll_fn, Future};
+use std::panic::Location;
 use std::sync::atomic::Ordering::{AcqRel, Release};
 use std::task::Poll::{Pending, Ready};
 use std::task::Waker;
@@ -445,6 +446,7 @@ impl Context {
 
 impl Handle {
     /// Spawns a future onto the `CurrentThread` scheduler
+    #[track_caller]
     pub(crate) fn spawn<F>(
         me: &Arc<Self>,
         future: F,
@@ -454,10 +456,12 @@ impl Handle {
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+        let spawned_at = Location::caller();
+        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
 
         me.task_hooks.spawn(&TaskMeta {
             id,
+            spawned_at,
             _phantom: Default::default(),
         });
 
@@ -474,6 +478,7 @@ impl Handle {
     /// This should only be used when this is a `LocalRuntime` or in another case where the runtime
     /// provably cannot be driven from or moved to different threads from the one on which the task
     /// is spawned.
+    #[track_caller]
     pub(crate) unsafe fn spawn_local<F>(
         me: &Arc<Self>,
         future: F,
@@ -483,10 +488,15 @@ impl Handle {
         F: crate::future::Future + 'static,
         F::Output: 'static,
     {
-        let (handle, notified) = me.shared.owned.bind_local(future, me.clone(), id);
+        let spawned_at = Location::caller();
+        let (handle, notified) = me
+            .shared
+            .owned
+            .bind_local(future, me.clone(), id, spawned_at);
 
         me.task_hooks.spawn(&TaskMeta {
             id,
+            spawned_at,
             _phantom: Default::default(),
         });
 
@@ -771,16 +781,16 @@ impl CoreGuard<'_> {
                     let task = context.handle.shared.owned.assert_owner(task);
 
                     #[cfg(tokio_unstable)]
-                    let task_id = task.task_id();
+                    let task_meta = task.task_meta();
 
                     let (c, ()) = context.run_task(core, || {
                         #[cfg(tokio_unstable)]
-                        context.handle.task_hooks.poll_start_callback(task_id);
+                        context.handle.task_hooks.poll_start_callback(&task_meta);
 
                         task.run();
 
                         #[cfg(tokio_unstable)]
-                        context.handle.task_hooks.poll_stop_callback(task_id);
+                        context.handle.task_hooks.poll_stop_callback(&task_meta);
                     });
 
                     core = c;

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -117,6 +117,7 @@ cfg_rt! {
             }
         }
 
+        #[track_caller]
         pub(crate) fn spawn<F>(&self, future: F, id: Id) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,
@@ -136,6 +137,7 @@ cfg_rt! {
         /// This should only be called in `LocalRuntime` if the runtime has been verified to be owned
         /// by the current thread.
         #[allow(irrefutable_let_patterns)]
+        #[track_caller]
         pub(crate) unsafe fn spawn_local<F>(&self, future: F, id: Id) -> JoinHandle<F::Output>
         where
             F: Future + 'static,

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -10,6 +10,7 @@ use crate::runtime::{
 use crate::util::RngSeedGenerator;
 
 use std::fmt;
+use std::panic::Location;
 
 mod metrics;
 
@@ -37,6 +38,7 @@ pub(crate) struct Handle {
 
 impl Handle {
     /// Spawns a future onto the thread pool
+    #[track_caller]
     pub(crate) fn spawn<F>(me: &Arc<Self>, future: F, id: task::Id) -> JoinHandle<F::Output>
     where
         F: crate::future::Future + Send + 'static,
@@ -49,15 +51,18 @@ impl Handle {
         self.close();
     }
 
+    #[track_caller]
     pub(super) fn bind_new_task<T>(me: &Arc<Self>, future: T, id: task::Id) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id);
+        let spawned_at = Location::caller();
+        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
 
         me.task_hooks.spawn(&TaskMeta {
             id,
+            spawned_at,
             _phantom: Default::default(),
         });
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -568,7 +568,7 @@ impl Context {
 
     fn run_task(&self, task: Notified, mut core: Box<Core>) -> RunResult {
         #[cfg(tokio_unstable)]
-        let task_id = task.task_id();
+        let task_meta = task.task_meta();
 
         let task = self.worker.handle.shared.owned.assert_owner(task);
 
@@ -592,12 +592,15 @@ impl Context {
             // Unlike the poll time above, poll start callback is attached to the task id,
             // so it is tightly associated with the actual poll invocation.
             #[cfg(tokio_unstable)]
-            self.worker.handle.task_hooks.poll_start_callback(task_id);
+            self.worker
+                .handle
+                .task_hooks
+                .poll_start_callback(&task_meta);
 
             task.run();
 
             #[cfg(tokio_unstable)]
-            self.worker.handle.task_hooks.poll_stop_callback(task_id);
+            self.worker.handle.task_hooks.poll_stop_callback(&task_meta);
 
             let mut lifo_polls = 0;
 
@@ -663,15 +666,18 @@ impl Context {
                 let task = self.worker.handle.shared.owned.assert_owner(task);
 
                 #[cfg(tokio_unstable)]
-                let task_id = task.task_id();
+                let task_meta = task.task_meta();
 
                 #[cfg(tokio_unstable)]
-                self.worker.handle.task_hooks.poll_start_callback(task_id);
+                self.worker
+                    .handle
+                    .task_hooks
+                    .poll_start_callback(&task_meta);
 
                 task.run();
 
                 #[cfg(tokio_unstable)]
-                self.worker.handle.task_hooks.poll_stop_callback(task_id);
+                self.worker.handle.task_hooks.poll_stop_callback(&task_meta);
             }
         })
     }

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -18,6 +18,7 @@ use crate::runtime::task::{Id, Schedule, TaskHarnessScheduleHooks};
 use crate::util::linked_list;
 
 use std::num::NonZeroU64;
+use std::panic::Location;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::task::{Context, Poll, Waker};
@@ -141,6 +142,12 @@ pub(super) struct Core<T: Future, S> {
     /// The task's ID, used for populating `JoinError`s.
     pub(super) task_id: Id,
 
+    /// The source code location where the task was spawned./
+    ///
+    /// This is used for populating the `TaskMeta` passed to the task runtime
+    /// hooks.
+    pub(super) spawned_at: &'static Location<'static>,
+
     /// Either the future or the output.
     pub(super) stage: CoreStage<T>,
 }
@@ -208,7 +215,13 @@ pub(super) enum Stage<T: Future> {
 impl<T: Future, S: Schedule> Cell<T, S> {
     /// Allocates a new task cell, containing the header, trailer, and core
     /// structures.
-    pub(super) fn new(future: T, scheduler: S, state: State, task_id: Id) -> Box<Cell<T, S>> {
+    pub(super) fn new(
+        future: T,
+        scheduler: S,
+        state: State,
+        task_id: Id,
+        spawned_at: &'static Location<'static>,
+    ) -> Box<Cell<T, S>> {
         // Separated into a non-generic function to reduce LLVM codegen
         fn new_header(
             state: State,
@@ -242,13 +255,20 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                     stage: UnsafeCell::new(Stage::Running(future)),
                 },
                 task_id,
+                spawned_at,
             },
         });
 
         #[cfg(debug_assertions)]
         {
             // Using a separate function for this code avoids instantiating it separately for every `T`.
-            unsafe fn check<S>(header: &Header, trailer: &Trailer, scheduler: &S, task_id: &Id) {
+            unsafe fn check<S>(
+                header: &Header,
+                trailer: &Trailer,
+                scheduler: &S,
+                task_id: &Id,
+                spawn_location: &&'static Location<'static>,
+            ) {
                 let trailer_addr = trailer as *const Trailer as usize;
                 let trailer_ptr = unsafe { Header::get_trailer(NonNull::from(header)) };
                 assert_eq!(trailer_addr, trailer_ptr.as_ptr() as usize);
@@ -260,6 +280,12 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                 let id_addr = task_id as *const Id as usize;
                 let id_ptr = unsafe { Header::get_id_ptr(NonNull::from(header)) };
                 assert_eq!(id_addr, id_ptr.as_ptr() as usize);
+
+                let spawn_location_addr =
+                    spawn_location as *const &'static Location<'static> as usize;
+                let spawn_location_ptr =
+                    unsafe { Header::get_spawn_location_ptr(NonNull::from(header)) };
+                assert_eq!(spawn_location_addr, spawn_location_ptr.as_ptr() as usize);
             }
             unsafe {
                 check(
@@ -267,6 +293,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
                     &result.trailer,
                     &result.core.scheduler,
                     &result.core.task_id,
+                    &result.core.spawned_at,
                 );
             }
         }
@@ -447,6 +474,34 @@ impl Header {
     /// The provided raw pointer must point at the header of a task.
     pub(super) unsafe fn get_id(me: NonNull<Header>) -> Id {
         let ptr = Header::get_id_ptr(me).as_ptr();
+        *ptr
+    }
+
+    /// Gets a pointer to the source code location where the task containing
+    /// this `Header` was spawned.
+    ///
+    /// # Safety
+    ///
+    /// The provided raw pointer must point at the header of a task.
+    pub(super) unsafe fn get_spawn_location_ptr(
+        me: NonNull<Header>,
+    ) -> NonNull<&'static Location<'static>> {
+        let offset = me.as_ref().vtable.spawn_location_offset;
+        let spawned_at = me
+            .as_ptr()
+            .cast::<u8>()
+            .add(offset)
+            .cast::<&'static Location<'static>>();
+        NonNull::new_unchecked(spawned_at)
+    }
+
+    /// Gets the id of the task containing this `Header`.
+    ///
+    /// # Safety
+    ///
+    /// The provided raw pointer must point at the header of a task.
+    pub(super) unsafe fn get_spawn_location(me: NonNull<Header>) -> &'static Location<'static> {
+        let ptr = Header::get_spawn_location_ptr(me).as_ptr();
         *ptr
     }
 

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -371,6 +371,7 @@ where
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                 f(&TaskMeta {
                     id: self.core().task_id,
+                    spawned_at: self.core().spawned_at,
                     _phantom: Default::default(),
                 })
             }));

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -226,6 +226,7 @@ use crate::util::sharded_list;
 
 use crate::runtime::TaskCallback;
 use std::marker::PhantomData;
+use std::panic::Location;
 use std::ptr::NonNull;
 use std::{fmt, mem};
 
@@ -243,6 +244,14 @@ unsafe impl<S> Sync for Task<S> {}
 #[repr(transparent)]
 pub(crate) struct Notified<S: 'static>(Task<S>);
 
+impl<S> Notified<S> {
+    #[cfg(tokio_unstable)]
+    #[inline]
+    pub(crate) fn task_meta<'task, 'meta>(&'task self) -> crate::runtime::TaskMeta<'meta> {
+        self.0.task_meta()
+    }
+}
+
 // safety: This type cannot be used to touch the task without first verifying
 // that the value is on a thread where it is safe to poll the task.
 unsafe impl<S: Schedule> Send for Notified<S> {}
@@ -258,8 +267,9 @@ pub(crate) struct LocalNotified<S: 'static> {
 
 impl<S> LocalNotified<S> {
     #[cfg(tokio_unstable)]
-    pub(crate) fn task_id(&self) -> Id {
-        self.task.id()
+    #[inline]
+    pub(crate) fn task_meta<'task, 'meta>(&'task self) -> crate::runtime::TaskMeta<'meta> {
+        self.task.task_meta()
     }
 }
 
@@ -317,13 +327,14 @@ cfg_rt! {
         task: T,
         scheduler: S,
         id: Id,
+        spawned_at: &'static Location<'static>,
     ) -> (Task<S>, Notified<S>, JoinHandle<T::Output>)
     where
         S: Schedule,
         T: Future + 'static,
         T::Output: 'static,
     {
-        let raw = RawTask::new::<T, S>(task, scheduler, id);
+        let raw = RawTask::new::<T, S>(task, scheduler, id, spawned_at);
         let task = Task {
             raw,
             _p: PhantomData,
@@ -341,13 +352,13 @@ cfg_rt! {
     /// only when the task is not going to be stored in an `OwnedTasks` list.
     ///
     /// Currently only blocking tasks use this method.
-    pub(crate) fn unowned<T, S>(task: T, scheduler: S, id: Id) -> (UnownedTask<S>, JoinHandle<T::Output>)
+    pub(crate) fn unowned<T, S>(task: T, scheduler: S, id: Id, spawned_at: &'static Location<'static>) -> (UnownedTask<S>, JoinHandle<T::Output>)
     where
         S: Schedule,
         T: Send + Future + 'static,
         T::Output: Send + 'static,
     {
-        let (task, notified, join) = new_task(task, scheduler, id);
+        let (task, notified, join) = new_task(task, scheduler, id, spawned_at);
 
         // This transfers the ref-count of task and notified into an UnownedTask.
         // This is valid because an UnownedTask holds two ref-counts.
@@ -401,6 +412,24 @@ impl<S: 'static> Task<S> {
     pub(crate) fn id(&self) -> crate::task::Id {
         // Safety: The header pointer is valid.
         unsafe { Header::get_id(self.raw.header_ptr()) }
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn spawned_at(&self) -> &'static Location<'static> {
+        // Safety: The header pointer is valid.
+        unsafe { Header::get_spawn_location(self.raw.header_ptr()) }
+    }
+
+    // Explicit `'task` and `'meta` lifetimes are necessary here, as otherwise,
+    // the compiler infers the lifetimes to be the same, and considers the task
+    // to be borrowed for the lifetime of the returned `TaskMeta`.
+    #[cfg(tokio_unstable)]
+    pub(crate) fn task_meta<'task, 'meta>(&'task self) -> crate::runtime::TaskMeta<'meta> {
+        crate::runtime::TaskMeta {
+            id: self.id(),
+            spawned_at: self.spawned_at(),
+            _phantom: PhantomData,
+        }
     }
 
     cfg_taskdump! {

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -2,6 +2,7 @@ use crate::future::Future;
 use crate::runtime::task::core::{Core, Trailer};
 use crate::runtime::task::{Cell, Harness, Header, Id, Schedule, State};
 
+use std::panic::Location;
 use std::ptr::NonNull;
 use std::task::{Poll, Waker};
 
@@ -41,6 +42,9 @@ pub(super) struct Vtable {
 
     /// The number of bytes that the `id` field is offset from the header.
     pub(super) id_offset: usize,
+
+    /// The number of bytes that the `spawned_at` field is offset from the header.
+    pub(super) spawn_location_offset: usize,
 }
 
 /// Get the vtable for the requested `T` and `S` generics.
@@ -56,6 +60,7 @@ pub(super) fn vtable<T: Future, S: Schedule>() -> &'static Vtable {
         trailer_offset: OffsetHelper::<T, S>::TRAILER_OFFSET,
         scheduler_offset: OffsetHelper::<T, S>::SCHEDULER_OFFSET,
         id_offset: OffsetHelper::<T, S>::ID_OFFSET,
+        spawn_location_offset: OffsetHelper::<T, S>::SPAWN_LOCATION_OFFSET,
     }
 }
 
@@ -88,6 +93,15 @@ impl<T: Future, S: Schedule> OffsetHelper<T, S> {
         std::mem::align_of::<Core<T, S>>(),
         std::mem::size_of::<S>(),
         std::mem::align_of::<Id>(),
+    );
+
+    const SPAWN_LOCATION_OFFSET: usize = get_spawn_location_offset(
+        std::mem::size_of::<Header>(),
+        std::mem::align_of::<Core<T, S>>(),
+        std::mem::size_of::<S>(),
+        std::mem::align_of::<Id>(),
+        std::mem::size_of::<Id>(),
+        std::mem::align_of::<&'static Location<'static>>(),
     );
 }
 
@@ -156,13 +170,48 @@ const fn get_id_offset(
     offset
 }
 
+/// Compute the offset of the `&'static Location<'static>` field in `Cell<T, S>`
+/// using the `#[repr(C)]` algorithm.
+///
+/// Pseudo-code for the `#[repr(C)]` algorithm can be found here:
+/// <https://doc.rust-lang.org/reference/type-layout.html#reprc-structs>
+const fn get_spawn_location_offset(
+    header_size: usize,
+    core_align: usize,
+    scheduler_size: usize,
+    id_align: usize,
+    id_size: usize,
+    spawn_location_align: usize,
+) -> usize {
+    let mut offset = get_id_offset(header_size, core_align, scheduler_size, id_align);
+    offset += id_size;
+
+    let spawn_location_misalign = offset % spawn_location_align;
+    if spawn_location_misalign > 0 {
+        offset += spawn_location_align - spawn_location_misalign;
+    }
+
+    offset
+}
+
 impl RawTask {
-    pub(super) fn new<T, S>(task: T, scheduler: S, id: Id) -> RawTask
+    pub(super) fn new<T, S>(
+        task: T,
+        scheduler: S,
+        id: Id,
+        spawned_at: &'static Location<'static>,
+    ) -> RawTask
     where
         T: Future,
         S: Schedule,
     {
-        let ptr = Box::into_raw(Cell::<_, S>::new(task, scheduler, State::new(), id));
+        let ptr = Box::into_raw(Cell::<_, S>::new(
+            task,
+            scheduler,
+            State::new(),
+            id,
+            spawned_at,
+        ));
         let ptr = unsafe { NonNull::new_unchecked(ptr.cast()) };
 
         RawTask { ptr }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -5,6 +5,7 @@ use crate::runtime::tests::NoopSchedule;
 
 use std::collections::VecDeque;
 use std::future::Future;
+use std::panic::Location;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -57,6 +58,7 @@ fn create_drop1() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     drop(notified);
     handle.assert_not_dropped();
@@ -74,6 +76,7 @@ fn create_drop2() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     drop(join);
     handle.assert_not_dropped();
@@ -91,6 +94,7 @@ fn drop_abort_handle1() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     let abort = join.abort_handle();
     drop(join);
@@ -111,6 +115,7 @@ fn drop_abort_handle2() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     let abort = join.abort_handle();
     drop(notified);
@@ -131,6 +136,7 @@ fn drop_abort_handle_clone() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     let abort = join.abort_handle();
     let abort_clone = abort.clone();
@@ -155,6 +161,7 @@ fn create_shutdown1() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     drop(join);
     handle.assert_not_dropped();
@@ -172,6 +179,7 @@ fn create_shutdown2() {
         },
         NoopSchedule,
         Id::next(),
+        Location::caller(),
     );
     handle.assert_not_dropped();
     notified.shutdown();
@@ -181,7 +189,7 @@ fn create_shutdown2() {
 
 #[test]
 fn unowned_poll() {
-    let (task, _) = unowned(async {}, NoopSchedule, Id::next());
+    let (task, _) = unowned(async {}, NoopSchedule, Id::next(), Location::caller());
     task.run();
 }
 
@@ -385,12 +393,16 @@ struct Core {
 static CURRENT: Mutex<Option<Runtime>> = Mutex::new(None);
 
 impl Runtime {
+    #[track_caller]
     fn spawn<T>(&self, future: T) -> JoinHandle<T::Output>
     where
         T: 'static + Send + Future,
         T::Output: 'static + Send,
     {
-        let (handle, notified) = self.0.owned.bind(future, self.clone(), Id::next());
+        let (handle, notified) =
+            self.0
+                .owned
+                .bind(future, self.clone(), Id::next(), Location::caller());
 
         if let Some(notified) = notified {
             self.schedule(notified);

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -1010,10 +1010,12 @@ impl Context {
         // Safety: called from the thread that owns the `LocalSet`
         let (handle, notified) = {
             self.shared.local_state.assert_called_from_owner_thread();
-            self.shared
-                .local_state
-                .owned
-                .bind(future, self.shared.clone(), id)
+            self.shared.local_state.owned.bind(
+                future,
+                self.shared.clone(),
+                id,
+                std::panic::Location::caller(),
+            )
         };
 
         if let Some(notified) = notified {


### PR DESCRIPTION
## Motivation

As described in issue #7411, task spawning APIs are currently annotated
with `#[track_caller]`, allowing us to capture the location in the user
source code where the task was spawned. This is used for `tracing`
events used by `tokio-console` and friends. However, this information is
*not* exposed to the runtime `on_task_spawn`, `on_before_task_poll`,
`on_after_task_poll`, and `on_task_terminate` hooks, which is a shame,
as it would be useful there as well.

## Solution

This branch adds the task's spawn location to the `TaskMeta` struct
provided to the runtime's task hooks. This is implemented by storing a
`&'static Location<'static>` in the task's `Core` alongside the
`task::Id`. In [this comment][1], @ADD-SP suggested storing the
`Location` in the task's `Trailer`.

I opted to store it in the `Core` instead, as the `Trailer` is intended
to store "cold" data that is only accessed when the task _completes_,
and not on every poll. Since the task meta is passed to the
`on_before_task_poll` and `on_after_task_poll` hooks, we would be
accessing the `Trailer` on polls if we stored the `Location` there.
Therefore, I put it in the `Core`, instead, which contains data that we
access every time the task is polled.

Closes #7411