### PR TITLE
util/future: fix `FutureExt` bias and fairness docs

### DIFF
--- a/tokio-util/src/future.rs
+++ b/tokio-util/src/future.rs
@@ -59,14 +59,13 @@ pub trait FutureExt: Future {
     }
 
     /// Similar to [`CancellationToken::run_until_cancelled`],
-    /// but with the advantage that it is easier to write fluent call chains,
-    /// and biased towards waiting for [`CancellationToken`] to complete.
+    /// but with the advantage that it is easier to write fluent call chains.
     ///
     /// # Fairness
     ///
     /// Calling this on an already-cancelled token directly returns `None`.
     /// For all subsequent polls, in case of concurrent completion and
-    /// cancellation, this is biased towards the future completion.
+    /// cancellation, this is biased towards the `self` future completion.
     ///
     /// # Examples
     ///
@@ -97,14 +96,13 @@ pub trait FutureExt: Future {
     }
 
     /// Similar to [`CancellationToken::run_until_cancelled_owned`],
-    /// but with the advantage that it is easier to write fluent call chains,
-    /// and biased towards waiting for [`CancellationToken`] to complete.
+    /// but with the advantage that it is easier to write fluent call chains.
     ///
     /// # Fairness
     ///
     /// Calling this on an already-cancelled token directly returns `None`.
     /// For all subsequent polls, in case of concurrent completion and
-    /// cancellation, this is biased towards the future completion.
+    /// cancellation, this is biased towards the `self` future completion.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This fixes the docstrings on `FutureExt` so that the bias and fairness notes are correct and consistent in all cases.
All cancellation-related wrappers are biased towards the completion of the inner future, but they do initially check if the token is already cancelled at construction time.

Followup for https://github.com/tokio-rs/tokio/pull/7475
