### PR TITLE
io: fix typos in the docs of two `AsyncFd` readiness guards

### DIFF
--- a/tokio/src/io/async_fd.rs
+++ b/tokio/src/io/async_fd.rs
@@ -988,7 +988,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyGuard<'a, Inner> {
     ///
     /// This method only clears readiness events that happened before the creation of this guard.
     /// In other words, if the IO resource becomes ready between the creation of the guard and
-    /// this call to `clear_ready`, then the readiness is not actually cleared.
+    /// this call to `clear_ready_matching`, then the readiness is not actually cleared.
     ///
     /// # Examples
     ///
@@ -1212,7 +1212,7 @@ impl<'a, Inner: AsRawFd> AsyncFdReadyMutGuard<'a, Inner> {
     ///
     /// This method only clears readiness events that happened before the creation of this guard.
     /// In other words, if the IO resource becomes ready between the creation of the guard and
-    /// this call to `clear_ready`, then the readiness is not actually cleared.
+    /// this call to `clear_ready_matching`, then the readiness is not actually cleared.
     ///
     /// # Examples
     ///


### PR DESCRIPTION

## Motivation

e53b92a9939565edb33575fff296804279e5e419 improved the documentation of clear_ready() and clear_ready_matching() methods but made a small copy/paste error - the documentation of clear_ready_matching() talks about `clear_ready()` as `this method`

## Solution

Fix the typos by replacing `clear_ready` with `clear_ready_matching` where wrong. 
