### PR TITLE
process: remove obsolete allow(deprecated) from is_rt_shutdown_err

### DIFF
--- a/tokio/src/process/unix/pidfd_reaper.rs
+++ b/tokio/src/process/unix/pidfd_reaper.rs
@@ -124,7 +124,6 @@ fn display_eq(d: impl std::fmt::Display, s: &str) -> bool {
     fmt_eq.remainder.is_empty() && !fmt_eq.unequal
 }
 
-#[allow(deprecated)]
 fn is_rt_shutdown_err(err: &io::Error) -> bool {
     if let Some(inner) = err.get_ref() {
         err.kind() == io::ErrorKind::Other


### PR DESCRIPTION
Follow-up to #7672