### PR TITLE
sync: fix a typo in the docs of `PollSender::is_closed`

### DIFF
--- a/tokio-util/src/sync/mpsc.rs
+++ b/tokio-util/src/sync/mpsc.rs
@@ -200,7 +200,7 @@ impl<T: Send> PollSender<T> {
         result
     }
 
-    /// Checks whether this sender is been closed.
+    /// Checks whether this sender is closed.
     ///
     /// The underlying channel that this sender was wrapping may still be open.
     pub fn is_closed(&self) -> bool {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Minor typo found in the public docs for PollSender's is_closed method

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
