### PR TITLE
sync: document cancel safety on `SetOnce::wait`

### DIFF
--- a/tokio/src/sync/set_once.rs
+++ b/tokio/src/sync/set_once.rs
@@ -338,17 +338,14 @@ impl<T> SetOnce<T> {
         }
     }
 
-    /// Waits until set is called. The future returned will keep blocking until
-    /// the `SetOnce` is initialized.
+    /// Waits until the value is set.
     ///
     /// If the `SetOnce` is already initialized, it will return the value
     /// immediately.
     ///
-    /// # Note
+    /// # Cancel safety
     ///
-    /// This will keep waiting until the `SetOnce` is initialized, so it
-    /// should be used with care to avoid blocking the current task
-    /// indefinitely.
+    /// This method is cancel safe.
     pub async fn wait(&self) -> &T {
         loop {
             if let Some(val) = self.get() {


### PR DESCRIPTION
I realized that the cancel safety section was missing.

I also removed use of the word "blocking" to avoid confusion with [blocking the thread](https://ryhl.io/blog/async-what-is-blocking/).