### PR TITLE
ci: Run benchmarks in the CI

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -27,25 +27,16 @@ jobs:
 
       - name: Run ct benchmarks
         run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
-        working-directory: benches
-
-        # Download previous benchmark result from cache (if exists)
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: "cargo"
-          output-file-path:
-            output.txt
-            # Where the previous data file is stored
-          external-data-json-path: ./cache/benchmark-data.json
-          # Workflow will fail when an alert happens
-          fail-on-alert: true
+          output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          comment-on-alert: true
           auto-push: true
+          fail-on-alert: true
+          # Show alert if performance drops > 15% 
+          alert-threshold: '150%' #TODO: TBD
+          comment-on-alert: true
+          #TODO: alert tokio maintainers?

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,52 @@
+name: benchmark
+on:
+  push:
+    branches: [master]
+
+jobs:
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bench:
+          - ct_spawn
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Install Valgrind
+        uses: taiki-e/install-action@valgrind
+
+      - uses: taiki-e/install-action@cargo-binstall
+      - name: Install gungraun-runner
+        run: |
+          version=$(cargo metadata --format-version=1 |\
+            jq '.packages[] | select(.name == "gungraun").version' |\
+            tr -d '"'
+          )
+          cargo binstall --no-confirm gungraun-runner --version $version
+
+      - name: Run ct benchmarks
+        run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
+        working-directory: benches
+
+       # Download previous benchmark result from cache (if exists)
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: ./cache
+          key: ${{ runner.os }}-benchmark
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'cargo'
+          output-file-path: output.txt
+           # Where the previous data file is stored
+          external-data-json-path: ./cache/benchmark-data.json
+          # Workflow will fail when an alert happens
+          fail-on-alert: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-on-alert: true
+          auto-push: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,7 +1,11 @@
 name: benchmark
 on:
   push:
-    branches: [master]
+    branches:
+      - master
+  pull_request: #TODO: remove after testing
+    branches:
+      - master
 
 jobs:
   benchmark:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   benchmark:
     name: Benchmark
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     env:
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
@@ -31,4 +33,9 @@ jobs:
       - uses: bencherdev/bencher@main
       - name: Run Bencher
         run: |
-          bencher run --adapter rust_gungraun --err "cargo bench --bench ${{ matrix.bench }}"
+          bencher run \
+          --branch master \
+          --err \
+          --adapter rust_gungraun \
+          --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+          "cargo bench --bench ${{ matrix.bench }}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,6 +8,8 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    env:
+      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
     strategy:
       matrix:
         bench:
@@ -26,32 +28,7 @@ jobs:
           )
           cargo binstall --no-confirm gungraun-runner --version $version
 
-      - name: Download previous benchmark data
-        uses: actions/cache@v4
-        with:
-          path: ./cache
-          key: ${{ runner.os }}-benchmark-${{ matrix.bench }}
-
-      - name: Run benchmarks
-        run: cargo bench --bench ${{ matrix.bench }} -- --output-format=json | jq -s | tee output.json
-
-      - name: Convert summary to benchmark format
+      - uses: bencherdev/bencher@main
+      - name: Run Bencher
         run: |
-          jq '[.[] | {
-          name: .id,
-          unit: "instructions",
-          value: .profiles[0].summaries.total.summary.Callgrind.Ir.metrics.Left.Int
-          }]' output.json > benchmark-results.json
-
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: "customSmallerIsBetter" # This is because github action doesn't support gungraun format with cargo tool
-          output-file-path: benchmark-results.json
-          # Previous results
-          external-data-json-path: ./cache/benchmark-results.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Alert if performance regresses by more than 10%
-          alert-threshold: "110%"
-          comment-on-alert: true
-          fail-on-alert: false
+          bencher run --adapter rust_gungraun --err "cargo bench --bench ${{ matrix.bench }}"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -36,7 +36,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           fail-on-alert: true
-          # Show alert if performance drops > 15% 
           alert-threshold: '150%' #TODO: TBD
           comment-on-alert: true
           #TODO: alert tokio maintainers?

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,7 +43,7 @@ jobs:
           jq '[.[] | {
           name: .id,
           unit: "instructions",
-          value: .profiles[0].summaries.total.summary.Callgrind["Ir"].metrics.Both[0].Int
+          value: .profiles[0].summaries.total.summary.Callgrind.Ir.metrics.Left.Int
           }]' output.json > benchmark-results.json
 
       - name: Store benchmark result

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -3,13 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request: #TODO: remove after testing
-    branches:
-      - master
-
-permissions:
-    contents: read
-    pull-requests: write
 
 jobs:
   benchmark:
@@ -59,6 +52,6 @@ jobs:
           external-data-json-path: ./cache/benchmark-results.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Alert if performance regresses by more than 10%
-          alert-threshold: "100%" #TODO: set this back to 110%
+          alert-threshold: "110%"
           comment-on-alert: true
           fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Download previous benchmark data
         uses: actions/cache@v4
         with:
-          path: .cache
+          path: ./cache
           key: ${{ runner.os }}-benchmark-${{ matrix.bench }}
 
       - name: Run benchmarks

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -32,8 +32,29 @@ jobs:
       - name: Download previous benchmark data
         uses: actions/cache@v4
         with:
-          path: target/gungraun
+          path: .cache
           key: ${{ runner.os }}-benchmark-${{ matrix.bench }}
 
-      - name: Run ct benchmarks
-        run: cargo bench --bench ${{ matrix.bench }}
+      - name: Run benchmarks
+        run: cargo bench --bench ${{ matrix.bench }} -- --output-format=json | jq -s | tee output.json
+
+      - name: Convert summary to benchmark format
+        run: |
+          jq '[.[] | {
+          name: .id,
+          unit: "instructions",
+          value: .profiles[0].summaries.total.summary.Callgrind["Ir"].metrics.Both[0].Int
+          }]' output.json > benchmark-results.json
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: "customSmallerIsBetter" # This is because github action doesn't support gungraun format with cargo tool
+          output-file-path: benchmark-results.json
+          # Previous results
+          external-data-json-path: ./cache/benchmark-results.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Alert if performance regresses by more than 10%
+          alert-threshold: "100%" #TODO: set this back to 110%
+          comment-on-alert: true
+          fail-on-alert: false

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,17 +29,20 @@ jobs:
           )
           cargo binstall --no-confirm gungraun-runner --version $version
 
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Run ct benchmarks
         run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
 
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: "cargo"
-          output-file-path: output.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-          fail-on-alert: true
-          alert-threshold: '150%' #TODO: TBD
-          comment-on-alert: true
-          #TODO: alert tokio maintainers?
+      # - name: Store benchmark result
+      #   uses: benchmark-action/github-action-benchmark@v1
+      #   with:
+      #     tool: "cargo"
+      #     output-file-path: output.txt
+      #     github-token: ${{ secrets.GITHUB_TOKEN }}
+      #     auto-push: true
+      #     fail-on-alert: true
+      #     alert-threshold: '150%' #TODO: TBD
+      #     comment-on-alert: true
+      #     #TODO: alert tokio maintainers?

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -35,14 +35,8 @@ jobs:
       - name: Run ct benchmarks
         run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
 
-      # - name: Store benchmark result
-      #   uses: benchmark-action/github-action-benchmark@v1
-      #   with:
-      #     tool: "cargo"
-      #     output-file-path: output.txt
-      #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     auto-push: true
-      #     fail-on-alert: true
-      #     alert-threshold: '150%' #TODO: TBD
-      #     comment-on-alert: true
-      #     #TODO: alert tokio maintainers?
+      - name: Store benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmarks-results
+          path: output.txt

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - master
 
+permissions:
+    contents: read
+    pull-requests: write
+
 jobs:
   benchmark:
     name: Benchmark

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,10 +13,8 @@ jobs:
           - ct_spawn
     steps:
       - uses: actions/checkout@v5
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - name: Install Valgrind
-        uses: taiki-e/install-action@valgrind
+      - run: sudo apt-get update && sudo apt-get install -y valgrind
 
       - uses: taiki-e/install-action@cargo-binstall
       - name: Install gungraun-runner
@@ -31,7 +29,7 @@ jobs:
         run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
         working-directory: benches
 
-       # Download previous benchmark result from cache (if exists)
+        # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@v4
         with:
@@ -41,9 +39,10 @@ jobs:
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          tool: 'cargo'
-          output-file-path: output.txt
-           # Where the previous data file is stored
+          tool: "cargo"
+          output-file-path:
+            output.txt
+            # Where the previous data file is stored
           external-data-json-path: ./cache/benchmark-data.json
           # Workflow will fail when an alert happens
           fail-on-alert: true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -29,14 +29,11 @@ jobs:
           )
           cargo binstall --no-confirm gungraun-runner --version $version
 
-      - name: Cache
-        uses: Swatinem/rust-cache@v2
+      - name: Download previous benchmark data
+        uses: actions/cache@v4
+        with:
+          path: target/gungraun
+          key: ${{ runner.os }}-benchmark-${{ matrix.bench }}
 
       - name: Run ct benchmarks
-        run: cargo bench --bench ${{ matrix.bench }} | tee output.txt
-
-      - name: Store benchmark result
-        uses: actions/upload-artifact@v4
-        with:
-          name: benchmarks-results
-          path: output.txt
+        run: cargo bench --bench ${{ matrix.bench }}

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,9 +8,11 @@ license = "MIT"
 [features]
 test-util = ["tokio/test-util"]
 
+
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
 criterion = "0.5.1"
+gungraun = "0.17.0"
 rand = "0.9"
 rand_chacha = "0.9"
 
@@ -99,6 +101,11 @@ harness = false
 [[bench]]
 name = "spawn_blocking"
 path = "spawn_blocking.rs"
+harness = false
+
+[[bench]]
+name = "ct_spawn"
+path = "ct_spawn.rs"
 harness = false
 
 [lints]

--- a/benches/ct_spawn.rs
+++ b/benches/ct_spawn.rs
@@ -1,0 +1,62 @@
+use gungraun::{library_benchmark, library_benchmark_group, main};
+use std::hint::black_box;
+use tokio::runtime::Runtime;
+
+fn single_rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap()
+}
+
+fn multi_rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .build()
+        .unwrap()
+}
+
+async fn work() -> usize {
+    let val = 1 + 1;
+    tokio::task::yield_now().await;
+    black_box(val)
+}
+
+fn spawn(runtime: Runtime) {
+    runtime.block_on(async {
+        let h = tokio::spawn(work());
+        assert_eq!(h.await.unwrap(), 2);
+    });
+}
+
+fn spawn10(runtime: Runtime) {
+    runtime.block_on(async {
+        let mut handles = Vec::with_capacity(10);
+        for _ in 0..10 {
+            handles.push(tokio::spawn(work()));
+        }
+        for handle in handles {
+            assert_eq!(handle.await.unwrap(), 2);
+        }
+    });
+}
+
+#[library_benchmark]
+#[bench::basic(setup = single_rt)]
+#[bench::threaded(setup = multi_rt)]
+fn spawn_rt(runtime: Runtime) {
+    black_box(spawn(runtime));
+}
+
+#[library_benchmark]
+#[bench::basic(setup = single_rt)]
+#[bench::threaded(setup = multi_rt)]
+fn spawn_rt_10(runtime: Runtime) {
+    black_box(spawn10(runtime));
+}
+
+library_benchmark_group!(
+    name = group;
+    benchmarks = spawn_rt,spawn_rt_10
+);
+
+main!(library_benchmark_groups = group);

--- a/benches/ct_spawn.rs
+++ b/benches/ct_spawn.rs
@@ -28,10 +28,10 @@ fn spawn(runtime: Runtime) {
     });
 }
 
-fn spawn10(runtime: Runtime) {
+fn spawn100(runtime: Runtime) {
     runtime.block_on(async {
-        let mut handles = Vec::with_capacity(10);
-        for _ in 0..10 {
+        let mut handles = Vec::with_capacity(100);
+        for _ in 0..100 {
             handles.push(tokio::spawn(work()));
         }
         for handle in handles {
@@ -50,13 +50,13 @@ fn spawn_rt(runtime: Runtime) {
 #[library_benchmark]
 #[bench::basic(setup = single_rt)]
 #[bench::threaded(setup = multi_rt)]
-fn spawn_rt_10(runtime: Runtime) {
-    black_box(spawn10(runtime));
+fn spawn_rt_100(runtime: Runtime) {
+    black_box(spawn100(runtime));
 }
 
 library_benchmark_group!(
     name = group;
-    benchmarks = spawn_rt,spawn_rt_10
+    benchmarks = spawn_rt,spawn_rt_100
 );
 
 main!(library_benchmark_groups = group);

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -222,7 +222,8 @@ Lines that start with `/// #` are removed when the documentation is generated.
 ### Benchmarks
 
 You can run benchmarks locally for the changes you've made to the tokio codebase.
-Tokio currently uses [Criterion](https://github.com/bheisler/criterion.rs) for wall-time benchmakrs and [Gungraun](https://github.com/gungraun/gungraun)
+Tokio currently uses [Criterion](https://github.com/bheisler/criterion.rs)
+for wall-time benchmakrs and [Gungraun](https://github.com/gungraun/gungraun)
 for deterministic benchmarks in the CI.
 
 To run a benchmark against the changes you have made, for example, you can run;
@@ -234,8 +235,9 @@ cd benches
 cargo bench
 
 # Run Gungraun benchmarks
+# NOTE: Gungraun is based on Valgrind. Make sure Valgrind is installed on your system,
+# or use Docker if your platform does not support it.
 cargo bench --bench ct_spawn
-NOTE: Gungraun is based on Valgrind. Make sure Valgrind is installed on your system, or use Docker if your platform doesn't support it.
 
 # Run all tests in the `benches/fs.rs` file
 cargo bench --bench fs

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -222,14 +222,20 @@ Lines that start with `/// #` are removed when the documentation is generated.
 ### Benchmarks
 
 You can run benchmarks locally for the changes you've made to the tokio codebase.
-Tokio currently uses [Criterion](https://github.com/bheisler/criterion.rs) as its benchmarking tool. To run a benchmark
-against the changes you have made, for example, you can run;
+Tokio currently uses [Criterion](https://github.com/bheisler/criterion.rs) for wall-time benchmakrs and [Gungraun](https://github.com/gungraun/gungraun)
+for deterministic benchmarks in the CI.
+
+To run a benchmark against the changes you have made, for example, you can run;
 
 ```bash
 cd benches
 
 # Run all benchmarks.
 cargo bench
+
+# Run Gungraun benchmarks
+cargo bench --bench ct_spawn
+NOTE: Gungraun is based on Valgrind. Make sure Valgrind is installed on your system, or use Docker if your platform doesn't support it.
 
 # Run all tests in the `benches/fs.rs` file
 cargo bench --bench fs
@@ -240,9 +246,10 @@ cargo bench async_read_buf
 # After running benches, you can check the statistics under `tokio/target/criterion/`
 ```
 
-You can also refer to [Criterion] docs for additional options and details.
+You can also refer to [Criterion] or [Gungraun] docs for additional options and details.
 
 [Criterion]: https://docs.rs/criterion/latest/criterion/
+[Gungraun]: https://gungraun.github.io/gungraun/
 
 ### Commits
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Starting from issue #6539, I would like to introduce some consistent benchmarks using Gungraun to be able to run benchmarks on the CI. For the moment we don't run any of the benchmarks due to the fact that the Criterion benchmarks use a wall-time approach and cannot considered reliable for a CI.

## Solution

The `iai-calgrind` library is now called `gungraun` and it's already used by some services (https://github.com/gungraun/gungraun/network/dependents) including Rust's compiler-builtins. I wanted to start with `spawn` first to understand if we want to proceed in this direction.

## Other Considerations

- Gungraun uses `Valgrind` which is only supported by Unix, therefore benchmarks on other system can only be run through Docker
- We are still discussing about whether we want to use Bencher or not

## Results

Multiple runs on M1 (Docker)

```
ct_spawn::group::spawn_rt basic:single_rt()
  Instructions:                        8133|8133                 (No change)
  L1 Hits:                            11844|11844                (No change)
  LL Hits:                               61|61                   (No change)
  RAM Hits:                             433|433                  (No change)
  Total read+write:                   12338|12338                (No change)
  Estimated Cycles:                   27304|27304                (No change)
ct_spawn::group::spawn_rt threaded:multi_rt()
  Instructions:                        7009|7009                 (No change)
  L1 Hits:                             9858|9858                 (No change)
  LL Hits:                              104|104                  (No change)
  RAM Hits:                             273|273                  (No change)
  Total read+write:                   10235|10235                (No change)
  Estimated Cycles:                   19933|19933                (No change)
ct_spawn::group::spawn_rt_100 basic:single_rt()
  Instructions:                      267414|267414               (No change)
  L1 Hits:                           407758|407758               (No change)
  LL Hits:                              340|340                  (No change)
  RAM Hits:                             914|914                  (No change)
  Total read+write:                  409012|409012               (No change)
  Estimated Cycles:                  441448|441448               (No change)
ct_spawn::group::spawn_rt_100 threaded:multi_rt()
  Instructions:                      156427|156427               (No change)
  L1 Hits:                           231658|231659               (-0.00043%) [-1.00000x]
  LL Hits:                              486|485                  (+0.20619%) [+1.00206x]
  RAM Hits:                             699|699                  (No change)
  Total read+write:                  232843|232843               (No change)
  Estimated Cycles:                  258553|258549               (+0.00155%) [+1.00002x]

Gungraun result: Ok. 4 without regressions; 0 regressed; 0 filtered; 4 benchmarks finished in 1.12675s
```