### PR TITLE
sync: Improve a bit the documentation about allocation failure

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -503,7 +503,7 @@ const MAX_RECEIVERS: usize = usize::MAX >> 2;
 /// This will panic if `capacity` is equal to `0`.
 ///
 /// This pre-allocates space for `capacity` messages. Allocation failure may result in a panic or
-/// [an allocation failure](std::alloc::handle_alloc_error).
+/// [an allocation error](std::alloc::handle_alloc_error).
 #[track_caller]
 pub fn channel<T: Clone>(capacity: usize) -> (Sender<T>, Receiver<T>) {
     // SAFETY: In the line below we are creating one extra receiver, so there will be 1 in total.


### PR DESCRIPTION

## Motivation

The old documentation was "Allocation failure may result in ... an [allocation failure]"

## Solution
This commit replaces the latter to `[allocation error]` to avoid the recursion in wording.
