### PR TITLE
taskdump: skip double wake on `Trace::capture`/`Trace::trace_with`

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -1,4 +1,4 @@
-323
+324
 &
 +
 <
@@ -89,6 +89,7 @@ decrementing
 demangled
 dequeued
 dereferenced
+derefs
 deregister
 deregistered
 deregistering

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -599,7 +599,7 @@ impl AsyncRead for File {
         cx: &mut Context<'_>,
         dst: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         let me = self.get_mut();
         let inner = me.inner.get_mut();
@@ -694,7 +694,7 @@ impl AsyncSeek for File {
     }
 
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         let inner = self.inner.get_mut();
 
         loop {
@@ -730,7 +730,7 @@ impl AsyncWrite for File {
         cx: &mut Context<'_>,
         src: &[u8],
     ) -> Poll<io::Result<usize>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
@@ -801,7 +801,7 @@ impl AsyncWrite for File {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
@@ -872,13 +872,13 @@ impl AsyncWrite for File {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         let inner = self.inner.get_mut();
         inner.poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         self.poll_flush(cx)
     }
 }
@@ -1077,7 +1077,7 @@ impl Inner {
     }
 
     fn poll_complete_inflight(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         match self.poll_flush(cx) {
             Poll::Ready(Err(e)) => {
                 self.last_write_err = Some(e.kind());

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -82,7 +82,7 @@ impl CopyBuffer {
         R: AsyncRead + ?Sized,
         W: AsyncWrite + ?Sized,
     {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         #[cfg(any(
             feature = "fs",
             feature = "io-std",

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -71,7 +71,7 @@ impl AsyncRead for Empty {
         cx: &mut Context<'_>,
         _: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
@@ -80,7 +80,7 @@ impl AsyncRead for Empty {
 impl AsyncBufRead for Empty {
     #[inline]
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(&[]))
     }
@@ -96,21 +96,21 @@ impl AsyncWrite for Empty {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(buf.len()))
     }
 
     #[inline]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
@@ -126,7 +126,7 @@ impl AsyncWrite for Empty {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         let num_bytes = bufs.iter().map(|b| b.len()).sum();
         Poll::Ready(Ok(num_bytes))
@@ -141,7 +141,7 @@ impl AsyncSeek for Empty {
 
     #[inline]
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(0))
     }

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -331,7 +331,7 @@ impl AsyncRead for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_read_internal(cx, buf);
@@ -348,7 +348,7 @@ impl AsyncRead for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             self.poll_read_internal(cx, buf)
         }
     }
@@ -361,7 +361,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_write_internal(cx, buf);
@@ -378,7 +378,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             self.poll_write_internal(cx, buf)
         }
     }
@@ -389,7 +389,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             bufs: &[std::io::IoSlice<'_>],
         ) -> Poll<Result<usize, std::io::Error>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_write_vectored_internal(cx, bufs);
@@ -406,7 +406,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             bufs: &[std::io::IoSlice<'_>],
         ) -> Poll<Result<usize, std::io::Error>> {
-            ready!(crate::trace::trace_leaf(cx));
+            ready!(crate::trace::trace_leaf());
             self.poll_write_vectored_internal(cx, bufs)
         }
     }

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -56,7 +56,7 @@ impl AsyncRead for Repeat {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         buf.put_bytes(self.byte, buf.remaining());
         Poll::Ready(Ok(()))

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -57,21 +57,21 @@ impl AsyncWrite for Sink {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(buf.len()))
     }
 
     #[inline]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -574,14 +574,14 @@ mod trace {
     cfg_not_taskdump! {
         #[inline(always)]
         #[allow(dead_code)]
-        pub(crate) fn trace_leaf(_: &mut std::task::Context<'_>) -> std::task::Poll<()> {
+        pub(crate) fn trace_leaf() -> std::task::Poll<()> {
             std::task::Poll::Ready(())
         }
     }
 
     #[cfg_attr(not(feature = "sync"), allow(dead_code))]
     pub(crate) async fn async_trace_leaf() {
-        std::future::poll_fn(trace_leaf).await
+        std::future::poll_fn(|_cx| trace_leaf()).await
     }
 }
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1135,7 +1135,7 @@ where
     type Output = Result<T, E>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -227,9 +227,10 @@ impl Trace {
     /// should not be much slower than calling `f` directly.
     ///
     /// Due to the way tracing is implemented, Tokio leaf futures will usually, instead of doing their
-    /// actual work, do the equivalent of a `yield_now` (returning a `Poll::Pending` and scheduling the
-    /// current context for execution), which means forward progress will probably not happen unless
-    /// you eventually call your future outside of `capture`.
+    /// actual work, return `Poll::Pending` without registering the task's waker with any driver.
+    /// This means forward progress will probably not happen unless you eventually call your future
+    /// outside of `capture`, or explicitly re-schedule the task (e.g. by calling
+    /// [`cx.waker().wake_by_ref()`][std::task::Waker::wake_by_ref]) after `capture` returns.
     ///
     /// [`Handle::dump`]: crate::runtime::Handle::dump
     ///

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -267,7 +267,7 @@ impl Trace {
     where
         F: FnOnce() -> R,
     {
-        let (res, trace) = super::task::trace::Trace::capture(f);
+        let (res, trace) = super::task::trace::Trace::capture_and_defer_wake(f);
         (res, Trace { inner: trace })
     }
 

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -146,7 +146,7 @@ impl Registration {
         cx: &mut Context<'_>,
         direction: Direction,
     ) -> Poll<io::Result<ReadyEvent>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
         let ev = ready!(self.shared.poll_readiness(cx, direction));

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -325,7 +325,7 @@ impl<T> Future for JoinHandle<T> {
     type Output = super::Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         let mut ret = Poll::Pending;
 
         // Keep track of task budget

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -509,6 +509,22 @@ impl<S: Schedule> LocalNotified<S> {
         mem::forget(self);
         raw.poll();
     }
+
+    /// Returns a new `Waker` for this task.
+    ///
+    /// The returned `Waker` is ref-counted independently of this
+    /// `LocalNotified`; it remains valid after the task is polled.
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        feature = "rt",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+    ))]
+    pub(crate) fn waker(&self) -> std::task::Waker {
+        let header_ptr = self.task.raw.header_ptr();
+        waker::waker_ref::<S>(&header_ptr).clone()
+    }
 }
 
 impl<S: Schedule> UnownedTask<S> {

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -510,10 +510,9 @@ impl<S: Schedule> LocalNotified<S> {
         raw.poll();
     }
 
-    /// Returns a new `Waker` for this task.
+    /// Returns a `WakerRef` borrowing from this task.
     ///
-    /// The returned `Waker` is ref-counted independently of this
-    /// `LocalNotified`; it remains valid after the task is polled.
+    /// `WakerRef` derefs to `Waker` without bumping the task's refcount.
     #[cfg(all(
         tokio_unstable,
         feature = "taskdump",
@@ -521,9 +520,8 @@ impl<S: Schedule> LocalNotified<S> {
         target_os = "linux",
         any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
     ))]
-    pub(crate) fn waker(&self) -> std::task::Waker {
-        let header_ptr = self.task.raw.header_ptr();
-        waker::waker_ref::<S>(&header_ptr).clone()
+    pub(crate) fn waker_ref(&self) -> waker::WakerRef<'_, S> {
+        waker::waker_ref::<S>(self.task.raw.header_ptr_ref())
     }
 }
 

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -242,6 +242,17 @@ impl RawTask {
         self.ptr
     }
 
+    #[cfg(all(
+        tokio_unstable,
+        feature = "taskdump",
+        feature = "rt",
+        target_os = "linux",
+        any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+    ))]
+    pub(super) fn header_ptr_ref(&self) -> &NonNull<Header> {
+        &self.ptr
+    }
+
     pub(super) fn trailer_ptr(&self) -> NonNull<Trailer> {
         unsafe { Header::get_trailer(self.ptr) }
     }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -34,7 +34,7 @@ pub(crate) struct Context {
     /// The function that is invoked at each leaf future inside of Tokio
     ///
     /// For example, within tokio::time:sleep, sockets. etc.
-    trace_leaf_fn: Cell<Option<fn(&TraceMeta)>>,
+    trace_leaf_fn: Cell<Option<NonNull<dyn FnMut(&TraceMeta)>>>,
 }
 
 /// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
@@ -114,19 +114,38 @@ impl Context {
         }
     }
 
+    /// Calls the provided closure if we are being traced.
     fn try_with_current_trace_leaf_fn<F, R>(f: F) -> Option<R>
     where
-        F: FnOnce(&Cell<Option<fn(&TraceMeta)>>) -> R,
+        F: for<'a> FnOnce(&'a mut dyn FnMut(&TraceMeta)) -> R,
     {
+        let mut ret = None;
+
+        let inner = |context: &Context| {
+            if let Some(mut trace_leaf_fn) = context.trace_leaf_fn.get() {
+                context.trace_leaf_fn.set(None);
+                let _restore = defer(move || {
+                    context.trace_leaf_fn.set(Some(trace_leaf_fn));
+                });
+
+                // SAFETY: The trace leaf fn is valid for the duration in which it's stored in the
+                // context. Furthermore, re-entrant calls are not possible since we store `None` for
+                // the duration in which we hold a mutable reference, so access is exclusive for that
+                // duration.
+                ret = Some(f(unsafe { trace_leaf_fn.as_mut() }));
+            }
+        };
+
         // SAFETY: This call can only access the trace_leaf_fn field, so it cannot
         // break the trace frame linked list.
-        unsafe { Self::try_with_current(|context| f(&context.trace_leaf_fn)) }
+        unsafe { Self::try_with_current(inner) };
+
+        ret
     }
 
     /// Produces `true` if the current task is being traced; otherwise false.
     pub(crate) fn is_tracing() -> bool {
-        Self::try_with_current_trace_leaf_fn(|maybe_trace_leaf| maybe_trace_leaf.get().is_some())
-            .unwrap_or(false)
+        Self::try_with_current_trace_leaf_fn(|_| ()).is_some()
     }
 }
 
@@ -189,20 +208,46 @@ pub struct TraceMeta {
 /// assert!(count > 0);
 /// # }
 /// ```
-pub fn trace_with<F, R>(f: F, trace_leaf: fn(&TraceMeta)) -> R
+pub fn trace_with<FN, FT, R>(f: FN, mut trace_leaf: FT) -> R
 where
-    F: FnOnce() -> R,
+    FN: FnOnce() -> R,
+    FT: FnMut(&TraceMeta),
 {
-    // store our new trace_leaf function
-    let previous =
-        Context::try_with_current_trace_leaf_fn(|current| current.replace(Some(trace_leaf)));
+    let trace_leaf_dyn = (&mut trace_leaf) as &mut (dyn FnMut(&TraceMeta) + '_);
+    // SAFETY: The raw pointer is removed from the thread local before `trace_leaf` is dropped, so
+    // this transmute cannot lead to the violation of any lifetime requirements.
+    let trace_leaf_dyn = unsafe {
+        std::mem::transmute::<
+            *mut (dyn FnMut(&TraceMeta) + '_),
+            *mut (dyn FnMut(&TraceMeta) + 'static),
+        >(trace_leaf_dyn)
+    };
+    // SAFETY: Pointer comes from reference, so not null.
+    let trace_leaf_dyn = unsafe { NonNull::new_unchecked(trace_leaf_dyn) };
 
-    // restore previous on drop. This is ensures state remains consistent
-    // even if the trace_leaf function panics
+    let mut old_trace_leaf_fn = None;
+
+    // Even if this access fails, that's okay. In that case, we still call the closure without
+    // actually performing any tracing.
+    //
+    // SAFETY: This call can only access the trace_leaf_fn field, so it cannot
+    // break the trace frame linked list.
+    unsafe {
+        Context::try_with_current(|ctx| {
+            old_trace_leaf_fn = ctx.trace_leaf_fn.replace(Some(trace_leaf_dyn));
+        })
+    };
+
     let _restore = defer(move || {
-        if let Some(previous) = previous {
-            Context::try_with_current_trace_leaf_fn(|current| current.set(previous));
-        }
+        // This ensures that `trace_leaf_fn` cannot be accessed after this call returns.
+        //
+        // SAFETY: This call can only access the trace_leaf_fn field, so it cannot
+        // break the trace frame linked list.
+        unsafe {
+            Context::try_with_current(|ctx| {
+                ctx.trace_leaf_fn.set(old_trace_leaf_fn);
+            })
+        };
     });
 
     f()
@@ -249,13 +294,14 @@ impl Trace {
 // internal implementation details of this crate).
 #[inline(never)]
 pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
-    let trace_leaf_fn = Context::try_with_current_trace_leaf_fn(|cell| cell.get()).flatten();
-    if let Some(trace_leaf_fn) = trace_leaf_fn {
+    let root_addr = Context::current_frame_addr();
+
+    let ret = Context::try_with_current_trace_leaf_fn(|leaf_fn| {
         let meta = TraceMeta {
-            root_addr: Context::current_frame_addr(),
+            root_addr,
             trace_leaf_addr: trace_leaf as *const c_void,
         };
-        trace_leaf_fn(&meta);
+        leaf_fn(&meta);
 
         // Use the same logic that `yield_now` uses to send out wakeups after
         // the task yields.
@@ -268,10 +314,11 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
                 }
             }
         });
+    });
 
-        Poll::Pending
-    } else {
-        Poll::Ready(())
+    match ret {
+        Some(()) => Poll::Pending,
+        None => Poll::Ready(()),
     }
 }
 

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -34,6 +34,7 @@ pub(crate) struct Context {
     /// The function that is invoked at each leaf future inside of Tokio
     ///
     /// For example, within tokio::time:sleep, sockets. etc.
+    #[allow(clippy::type_complexity)]
     trace_leaf_fn: Cell<Option<NonNull<dyn FnMut(&TraceMeta)>>>,
 }
 

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::ptr::NonNull;
-use std::task::{self, Poll};
+use std::task::{self, Poll, Waker};
 
 mod symbol;
 mod trace_impl;
@@ -35,7 +35,7 @@ pub(crate) struct Context {
     ///
     /// For example, within tokio::time:sleep, sockets. etc.
     #[allow(clippy::type_complexity)]
-    trace_leaf_fn: Cell<Option<NonNull<dyn FnMut(&TraceMeta)>>>,
+    trace_leaf_fn: Cell<Option<NonNull<dyn for<'a> FnMut(&TraceMeta<'a>)>>>,
 }
 
 /// A [`Frame`] in an intrusive, doubly-linked tree of [`Frame`]s.
@@ -118,7 +118,7 @@ impl Context {
     /// Calls the provided closure if we are being traced.
     fn try_with_current_trace_leaf_fn<F, R>(f: F) -> Option<R>
     where
-        F: for<'a> FnOnce(&'a mut dyn FnMut(&TraceMeta)) -> R,
+        F: for<'a> FnOnce(&'a mut dyn for<'b> FnMut(&TraceMeta<'b>)) -> R,
     {
         let mut ret = None;
 
@@ -153,7 +153,7 @@ impl Context {
 /// Metadata passed into the `trace_leaf` callback for [`trace_with`]
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct TraceMeta {
+pub struct TraceMeta<'a> {
     /// The root boundary address set by [`Root::poll`] if any.
     ///
     /// When using unwinding the stack, this is the address at which
@@ -165,6 +165,12 @@ pub struct TraceMeta {
     /// When capturing a backtrace, use this as the lower bound — frames at or below
     /// this address are internal implementation details and should be excluded.
     pub trace_leaf_addr: *const c_void,
+
+    /// The [`Waker`] for the task context being traced.
+    ///
+    /// Trace callbacks that need to re-schedule the task (e.g. during a full
+    /// runtime dump) can use this to defer a wakeup.
+    pub waker: &'a Waker,
 }
 
 /// Runs `f`. If `f` hits a Tokio yield point `trace_leaf` will be invoked.
@@ -189,7 +195,7 @@ pub struct TraceMeta {
 ///     static LEAF_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
 /// }
 ///
-/// fn my_trace_leaf(_meta: &TraceMeta) {
+/// fn my_trace_leaf(_meta: &TraceMeta<'_>) {
 ///     LEAF_COUNT.with(|c| c.set(c.get() + 1));
 /// }
 ///
@@ -212,15 +218,15 @@ pub struct TraceMeta {
 pub fn trace_with<FN, FT, R>(f: FN, mut trace_leaf: FT) -> R
 where
     FN: FnOnce() -> R,
-    FT: FnMut(&TraceMeta),
+    FT: for<'a> FnMut(&TraceMeta<'a>),
 {
-    let trace_leaf_dyn = (&mut trace_leaf) as &mut (dyn FnMut(&TraceMeta) + '_);
+    let trace_leaf_dyn = (&mut trace_leaf) as &mut (dyn for<'a> FnMut(&TraceMeta<'a>) + '_);
     // SAFETY: The raw pointer is removed from the thread local before `trace_leaf` is dropped, so
     // this transmute cannot lead to the violation of any lifetime requirements.
     let trace_leaf_dyn = unsafe {
         std::mem::transmute::<
-            *mut (dyn FnMut(&TraceMeta) + '_),
-            *mut (dyn FnMut(&TraceMeta) + 'static),
+            *mut (dyn for<'a> FnMut(&TraceMeta<'a>) + '_),
+            *mut (dyn for<'a> FnMut(&TraceMeta<'a>) + 'static),
         >(trace_leaf_dyn)
     };
     // SAFETY: Pointer comes from reference, so not null.
@@ -257,12 +263,35 @@ where
 impl Trace {
     /// Invokes `f`, returning both its result and the collection of backtraces
     /// captured at each sub-invocation of [`trace_leaf`].
+    ///
+    /// After the tracing is complete, a deferred wakeup is scheduled
     #[inline(never)]
-    pub(crate) fn capture<F, R>(f: F) -> (R, Trace)
+    pub(crate) fn capture_and_defer_wake<F, R>(f: F) -> (R, Trace)
     where
         F: FnOnce() -> R,
     {
-        trace_impl::capture(f)
+        let mut trace = Trace::empty();
+
+        let result = trace_with(f, |meta| {
+            // Capture the backtrace.
+            trace_impl::trace_leaf(meta, &mut trace);
+
+            // Use the same logic that `yield_now` uses to send out wakeups
+            // after the task yields. This is only needed during a full
+            // runtime dump so that tasks are re-queued after being polled
+            // for tracing.
+            context::with_scheduler(|scheduler| {
+                if let Some(scheduler) = scheduler {
+                    match scheduler {
+                        scheduler::Context::CurrentThread(s) => s.defer.defer(meta.waker),
+                        #[cfg(feature = "rt-multi-thread")]
+                        scheduler::Context::MultiThread(s) => s.defer.defer(meta.waker),
+                    }
+                }
+            });
+        });
+
+        (result, trace)
     }
 
     pub(crate) fn empty() -> Self {
@@ -301,20 +330,9 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
         let meta = TraceMeta {
             root_addr,
             trace_leaf_addr: trace_leaf as *const c_void,
+            waker: cx.waker(),
         };
         leaf_fn(&meta);
-
-        // Use the same logic that `yield_now` uses to send out wakeups after
-        // the task yields.
-        context::with_scheduler(|scheduler| {
-            if let Some(scheduler) = scheduler {
-                match scheduler {
-                    scheduler::Context::CurrentThread(s) => s.defer.defer(cx.waker()),
-                    #[cfg(feature = "rt-multi-thread")]
-                    scheduler::Context::MultiThread(s) => s.defer.defer(cx.waker()),
-                }
-            }
-        });
     });
 
     match ret {
@@ -464,7 +482,7 @@ fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -
         .map(|task| {
             let local_notified = owned.assert_owner(task);
             let id = local_notified.task.id();
-            let ((), trace) = Trace::capture(|| local_notified.run());
+            let ((), trace) = Trace::capture_and_defer_wake(|| local_notified.run());
             (id, trace)
         })
         .collect()

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -257,7 +257,9 @@ impl Trace {
     where
         F: FnOnce() -> R,
     {
-        trace_impl::capture(f)
+        let mut trace = Trace::empty();
+        let result = trace_with(f, |meta| trace_impl::trace_leaf(meta, &mut trace));
+        (result, trace)
     }
 
     pub(crate) fn empty() -> Self {
@@ -279,17 +281,17 @@ impl Trace {
     }
 }
 
-/// If this is a sub-invocation of [`Trace::capture`], capture a backtrace.
+/// If this is a sub-invocation of [`trace_with`], capture a backtrace.
 ///
-/// The captured backtrace will be returned by [`Trace::capture`].
+/// The captured backtrace will be returned by [`trace_with`].
 ///
 /// Invoking this function does nothing when it is not a sub-invocation
-/// [`Trace::capture`].
+/// [`trace_with`].
 // This function is marked `#[inline(never)]` to ensure that it gets a distinct `Frame` in the
 // backtrace, below which frames should not be included in the backtrace (since they reflect the
 // internal implementation details of this crate).
 #[inline(never)]
-pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
+pub(crate) fn trace_leaf() -> Poll<()> {
     let root_addr = Context::current_frame_addr();
 
     let ret = Context::try_with_current_trace_leaf_fn(|leaf_fn| {
@@ -298,18 +300,6 @@ pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
             trace_leaf_addr: trace_leaf as *const c_void,
         };
         leaf_fn(&meta);
-
-        // Use the same logic that `yield_now` uses to send out wakeups after
-        // the task yields.
-        context::with_scheduler(|scheduler| {
-            if let Some(scheduler) = scheduler {
-                match scheduler {
-                    scheduler::Context::CurrentThread(s) => s.defer.defer(cx.waker()),
-                    #[cfg(feature = "rt-multi-thread")]
-                    scheduler::Context::MultiThread(s) => s.defer.defer(cx.waker()),
-                }
-            }
-        });
     });
 
     match ret {
@@ -459,6 +449,25 @@ fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -
         .map(|task| {
             let local_notified = owned.assert_owner(task);
             let id = local_notified.task.id();
+
+            // Re-enqueue the task's waker on the scheduler's defer queue so
+            // the task is polled again after the dump completes. This is the
+            // same mechanism `yield_now` uses; the defer queue is drained
+            // after `trace_current_thread` / `trace_multi_thread` returns.
+            //
+            // We do this before polling so that the waker lives independently
+            // of the `LocalNotified` we are about to consume in `run()`.
+            let waker = local_notified.waker();
+            context::with_scheduler(|scheduler| {
+                if let Some(scheduler) = scheduler {
+                    match scheduler {
+                        scheduler::Context::CurrentThread(s) => s.defer.defer(&waker),
+                        #[cfg(feature = "rt-multi-thread")]
+                        scheduler::Context::MultiThread(s) => s.defer.defer(&waker),
+                    }
+                }
+            });
+
             let ((), trace) = Trace::capture(|| local_notified.run());
             (id, trace)
         })

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -455,15 +455,17 @@ fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -
             // same mechanism `yield_now` uses; the defer queue is drained
             // after `trace_current_thread` / `trace_multi_thread` returns.
             //
-            // We do this before polling so that the waker lives independently
-            // of the `LocalNotified` we are about to consume in `run()`.
-            let waker = local_notified.waker();
+            // We do this before polling so the borrow of the task ends before
+            // the `LocalNotified` is consumed in `run()`. `defer` clones the
+            // waker into its own queue, so the deferred entry outlives the
+            // `WakerRef` here.
+            let waker_ref = local_notified.waker_ref();
             context::with_scheduler(|scheduler| {
                 if let Some(scheduler) = scheduler {
                     match scheduler {
-                        scheduler::Context::CurrentThread(s) => s.defer.defer(&waker),
+                        scheduler::Context::CurrentThread(s) => s.defer.defer(&waker_ref),
                         #[cfg(feature = "rt-multi-thread")]
-                        scheduler::Context::MultiThread(s) => s.defer.defer(&waker),
+                        scheduler::Context::MultiThread(s) => s.defer.defer(&waker_ref),
                     }
                 }
             });

--- a/tokio/src/runtime/task/trace/trace_impl.rs
+++ b/tokio/src/runtime/task/trace/trace_impl.rs
@@ -2,24 +2,9 @@
 //!
 //! This implementation may eventually be extracted into a separate `tokio-taskdump` crate.
 
-use std::{cell::Cell, ptr};
+use std::ptr;
 
 use crate::runtime::task::trace::{trace_with, Trace, TraceMeta};
-
-use super::defer;
-
-/// Thread local state used to communicate between calling the trace and the interior `trace_leaf` function
-struct TraceContext {
-    collector: Cell<Option<Trace>>,
-}
-
-thread_local! {
-    static TRACE_CONTEXT: TraceContext = const {
-        TraceContext {
-            collector: Cell::new(None),
-        }
-    };
-}
 
 /// Capture using the default `backtrace::trace`-based implementation.
 #[inline(never)]
@@ -27,48 +12,32 @@ pub(super) fn capture<F, R>(f: F) -> (R, Trace)
 where
     F: FnOnce() -> R,
 {
-    let collector = Trace::empty();
+    let mut trace = Trace::empty();
 
-    let previous = TRACE_CONTEXT.with(|state| state.collector.replace(Some(collector)));
+    let result = trace_with(f, |meta| trace_leaf(meta, &mut trace));
 
-    // restore previous collector on drop even if the callback panics
-    let _restore = defer(move || {
-        TRACE_CONTEXT.with(|state| state.collector.set(previous));
-    });
-
-    let result = trace_with(f, trace_leaf);
-
-    // take the collector before _restore runs
-    let collector = TRACE_CONTEXT.with(|state| state.collector.take()).unwrap();
-
-    (result, collector)
+    (result, trace)
 }
 
-/// Capture a backtrace via `backtrace::trace` and collect it into `STATE`
-#[inline(never)]
-pub(crate) fn trace_leaf(meta: &TraceMeta) {
-    TRACE_CONTEXT.with(|state| {
-        if let Some(mut collector) = state.collector.take() {
-            let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
-            let mut above_leaf = false;
+/// Capture a backtrace via `backtrace::trace` and collect it into `trace`.
+pub(crate) fn trace_leaf(meta: &TraceMeta, trace: &mut Trace) {
+    let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
+    let mut above_leaf = false;
 
-            if let Some(root_addr) = meta.root_addr {
-                backtrace::trace(|frame| {
-                    let below_root = !ptr::eq(frame.symbol_address(), root_addr);
+    if let Some(root_addr) = meta.root_addr {
+        backtrace::trace(|frame| {
+            let below_root = !ptr::eq(frame.symbol_address(), root_addr);
 
-                    if above_leaf && below_root {
-                        frames.push(frame.to_owned().into());
-                    }
-
-                    if ptr::eq(frame.symbol_address(), meta.trace_leaf_addr) {
-                        above_leaf = true;
-                    }
-
-                    below_root
-                });
+            if above_leaf && below_root {
+                frames.push(frame.to_owned().into());
             }
-            collector.push_backtrace(frames);
-            state.collector.set(Some(collector));
-        }
-    });
+
+            if ptr::eq(frame.symbol_address(), meta.trace_leaf_addr) {
+                above_leaf = true;
+            }
+
+            below_root
+        });
+    }
+    trace.push_backtrace(frames);
 }

--- a/tokio/src/runtime/task/trace/trace_impl.rs
+++ b/tokio/src/runtime/task/trace/trace_impl.rs
@@ -4,20 +4,7 @@
 
 use std::ptr;
 
-use crate::runtime::task::trace::{trace_with, Trace, TraceMeta};
-
-/// Capture using the default `backtrace::trace`-based implementation.
-#[inline(never)]
-pub(super) fn capture<F, R>(f: F) -> (R, Trace)
-where
-    F: FnOnce() -> R,
-{
-    let mut trace = Trace::empty();
-
-    let result = trace_with(f, |meta| trace_leaf(meta, &mut trace));
-
-    (result, trace)
-}
+use crate::runtime::task::trace::{Trace, TraceMeta};
 
 /// Capture a backtrace via `backtrace::trace` and collect it into `trace`.
 pub(crate) fn trace_leaf(meta: &TraceMeta, trace: &mut Trace) {

--- a/tokio/src/runtime/task/trace/trace_impl.rs
+++ b/tokio/src/runtime/task/trace/trace_impl.rs
@@ -4,23 +4,10 @@
 
 use std::ptr;
 
-use crate::runtime::task::trace::{trace_with, Trace, TraceMeta};
-
-/// Capture using the default `backtrace::trace`-based implementation.
-#[inline(never)]
-pub(super) fn capture<F, R>(f: F) -> (R, Trace)
-where
-    F: FnOnce() -> R,
-{
-    let mut trace = Trace::empty();
-
-    let result = trace_with(f, |meta| trace_leaf(meta, &mut trace));
-
-    (result, trace)
-}
+use crate::runtime::task::trace::{Trace, TraceMeta};
 
 /// Capture a backtrace via `backtrace::trace` and collect it into `trace`.
-pub(crate) fn trace_leaf(meta: &TraceMeta, trace: &mut Trace) {
+pub(crate) fn trace_leaf(meta: &TraceMeta<'_>, trace: &mut Trace) {
     let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
     let mut above_leaf = false;
 

--- a/tokio/src/runtime/task/waker.rs
+++ b/tokio/src/runtime/task/waker.rs
@@ -6,7 +6,7 @@ use std::ops;
 use std::ptr::NonNull;
 use std::task::{RawWaker, RawWakerVTable, Waker};
 
-pub(super) struct WakerRef<'a, S: 'static> {
+pub(crate) struct WakerRef<'a, S: 'static> {
     waker: ManuallyDrop<Waker>,
     _p: PhantomData<(&'a Header, S)>,
 }

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -576,7 +576,7 @@ impl Future for Acquire<'_> {
     type Output = Result<(), AcquireError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let _resource_span = self.node.ctx.resource_span.clone().entered();

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1605,7 +1605,7 @@ where
     type Output = Result<T, RecvError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         let (receiver, waiter) = self.project();
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -289,7 +289,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     pub(crate) fn recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         use super::block::Read;
 
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
@@ -349,7 +349,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     ) -> Poll<usize> {
         use super::block::Read;
 
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1227,9 +1227,8 @@ impl NotifiedProject<'_> {
                 }
                 State::Waiting => {
                     #[cfg(feature = "taskdump")]
-                    if let Some(waker) = waker {
-                        let mut ctx = Context::from_waker(waker);
-                        std::task::ready!(crate::trace::trace_leaf(&mut ctx));
+                    if let Some(_waker) = waker {
+                        std::task::ready!(crate::trace::trace_leaf());
                     }
 
                     if waiter.notification.load(Acquire).is_some() {
@@ -1321,9 +1320,8 @@ impl NotifiedProject<'_> {
                 }
                 State::Done => {
                     #[cfg(feature = "taskdump")]
-                    if let Some(waker) = waker {
-                        let mut ctx = Context::from_waker(waker);
-                        std::task::ready!(crate::trace::trace_leaf(&mut ctx));
+                    if let Some(_waker) = waker {
+                        std::task::ready!(crate::trace::trace_leaf());
                     }
                     return Poll::Ready(());
                 }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -818,7 +818,7 @@ impl<T> Sender<T> {
     /// # }
     /// ```
     pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
@@ -1313,7 +1313,7 @@ impl<T> Inner<T> {
     }
 
     fn poll_recv(&self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 

--- a/tokio/src/task/coop/consume_budget.rs
+++ b/tokio/src/task/coop/consume_budget.rs
@@ -26,7 +26,7 @@ pub async fn consume_budget() {
     let mut status = std::task::Poll::Pending;
 
     std::future::poll_fn(move |cx| {
-        std::task::ready!(crate::trace::trace_leaf(cx));
+        std::task::ready!(crate::trace::trace_leaf());
         if status.is_ready() {
             return status;
         }

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -38,7 +38,7 @@ use std::task::{ready, Poll};
 pub async fn yield_now() {
     let mut yielded = false;
     poll_fn(|cx| {
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         if yielded {
             return Poll::Ready(());

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -417,7 +417,7 @@ impl Sleep {
     fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         let me = self.project();
 
-        ready!(crate::trace::trace_leaf(cx));
+        ready!(crate::trace::trace_leaf());
 
         // Keep track of task budget
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -109,48 +109,41 @@ async fn task_trace_self() {
 
 /// Collect frames between `trace_leaf_for_test` and `root_addr` using
 /// `backtrace::trace`, resolve them, and store pretty-printed symbol names
-/// (with compiler hashes stripped) into `TRACE_WITH_LOG`.
+/// (with compiler hashes stripped) into `logs`.
 #[inline(never)]
-fn trace_leaf_for_test(meta: &TraceMeta) {
-    TRACE_WITH_LOG.with(|log| {
-        let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
-        let mut above_leaf = false;
+fn trace_leaf_for_test(meta: &TraceMeta, log: &mut Vec<Vec<String>>) {
+    let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
+    let mut above_leaf = false;
 
-        if let Some(root_addr) = meta.root_addr {
-            backtrace::trace(|frame| {
-                let below_root = !ptr::eq(frame.symbol_address(), root_addr);
+    if let Some(root_addr) = meta.root_addr {
+        backtrace::trace(|frame| {
+            let below_root = !ptr::eq(frame.symbol_address(), root_addr);
 
-                if above_leaf && below_root {
-                    frames.push(frame.to_owned().into());
-                }
+            if above_leaf && below_root {
+                frames.push(frame.to_owned().into());
+            }
 
-                if ptr::eq(frame.symbol_address(), meta.trace_leaf_addr) {
-                    above_leaf = true;
-                }
+            if ptr::eq(frame.symbol_address(), meta.trace_leaf_addr) {
+                above_leaf = true;
+            }
 
-                below_root
-            });
-        }
+            below_root
+        });
+    }
 
-        // Resolve frames into human-readable symbol names with hashes stripped.
-        let mut bt = backtrace::Backtrace::from(frames);
-        bt.resolve();
-        let mut names = vec![];
-        for frame in bt.frames() {
-            for symbol in frame.symbols() {
-                if let Some(name) = symbol.name() {
-                    names.push(strip_symbol_hash(&format!("{name}")).to_owned());
-                }
+    // Resolve frames into human-readable symbol names with hashes stripped.
+    let mut bt = backtrace::Backtrace::from(frames);
+    bt.resolve();
+    let mut names = vec![];
+    for frame in bt.frames() {
+        for symbol in frame.symbols() {
+            if let Some(name) = symbol.name() {
+                names.push(strip_symbol_hash(&format!("{name}")).to_owned());
             }
         }
+    }
 
-        log.borrow_mut().push(names);
-    });
-}
-
-thread_local! {
-    static TRACE_WITH_LOG: std::cell::RefCell<Vec<Vec<String>>> =
-        const { std::cell::RefCell::new(vec![]) };
+    log.push(names);
 }
 
 /// Strip the trailing `::h<hex>` hash that rustc appends to symbol names.
@@ -197,13 +190,17 @@ impl<F: Future> Future for TaskDump<F> {
             Poll::Pending => {}
         };
 
+        let mut logs = Vec::new();
+
         // Tracing poll with a noop waker. If the future is at a yield
         // point, trace_leaf fires our callback and returns Pending. We discard
         // the result — this poll is purely for capturing the backtrace.
         let noop = futures::task::noop_waker();
         let mut noop_cx = Context::from_waker(&noop);
-        let logs = this.logs.clone();
-        let trace_poll = trace_with(|| this.f.as_mut().poll(&mut noop_cx), trace_leaf_for_test);
+        let trace_poll = trace_with(
+            || this.f.as_mut().poll(&mut noop_cx),
+            |meta| trace_leaf_for_test(meta, &mut logs),
+        );
         // trace should always produce poll pending
         assert!(
             matches!(trace_poll, Poll::Pending),
@@ -211,11 +208,7 @@ impl<F: Future> Future for TaskDump<F> {
         );
 
         // Drain any frames captured by trace_leaf_for_test into our log.
-        TRACE_WITH_LOG.with(|tl| {
-            let mut tl = tl.borrow_mut();
-            let mut dest = logs.lock().unwrap();
-            dest.append(&mut tl);
-        });
+        this.logs.lock().unwrap().extend(logs);
         Poll::Pending
     }
 }

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -61,6 +61,10 @@ impl<F: Future> Future for PrettyFuture<F> {
             let (res, trace) = tokio::runtime::dump::Trace::capture(|| this.f.as_mut().poll(cx));
             this.logs.lock().unwrap().push(trace);
             *this.t_last = State::Alerted;
+            // `Trace::capture` does not reschedule the task. Wake the task
+            // ourselves so the wrapped future gets polled again and can make
+            // progress now that tracing has captured its state.
+            cx.waker().wake_by_ref();
             return res;
         }
         this.f.poll(cx)
@@ -184,21 +188,16 @@ impl<F: Future> Future for TaskDump<F> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
         let mut this = self.project();
 
-        // Poll the future with a real waker. if it returns Ready, exit immediately
-        match this.f.as_mut().poll(cx) {
-            Poll::Ready(result) => return Poll::Ready(result),
-            Poll::Pending => {}
+        // if the future is ready, exit immediately
+        if let Poll::Ready(result) = this.f.as_mut().poll(cx) {
+            return Poll::Ready(result);
         };
 
+        // if is pending, trace its location:
         let mut logs = Vec::new();
 
-        // Tracing poll with a noop waker. If the future is at a yield
-        // point, trace_leaf fires our callback and returns Pending. We discard
-        // the result — this poll is purely for capturing the backtrace.
-        let noop = futures::task::noop_waker();
-        let mut noop_cx = Context::from_waker(&noop);
         let trace_poll = trace_with(
-            || this.f.as_mut().poll(&mut noop_cx),
+            || this.f.as_mut().poll(cx),
             |meta| trace_leaf_for_test(meta, &mut logs),
         );
         // trace should always produce poll pending

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -111,7 +111,7 @@ async fn task_trace_self() {
 /// `backtrace::trace`, resolve them, and store pretty-printed symbol names
 /// (with compiler hashes stripped) into `logs`.
 #[inline(never)]
-fn trace_leaf_for_test(meta: &TraceMeta, log: &mut Vec<Vec<String>>) {
+fn trace_leaf_for_test(meta: &TraceMeta<'_>, log: &mut Vec<Vec<String>>) {
     let mut frames: Vec<backtrace::BacktraceFrame> = vec![];
     let mut above_leaf = false;
 
@@ -184,21 +184,16 @@ impl<F: Future> Future for TaskDump<F> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<F::Output> {
         let mut this = self.project();
 
-        // Poll the future with a real waker. if it returns Ready, exit immediately
-        match this.f.as_mut().poll(cx) {
-            Poll::Ready(result) => return Poll::Ready(result),
-            Poll::Pending => {}
+        // if the future is ready, exit immediately
+        if let Poll::Ready(result) = this.f.as_mut().poll(cx) {
+            return Poll::Ready(result);
         };
 
+        // if is pending, trace its location:
         let mut logs = Vec::new();
 
-        // Tracing poll with a noop waker. If the future is at a yield
-        // point, trace_leaf fires our callback and returns Pending. We discard
-        // the result — this poll is purely for capturing the backtrace.
-        let noop = futures::task::noop_waker();
-        let mut noop_cx = Context::from_waker(&noop);
         let trace_poll = trace_with(
-            || this.f.as_mut().poll(&mut noop_cx),
+            || this.f.as_mut().poll(cx),
             |meta| trace_leaf_for_test(meta, &mut logs),
         );
         // trace should always produce poll pending


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

> This is a _subtly_ breaking change but I think is very unlikely to break any actual code.

Previously, when `Trace::capture` was called, the task was always scheduled to be woken again. This is really problematic if you want to make a wrapper future that takes a TaskDump; When you capture a task dump you will immediately get polled again. If you capture a task dump on every poll, you have caused an infinite loop!

The alternative I tried was passing a no-op waker. This works _most_ of the time, but in a few edge cases can cause lost wakes.

This moves the rewake to only user that actually _wants_ to rewake the future, the `dump` path where we are trying to dump all futures.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Move the deferred wake into `Runtime::dump`. Expose a `waker` accessor to enable this.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

_Assisted by Claude Opus 4.7_
