### PR TITLE
deps: bump tokio to `1.47.0`

### DIFF
--- a/tokio-util/Cargo.toml
+++ b/tokio-util/Cargo.toml
@@ -35,7 +35,7 @@ join-map = ["rt", "hashbrown"]
 __docs_rs = ["futures-util"]
 
 [dependencies]
-tokio = { version = "1.44.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.47.0", path = "../tokio", features = ["sync"] }
 bytes = "1.5.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

#7565 added usage of `coop::poll_proceed` in tokio-util, which was released in tokio 1.47.0 (https://github.com/tokio-rs/tokio/releases/tag/tokio-1.47.0).

The CI was not able to detect this due to checks against the latest version available of Tokio.

## Solution

Bump the tokio version to 1.47.0

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
