### PR TITLE
util: Use owned token in pending_only_on_first_poll_with_cancellation_token_owned_test

### DIFF
--- a/tokio-util/tests/future.rs
+++ b/tokio-util/tests/future.rs
@@ -250,7 +250,7 @@ fn pending_fut_with_owned_token_cancelled_test() {
 fn pending_only_on_first_poll_with_cancellation_token_owned_test() {
     let (waker, wake_count) = new_count_waker();
     let token = CancellationToken::new();
-    let fut = ReadyOnTheSecondPollFuture::default().with_cancellation_token(&token);
+    let fut = ReadyOnTheSecondPollFuture::default().with_cancellation_token_owned(token.clone());
     pin!(fut);
 
     // first poll, ReadyOnTheSecondPollFuture returned Pending


### PR DESCRIPTION

## Motivation

The name of the test suggests that it should test the with_cancellation_token**_owned**() extension method.

The new test has been introduced with https://github.com/tokio-rs/tokio/commit/0e5c5d64f5aa4387e7d0fb3c1a69561b170fbfcf#diff-1a65d95f2c318eb9684e46133805c20a0037726ce9ac14f29fb44f156a9726f1R250

## Solution

Use the with_cancellation_token**_owned**() method and pass a owned token (rc clone).