### PR TITLE
sync: improve the docs for the errors of mpsc

### DIFF
--- a/tokio/src/sync/mpsc/error.rs
+++ b/tokio/src/sync/mpsc/error.rs
@@ -3,7 +3,7 @@
 use std::error::Error;
 use std::fmt;
 
-/// Error returned by the `Sender`.
+/// Error returned by [`Sender::send`](super::Sender::send).
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct SendError<T>(pub T);
 


### PR DESCRIPTION
Standardize and fix code docs for the `TrySendError` and `SendTimeoutError` enums.

The `TrySendError` code docs were changed to match the `SendTimeoutError` and `TryRecvError` docs.