### PR TITLE
docs: add missing `tokio::select!` link

### DIFF
--- a/tokio-util/src/task/join_map.rs
+++ b/tokio-util/src/task/join_map.rs
@@ -451,7 +451,7 @@ where
     ///    that panicked or was aborted.
     ///  * `None` if the `JoinMap` is empty.
     ///
-    /// [`tokio::select!`]: tokio::select
+    /// [`tokio::select!`]: https://docs.rs/tokio/latest/tokio/macro.select.html
     pub async fn join_next(&mut self) -> Option<(K, Result<V, JoinError>)> {
         loop {
             let (res, id) = match self.tasks.join_next_with_id().await {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

A small follow-up of #7860, noticed that there was another `tokio::select!` broken link

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

[rendered](https://deploy-preview-7867--tokio-rs.netlify.app/tokio/)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
