### PR TITLE
Update mpsc capacity docs

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -792,8 +792,8 @@ impl<T> Sender<T> {
     /// capacity, then use the returned [`Permit`] to send the message.
     ///
     /// This channel uses a queue to ensure that calls to `send` and `reserve`
-    /// complete in the order they were requested.  Cancelling a call to
-    /// `send` makes you lose your place in the queue.
+    /// are granted capacity in the order they were requested. Cancelling a
+    /// call to `send` makes you lose your place in the queue.
     ///
     /// # Examples
     ///
@@ -1095,8 +1095,8 @@ impl<T> Sender<T> {
     /// # Cancel safety
     ///
     /// This channel uses a queue to ensure that calls to `send` and `reserve`
-    /// complete in the order they were requested.  Cancelling a call to
-    /// `reserve` makes you lose your place in the queue.
+    /// are granted capacity in the order they were requested. Cancelling a
+    /// call to `reserve` makes you lose your place in the queue.
     ///
     /// # Examples
     ///
@@ -1151,7 +1151,7 @@ impl<T> Sender<T> {
     /// # Cancel safety
     ///
     /// This channel uses a queue to ensure that calls to `send` and `reserve_many`
-    /// complete in the order they were requested. Cancelling a call to
+    /// are granted capacity in the order they were requested. Cancelling a call to
     /// `reserve_many` makes you lose your place in the queue.
     ///
     /// # Examples
@@ -1214,8 +1214,8 @@ impl<T> Sender<T> {
     /// # Cancel safety
     ///
     /// This channel uses a queue to ensure that calls to `send` and `reserve`
-    /// complete in the order they were requested.  Cancelling a call to
-    /// `reserve_owned` makes you lose your place in the queue.
+    /// are granted capacity in the order they were requested. Cancelling a
+    /// call to `reserve_owned` makes you lose your place in the queue.
     ///
     /// # Examples
     /// Sending a message using an [`OwnedPermit`]:


### PR DESCRIPTION
## Motivation

The docs for `tokio::mpsc::Sender` and `tokio::mpsc::Receiver` both include `capacity`, which only describes behavior accurately when there are no pending `send` or `reserve` futures that have been queued.

In the case that these futures exist, some of the documentation on `capacity` is no longer accurate. For example: it's possible for a receiver to `recv` a message, but for the capacity to appear unchanged! This can happen when a slot is transferred directly to one of the waiting calls to `send`, which had not previously returned `Poll::Ok`.

## Solution

This PR re-writes the capacity documentation to more explicitly handle these cases.

This aligns with some of the existing documentation on `send` and `reserve` for the `Sender`, which mention the following:

> This channel uses a queue to ensure that calls to send and reserve complete in the order they were requested. Cancelling a call to send makes you lose your place in the queue.