### PR TITLE
net: use null get_peer_cred on Hurd

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -62,7 +62,7 @@ pub(crate) use self::impl_solaris::get_peer_cred;
 #[cfg(target_os = "aix")]
 pub(crate) use self::impl_aix::get_peer_cred;
 
-#[cfg(any(target_os = "espidf", target_os = "vita"))]
+#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
 pub(crate) use self::impl_noproc::get_peer_cred;
 
 #[cfg(any(
@@ -317,7 +317,7 @@ pub(crate) mod impl_aix {
     }
 }
 
-#[cfg(any(target_os = "espidf", target_os = "vita"))]
+#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
 pub(crate) mod impl_noproc {
     use crate::net::unix::UnixStream;
     use std::io;


### PR DESCRIPTION
## Motivation

Make tokio more usable on GNU/Hurd. Currently, users of tokio may fail to build because `get_peer_cred()` is not implemented.

## Solution

Due to the lack of (non-portable) APIs for this task (which makes it not possible to use any of the existing implementations), for now use the the null/empty `get_peer_cred()` implementation.