### PR TITLE
Merge 1.43.2 into 1.47.x

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -240,6 +240,14 @@ comment on [#7172].
 [#7186]: https://github.com/tokio-rs/tokio/pull/7186
 [#7192]: https://github.com/tokio-rs/tokio/pull/7192
 
+# 1.43.2 (August 1st, 2025)
+
+### Fixed
+
+- process: fix panic from spurious pidfd wakeup ([#7494])
+
+[#7494]: https://github.com/tokio-rs/tokio/pull/7494
+
 # 1.43.1 (April 5th, 2025)
 
 This release fixes a soundness issue in the broadcast channel. The channel

--- a/tokio/src/io/poll_evented.rs
+++ b/tokio/src/io/poll_evented.rs
@@ -125,7 +125,7 @@ impl<E: Source> PollEvented<E> {
     }
 
     /// Returns a reference to the registration.
-    #[cfg(feature = "net")]
+    #[cfg(any(feature = "net", all(feature = "process", target_os = "linux")))]
     pub(crate) fn registration(&self) -> &Registration {
         &self.registration
     }
@@ -136,14 +136,6 @@ impl<E: Source> PollEvented<E> {
         let mut inner = self.io.take().unwrap(); // As io shouldn't ever be None, just unwrap here.
         self.registration.deregister(&mut inner)?;
         Ok(inner)
-    }
-
-    #[cfg(all(feature = "process", target_os = "linux"))]
-    pub(crate) fn poll_read_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        self.registration
-            .poll_read_ready(cx)
-            .map_err(io::Error::from)
-            .map_ok(|_| ())
     }
 
     /// Re-register under new runtime with `interest`.

--- a/tokio/tests/process_issue_7144.rs
+++ b/tokio/tests/process_issue_7144.rs
@@ -1,0 +1,28 @@
+#![cfg(feature = "process")]
+#![warn(rust_2018_idioms)]
+#![cfg(target_os = "linux")]
+#![cfg(not(miri))]
+
+use tokio::process::Command;
+use tokio::time::{sleep, Duration};
+
+#[tokio::test]
+async fn issue_7144() {
+    let mut threads = vec![];
+    for _ in 0..20 {
+        threads.push(tokio::spawn(test_one()));
+    }
+    for thread in threads {
+        thread.await.unwrap();
+    }
+}
+
+async fn test_one() {
+    let mut t = Command::new("strace")
+        .args("-o /dev/null -D sleep 5".split(' '))
+        .spawn()
+        .unwrap();
+    sleep(Duration::from_millis(100)).await;
+    unsafe { libc::kill(t.id().unwrap() as _, libc::SIGINT) };
+    t.wait().await.unwrap();
+}


### PR DESCRIPTION
This merge commit pulls the backport to 1.43.2 into the 1.47.x branch so that a LTS release on 1.47.x can be made.

Must be merged using the command line.