### PR TITLE
Deterministic async tests with reproducible seed for property-testing

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -137,6 +137,10 @@ pub struct Builder {
     pub(super) unhandled_panic: UnhandledPanic,
 
     timer_flavor: TimerFlavor,
+
+    /// Shuffles task in the queue
+    #[cfg(tokio_unstable)]
+    pub(super) shuffle_tasks: bool,
 }
 
 cfg_unstable! {
@@ -326,6 +330,9 @@ impl Builder {
             disable_lifo_slot: false,
 
             timer_flavor: TimerFlavor::Traditional,
+
+            #[cfg(tokio_unstable)]
+            shuffle_tasks: false,
         }
     }
 
@@ -1295,6 +1302,12 @@ impl Builder {
             self.seed_generator = RngSeedGenerator::new(seed);
             self
         }
+
+        /// Shuffles task in the queue
+        pub fn shuffle_tasks(&mut self) -> &mut Self {
+            self.shuffle_tasks = true;
+            self
+        }
     }
 
     cfg_unstable_metrics! {
@@ -1631,6 +1644,8 @@ impl Builder {
                 disable_lifo_slot: self.disable_lifo_slot,
                 seed_generator: seed_generator_1,
                 metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
+                #[cfg(tokio_unstable)]
+                shuffle_tasks: self.shuffle_tasks,
             },
             local_tid,
         );
@@ -1812,6 +1827,8 @@ cfg_rt_multi_thread! {
                     disable_lifo_slot: self.disable_lifo_slot,
                     seed_generator: seed_generator_1,
                     metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
+                    #[cfg(tokio_unstable)]
+                    shuffle_tasks: false,
                 },
                 self.timer_flavor,
             );

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -51,4 +51,8 @@ pub(crate) struct Config {
     #[cfg(tokio_unstable)]
     /// How to respond to unhandled task panics.
     pub(crate) unhandled_panic: crate::runtime::UnhandledPanic,
+
+    /// Shuffles task in the queue
+    #[cfg(tokio_unstable)]
+    pub(crate) shuffle_tasks: bool,
 }


### PR DESCRIPTION
## Motivation

I've been trying to write deterministic async tests, and I'd like to get a feedback if the following approach is what could be included to Tokio.

The issue is that the following simple async test is flaky. It runs without an error in ~90% on my laptop.

```rust
#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
async fn test_multi_thread_flaky() {
    let counter = Arc::new(tokio::sync::Mutex::new(0u32));

    let c1 = Arc::clone(&counter);
    let f1 = async move {
        let mut guard = c1.lock().await;
        if *guard == 0 {
            *guard += 1;
        }
    };
    let f1 = tokio::spawn(f1);

    let c2 = Arc::clone(&counter);
    let f2 = async move {
        let mut guard = c2.lock().await;
        if *guard == 1 {
            *guard += 1;
        }
    };
    let f2 = tokio::spawn(f2);

    _ = join!(f1, f2);
    assert_eq!(*counter.lock().await, 2);
    println!("PASS");
}
```

But I can't add property-testing to it and have a seed in logs to reproduce the concurrency bug. 
From my understanding for`multi_thread` favor it's impossible to do due to parallel execution (correct me if I'm wrong).

So the better way would be sequential runtime, to run it with `current_thread` scheduler:

```rust
#[tokio::test]
async fn test_current_thread_fifo() {
    let counter = Arc::new(tokio::sync::Mutex::new(0u32));

    let c1 = Arc::clone(&counter);
    let f1 = async move {
        let mut guard = c1.lock().await;
        if *guard == 0 {
            *guard += 1;
        }
    };
    let f1 = tokio::spawn(f1);

    let c2 = Arc::clone(&counter);
    let f2 = async move {
        let mut guard = c2.lock().await;
        if *guard == 1 {
            *guard += 1;
        }
    };
    let f2 = tokio::spawn(f2);

    _ = join!(f1, f2);
    assert_eq!(*counter.lock().await, 2);
    println!("PASS");
}
```

This test passes 100% runs. The thing is it uses the FIFO queue for tasks internally.

So in order to make the test work I experimented with Tokio code and ended up with the draft code changes in this PR. 

## Solution

I added `shuffle_tasks()` which changes the FIFO to random choice, and with the existing option `rng_seed()` it allowed me to get the reproducible seed for property-testing.

```rust
#[cfg(tokio_unstable)]
#[test]
fn test_current_thread_property_ready() {
    for i in 0..999999 {
        let seed = tokio::runtime::RngSeed::from_bytes(format!("{}", i).as_bytes());
        println!("seed: {i:?}");
        runtime::Builder::new_current_thread()
            .enable_all()
            .shuffle_tasks()
            .rng_seed(seed)
            .build()
            .expect("failed to build Tokio runtime")
            .block_on(async {
                let counter = Arc::new(tokio::sync::Mutex::new(0u32));

                let c1 = Arc::clone(&counter);
                let f1 = async move {
                    let mut guard = c1.lock().await;
                    if *guard == 0 {
                        *guard += 1;
                    }
                };
                let f1 = tokio::spawn(f1);

                let c2 = Arc::clone(&counter);
                let f2 = async move {
                    let mut guard = c2.lock().await;
                    if *guard == 1 {
                        *guard += 1;
                    }
                };
                let f2 = tokio::spawn(f2);

                _ = join!(f1, f2);
                assert_eq!(*counter.lock().await, 2);
                println!("PASS");
            });
    }
}
```

```
test tests::test_current_thread_property_ready ... FAILED

failures:

---- tests::test_current_thread_property_ready stdout ----
seed: 0
PASS
seed: 1
PASS
seed: 2
PASS
seed: 3
PASS
seed: 4
PASS
seed: 5
PASS
seed: 6
```

What do you think, is it a good approach? 
Looking for your feedback! 
Thank you for your time!