### PR TITLE
net: implement `AsRef<Self>` for `TcpStream` and `UnixStream`

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -70,12 +70,6 @@ cfg_net! {
     pub struct TcpStream {
         io: PollEvented<mio::net::TcpStream>,
     }
-
-    impl AsRef<TcpStream> for TcpStream {
-        fn as_ref(&self) -> &Self {
-            self
-        }
-    }
 }
 
 impl TcpStream {
@@ -1465,6 +1459,12 @@ impl AsyncWrite for TcpStream {
 impl fmt::Debug for TcpStream {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.io.fmt(f)
+    }
+}
+
+impl AsRef<Self> for TcpStream {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -70,6 +70,12 @@ cfg_net! {
     pub struct TcpStream {
         io: PollEvented<mio::net::TcpStream>,
     }
+
+    impl AsRef<TcpStream> for TcpStream {
+        fn as_ref(&self) -> &Self {
+            self
+        }
+    }
 }
 
 impl TcpStream {

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -1076,6 +1076,12 @@ impl fmt::Debug for UnixStream {
     }
 }
 
+impl AsRef<Self> for UnixStream {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl AsRawFd for UnixStream {
     fn as_raw_fd(&self) -> RawFd {
         self.io.as_raw_fd()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

I'm writing a wrapper that I want to work for `OwnedReadHalf` _and_ `TcpStream`.
`OwnedReadHalf: AsRef<TcpStream>` already, so this helps.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
`TcpStream: AsRef<Self>`