### PR TITLE
chore: Bump windows-sys to version 0.61

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -25,7 +25,7 @@ httpdate = "1.0"
 once_cell = "1.5.2"
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.59"
+version = "0.61"
 
 [[example]]
 name = "chat"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -127,11 +127,11 @@ libc = { version = "0.2.168" }
 nix = { version = "0.29.0", default-features = false, features = ["aio", "fs", "socket"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.59"
+version = "0.61"
 optional = true
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
-version = "0.59"
+version = "0.61"
 features = [
   "Win32_Foundation",
   "Win32_Security_Authorization",

--- a/tokio/src/process/windows.rs
+++ b/tokio/src/process/windows.rs
@@ -33,9 +33,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use windows_sys::{
-    Win32::Foundation::{
-        DuplicateHandle, BOOLEAN, DUPLICATE_SAME_ACCESS, HANDLE, INVALID_HANDLE_VALUE,
-    },
+    Win32::Foundation::{DuplicateHandle, DUPLICATE_SAME_ACCESS, HANDLE, INVALID_HANDLE_VALUE},
     Win32::System::Threading::{
         GetCurrentProcess, RegisterWaitForSingleObject, UnregisterWaitEx, INFINITE,
         WT_EXECUTEINWAITTHREAD, WT_EXECUTEONLYONCE,
@@ -163,7 +161,7 @@ impl Drop for Waiting {
     }
 }
 
-unsafe extern "system" fn callback(ptr: *mut std::ffi::c_void, _timer_fired: BOOLEAN) {
+unsafe extern "system" fn callback(ptr: *mut std::ffi::c_void, _timer_fired: bool) {
     let complete = &mut *(ptr as *mut Option<oneshot::Sender<()>>);
     let _ = complete.take().unwrap().send(());
 }

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -4,7 +4,7 @@ use std::sync::Once;
 use crate::signal::registry::{globals, EventId, EventInfo, Init, Storage};
 use crate::signal::RxFuture;
 
-use windows_sys::Win32::Foundation::BOOL;
+use windows_sys::core::BOOL;
 use windows_sys::Win32::System::Console as console;
 
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {


### PR DESCRIPTION
## Motivation
Update the windows-sys dependency to the latest version.

## Solution
Minor change needed as the BOOLEAN type has been removed but a standard bool is
the replacement.
