### PR TITLE
chore: remove cargo-deny Unicode-DFS-2016 license exception config

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -9,7 +9,7 @@ allow = [
     "Apache-2.0",
 ]
 exceptions = [
-    { allow = ["Unicode-3.0", "Unicode-DFS-2016"], crate = "unicode-ident" },
+    { allow = ["Unicode-3.0"], crate = "unicode-ident" },
 ]
 
 [bans]


### PR DESCRIPTION
## Motivation

Unicode-DFS-2016 license exception seems to be resolved.

## Solution

Removes cargo-deny Unicode-DFS-2016 license exception config.
