### PR TITLE
process: fix unit test for trailing LF in `uname -r`

### DIFF
--- a/tokio/src/process/unix/pidfd_reaper.rs
+++ b/tokio/src/process/unix/pidfd_reaper.rs
@@ -256,7 +256,7 @@ mod test {
         .split('.');
 
         let major: u32 = kernel_version_iter.next().unwrap().parse().unwrap();
-        let minor: u32 = kernel_version_iter.next().unwrap().parse().unwrap();
+        let minor: u32 = kernel_version_iter.next().unwrap().trim().parse().unwrap();
 
         major >= 6 || (major == 5 && minor >= 10)
     }


### PR DESCRIPTION

## Motivation
`uname -r` returns a string that ends with a newline.

4825c444eb29b05c9c0b6f4a4c89475cb2556c65 improved the parsing of the `uname -r` result to handle the case when there is no '-'.

Usually the version string looks like `6.11.0-109019` but 4825c444eb29b05c9c0b6f4a4c89475cb2556c65 explained it could also be just `6.11.0` (this is how it behaves on MacOS!).
Custom kernel builds could even use shorter version like `6.11`. In this case the string returned by `uname -r` will be "6.11\n" and the parse of "11\n" would fail. 

## Solution

Trimming the `minor` part would keep it working.