### PR TITLE
chore: prepare tokio-macros v2.6.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 2.6.0 (Oct 14th, 2025)
+
+The MSRV is raised to 1.71.
+
+- msrv: increase MSRV to 1.71 ([#7658])
+- macros: add `local` runtime flavor ([#7375], [#7597])
+- macros: suppress `clippy::unwrap_in_result` in `#[tokio::main]` ([#7651])
+
+[#7375]: https://github.com/tokio-rs/tokio/pull/7375
+[#7597]: https://github.com/tokio-rs/tokio/pull/7597
+[#7651]: https://github.com/tokio-rs/tokio/pull/7651
+[#7658]: https://github.com/tokio-rs/tokio/pull/7658
+
 # 2.5.0 (Jan 8th, 2025)
 
 - macros: suppress `clippy::needless_return` in `#[tokio::main]` ([#6874])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
-version = "2.5.0"
+version = "2.6.0"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -90,7 +90,7 @@ io-uring = ["dep:io-uring", "libc", "mio/os-poll", "mio/os-ext", "dep:slab"]
 taskdump = ["dep:backtrace"]
 
 [dependencies]
-tokio-macros = { version = "~2.5.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.6.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
 


### PR DESCRIPTION
# 2.6.0 (Oct 14th, 2025)

The MSRV is raised to 1.71.

- msrv: increase MSRV to 1.71 ([#7658])
- macros: add `local` runtime flavor ([#7375], [#7597])
- macros: suppress `clippy::unwrap_in_result` in `#[tokio::main]` ([#7651])

[#7375]: https://github.com/tokio-rs/tokio/pull/7375
[#7597]: https://github.com/tokio-rs/tokio/pull/7597
[#7651]: https://github.com/tokio-rs/tokio/pull/7651
[#7658]: https://github.com/tokio-rs/tokio/pull/7658