### PR TITLE
runtime: cleanup legacy tests of alt multi-threaded runtime

### DIFF
--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -53,40 +53,6 @@ macro_rules! rt_test {
                     .into()
             }
         }
-
-        #[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
-        #[cfg(tokio_unstable)]
-        mod alt_threaded_scheduler_4_threads {
-            $($t)*
-
-            const NUM_WORKERS: usize = 4;
-
-            fn rt() -> Arc<Runtime> {
-                tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(4)
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .into()
-            }
-        }
-
-        #[cfg(not(target_os = "wasi"))] // Wasi doesn't support threads
-        #[cfg(tokio_unstable)]
-        mod alt_threaded_scheduler_1_thread {
-            $($t)*
-
-            const NUM_WORKERS: usize = 1;
-
-            fn rt() -> Arc<Runtime> {
-                tokio::runtime::Builder::new_multi_thread()
-                    .worker_threads(1)
-                    .enable_all()
-                    .build()
-                    .unwrap()
-                    .into()
-            }
-        }
     }
 }
 


### PR DESCRIPTION
These alt multi-threaded runtime and relevant tests were initially added in #5823, and the alt multi-threaded runtime was removed in #7275.

However, there are two test combinations in `tokio/tests/rt_common.rs` that should have been deleted in #7275 were not.