### PR TITLE
runtime: fix TOCTOU issue when decreasing `num_idle_threads`

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -572,7 +572,10 @@ impl Inner {
         // with a descriptive message if it is not the
         // case.
         let prev_idle = self.metrics.dec_num_idle_threads();
-        assert_ne!(prev_idle, 0, "`num_idle_threads` underflowed on thread exit");
+        assert_ne!(
+            prev_idle, 0,
+            "`num_idle_threads` underflowed on thread exit"
+        );
 
         if shared.shutdown && self.metrics.num_threads() == 0 {
             self.condvar.notify_one();


### PR DESCRIPTION
Follow-up of <https://github.com/tokio-rs/tokio/pull/7910>.

FIx a flaky test: <https://github.com/tokio-rs/tokio/actions/runs/22089452533/job/63831219292>

<img src="https://github.com/user-attachments/assets/168aaee2-42fc-40f7-82fb-6605b184b11a" />

---

This bug was introduced in <https://github.com/tokio-rs/tokio/commit/d2ba276e7896d6fc6d6897fe6680a75602e01c7b>, which changed the metrics from a ordinary counter to atomic counter, so there is a [TOCTOU](https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use) issue.

Apparently, we can catch the underflow/overflow issue via CAS loop. However, it will be a significant change, thus I prefer to delete this assertion to address the flaky test at first.

But I would highly suggest to check the underflow/overflow in the implementation of `MetricAtomicUsize` later, and also measure the performance impact. Correctness should over the performance. Or introducing something like `checked_sub` for caller to optimize the performance.