### PR TITLE
fs: add missing Windows OpenOptionsExt methods

### DIFF
--- a/tokio/build.rs
+++ b/tokio/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::process::Command;
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(tokio_nightly)");
+    let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+    let output = Command::new(&rustc)
+        .arg("--version")
+        .output()
+        .expect("failed to run rustc --version");
+    let version = String::from_utf8_lossy(&output.stdout);
+    if version.contains("nightly") || version.contains("dev") {
+        println!("cargo:rustc-cfg=tokio_nightly");
+    }
+}

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -834,56 +834,31 @@ cfg_windows! {
             self.as_inner_mut().security_qos_flags(flags);
             self
         }
+    }
+}
 
-        /// Sets whether the file handle will prevent modification of the last
-        /// access time of the file.
-        ///
-        /// When this option is enabled and a file is opened, the system will not
-        /// update the last access time of the file when it is read from.
-        ///
-        /// # Examples
-        ///
-        /// ```no_run
-        /// use tokio::fs::OpenOptions;
-        ///
-        /// # #[tokio::main]
-        /// # async fn main() -> std::io::Result<()> {
-        /// let file = OpenOptions::new()
-        ///     .read(true)
-        ///     .freeze_last_access_time(true)
-        ///     .open("foo.txt").await?;
-        /// # Ok(())
-        /// # }
-        /// ```
-        pub fn freeze_last_access_time(&mut self, freeze: bool) -> &mut OpenOptions {
-            self.as_inner_mut().freeze_last_access_time(freeze);
-            self
-        }
+// These methods are gated on nightly because `freeze_last_access_time` and
+// `freeze_last_write_time` are unstable in `std::os::windows::fs::OpenOptionsExt`.
+#[cfg(all(windows, tokio_nightly))]
+impl OpenOptions {
+    /// Sets whether the file handle will prevent modification of the last
+    /// access time of the file.
+    ///
+    /// When this option is enabled and a file is opened, the system will not
+    /// update the last access time of the file when it is read from.
+    pub fn freeze_last_access_time(&mut self, freeze: bool) -> &mut OpenOptions {
+        self.as_inner_mut().freeze_last_access_time(freeze);
+        self
+    }
 
-        /// Sets whether the file handle will prevent modification of the last
-        /// write time of the file.
-        ///
-        /// When this option is enabled and a file is opened, the system will not
-        /// update the last write time of the file when it is written to.
-        ///
-        /// # Examples
-        ///
-        /// ```no_run
-        /// use tokio::fs::OpenOptions;
-        ///
-        /// # #[tokio::main]
-        /// # async fn main() -> std::io::Result<()> {
-        /// let file = OpenOptions::new()
-        ///     .write(true)
-        ///     .freeze_last_write_time(true)
-        ///     .open("foo.txt").await?;
-        /// # Ok(())
-        /// # }
-        /// ```
-        pub fn freeze_last_write_time(&mut self, freeze: bool) -> &mut OpenOptions {
-            self.as_inner_mut().freeze_last_write_time(freeze);
-            self
-        }
+    /// Sets whether the file handle will prevent modification of the last
+    /// write time of the file.
+    ///
+    /// When this option is enabled and a file is opened, the system will not
+    /// update the last write time of the file when it is written to.
+    pub fn freeze_last_write_time(&mut self, freeze: bool) -> &mut OpenOptions {
+        self.as_inner_mut().freeze_last_write_time(freeze);
+        self
     }
 }
 

--- a/tokio/src/fs/open_options/mock_open_options.rs
+++ b/tokio/src/fs/open_options/mock_open_options.rs
@@ -9,6 +9,58 @@ use std::os::unix::fs::OpenOptionsExt;
 use std::os::windows::fs::OpenOptionsExt;
 use std::{io, path::Path};
 
+// On nightly, OpenOptionsExt includes unstable methods that must be implemented.
+#[cfg(all(windows, tokio_nightly))]
+mock! {
+    #[derive(Debug)]
+    pub OpenOptions {
+        pub fn append(&mut self, append: bool) -> &mut Self;
+        pub fn create(&mut self, create: bool) -> &mut Self;
+        pub fn create_new(&mut self, create_new: bool) -> &mut Self;
+        pub fn open<P: AsRef<Path> + 'static>(&self, path: P) -> io::Result<MockFile>;
+        pub fn read(&mut self, read: bool) -> &mut Self;
+        pub fn truncate(&mut self, truncate: bool) -> &mut Self;
+        pub fn write(&mut self, write: bool) -> &mut Self;
+    }
+    impl Clone for OpenOptions {
+        fn clone(&self) -> Self;
+    }
+    impl OpenOptionsExt for OpenOptions {
+        fn access_mode(&mut self, access: u32) -> &mut Self;
+        fn share_mode(&mut self, val: u32) -> &mut Self;
+        fn custom_flags(&mut self, flags: u32) -> &mut Self;
+        fn attributes(&mut self, val: u32) -> &mut Self;
+        fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
+        fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self;
+        fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
+    }
+}
+
+#[cfg(all(windows, not(tokio_nightly)))]
+mock! {
+    #[derive(Debug)]
+    pub OpenOptions {
+        pub fn append(&mut self, append: bool) -> &mut Self;
+        pub fn create(&mut self, create: bool) -> &mut Self;
+        pub fn create_new(&mut self, create_new: bool) -> &mut Self;
+        pub fn open<P: AsRef<Path> + 'static>(&self, path: P) -> io::Result<MockFile>;
+        pub fn read(&mut self, read: bool) -> &mut Self;
+        pub fn truncate(&mut self, truncate: bool) -> &mut Self;
+        pub fn write(&mut self, write: bool) -> &mut Self;
+    }
+    impl Clone for OpenOptions {
+        fn clone(&self) -> Self;
+    }
+    impl OpenOptionsExt for OpenOptions {
+        fn access_mode(&mut self, access: u32) -> &mut Self;
+        fn share_mode(&mut self, val: u32) -> &mut Self;
+        fn custom_flags(&mut self, flags: u32) -> &mut Self;
+        fn attributes(&mut self, val: u32) -> &mut Self;
+        fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
+    }
+}
+
+#[cfg(not(windows))]
 mock! {
     #[derive(Debug)]
     pub OpenOptions {
@@ -27,15 +79,5 @@ mock! {
     impl OpenOptionsExt for OpenOptions {
         fn custom_flags(&mut self, flags: i32) -> &mut Self;
         fn mode(&mut self, mode: u32) -> &mut Self;
-    }
-    #[cfg(windows)]
-    impl OpenOptionsExt for OpenOptions {
-        fn access_mode(&mut self, access: u32) -> &mut Self;
-        fn share_mode(&mut self, val: u32) -> &mut Self;
-        fn custom_flags(&mut self, flags: u32) -> &mut Self;
-        fn attributes(&mut self, val: u32) -> &mut Self;
-        fn security_qos_flags(&mut self, flags: u32) -> &mut Self;
-        fn freeze_last_access_time(&mut self, freeze: bool) -> &mut Self;
-        fn freeze_last_write_time(&mut self, freeze: bool) -> &mut Self;
     }
 }


### PR DESCRIPTION
Add `freeze_last_access_time` and `freeze_last_write_time` to both the mock and real OpenOptions implementations to match the updated `std::os::windows::fs::OpenOptionsExt` trait in newer Rust versions.