### PR TITLE
fix(test): fix flaky joinmap test during abort

### DIFF
--- a/tokio-util/src/task/join_map.rs
+++ b/tokio-util/src/task/join_map.rs
@@ -65,7 +65,7 @@ use tokio::task::{AbortHandle, Id, JoinError, JoinSet, LocalSet};
 /// ```
 /// use tokio_util::task::JoinMap;
 ///
-/// #[tokio::main]
+/// #[tokio::main(flavor = "current_thread")]
 /// async fn main() {
 ///     let mut map = JoinMap::new();
 ///
@@ -495,7 +495,7 @@ where
     /// ```
     /// use tokio_util::task::JoinMap;
     ///
-    /// # #[tokio::main]
+    /// # #[tokio::main(flavor = "current_thread")]
     /// # async fn main() {
     /// let mut map = JoinMap::new();
     ///

--- a/tokio-util/src/task/join_map.rs
+++ b/tokio-util/src/task/join_map.rs
@@ -65,12 +65,12 @@ use tokio::task::{AbortHandle, Id, JoinError, JoinSet, LocalSet};
 /// ```
 /// use tokio_util::task::JoinMap;
 ///
-/// #[tokio::main(flavor = "current_thread")]
+/// #[tokio::main]
 /// async fn main() {
 ///     let mut map = JoinMap::new();
 ///
-///     map.spawn("hello world", async move { /* ... */ });
-///     map.spawn("goodbye world", async move { /* ... */});
+///     map.spawn("hello world", std::future::ready(1));
+///     map.spawn("goodbye world", std::future::pending());
 ///
 ///     // Look up the "goodbye world" task in the map and abort it.
 ///     let aborted = map.abort("goodbye world");
@@ -85,7 +85,7 @@ use tokio::task::{AbortHandle, Id, JoinError, JoinSet, LocalSet};
 ///             assert!(res.unwrap_err().is_cancelled());
 ///         } else {
 ///             // Other tasks should complete normally.
-///             assert!(res.is_ok());
+///             assert_eq!(res.unwrap(), 1);
 ///         }
 ///     }
 /// }
@@ -499,8 +499,8 @@ where
     /// # async fn main() {
     /// let mut map = JoinMap::new();
     ///
-    /// map.spawn("hello world", async move { /* ... */ });
-    /// map.spawn("goodbye world", async move { /* ... */});
+    /// map.spawn("hello world", std::future::ready(1));
+    /// map.spawn("goodbye world", std::future::pending());
     ///
     /// // Look up the "goodbye world" task in the map and abort it.
     /// map.abort("goodbye world");
@@ -511,7 +511,7 @@ where
     ///         assert!(res.unwrap_err().is_cancelled());
     ///     } else {
     ///         // Other tasks should complete normally.
-    ///         assert!(res.is_ok());
+    ///         assert_eq!(res.unwrap(), 1);
     ///     }
     /// }
     /// # }


### PR DESCRIPTION
## Motivation

#7508. Flaky test due to the task completing prior to the task abortion being observed.

## Solution

Ensure the task can never complete by using `std::future::pending()`.