### PR TITLE
chore: prepare to release v1.46.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.46.0", features = ["full"] }
+tokio = { version = "1.46.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,6 +1,20 @@
+# 1.46.1 (July 4th, 2025)
+
+This release fixes incorrect spawn locations in runtime task hooks for tasks
+spawned using `tokio::spawn` rather than `Runtime::spawn`. This issue only
+effected the spawn location in `TaskMeta::spawned_at`, and did not effect task
+locations in Tracing events.
+
+## Unstable
+
+- runtime: add `TaskMeta::spawn_location` tracking where a task was spawned
+  ([#7440])
+
+[#7440]: https://github.com/tokio-rs/tokio/pull/7440
+
 # 1.46.0 (July 2nd, 2025)
 
-### Fixed
+## Fixed
 
 - net: fixed `TcpStream::shutdown` incorrectly returning an error on macOS ([#7290])
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.46.0"
+version = "1.46.1"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.46.0", features = ["full"] }
+tokio = { version = "1.46.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.46.1 (July 4th, 2025)

This release fixes incorrect spawn locations in runtime task hooks for tasks spawned using `tokio::spawn` rather than `Runtime::spawn`. This issue only effected the spawn location in `TaskMeta::spawned_at`, and did not effect task locations in Tracing events.

## Unstable

- runtime: add `TaskMeta::spawn_location` tracking where a task was spawned ([#7440])

[#7440]: https://github.com/tokio-rs/tokio/pull/7440
