### PR TITLE
macros: add missing `local` flavor to `tokio::main` error message

### DIFF
--- a/tests-build/tests/fail/macros_invalid_input.stderr
+++ b/tests-build/tests/fail/macros_invalid_input.stderr
@@ -40,7 +40,7 @@ error: Failed to parse value of `flavor` as string.
 23 | #[tokio::test(flavor = 123)]
    |                        ^^^
 
-error: No such runtime flavor `foo`. The runtime flavors are `current_thread` and `multi_thread`.
+error: No such runtime flavor `foo`. The runtime flavors are `current_thread`, `local`, and `multi_thread`.
   --> tests/fail/macros_invalid_input.rs:26:24
    |
 26 | #[tokio::test(flavor = "foo")]

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -22,7 +22,7 @@ impl RuntimeFlavor {
             "single_thread" => Err("The single threaded runtime flavor is called `current_thread`.".to_string()),
             "basic_scheduler" => Err("The `basic_scheduler` runtime flavor has been renamed to `current_thread`.".to_string()),
             "threaded_scheduler" => Err("The `threaded_scheduler` runtime flavor has been renamed to `multi_thread`.".to_string()),
-            _ => Err(format!("No such runtime flavor `{s}`. The runtime flavors are `current_thread` and `multi_thread`.")),
+            _ => Err(format!("No such runtime flavor `{s}`. The runtime flavors are `current_thread`, `local`, and `multi_thread`.")),
         }
     }
 }


### PR DESCRIPTION

## Motivation

https://github.com/tokio-rs/tokio/pull/7375 added the Local runtime flavour but forgot to update the error message when an unknown value is passed to from_str()

## Solution

Add `local` to the list of available flavours in the error message for from_str()