### PR TITLE
net: UdpSocket's join_multicast_v4 params differs from std

### DIFF
--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -2095,8 +2095,8 @@ impl UdpSocket {
     /// address of the local interface with which the system should join the
     /// multicast group. If it's equal to `INADDR_ANY` then an appropriate
     /// interface is chosen by the system.
-    pub fn join_multicast_v4(&self, multiaddr: Ipv4Addr, interface: Ipv4Addr) -> io::Result<()> {
-        self.io.join_multicast_v4(&multiaddr, &interface)
+    pub fn join_multicast_v4(&self, multiaddr: &Ipv4Addr, interface: &Ipv4Addr) -> io::Result<()> {
+        self.io.join_multicast_v4(multiaddr, interface)
     }
 
     /// Executes an operation of the `IPV6_ADD_MEMBERSHIP` type.


### PR DESCRIPTION
Aligned the `join_multicast_v4` params in `UdpSocket` to match `std`.

Fixes: #7459

## Motivation

`join_multicast_v4` in `tokio` takes ownership of both `multiaddr` and `interface`, whereas `std` takes a reference.

## Solution

Trivial: from ownership to reference params