### PR TITLE
Add optional buffer to CopyToBytes

### DIFF
--- a/tokio-util/src/io/copy_to_bytes.rs
+++ b/tokio-util/src/io/copy_to_bytes.rs
@@ -81,7 +81,6 @@ where
 
         if let Some(buf) = this.buf {
             if buf.len() + item.len() > buf.capacity() {
-                drop(this);
                 self.as_mut().flush_buf()?;
                 this = self.as_mut().project();
             }


### PR DESCRIPTION
Added an internal buffer to CopyToBytes so it can send data in chunks.

When using buffered mode (`with_capacity`), `flush_buf()` is now called if `start_send()` would overflow the buffer. This keeps memory usage under control and ensures data is sent out in chunks, without needing manual flushes.

My motivation: I'm building a logging system that sends logs in parts.