### PR TITLE
ci: unfreeze wasm-unknown-unknown from rustc 1.81

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1038,6 +1038,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ env.rust_stable }}


### PR DESCRIPTION
This reverts the remaining part of the https://github.com/tokio-rs/tokio/commit/32e0b4325f877d53ddc76818198becad9312159a. I executed this test manually on my dev box and got passed.

*Follow-up of #6911, closes #6910.

*This PR also unblocks #7461.*