### PR TITLE
macros: update the example git tag used in the release guide

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -3,7 +3,7 @@ name = "tokio-macros"
 # When releasing to crates.io:
 # - Remove path dependencies
 # - Update CHANGELOG.md.
-# - Create "tokio-macros-1.x.y" git tag.
+# - Create "tokio-macros-x.y.z" git tag.
 version = "2.5.0"
 edition = "2021"
 rust-version = "1.70"


### PR DESCRIPTION

## Motivation

The release steps at tokio-macros/Cargo.toml use old version for the Git tag name: 1.x.y
https://github.com/tokio-rs/tokio/blob/f07233f742c02cd84c48b9c6010ed7f4671e0a3a/tokio-macros/Cargo.toml#L6-L7

## Solution

Change `1.x.y` to `x.y.z` so that it does not become obsolete again when tokio-macros 3.x is released