### PR TITLE
task: add example for `spawn_local` usage on local runtime flavor

### DIFF
--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -395,7 +395,7 @@ cfg_rt! {
     /// [`LocalSet`]: struct@crate::task::LocalSet
     /// [`LocalRuntime`]: struct@crate::runtime::LocalRuntime
     /// [`tokio::spawn`]: fn@crate::task::spawn
-    /// [unstable]: ../../index.html#unstable-features
+    /// [unstable]: ../../tokio/index.html#unstable-features
     #[track_caller]
     pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
     where


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

In the task's `spawn_local` method there was only example related to `LocalSet`, this PR adds an example on how to use it on the local runtime.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Add an example with local runtime flavor, marking as unstable before the stabilization tracked on #7558

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
