### PR TITLE
sync: improve unbounded send method docs

### DIFF
--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -533,9 +533,10 @@ impl<T> UnboundedSender<T> {
 
     /// Attempts to send a message on this `UnboundedSender` without blocking.
     ///
-    /// This method is not marked async because sending a message to an unbounded channel
-    /// never requires any form of waiting. Because of this, the `send` method can be
-    /// used in both synchronous and asynchronous code without problems.
+    /// This method is not marked as `async` because sending a message to an unbounded channel
+    /// never requires any form of waiting. This is due to the channel's infinite capacity,
+    /// allowing the `send` operation to complete immediately. As a result, the `send` method can be
+    /// used in both synchronous and asynchronous code without issues.
     ///
     /// If the receive half of the channel is closed, either due to [`close`]
     /// being called or the [`UnboundedReceiver`] having been dropped, this


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

While trying to understand how the send for unbounded channel works, I wasn't sure why an unbounded channel never requires any form of waiting. I found a similar explanation in the sync's mod.rs that explains it well, so I was wondering if it's worth adding it also within the send docs.

## Solution

Adds explanation on why an unbounded channel never requires any form of waiting.
