### PR TITLE
rt: do not leak fd when cancelling io_uring open operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.1", features = ["full"] }
+tokio = { version = "1.51.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,14 +1,3 @@
-# 1.51.1 (April x, 2026)
-
-This release fixes an issue where cancelling a file opening operation
-could lead to a leak of file descriptors on Linux when using io-uring.
-
-### Unstable
-
-- runtime: (io-uring) ensure fds are closed when invoking cancel op ([#7983])
-
-[#7983]: https://github.com/tokio-rs/tokio/pull/7983
-
 # 1.51.0 (April 3rd, 2026)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.51.1"
+version = "1.51.0"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.1", features = ["full"] }
+tokio = { version = "1.51.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

fixes: #7979 

## Solution

When we receive a CQ that contains a cancelled event (open op), we now close the related fd.

## result of PoC run after the fix

```sh
thread 'main' (1) panicked at src/main.rs:58:9:
expected many leaked fds, saw 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
before=7
after=8
leaked=1
```