### PR TITLE
ci: freeze rustc on nightly-2025-01-25 in `netlify.toml`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,15 @@
 [build]
+  # TODO: unfreeze toolchain
+  # error[E0557]: feature has been removed
+  #   --> /opt/buildhome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.13/src/lib.rs:89:29
+  #    |
+  # 89 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+  #    |                             ^^^^^^^^^^^^ feature has been removed
+  #    |
+  #    = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907; for more information
+  #    = note: merged into `doc_cfg`
   command = """
-    rustup install nightly --profile minimal && cargo doc --no-deps --all-features
+    rustup install nightly-2025-01-25 --profile minimal && cargo doc --no-deps --all-features
     """
   publish = "target/doc"
 


### PR DESCRIPTION
See <https://app.netlify.com/projects/tokio-rs/deploys/68d8b0ea0ad8820008da8f26>, I opened a issue to the `lock_api` (<https://github.com/Amanieu/parking_lot/issues/494>).

```
11:53:23 AM: error[E0557]: feature has been removed
11:53:23 AM:   --> /opt/buildhome/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/lock_api-0.4.13/src/lib.rs:89:29
11:53:23 AM:    |
11:53:23 AM: 89 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
11:53:23 AM:    |                             ^^^^^^^^^^^^ feature has been removed
11:53:23 AM:    |
11:53:23 AM:    = note: removed in 1.58.0; see <[https://github.com/rust-lang/rust/pull/138907&gt;](https://github.com/rust-lang/rust/pull/138907%3E) for more information
11:53:23 AM:    = note: merged into `doc_cfg`
11:53:23 AM: For more information about this error, try `rustc --explain E0557`.
11:53:23 AM: error: could not compile `lock_api` (lib) due to 1 previous error
11:53:23 AM: warning: build failed, waiting for other jobs to finish...
```

