### PR TITLE
ci: fix compiler output changes in Rust 1.90.0

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -25,7 +25,7 @@ error[E0308]: mismatched types
                    found enum `Result<(), _>`
 help: a return type might be missing here
    |
-9  | async fn missing_return_type() -> _ {
+ 9 | async fn missing_return_type() -> _ {
    |                                ++++
 help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panicking if the value is a `Result::Err`
    |


### PR DESCRIPTION
CI is failing due to the Rust 1.90.0, see <https://github.com/tokio-rs/tokio/actions/runs/17831193133/job/50699935384?pr=7467>.