### PR TITLE
net: clarify the drop behavior of `unix::OwnedWriteHalf`

### DIFF
--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -974,7 +974,7 @@ impl UnixStream {
     /// Unlike [`split`], the owned halves can be moved to separate tasks, however
     /// this comes at the cost of a heap allocation.
     ///
-    /// **Note:** Dropping the write half will shut down the write half of the
+    /// **Note:** Dropping the write half will only shut down the write half of the
     /// stream. This is equivalent to calling [`shutdown()`] on the `UnixStream`.
     ///
     /// [`split`]: Self::split()


### PR DESCRIPTION
## Motivation
Provide clarity in documentation, based on feedback from #7723. The goal is to provide context on dropping the write half of the socket connection.

## Solution
Inserted single word. 
What could be added, to provide even more context could be, the [reason](https://github.com/tokio-rs/tokio/issues/7723#issuecomment-3491309933) for this behavior but that could become too verbose.