### PR TITLE
examples: improve error handling of `chat` and `echo-tcp`

### DIFF
--- a/examples/connect-tcp.rs
+++ b/examples/connect-tcp.rs
@@ -58,7 +58,7 @@ pub async fn connect(
             //BytesMut into Bytes
             Ok(i) => future::ready(Some(i.freeze())),
             Err(e) => {
-                println!("failed to read from socket; error={e}");
+                eprintln!("failed to read from socket; error={e}");
                 future::ready(None)
             }
         })


### PR DESCRIPTION
… handling in TCP examples

- Added `DEFAULT_ADDR` constant to `chat.rs` and `echo-tcp.rs` for better maintainability.
- Enhanced error logging in `connect-tcp.rs` and `echo-tcp.rs` to include connection addresses.
- Improved peer management in `chat.rs` by automatically cleaning up disconnected peers.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
