### PR TITLE
docs: improve contributing docs on how to specify crates dependency versions

### DIFF
--- a/docs/contributing/how-to-specify-crates-dependencies-versions.md
+++ b/docs/contributing/how-to-specify-crates-dependencies-versions.md
@@ -25,7 +25,7 @@ tokio = { version = "1.38.0", path = "../tokio", features = ["sync"] }
 
 In this case, local development of `tokio-stream` uses the local version
 of `tokio` via the `path` dependency. This means that it's currently not
-possible to release `tokio-stream` and `tokio` should be released first.
+possible to release `tokio-stream`, and `tokio` should be released first.
 Once a new version of `tokio` is released (in this example the `1.38.0`),
 the path dependency should be removed.
 As mentioned before, this version should only be bumped when adding a new


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Provide some improvements for the contributing docs related to how to specify creates dependency versions

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->