### PR TITLE
runtime: use compare_exchange_weak() in worker queue

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -298,7 +298,7 @@ impl<T> Local<T> {
         if self
             .inner
             .head
-            .compare_exchange(
+            .compare_exchange_weak(
                 prev,
                 pack(
                     head.wrapping_add(NUM_TASKS_TAKEN),
@@ -387,7 +387,7 @@ impl<T> Local<T> {
             let res = self
                 .inner
                 .head
-                .compare_exchange(head, next, AcqRel, Acquire);
+                .compare_exchange_weak(head, next, AcqRel, Acquire);
 
             match res {
                 Ok(_) => break real as usize & MASK,
@@ -523,7 +523,7 @@ impl<T> Steal<T> {
             let res = self
                 .0
                 .head
-                .compare_exchange(prev_packed, next_packed, AcqRel, Acquire);
+                .compare_exchange_weak(prev_packed, next_packed, AcqRel, Acquire);
 
             match res {
                 Ok(_) => break n,
@@ -572,17 +572,11 @@ impl<T> Steal<T> {
             let res = self
                 .0
                 .head
-                .compare_exchange(prev_packed, next_packed, AcqRel, Acquire);
+                .compare_exchange_weak(prev_packed, next_packed, AcqRel, Acquire);
 
             match res {
                 Ok(_) => return n,
-                Err(actual) => {
-                    let (actual_steal, actual_real) = unpack(actual);
-
-                    assert_ne!(actual_steal, actual_real);
-
-                    prev_packed = actual;
-                }
+                Err(actual) => prev_packed = actual,
             }
         }
     }


### PR DESCRIPTION
I was looking at this code, and I realized there is no reason to use the strong CAS in these cases. If the CAS fails spuriously even though the old value is unchanged, we can just go around the loop and try again, instead of letting the `compare_exchange()` function's internal loop run again.