### PR TITLE
ci: use ubuntu-24.04-arm instead of ubuntu-22.04-arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,9 +583,9 @@ jobs:
           - target: armv5te-unknown-linux-gnueabi
             os: ubuntu-latest
           - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+            os: ubuntu-24.04-arm
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+            os: ubuntu-24.04-arm
             rustflags: --cfg tokio_taskdump
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
@@ -629,9 +629,9 @@ jobs:
           - target: armv5te-unknown-linux-gnueabi
             os: ubuntu-latest
           - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+            os: ubuntu-24.04-arm
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm # TODO: update to 24.04 when https://github.com/rust-lang/rust/issues/135867 solved
+            os: ubuntu-24.04-arm
             rustflags: --cfg tokio_taskdump
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The upstream issue causing crashes (https://github.com/rust-lang/rust/issues/135867) has been fixed.
