### PR TITLE
Implement Drop to SimplexStream. ensure that the read half of the stream is waked wh…

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -427,3 +427,10 @@ impl AsyncWrite for SimplexStream {
         Poll::Ready(Ok(()))
     }
 }
+
+impl Drop for SimplexStream {
+    fn drop(&mut self) {
+        self.close_write();
+    }
+}
+


### PR DESCRIPTION

## Motivation

When I use `simplex` in an asynchronous context:

```rust
let (reader, writer) = tokio::io::simplex(64);
```

I noticed that after `writer` is dropped, the `reader` remains in a pending state.
Therefore, I added a `Drop` implementation for `SimplexStream`.
I hope this change can be accepted.


## Solution

Implement Drop to ensure that the read half of the stream is waked when the write half of the stream is dropped.