### PR TITLE
sync: add missing period to `mpsc::Sender::try_send` docs

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -863,7 +863,7 @@ impl<T> Sender<T> {
         self.chan.closed().await;
     }
 
-    /// Attempts to immediately send a message on this `Sender`
+    /// Attempts to immediately send a message on this `Sender`.
     ///
     /// This method differs from [`send`] by returning immediately if the channel's
     /// buffer is full or no receiver is waiting to acquire some data. Compared


### PR DESCRIPTION
Sorry if this PR is noise, but noticed the missing full stop.