### PR TITLE
runtime: clarify the behavior of `Handle::block_on`

### DIFF
--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -309,7 +309,8 @@ impl Handle {
     /// # }
     /// ```
     ///
-    /// `Handle::block_on` may use [`task::block_in_place`] to re-enter the async context of a multi-thread scheduler runtime:
+    /// `Handle::block_on` may be combined with [`task::block_in_place`] to
+    /// re-enter the async context of a multi-thread scheduler runtime:
     /// ```
     /// # #[cfg(not(target_family = "wasm"))]
     /// # {


### PR DESCRIPTION
## Motivation

See: https://github.com/tokio-rs/tokio/issues/7387

## Solution

This commit adds documentation to the `Handle::block_on` method to clarify its behavior when called from within a Tokio runtime's asynchronous context, and how it can be used along with `block_in_place` to re-enter the runtime.

Note: the issue proposes updating the [Cannot start a runtime from within a runtime](https://github.com/tokio-rs/tokio/blob/9255d96b1b5d6ac85e348d718ed69ea2f80b585c/tokio/src/runtime/context/runtime.rs#L69-L72) error message. I chose not to change it here, since a more detailed explanation would make the message too verbose. I'm happy to adjust it if maintainers think it's worth including in this PR.

closes: #7387
