### PR TITLE
Implement `Stream::hint_size` for `ReceiverStream` and `UnboundedReceiverStream`

### DIFF
--- a/tokio-stream/src/wrappers/mpsc_bounded.rs
+++ b/tokio-stream/src/wrappers/mpsc_bounded.rs
@@ -67,6 +67,27 @@ impl<T> Stream for ReceiverStream<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.poll_recv(cx)
     }
+
+    /// Returns the bounds of the stream based on the underlying receiver.
+    ///
+    /// For open channels, it returns `(receiver.len(), None)`.
+    ///
+    /// For closed channels, it returns `(receiver.len(), Some(used_capacity))`
+    /// where `used_capacity` is calculated as `receiver.max_capacity() -
+    /// receiver.capacity()`. This accounts for any [`Permit`] that is still
+    /// able to send a message.
+    ///
+    /// [`Permit`]: struct@tokio::sync::mpsc::Permit
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let upper = if self.inner.is_closed() {
+            let used_capacity = self.inner.max_capacity() - self.inner.capacity();
+            Some(used_capacity)
+        } else {
+            None
+        };
+
+        (self.inner.len(), upper)
+    }
 }
 
 impl<T> AsRef<Receiver<T>> for ReceiverStream<T> {

--- a/tokio-stream/src/wrappers/mpsc_unbounded.rs
+++ b/tokio-stream/src/wrappers/mpsc_unbounded.rs
@@ -61,6 +61,22 @@ impl<T> Stream for UnboundedReceiverStream<T> {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.poll_recv(cx)
     }
+
+    /// Returns the bounds of the stream based on the underlying receiver.
+    ///
+    /// For open channels, it returns `(receiver.len(), None)`.
+    ///
+    /// For closed channels, it returns `(receiver.len(), receiver.len())`.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.inner.len();
+        let upper = if self.inner.is_closed() {
+            Some(len)
+        } else {
+            None
+        };
+
+        (len, upper)
+    }
 }
 
 impl<T> AsRef<UnboundedReceiver<T>> for UnboundedReceiverStream<T> {

--- a/tokio-stream/tests/mpsc_bounded_stream.rs
+++ b/tokio-stream/tests/mpsc_bounded_stream.rs
@@ -1,0 +1,71 @@
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
+
+#[tokio::test]
+async fn size_hint_stream_open() {
+    let (tx, rx) = mpsc::channel(4);
+
+    tx.send(1).await.unwrap();
+    tx.send(2).await.unwrap();
+
+    let mut stream = ReceiverStream::new(rx);
+
+    assert_eq!(stream.size_hint(), (2, None));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, None));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, None));
+}
+
+#[tokio::test]
+async fn size_hint_stream_closed() {
+    let (tx, rx) = mpsc::channel(4);
+
+    tx.send(1).await.unwrap();
+    tx.send(2).await.unwrap();
+
+    let mut stream = ReceiverStream::new(rx);
+    stream.close();
+
+    assert_eq!(stream.size_hint(), (2, Some(2)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, Some(1)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn size_hint_stream_instantly_closed() {
+    let (_tx, rx) = mpsc::channel::<i32>(4);
+
+    let mut stream = ReceiverStream::new(rx);
+    stream.close();
+
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+}
+
+#[tokio::test]
+async fn size_hint_stream_closed_permits() {
+    let (tx, rx) = mpsc::channel(4);
+
+    tx.send(1).await.unwrap();
+    let permit1 = tx.reserve().await.unwrap();
+    let permit2 = tx.reserve().await.unwrap();
+
+    let mut stream = ReceiverStream::new(rx);
+    stream.close();
+
+    assert_eq!(stream.size_hint(), (1, Some(3)));
+    permit1.send(2);
+    assert_eq!(stream.size_hint(), (2, Some(3)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, Some(2)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, Some(1)));
+    permit2.send(3);
+    assert_eq!(stream.size_hint(), (1, Some(1)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+    assert_eq!(stream.next().await, None);
+}

--- a/tokio-stream/tests/mpsc_unbounded_stream.rs
+++ b/tokio-stream/tests/mpsc_unbounded_stream.rs
@@ -1,0 +1,46 @@
+use futures::{Stream, StreamExt};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+#[tokio::test]
+async fn size_hint_stream_open() {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    tx.send(1).unwrap();
+    tx.send(2).unwrap();
+
+    let mut stream = UnboundedReceiverStream::new(rx);
+
+    assert_eq!(stream.size_hint(), (2, None));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, None));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, None));
+}
+
+#[tokio::test]
+async fn size_hint_stream_closed() {
+    let (tx, rx) = mpsc::unbounded_channel();
+
+    tx.send(1).unwrap();
+    tx.send(2).unwrap();
+
+    let mut stream = UnboundedReceiverStream::new(rx);
+    stream.close();
+
+    assert_eq!(stream.size_hint(), (2, Some(2)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, Some(1)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+}
+
+#[test]
+fn size_hint_stream_instantly_closed() {
+    let (_tx, rx) = mpsc::unbounded_channel::<i32>();
+
+    let mut stream = UnboundedReceiverStream::new(rx);
+    stream.close();
+
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+}


### PR DESCRIPTION
Closes #7488

## Motivation

`ReceiverStream` and `UnboundedReceiverStream` used default `Stream::size_hint` implementation, I believe providing custom implementation here is beneficial.

## Solution
 For `UnboundedReceiverStream` we return:
-  `(receiver.len(), None)` for open stream
- `(receiver.len(), receiver.len())` for closed stream

For `ReceiverStream` it is a little bit more complex since we need to take into account existing `Permits`:
- `(receiver.len(), None)` for open stream
- `(receiver.len(), receiver.max_capacity() - receiver.capacity())` for closed stream
