### PR TITLE
ci: bump Miri to `nightly-2025-11-09`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2025-06-02
+  rust_miri_nightly: nightly-2025-11-09
   rust_clippy: '1.88'
   # When updating this, also update:
   # - README.md


### PR DESCRIPTION
## Motivation

See <https://github.com/tokio-rs/tokio/issues/7712#issuecomment-3451655114>. We can bump Miri to improve data race detection capabilities.