### PR TITLE
net: add `unix::SocketAddr::as_abstract_name`

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-306
+307
 &
 +
 <
@@ -184,6 +184,7 @@ mut
 mutex
 Mutex
 Nagle
+namespace
 nonblocking
 nondecreasing
 noop

--- a/tokio/src/net/unix/socketaddr.rs
+++ b/tokio/src/net/unix/socketaddr.rs
@@ -12,7 +12,7 @@ pub struct SocketAddr(pub(super) std::os::unix::net::SocketAddr);
 impl SocketAddr {
     /// Returns `true` if the address is unnamed.
     ///
-    /// Documentation reflected in [`SocketAddr`]
+    /// Documentation reflected in [`SocketAddr`].
     ///
     /// [`SocketAddr`]: std::os::unix::net::SocketAddr
     pub fn is_unnamed(&self) -> bool {
@@ -21,11 +21,29 @@ impl SocketAddr {
 
     /// Returns the contents of this address if it is a `pathname` address.
     ///
-    /// Documentation reflected in [`SocketAddr`]
+    /// Documentation reflected in [`SocketAddr`].
     ///
     /// [`SocketAddr`]: std::os::unix::net::SocketAddr
     pub fn as_pathname(&self) -> Option<&Path> {
         self.0.as_pathname()
+    }
+
+    /// Returns the contents of this address if it is in the abstract namespace.
+    ///
+    /// Documentation reflected in [`SocketAddrExt`].
+    /// The abstract namespace is a Linux-specific feature.
+    ///
+    ///
+    /// [`SocketAddrExt`]: std::os::linux::net::SocketAddrExt
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    #[cfg_attr(docsrs, doc(cfg(any(target_os = "linux", target_os = "android"))))]
+    pub fn as_abstract_name(&self) -> Option<&[u8]> {
+        #[cfg(target_os = "android")]
+        use std::os::android::net::SocketAddrExt;
+        #[cfg(target_os = "linux")]
+        use std::os::linux::net::SocketAddrExt;
+
+        self.0.as_abstract_name()
     }
 }
 


### PR DESCRIPTION
This adds a Linux-specific `SocketAddr::as_abstract_name()` based on stdlib `SocketAddrExt` trait .
The current MSRV is already 1.70.0, so this is not a breaking change (available since Rust 1.70).

Closes: https://github.com/tokio-rs/tokio/issues/6202