### PR TITLE
test: remove `churn()` task from `lifo_stealable`

### DIFF
--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -730,18 +730,6 @@ fn lifo_stealable() {
         .unwrap();
 
     rt.block_on(async {
-        // Keep the runtime busy so that the workers that might steal the
-        // blocked task don't all park themselves forever.
-        //
-        // Since this task will always be woken by whichever worker is holding
-        // the time driver, rather than a worker that's executing tasks, it
-        // shouldn't ever kick the victim task out of its worker's LIFO slot.
-        let churn = tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(Duration::from_millis(4)).await;
-            }
-        });
-
         let victim_task_joined = tokio::spawn(async move {
             println!("[victim] task started");
             task_started_tx.send(()).unwrap();
@@ -791,7 +779,6 @@ fn lifo_stealable() {
         // Before possibly panicking, make sure that we wake up the blocker task
         // so that it doesn't stop the runtime from shutting down.
         block_thread_tx.send(()).unwrap();
-        churn.abort();
         result
             .expect("task in LIFO slot should complete within 30 seconds")
             .expect("task in LIFO slot should not panic");


### PR DESCRIPTION
Currently, the `rt_threaded::lifo_stealable` test I added in #7431 spawns an additional task which sleeps on a 4ms timer in a loop. This ensures that no worker remains permanently parked. This was added because it was necessary to stop the LIFO slot deadlock from occurring prior to changes in the logic for determining whether to notify another worker, which is what @Darksonn  was referring to in [this comment][1]. Removing the `churn()` test makes the test actually validate that another worker is notified to steal the LIFO task, and that the changes from #7431 will *always* prevent a LIFO slot deadlock, regardless of the behavior of other tasks on the runtime. See also [this comment][2] for further discussion.

[1]: https://github.com/tokio-rs/tokio/pull/7431#discussion_r2184724657
[2]: https://github.com/tokio-rs/tokio/pull/8069#issuecomment-4274244723
