### PR TITLE
fix(process): upgrade Command::spawn_with to use FnOnce

### DIFF
--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -933,7 +933,7 @@ impl Command {
     #[inline]
     pub fn spawn_with(
         &mut self,
-        with: impl Fn(&mut StdCommand) -> io::Result<StdChild>,
+        with: impl FnOnce(&mut StdCommand) -> io::Result<StdChild>,
     ) -> io::Result<Child> {
         // On two lines to circumvent a mutable borrow check failure.
         let child = with(&mut self.std)?;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
See https://github.com/tokio-rs/tokio/pull/7249#issuecomment-3146995525, since the `with` closure is only called once, it can be upgraded to `FnOnce` to allow mutation.

## Solution
Changed `Fn` to `FnOnce` in `Command::spawn_with`

Tested with the following code
```rust
use tokio::process::{Command};
use std::process::Stdio;

#[tokio::main]
async fn main() {
    let mut std_io: Option<Stdio> = None;
    let hello = Command::new("echo")
        .arg("Hello, world!")
        .stdout(Stdio::piped())
        .spawn_with(|cmd| {
            let mut child = cmd.spawn()?;
            std_io = child.stdout.take().map(Stdio::from);
            Ok(child)
        })
        .expect("failed echo command");
    
    let reverse = Command::new("rev")
        .stdin(std_io.take().unwrap())
        .output().await.unwrap();
    
    assert_eq!(reverse.stdout, b"!dlrow ,olleH\n");
}
```

*I don't know all the implications of piping stdout into stdin in this way versus the one in the module documentation that uses `TryInto<Stdio>` on the spawned child. This PR isn't intended to solve that problem anyway, so I didn't add any automated test.
