### PR TITLE
miri tests: fstat is supported now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2025-11-13
+  rust_miri_nightly: nightly-2025-12-08
   rust_clippy: '1.88'
   # When updating this, also update:
   # - README.md

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -226,7 +226,6 @@ async fn from_file() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `fstat` in miri.
 async fn from_file_detects_not_a_fifo() -> io::Result<()> {
     let dir = tempfile::Builder::new()
         .prefix("tokio-fifo-tests")
@@ -500,7 +499,6 @@ async fn anon_pipe_spawn_echo() -> std::io::Result<()> {
 
 #[tokio::test]
 #[cfg(target_os = "linux")]
-#[cfg_attr(miri, ignore)] // No `fstat` in miri.
 async fn anon_pipe_from_owned_fd() -> std::io::Result<()> {
     use nix::fcntl::OFlag;
 


### PR DESCRIPTION
So we can enable the tests that apparently were blocked on that.