### PR TITLE
sync: improve AtomicWaker::wake performance

### DIFF
--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -320,7 +320,7 @@ impl AtomicWaker {
                 let waker = unsafe { self.waker.with_mut(|t| (*t).take()) };
 
                 // Release the lock.
-                self.state.store(WAITING, Release);
+                self.state.swap(WAITING, Release);
 
                 waker
             }

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -316,11 +316,11 @@ impl AtomicWaker {
         // memory the `AtomicWaker` is associated with.
         match self.state.fetch_or(WAKING, AcqRel) {
             WAITING => {
-                // The waking lock has been acquired.
+                // SAFETY: the waking lock has been acquired.
                 let waker = unsafe { self.waker.with_mut(|t| (*t).take()) };
 
-                // Release the lock
-                self.state.fetch_and(!WAKING, Release);
+                // Release the lock.
+                self.state.store(WAITING, Release);
 
                 waker
             }

--- a/tokio/src/sync/task/atomic_waker.rs
+++ b/tokio/src/sync/task/atomic_waker.rs
@@ -320,7 +320,8 @@ impl AtomicWaker {
                 let waker = unsafe { self.waker.with_mut(|t| (*t).take()) };
 
                 // Release the lock.
-                self.state.swap(WAITING, Release);
+                let old_state = self.state.swap(WAITING, Release);
+                debug_assert!(old_state == WAKING);
 
                 waker
             }

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -40,6 +40,7 @@ fn wake_without_register() {
 }
 
 #[test]
+#[cfg_attr(target_family = "wasm", ignore)] // threads not supported
 fn failed_wake_synchronizes() {
     for _ in 0..1000 {
         failed_wake_synchronizes_inner();

--- a/tokio/src/sync/tests/atomic_waker.rs
+++ b/tokio/src/sync/tests/atomic_waker.rs
@@ -39,6 +39,37 @@ fn wake_without_register() {
     assert!(!waker.is_woken());
 }
 
+#[test]
+fn failed_wake_synchronizes() {
+    for _ in 0..1000 {
+        failed_wake_synchronizes_inner();
+    }
+}
+
+fn failed_wake_synchronizes_inner() {
+    use futures::task::noop_waker_ref;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static DID_SYNCHRONIZE: AtomicBool = AtomicBool::new(false);
+    DID_SYNCHRONIZE.store(false, Ordering::Relaxed);
+
+    let waker = AtomicWaker::new();
+    waker.register_by_ref(noop_waker_ref());
+
+    std::thread::scope(|s| {
+        let jh = s.spawn(|| {
+            DID_SYNCHRONIZE.store(true, Ordering::Relaxed);
+            waker.take_waker()
+        });
+
+        waker.take_waker();
+        waker.register_by_ref(noop_waker_ref());
+
+        let did_synchronize = DID_SYNCHRONIZE.load(Ordering::Relaxed);
+        let did_take = jh.join().unwrap().is_some();
+        assert!(did_synchronize || did_take);
+    });
+}
+
 #[cfg(panic = "unwind")]
 #[test]
 #[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding


### PR DESCRIPTION
## Motivation

The `AtomicWaker` does a read-modify-write operation to release its lock on the state, but this is not necessary.
The only other place `state` can be modified concurrently is through another `fetch_or(WAKING)` in `fn take` (a no-op since the state is already `WAKING`), or through a `compare_exchange(WAITING, REGISTERING)` in `fn register`, however this will always fail as we are currently in `WAKING`. Thus we know with 100% certainty the state is `WAKING` and will remain so, so the `fetch_and(!WAKING)` is equivalent to just storing `WAITING`.

One other reason one might use a read-modify-write operation instead of a simple store is if one is also `Acquire`ing. But here we only use `Release`, so the read portion of the atomic operation is entirely unnecessary.

## Solution

~~I changed the release  of the lock to a simple `Release` `store`.~~

As @Darksonn points out we still need to store with a read-modify-write operation to ensure the release sequence from wake-during-wakes stays intact. So I changed the release to a `swap` which is still more efficient than a `fetch_and`.