### PR TITLE
add wasm32-wasip2 networking support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1119,6 +1119,32 @@ jobs:
           CARGO_TARGET_WASM32_WASIP1_THREADS_RUNNER: "wasmtime run -W bulk-memory=y -W threads=y -W shared-memory=y -S threads=y --"
           RUSTFLAGS: --cfg tokio_unstable -Dwarnings -C target-feature=+atomics,+bulk-memory -C link-args=--max-memory=67108864
 
+  wasm32-wasip2:
+    name: test tokio for wasm32-wasip2
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust ${{ env.rust_stable }}
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.rust_stable }}
+          targets: wasm32-wasip2
+
+      - name: Install cargo-nextest, wasmtime
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest,wasmtime-cli
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: test tokio --target wasm32-wasip2
+        run: cargo nextest run --target wasm32-wasip2 --features net,macros,rt,io-util
+        working-directory: tokio
+        env:
+          RUSTFLAGS: --cfg tokio_unstable
+          CARGO_TARGET_WASM32_WASIP2_RUNNER: wasmtime run -Sinherit-network
+
   check-external-types:
     name: check-external-types (${{ matrix.os }})
     needs: basics

--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-313
+314
 &
 +
 <
@@ -310,5 +310,6 @@ wakers
 Wakers
 wakeup
 wakeups
+WASI
 workstealing
 ZST

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -96,11 +96,11 @@ pin-project-lite = "0.2.11"
 
 # Everything else is optional...
 bytes = { version = "1.2.1", optional = true }
-mio = { version = "1.0.1", optional = true, default-features = false }
+mio = { version = "1.2.0", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
 
-[target.'cfg(not(target_family = "wasm"))'.dependencies]
-socket2 = { version = "0.6.0", optional = true, features = ["all"] }
+[target.'cfg(any(not(target_family = "wasm"), all(target_os = "wasi", not(target_env = "p1"))))'.dependencies]
+socket2 = { version = "0.6.3", optional = true, features = ["all"] }
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
@@ -112,13 +112,16 @@ tracing = { version = "0.1.29", default-features = false, features = ["std"], op
 [target.'cfg(all(tokio_unstable, target_os = "linux"))'.dependencies]
 io-uring = { version = "0.7.11", default-features = false, optional = true }
 libc = { version = "0.2.168", optional = true }
-mio = { version = "1.0.1", default-features = false, features = ["os-poll", "os-ext"], optional = true }
+mio = { version = "1.2.0", default-features = false, features = ["os-poll", "os-ext"], optional = true }
 slab = { version = "0.4.9", optional = true }
 backtrace = { version = "0.3.58", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.168", optional = true }
 signal-hook-registry = { version = "1.1.1", optional = true }
+
+[target.'cfg(target_os = "wasi")'.dependencies]
+libc = { version = "0.2.168", optional = true }
 
 [target.'cfg(unix)'.dev-dependencies]
 libc = { version = "0.2.168" }

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -58,6 +58,18 @@ macro_rules! cfg_unix {
     }
 }
 
+/// Enables Unix-specific code, including WASI.
+/// Use this macro instead of `cfg(any(unix, target_os = "wasi"))` to generate docs properly.
+macro_rules! cfg_unix_or_wasi {
+    ($($item:item)*) => {
+        $(
+            #[cfg(any(all(doc, docsrs), unix, target_os = "wasi"))]
+            #[cfg_attr(docsrs, doc(cfg(any(unix, target_os = "wasi"))))]
+            $item
+        )*
+    }
+}
+
 /// Enables unstable Windows-specific code.
 /// Use this macro instead of `cfg(windows)` to generate docs properly.
 macro_rules! cfg_unstable_windows {
@@ -669,6 +681,15 @@ macro_rules! cfg_not_wasi {
     ($($item:item)*) => {
         $(
             #[cfg(not(target_os = "wasi"))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_not_wasip1 {
+    ($($item:item)*) => {
+        $(
+            #[cfg(not(all(target_os = "wasi", target_env = "p1")))]
             $item
         )*
     }

--- a/tokio/src/net/mod.rs
+++ b/tokio/src/net/mod.rs
@@ -29,7 +29,7 @@
 //! [`AsyncFd`]: crate::io::unix::AsyncFd
 
 mod addr;
-cfg_not_wasi! {
+cfg_not_wasip1! {
     #[cfg(feature = "net")]
     pub(crate) use addr::to_socket_addrs;
 }
@@ -42,7 +42,7 @@ cfg_net! {
     pub mod tcp;
     pub use tcp::listener::TcpListener;
     pub use tcp::stream::TcpStream;
-    cfg_not_wasi! {
+    cfg_not_wasip1! {
         pub use tcp::socket::TcpSocket;
 
         mod udp;

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -2,7 +2,7 @@ use crate::io::{Interest, PollEvented};
 use crate::net::tcp::TcpStream;
 use crate::util::check_socket_for_blocking;
 
-cfg_not_wasi! {
+cfg_not_wasip1! {
     use crate::net::{to_socket_addrs, ToSocketAddrs};
 }
 
@@ -60,7 +60,7 @@ cfg_net! {
 }
 
 impl TcpListener {
-    cfg_not_wasi! {
+    cfg_not_wasip1! {
         /// Creates a new `TcpListener`, which will be bound to the specified address.
         ///
         /// The returned listener is ready for accepting connections.
@@ -292,7 +292,7 @@ impl TcpListener {
 
         #[cfg(target_os = "wasi")]
         {
-            use std::os::wasi::io::{FromRawFd, IntoRawFd};
+            use std::os::fd::{FromRawFd, IntoRawFd};
             self.io
                 .into_inner()
                 .map(|io| io.into_raw_fd())
@@ -300,7 +300,7 @@ impl TcpListener {
         }
     }
 
-    cfg_not_wasi! {
+    cfg_not_wasip1! {
         pub(crate) fn new(listener: mio::net::TcpListener) -> io::Result<TcpListener> {
             let io = PollEvented::new(listener)?;
             Ok(TcpListener { io })
@@ -427,7 +427,7 @@ cfg_unstable! {
     #[cfg(target_os = "wasi")]
     mod sys {
         use super::TcpListener;
-        use std::os::wasi::prelude::*;
+        use std::os::fd::{RawFd, BorrowedFd, AsRawFd, AsFd};
 
         impl AsRawFd for TcpListener {
             fn as_raw_fd(&self) -> RawFd {

--- a/tokio/src/net/tcp/mod.rs
+++ b/tokio/src/net/tcp/mod.rs
@@ -2,7 +2,7 @@
 
 pub(crate) mod listener;
 
-cfg_not_wasi! {
+cfg_not_wasip1! {
     pub(crate) mod socket;
 }
 

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -1,7 +1,10 @@
 cfg_not_wasi! {
+    use std::time::Duration;
+}
+
+cfg_not_wasip1! {
     use crate::net::{to_socket_addrs, ToSocketAddrs};
     use std::future::poll_fn;
-    use std::time::Duration;
 }
 
 use crate::io::{AsyncRead, AsyncWrite, Interest, PollEvented, ReadBuf, Ready};
@@ -73,7 +76,7 @@ cfg_net! {
 }
 
 impl TcpStream {
-    cfg_not_wasi! {
+    cfg_not_wasip1! {
         /// Opens a TCP connection to a remote host.
         ///
         /// `addr` is an address of the remote host. Anything which implements the
@@ -272,7 +275,7 @@ impl TcpStream {
 
         #[cfg(target_os = "wasi")]
         {
-            use std::os::wasi::io::{FromRawFd, IntoRawFd};
+            use std::os::fd::{FromRawFd, IntoRawFd};
             self.io
                 .into_inner()
                 .map(|io| io.into_raw_fd())
@@ -1564,7 +1567,7 @@ cfg_windows! {
 #[cfg(all(tokio_unstable, target_os = "wasi"))]
 mod sys {
     use super::TcpStream;
-    use std::os::wasi::prelude::*;
+    use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
     impl AsRawFd for TcpStream {
         fn as_raw_fd(&self) -> RawFd {

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -254,9 +254,9 @@ impl UdpSocket {
     /// [`std::net::UdpSocket`]: std::net::UdpSocket
     /// [`set_nonblocking`]: fn@std::net::UdpSocket::set_nonblocking
     pub fn into_std(self) -> io::Result<std::net::UdpSocket> {
-        #[cfg(unix)]
+        #[cfg(not(windows))]
         {
-            use std::os::unix::io::{FromRawFd, IntoRawFd};
+            use std::os::fd::{FromRawFd, IntoRawFd};
             self.io
                 .into_inner()
                 .map(IntoRawFd::into_raw_fd)
@@ -2084,7 +2084,8 @@ impl UdpSocket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
-        target_os = "haiku"
+        target_os = "haiku",
+        target_os = "wasi",
     )))]
     #[cfg_attr(
         docsrs,
@@ -2093,7 +2094,8 @@ impl UdpSocket {
             target_os = "redox",
             target_os = "solaris",
             target_os = "illumos",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi",
         ))))
     )]
     pub fn tos_v4(&self) -> io::Result<u32> {
@@ -2112,7 +2114,8 @@ impl UdpSocket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
-        target_os = "haiku"
+        target_os = "haiku",
+        target_os = "wasi",
     )))]
     #[cfg_attr(
         docsrs,
@@ -2121,7 +2124,8 @@ impl UdpSocket {
             target_os = "redox",
             target_os = "solaris",
             target_os = "illumos",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi",
         ))))
     )]
     pub fn tos(&self) -> io::Result<u32> {
@@ -2144,7 +2148,8 @@ impl UdpSocket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
-        target_os = "haiku"
+        target_os = "haiku",
+        target_os = "wasi",
     )))]
     #[cfg_attr(
         docsrs,
@@ -2153,7 +2158,8 @@ impl UdpSocket {
             target_os = "redox",
             target_os = "solaris",
             target_os = "illumos",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi",
         ))))
     )]
     pub fn set_tos_v4(&self, tos: u32) -> io::Result<()> {
@@ -2172,7 +2178,8 @@ impl UdpSocket {
         target_os = "redox",
         target_os = "solaris",
         target_os = "illumos",
-        target_os = "haiku"
+        target_os = "haiku",
+        target_os = "wasi",
     )))]
     #[cfg_attr(
         docsrs,
@@ -2181,7 +2188,8 @@ impl UdpSocket {
             target_os = "redox",
             target_os = "solaris",
             target_os = "illumos",
-            target_os = "haiku"
+            target_os = "haiku",
+            target_os = "wasi",
         ))))
     )]
     pub fn set_tos(&self, tos: u32) -> io::Result<()> {
@@ -2297,10 +2305,10 @@ impl fmt::Debug for UdpSocket {
     }
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 mod sys {
     use super::UdpSocket;
-    use std::os::unix::prelude::*;
+    use std::os::fd::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
     impl AsRawFd for UdpSocket {
         fn as_raw_fd(&self) -> RawFd {

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -118,7 +118,7 @@ impl Registration {
 
     // Uses the poll path, requiring the caller to ensure mutual exclusion for
     // correctness. Only the last task to call this function is notified.
-    #[cfg(not(target_os = "wasi"))]
+    #[cfg(not(all(target_os = "wasi", target_env = "p1")))]
     pub(crate) fn poll_read_io<R>(
         &self,
         cx: &mut Context<'_>,

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,5 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support panic recovery or bind
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use tokio::net::TcpListener;
 

--- a/tokio/tests/net_lookup_host.rs
+++ b/tokio/tests/net_lookup_host.rs
@@ -1,4 +1,11 @@
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support direct socket operations
+// WASIp1 doesn't support direct socket operations
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+))]
 
 use tokio::net;
 use tokio_test::assert_ok;
@@ -22,6 +29,13 @@ async fn lookup_str_socket_addr() {
     assert_eq!(vec![addr], actual);
 }
 
+// Note that WASIp2 _does_ support asynchronous name lookups without requiring a
+// worker thread, so this test could be ungated for WASI if/when that's
+// implemented.
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "net::lookup_host requires multithreading, which WASI does not yet support"
+)]
 #[tokio::test]
 #[cfg_attr(miri, ignore)] // No `getaddrinfo` in miri.
 async fn resolve_dns() -> io::Result<()> {

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,6 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
-                                                                   // No `socket` on miri.
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
@@ -96,6 +104,13 @@ async fn connect_addr_ip_str_slice() {
     join!(server, client);
 }
 
+// Note that WASIp2 _does_ support asynchronous name lookups without
+// requiring a worker thread, so this test could be ungated if/when that's
+// implemented.
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "net::lookup_host requires multithreading, which WASI does not yet support"
+)]
 #[tokio::test]
 async fn connect_addr_host_string() {
     let srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
@@ -147,6 +162,13 @@ async fn connect_addr_ip_str_port_tuple() {
     join!(server, client);
 }
 
+// Note that WASIp2 _does_ support asynchronous name lookups without
+// requiring a worker thread, so this test could be ungated if/when that's
+// implemented.
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "net::lookup_host requires multithreading, which WASI does not yet support"
+)]
 #[tokio::test]
 async fn connect_addr_host_str_port_tuple() {
     let srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,6 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
-                                                                   // No socket on miri.
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support multithreading or peeking
                                                                    // No `socket` on miri.
 
 use std::io::{Error, ErrorKind, Result};

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -1,6 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
-                                                                   // No socket on `miri`.
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use std::io::Read;
 use std::io::Result;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support peeking
                                                                    // No `socket` on miri.
 
 use tokio::io::AsyncReadExt;

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support mulithreading
                                                                    // No `socket` on miri.
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -1,6 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
-                                                                   // No `socket` on miri.
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use std::time::Duration;
 use tokio::net::TcpSocket;
@@ -61,6 +69,7 @@ async fn bind_before_connect() {
     let _ = assert_ok!(srv.accept().await);
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support `SO_LINGER`")]
 #[tokio::test]
 async fn basic_linger() {
     // Create server
@@ -154,6 +163,7 @@ test!(
 );
 
 test!(
+    #[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support `SO_LINGER`")]
     #[expect(deprecated, reason = "set_linger is deprecated")]
     linger,
     set_linger(Some(Duration::from_secs(10)))
@@ -179,6 +189,7 @@ test!(IPv6 tclass_v6, set_tclass_v6(96));
     target_os = "redox",
     target_os = "solaris",
     target_os = "illumos",
-    target_os = "haiku"
+    target_os = "haiku",
+    target_os = "wasi"
 )))]
 test!(IPv4 tos_v4, set_tos_v4(96));

--- a/tokio/tests/tcp_split.rs
+++ b/tokio/tests/tcp_split.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support bind
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support peeking
                                                                    // No `socket` on miri.
 
 use std::io::Result;

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -1,6 +1,14 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi does not support bind or UDP
-                                                                   // No `socket` on miri.
+// WASIp1 doesn't support bind
+// No `socket` on miri.
+#![cfg(all(
+    feature = "net",
+    feature = "macros",
+    feature = "rt",
+    feature = "io-util",
+    not(all(target_os = "wasi", target_env = "p1")),
+    not(miri)
+))]
 
 use std::future::poll_fn;
 use std::io;
@@ -47,6 +55,10 @@ async fn send_recv_poll() -> std::io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn send_to_recv_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -63,6 +75,10 @@ async fn send_to_recv_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn send_to_recv_from_poll() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -79,6 +95,7 @@ async fn send_to_recv_from_poll() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn send_to_peek_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -107,6 +124,7 @@ async fn send_to_peek_from() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn send_to_try_peek_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -146,6 +164,7 @@ async fn send_to_try_peek_from() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn send_to_peek_from_poll() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -174,6 +193,7 @@ async fn send_to_peek_from_poll() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn peek_sender() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -199,6 +219,7 @@ async fn peek_sender() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn poll_peek_sender() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -225,6 +246,7 @@ async fn poll_peek_sender() -> std::io::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support peeking")]
 #[tokio::test]
 async fn try_peek_sender() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -353,6 +375,10 @@ async fn split_chan_poll() -> std::io::Result<()> {
 // **not** be okay because it's resources are completion based (via IOCP).
 // If data is sent and not yet received, attempting to send more data will
 // result in `ErrorKind::WouldBlock` until the first operation completes.
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not yet support multithreading"
+)]
 #[tokio::test]
 async fn try_send_spawn() {
     const MSG2: &[u8] = b"world!";
@@ -439,6 +465,10 @@ async fn try_send_recv() {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn try_send_to_recv_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -543,6 +573,10 @@ async fn recv_buf() -> std::io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn try_recv_buf_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -586,6 +620,10 @@ async fn try_recv_buf_from() {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn recv_buf_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -603,6 +641,10 @@ async fn recv_buf_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+)]
 async fn poll_ready() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -690,13 +732,16 @@ macro_rules! test {
     };
 }
 
+#[cfg(not(target_os = "wasi"))] // WASI does not yet support broadcast
 test!(broadcast, set_broadcast(true));
 
+#[cfg(not(target_os = "wasi"))] // WASI does not yet support multicast
 test!(IPv4 multicast_loop_v4, set_multicast_loop_v4(false));
 
 #[cfg(target_os = "linux")] // broken on non-Linux platforms https://github.com/rust-lang/socket2/pull/630
 test!(multicast_ttl_v4, set_multicast_ttl_v4(40));
 
+#[cfg(not(target_os = "wasi"))] // WASI does not yet support multicast
 test!(IPv6 multicast_loop_v6, set_multicast_loop_v6(false));
 
 #[cfg(any(
@@ -719,6 +764,7 @@ test!(IPv4 ttl, set_ttl(40));
     target_os = "redox",
     target_os = "solaris",
     target_os = "illumos",
-    target_os = "haiku"
+    target_os = "haiku",
+    target_os = "wasi"
 )))]
 test!(IPv4 tos_v4, set_tos_v4(96));


### PR DESCRIPTION
## Motivation

This adds networking support for the `wasm32-wasip2` target platform, which includes more extensive support for sockets than `wasm32-wasip1`.

## Solution

The bulk of the changes are in https://github.com/tokio-rs/mio/pull/1931.  This patch mainly tweaks a few `cfg` directives to indicate `wasm32-wasip2`'s additional capabilities.

~~Note that this is a draft PR until https://github.com/tokio-rs/mio/pull/1931 and https://github.com/rust-lang/socket2/pull/639 have been include in stable releases of their respective projects.~~

Also note that I've added a `wasm32-wasip2` target to CI and triaged each test which was previously disabled for WASI into one of three categories:

- Disabled on both WASIp1 and p2 due to not-yet-supported features such as multithreading
- Disabled on p1 but enabled on p2
- Disabled on p1 and _temporarily_ disabled on p2 due to `wasi-libc` bugfixes which have been merged but not yet included in a Rust release.  I'll open an issue to re-enable them when the fixes land in Rust.

## Future Work

In the future, we could consider adding support for `tokio::net::lookup_host`. WASIp2 natively supports asynchronous DNS lookups and is single threaded, whereas Tokio currently assumes DNS lookups are blocking and require multithreading to emulate async lookups.  A WASIp2-specific implementation could do the lookup directly without multithreading.

WASIp2 also supports single-threaded, asynchronous file I/O, timers, etc.  We could either support those directly or wait for WASIp3's multithreading support, in which case most of `tokio::fs` (as well as `tokio::net::lookup_host`, etc.) _should_ work unchanged via `wasi-libc` and worker threads.

Currently, building for WASIp2 requires `RUSTFLAGS="--cfg tokio_unstable"`.  Once we have a solid maintenance plan, we can remove that requirement.
