### PR TITLE
 docs: remove outdated path dependency removal step from release instructions

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio-macros"
 # When releasing to crates.io:
-# - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
 version = "2.6.0"

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio-stream"
 # When releasing to crates.io:
-# - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
 version = "0.1.18"

--- a/tokio-test/Cargo.toml
+++ b/tokio-test/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio-test"
 # When releasing to crates.io:
-# - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-test-0.4.x" git tag.
 version = "0.4.5"

--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio-util"
 # When releasing to crates.io:
-# - Remove path dependencies
 # - Update CHANGELOG.md.
 # - Create "tokio-util-0.7.x" git tag.
 version = "0.7.18"

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "tokio"
 # When releasing to crates.io:
-# - Remove path dependencies
 # - Update doc url
 #   - README.md
 # - Update CHANGELOG.md.


### PR DESCRIPTION
## Summary

  Removes the outdated "Remove path dependencies" instruction from release documentation in all workspace crate
  `Cargo.toml` files.

  ## Background

  As discussed in issue #7832, the manual step of removing path dependencies during releases no longer works due to
  ambiguity errors in the monorepo setup. The CI automation now handles dependency validation automatically, making
  this manual step obsolete.

  ## Changes

  - Removed `# - Remove path dependencies` line from release instructions in:
    - `tokio/Cargo.toml`
    - `tokio-util/Cargo.toml`
    - `tokio-stream/Cargo.toml`
    - `tokio-test/Cargo.toml`
    - `tokio-macros/Cargo.toml`

  ## Related

  Fixes #7832