### PR TITLE
stream: improve the the docs of `TcpListenerStream`

### DIFF
--- a/tokio-stream/src/wrappers/tcp_listener.rs
+++ b/tokio-stream/src/wrappers/tcp_listener.rs
@@ -18,12 +18,12 @@ use tokio::net::{TcpListener, TcpStream};
 ///
 /// # #[tokio::main(flavor = "current_thread")]
 /// # async fn main() -> std::io::Result<()> {
-/// let ipv4_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 8080)).await?;
-/// let ipv6_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 8080)).await?;
+/// let ipv4_listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 8080)).await?;
+/// let ipv6_listener = TcpListener::bind((Ipv6Addr::LOCALHOST, 8080)).await?;
 /// let ipv4_connections = TcpListenerStream::new(ipv4_listener);
 /// let ipv6_connections = TcpListenerStream::new(ipv6_listener);
 ///
-/// let mut connections = ipv4_connections.chain(ipv6_connections);
+/// let mut connections = ipv4_connections.merge(ipv6_connections);
 /// while let Some(tcp_stream) = connections.next().await {
 ///     let stream = tcp_stream?;
 ///     let peer_addr = stream.peer_addr()?;


### PR DESCRIPTION
The example of TcpListenerStream uses listener1.chain(listener2). This way it will always poll the first listener until it is fully consumed, i.e. closed. Then it will start polling the second listener. It would be better to use `listener1.merge(listener2)` instead. This way both listeners will be polled one after the other.

While here also fix a typo in the constants for LOCALHOST - ipv4_listener actually used Ipv6Addr::LOCALHOST and ipv6_listener - Ipv4Addr::LOCALHOST

## Motivation

The documentation of TcpListenerStream was using the wrong constants. Also the `chain()` method will try to consumer the first Stream fully before polling the second. Using `merge()` would be better because it will poll both listeners one after the other.

## Solution

Improve the sample in the documentation.
