### PR TITLE
chore: remove path deps for tokio-macros 2.7.0

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -27,7 +27,7 @@ quote = "1"
 syn = { version = "2.0", features = ["full"] }
 
 [dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full", "test-util"] }
+tokio = { version = "1.0.0", features = ["full", "test-util"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -90,7 +90,7 @@ io-uring = ["dep:io-uring", "libc", "mio/os-poll", "mio/os-ext", "dep:slab"]
 taskdump = ["dep:backtrace"]
 
 [dependencies]
-tokio-macros = { version = "~2.7.0", path = "../tokio-macros", optional = true }
+tokio-macros = { version = "~2.7.0", optional = true }
 
 pin-project-lite = "0.2.11"
 


### PR DESCRIPTION
Hopefully this works now that 1.51.0 is on crates.io