### PR TITLE
task: clarify when to use spawn_blocking vs dedicated threads

### DIFF
--- a/tokio/src/task/blocking.rs
+++ b/tokio/src/task/blocking.rs
@@ -103,21 +103,6 @@ cfg_rt! {
     /// their own. If you want to spawn an ordinary thread, you should use
     /// [`thread::spawn`] instead.
     ///
-    /// # When to use `spawn_blocking` vs dedicated threads
-    ///
-    /// `spawn_blocking` is intended for *bounded* blocking work that eventually finishes.
-    /// Each call occupies a thread from the runtime's blocking thread pool for the duration
-    /// of the task. Long-lived tasks therefore reduce the pool's effective capacity, which
-    /// can delay other blocking operations once the pool is saturated and work is queued.
-    ///
-    /// For workloads that run indefinitely or for extended periods (for example,
-    /// background workers or persistent processing loops), prefer a dedicated thread created with
-    /// [`thread::spawn`].
-    ///
-    /// As a rule of thumb:
-    /// - Use `spawn_blocking` for short-lived blocking operations
-    /// - Use dedicated threads for long-lived or persistent blocking workloads
-    ///
     /// Be aware that tasks spawned using `spawn_blocking` cannot be aborted
     /// because they are not async. If you call [`abort`] on a `spawn_blocking`
     /// task, then this *will not have any effect*, and the task will continue
@@ -133,6 +118,21 @@ cfg_rt! {
     /// the tasks — they are simply allowed to keep running after the method
     /// returns. It is possible for a blocking task to be cancelled if it has
     /// not yet started running, but this is not guaranteed.
+    ///
+    /// # When to use `spawn_blocking` vs dedicated threads
+    ///
+    /// `spawn_blocking` is intended for *bounded* blocking work that eventually finishes.
+    /// Each call occupies a thread from the runtime's blocking thread pool for the duration
+    /// of the task. Long-lived tasks therefore reduce the pool's effective capacity, which
+    /// can delay other blocking operations once the pool is saturated and work is queued.
+    ///
+    /// For workloads that run indefinitely or for extended periods (for example,
+    /// background workers or persistent processing loops), prefer a dedicated thread created with
+    /// [`thread::spawn`].
+    ///
+    /// As a rule of thumb:
+    /// - Use `spawn_blocking` for short-lived blocking operations
+    /// - Use dedicated threads for long-lived or persistent blocking workloads
     ///
     /// Note that if you are using the single threaded runtime, this function will
     /// still spawn additional threads for blocking operations. The current-thread


### PR DESCRIPTION
## Motivation

The current spawn_blocking documentation states that the function is intended for operations that eventually finish and that thread::spawn should be used for ordinary threads.
However, the practical distinction between bounded blocking work and long-lived or persistent workers is not explicit. This often leads to confusion about when long-running tasks should use spawn_blocking versus a dedicated thread.
This clarification was requested following discussion #7878 .

## Solution

Add a short guidance section to the spawn_blocking documentation explaining:
  - spawn_blocking is intended for short-lived, bounded blocking work
  - Long-lived or persistent blocking tasks reduce the effective capacity of the blocking thread pool
  - For such workloads, a dedicated thread via std::thread::spawn is preferred
The change is documentation-only and does not modify behavior.
