### PR TITLE
docs: add docs flag for task-dump related features

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -520,6 +520,20 @@ macro_rules! cfg_taskdump {
                     target_arch = "x86_64"
                 )
             ))]
+            #[cfg_attr(
+                docsrs,
+                doc(cfg(all(
+                    tokio_unstable,
+                    feature = "taskdump",
+                    feature = "rt",
+                    target_os = "linux",
+                    any(
+                        target_arch = "aarch64",
+                        target_arch = "x86",
+                        target_arch = "x86_64"
+                    )
+                )))
+            )]
             $item
         )*
     };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

It seems that task-dump related features are not marked as available only for specific targets.

Currently we have:
<img width="1071" height="472" alt="image" src="https://github.com/user-attachments/assets/6b11742e-1b78-4bfb-a49f-4f0020d51bca" />

Rendered docs with the fix:
<img width="949" height="392" alt="image" src="https://github.com/user-attachments/assets/de745a19-a492-47ce-82cf-5939860e1f6b" />


<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

[Rendered](https://deploy-preview-8064--tokio-rs.netlify.app/tokio/runtime/struct.handle)

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
