### PR TITLE
macros: remove extern crate proc_macro

### DIFF
--- a/tokio-macros/src/lib.rs
+++ b/tokio-macros/src/lib.rs
@@ -12,11 +12,6 @@
 
 //! Macros for use with Tokio
 
-// This `extern` is required for older `rustc` versions but newer `rustc`
-// versions warn about the unused `extern crate`.
-#[allow(unused_extern_crates)]
-extern crate proc_macro;
-
 mod entry;
 mod select;
 


### PR DESCRIPTION
From #2178, this is only needed for older Rust version 1.40 and before. And our MSRV has been set to `1.71`.