### PR TITLE
codec: add `FramedWrite::with_capacity`

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -119,7 +119,10 @@ where
                         buffer: BytesMut::with_capacity(capacity),
                         has_errored: false,
                     },
-                    write: WriteFrame::default(),
+                    write: WriteFrame {
+                        buffer: BytesMut::with_capacity(capacity),
+                        backpressure_boundary: capacity,
+                    },
                 },
             },
         }

--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -119,10 +119,7 @@ where
                         buffer: BytesMut::with_capacity(capacity),
                         has_errored: false,
                     },
-                    write: WriteFrame {
-                        buffer: BytesMut::with_capacity(capacity),
-                        backpressure_boundary: capacity,
-                    },
+                    write: WriteFrame::default(),
                 },
             },
         }

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -47,6 +47,21 @@ where
             },
         }
     }
+
+    /// Creates a new `FramedWrite` with the given `encoder` and a buffer of `capacity`
+    /// initial size.
+    pub fn with_capacity(inner: T, encoder: E, capacity: usize) -> FramedWrite<T, E> {
+        FramedWrite {
+            inner: FramedImpl {
+                inner,
+                codec: encoder,
+                state: WriteFrame {
+                    buffer: BytesMut::with_capacity(capacity),
+                    backpressure_boundary: capacity,
+                },
+            },
+        }
+    }
 }
 
 impl<T, E> FramedWrite<T, E> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Fixes #7481 

## Motivation

There is no function to create an instance of `FramedWrite` with a specified capacity in a similar manner that `FramedRead::with_capacity` is currently implemented.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `FramedWrite::with_capacity` to create a BytesMut buffer and set backpressure boundary with the specified capacity.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->