### PR TITLE
Rewrite CancellationToken tree logic to utilize AtomicBool for is_cancelled

### DIFF
--- a/tokio-util/src/loom.rs
+++ b/tokio-util/src/loom.rs
@@ -3,7 +3,14 @@
 
 pub(crate) mod sync {
     #[cfg(all(test, loom))]
-    pub(crate) use loom::sync::{Arc, Mutex, MutexGuard};
+    pub(crate) use {
+        loom::sync::{atomic::AtomicBool, Arc, Mutex, MutexGuard},
+        std::sync::atomic::Ordering,
+    };
+
     #[cfg(not(all(test, loom)))]
-    pub(crate) use std::sync::{Arc, Mutex, MutexGuard};
+    pub(crate) use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, MutexGuard,
+    };
 }

--- a/tokio-util/src/sync/cancellation_token/tree_node.rs
+++ b/tokio-util/src/sync/cancellation_token/tree_node.rs
@@ -42,9 +42,8 @@
 //! Specifically, through invariant #2, we know that we always have to lock a parent
 //! before its child.
 //!
-use std::sync::atomic::{AtomicBool, Ordering};
 
-use crate::loom::sync::{Arc, Mutex, MutexGuard};
+use crate::loom::sync::{Arc, AtomicBool, Mutex, MutexGuard, Ordering};
 
 /// A node of the cancellation tree structure
 ///


### PR DESCRIPTION
As per [ISSUE #7775 ] : Rewritten the TreeNode for CancellationToken to store is_cancelled as an AtomicBool instead of a bool within the Mutex. This makes for easier loading access to the property using the is_cancelled function. Added invariant for future modifications.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
[ISSUE #7775]

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
TreeNode now utilizes AtomicBool for is_cancelled. The added invariant guarantees the consistency of results between the previous solution and this one. Loading the AtomicBool is faster than locking the Mutex.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
