### PR TITLE
Add AbortOnDrop complement type to AbortOnDropHandle

### DIFF
--- a/tokio-util/src/task/abort_on_drop.rs
+++ b/tokio-util/src/task/abort_on_drop.rs
@@ -87,11 +87,12 @@ impl<T> AsRef<JoinHandle<T>> for AbortOnDropHandle<T> {
 /// A wrapper around a [`tokio::task::AbortHandle`],
 /// which [aborts] the task when it is dropped.
 ///
-/// Unlike [`AbortOnDropHandle`], [`AbortOnDrop`] does not represent the permission to await a
-/// tasks completion, and in exchange can be a concrete type.
+/// Unlike [`AbortOnDropHandle`], [`AbortOnDrop`] cannot be `.await`ed for a result.
 ///
+/// It has no generic parameter, making it suitable when you only need to keep
+/// a task handle in a struct and do not care about the output.
 ///
-/// [aborts]: tokio::task::JoinHandle::abort
+/// [aborts]: tokio::task::AbortHandle::abort
 #[must_use = "Dropping the handle aborts the task immediately"]
 pub struct AbortOnDrop(AbortHandle);
 

--- a/tokio-util/src/task/mod.rs
+++ b/tokio-util/src/task/mod.rs
@@ -12,7 +12,7 @@ cfg_rt! {
     pub use task_tracker::TaskTracker;
 
     mod abort_on_drop;
-    pub use abort_on_drop::{AbortOnDropHandle, AbortOnDrop};
+    pub use abort_on_drop::{AbortOnDrop, AbortOnDropHandle};
 
     mod join_queue;
     pub use join_queue::JoinQueue;

--- a/tokio-util/tests/abort_on_drop.rs
+++ b/tokio-util/tests/abort_on_drop.rs
@@ -70,7 +70,7 @@ async fn handle_does_not_abort_after_detach() {
         let _ = rx.await;
     });
     let handle = AbortOnDrop::new(handle.abort_handle());
-    handle.detach(); // returns and drops the original join handle
+    handle.detach(); // returns and drops the original abort handle
     yield_now().await;
     assert!(!tx.is_closed()); // the task is still alive
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`AbortOnDropHandle<T>` exists for cases where you wish to "forward cancel" a `JoinHandle<T>`, but frequently in code I find myself writing a wrapper around `AbortHandle`. This is for the same reasons someone would use `AbortHandle` (no generic param to carry, can hold multiple in different places, don't need the return value).


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

This PR adds a complement to `AbortOnDropHandle<T>`; `AbortOnDrop`. This simply wraps `AbortHandle` and otherwise mimics the API/function of `AbortOnDropHandle<T>`. The name is perhaps unfortunate and open to bikeshedding, but I couldn't come up with anything that felt great considering that `AbortOnDropHandle` is already taken.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
