### PR TITLE
task: Better typed RawTask::try_read_output

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -339,8 +339,7 @@ impl<T> Future for JoinHandle<T> {
         //
         // The type of `T` must match the task's output type.
         unsafe {
-            self.raw
-                .try_read_output(&mut ret as *mut _ as *mut (), cx.waker());
+            self.raw.try_read_output(&mut ret, cx.waker());
         }
 
         if ret.is_ready() {

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -281,9 +281,9 @@ impl RawTask {
 
     /// Safety: `dst` must be a `*mut Poll<super::Result<T::Output>>` where `T`
     /// is the future stored by the task.
-    pub(super) unsafe fn try_read_output(self, dst: *mut (), waker: &Waker) {
+    pub(super) unsafe fn try_read_output<O>(self, dst: *mut Poll<super::Result<O>>, waker: &Waker) {
         let vtable = self.header().vtable;
-        (vtable.try_read_output)(self.ptr, dst, waker);
+        (vtable.try_read_output)(self.ptr, dst as *mut _, waker);
     }
 
     pub(super) fn drop_join_handle_slow(self) {


### PR DESCRIPTION
## Motivation

Types help reading code.

## Solution

Add more precise type to `RawTask::try_read_output`.