### PR TITLE
docs: Fix the docs and example snippers in the examples use `connect-tcp`

### DIFF
--- a/examples/echo-tcp.rs
+++ b/examples/echo-tcp.rs
@@ -16,7 +16,7 @@
 //!     cargo run --example connect-tcp 127.0.0.1:8080
 //!
 //! Each line you type in to the `connect-tcp` terminal should be echo'd back to
-//! you! If you open up multiple terminals running the `connect` example you
+//! you! If you open up multiple terminals running the `connect-tcp` example you
 //! should be able to see them all make progress simultaneously.
 
 #![warn(rust_2018_idioms)]

--- a/examples/tinydb.rs
+++ b/examples/tinydb.rs
@@ -19,7 +19,7 @@
 //! is:
 //!
 //!
-//!     $ cargo run --example connect 127.0.0.1:8080
+//!     $ cargo run --example connect-tcp 127.0.0.1:8080
 //!     GET foo
 //!     foo = bar
 //!     GET FOOBAR


### PR DESCRIPTION

## Motivation

1434b32b5a0df3b38a0d588485cd9a20a8e92a89 split the connect example into connect-tcp and connect-udp examples but some of the other examples still talk about `connect` example

## Solution

s/connect/connect-tcp/ where needed