### PR TITLE
sync: use `UnsafeCell::get_mut` in `Mutex::get_mut` and `RwLock::get_mut`

### DIFF
--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -716,10 +716,7 @@ impl<T: ?Sized> Mutex<T> {
     /// }
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
-        unsafe {
-            // Safety: This is https://github.com/rust-lang/rust/pull/76936
-            &mut *self.c.get()
-        }
+        self.c.get_mut()
     }
 
     /// Attempts to acquire the lock, and returns [`TryLockError`] if the lock

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -1073,10 +1073,7 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     pub fn get_mut(&mut self) -> &mut T {
-        unsafe {
-            // Safety: This is https://github.com/rust-lang/rust/pull/76936
-            &mut *self.c.get()
-        }
+        self.c.get_mut()
     }
 
     /// Consumes the lock, returning the underlying data.


### PR DESCRIPTION
Remove two `unsafe {}` in the code. Blocked until rustc 1.83 MSRV.