### PR TITLE
loom: loom::std::parking_lot::RwLock try_read/try_write methods block

### DIFF
--- a/tokio/src/loom/std/parking_lot.rs
+++ b/tokio/src/loom/std/parking_lot.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
-use std::sync::LockResult;
+use std::sync::{LockResult, TryLockError};
 use std::time::Duration;
 
 // All types in this file are marked with PhantomData to ensure that
@@ -101,7 +101,9 @@ impl<T> RwLock<T> {
     }
 
     pub(crate) fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
-        Some(RwLockReadGuard(PhantomData, self.1.read()))
+        self.1
+            .try_read()
+            .map(|guard| RwLockReadGuard(PhantomData, guard))
     }
 
     pub(crate) fn write(&self) -> RwLockWriteGuard<'_, T> {
@@ -109,7 +111,9 @@ impl<T> RwLock<T> {
     }
 
     pub(crate) fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
-        Some(RwLockWriteGuard(PhantomData, self.1.write()))
+        self.1
+            .try_write()
+            .map(|guard| RwLockWriteGuard(PhantomData, guard))
     }
 }
 


### PR DESCRIPTION

## Motivation

bd4ccae184b0359cb88f9ebc2ba157867e1eee0e introduced a wrapper for the RwLock to get rid of poisoning aspects.

By mistake (?!) its try_read/write methods actually delegate to read/write() and this would lead to blocking

## Solution

Delegate the to try_** methods of the delegate to avoid blocking.
