### PR TITLE
sync: hide `#[tokio::main]` attribute in the docs of `sync::watch`

### DIFF
--- a/tokio/src/sync/watch.rs
+++ b/tokio/src/sync/watch.rs
@@ -111,7 +111,7 @@
 //! ```
 //! use tokio::sync::watch;
 //!
-//! #[tokio::main(flavor = "current_thread")]
+//! # #[tokio::main(flavor = "current_thread")]
 //! # async fn main() {
 //! let (tx, mut rx) = watch::channel("hello");
 //! tx.send("goodbye").unwrap();


### PR DESCRIPTION
This fixes the appearance of the `#[tokio::main(flavor = "current_thread")]` attribute in one of the examples in the documentation of the `watch` module.