### PR TITLE
impl Clone for net::unix::SocketAddr

### DIFF
--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 /// This type is a thin wrapper around [`std::os::unix::net::SocketAddr`]. You
 /// can convert to and from the standard library `SocketAddr` type using the
 /// [`From`] trait.
+#[derive(Clone)]
 pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 
 impl SocketAddr {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`tokio::net::unix::SocketAddr` wraps a `std::os::unix::net::SocketAddr`. The latter implements `Clone`, but the former does not. This can be a bit annoying for certain niche use cases, such as when we want to use the `tokio` version in relation to `axum::extract::connect_info::Connected`. More than that, it simply makes sense to `impl Clone` here if the wrapped inner is already `impl Clone`.

## Solution

added a `#[derive(Clone)]`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Closes https://github.com/tokio-rs/tokio/issues/7421.