### PR TITLE
task: add `ignore-wasm` to failing wasm tests

### DIFF
--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -36,7 +36,7 @@
 //! scheduling. When a future is wrapped with `unconstrained`, it will never be forced to yield to
 //! Tokio. For example:
 //!
-//! ```
+//! ```ignore-wasm
 //! # #[tokio::main]
 //! # async fn main() {
 //! use tokio::{task, sync::mpsc};

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -28,7 +28,7 @@ use crate::util::IdleNotifiedSet;
 ///
 /// Spawn multiple tasks and wait for them.
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::task::JoinSet;
 ///
 /// #[tokio::main]
@@ -208,7 +208,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// Spawn multiple blocking tasks and wait for them.
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::task::JoinSet;
     ///
     /// #[tokio::main]
@@ -382,7 +382,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// Spawn multiple tasks and `join_all` them.
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::task::JoinSet;
     /// use std::time::Duration;
     ///
@@ -404,7 +404,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// Equivalent implementation of `join_all`, using [`join_next`] and loop.
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::task::JoinSet;
     /// use std::panic;
     ///
@@ -600,7 +600,7 @@ impl<T> Default for JoinSet<T> {
 ///
 /// The main example from [`JoinSet`]'s documentation can also be written using [`collect`]:
 ///
-/// ```
+/// ```ignore-wasm
 /// use tokio::task::JoinSet;
 ///
 /// #[tokio::main]

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -60,7 +60,7 @@ cfg_rt! {
     /// local task set, we can use [`task::spawn_local`], which can spawn
     /// `!Send` futures. For example:
     ///
-    /// ```rust
+    /// ```rust,ignore-wasm
     /// use std::rc::Rc;
     /// use tokio::task;
     ///
@@ -94,7 +94,7 @@ cfg_rt! {
     /// several futures on a `LocalSet` and drive the whole set until they
     /// complete. For example,
     ///
-    /// ```rust
+    /// ```rust,ignore-wasm
     /// use tokio::{task, time};
     /// use std::rc::Rc;
     ///
@@ -132,7 +132,7 @@ cfg_rt! {
     /// and communicate with it using an [`mpsc`] channel.
     ///
     /// The following example puts the `LocalSet` inside a new thread.
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::runtime::Builder;
     /// use tokio::sync::{mpsc, oneshot};
     /// use tokio::task::LocalSet;
@@ -350,7 +350,7 @@ cfg_rt! {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,ignore-wasm
     /// use std::rc::Rc;
     /// use tokio::task;
     ///
@@ -540,7 +540,7 @@ impl LocalSet {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,ignore-wasm
     /// use tokio::task;
     ///
     /// #[tokio::main]
@@ -608,7 +608,7 @@ impl LocalSet {
     /// issued from a local task, the [`spawn_blocking`] API may be used instead.
     ///
     /// For example, this will panic:
-    /// ```should_panic
+    /// ```should_panic,ignore-wasm
     /// use tokio::runtime::Runtime;
     /// use tokio::task;
     ///
@@ -625,7 +625,7 @@ impl LocalSet {
     /// })
     /// ```
     /// This, however, will not panic:
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::runtime::Runtime;
     /// use tokio::task;
     ///
@@ -672,7 +672,7 @@ impl LocalSet {
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,ignore-wasm
     /// use tokio::task;
     ///
     /// #[tokio::main]

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -67,7 +67,7 @@
 //! A `JoinHandle` is itself a future which may be used to await the output of
 //! the spawned task. For example:
 //!
-//! ```
+//! ```ignore-wasm
 //! use tokio::task;
 //!
 //! # #[tokio::main] async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -89,7 +89,7 @@
 //! task panics, awaiting its `JoinHandle` will return a [`JoinError`]. For
 //! example:
 //!
-//! ```
+//! ```ignore-wasm
 //! use tokio::task;
 //!
 //! # #[tokio::main] async fn main() {
@@ -220,7 +220,7 @@
 //!
 //! For example:
 //!
-//! ```
+//! ```ignore-wasm
 //! use tokio::task;
 //!
 //! # async fn docs() {
@@ -242,7 +242,7 @@
 //! scheduled. Eventually, the yielding task will be polled again, allowing it
 //! to execute. For example:
 //!
-//! ```rust
+//! ```rust,ignore-wasm
 //! use tokio::task;
 //!
 //! # #[tokio::main] async fn main() {

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -34,7 +34,7 @@ cfg_rt! {
     /// In this example, a server is started and `spawn` is used to start a new task
     /// that processes each received connection.
     ///
-    /// ```no_run
+    /// ```no_run,ignore-wasm
     /// use tokio::net::{TcpListener, TcpStream};
     ///
     /// use std::io;
@@ -102,7 +102,7 @@ cfg_rt! {
     ///
     /// For example, this will work:
     ///
-    /// ```
+    /// ```ignore-wasm
     /// use tokio::task;
     ///
     /// use std::rc::Rc;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Addresses failing task wasm tests: #7519 

## Motivation

See #7537 

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add `ignore-wasm` to failing doctests in `tokio/src/task` until these tests pass with the new release.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
