### PR TITLE
Reduce the generated code size of Timeout<T>::poll

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -203,26 +203,32 @@ where
             return Poll::Ready(Ok(v));
         }
 
-        let has_budget_now = coop::has_budget_remaining();
+        poll_delay(had_budget_before, me.delay, cx).map_ok(|infallible| match infallible {})
+    }
+}
 
-        let delay = me.delay;
+// The T-invariant portion of Timeout::<T>::poll. Pulling this out reduces the
+// amount of code that gets duplicated during monomorphization.
+fn poll_delay(
+    had_budget_before: bool,
+    delay: Pin<&mut Sleep>,
+    cx: &mut task::Context<'_>,
+) -> Poll<Result<std::convert::Infallible, Elapsed>> {
+    let poll_delay = || match delay.poll(cx) {
+        Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
+        Poll::Pending => Poll::Pending,
+    };
 
-        let poll_delay = || -> Poll<Self::Output> {
-            match delay.poll(cx) {
-                Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
-                Poll::Pending => Poll::Pending,
-            }
-        };
+    let has_budget_now = coop::has_budget_remaining();
 
-        if let (true, false) = (had_budget_before, has_budget_now) {
-            // if it is the underlying future that exhausted the budget, we poll
-            // the `delay` with an unconstrained one. This prevents pathological
-            // cases where the underlying future always exhausts the budget and
-            // we never get a chance to evaluate whether the timeout was hit or
-            // not.
-            coop::with_unconstrained(poll_delay)
-        } else {
-            poll_delay()
-        }
+    if let (true, false) = (had_budget_before, has_budget_now) {
+        // if it is the underlying future that exhausted the budget, we poll
+        // the `delay` with an unconstrained one. This prevents pathological
+        // cases where the underlying future always exhausts the budget and
+        // we never get a chance to evaluate whether the timeout was hit or
+        // not.
+        coop::with_unconstrained(poll_delay)
+    } else {
+        poll_delay()
     }
 }

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -214,7 +214,7 @@ fn poll_delay(
     delay: Pin<&mut Sleep>,
     cx: &mut task::Context<'_>,
 ) -> Poll<Result<std::convert::Infallible, Elapsed>> {
-    let poll_delay = || match delay.poll(cx) {
+    let delay_poll = || match delay.poll(cx) {
         Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
         Poll::Pending => Poll::Pending,
     };
@@ -227,8 +227,8 @@ fn poll_delay(
         // cases where the underlying future always exhausts the budget and
         // we never get a chance to evaluate whether the timeout was hit or
         // not.
-        coop::with_unconstrained(poll_delay)
+        coop::with_unconstrained(delay_poll)
     } else {
-        poll_delay()
+        delay_poll()
     }
 }

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -203,7 +203,7 @@ where
             return Poll::Ready(Ok(v));
         }
 
-        poll_delay(had_budget_before, me.delay, cx).map_ok(|infallible| match infallible {})
+        poll_delay(had_budget_before, me.delay, cx).map(Err)
     }
 }
 
@@ -213,9 +213,9 @@ fn poll_delay(
     had_budget_before: bool,
     delay: Pin<&mut Sleep>,
     cx: &mut task::Context<'_>,
-) -> Poll<Result<std::convert::Infallible, Elapsed>> {
+) -> Poll<Elapsed> {
     let delay_poll = || match delay.poll(cx) {
-        Poll::Ready(()) => Poll::Ready(Err(Elapsed::new())),
+        Poll::Ready(()) => Poll::Ready(Elapsed::new()),
         Poll::Pending => Poll::Pending,
     };
 


### PR DESCRIPTION
Pull out the tail portion that is invariant for T into a separate function. 

## Motivation

This reduces the size of the built binaries for crates that use Tokio and target minimal code size.

## Solution

The Rust compiler generates a separate copy of LLVM IR for each instantiation of templated functions. That means that code in a templated function that doesn't depend on the template types can be needlessly duplicated. The tail of `Timeout::poll` is one such function. Pulling the code that doesn't depend on the type `T` out into a separate function lets the compiler emit it once instead of once for each instantiation of `Timeout`.