### PR TITLE
fs: Preserve the max_buf_size when cloning a File

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -465,7 +465,9 @@ impl File {
         self.inner.lock().await.complete_inflight().await;
         let std = self.std.clone();
         let std_file = asyncify(move || std.try_clone()).await?;
-        Ok(File::from_std(std_file))
+        let mut file = File::from_std(std_file);
+        file.set_max_buf_size(self.max_buf_size);
+        Ok(file)
     }
 
     /// Destructures `File` into a [`std::fs::File`]. This function is


### PR DESCRIPTION

## Motivation

File::try_clone() should preserve the max_buf_size of the origin, otherwise the cloning would use the default (`tokio::io::blocking::DEFAULT_MAX_BUF_SIZE`)

## Solution

Set the max_buf_size of the cloning to the one used by the origin.