### PR TITLE
tokio: fix typos in `tokio/CHANGELOG.md`

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -45,7 +45,7 @@ a lifetime parameter.
 
 This release fixes incorrect spawn locations in runtime task hooks for tasks
 spawned using `tokio::spawn` rather than `Runtime::spawn`. This issue only
-effected the spawn location in `TaskMeta::spawned_at`, and did not effect task
+affected the spawn location in `TaskMeta::spawned_at`, and did not affect task
 locations in Tracing events.
 
 ## Unstable


### PR DESCRIPTION

## Motivation

There is a typo in the main text for 1.46.1 release: `effect` is used in two places where it actually should be `affect` 

## Solution

Replace `effect` with `affect` in the text for 1.46.1 release
