### PR TITLE
feat: introduce `NotifiedOwned`

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -449,7 +449,7 @@
 cfg_sync! {
     /// Named future types.
     pub mod futures {
-        pub use super::notify::Notified;
+        pub use super::notify::{Notified, NotifiedOwned};
     }
 
     mod barrier;


### PR DESCRIPTION
Allows returning an owned notification future that can be moved across threads. Inspired by #7231. Continuing from #7391

## Motivation

The `Notify` api returns `Notified<'_>` Future for the non-blocking wait of  But having a lifetime makes it hard to use in `Future`  since it requires self referencing lifetime.

In most if not all use cases, even in the example, the `Notify` will be wrapped in an `Arc`, so having an owned version will eliminate lifetime requirement.

Other use case mentioned in #7391 is to launch tasks and then notify them at the same time using `notify_waiters`.

```rust
let n = Arc::new(Notify::new()); // We can't use notified here because we need to send it.

tokio::spawn({
  let n = n.clone();
  async move {
    // if we need the code to be correct we need to register the waiter here
    tokio::sleep(10).await;
    n.notified().await;
    println!("event received");
}})

n.notify_waiters();
```

## Solution

Introduced new a type `NotifiedOwned`, a `Future` that holds `Arc` instead of shared reference to `Notify`, eliminating lifetime requirement. Add corresponding `Notify::notified_owned`. The new method can only be called if `self` is within an `Arc`.
