### PR TITLE
net: add support for `TCLASS` option on IPv6

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -489,6 +489,79 @@ impl TcpSocket {
         self.inner.tcp_nodelay()
     }
 
+    /// Gets the value of the `IPV6_TCLASS` option for this socket.
+    ///
+    /// For more information about this option, see [`set_tclass_v6`].
+    ///
+    /// [`set_tclass_v6`]: Self::set_tclass_v6
+    // https://docs.rs/socket2/0.6.1/src/socket2/sys/unix.rs.html#2541
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "cygwin",
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "cygwin",
+        )))
+    )]
+    pub fn tclass_v6(&self) -> io::Result<u32> {
+        self.inner.tclass_v6()
+    }
+
+    /// Sets the value for the `IPV6_TCLASS` option on this socket.
+    ///
+    /// Specifies the traffic class field that is used in every packet
+    /// sent from this socket.
+    ///
+    /// # Note
+    ///
+    /// This may not have any effect on IPv4 sockets.
+    // https://docs.rs/socket2/0.6.1/src/socket2/sys/unix.rs.html#2566
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "cygwin",
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "cygwin",
+        )))
+    )]
+    pub fn set_tclass_v6(&self, tclass: u32) -> io::Result<()> {
+        self.inner.set_tclass_v6(tclass)
+    }
+
     /// Gets the value of the `IP_TOS` option for this socket.
     ///
     /// For more information about this option, see [`set_tos_v4`].

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1955,6 +1955,79 @@ impl UdpSocket {
         self.io.set_multicast_loop_v6(on)
     }
 
+    /// Gets the value of the `IPV6_TCLASS` option for this socket.
+    ///
+    /// For more information about this option, see [`set_tclass_v6`].
+    ///
+    /// [`set_tclass_v6`]: Self::set_tclass_v6
+    // https://docs.rs/socket2/0.6.1/src/socket2/sys/unix.rs.html#2541
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "cygwin",
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "cygwin",
+        )))
+    )]
+    pub fn tclass_v6(&self) -> io::Result<u32> {
+        self.as_socket().tclass_v6()
+    }
+
+    /// Sets the value for the `IPV6_TCLASS` option on this socket.
+    ///
+    /// Specifies the traffic class field that is used in every packet
+    /// sent from this socket.
+    ///
+    /// # Note
+    ///
+    /// This may not have any effect on IPv4 sockets.
+    // https://docs.rs/socket2/0.6.1/src/socket2/sys/unix.rs.html#2566
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "fuchsia",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "cygwin",
+    ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            target_os = "android",
+            target_os = "dragonfly",
+            target_os = "freebsd",
+            target_os = "fuchsia",
+            target_os = "linux",
+            target_os = "macos",
+            target_os = "netbsd",
+            target_os = "openbsd",
+            target_os = "cygwin",
+        )))
+    )]
+    pub fn set_tclass_v6(&self, tclass: u32) -> io::Result<()> {
+        self.as_socket().set_tclass_v6(tclass)
+    }
+
     /// Gets the value of the `IP_TTL` option for this socket.
     ///
     /// For more information about this option, see [`set_ttl`].

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -162,6 +162,19 @@ test!(
 
 test!(nodelay, set_nodelay(true));
 
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "cygwin",
+))]
+test!(IPv6 tclass_v6, set_tclass_v6(96));
+
 #[cfg(not(any(
     target_os = "fuchsia",
     target_os = "redox",

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -699,6 +699,19 @@ test!(multicast_ttl_v4, set_multicast_ttl_v4(40));
 
 test!(IPv6 multicast_loop_v6, set_multicast_loop_v6(false));
 
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "fuchsia",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "cygwin",
+))]
+test!(IPv6 tclass_v6, set_tclass_v6(96));
+
 test!(IPv4 ttl, set_ttl(40));
 
 #[cfg(not(any(


### PR DESCRIPTION
- Rename `{Udp,Tcp}Socket::tos` to `tos_v4` as it is IPv4-specific, following the [rename](https://github.com/rust-lang/socket2/pull/592) from socket2 0.6.0.
- Add `{Tcp,Udp}Socket::tclass_v6` as its IPv6 equivalent.
- Fix affect/effect typos.

## Motivation

I want to be able to set IPv6 [*Traffic Class* field](https://en.wikipedia.org/wiki/IPv6_packet#Traffic_Class_field) as conveniently as the corresponding IPv4 [*Type of Service* field](https://en.wikipedia.org/wiki/Type_of_service), which allows setting the [*Differentiated Services* subfield](https://en.wikipedia.org/wiki/Differentiated_services) necessary for [Quality of Service](https://en.wikipedia.org/wiki/Quality_of_service) requirements.

## Solution

Just addding an extra getter/setter exposing the underlying API.
