### PR TITLE
net: Update the docs of net::unix::pipe::OpenOptions that read_write is supported on Android too

### DIFF
--- a/tokio/src/net/unix/pipe.rs
+++ b/tokio/src/net/unix/pipe.rs
@@ -99,7 +99,7 @@ pub fn pipe() -> io::Result<(Sender, Receiver)> {
 /// # }
 /// ```
 ///
-/// Opening a [`Sender`] on Linux when you are sure the file is a FIFO:
+/// Opening a [`Sender`] on Linux/Android when you are sure the file is a FIFO:
 ///
 /// ```ignore
 /// use tokio::net::unix::pipe;
@@ -141,7 +141,7 @@ impl OpenOptions {
     ///
     /// This option, when true, will indicate that a FIFO file will be opened
     /// in read-write access mode. This operation is not defined by the POSIX
-    /// standard and is only guaranteed to work on Linux.
+    /// standard and is only guaranteed to work on Linux and Android.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
## Motivation

https://github.com/tokio-rs/tokio/pull/7426 made `tokio::net::unix::pipe::OpenOptions::read_write` available on Android too

## Solution

Update the docs to mention `Android` next to `Linux`