### PR TITLE
runtime: use the Cargo feature for taskdump instead of cfg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,10 +248,10 @@ jobs:
       matrix:
         include:
           # We use `--features "full,test-util"` instead of `--all-features` since
-          # `--all-features` includes `io_uring`, which is not available on all targets.
+          # `--all-features` includes `io_uring` and `taskdump`, which is not available on all targets.
           - { os: windows-latest, features: "full,test-util" }
           - { os: ubuntu-latest, features: "full,test-util" }
-          - { os: ubuntu-latest, features: "full,test-util,io-uring" }
+          - { os: ubuntu-latest, features: "full,test-util,taskdump,io-uring" }
           - { os: macos-latest, features: "full,test-util" }
     steps:
       - uses: actions/checkout@v5
@@ -278,40 +278,6 @@ jobs:
           # in order to run doctests for unstable features, we must also pass
           # the unstable cfg to RustDoc
           RUSTDOCFLAGS: --cfg tokio_unstable
-
-  test-unstable-taskdump:
-    name: test tokio full --unstable --taskdump
-    needs: basics
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - name: Install Rust ${{ env.rust_stable }}
-        uses: dtolnay/rust-toolchain@stable
-        with:
-            toolchain: ${{ env.rust_stable }}
-
-      - name: Install cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-nextest
-
-      - uses: Swatinem/rust-cache@v2
-      # Run `tokio` with "unstable" and "taskdump" cfg flags.
-      - name: test tokio full --cfg unstable --cfg taskdump
-        run: |
-          set -euxo pipefail
-          cargo nextest run --all-features
-          cargo test --doc --all-features
-        working-directory: tokio
-        env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
-          # in order to run doctests for unstable features, we must also pass
-          # the unstable cfg to RustDoc
-          RUSTDOCFLAGS: --cfg tokio_unstable --cfg tokio_taskdump
 
   check-unstable-mt-counters:
     name: check tokio full --internal-mt-counters
@@ -507,19 +473,25 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # See <https://github.com/tokio-rs/io-uring/blob/dbd2b4aab8b7ffb13b4a23806339c97ee5c11920/src/sys/mod.rs#L18-L28>
+        # for default io-uring binding provided by the io-uring crate.
         include:
           - target: i686-unknown-linux-gnu
             os: ubuntu-latest
-            rustflags: --cfg tokio_taskdump
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for i686
           - target: armv5te-unknown-linux-gnueabi
             os: ubuntu-latest
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for armv5te
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-24.04-arm
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for armv7
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-            rustflags: --cfg tokio_taskdump
+            rustflags: --cfg tokio_unstable
+            features: "full,test-util,io-uring,taskdump"
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
+            features: "full,test-util" # io-uring and taskdump don't work on Windows
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable
@@ -542,32 +514,36 @@ jobs:
       - name: Tests run with all features (including parking_lot)
         run: |
           set -euxo pipefail
-          # We use `--features "full,test-util"` instead of `--all-features` since
-          # `--all-features` includes `io_uring`, which is not available on all targets.
-          cargo nextest run -p tokio --features full,test-util --target ${{ matrix.target }}
-          cargo test --doc -p tokio --features full,test-util --target ${{ matrix.target }}
+          cargo nextest run -p tokio --features ${{ matrix.features }} --target ${{ matrix.target }}
+          cargo test --doc -p tokio --features ${{ matrix.features }} --target ${{ matrix.target }}
         env:
           RUST_TEST_THREADS: 1
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_tuning_tests ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_tuning_tests
 
   cross-test-without-parking_lot:
     needs: basics
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # See <https://github.com/tokio-rs/io-uring/blob/dbd2b4aab8b7ffb13b4a23806339c97ee5c11920/src/sys/mod.rs#L18-L28>
+        # for default io-uring binding provided by the io-uring crate.
         include:
           - target: i686-unknown-linux-gnu
             os: ubuntu-latest
-            rustflags: --cfg tokio_taskdump
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for i686
           - target: armv5te-unknown-linux-gnueabi
             os: ubuntu-latest
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for armv5te
           - target: armv7-unknown-linux-gnueabihf
             os: ubuntu-24.04-arm
+            features: "full,test-util,taskdump" # crate io-uring has no default binding for armv7
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
-            rustflags: --cfg tokio_taskdump
+            rustflags: --cfg tokio_unstable
+            features: "full,test-util,io-uring,taskdump"
           - target: aarch64-pc-windows-msvc
             os: windows-11-arm
+            features: "full,test-util" # io-uring and taskdump don't work on Windows
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust stable
@@ -594,13 +570,11 @@ jobs:
       - name: Tests run with all features (without parking_lot)
         run: |
           set -euxo pipefail
-          # We use `--features "full,test-util"` instead of `--all-features` since
-          # `--all-features` includes `io_uring`, which is not available on all targets.
-          cargo nextest run -p tokio --features full,test-util --target ${{ matrix.target }}
-          cargo test --doc -p tokio --features full,test-util --target ${{ matrix.target }}
+          cargo nextest run -p tokio --features ${{ matrix.features }} --target ${{ matrix.target }}
+          cargo test --doc -p tokio --features ${{ matrix.features }} --target ${{ matrix.target }}
         env:
           RUST_TEST_THREADS: 1
-          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_parking_lot --cfg tokio_no_tuning_tests ${{ matrix.rustflags }}
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_parking_lot --cfg tokio_no_tuning_tests
 
   # See https://github.com/tokio-rs/tokio/issues/5187
   no-atomic-u64-test:
@@ -628,13 +602,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: test tokio --all-features
         run: |
-          # We use `--features "full,test-util"` instead of `--all-features` since
+          # We use `--features "full,test-util,taskdump"` instead of `--all-features` since
           # `--all-features` includes `io_uring`, which is not available on all targets.
-          cargo nextest run -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --features full,test-util
-          cargo test --doc -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --features full,test-util
+          cargo nextest run -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --features full,test-util,taskdump
+          cargo test --doc -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --features full,test-util,taskdump
         env:
           RUST_TEST_THREADS: 1
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings --cfg tokio_no_tuning_tests
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings --cfg tokio_no_tuning_tests
 
   no-atomic-u64-check:
     name: Check tokio --feature-powerset --depth 2 on i686-unknown-linux-gnu without AtomicU64
@@ -660,7 +634,7 @@ jobs:
         # We use `--skip io-uring` since io-uring crate doesn't provide a binding for the i686 target.
         run: cargo hack check -Zbuild-std --target target-specs/i686-unknown-linux-gnu.json -p tokio --feature-powerset --skip io-uring --depth 2 --keep-going
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
 
   features:
     name: features ${{ matrix.name }}
@@ -671,7 +645,6 @@ jobs:
         include:
           - { name: "", rustflags: "" }
           - { name: "--unstable", rustflags: "--cfg tokio_unstable -Dwarnings" }
-          - { name: "--unstable --taskdump", rustflags: "--cfg tokio_unstable -Dwarnings --cfg tokio_taskdump" }
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust ${{ env.rust_nightly }}
@@ -734,7 +707,7 @@ jobs:
           cargo hack check --all-features --ignore-private
       - name: "check --all-features --unstable -Z minimal-versions"
         env:
-          RUSTFLAGS: --cfg tokio_unstable --cfg tokio_taskdump -Dwarnings
+          RUSTFLAGS: --cfg tokio_unstable -Dwarnings
         run: |
           # Remove dev-dependencies from Cargo.toml to prevent the next `cargo update`
           # from determining minimal versions based on dev-dependencies.
@@ -770,7 +743,7 @@ jobs:
       matrix:
         rustflags:
           - ""
-          - "--cfg tokio_unstable --cfg tokio_taskdump -Dwarnings"
+          - "--cfg tokio_unstable Dwarnings"
     steps:
       - uses: actions/checkout@v5
       - name: Install Rust ${{ env.rust_clippy }}
@@ -793,8 +766,6 @@ jobs:
         run:
           - os: windows-latest
           - os: ubuntu-latest
-            RUSTFLAGS: --cfg tokio_taskdump
-            RUSTDOCFLAGS: --cfg tokio_taskdump
 
     steps:
       - uses: actions/checkout@v5
@@ -807,8 +778,8 @@ jobs:
         run: |
           cargo doc --lib --no-deps --all-features --document-private-items
         env:
-          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable ${{ matrix.run.RUSTFLAGS }}
-          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings ${{ matrix.run.RUSTDOCFLAGS }}
+          RUSTFLAGS: --cfg docsrs --cfg tokio_unstable
+          RUSTDOCFLAGS: --cfg docsrs --cfg tokio_unstable -Dwarnings
 
   loom-compile:
     name: build loom tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(tokio_internal_mt_counters)',
   'cfg(tokio_no_parking_lot)',
   'cfg(tokio_no_tuning_tests)',
-  'cfg(tokio_taskdump)',
   'cfg(tokio_unstable)',
   'cfg(target_os, values("cygwin"))',
 ] }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,9 @@ httparse = "1.0"
 httpdate = "1.0"
 once_cell = "1.5.2"
 
+[features]
+taskdump = ["tokio/taskdump"]
+
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.59"
 

--- a/examples/dump.rs
+++ b/examples/dump.rs
@@ -4,7 +4,7 @@
 
 #[cfg(all(
     tokio_unstable,
-    tokio_taskdump,
+    feature = "taskdump",
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]
@@ -82,7 +82,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(not(all(
     tokio_unstable,
-    tokio_taskdump,
+    feature = "taskdump",
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 )))]

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,9 +8,8 @@
   RUSTDOCFLAGS="""
     --cfg docsrs \
     --cfg tokio_unstable \
-    --cfg tokio_taskdump \
     """
-  RUSTFLAGS="--cfg tokio_unstable --cfg tokio_taskdump --cfg docsrs"
+  RUSTFLAGS="--cfg tokio_unstable --cfg docsrs"
 
 [[redirects]]
   from = "/"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -86,6 +86,8 @@ test-util = ["rt", "sync", "time"]
 time = []
 # Unstable feature. Requires `--cfg tokio_unstable` to enable.
 io-uring = ["dep:io-uring", "libc", "mio/os-poll", "mio/os-ext", "dep:slab"]
+# Unstable feature. Requires `--cfg tokio_unstable` to enable.
+taskdump = ["dep:backtrace"]
 
 [dependencies]
 tokio-macros = { version = "~2.5.0", path = "../tokio-macros", optional = true }
@@ -104,6 +106,7 @@ socket2 = { version = "0.6.0", optional = true, features = ["all"] }
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(tokio_unstable)'.dependencies]
 tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true } # Not in full
+backtrace = { version = "0.3.58", optional = true } # used by feature "taskdump"
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
@@ -112,11 +115,6 @@ io-uring = { version = "0.7.6", default-features = false, optional = true }
 libc = { version = "0.2.168", optional = true }
 mio = { version = "1.0.1", default-features = false, features = ["os-poll", "os-ext"], optional = true }
 slab = { version = "0.4.9", optional = true }
-
-# Currently unstable. The API exposed by these features may be broken at any time.
-# Requires `--cfg tokio_unstable` to enable.
-[target.'cfg(tokio_taskdump)'.dependencies]
-backtrace = { version = "0.3.58" }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.168", optional = true }
@@ -169,10 +167,10 @@ tracing-mock = "= 0.1.0-beta.1"
 [package.metadata.docs.rs]
 all-features = true
 # enable unstable features in the documentation
-rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]
-# it's necessary to _also_ pass `--cfg tokio_unstable` and `--cfg tokio_taskdump`
-# to rustc, or else dependencies will not be enabled, and the docs build will fail.
-rustc-args = ["--cfg", "tokio_unstable", "--cfg", "tokio_taskdump"]
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "tokio_unstable"]
+# it's necessary to _also_ pass `--cfg tokio_unstable` to rustc,
+# or else dependencies will not be enabled, and the docs build will fail.
+rustc-args = ["--cfg", "tokio_unstable"]
 
 [package.metadata.playground]
 features = ["full", "test-util"]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -474,11 +474,12 @@ compile_error! {
 ))]
 compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
 
-#[cfg(all(not(tokio_unstable), tokio_taskdump))]
-compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
+#[cfg(all(not(tokio_unstable), feature = "taskdump"))]
+compile_error!("The `taskdump` feature requires `--cfg tokio_unstable`.");
 
 #[cfg(all(
-    tokio_taskdump,
+    tokio_unstable,
+    feature = "taskdump",
     not(doc),
     not(all(
         target_os = "linux",
@@ -486,7 +487,7 @@ compile_error!("The `tokio_taskdump` feature requires `--cfg tokio_unstable`.");
     ))
 ))]
 compile_error!(
-    "The `tokio_taskdump` feature is only currently supported on \
+    "The `taskdump` feature is only currently supported on \
 linux, on `aarch64`, `x86` and `x86_64`."
 );
 

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -499,7 +499,7 @@ macro_rules! cfg_taskdump {
         $(
             #[cfg(all(
                 tokio_unstable,
-                tokio_taskdump,
+                feature = "taskdump",
                 feature = "rt",
                 target_os = "linux",
                 any(
@@ -508,6 +508,19 @@ macro_rules! cfg_taskdump {
                     target_arch = "x86_64"
                 )
             ))]
+            #[cfg_attr(docsrs, doc(cfg(
+                all(
+                    tokio_unstable,
+                    feature = "taskdump",
+                    feature = "rt",
+                    target_os = "linux",
+                    any(
+                        target_arch = "aarch64",
+                        target_arch = "x86",
+                        target_arch = "x86_64"
+                    )
+                )
+            )))]
             $item
         )*
     };
@@ -518,7 +531,7 @@ macro_rules! cfg_not_taskdump {
         $(
             #[cfg(not(all(
                 tokio_unstable,
-                tokio_taskdump,
+                feature = "taskdump",
                 feature = "rt",
                 target_os = "linux",
                 any(
@@ -527,6 +540,17 @@ macro_rules! cfg_not_taskdump {
                     target_arch = "x86_64"
                 )
             )))]
+            #[cfg_attr(docsrs, doc(cfg(not(all(
+                tokio_unstable,
+                feature = "taskdump",
+                feature = "rt",
+                target_os = "linux",
+                any(
+                    target_arch = "aarch64",
+                    target_arch = "x86",
+                    target_arch = "x86_64"
+                )
+            )))))]
             $item
         )*
     };

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -66,7 +66,7 @@ struct Context {
 
     #[cfg(all(
         tokio_unstable,
-        tokio_taskdump,
+        feature = "taskdump",
         feature = "rt",
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
@@ -107,7 +107,7 @@ tokio_thread_local! {
 
             #[cfg(all(
                 tokio_unstable,
-                tokio_taskdump,
+                feature = "taskdump",
                 feature = "rt",
                 target_os = "linux",
                 any(

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -310,7 +310,7 @@ impl Handle {
     fn block_on_inner<F: Future>(&self, future: F, _meta: SpawnMeta<'_>) -> F::Output {
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
@@ -337,7 +337,7 @@ impl Handle {
         let id = crate::runtime::task::Id::next();
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
@@ -362,7 +362,7 @@ impl Handle {
         let id = crate::runtime::task::Id::next();
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -232,7 +232,7 @@ impl LocalRuntime {
     fn block_on_inner<F: Future>(&self, future: F, _meta: SpawnMeta<'_>) -> F::Output {
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -335,7 +335,7 @@ impl Runtime {
     fn block_on_inner<F: Future>(&self, future: F, _meta: SpawnMeta<'_>) -> F::Output {
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -350,11 +350,12 @@ impl Core {
     }
 }
 
-#[cfg(tokio_taskdump)]
-fn wake_deferred_tasks_and_free(context: &Context) {
-    let wakers = context.defer.take_deferred();
-    for waker in wakers {
-        waker.wake();
+cfg_taskdump! {
+    fn wake_deferred_tasks_and_free(context: &Context) {
+        let wakers = context.defer.take_deferred();
+        for waker in wakers {
+            waker.wake();
+        }
     }
 }
 
@@ -509,7 +510,7 @@ impl Handle {
     /// Capture a snapshot of this runtime's state.
     #[cfg(all(
         tokio_unstable,
-        tokio_taskdump,
+        feature = "taskdump",
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]

--- a/tokio/src/runtime/scheduler/defer.rs
+++ b/tokio/src/runtime/scheduler/defer.rs
@@ -35,9 +35,10 @@ impl Defer {
         }
     }
 
-    #[cfg(tokio_taskdump)]
-    pub(crate) fn take_deferred(&self) -> Vec<Waker> {
-        let mut deferred = self.deferred.borrow_mut();
-        std::mem::take(&mut *deferred)
+    cfg_taskdump! {
+        pub(crate) fn take_deferred(&self) -> Vec<Waker> {
+            let mut deferred = self.deferred.borrow_mut();
+            std::mem::take(&mut *deferred)
+        }
     }
 }

--- a/tokio/src/runtime/scheduler/inject.rs
+++ b/tokio/src/runtime/scheduler/inject.rs
@@ -35,11 +35,12 @@ impl<T: 'static> Inject<T> {
         }
     }
 
-    // Kind of annoying to have to include the cfg here
-    #[cfg(tokio_taskdump)]
-    pub(crate) fn is_closed(&self) -> bool {
-        let synced = self.synced.lock();
-        self.shared.is_closed(&synced)
+    cfg_taskdump! {
+        // Kind of annoying to have to include the cfg here
+        pub(crate) fn is_closed(&self) -> bool {
+            let synced = self.synced.lock();
+            self.shared.is_closed(&synced)
+        }
     }
 
     /// Closes the injection queue, returns `true` if the queue is open when the

--- a/tokio/src/runtime/scheduler/inject/shared.rs
+++ b/tokio/src/runtime/scheduler/inject/shared.rs
@@ -38,7 +38,16 @@ impl<T: 'static> Shared<T> {
     }
 
     // Kind of annoying to have to include the cfg here
-    #[cfg(any(tokio_taskdump, feature = "rt-multi-thread"))]
+    #[cfg(any(
+            all(
+                tokio_unstable,
+                feature = "taskdump",
+                target_os = "linux",
+                any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+            ),
+            feature = "rt-multi-thread"
+        )
+    )]
     pub(crate) fn is_closed(&self, synced: &Synced) -> bool {
         synced.is_closed
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -402,15 +402,10 @@ impl<S: 'static> Task<S> {
         Task::new(RawTask::from_raw(ptr))
     }
 
-    #[cfg(all(
-        tokio_unstable,
-        tokio_taskdump,
-        feature = "rt",
-        target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
-    ))]
-    pub(super) fn as_raw(&self) -> RawTask {
-        self.raw
+    cfg_taskdump! {
+        pub(super) fn as_raw(&self) -> RawTask {
+            self.raw
+        }
     }
 
     fn header(&self) -> &Header {

--- a/tokio/src/runtime/task/state.rs
+++ b/tokio/src/runtime/task/state.rs
@@ -277,28 +277,23 @@ impl State {
         })
     }
 
-    /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref
-    /// count.
-    ///
-    /// Returns `true` if the notified bit was transitioned from `0` to `1`;
-    /// otherwise `false.`
-    #[cfg(all(
-        tokio_unstable,
-        tokio_taskdump,
-        feature = "rt",
-        target_os = "linux",
-        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
-    ))]
-    pub(super) fn transition_to_notified_for_tracing(&self) -> bool {
-        self.fetch_update_action(|mut snapshot| {
-            if snapshot.is_notified() {
-                (false, None)
-            } else {
-                snapshot.set_notified();
-                snapshot.ref_inc();
-                (true, Some(snapshot))
-            }
-        })
+    cfg_taskdump! {
+        /// Transitions the state to `NOTIFIED`, unconditionally increasing the ref
+        /// count.
+        ///
+        /// Returns `true` if the notified bit was transitioned from `0` to `1`;
+        /// otherwise `false.`
+        pub(super) fn transition_to_notified_for_tracing(&self) -> bool {
+            self.fetch_update_action(|mut snapshot| {
+                if snapshot.is_notified() {
+                    (false, None)
+                } else {
+                    snapshot.set_notified();
+                    snapshot.ref_inc();
+                    (true, Some(snapshot))
+                }
+            })
+        }
     }
 
     /// Sets the cancelled bit and transitions the state to `NOTIFIED` if idle.

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1218,7 +1218,12 @@ impl NotifiedProject<'_> {
                     return Poll::Pending;
                 }
                 State::Waiting => {
-                    #[cfg(tokio_taskdump)]
+                    #[cfg(all(
+                        tokio_unstable,
+                        feature = "taskdump",
+                        target_os = "linux",
+                        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+                    ))]
                     if let Some(waker) = waker {
                         let mut ctx = Context::from_waker(waker);
                         std::task::ready!(crate::trace::trace_leaf(&mut ctx));
@@ -1312,7 +1317,12 @@ impl NotifiedProject<'_> {
                     drop(old_waker);
                 }
                 State::Done => {
-                    #[cfg(tokio_taskdump)]
+                    #[cfg(all(
+                        tokio_unstable,
+                        feature = "taskdump",
+                        target_os = "linux",
+                        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+                    ))]
                     if let Some(waker) = waker {
                         let mut ctx = Context::from_waker(waker);
                         std::task::ready!(crate::trace::trace_leaf(&mut ctx));

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -408,7 +408,7 @@ cfg_rt! {
 
                 #[cfg(all(
                     tokio_unstable,
-                    tokio_taskdump,
+                    feature = "taskdump",
                     feature = "rt",
                     target_os = "linux",
                     any(

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -186,7 +186,7 @@ cfg_rt! {
 
         #[cfg(all(
             tokio_unstable,
-            tokio_taskdump,
+            feature = "taskdump",
             feature = "rt",
             target_os = "linux",
             any(

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -1,6 +1,6 @@
 #![cfg(all(
     tokio_unstable,
-    tokio_taskdump,
+    feature = "taskdump",
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -1,7 +1,7 @@
 #![allow(unknown_lints, unexpected_cfgs)]
 #![cfg(all(
     tokio_unstable,
-    tokio_taskdump,
+    feature = "taskdump",
     target_os = "linux",
     any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
 ))]


### PR DESCRIPTION
*closes #5875*