### PR TITLE
runtime: add comments to `schedule_option_task_without_yield`

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1280,6 +1280,7 @@ impl Handle {
         });
     }
 
+    // Separated case to reduce LLVM codegen in `Handle::bind_new_task`.
     pub(super) fn schedule_option_task_without_yield(&self, task: Option<Notified>) {
         if let Some(task) = task {
             self.schedule_task(task, false);


### PR DESCRIPTION
## Motivation

Strange, magical function, seems like manual hack.

## Solution

Add comment about LLVM codegen reduction.
