### PR TITLE
fs: add `File::max_buf_size`

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -579,6 +579,11 @@ impl File {
     pub fn set_max_buf_size(&mut self, max_buf_size: usize) {
         self.max_buf_size = max_buf_size;
     }
+
+    /// Get the maximum buffer size for the underlying [`AsyncRead`] / [`AsyncWrite`] operation.
+    pub fn max_buf_size(&self) -> usize {
+        self.max_buf_size
+    }
 }
 
 impl AsyncRead for File {


### PR DESCRIPTION
## Motivation

Add a getter for fs::File::max_buf_size.
Requested at https://github.com/tokio-rs/tokio/pull/7593#issuecomment-3269352816 for a cleaner changelog

## Solution

Add a simple getter for fs::File::max_buf_size field