### PR TITLE
time: Introduce advance_stable

### DIFF
--- a/tokio/src/runtime/time/handle.rs
+++ b/tokio/src/runtime/time/handle.rs
@@ -3,8 +3,8 @@ use std::fmt;
 
 /// Handle to time driver instance.
 pub(crate) struct Handle {
-    pub(super) time_source: TimeSource,
-    pub(super) inner: super::Inner,
+    pub(crate) time_source: TimeSource,
+    pub(crate) inner: super::Inner,
 }
 
 impl Handle {

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -90,7 +90,7 @@ pub(crate) struct Driver {
 }
 
 /// Timer state shared between `Driver`, `Handle`, and `Registration`.
-struct Inner {
+pub(crate) struct Inner {
     // The state is split like this so `Handle` can access `is_shutdown` without locking the mutex
     state: Mutex<InnerState>,
 
@@ -108,12 +108,12 @@ struct Inner {
 }
 
 /// Time state shared which must be protected by a `Mutex`
-struct InnerState {
+pub(crate) struct InnerState {
     /// The earliest time at which we promise to wake up without unparking.
-    next_wake: Option<NonZeroU64>,
+    pub(crate) next_wake: Option<NonZeroU64>,
 
     /// Timer wheel.
-    wheel: wheel::Wheel,
+    pub(crate) wheel: wheel::Wheel,
 }
 
 // ===== impl Driver =====
@@ -389,7 +389,7 @@ impl Handle {
 
 impl Inner {
     /// Locks the driver's inner structure
-    pub(super) fn lock(&self) -> crate::loom::sync::MutexGuard<'_, InnerState> {
+    pub(crate) fn lock(&self) -> crate::loom::sync::MutexGuard<'_, InnerState> {
         self.state.lock()
     }
 

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -193,7 +193,7 @@ impl Wheel {
 
     /// Returns the tick at which this timer wheel next needs to perform some
     /// processing, or None if there are no timers registered.
-    pub(super) fn next_expiration_time(&self) -> Option<u64> {
+    pub(crate) fn next_expiration_time(&self) -> Option<u64> {
         self.next_expiration().map(|ex| ex.deadline)
     }
 

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -87,7 +87,7 @@
 mod clock;
 pub(crate) use self::clock::Clock;
 cfg_test_util! {
-    pub use clock::{advance, pause, resume};
+    pub use clock::{advance, advance_stable, pause, resume};
 }
 
 pub mod error;


### PR DESCRIPTION
#7463 

## Motivation

Current time manipulation methods may not guarantee all futures are consistently polled to pending before the clock advances, potentially resulting in missed wakes or "unstable" advancing behavior.

What is meant by unstable behavior is that running `M*advance(N)` does not yield the same results as `advance(M*N)`. I think this behavior is not intuitive and also not helpful in tests, especially when performing SUT-like testing, where we want to advance a system's time by a certain amount. This should mimic how time advances in a real program.

Additionally, if we want to create a program that uses logical time steps, then every call to advance should awake timers in the order of their expiration. Any subsequent timers created from polling a future that would fall within the current logical time step should also be polled and driven further. This way, we can test and run the program in the exact same way, eliminating one source of non-determinism and closing the distance between test and release code.

## Solution

This patch implements `advance_stable`, a function that:

1. Polls all tasks from the task queue, ensuring that all timers are registered.
2. Advances time by the smallest timeout, so long it's less than the given duration.
3. Drives the timer in order to enqueue their associated futures to the task queue.
4. Calls yield_now() to drive these expired timeouts.
5. Repeats these steps until the provided timeout value is reached, and the clock has advanced by exactly that provided timeout.

This function requires time to be paused, and can only be used with a current-thread or local executor.