### PR TITLE
task: clarify task ID reuse guarantees

### DIFF
--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -8,19 +8,25 @@ use std::{fmt, num::NonZeroU64};
 /// A task's ID may be re-used for another task only once *both* of the
 /// following happen:
 /// 1. The task itself exits.
-/// 2. The task's [`JoinHandle`](crate::task::JoinHandle) is either dropped, or
-///    joined on (for example, by `await`ing it to completion).
+/// 2. There is no active [`JoinHandle`] associated with this task.
+///
+/// A [`JoinHandle`] is considered active in the following situations:
+/// - You are explicitly holding a [`JoinHandle`], [`AbortHandle`], or
+///   `tokio_util::task::AbortOnDropHandle`.
+/// - The task is being tracked by a [`JoinSet`] or `tokio_util::task::JoinMap`.
 ///
 /// # Notes
 ///
 /// - Task IDs are *not* sequential, and do not indicate the order in which
 ///   tasks are spawned, what runtime a task is spawned on, or any other data.
-/// - Holding an [`AbortHandle`](crate::task::AbortHandle) alone does not
-///   prevent a completed task's ID from being re-used.
 /// - The task ID of the currently running task can be obtained from inside the
 ///   task via the [`task::try_id()`](crate::task::try_id()) and
 ///   [`task::id()`](crate::task::id()) functions and from outside the task via
 ///   the [`JoinHandle::id()`](crate::task::JoinHandle::id()) function.
+///
+/// [`JoinHandle`]: crate::task::JoinHandle
+/// [`AbortHandle`]: crate::task::AbortHandle
+/// [`JoinSet`]: crate::task::JoinSet
 #[cfg_attr(docsrs, doc(cfg(all(feature = "rt"))))]
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Id(pub(crate) NonZeroU64);

--- a/tokio/src/runtime/task/id.rs
+++ b/tokio/src/runtime/task/id.rs
@@ -5,12 +5,18 @@ use std::{fmt, num::NonZeroU64};
 /// An opaque ID that uniquely identifies a task relative to all other currently
 /// running tasks.
 ///
+/// A task's ID may be re-used for another task only once *both* of the
+/// following happen:
+/// 1. The task itself exits.
+/// 2. The task's [`JoinHandle`](crate::task::JoinHandle) is either dropped, or
+///    joined on (for example, by `await`ing it to completion).
+///
 /// # Notes
 ///
-/// - Task IDs are unique relative to other *currently running* tasks. When a
-///   task completes, the same ID may be used for another task.
 /// - Task IDs are *not* sequential, and do not indicate the order in which
 ///   tasks are spawned, what runtime a task is spawned on, or any other data.
+/// - Holding an [`AbortHandle`](crate::task::AbortHandle) alone does not
+///   prevent a completed task's ID from being re-used.
 /// - The task ID of the currently running task can be obtained from inside the
 ///   task via the [`task::try_id()`](crate::task::try_id()) and
 ///   [`task::id()`](crate::task::id()) functions and from outside the task via

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -295,7 +295,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// This method is cancel safe. If `join_next_with_id` is used as the event in a `tokio::select!`
     /// statement and some other branch completes first, it is guaranteed that no tasks were
-    /// removed from this `JoinSet`.
+    /// removed from this `JoinSet`, nor any task's ID freed for re-use by another task.
     ///
     /// [task ID]: crate::task::Id
     /// [`JoinError::id`]: fn@crate::task::JoinError::id
@@ -535,7 +535,9 @@ impl<T: 'static> JoinSet<T> {
     ///  * `Poll::Ready(None)` if the `JoinSet` is empty.
     ///
     /// Note that this method may return `Poll::Pending` even if one of the tasks has completed.
-    /// This can happen if the [coop budget] is reached.
+    /// This can happen if the [coop budget] is reached. However, the task's `JoinHandle` is only
+    /// consumed (and the task ID freed for potential re-use) if this method returns
+    /// `Poll::Ready(Some(_))`.
     ///
     /// [coop budget]: crate::task::coop#cooperative-scheduling
     /// [task ID]: crate::task::Id

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -50,6 +50,16 @@ use crate::util::IdleNotifiedSet;
 ///     }
 /// }
 /// ```
+///
+/// # Task ID guarantees
+///
+/// While a task is tracked in a `JoinSet`, that task's ID is unique relative
+/// to all other running tasks in Tokio. For this purpose, tracking a task in a
+/// `JoinSet` is equivalent to holding a [`JoinHandle`] to it. See the [task ID]
+/// documentation for more info.
+///
+/// [`JoinHandle`]: crate::task::JoinHandle
+/// [task ID]: crate::task::Id
 #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub struct JoinSet<T> {
     inner: IdleNotifiedSet<JoinHandle<T>>,
@@ -295,7 +305,7 @@ impl<T: 'static> JoinSet<T> {
     ///
     /// This method is cancel safe. If `join_next_with_id` is used as the event in a `tokio::select!`
     /// statement and some other branch completes first, it is guaranteed that no tasks were
-    /// removed from this `JoinSet`, nor any task's ID freed for re-use by another task.
+    /// removed from this `JoinSet`.
     ///
     /// [task ID]: crate::task::Id
     /// [`JoinError::id`]: fn@crate::task::JoinError::id
@@ -535,9 +545,7 @@ impl<T: 'static> JoinSet<T> {
     ///  * `Poll::Ready(None)` if the `JoinSet` is empty.
     ///
     /// Note that this method may return `Poll::Pending` even if one of the tasks has completed.
-    /// This can happen if the [coop budget] is reached. However, the task's `JoinHandle` is only
-    /// consumed (and the task ID freed for potential re-use) if this method returns
-    /// `Poll::Ready(Some(_))`.
+    /// This can happen if the [coop budget] is reached.
     ///
     /// [coop budget]: crate::task::coop#cooperative-scheduling
     /// [task ID]: crate::task::Id


### PR DESCRIPTION
Fixes: #7553

As discussed in the above issue, we have an implicit guarantee that a task ID is not reused until both the task finishes and its `JoinHandle` is joined on or dropped. User code requires this guarantee to do useful things with the ID, so this PR updates docs to make it more explicit.

I chose the wording "joined on" to cover cases outside of plain `.await`. In particular, joining a task via `&mut JoinHandle` (e.g. `tokio::select!`) counts for all intents and purposes, despite not strictly consuming the `JoinHandle`.