### PR TITLE
rt: don't notify when pushing task to empty LIFO slot

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/idle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/idle.rs
@@ -150,6 +150,12 @@ impl Idle {
         lock.idle.sleepers.contains(&worker_id)
     }
 
+    /// Returns `true` if all other workers are currently parked.
+    pub(super) fn all_parked(&self) -> bool {
+        let state = State(self.state.fetch_add(0, SeqCst));
+        state.num_unparked() <= 1
+    }
+
     fn notify_should_wakeup(&self) -> bool {
         let state = State(self.state.fetch_add(0, SeqCst));
         state.num_searching() == 0 && state.num_unparked() < self.num_workers

--- a/tokio/src/runtime/scheduler/multi_thread/idle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/idle.rs
@@ -23,8 +23,14 @@ pub(super) struct Synced {
     sleepers: Vec<usize>,
 }
 
-const UNPARK_SHIFT: usize = 16;
-const UNPARK_MASK: usize = !SEARCH_MASK;
+pub(super) struct TransitionToParked {
+    pub(super) is_last_searcher: bool,
+    pub(super) any_lifo: bool,
+}
+
+const UNPARK_SHIFT: usize = (usize::BITS as usize / 2) - 2;
+const ANY_LIFO: usize = 1 << (usize::BITS - 1);
+const UNPARK_MASK: usize = !(SEARCH_MASK | ANY_LIFO);
 const SEARCH_MASK: usize = (1 << UNPARK_SHIFT) - 1;
 
 #[derive(Copy, Clone)]
@@ -32,6 +38,10 @@ struct State(usize);
 
 impl Idle {
     pub(super) fn new(num_workers: usize) -> (Idle, Synced) {
+        assert!(
+            num_workers <= UNPARK_MASK,
+            "{num_workers} is too many workers (max is {UNPARK_MASK})"
+        );
         let init = State::new(num_workers);
 
         let idle = Idle {
@@ -88,7 +98,7 @@ impl Idle {
         shared: &Shared,
         worker: usize,
         is_searching: bool,
-    ) -> bool {
+    ) -> TransitionToParked {
         // Acquire the lock
         let mut lock = shared.synced.lock();
 
@@ -144,16 +154,23 @@ impl Idle {
         false
     }
 
+    pub(super) fn put_lifo(&self) -> bool {
+        State(self.state.fetch_or(ANY_LIFO, SeqCst)).any_lifo()
+    }
+
+    pub(super) fn clear_lifo(&self) {
+        self.state.fetch_and(!ANY_LIFO, SeqCst);
+    }
+
+    pub(super) fn should_attempt_lifo_steal(&self) -> bool {
+        let state = State(self.state.fetch_add(0, SeqCst));
+        state.any_lifo()
+    }
+
     /// Returns `true` if `worker_id` is contained in the sleep set.
     pub(super) fn is_parked(&self, shared: &Shared, worker_id: usize) -> bool {
         let lock = shared.synced.lock();
         lock.idle.sleepers.contains(&worker_id)
-    }
-
-    /// Returns `true` if all other workers are currently parked.
-    pub(super) fn all_parked(&self) -> bool {
-        let state = State(self.state.fetch_add(0, SeqCst));
-        state.num_unparked() <= 1
     }
 
     fn notify_should_wakeup(&self) -> bool {
@@ -192,7 +209,7 @@ impl State {
     /// Track a sleeping worker
     ///
     /// Returns `true` if this is the final searching worker.
-    fn dec_num_unparked(cell: &AtomicUsize, is_searching: bool) -> bool {
+    fn dec_num_unparked(cell: &AtomicUsize, is_searching: bool) -> TransitionToParked {
         let mut dec = 1 << UNPARK_SHIFT;
 
         if is_searching {
@@ -200,7 +217,11 @@ impl State {
         }
 
         let prev = State(cell.fetch_sub(dec, SeqCst));
-        is_searching && prev.num_searching() == 1
+        let is_last_searcher = is_searching && prev.num_searching() == 1;
+        TransitionToParked {
+            is_last_searcher,
+            any_lifo: prev.any_lifo(),
+        }
     }
 
     /// Number of workers currently searching
@@ -211,6 +232,10 @@ impl State {
     /// Number of workers currently unparked
     fn num_unparked(self) -> usize {
         (self.0 & UNPARK_MASK) >> UNPARK_SHIFT
+    }
+
+    fn any_lifo(self) -> bool {
+        self.0 & ANY_LIFO == ANY_LIFO
     }
 }
 
@@ -243,4 +268,12 @@ fn test_state() {
     let state = State::new(10);
     assert_eq!(10, state.num_unparked());
     assert_eq!(0, state.num_searching());
+}
+
+#[test]
+fn masks() {
+    println!("UNPARK_SHIFT = {UNPARK_SHIFT}");
+    println!("UNPARK_MASK  = {UNPARK_MASK:064b}");
+    println!("SEARCH_MASK  = {SEARCH_MASK:064b}");
+    println!("ANY_LIFO     = {ANY_LIFO:064b}");
 }

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -440,6 +440,10 @@ impl<T> Steal<T> {
         self.len() == 0
     }
 
+    pub(crate) fn has_lifo(&self) -> bool {
+        self.0.lifo.is_some()
+    }
+
     /// Steals half the tasks from self and place them into `dst`.
     pub(crate) fn steal_into(
         &self,

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1352,8 +1352,6 @@ impl Handle {
         let should_notify = if is_yield || !core.lifo_enabled {
             core.run_queue
                 .push_back_or_overflow(task, self, &mut core.stats);
-            // Always notify another parked worker when pushing a yielded task
-            // to the main run queue if we are not currently parked.
             true
         } else {
             // Push to the LIFO slot
@@ -1362,19 +1360,9 @@ impl Handle {
                 // to be pushed to the back of the run queue.
                 core.run_queue
                     .push_back_or_overflow(prev, self, &mut core.stats);
-                // We have pushed the previous LIFO task to the back of the run
-                // queue, so we should attempt to notify another worker if we
-                // are not currently parked.
                 true
             } else {
-                // If the scheduled task was pushed to the LIFO slot and there
-                // is no other task previously in the slot, skip notifying
-                // another worker, so that we can preferentially poll the LIFO
-                // task next. It can still be stolen if another worker is
-                // searching. This reduces cross thread notifications, and
-                // reduces the chance of the LIFO task moving across threads if
-                // the next poll is short.
-                false
+                self.shared.idle.all_parked()
             }
         };
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -256,6 +256,15 @@ type Notified = task::Notified<Arc<Handle>>;
 /// improvements.
 const MAX_LIFO_POLLS_PER_TICK: usize = 3;
 
+/// Maximum time a parked worker will sleep before waking to check
+/// for tasks stranded in other workers' LIFO slots.
+const LIFO_EXCLUSIVITY_TIMEOUT: Duration = Duration::from_millis(100);
+
+enum TransitionToParked {
+    No,
+    Yes(Option<Duration>),
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn create(
     size: usize,
@@ -804,13 +813,13 @@ impl Context {
             f();
         }
 
-        if core.transition_to_parked(&self.worker) {
+        if let TransitionToParked::Yes(timeout) = core.transition_to_parked(&self.worker) {
             while !core.is_shutdown && !core.is_traced {
                 core.stats.about_to_park();
                 core.stats
                     .submit(&self.worker.handle.shared.worker_metrics[self.worker.index]);
 
-                core = self.park_internal(core, None);
+                core = self.park_internal(core, timeout);
 
                 core.stats.unparked();
 
@@ -820,6 +829,10 @@ impl Context {
                 if core.transition_from_parked(&self.worker) {
                     break;
                 }
+
+                if self.steal_stranded_lifo(&mut core) {
+                    break;
+                }
             }
         }
 
@@ -827,6 +840,26 @@ impl Context {
             f();
         }
         core
+    }
+
+    fn steal_stranded_lifo(&self, _core: &mut Core) -> bool {
+        if !self.worker.handle.shared.idle.should_attempt_lifo_steal() {
+            return false;
+        }
+
+        let remotes = self.worker.handle.shared.remotes.iter().enumerate();
+        for (i, remote) in remotes {
+            if i != self.worker.index && remote.steal.has_lifo() {
+                self.worker
+                    .handle
+                    .shared
+                    .idle
+                    .unpark_worker_by_id(&self.worker.handle.shared, self.worker.index);
+                return true;
+            }
+        }
+
+        false
     }
 
     fn park_yield(&self, core: Box<Core>) -> Box<Core> {
@@ -1193,16 +1226,19 @@ impl Core {
     /// Prepares the worker state for parking.
     ///
     /// Returns true if the transition happened, false if there is work to do first.
-    fn transition_to_parked(&mut self, worker: &Worker) -> bool {
+    fn transition_to_parked(&mut self, worker: &Worker) -> TransitionToParked {
         // Workers should not park if they have work to do
         if self.has_tasks() || self.is_traced {
-            return false;
+            return TransitionToParked::No;
         }
 
         // When the final worker transitions **out** of searching to parked, it
         // must check all the queues one last time in case work materialized
         // between the last work scan and transitioning out of searching.
-        let is_last_searcher = worker.handle.shared.idle.transition_worker_to_parked(
+        let idle::TransitionToParked {
+            is_last_searcher,
+            any_lifo,
+        } = worker.handle.shared.idle.transition_worker_to_parked(
             &worker.handle.shared,
             worker.index,
             self.is_searching,
@@ -1216,7 +1252,11 @@ impl Core {
             worker.handle.notify_if_work_pending();
         }
 
-        true
+        TransitionToParked::Yes(if any_lifo {
+            Some(LIFO_EXCLUSIVITY_TIMEOUT)
+        } else {
+            None
+        })
     }
 
     /// Returns `true` if the transition happened.
@@ -1362,7 +1402,7 @@ impl Handle {
                     .push_back_or_overflow(prev, self, &mut core.stats);
                 true
             } else {
-                self.shared.idle.all_parked()
+                !self.shared.idle.put_lifo()
             }
         };
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -830,7 +830,7 @@ impl Context {
                     break;
                 }
 
-                if self.steal_stranded_lifo(&mut core) {
+                if self.steal_stranded_lifo() {
                     break;
                 }
             }
@@ -842,23 +842,21 @@ impl Context {
         core
     }
 
-    fn steal_stranded_lifo(&self, _core: &mut Core) -> bool {
-        if !self.worker.handle.shared.idle.should_attempt_lifo_steal() {
+    fn steal_stranded_lifo(&self) -> bool {
+        let shared = &self.worker.handle.shared;
+        if !shared.idle.should_attempt_lifo_steal() {
             return false;
         }
 
-        let remotes = self.worker.handle.shared.remotes.iter().enumerate();
-        for (i, remote) in remotes {
+        for (i, remote) in shared.remotes.iter().enumerate() {
             if i != self.worker.index && remote.steal.has_lifo() {
-                self.worker
-                    .handle
-                    .shared
-                    .idle
-                    .unpark_worker_by_id(&self.worker.handle.shared, self.worker.index);
+                shared.idle.unpark_worker_by_id(shared, self.worker.index);
                 return true;
             }
         }
 
+        // didn't find any lifo task, unset the lifo steal bit.
+        shared.idle.clear_lifo();
         false
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1349,9 +1349,12 @@ impl Handle {
         // task must always be pushed to the back of the queue, enabling other
         // tasks to be executed. If **not** a yield, then there is more
         // flexibility and the task may go to the front of the queue.
-        if is_yield || !core.lifo_enabled {
+        let should_notify = if is_yield || !core.lifo_enabled {
             core.run_queue
                 .push_back_or_overflow(task, self, &mut core.stats);
+            // Always notify another parked worker when pushing a yielded task
+            // to the main run queue if we are not currently parked.
+            true
         } else {
             // Push to the LIFO slot
             if let Some(prev) = core.run_queue.push_lifo(task) {
@@ -1359,13 +1362,26 @@ impl Handle {
                 // to be pushed to the back of the run queue.
                 core.run_queue
                     .push_back_or_overflow(prev, self, &mut core.stats);
+                // We have pushed the previous LIFO task to the back of the run
+                // queue, so we should attempt to notify another worker if we
+                // are not currently parked.
+                true
+            } else {
+                // If the scheduled task was pushed to the LIFO slot and there
+                // is no other task previously in the slot, skip notifying
+                // another worker, so that we can preferentially poll the LIFO
+                // task next. It can still be stolen if another worker is
+                // searching. This reduces cross thread notifications, and
+                // reduces the chance of the LIFO task moving across threads if
+                // the next poll is short.
+                false
             }
         };
 
         // Only notify if not currently parked. If `park` is `None`, then the
         // scheduling is from a resource driver. As notifications often come in
         // batches, the notification is delayed until the park is complete.
-        if core.park.is_some() {
+        if should_notify && core.park.is_some() {
             self.notify_parked_local();
         }
     }

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -730,18 +730,6 @@ fn lifo_stealable() {
         .unwrap();
 
     rt.block_on(async {
-        // Keep the runtime busy so that the workers that might steal the
-        // blocked task don't all park themselves forever.
-        //
-        // Since this task will always be woken by whichever worker is holding
-        // the time driver, rather than a worker that's executing tasks, it
-        // shouldn't ever kick the victim task out of its worker's LIFO slot.
-        let churn = tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(Duration::from_millis(4)).await;
-            }
-        });
-
         let victim_task_joined = tokio::spawn(async move {
             println!("[victim] task started");
             task_started_tx.send(()).unwrap();
@@ -791,7 +779,6 @@ fn lifo_stealable() {
         // Before possibly panicking, make sure that we wake up the blocker task
         // so that it doesn't stop the runtime from shutting down.
         block_thread_tx.send(()).unwrap();
-        churn.abort();
         result
             .expect("task in LIFO slot should complete within 30 seconds")
             .expect("task in LIFO slot should not panic");


### PR DESCRIPTION
See #8065

This change un-does the increase in notifications described in #8065. Running the repro from https://github.com/tokio-rs/tokio/issues/8065#issuecomment-4272562127, I see voluntary context switches back to 1.50.0 counts (note the `cargo build` output saying that this is a local Tokio checkout):
```console
eliza@hekate ~/Code/tokio-8065 $ cargo build --release
   Compiling tokio v1.52.1 (/home/eliza/Code/tokio/tokio)
   Compiling tokio-8065 v0.1.0 (/home/eliza/Code/tokio-8065)
    Finished `release` profile [optimized] target(s) in 2.76s

eliza@hekate ~/Code/tokio-8065 $ nix run nixpkgs#time -- -v target/release/tokio-8065
	Command being timed: "target/release/tokio-8065"
	User time (seconds): 0.01
	System time (seconds): 0.00
	Percent of CPU this job got: 0%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:10.00
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 1984
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 146
	Voluntary context switches: 6563
	Involuntary context switches: 1
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
``
