### PR TITLE
task: remove duplicated code in `JoinMap::remove_by_id`

### DIFF
--- a/tokio-util/src/task/join_map.rs
+++ b/tokio-util/src/task/join_map.rs
@@ -761,7 +761,6 @@ where
             Ok(entry) => entry.remove().0,
             _ => return None,
         };
-        self.hashes_by_task.remove(&id);
         Some(key)
     }
 }


### PR DESCRIPTION


## Motivation

The hash is first removed at the beginning of the method - https://github.com/tokio-rs/tokio/blob/7127e257a7d7025a5f6a62eb8aab81c2191f5cdb/tokio-util/src/task/join_map.rs#L754 And then again at the end - https://github.com/tokio-rs/tokio/blob/7127e257a7d7025a5f6a62eb8aab81c2191f5cdb/tokio-util/src/task/join_map.rs#L764 The second removal does nothing.

## Solution

Delete the line with the second removal.