### PR TITLE
docs(io): fix incorrect and confusing AsyncWrite documentation

### DIFF
--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -31,7 +31,7 @@ use std::task::{Context, Poll};
 /// [`AsyncWriteExt`]. Most users will interact with `AsyncWrite` types through
 /// these extension methods, which provide ergonomic async functions such as
 /// `write_all` and `flush`.
-/// 
+///
 /// [`std::io::Write`]: std::io::Write
 /// [`Write::write`]: std::io::Write::write()
 /// [`poll_write`]: AsyncWrite::poll_write()


### PR DESCRIPTION
This PR clarifies the documentation for `tokio::io::AsyncWrite` by correcting
several inaccurate statements, improving terminology around asynchronous
behavior, and better directing users to `AsyncWriteExt` for ergonomic usage.

Fixed #7298 
