### PR TITLE
Fix grammar typos in bounded.rs and park.rs

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -313,7 +313,7 @@ impl Inner {
     }
 }
 
-// TODO: Is this really a unsafe function?
+// TODO: Is this really an unsafe function?
 unsafe fn unparker_to_raw_waker(unparker: Arc<Inner>) -> RawWaker {
     RawWaker::new(
         Inner::into_raw(unparker),

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1128,7 +1128,7 @@ impl<T> Sender<T> {
     /// A [`PermitIterator`] is returned to track the reserved capacity.
     /// You can call this [`Iterator`] until it is exhausted to
     /// get a [`Permit`] and then call [`Permit::send`]. This function is similar to
-    /// [`try_reserve_many`] except it awaits for the slots to become available.
+    /// [`try_reserve_many`] except it waits for the slots to become available.
     ///
     /// If the channel is closed, the function returns a [`SendError`].
     ///


### PR DESCRIPTION
## PR Description

### Motivation
While reading through the documentation and comments, I noticed a couple of minor grammar issues that affected clarity:

- **"awaits for"** in `tokio/src/sync/mpsc/bounded.rs` (incorrect phrase)
- **"a unsafe"** in `tokio/src/runtime/park.rs` (incorrect article before a vowel sound)

### Solution
This PR corrects these typos to improve readability and maintain documentation quality:

- Changed **"awaits for"** → **"waits for"**
- Changed **"a unsafe"** → **"an unsafe"**

No functional or code-behavior changes were made-this is a documentation/comment-only cleanup.
