### PR TITLE
task: inline the docs of `TaskTracker` while re-exporting it

### DIFF
--- a/tokio-util/src/task/mod.rs
+++ b/tokio-util/src/task/mod.rs
@@ -8,6 +8,7 @@ cfg_rt! {
     pub use spawn_pinned::LocalPoolHandle;
 
     pub mod task_tracker;
+    #[doc(inline)]
     pub use task_tracker::TaskTracker;
 
     mod abort_on_drop;


### PR DESCRIPTION
<img width="3126" height="990" src="https://github.com/user-attachments/assets/8866c947-2342-419d-a122-464a37ccbb0b" />
