### PR TITLE
examples: use `select!` instead of `join!` in connect_(tcp|udp) examples

### DIFF
--- a/examples/connect-tcp.rs
+++ b/examples/connect-tcp.rs
@@ -17,7 +17,6 @@
 
 use tokio::io::{stdin, stdout};
 use tokio::net::TcpStream;
-use tokio::select;
 use tokio_util::codec::{BytesCodec, FramedRead, FramedWrite};
 
 use bytes::Bytes;
@@ -65,7 +64,7 @@ pub async fn connect(
         })
         .map(Ok);
 
-    select! {
+    tokio::select! {
         r = sink.send_all(&mut stdin) => r?,
         r = stdout.send_all(&mut stream) => r?,
     }

--- a/examples/connect-udp.rs
+++ b/examples/connect-udp.rs
@@ -17,7 +17,6 @@
 
 use tokio::io::{stdin, stdout};
 use tokio::net::UdpSocket;
-use tokio::select;
 use tokio_util::codec::{BytesCodec, FramedRead, FramedWrite};
 
 use bytes::Bytes;
@@ -60,7 +59,7 @@ pub async fn connect(
     let socket = UdpSocket::bind(&bind_addr).await?;
     socket.connect(addr).await?;
 
-    select! {
+    tokio::select! {
         r = send(stdin, &socket) => r?,
         r = recv(stdout, &socket) => r?,
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

When playing with the connect_tcp and connect_udp examples for tokio, I noticed that when I sent Ctrl+D to close stdin, the program would hang, but would no longer accept stdin content. 

This is caused by calling join and try_join on the futures for stdin and stdout. When stdin is terminated, it is still waiting for the stdout future to complete or fail. Even try_join doesn't save us here, because stdin is exiting gracefully, and not returning an error.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

`tokio::select!` fixes the problem because it waits for the first one to complete, and returns Ok(()) or Err for that one.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
