### PR TITLE
fix: return `RecvError` if channel is closed when calling `watch::Receiver::changed`

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -827,10 +827,6 @@ impl<T> Receiver<T> {
     ) -> Result<Ref<'_, T>, error::RecvError> {
         let mut closed = false;
         loop {
-            if closed {
-                return Err(error::RecvError(()));
-            }
-
             {
                 let inner = self.shared.value.read();
 
@@ -856,6 +852,10 @@ impl<T> Receiver<T> {
                         }
                     };
                 }
+            }
+
+            if closed {
+                return Err(error::RecvError(()));
             }
 
             // Wait for the value to change.

--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -825,8 +825,7 @@ impl<T> Receiver<T> {
         &mut self,
         mut f: impl FnMut(&T) -> bool,
     ) -> Result<Ref<'_, T>, error::RecvError> {
-        let state = self.shared.state.load();
-        let mut closed = state.is_closed();
+        let mut closed = false;
         loop {
             if closed {
                 return Err(error::RecvError(()));

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -466,23 +466,10 @@ async fn changed_errors_on_closed_channel() {
 #[tokio::test]
 async fn wait_for_errors_on_closed_channel_true_predicate() {
     let (tx, mut rx) = watch::channel(());
-    tx.send(()).unwrap();
 
     drop(tx);
 
-    rx.wait_for(|_| true).await.expect_err(
-        "`wait_for` call returns an error IFF the channel is closed by dropping the senders.",
-    );
-}
-
-#[tokio::test]
-async fn wait_for_errors_on_closed_channel_false_predicate() {
-    let (tx, mut rx) = watch::channel(());
-    tx.send(()).unwrap();
-
-    drop(tx);
-
-    rx.wait_for(|_| false).await.expect_err(
-        "`wait_for` call returns an error IFF the channel is closed by dropping the senders.",
+    rx.wait_for(|_| true).await.expect(
+        "`wait_for` call does not return error even if channel is closed when predicate is true for last value.",
     );
 }

--- a/tokio/tests/sync_watch.rs
+++ b/tokio/tests/sync_watch.rs
@@ -450,3 +450,39 @@ async fn sender_closed_is_cooperative() {
         _ = tokio::task::yield_now() => {},
     }
 }
+
+#[tokio::test]
+async fn changed_errors_on_closed_channel() {
+    let (tx, mut rx) = watch::channel(());
+    tx.send(()).unwrap();
+
+    drop(tx);
+
+    rx.changed().await.expect_err(
+        "`changed` call returns an error IFF the channel is closed by dropping the senders.",
+    );
+}
+
+#[tokio::test]
+async fn wait_for_errors_on_closed_channel_true_predicate() {
+    let (tx, mut rx) = watch::channel(());
+    tx.send(()).unwrap();
+
+    drop(tx);
+
+    rx.wait_for(|_| true).await.expect_err(
+        "`wait_for` call returns an error IFF the channel is closed by dropping the senders.",
+    );
+}
+
+#[tokio::test]
+async fn wait_for_errors_on_closed_channel_false_predicate() {
+    let (tx, mut rx) = watch::channel(());
+    tx.send(()).unwrap();
+
+    drop(tx);
+
+    rx.wait_for(|_| false).await.expect_err(
+        "`wait_for` call returns an error IFF the channel is closed by dropping the senders.",
+    );
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Solves #7281 . The specification of [watch::Receiver::changed](https://docs.rs/tokio/latest/tokio/sync/watch/struct.Receiver.html#method.changed) says,
>"This method returns an error if and only if the Sender is dropped."

A regression test has been added, `changed_errors_on_closed_channel`, to verify that the proposed changes fixes the implementation of `changed` to conform to he specification.


## Solution

The PR fixes the bug in `changed` by adding an early check in `changed_impl` on whether the channel is closed before checking if the value is changed.
