### PR TITLE
task: opens `Id::as_u64` to clients

### DIFF
--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -74,7 +74,21 @@ impl Id {
         }
     }
 
-    pub(crate) fn as_u64(&self) -> u64 {
+    /// Retrieves the underlying [`u64`] for this [`Id`]
+    /// There are no guarantees about the order or contents of this [`u64`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # tokio_test::block_on(async {
+    /// let handle = tokio::spawn(async {
+    ///     let id = tokio::task::id();
+    ///     let id_as_u64 : u64 = id.as_u64();
+    /// });
+    /// handle.await.unwrap();
+    /// # });
+    /// ```
+    pub fn as_u64(&self) -> u64 {
         self.0.get()
     }
 }


### PR DESCRIPTION
Allows clients to observe the contents of Task IDs, with no guarantees on contents.

Fixes: #7430


## Motivation

Solves the ask in the referenced issue (#7430) to allow a lightweight/cheap way to see the contents of a task Id. 

## Solution

Simply opens `task::Id::as_u64` to `pub` instead of `pub(crate)`
