### PR TITLE
net: qualify that `SO_REUSEADDR` is only set on Unix

### DIFF
--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -75,7 +75,7 @@ impl TcpListener {
         /// the addresses succeed in creating a listener, the error returned from
         /// the last attempt (the last address) is returned.
         ///
-        /// This function sets the `SO_REUSEADDR` option on the socket.
+        /// This function sets the `SO_REUSEADDR` option on the socket on Unix.
         ///
         /// To configure the socket before binding, you can use the [`TcpSocket`]
         /// type.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Closes #7532 
