### PR TITLE
tests: skip issue_7144 if strace is missing

### DIFF
--- a/tokio/tests/process_issue_7144.rs
+++ b/tokio/tests/process_issue_7144.rs
@@ -17,7 +17,15 @@ async fn issue_7144() {
     }
 }
 
+async fn has_strace() -> bool {
+    Command::new("strace").arg("-V").output().await.is_ok()
+}
+
 async fn test_one() {
+    if !has_strace().await {
+        return;
+    }
+
     let mut t = Command::new("strace")
         .args("-o /dev/null -D sleep 5".split(' '))
         .spawn()


### PR DESCRIPTION
## Motivation

The unit test `issue_7144` requires `strace` to run. On systems where it is not installed, the test fails, causing the test suite to fail unexpectedly, and currently triggers `unwrap()`: <https://github.com/tokio-rs/tokio/blob/9dacb1c53e341b1183a89800d46ee33c6eabf7ad/tokio/tests/process_issue_7144.rs#L21-L24>

This is an environment-dependent issue, not a problem with the library or unit test itself, and makes local testing less reliable.

This change aims to make the test suite pass consistently, regardless of whether `strace` is present.

## Solution

The test now checks if `strace` is available before running. If `strace` is missing, the test is skipped gracefully with no failure.

A check was added and it uses only `tokio::process::Command`. This change makes local testing more reliable without affecting the behavior of the test on systems where `strace` is present.