### PR TITLE
stream: bump minimum tokio version to 1.38

### DIFF
--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -38,7 +38,7 @@ signal = ["tokio/signal"]
 [dependencies]
 futures-core = { version = "0.3.0" }
 pin-project-lite = "0.2.11"
-tokio = { version = "1.15.0", path = "../tokio", features = ["sync"] }
+tokio = { version = "1.38.0", path = "../tokio", features = ["sync"] }
 tokio-util = { version = "0.7.0", path = "../tokio-util", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Motivation

`tokio-stream` 0.1.18 added `Stream::size_hint` for `ReceiverStream` and `UnboundedReceiverStream` (#7492), which uses `Receiver::is_closed()` and `Receiver::len()` (added in tokio 1.37.0, #6348) and `Receiver::capacity()` and `Receiver::max_capacity()` (added in tokio 1.38.0, #6511).

However, the declared minimum tokio version in `tokio-stream/Cargo.toml` is still `1.15.0`. This causes compilation failures for any downstream crate that uses `cargo build -Z direct-minimal-versions`, since tokio resolves to 1.15.0 which lacks these methods.

This was discovered while working on [rust-vsock/tokio-vsock#69](https://github.com/rust-vsock/tokio-vsock/pull/69), where the nightly CI `Build (min-deps)` step fails with:

```
error[E0599]: no method named `is_closed` found for struct `tokio::sync::mpsc::Receiver<T>`
error[E0599]: no method named `max_capacity` found for struct `tokio::sync::mpsc::Receiver<T>`
error[E0599]: no method named `capacity` found for struct `tokio::sync::mpsc::Receiver<T>`
error[E0599]: no method named `len` found for struct `tokio::sync::mpsc::Receiver<T>`
```

## Solution

Bump the minimum `tokio` dependency in `tokio-stream/Cargo.toml` from `1.15.0` to `1.38.0`, which is the first version that includes all the `Receiver` methods used by the `size_hint` implementation.

Refs: #7492, #6348, #6511