### PR TITLE
runtime: clarify the edge case of `Builder::global_queue_interval()`

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -980,8 +980,10 @@ impl Builder {
     /// tasks. Setting the interval to a smaller value increases the fairness of the scheduler,
     /// at the cost of more synchronization overhead. That can be beneficial for prioritizing
     /// getting started on new work, especially if tasks frequently yield rather than complete
-    /// or await on further I/O. Conversely, a higher value prioritizes existing work, and
-    /// is a good choice when most tasks quickly complete polling.
+    /// or await on further I/O. Setting the interval to `1` will prioritize the global queue and
+    /// tasks from the local queue will be executed only if the global queue is empty.
+    /// Conversely, a higher value prioritizes existing work, and is a good choice when most
+    /// tasks quickly complete polling.
     ///
     /// [the module documentation]: crate::runtime#multi-threaded-runtime-behavior-at-the-time-of-writing
     ///


### PR DESCRIPTION


## Motivation

If the interval is set to 1 then the schedulers will always execute tasks from the global queue. Tasks from the local queue will be executed only if the global queue is empty.

multi_thread scheduler: https://github.com/tokio-rs/tokio/blob/7127e257a7d7025a5f6a62eb8aab81c2191f5cdb/tokio/src/runtime/scheduler/multi_thread/worker.rs#L806-L813

I think this clarification is needed because of
```
Setting the interval to a smaller value increases the fairness of the scheduler,
    /// at the cost of more synchronization overhead.
```
at https://github.com/tokio-rs/tokio/blob/7127e257a7d7025a5f6a62eb8aab81c2191f5cdb/tokio/src/runtime/builder.rs#L980C16-L981C54
With `1` there is no fairness anymore

## Solution

Add a sentence to the documentation about the special case of `global_queue_interval=1`
