### PR TITLE
Add freeze_last_access_time/freeze_last_write_time for Windows

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -88,6 +88,7 @@ time = []
 io-uring = ["dep:io-uring", "libc", "mio/os-poll", "mio/os-ext", "dep:slab"]
 # Unstable feature. Requires `--cfg tokio_unstable` to enable.
 taskdump = ["dep:backtrace"]
+windows_freeze_file_times = []
 
 [dependencies]
 tokio-macros = { version = "~2.6.0", optional = true }

--- a/tokio/src/fs/open_options/mock_open_options.rs
+++ b/tokio/src/fs/open_options/mock_open_options.rs
@@ -35,5 +35,10 @@ mock! {
         fn custom_flags(&mut self, flags: u32) -> &mut Self;
         fn attributes(&mut self, val: u32) -> &mut Self;
         fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
+
+        #[cfg(feature = "windows_freeze_file_times")]
+        fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self;
+        #[cfg(feature = "windows_freeze_file_times")]
+        fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
     }
 }


### PR DESCRIPTION


## Motivation

The Windows build started failing with Rust 1.94.0:
```
error[E0046]: not all trait items implemented, missing: `freeze_last_access_time`, `freeze_last_write_time`
  --> tokio\src\fs\open_options\mock_open_options.rs:12:1
   |
12 | / mock! {
13 | |     #[derive(Debug)]
14 | |     pub OpenOptions {
15 | |         pub fn append(&mut self, append: bool) -> &mut Self;
...  |
31 | |     #[cfg(windows)]
32 | |     impl OpenOptionsExt for OpenOptions {
   | |_______________________________________^ missing `freeze_last_access_time`, `freeze_last_write_time` in implementation
   |
   = note: this error originates in the macro `mock` (in Nightly builds, run with -Z macro-backtrace for more info)
   = help: implement the missing item: `fn freeze_last_access_time(&mut self, _: bool) -> &mut Self { todo!() }`
   = help: implement the missing item: `fn freeze_last_write_time(&mut self, _: bool) -> &mut Self { todo!() }`
```

https://github.com/tokio-rs/tokio/actions/runs/22751306508/job/65986377619?pr=7954

Caused by: https://github.com/rust-lang/rust/commit/d772c3d99d41d1f44a23ab5256e2fbf62b589b03
Rust issue: https://github.com/rust-lang/rust/issues/149715

## Solution

Add the missing methods