### PR TITLE
fs: check for opcode support before starting operation

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-311
+312
 &
 +
 <
@@ -195,6 +195,7 @@ ntasks
 NUMA
 ok
 oneshot
+opcode
 ORed
 os
 parker

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -110,7 +110,7 @@ tracing = { version = "0.1.29", default-features = false, features = ["std"], op
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
 [target.'cfg(all(tokio_unstable, target_os = "linux"))'.dependencies]
-io-uring = { version = "0.7.6", default-features = false, optional = true }
+io-uring = { version = "0.7.11", default-features = false, optional = true }
 libc = { version = "0.2.168", optional = true }
 mio = { version = "1.0.1", default-features = false, features = ["os-poll", "os-ext"], optional = true }
 slab = { version = "0.4.9", optional = true }

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -531,7 +531,7 @@ impl OpenOptions {
                 let handle = crate::runtime::Handle::current();
                 let driver_handle = handle.inner.driver().io();
 
-                if driver_handle.check_and_init()? {
+                if driver_handle.check_and_init(io_uring::opcode::OpenAt::CODE)? {
                     Op::open(path.as_ref(), opts)?.await
                 } else {
                     let opts = opts.clone().into();

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -68,7 +68,7 @@ pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
 
         let handle = crate::runtime::Handle::current();
         let driver_handle = handle.inner.driver().io();
-        if driver_handle.check_and_init()? {
+        if driver_handle.check_and_init(io_uring::opcode::Read::CODE)? {
             return read_uring(&path).await;
         }
     }

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -37,7 +37,7 @@ pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Re
     {
         let handle = crate::runtime::Handle::current();
         let driver_handle = handle.inner.driver().io();
-        if driver_handle.check_and_init()? {
+        if driver_handle.check_and_init(io_uring::opcode::Write::CODE)? {
             return write_uring(path, contents).await;
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

`io_uring` exposes additional opcodes with successive kernel versions. Ideally, we can tell which opcodes are supported, so we can know whether to use the `io_uring` version or the threadpool version of an asynchronous function.

This functionality is exposed through `io_uring`'s probing feature, which lists the supported opcodes. This is introduced in kernel 5.6. We fallback to attempting any opcode if probing support is not available.

All of the currently used opcodes (openat, read, write) were introduced before probing support in `io_uring`, so this is unnecessary for the current functionality. However, future additions can benefit from this check.

(Technically, #7799 and #7800 would benefit from this, although running on kernel [5.6, 5.10) is likely rare. But, other opcodes like `mkdirat` are not available on 5.10, which is an LTS.)

I bumped the `io-uring` crate to 0.7.11 to expose `get_opcode`, since it is tokio_unstable.