### PR TITLE
examples: fix the write length in the `connect-tcp` example

### DIFF
--- a/examples/connect-udp.rs
+++ b/examples/connect-udp.rs
@@ -85,7 +85,7 @@ async fn recv(
         let n = reader.recv(&mut buf[..]).await?;
 
         if n > 0 {
-            stdout.send(Bytes::from(buf)).await?;
+            stdout.send(Bytes::copy_from_slice(&buf[..n])).await?;
         }
     }
 }


### PR DESCRIPTION

## Motivation

The connect-udp example reads `n` bytes from the reader but writes the full 1024 bytes buffer to stdout. It should write only the `n` bytes it just read.

## Solution

Write only `n` bytes to stdout: 
```rust
Bytes::copy_from_slice(&buf[..n])
```