### PR TITLE
metrics: clarify that `num_alive_tasks` is not strongly consistent

### DIFF
--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -54,6 +54,10 @@ impl RuntimeMetrics {
     /// This counter increases when a task is spawned and decreases when a
     /// task exits.
     ///
+    /// Note: When using the multi-threaded runtime this number may not
+    /// not have strong consistency i.e. no tasks may be running but the metric
+    /// reports otherwise.
+    ///
     /// # Examples
     ///
     /// ```


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

I was confused by this to I opened  https://github.com/tokio-rs/tokio/issues/7591

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Update the documentation so future people know not to trust this metric when using the multithreaded runtime.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
