### PR TITLE
codec: remove unnecessary trait bounds on all `Framed` constructors

### DIFF
--- a/tokio-util/src/codec/framed.rs
+++ b/tokio-util/src/codec/framed.rs
@@ -124,9 +124,7 @@ impl<T, U> Framed<T, U> {
             },
         }
     }
-}
 
-impl<T, U> Framed<T, U> {
     /// Provides a [`Stream`] and [`Sink`] interface for reading and writing to this
     /// I/O object, using [`Decoder`] and [`Encoder`] to read and write the raw data.
     ///

--- a/tokio-util/src/codec/framed_read.rs
+++ b/tokio-util/src/codec/framed_read.rs
@@ -64,9 +64,7 @@ impl<T, D> FramedRead<T, D> {
             },
         }
     }
-}
 
-impl<T, D> FramedRead<T, D> {
     /// Returns a reference to the underlying I/O stream wrapped by
     /// `FramedRead`.
     ///

--- a/tokio-util/src/codec/framed_write.rs
+++ b/tokio-util/src/codec/framed_write.rs
@@ -61,9 +61,7 @@ impl<T, E> FramedWrite<T, E> {
             },
         }
     }
-}
 
-impl<T, E> FramedWrite<T, E> {
     /// Returns a reference to the underlying I/O stream wrapped by
     /// `FramedWrite`.
     ///


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Minor ergonomics, mostly. To avoid `Framed::from_parts(parts)` which always reserves 8KiB in the read and write buffers I have been using

```rust
fn my_from_parts<T, U>(parts: FramedParts<T, U>) -> Framed<T, U> {
    let mut framed = Framed::with_capacity(parts.io, parts.codec, 0);
    *framed.read_buffer_mut() = parts.read_buf;
    *framed.write_buffer_mut() = parts.write_buf;
    framed
}
```

It's a minor annoyance that the above function actually needs a `T: AsyncRead + AsyncWrite` bounds, whereas `Framed::from_parts(parts)` doesn't.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Remove the bounds on all Framed constructors.