### PR TITLE
io: clarify the zero capacity case of `AsyncRead::poll_read`

### DIFF
--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -46,7 +46,8 @@ pub trait AsyncRead {
     ///
     /// On success, returns `Poll::Ready(Ok(()))` and places data in the
     /// unfilled portion of `buf`. If no data was read (`buf.filled().len()` is
-    /// unchanged), it implies that EOF has been reached.
+    /// unchanged), it implies that EOF has been reached, or the output buffer
+    /// had zero capacity (i.e. `buf.remaining()` == 0).
     ///
     /// If no data is available for reading, the method returns `Poll::Pending`
     /// and arranges for the current task (via `cx.waker()`) to receive a


### PR DESCRIPTION
## Motivation

5b9a290acd25d88416e70c73c49a54106fcf02b5 improved the trait documentation for the cases when the buf length didn't change but forgot to do the same for the method documentation.

## Solution

Apply the improvement also for the method documentation.