### PR TITLE
sync: Fix a typo in the documentation for `watch` channel

### DIFF
--- a/tokio/src/sync/mod.rs
+++ b/tokio/src/sync/mod.rs
@@ -279,7 +279,7 @@
 //! ## `watch` channel
 //!
 //! The [`watch` channel] supports sending **many** values from a **many**
-//! producer to **many** consumers. However, only the **most recent** value is
+//! producers to **many** consumers. However, only the **most recent** value is
 //! stored in the channel. Consumers are notified when a new value is sent, but
 //! there is no guarantee that consumers will see **all** values.
 //!


### PR DESCRIPTION
## Motivation

There is a minor typo in the documentation of tokio::sync::channel::watch : 
"many producer" (without 's') should be "many producers"

## Solution

Append the missing `s`