### PR TITLE
[ci] Use Dependabot to keep github actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Motivation

Use Dependabot to keep the GitHub Actions used in CI workflows up to date.

Docs how to set it up and how to use it - https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates

## Solution

Add .github/dependabot.yml with configuration for "github-actions". 

The Cargo dependencies will not be managed by Dependabot !