### PR TITLE
sync: fix broken link of Python `asyncio.Event` in `SetOnce` docs

### DIFF
--- a/tokio/src/sync/set_once.rs
+++ b/tokio/src/sync/set_once.rs
@@ -85,7 +85,7 @@ use std::sync::atomic::Ordering;
 /// }
 /// ```
 ///
-/// [`asyncio.Event`]: https://docs.python.org/3/library/asyncio-event.html
+/// [`asyncio.Event`]: https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event
 pub struct SetOnce<T> {
     value_set: AtomicBool,
     value: UnsafeCell<MaybeUninit<T>>,


### PR DESCRIPTION
The link to Python's asyncio.Event documentation was pointing to asyncio-event.html which doesn't exist. This corrects it to the proper URL at asyncio-sync.html#asyncio.Event as mentioned in PR #7418.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The documentation contains a broken link to Python's asyncio.Event documentation. 
The current link points to `https://docs.python.org/3/library/asyncio-event.html` 
which returns a 404 error. 

PR #7418 mentioned the correct URL should be 
`https://docs.python.org/3/library/asyncio-sync.html#asyncio.Event`.

## Solution

Updated the documentation link from the non-existent `asyncio-event.html` to 
the correct `asyncio-sync.html#asyncio.Event`.
