### PR TITLE
tokio: bump `parking_lot` to `0.12.5`

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -95,7 +95,7 @@ pin-project-lite = "0.2.11"
 # Everything else is optional...
 bytes = { version = "1.2.1", optional = true }
 mio = { version = "1.0.1", optional = true, default-features = false }
-parking_lot = { version = "0.12.0", optional = true }
+parking_lot = { version = "0.12.5", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 socket2 = { version = "0.6.0", optional = true, features = ["all"] }


### PR DESCRIPTION
See #7653.

We cannot revert <https://github.com/tokio-rs/tokio/commit/02486978d1a6c976b3e8b06051015b6df72cecf9> because of

```
error[E0557]: feature has been removed
  --> /home/dev/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/socket2-0.6.0/src/lib.rs:57:29
   |
57 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in CURRENT_RUSTC_VERSION; see <https://github.com/rust-lang/rust/pull/138907> for more information
   = note: merged into `doc_cfg`
```