### PR TITLE
chore: prepare tokio-macros v2.7.0

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 2.7.0 (April 3rd, 2026)
+
+- macros: stabilize `LocalRuntime` ([#7557])
+- macros: add runtime name ([#7924])
+
+[#7557]: https://github.com/tokio-rs/tokio/pull/7557
+[#7924]: https://github.com/tokio-rs/tokio/pull/7924
+
 # 2.6.1 (Mar 2nd, 2026)
 
 - macros: improve error message for return type mismatch in #[tokio::main] ([#7856])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
-version = "2.6.1"
+version = "2.7.0"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -90,7 +90,7 @@ io-uring = ["dep:io-uring", "libc", "mio/os-poll", "mio/os-ext", "dep:slab"]
 taskdump = ["dep:backtrace"]
 
 [dependencies]
-tokio-macros = { version = "~2.6.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.7.0", path = "../tokio-macros", optional = true }
 
 pin-project-lite = "0.2.11"
 


### PR DESCRIPTION
# 2.7.0 (April 3rd, 2026)

- macros: stabilize `LocalRuntime` ([#7557])
- macros: add runtime name ([#7924])

[#7557]: https://github.com/tokio-rs/tokio/pull/7557
[#7924]: https://github.com/tokio-rs/tokio/pull/7924