### PR TITLE
io: replace `Result<T, io::Error>` with `io::Result<T>` in `AsyncWrite`

### DIFF
--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -54,7 +54,7 @@ pub trait AsyncWrite {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &[u8],
-    ) -> Poll<Result<usize, io::Error>>;
+    ) -> Poll<io::Result<usize>>;
 
     /// Attempts to flush the object, ensuring that any buffered data reach
     /// their destination.
@@ -65,7 +65,7 @@ pub trait AsyncWrite {
     /// `Poll::Pending` and arranges for the current task (via
     /// `cx.waker()`) to receive a notification when the object can make
     /// progress towards flushing.
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>>;
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
 
     /// Initiates or attempts to shut down this writer, returning success when
     /// the I/O connection has completely shut down.
@@ -125,7 +125,7 @@ pub trait AsyncWrite {
     ///
     /// This function will panic if not called within the context of a future's
     /// task.
-    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>>;
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>>;
 
     /// Like [`poll_write`], except that it writes from a slice of buffers.
     ///
@@ -154,7 +154,7 @@ pub trait AsyncWrite {
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         bufs: &[IoSlice<'_>],
-    ) -> Poll<Result<usize, io::Error>> {
+    ) -> Poll<io::Result<usize>> {
         let buf = bufs
             .iter()
             .find(|b| !b.is_empty())


### PR DESCRIPTION
## Motivation

`std::io::Read`, `std::io::Write` and `std::io::Seek` use the `std::io::Result<T>` type. So does `tokio::io::AsyncRead`. `tokio::io::AsyncWrite` instead follows the manual approach of `std::result::Result<T, io::Error>`.

This is very annoying because when implementing `AsyncWrite` with the help of rust-analyzer, this inconsistency is then propagated to the user's code.

## Solution

This changes `AsyncWrite` to use `std::io::Result`.