### PR TITLE
net: render the `cygwin` in the docs of `quickack` and `set_quickack`

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1194,7 +1194,12 @@ impl TcpStream {
     ))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))
+        doc(cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "cygwin"
+        )))
     )]
     pub fn quickack(&self) -> io::Result<bool> {
         socket2::SockRef::from(self).tcp_quickack()
@@ -1229,7 +1234,12 @@ impl TcpStream {
     ))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))
+        doc(cfg(any(
+            target_os = "linux",
+            target_os = "android",
+            target_os = "fuchsia",
+            target_os = "cygwin"
+        )))
     )]
     pub fn set_quickack(&self, quickack: bool) -> io::Result<()> {
         socket2::SockRef::from(self).set_tcp_quickack(quickack)


### PR DESCRIPTION
Follow up of https://github.com/tokio-rs/tokio/pull/7490#discussion_r2242177094.

```bash
# nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.91.0-nightly (0060d5a2a 2025-08-04)
RUSTDOCFLAGS="--cfg docsrs --cfg tokio_unstable" \
RUSTFLAGS="--cfg docsrs --cfg tokio_unstable" \
cargo +nightly doc --all-features
```

<img width="1547" height="1175" src="https://github.com/user-attachments/assets/3e4fbd3f-acbf-42e6-a3db-a89898674835" />


