### PR TITLE
Document ordering bwetween future drop and JoinHandle completion

### DIFF
--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -1,4 +1,4 @@
-use crate::runtime::task::{Header, RawTask};
+use crate::runtime::task::{AbortHandle, Header, RawTask};
 
 use std::fmt;
 use std::future::Future;
@@ -21,6 +21,10 @@ cfg_rt! {
     ///
     /// This `struct` is created by the [`task::spawn`] and [`task::spawn_blocking`]
     /// functions.
+    ///
+    /// It is guaranteed that the destructor of the spawned task has finished
+    /// before task completion is observed via `JoinHandle` `await`,
+    /// [`JoinHandle::is_finished`] or [`AbortHandle::is_finished`].
     ///
     /// # Cancel safety
     ///
@@ -300,9 +304,9 @@ impl<T> JoinHandle<T> {
     /// ```
     /// [cancelled]: method@super::error::JoinError::is_cancelled
     #[must_use = "abort handles do nothing unless `.abort` is called"]
-    pub fn abort_handle(&self) -> super::AbortHandle {
+    pub fn abort_handle(&self) -> AbortHandle {
         self.raw.ref_inc();
-        super::AbortHandle::new(self.raw)
+        AbortHandle::new(self.raw)
     }
 
     /// Returns a [task ID] that uniquely identifies this task relative to other


### PR DESCRIPTION
## Motivation

Consider this code

```
struct MyFuture;

impl Drop for MyFuture {
  fn drop(&mut self) { println!("A"); }
}

impl Future for MyFuture { ... }


let join_handle = tokio::spawn(MyFuture);
let _ = join_handle.await; // Can be completion or abort
println!("B");
```

Is it guaranteed that `B` is always printed after `A`?

Use case can be this:

```
let task = spawn({ some work });
task.await;
let task2 = spawn({ some work on the same data });
```

It would be good to know that destructor of data in the first future (e.g. sending some final message from the destructor) does not intersect with the second task.

After reading the code of tokio, I came to conclusion, it is guaranteed.

## Solution

Let's make it formal, so users can rely on this behavior.