### PR TITLE
io: split read/write ticks in ScheduledIo

### DIFF
--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.52.2 (unreleased)
+
+## Fixed
+
+- io: split read/write ticks in the I/O driver so write-only `mio` notifications no longer invalidate read-side `clear_readiness` ([#8054])
+
 # 1.52.1 (April 16th, 2026)
 
 ## Fixed
@@ -7,6 +13,7 @@
 [#7757]: https://github.com/tokio-rs/tokio/pull/7757
 [#8056]: https://github.com/tokio-rs/tokio/pull/8056
 [#8057]: https://github.com/tokio-rs/tokio/pull/8057
+[#8054]: https://github.com/tokio-rs/tokio/issues/8054
 
 # 1.52.0 (April 14th, 2026)
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,9 +1,3 @@
-# 1.52.2 (unreleased)
-
-## Fixed
-
-- io: split read/write ticks in the I/O driver so write-only `mio` notifications no longer invalidate read-side `clear_readiness` ([#8054])
-
 # 1.52.1 (April 16th, 2026)
 
 ## Fixed
@@ -13,7 +7,6 @@
 [#7757]: https://github.com/tokio-rs/tokio/pull/7757
 [#8056]: https://github.com/tokio-rs/tokio/pull/8056
 [#8057]: https://github.com/tokio-rs/tokio/pull/8057
-[#8054]: https://github.com/tokio-rs/tokio/issues/8054
 
 # 1.52.0 (April 14th, 2026)
 

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -101,10 +101,7 @@ pub(super) enum Direction {
 
 pub(super) enum Tick {
     /// Clear readiness bits; only the tick(s) for directions present in the mask are checked.
-    Clear {
-        read: Option<u8>,
-        write: Option<u8>,
-    },
+    Clear { read: Option<u8>, write: Option<u8> },
 }
 
 const TOKEN_WAKEUP: mio::Token = mio::Token(0);

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -72,7 +72,10 @@ pub(crate) struct Handle {
 
 #[derive(Debug)]
 pub(crate) struct ReadyEvent {
-    pub(super) tick: u8,
+    /// Generation counter for read-side readiness (readable, read closed, error, …).
+    pub(super) read_tick: u8,
+    /// Generation counter for write-side readiness (writable, write closed).
+    pub(super) write_tick: u8,
     pub(crate) ready: Ready,
     pub(super) is_shutdown: bool,
 }
@@ -82,7 +85,8 @@ cfg_net_unix!(
         pub(crate) fn with_ready(&self, ready: Ready) -> Self {
             Self {
                 ready,
-                tick: self.tick,
+                read_tick: self.read_tick,
+                write_tick: self.write_tick,
                 is_shutdown: self.is_shutdown,
             }
         }
@@ -96,8 +100,11 @@ pub(super) enum Direction {
 }
 
 pub(super) enum Tick {
-    Set,
-    Clear(u8),
+    /// Clear readiness bits; only the tick(s) for directions present in the mask are checked.
+    Clear {
+        read: Option<u8>,
+        write: Option<u8>,
+    },
 }
 
 const TOKEN_WAKEUP: mio::Token = mio::Token(0);
@@ -215,7 +222,7 @@ impl Driver {
                 // an `Arc<ScheduledIo>` so we can safely cast this to a ref.
                 let io: &ScheduledIo = unsafe { &*ptr };
 
-                io.set_readiness(Tick::Set, |curr| curr | ready);
+                io.merge_readiness_from_driver(ready);
                 io.wake(ready);
 
                 ready_count += 1;

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -163,15 +163,59 @@ enum State {
 
 // The `ScheduledIo::readiness` (`AtomicUsize`) is packed full of goodness.
 //
-// | shutdown | driver tick | readiness |
-// |----------+-------------+-----------|
-// |   1 bit  |   15 bits   |  16 bits  |
+// | shutdown | write tick | read tick | readiness |
+// |----------+------------+-----------+-----------|
+// |   1 bit  |   8 bits   |  8 bits   |  16 bits  |
 
 const READINESS: bit::Pack = bit::Pack::least_significant(16);
 
-const TICK: bit::Pack = READINESS.then(15);
+const READ_TICK: bit::Pack = READINESS.then(8);
 
-const SHUTDOWN: bit::Pack = TICK.then(1);
+const WRITE_TICK: bit::Pack = READ_TICK.then(8);
+
+const SHUTDOWN: bit::Pack = WRITE_TICK.then(1);
+
+/// Pack readiness and both generation counters plus shutdown into one word.
+fn pack_io_state(ready: usize, read_tick: usize, write_tick: usize, shutdown: usize) -> usize {
+    let mut x = READINESS.pack(ready, 0);
+    x = READ_TICK.pack(read_tick, x);
+    x = WRITE_TICK.pack(write_tick, x);
+    SHUTDOWN.pack(shutdown, x)
+}
+
+/// Returns true if a poll event with this readiness should bump the read-side tick.
+fn tick_increments_read(r: Ready) -> bool {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        r.is_readable() || r.is_read_closed() || r.is_error() || r.is_priority()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        r.is_readable() || r.is_read_closed() || r.is_error()
+    }
+}
+
+/// Returns true if a poll event with this readiness should bump the write-side tick.
+fn tick_increments_write(r: Ready) -> bool {
+    r.is_writable() || r.is_write_closed()
+}
+
+/// Bits whose clearing is validated against [`ReadyEvent::read_tick`].
+fn read_side_tick_mask() -> Ready {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    {
+        Ready::READABLE | Ready::READ_CLOSED | Ready::ERROR | Ready::PRIORITY
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    {
+        Ready::READABLE | Ready::READ_CLOSED | Ready::ERROR
+    }
+}
+
+/// Bits whose clearing is validated against [`ReadyEvent::write_tick`].
+fn write_side_tick_mask() -> Ready {
+    Ready::WRITABLE | Ready::WRITE_CLOSED
+}
 
 // ===== impl ScheduledIo =====
 
@@ -198,30 +242,67 @@ impl ScheduledIo {
         self.wake(Ready::ALL);
     }
 
-    /// Sets the readiness on this `ScheduledIo` by invoking the given closure on
-    /// the current value, returning the previous readiness value.
+    /// Merges readiness from the I/O driver after `mio` reports `incoming`.
     ///
-    /// # Arguments
-    /// - `tick`: whether setting the tick or trying to clear readiness for a
-    ///   specific tick.
-    /// - `f`: a closure returning a new readiness value given the previous
-    ///   readiness.
-    pub(super) fn set_readiness(&self, tick_op: Tick, f: impl Fn(Ready) -> Ready) {
+    /// Read-side and write-side ticks are advanced independently so that a
+    /// write-only notification does not invalidate a pending read-side
+    /// [`clear_readiness`] (see tokio-rs/tokio#8054).
+    pub(super) fn merge_readiness_from_driver(&self, incoming: Ready) {
         let _ = self.readiness.fetch_update(AcqRel, Acquire, |curr| {
-            // If the io driver is shut down, then you are only allowed to clear readiness.
-            debug_assert!(SHUTDOWN.unpack(curr) == 0 || matches!(tick_op, Tick::Clear(_)));
+            if SHUTDOWN.unpack(curr) != 0 {
+                return None;
+            }
+            let read_t = READ_TICK.unpack(curr);
+            let write_t = WRITE_TICK.unpack(curr);
+            let old_ready = Ready::from_usize(READINESS.unpack(curr));
+            let new_ready = old_ready | incoming;
 
-            const MAX_TICK: usize = TICK.max_value() + 1;
-            let tick = TICK.unpack(curr);
+            let mut nr = read_t;
+            let mut nw = write_t;
+            if tick_increments_read(incoming) {
+                nr = (nr + 1) % (READ_TICK.max_value() + 1);
+            }
+            if tick_increments_write(incoming) {
+                nw = (nw + 1) % (WRITE_TICK.max_value() + 1);
+            }
 
-            let new_tick = match tick_op {
-                // Trying to clear readiness with an old event!
-                Tick::Clear(t) if tick as u8 != t => return None,
-                Tick::Clear(t) => t as usize,
-                Tick::Set => tick.wrapping_add(1) % MAX_TICK,
-            };
+            Some(pack_io_state(
+                new_ready.as_usize(),
+                nr,
+                nw,
+                SHUTDOWN.unpack(curr),
+            ))
+        });
+    }
+
+    /// Clears readiness by invoking `f` on the current value, after validating
+    /// tick(s) for the directions being cleared.
+    pub(super) fn set_readiness(&self, tick_op: Tick, f: impl Fn(Ready) -> Ready) {
+        let Tick::Clear { read, write } = tick_op;
+
+        let _ = self.readiness.fetch_update(AcqRel, Acquire, |curr| {
+            let curr_read = READ_TICK.unpack(curr) as u8;
+            let curr_write = WRITE_TICK.unpack(curr) as u8;
+
+            if let Some(t) = read {
+                if curr_read != t {
+                    return None;
+                }
+            }
+            if let Some(t) = write {
+                if curr_write != t {
+                    return None;
+                }
+            }
+
             let ready = Ready::from_usize(READINESS.unpack(curr));
-            Some(TICK.pack(new_tick, f(ready).as_usize()))
+            let new_ready = f(ready);
+            Some(pack_io_state(
+                new_ready.as_usize(),
+                READ_TICK.unpack(curr),
+                WRITE_TICK.unpack(curr),
+                SHUTDOWN.unpack(curr),
+            ))
         });
     }
 
@@ -291,7 +372,8 @@ impl ScheduledIo {
         let curr = self.readiness.load(Acquire);
 
         ReadyEvent {
-            tick: TICK.unpack(curr) as u8,
+            read_tick: READ_TICK.unpack(curr) as u8,
+            write_tick: WRITE_TICK.unpack(curr) as u8,
             ready: interest.mask() & Ready::from_usize(READINESS.unpack(curr)),
             is_shutdown: SHUTDOWN.unpack(curr) != 0,
         }
@@ -334,7 +416,8 @@ impl ScheduledIo {
             let is_shutdown = SHUTDOWN.unpack(curr) != 0;
             if is_shutdown {
                 Poll::Ready(ReadyEvent {
-                    tick: TICK.unpack(curr) as u8,
+                    read_tick: READ_TICK.unpack(curr) as u8,
+                    write_tick: WRITE_TICK.unpack(curr) as u8,
                     ready: direction.mask(),
                     is_shutdown,
                 })
@@ -342,14 +425,16 @@ impl ScheduledIo {
                 Poll::Pending
             } else {
                 Poll::Ready(ReadyEvent {
-                    tick: TICK.unpack(curr) as u8,
+                    read_tick: READ_TICK.unpack(curr) as u8,
+                    write_tick: WRITE_TICK.unpack(curr) as u8,
                     ready,
                     is_shutdown,
                 })
             }
         } else {
             Poll::Ready(ReadyEvent {
-                tick: TICK.unpack(curr) as u8,
+                read_tick: READ_TICK.unpack(curr) as u8,
+                write_tick: WRITE_TICK.unpack(curr) as u8,
                 ready,
                 is_shutdown,
             })
@@ -360,7 +445,21 @@ impl ScheduledIo {
         // This consumes the current readiness state **except** for closed
         // states. Closed states are excluded because they are final states.
         let mask_no_closed = event.ready - Ready::READ_CLOSED - Ready::WRITE_CLOSED;
-        self.set_readiness(Tick::Clear(event.tick), |curr| curr - mask_no_closed);
+        let read_mask = mask_no_closed & read_side_tick_mask();
+        let write_mask = mask_no_closed & write_side_tick_mask();
+
+        let read = if !read_mask.is_empty() {
+            Some(event.read_tick)
+        } else {
+            None
+        };
+        let write = if !write_mask.is_empty() {
+            Some(event.write_tick)
+        } else {
+            None
+        };
+
+        self.set_readiness(Tick::Clear { read, write }, |curr| curr - mask_no_closed);
     }
 
     pub(crate) fn clear_wakers(&self) {
@@ -454,10 +553,10 @@ impl Future for Readiness<'_> {
 
                     if !ready.is_empty() || is_shutdown {
                         // Currently ready!
-                        let tick = TICK.unpack(curr) as u8;
                         *state = State::Done;
                         return Poll::Ready(ReadyEvent {
-                            tick,
+                            read_tick: READ_TICK.unpack(curr) as u8,
+                            write_tick: WRITE_TICK.unpack(curr) as u8,
                             ready,
                             is_shutdown,
                         });
@@ -478,10 +577,10 @@ impl Future for Readiness<'_> {
 
                     if !ready.is_empty() || is_shutdown {
                         // Currently ready!
-                        let tick = TICK.unpack(curr) as u8;
                         *state = State::Done;
                         return Poll::Ready(ReadyEvent {
-                            tick,
+                            read_tick: READ_TICK.unpack(curr) as u8,
+                            write_tick: WRITE_TICK.unpack(curr) as u8,
                             ready,
                             is_shutdown,
                         });
@@ -538,10 +637,9 @@ impl Future for Readiness<'_> {
                     let curr = scheduled_io.readiness.load(Acquire);
                     let is_shutdown = SHUTDOWN.unpack(curr) != 0;
 
-                    // The returned tick might be newer than the event
+                    // The returned ticks might be newer than the event
                     // which notified our waker. This is ok because the future
                     // still didn't return `Poll::Ready`.
-                    let tick = TICK.unpack(curr) as u8;
 
                     // Safety: We don't need to acquire the lock here because
                     //   1. `State::Done`` means `waiter` is no longer shared,
@@ -555,7 +653,8 @@ impl Future for Readiness<'_> {
                     let ready = Ready::from_usize(READINESS.unpack(curr)).intersection(interest);
 
                     return Poll::Ready(ReadyEvent {
-                        tick,
+                        read_tick: READ_TICK.unpack(curr) as u8,
+                        write_tick: WRITE_TICK.unpack(curr) as u8,
                         ready,
                         is_shutdown,
                     });

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -165,13 +165,17 @@ enum State {
 //
 // | shutdown | write tick | read tick | readiness |
 // |----------+------------+-----------+-----------|
-// |   1 bit  |   8 bits   |  8 bits   |  16 bits  |
+// |   1 bit  |   7 bits   |  7 bits   |  16 bits  |
+//
+// Read and write ticks use 7 bits each so the full layout fits in `usize` on
+// 32-bit targets (including `wasm32`), where the previous single 15-bit tick
+// fit with 16 bits of readiness.
 
 const READINESS: bit::Pack = bit::Pack::least_significant(16);
 
-const READ_TICK: bit::Pack = READINESS.then(8);
+const READ_TICK: bit::Pack = READINESS.then(7);
 
-const WRITE_TICK: bit::Pack = READ_TICK.then(8);
+const WRITE_TICK: bit::Pack = READ_TICK.then(7);
 
 const SHUTDOWN: bit::Pack = WRITE_TICK.then(1);
 
@@ -246,7 +250,8 @@ impl ScheduledIo {
     ///
     /// Read-side and write-side ticks are advanced independently so that a
     /// write-only notification does not invalidate a pending read-side
-    /// [`clear_readiness`] (see tokio-rs/tokio#8054).
+    /// [`Registration::clear_readiness`](crate::runtime::io::Registration::clear_readiness)
+    /// (see <https://github.com/tokio-rs/tokio/issues/8054>).
     pub(super) fn merge_readiness_from_driver(&self, incoming: Ready) {
         let _ = self.readiness.fetch_update(AcqRel, Acquire, |curr| {
             if SHUTDOWN.unpack(curr) != 0 {


### PR DESCRIPTION
Separate read_tick and write_tick so write-only mio notifications do not invalidate clear_readiness for the read path. Fixes livelock when the reactor advances the shared tick between poll_read_ready and clear_readiness.

Fixes #8054

### Motivation
ScheduledIo used a single readiness generation counter (tick). The I/O driver incremented it on every mio event via set_readiness(Tick::Set, …), including write-only notifications.

A task can observe read readiness at tick T, then perform a read that returns WouldBlock and call clear_readiness with that snapshot. If another thread handles the reactor and processes a writable-only event before the clear runs, the shared tick becomes T+1. clear_readiness uses Tick::Clear(T), sees a tick mismatch, and does not clear the read bits. Read readiness stays set, so poll_read_ready keeps returning ready while read keeps returning WouldBlock — a busy-loop / livelock.

This was reported on Windows (e.g. Hyper HTTP/2 repro in #8054), but the tick logic is platform-agnostic.

### Solution
Replace the single 15-bit tick with 7-bit read_tick and 7-bit write_tick in the packed AtomicUsize (16 + 7 + 7 + 1 bit total so the layout still fits in usize on 32-bit targets, including wasm32).

On each mio event, merge_readiness_from_driver advances read_tick only if the event has read-side bits (readable / read closed / error [+ priority on Linux]), and write_tick only if it has write-side bits (writable / write closed).

ReadyEvent carries both ticks; clear_readiness checks only the tick(s) that correspond to the bits being cleared (via read/write tick masks).
