### PR TITLE
chore: perpare 1.52.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.1", features = ["full"] }
+tokio = { version = "1.52.0", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,49 @@
+# 1.52.0 (April 14th, 2026)
+
+## Added
+
+- io: `AioSource::register_borrowed` for I/O safety support ([#7992])
+- net: add `try_io` function to `unix::pipe` sender and receiver types 
+  ([#8030])
+
+## Added (unstable)
+
+- runtime: `Builder::enable_eager_driver_handoff` setting enable eager hand  
+  off of the I/O and time drivers before polling tasks ([#8010])
+- taskdump: add `trace_with()` for customized task dumps ([#8025])
+- taskdump: allow `impl FnMut()` in `trace_with`` instead of just `fn()` 
+  ([#8040])
+- fs: support `io_uring` in `AsyncRead` for `File` ([#7907])
+
+## Changed
+
+- runtime: improve `spawn_blocking` scalability with sharded queue ([#7757])
+- runtime: use `compare_exchange_weak()` in worker queue ([#8028])
+
+## Fixed
+
+- runtime: overflow second half of tasks when local queue is filled instead of
+  first half ([#8029])
+
+## Documented
+
+- docs: fix typo in `oneshot::Sender::send` docs ([#8026])
+- docs: hide #[tokio::main] attribute in the docs of `sync::watch` ([#8035])
+- net: add docs on `ConnectionRefused` errors with UDP sockets ([#7870])
+
+[#7757]: https://github.com/tokio-rs/tokio/pull/7757
+[#7870]: https://github.com/tokio-rs/tokio/pull/7870
+[#7907]: https://github.com/tokio-rs/tokio/pull/7907
+[#7992]: https://github.com/tokio-rs/tokio/pull/7992
+[#8010]: https://github.com/tokio-rs/tokio/pull/8010
+[#8025]: https://github.com/tokio-rs/tokio/pull/8025
+[#8026]: https://github.com/tokio-rs/tokio/pull/8026
+[#8028]: https://github.com/tokio-rs/tokio/pull/8028
+[#8029]: https://github.com/tokio-rs/tokio/pull/8029
+[#8030]: https://github.com/tokio-rs/tokio/pull/8030
+[#8035]: https://github.com/tokio-rs/tokio/pull/8035
+[#8040]: https://github.com/tokio-rs/tokio/pull/8040
+
 # 1.51.1 (April 8th, 2026)
 
 ### Fixed

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -3,16 +3,13 @@
 ## Added
 
 - io: `AioSource::register_borrowed` for I/O safety support ([#7992])
-- net: add `try_io` function to `unix::pipe` sender and receiver types 
-  ([#8030])
+- net: add `try_io` function to `unix::pipe` sender and receiver types ([#8030])
 
 ## Added (unstable)
 
-- runtime: `Builder::enable_eager_driver_handoff` setting enable eager hand  
-  off of the I/O and time drivers before polling tasks ([#8010])
+- runtime: `Builder::enable_eager_driver_handoff` setting enable eager hand off of the I/O and time drivers before polling tasks ([#8010])
 - taskdump: add `trace_with()` for customized task dumps ([#8025])
-- taskdump: allow `impl FnMut()` in `trace_with` instead of just `fn()` 
-  ([#8040])
+- taskdump: allow `impl FnMut()` in `trace_with` instead of just `fn()` ([#8040])
 - fs: support `io_uring` in `AsyncRead` for `File` ([#7907])
 
 ## Changed
@@ -22,8 +19,7 @@
 
 ## Fixed
 
-- runtime: overflow second half of tasks when local queue is filled instead of
-  first half ([#8029])
+- runtime: overflow second half of tasks when local queue is filled instead of first half ([#8029])
 
 ## Documented
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -11,7 +11,7 @@
 - runtime: `Builder::enable_eager_driver_handoff` setting enable eager hand  
   off of the I/O and time drivers before polling tasks ([#8010])
 - taskdump: add `trace_with()` for customized task dumps ([#8025])
-- taskdump: allow `impl FnMut()` in `trace_with`` instead of just `fn()` 
+- taskdump: allow `impl FnMut()` in `trace_with` instead of just `fn()` 
   ([#8040])
 - fs: support `io_uring` in `AsyncRead` for `File` ([#7907])
 

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.51.1"
+version = "1.52.0"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.1", features = ["full"] }
+tokio = { version = "1.52.0", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.52.0 (April 14th, 2026)

## Added

- io: `AioSource::register_borrowed` for I/O safety support ([#7992])
- net: add `try_io` function to `unix::pipe` sender and receiver types ([#8030])

## Added (unstable)

- runtime: `Builder::enable_eager_driver_handoff` setting enable eager hand off of the I/O and time drivers before polling tasks ([#8010])
- taskdump: add `trace_with()` for customized task dumps ([#8025])
- taskdump: allow `impl FnMut()` in `trace_with` instead of just `fn()` ([#8040])
- fs: support `io_uring` in `AsyncRead` for `File` ([#7907])

## Changed

- runtime: improve `spawn_blocking` scalability with sharded queue ([#7757])
- runtime: use `compare_exchange_weak()` in worker queue ([#8028])

## Fixed

- runtime: overflow second half of tasks when local queue is filled instead of first half ([#8029])

## Documented

- docs: fix typo in `oneshot::Sender::send` docs ([#8026])
- docs: hide #[tokio::main] attribute in the docs of `sync::watch` ([#8035])
- net: add docs on `ConnectionRefused` errors with UDP sockets ([#7870])

[#7757]: https://github.com/tokio-rs/tokio/pull/7757
[#7870]: https://github.com/tokio-rs/tokio/pull/7870
[#7907]: https://github.com/tokio-rs/tokio/pull/7907
[#7992]: https://github.com/tokio-rs/tokio/pull/7992
[#8010]: https://github.com/tokio-rs/tokio/pull/8010
[#8025]: https://github.com/tokio-rs/tokio/pull/8025
[#8026]: https://github.com/tokio-rs/tokio/pull/8026
[#8028]: https://github.com/tokio-rs/tokio/pull/8028
[#8029]: https://github.com/tokio-rs/tokio/pull/8029
[#8030]: https://github.com/tokio-rs/tokio/pull/8030
[#8035]: https://github.com/tokio-rs/tokio/pull/8035
[#8040]: https://github.com/tokio-rs/tokio/pull/8040