### PR TITLE
net: clarify socket gets closed on drop

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -19,6 +19,8 @@ cfg_net! {
     ///
     /// A `TcpListener` can be turned into a `Stream` with [`TcpListenerStream`].
     ///
+    /// The socket will be closed when the value is dropped.
+    ///
     /// [`TcpListenerStream`]: https://docs.rs/tokio-stream/0.1/tokio_stream/wrappers/struct.TcpListenerStream.html
     ///
     /// # Errors


### PR DESCRIPTION
Add a note like in std::net::TcpListener.

## Motivation

I wasn't sure whether tokio TcpListener closes the connection on close, and had to look at the internals to figure out it just wraps a reguilar TcpListener. Also, I was using the crates warp->hyper and had to look all down the stack to see how the port is managed.

## Solution
Added to the docs a note just like in `std::net::TcpListener`