### PR TITLE
net: clarify platform-dependent backlog in TcpSocket docs

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -68,6 +68,9 @@ cfg_net! {
     ///     socket.set_reuseaddr(true)?;
     ///     socket.bind(addr)?;
     ///
+    ///     // Note: the actual backlog used by `TcpListener::bind` is platform-dependent,
+    ///     // as Tokio relies on Mio's default backlog value configuration. The `1024` here is only
+    ///     // illustrative and does not reflect the real value used.
     ///     let listener = socket.listen(1024)?;
     /// # drop(listener);
     ///


### PR DESCRIPTION
Fixes: #7729

## Motivation

The documentation example for reproducing the behavior of  `TcpListener::bind` uses a hardcoded backlog value of 1024. However, Tokio now relies on Mio's platform-dependent default backlog configuration, so the value in the example was misleading.

## Solution

This commit updates the documentation by adding a note explaining that the
actual backlog used by `TcpListener::bind` varies by platform and that the
example value is only illustrative.
