### PR TITLE
tokio-uitls: into_parts() for Framed Read/Write

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -377,7 +377,7 @@ pub struct FramedParts<T, U> {
 
     /// This private field allows us to add additional fields in the future in a
     /// backwards compatible way.
-    _priv: (),
+    pub(crate) _priv: (),
 }
 
 impl<T, U> FramedParts<T, U> {

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -11,6 +11,8 @@ use std::fmt;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use super::FramedParts;
+
 pin_project! {
     /// A [`Stream`] of messages decoded from an [`AsyncRead`].
     ///
@@ -152,6 +154,18 @@ impl<T, D> FramedRead<T, D> {
     /// Returns a mutable reference to the read buffer.
     pub fn read_buffer_mut(&mut self) -> &mut BytesMut {
         &mut self.inner.state.buffer
+    }
+
+    /// Consumes the `FramedRead`, returning its underlying I/O stream, the buffer
+    /// with unprocessed data, and the codec.
+    pub fn into_parts(self) -> FramedParts<T, D> {
+        FramedParts {
+            io: self.inner.inner,
+            codec: self.inner.codec,
+            read_buf: self.inner.state.buffer,
+            write_buf: BytesMut::new(),
+            _priv: (),
+        }
     }
 }
 

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -12,6 +12,8 @@ use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
+use super::FramedParts;
+
 pin_project! {
     /// A [`Sink`] of frames encoded to an `AsyncWrite`.
     ///
@@ -158,6 +160,18 @@ impl<T, E> FramedWrite<T, E> {
     /// Updates backpressure boundary
     pub fn set_backpressure_boundary(&mut self, boundary: usize) {
         self.inner.state.backpressure_boundary = boundary;
+    }
+
+    /// Consumes the `FramedWrite`, returning its underlying I/O stream, the buffer
+    /// with unprocessed data, and the codec.
+    pub fn into_parts(self) -> FramedParts<T, E> {
+        FramedParts {
+            io: self.inner.inner,
+            codec: self.inner.codec,
+            read_buf: BytesMut::new(),
+            write_buf: self.inner.state.buffer,
+            _priv: (),
+        }
     }
 }
 


### PR DESCRIPTION
Implement into_parts for FramedRead and FramedWrite.

Fixes #7472


## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

into_parts() functionality is lacking for FramedRead and FramedWrite

## Solution

Implement `into_parts()` method for `FramedRead` and `FramedWrite`
