### PR TITLE
Prepare Tokio v1.43.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.43.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.43.2 (August 1st, 2025)
+
+### Fixed
+
+- process: fix panic from spurious pidfd wakeup ([#7494])
+
+[#7494]: https://github.com/tokio-rs/tokio/pull/7494
+
 # 1.43.1 (April 5th, 2025)
 
 This release fixes a soundness issue in the broadcast channel. The channel

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.43.1"
+version = "1.43.2"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.43.2", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.43.2 (August 1st, 2025)

### Fixed

- process: fix panic from spurious pidfd wakeup ([#7494])

[#7494]: https://github.com/tokio-rs/tokio/pull/7494