### PR TITLE
sync: clarify the cancellation safety of `oneshot::Receiver`

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -247,7 +247,7 @@ pub struct Sender<T> {
 ///
 /// The `Receiver` is cancel safe. If it is used as the event in a
 /// [`tokio::select!`](crate::select) statement and some other branch
-/// completes first, it is guaranteed that no messages were received on this
+/// completes first, it is guaranteed that no message was received on this
 /// channel.
 ///
 /// # Examples


### PR DESCRIPTION
closes #7778 