### PR TITLE
macros: suppress `clippy::unwrap_in_result` in `#[tokio::main]`

### DIFF
--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -468,7 +468,7 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
         #do_checks
 
         #[cfg(all(#(#checks),*))]
-        #[allow(clippy::expect_used, clippy::diverging_sub_expression, clippy::needless_return)]
+        #[allow(clippy::expect_used, clippy::diverging_sub_expression, clippy::needless_return, clippy::unwrap_in_result)]
         {
             return #rt
                 .enable_all()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

This PR intent to resolve bug mentioned in #7650 

## Motivation

When user explicitly set on clippy lint rule, `clippy::unwrap_in_result`, and use macro `tokyo::main`, they will get error.

An example test program:

```toml
# rust-toolchain.toml
[toolchain]
channel = "nightly"
```

```toml
# Cargo.toml
[package]
name = "tokio-test"
version = "0.1.0"
edition = "2024"

[dependencies]
anyhow = "1.0.100"
tokio = { version = "1.47.1", features = ["macros", "rt", "rt-multi-thread"] }

[lints.clippy]
unwrap_in_result = "deny
```

```rust
// main.rs
use anyhow::Result;

#[tokio::main]
async fn main() -> Result<()> {
    println!("Hello, world!");

    Ok(())
}
```

Than, run command `cargo clippy`:

```terminal
# Output of command `cargo clippy`
error: `expect` used in a function that returns a `Result`
 --> src/main.rs:7:5
  |
7 |     Ok(())
  |     ^^^^^^
  |
note: in this function signature
 --> src/main.rs:4:20
  |
4 | async fn main() -> Result<()> {
  |                    ^^^^^^^^^^
  = help: consider using the `?` operator or calling the `.map_err()` method
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_in_result
  = note: requested on the command line with `-D clippy::unwrap-in-result`

error: could not compile `tokio-test` (bin "tokio-test") due to 1 previous error
```

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

I suggest `tokio` to suppress this clippy rule (`clippy::unwrap_in_result`) in macro expansion, just like suppressing other rules in this [file](https://github.com/tokio-rs/tokio/blob/8ccf2fb92e7568bf16318dc8f3205cad14a9bc5d/tokio-macros/src/entry.rs#L467-L483)

https://github.com/tokio-rs/tokio/blob/8ccf2fb92e7568bf16318dc8f3205cad14a9bc5d/tokio-macros/src/entry.rs#L467-L483

After modification:

https://github.com/ry-sun/tokio/blob/2b9524813e01f61d3f108af25b61f8a661af59c8/tokio-macros/src/entry.rs#L467-L483


