### PR TITLE
Update AsRawFd documentation link to current Rust stdlib location

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -81,7 +81,7 @@ cfg_net! {
     ///
     /// [`RawFd`]: https://doc.rust-lang.org/std/os/fd/type.RawFd.html
     /// [`RawSocket`]: https://doc.rust-lang.org/std/os/windows/io/type.RawSocket.html
-    /// [`AsRawFd`]: https://doc.rust-lang.org/std/os/unix/io/trait.AsRawFd.html
+    /// [`AsRawFd`]: https://doc.rust-lang.org/std/os/fd/trait.AsRawFd.html
     /// [`AsRawSocket`]: https://doc.rust-lang.org/std/os/windows/io/trait.AsRawSocket.html
     /// [`socket2`]: https://docs.rs/socket2/
     #[cfg_attr(docsrs, doc(alias = "connect_std"))]


### PR DESCRIPTION
Replaced the outdated AsRawFd documentation URL (pointing to std/os/unix/io) with the current, canonical link (https://doc.rust-lang.org/std/os/fd/trait.AsRawFd.html) in the TcpSocket documentation. This ensures that users are directed to the correct and up-to-date Rust standard library documentation for the AsRawFd trait. No functional code changes were made.