### PR TITLE
signal: specialize unix OsStorage

### DIFF
--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -18,21 +18,33 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::task::{Context, Poll};
 
-pub(crate) type OsStorage = Box<[SignalInfo]>;
+// There are reliable signals ranging from 1 to 33 available on every Unix platform.
+#[cfg(not(any(target_os = "linux", target_os = "illumos")))]
+pub(crate) type OsStorage = [SignalInfo; 34];
 
+#[cfg(not(any(target_os = "linux", target_os = "illumos")))]
 impl Init for OsStorage {
     fn init() -> Self {
-        // There are reliable signals ranging from 1 to 33 available on every Unix platform.
-        #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
-        let possible = 0..=33;
+        use std::array;
 
-        // On Linux and illumos, there are additional real-time signals
-        // available. (This is also likely true on Solaris, but this should be
-        // verified before being enabled.)
-        #[cfg(any(target_os = "linux", target_os = "illumos"))]
-        let possible = 0..=libc::SIGRTMAX();
+        array::from_fn(|_| SignalInfo::default())
+    }
+}
 
-        possible.map(|_| SignalInfo::default()).collect()
+// On Linux and illumos, there are additional real-time signals available.
+// (This is also likely true on Solaris, but this should be verified before
+// being enabled.)
+#[cfg(any(target_os = "linux", target_os = "illumos"))]
+pub(crate) type OsStorage = Box<[SignalInfo]>;
+
+#[cfg(any(target_os = "linux", target_os = "illumos"))]
+impl Init for OsStorage {
+    fn init() -> Self {
+        use std::iter;
+
+        iter::repeat_with(SignalInfo::default)
+            .take(libc::SIGRTMAX() as usize + 1)
+            .collect()
     }
 }
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -22,29 +22,21 @@ use std::task::{Context, Poll};
 #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
 pub(crate) type OsStorage = [SignalInfo; 34];
 
-#[cfg(not(any(target_os = "linux", target_os = "illumos")))]
-impl Init for OsStorage {
-    fn init() -> Self {
-        use std::array;
-
-        array::from_fn(|_| SignalInfo::default())
-    }
-}
-
 // On Linux and illumos, there are additional real-time signals available.
 // (This is also likely true on Solaris, but this should be verified before
 // being enabled.)
 #[cfg(any(target_os = "linux", target_os = "illumos"))]
 pub(crate) type OsStorage = Box<[SignalInfo]>;
 
-#[cfg(any(target_os = "linux", target_os = "illumos"))]
 impl Init for OsStorage {
     fn init() -> Self {
-        use std::iter;
+        #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
+        return std::array::from_fn(|_| SignalInfo::default());
 
-        iter::repeat_with(SignalInfo::default)
+        #[cfg(any(target_os = "linux", target_os = "illumos"))]
+        return std::iter::repeat_with(SignalInfo::default)
             .take(libc::SIGRTMAX() as usize + 1)
-            .collect()
+            .collect();
     }
 }
 

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -18,21 +18,21 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Once;
 use std::task::{Context, Poll};
 
-// There are reliable signals ranging from 1 to 33 available on every Unix platform.
 #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
 pub(crate) type OsStorage = [SignalInfo; 34];
 
-// On Linux and illumos, there are additional real-time signals available.
-// (This is also likely true on Solaris, but this should be verified before
-// being enabled.)
 #[cfg(any(target_os = "linux", target_os = "illumos"))]
 pub(crate) type OsStorage = Box<[SignalInfo]>;
 
 impl Init for OsStorage {
     fn init() -> Self {
+        // There are reliable signals ranging from 1 to 33 available on every Unix platform.
         #[cfg(not(any(target_os = "linux", target_os = "illumos")))]
         return std::array::from_fn(|_| SignalInfo::default());
 
+        // On Linux and illumos, there are additional real-time signals
+        // available. (This is also likely true on Solaris, but this should be
+        // verified before being enabled.)
         #[cfg(any(target_os = "linux", target_os = "illumos"))]
         return std::iter::repeat_with(SignalInfo::default)
             .take(libc::SIGRTMAX() as usize + 1)


### PR DESCRIPTION
Noticed that this was unnecessarily boxed, even though that's only required for linux and illumos.