### PR TITLE
chore: remove TokioConf 2026 CFP announcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-
-
-*[The TokioConf 2026 Call For Talk Proposals is now open](https://tokio.rs/blog/2025-09-26-announcing-tokio-conf-cfp)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,9 +1,3 @@
-
-
-*[The TokioConf 2026 Call For Talk Proposals is now open](https://tokio.rs/blog/2025-09-26-announcing-tokio-conf-cfp)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with


### PR DESCRIPTION
CFP ended on the 8th of December.