### PR TITLE
Implement `skip_until`

### DIFF
--- a/tokio-util/src/io/sync_bridge.rs
+++ b/tokio-util/src/io/sync_bridge.rs
@@ -279,6 +279,13 @@ impl<T: AsyncBufRead + Unpin> BufRead for SyncIoBridge<T> {
         self.rt
             .block_on(AsyncBufReadExt::read_until(src, byte, buf))
     }
+
+    fn skip_until(&mut self, byte: u8) -> std::io::Result<usize> {
+        let src = &mut self.src;
+        self.rt
+            .block_on(AsyncBufReadExt::skip_until(src, byte))
+    }
+
     fn read_line(&mut self, buf: &mut String) -> std::io::Result<usize> {
         let src = &mut self.src;
         self.rt.block_on(AsyncBufReadExt::read_line(src, buf))

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -59,6 +59,7 @@ cfg_io_util! {
 
     mod read_to_string;
     mod read_until;
+    mod skip_until;
 
     mod repeat;
     pub use repeat::{repeat, Repeat};

--- a/tokio/src/io/util/skip_until.rs
+++ b/tokio/src/io/util/skip_until.rs
@@ -1,0 +1,73 @@
+use crate::io::AsyncBufRead;
+use crate::util::memchr;
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io;
+use std::marker::PhantomPinned;
+use std::mem;
+use std::pin::Pin;
+use std::task::{ready, Context, Poll};
+
+pin_project! {
+    /// Future for the [`skip_until`](crate::io::AsyncBufReadExt::skip_until) method.
+    /// The delimiter is included in the resulting vector.
+    #[derive(Debug)]
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct SkipUntil<'a, R: ?Sized> {
+        reader: &'a mut R,
+        delimiter: u8,
+        // The number of bytes skipped.
+        read: usize,
+        // Make this future `!Unpin` for compatibility with async trait methods.
+        #[pin]
+        _pin: PhantomPinned,
+    }
+}
+
+pub(crate) fn skip_until<'a, R>(
+    reader: &'a mut R,
+    delimiter: u8,
+) -> SkipUntil<'a, R>
+where
+    R: AsyncBufRead + ?Sized + Unpin,
+{
+    SkipUntil {
+        reader,
+        delimiter,
+        read: 0,
+        _pin: PhantomPinned,
+    }
+}
+
+pub(super) fn skip_until_internal<R: AsyncBufRead + ?Sized>(
+    mut reader: Pin<&mut R>,
+    cx: &mut Context<'_>,
+    delimiter: u8,
+    read: &mut usize,
+) -> Poll<io::Result<usize>> {
+    loop {
+        let (done, used) = {
+            let available = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            if let Some(i) = memchr::memchr(delimiter, available) {
+                (true, i + 1)
+            } else {
+                (false, available.len())
+            }
+        };
+        reader.as_mut().consume(used);
+        *read += used;
+        if done || used == 0 {
+            return Poll::Ready(Ok(mem::replace(read, 0)));
+        }
+    }
+}
+
+impl<R: AsyncBufRead + ?Sized + Unpin> Future for SkipUntil<'_, R> {
+    type Output = io::Result<usize>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let me = self.project();
+        skip_until_internal(Pin::new(*me.reader), cx, *me.delimiter, me.read)
+    }
+}

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -604,6 +604,7 @@ async_assert_fn!(tokio::io::stdout(): Send & Sync & Unpin);
 async_assert_fn!(tokio::io::Split<tokio::io::BufReader<TcpStream>>::next_segment(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::io::Lines<tokio::io::BufReader<TcpStream>>::next_line(_): Send & Sync & !Unpin);
 async_assert_fn!(tokio::io::AsyncBufReadExt::read_until(&mut BoxAsyncRead, u8, &mut Vec<u8>): Send & Sync & !Unpin);
+async_assert_fn!(tokio::io::AsyncBufReadExt::skip_until(&mut BoxAsyncRead, u8): Send & Sync & !Unpin);
 async_assert_fn!(
     tokio::io::AsyncBufReadExt::read_line(&mut BoxAsyncRead, &mut String): Send & Sync & !Unpin
 );

--- a/tokio/tests/io_skip_until.rs
+++ b/tokio/tests/io_skip_until.rs
@@ -1,0 +1,58 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use std::io::ErrorKind;
+use tokio::io::{AsyncBufReadExt, BufReader, Error};
+use tokio_test::{assert_ok, io::Builder};
+
+#[tokio::test]
+async fn skip_until() {
+    let mut rd: &[u8] = b"hello world";
+
+    let n = assert_ok!(rd.skip_until(b' ').await);
+    assert_eq!(n, 6);
+    let n = assert_ok!(rd.skip_until(b' ').await);
+    assert_eq!(n, 5);
+    let n = assert_ok!(rd.skip_until(b' ').await);
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+async fn skip_until_not_all_ready() {
+    let mock = Builder::new()
+        .read(b"Hello Wor")
+        .read(b"ld#Fizz\xffBuz")
+        .read(b"z#1#2")
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let bytes = read.skip_until(b'#').await.unwrap();
+    assert_eq!(bytes, b"Hello World#".len());
+
+    let bytes = read.skip_until(b'#').await.unwrap();
+    assert_eq!(bytes, b"Fizz\xffBuzz\n".len());
+
+    let bytes = read.skip_until(b'#').await.unwrap();
+    assert_eq!(bytes, 2);
+
+    let bytes = read.skip_until(b'#').await.unwrap();
+    assert_eq!(bytes, 1);
+}
+
+#[tokio::test]
+async fn skip_until_fail() {
+    let mock = Builder::new()
+        .read(b"Hello \xffWor")
+        .read_error(Error::new(ErrorKind::Other, "The world has no end"))
+        .build();
+
+    let mut read = BufReader::new(mock);
+
+    let err = read
+        .skip_until(b'#')
+        .await
+        .expect_err("Should fail");
+    assert_eq!(err.kind(), ErrorKind::Other);
+    assert_eq!(err.to_string(), "The world has no end");
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

[`std::io::BufRead::skip_until`](https://doc.rust-lang.org/std/io/trait.BufRead.html#method.skip_until) was stabilized in Rust 1.83.0. Let's implement it into Tokio, too.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I have simply adapted existing `read_until` code to discard the read bytes rather than writing them in to a buffer.