### PR TITLE
changelog: fix incorrect PR number for 1.47.0

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -9,7 +9,7 @@ a lifetime parameter.
 ## Added
 
 - coop: add `cooperative` and `poll_proceed` ([#7405])
-- sync: add `SetOnce` ([#7148])
+- sync: add `SetOnce` ([#7418])
 - sync: add `sync::Notify::notified_owned()` ([#7465])
 
 ## Changed
@@ -23,9 +23,9 @@ a lifetime parameter.
 - metrics: fix listed feature requirements for some metrics ([#7449])
 - runtime: improve safety comments of `Readiness<'_>` ([#7415])
 
-[#7148]: https://github.com/tokio-rs/tokio/pull/7148
 [#7405]: https://github.com/tokio-rs/tokio/pull/7405
 [#7415]: https://github.com/tokio-rs/tokio/pull/7415
+[#7418]: https://github.com/tokio-rs/tokio/pull/7418
 [#7449]: https://github.com/tokio-rs/tokio/pull/7449
 [#7450]: https://github.com/tokio-rs/tokio/pull/7450
 [#7465]: https://github.com/tokio-rs/tokio/pull/7465


### PR DESCRIPTION
Corrects the pull request reference from #7148 to #7418 in the tokio changelog entry.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The CHANGELOG.md in the tokio crate contains an incorrect PR reference. It currently shows #7148 but should reference #7418. This is a simple documentation fix to ensure the changelog accurately links to the correct pull request.

## Solution

Changed the PR number from #7148 to #7418 in the tokio/CHANGELOG.md file.