### PR TITLE
task: fix task module feature flags

### DIFF
--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -555,7 +555,6 @@ cfg_not_sync! {
 // of the task module.
 #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
 pub mod task;
-
 cfg_rt! {
     pub use task::spawn;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Currently, if you look at the Tokio docs the task module it's not under the rt feature flag:

<img width="323" height="359" alt="image" src="https://github.com/user-attachments/assets/55560c93-4d4f-43a9-951e-380c196e7d58" />

But every public module and struct inside task is under `rt` feature flag (except for coop which is only available for the crate).

This also leads to confusion because items that have multiple feature flags don't display the rt flag:

<img width="320" height="443" alt="image" src="https://github.com/user-attachments/assets/2e312414-58b2-4246-a26b-4f7c9a19166e" />

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

The solution is to gate the task module under rt feature flag:

<img width="320" height="377" alt="image" src="https://github.com/user-attachments/assets/ec5f7000-5c82-468d-ac26-d6d338b68ea3" />

<img width="317" height="193" alt="image" src="https://github.com/user-attachments/assets/db2cae12-1f9a-4d9a-9e32-bab34e30f482" />

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Docs

[rendered docs](https://deploy-preview-7891--tokio-rs.netlify.app/tokio/)