### PR TITLE
test: add error case tests for fs::hard_link

### DIFF
--- a/tokio/tests/fs_link.rs
+++ b/tokio/tests/fs_link.rs
@@ -68,10 +68,7 @@ async fn test_hard_link_error_source_not_found() {
     let src = dir.path().join("nonexistent.txt");
     let dst = dir.path().join("dst.txt");
 
-    let result = fs::hard_link(&src, &dst).await;
-
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    let err = fs::hard_link(&src, &dst).await.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
 }
 
@@ -83,22 +80,13 @@ async fn test_hard_link_error_destination_already_exists() {
     let dst = dir.path().join("dst.txt");
 
     // Create source file
-    std::fs::File::create(&src)
-        .unwrap()
-        .write_all(b"source content")
-        .unwrap();
+    std::fs::write(&src, b"source content").unwrap();
 
     // Create destination file
-    std::fs::File::create(&dst)
-        .unwrap()
-        .write_all(b"destination content")
-        .unwrap();
+    std::fs::write(&dst, b"destination content").unwrap();
 
     // Attempt to create hard link when destination already exists
-    let result = fs::hard_link(&src, &dst).await;
-
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    let err = fs::hard_link(&src, &dst).await.unwrap_err();
     assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists);
 }
 
@@ -113,11 +101,8 @@ async fn test_hard_link_error_source_is_directory() {
     fs::create_dir(&src_dir).await.unwrap();
 
     // Attempt to create hard link from a directory
-    let result = fs::hard_link(&src_dir, &dst).await;
-
     // On most systems, hard linking directories is not allowed
-    assert!(result.is_err());
-    let err = result.unwrap_err();
+    let err = fs::hard_link(&src_dir, &dst).await.unwrap_err();
 
     // Different platforms return different error kinds
     #[cfg(unix)]


### PR DESCRIPTION
## Motivation

  The `tokio::fs::hard_link` function currently lacks test coverage for error scenarios. The existing test only
  covers the success case, leaving error handling untested.

  ## Solution

  This PR adds three test cases to verify proper error handling:

  1. **test_hard_link_error_source_not_found** - Verifies that `NotFound` error is returned when the source file
  does not exist
  2. **test_hard_link_error_destination_already_exists** - Verifies that `AlreadyExists` error is returned when the
  destination file already exists
  3. **test_hard_link_error_source_is_directory** - Verifies that an error is returned when attempting to hard link
  a directory (which is not allowed on most systems)

  These tests improve coverage by ensuring `hard_link` properly handles common error scenarios and returns
  appropriate `io::ErrorKind` values.

  ## Testing

  All new tests pass:
  4. running 5 tests
  test test_hard_link ... ok
  test test_hard_link_error_destination_already_exists ... ok
  test test_hard_link_error_source_is_directory ... ok
  test test_hard_link_error_source_not_found ... ok
  test test_symlink ... ok

  4. test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out