### PR TITLE
macros: improve overall macro hygiene

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -659,7 +659,7 @@ doc! {macro_rules! select {
             $crate::macros::support::poll_fn(|cx| {
                 // Return `Pending` when the task budget is depleted since budget-aware futures
                 // are going to yield anyway and other futures will not cooperate.
-                ::std::task::ready!($crate::macros::support::poll_budget_available(cx));
+                $crate::macros::support::ready!($crate::macros::support::poll_budget_available(cx));
 
                 // Track if any branch returns pending. If no branch completes
                 // **or** returns pending, this implies that all branches are
@@ -699,7 +699,7 @@ doc! {macro_rules! select {
 
                                 // Safety: future is stored on the stack above
                                 // and never moved.
-                                let mut fut = unsafe { Pin::new_unchecked(fut) };
+                                let mut fut = unsafe { $crate::macros::support::Pin::new_unchecked(fut) };
 
                                 // Try polling it
                                 let out = match $crate::macros::support::Future::poll(fut, cx) {

--- a/tokio/src/macros/support.rs
+++ b/tokio/src/macros/support.rs
@@ -29,4 +29,5 @@ cfg_macros! {
 
 pub use std::future::{Future, IntoFuture};
 pub use std::pin::Pin;
-pub use std::task::{Context, Poll};
+pub use std::result::Result;
+pub use std::task::{ready, Context, Poll};

--- a/tokio/src/macros/trace.rs
+++ b/tokio/src/macros/trace.rs
@@ -12,13 +12,13 @@ cfg_trace! {
     macro_rules! trace_poll_op {
         ($name:expr, $poll:expr $(,)*) => {
             match $poll {
-                std::task::Poll::Ready(t) => {
+                $crate::macros::support::Poll::Ready(t) => {
                     trace_op!($name, true);
-                    std::task::Poll::Ready(t)
+                    $crate::macros::support::Poll::Ready(t)
                 }
-                std::task::Poll::Pending => {
+                $crate::macros::support::Poll::Pending => {
                     trace_op!($name, false);
-                    return std::task::Poll::Pending;
+                    return $crate::macros::support::Poll::Pending;
                 }
             }
         };

--- a/tokio/src/macros/try_join.rs
+++ b/tokio/src/macros/try_join.rs
@@ -229,7 +229,7 @@ doc! {macro_rules! try_join {
                     if $crate::macros::support::Future::poll(fut.as_mut(), cx).is_pending() {
                         is_pending = true;
                     } else if fut.as_mut().output_mut().expect("expected completed future").is_err() {
-                        return $crate::macros::support::Poll::Ready(Err(fut.take_output().expect("expected completed future").err().unwrap()))
+                        return $crate::macros::support::Poll::Ready($crate::macros::support::Result::Err(fut.take_output().expect("expected completed future").err().unwrap()))
                     }
                 } else {
                     // Future skipped, one less future to skip in the next iteration
@@ -241,7 +241,7 @@ doc! {macro_rules! try_join {
             if is_pending {
                 $crate::macros::support::Poll::Pending
             } else {
-                $crate::macros::support::Poll::Ready(Ok(($({
+                $crate::macros::support::Poll::Ready($crate::macros::support::Result::Ok(($({
                     // Extract the future for this branch from the tuple.
                     let ( $($skip,)* fut, .. ) = &mut futures;
 


### PR DESCRIPTION
## Motivation

Multiple macro expansions were previously assuming the existence of some
standard library symbols to both be in-scope and referring to the right symbol,
and not only having the same identifier.

## Solution

This has now been refactored into using reexports from the `support` module
under the `macros` module. Some other macro invocations were also using absolute
standard library paths instead of calling into the afore mentioned module
through the special `$crate` metavariable. This has been changed, thus also
reexporting some other items in `support`.