### PR TITLE
time: add `ignore-wasm` to failing wasm tests

### DIFF
--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -78,7 +78,7 @@ impl Instant {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time::{Duration, Instant, sleep};
     ///
     /// #[tokio::main]
@@ -99,7 +99,7 @@ impl Instant {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time::{Duration, Instant, sleep};
     ///
     /// #[tokio::main]
@@ -120,7 +120,7 @@ impl Instant {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time::{Duration, Instant, sleep};
     ///
     /// #[tokio::main]

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -23,7 +23,7 @@ use std::task::{ready, Context, Poll};
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time::{self, Duration};
 ///
 /// #[tokio::main]
@@ -49,7 +49,7 @@ use std::task::{ready, Context, Poll};
 /// would only be executed once every three seconds, and not every two
 /// seconds.
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time;
 ///
 /// async fn task_that_takes_a_second() {
@@ -89,7 +89,7 @@ pub fn interval(period: Duration) -> Interval {
 ///
 /// # Examples
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time::{interval_at, Duration, Instant};
 ///
 /// #[tokio::main]
@@ -151,7 +151,7 @@ fn internal_interval_at(
 /// Sometimes, an [`Interval`]'s tick is missed. For example, consider the
 /// following:
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time::{self, Duration};
 /// # async fn task_that_takes_one_to_three_millis() {}
 ///
@@ -413,7 +413,7 @@ impl Interval {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time;
     ///
     /// use std::time::Duration;
@@ -501,7 +501,7 @@ impl Interval {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time;
     ///
     /// use std::time::Duration;
@@ -533,7 +533,7 @@ impl Interval {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time;
     ///
     /// use std::time::Duration;
@@ -565,7 +565,7 @@ impl Interval {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time;
     ///
     /// use std::time::Duration;
@@ -601,7 +601,7 @@ impl Interval {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time::{self, Instant};
     ///
     /// use std::time::Duration;

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! Wait 100ms and print "100 ms have elapsed"
 //!
-//! ```
+//! ```ignore-wasm
 //! use std::time::Duration;
 //! use tokio::time::sleep;
 //!
@@ -63,7 +63,7 @@
 //! would only be executed once every three seconds, and not every two
 //! seconds.
 //!
-//! ```
+//! ```ignore-wasm
 //! use tokio::time;
 //!
 //! async fn task_that_takes_a_second() {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -25,7 +25,7 @@ use std::task::{self, ready, Poll};
 ///
 /// Wait 100ms and print "100 ms have elapsed".
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time::{sleep_until, Instant, Duration};
 ///
 /// #[tokio::main]
@@ -85,7 +85,7 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 ///
 /// Wait 100ms and print "100 ms have elapsed".
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::time::{sleep, Duration};
 ///
 /// #[tokio::main]
@@ -140,7 +140,7 @@ pin_project! {
     ///
     /// Wait 100ms and print "100 ms have elapsed".
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::time::{sleep, Duration};
     ///
     /// #[tokio::main]
@@ -152,7 +152,7 @@ pin_project! {
     ///
     /// Use with [`select!`]. Pinning the `Sleep` with [`tokio::pin!`] is
     /// necessary when the same `Sleep` is selected on multiple times.
-    /// ```no_run
+    /// ```no_run,ignore-wasm
     /// use tokio::time::{self, Duration, Instant};
     ///
     /// #[tokio::main]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Addresses failing time tests: #7519 

## Motivation

Currently, the MSRV is pinned temporarily and there is a large amount of failures for wasm doctests with the Rust 1.89.0 release.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `ignore-wasm` to failing doctests in `tokio/src/time` until these tests pass with the new release.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
