### PR TITLE
sync: clarify RwLock fairness documentation

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -41,11 +41,10 @@ const MAX_READS: u32 = 10;
 /// The priority policy of Tokio's read-write lock is _fair_ (or
 /// [_write-preferring_]), in order to ensure that readers cannot starve
 /// writers. Fairness is ensured using a first-in, first-out queue for the tasks
-/// awaiting the lock; if a task that wishes to acquire the write lock is at the
-/// head of the queue, read locks will not be given out until the write lock has
-/// been released. This is in contrast to the Rust standard library's
-/// `std::sync::RwLock`, where the priority policy is dependent on the
-/// operating system's implementation.
+/// awaiting the lock; a read lock will not be given out until all write lock
+/// requests that were queued before it have been acquired and released. This is
+/// in contrast to the Rust standard library's `std::sync::RwLock`, where the
+/// priority policy is dependent on the operating system's implementation.
 ///
 /// The type parameter `T` represents the data that this lock protects. It is
 /// required that `T` satisfies [`Send`] to be shared across threads. The RAII guards


### PR DESCRIPTION
Fixes #6901

## Problem

The previous wording in the `RwLock` documentation was misleading:

> if a task that wishes to acquire the write lock is **at the head of the queue**, read locks will not be given out until the write lock has been released

This implies that readers are only blocked when the writer is at position #1 in the queue. However, due to the FIFO ordering policy, any write request queued *before* a read request will block that reader — the writer's position (head or not) is irrelevant from the reader's perspective.

**Example:** If R1 → W → R2 are queued in that order, R2 is blocked by W even though W is not at the head of the queue. Once R1 gets the lock (it was already queued before W), R2 cannot skip past W.

## Fix

Replace with a more accurate description:

> a read lock will not be given out until all write lock requests that were queued before it have been acquired and released

This clearly communicates the FIFO semantics without the misleading "head of the queue" implication.

This rephrasing was suggested in the issue by @cip999 and acknowledged as reasonable by @Darksonn.