### PR TITLE
fs: simplify lock handling

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -416,15 +416,12 @@ impl File {
 
         inner.state = State::Idle(Some(buf));
 
-        let final_res = match op {
+        match op {
             Operation::Seek(res) => res.map(|pos| {
                 inner.pos = pos;
             }),
             _ => unreachable!(),
-        };
-        drop(inner);
-
-        final_res
+        }
     }
 
     /// Queries metadata about the underlying file.


### PR DESCRIPTION
Simplify lock handling to aovid needless contention

```
async_read_std_file     time:   [541.61 µs 543.06 µs 545.22 µs]
                        change: [-3.6664% -2.8611% -2.2091%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

async_read_buf          time:   [4.6885 ms 4.7884 ms 4.8959 ms]
                        change: [-12.406% -7.0308% -1.7695%] (p = 0.02 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high mild

async_read_codec        time:   [4.9421 ms 5.1000 ms 5.2688 ms]
                        change: [-20.854% -16.600% -12.146%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  13 (13.00%) high mild

sync_read               time:   [441.78 µs 443.39 µs 445.51 µs]
                        change: [-0.9406% -0.5037% +0.0075%] (p = 0.03 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
```