### PR TITLE
deps: bump `tokio` to `1.44.0` in `tokio-util`

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -35,7 +35,7 @@ join-map = ["rt", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.28.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.44.0", path = "../tokio", features = ["sync"] }
 bytes = "1.5.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"


### PR DESCRIPTION
*closes #7732*

The minimal version should be `1.44.0`, this is also verified by
```bash
# remove the `path = "../tokio", ` dependency
sed -i 's/path = "..\/tokio", //' tokio-util/Cargo.toml

# bump the version from "1.28.0" to "1.44.0"
sed -i 's/1.28.0/1.44.0/' tokio-util/Cargo.toml
cargo minimal-versions check -p tokio-util --all-features # this will success

# downgrade the version from "1.44.0" to "1.43.0"
sed -i 's/1.44.0/1.43.0/' tokio-util/Cargo.toml
cargo minimal-versions check -p tokio-util --all-features # this will fail
```

*Signed-off-by: ADD-SP <qiqi.zhang@konghq.com>*