### PR TITLE
task: remove unnecessary trait bounds on the `Debug` implementation

### DIFF
--- a/tokio-util/src/task/abort_on_drop.rs
+++ b/tokio-util/src/task/abort_on_drop.rs
@@ -15,7 +15,6 @@ use std::{
 ///
 /// [aborts]: tokio::task::JoinHandle::abort
 #[must_use = "Dropping the handle aborts the task immediately"]
-#[derive(Debug)]
 pub struct AbortOnDropHandle<T>(JoinHandle<T>);
 
 impl<T> Drop for AbortOnDropHandle<T> {
@@ -58,6 +57,14 @@ impl<T> AbortOnDropHandle<T> {
     }
 }
 
+impl<T> std::fmt::Debug for AbortOnDropHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AbortOnDropHandle")
+            .field("id", &self.0.id())
+            .finish()
+    }
+}
+
 impl<T> Future for AbortOnDropHandle<T> {
     type Output = Result<T, JoinError>;
 
@@ -69,5 +76,20 @@ impl<T> Future for AbortOnDropHandle<T> {
 impl<T> AsRef<JoinHandle<T>> for AbortOnDropHandle<T> {
     fn as_ref(&self) -> &JoinHandle<T> {
         &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A simple type that does not implement [`std::fmt::Debug`].
+    struct NotDebug;
+
+    fn is_debug<T: std::fmt::Debug>() {}
+
+    #[test]
+    fn assert_debug() {
+        is_debug::<AbortOnDropHandle<NotDebug>>();
     }
 }

--- a/tokio-util/src/task/join_queue.rs
+++ b/tokio-util/src/task/join_queue.rs
@@ -21,7 +21,6 @@ use tokio::{
 ///
 /// When the [`JoinQueue`] is dropped, all tasks in the [`JoinQueue`] are
 /// immediately aborted.
-#[derive(Debug)]
 pub struct JoinQueue<T>(VecDeque<AbortOnDropHandle<T>>);
 
 impl<T> JoinQueue<T> {
@@ -379,6 +378,14 @@ impl<T> JoinQueue<T> {
     }
 }
 
+impl<T> std::fmt::Debug for JoinQueue<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list()
+            .entries(self.0.iter().map(|jh| JoinHandle::id(jh.as_ref())))
+            .finish()
+    }
+}
+
 impl<T> Default for JoinQueue<T> {
     fn default() -> Self {
         Self::new()
@@ -399,5 +406,20 @@ where
             set.spawn(task);
         });
         set
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A simple type that does not implement [`std::fmt::Debug`].
+    struct NotDebug;
+
+    fn is_debug<T: std::fmt::Debug>() {}
+
+    #[test]
+    fn assert_debug() {
+        is_debug::<JoinQueue<NotDebug>>();
     }
 }


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/a792f484-34fd-4019-a151-553d73d4e967" />

It is inconvenient for downstream to use the derived `Debug` implementation.
