### PR TITLE
net: allow `pipe::OpenOptions::read_write` on Android

### DIFF
--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -120,7 +120,7 @@ pub fn pipe() -> io::Result<(Sender, Receiver)> {
 /// ```
 #[derive(Clone, Debug)]
 pub struct OpenOptions {
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     read_write: bool,
     unchecked: bool,
 }
@@ -131,7 +131,7 @@ impl OpenOptions {
     /// All options are initially set to `false`.
     pub fn new() -> OpenOptions {
         OpenOptions {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "android"))]
             read_write: false,
             unchecked: false,
         }
@@ -168,8 +168,8 @@ impl OpenOptions {
     ///     .read_write(true)
     ///     .open_receiver("path/to/a/fifo");
     /// ```
-    #[cfg(target_os = "linux")]
-    #[cfg_attr(docsrs, doc(cfg(target_os = "linux")))]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
     pub fn read_write(&mut self, value: bool) -> &mut Self {
         self.read_write = value;
         self
@@ -264,7 +264,7 @@ impl OpenOptions {
             .write(pipe_end == PipeEnd::Sender)
             .custom_flags(libc::O_NONBLOCK);
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "android"))]
         if self.read_write {
             options.read(true).write(true);
         }

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -68,7 +68,7 @@ async fn fifo_simple_send() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[cfg_attr(miri, ignore)] // No `mkfifo` in miri.
 async fn fifo_simple_send_sender_first() -> io::Result<()> {
     const DATA: &[u8] = b"this is some data to write to the fifo";
@@ -134,7 +134,7 @@ async fn fifo_multiple_writes() -> io::Result<()> {
 /// Checks behavior of a resilient reader (Receiver in O_RDWR access mode)
 /// with writers sequentially opening and closing a FIFO.
 #[tokio::test]
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[cfg_attr(miri, ignore)] // No `socket` in miri.
 async fn fifo_resilient_reader() -> io::Result<()> {
     const DATA: &[u8] = b"this is some data to write to the fifo";


### PR DESCRIPTION
## Motivation

I'd like to read from a fifo forever on Android. However, `OpenOptions.read_write()` isn't present on Android.

## Solution

Tweaked the `cfg` to enable `read_write` on both Linux and Android.

I'm not sure if CI is set up for Android, but I enabled Android for the tests that I saw used read_write as well.