### PR TITLE
Notify receivers in mpsc channel `OwnedPermit::release()` method

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1844,14 +1844,12 @@ impl<T> OwnedPermit<T> {
     ///
     /// [`Sender`]: Sender
     pub fn release(mut self) -> Sender<T> {
-        use chan::Semaphore;
-
         let chan = self.chan.take().unwrap_or_else(|| {
             unreachable!("OwnedPermit channel is only taken when the permit is moved")
         });
 
         // Add the permit back to the semaphore
-        chan.semaphore().add_permit();
+        drop(Permit { chan: &chan });
         Sender { chan }
     }
 
@@ -1910,21 +1908,10 @@ impl<T> OwnedPermit<T> {
 
 impl<T> Drop for OwnedPermit<T> {
     fn drop(&mut self) {
-        use chan::Semaphore;
-
         // Are we still holding onto the sender?
         if let Some(chan) = self.chan.take() {
-            let semaphore = chan.semaphore();
-
-            // Add the permit back to the semaphore
-            semaphore.add_permit();
-
-            // If this `OwnedPermit` is holding the last sender for this
-            // channel, wake the receiver so that it can be notified that the
-            // channel is closed.
-            if semaphore.is_closed() && semaphore.is_idle() {
-                chan.wake_rx();
-            }
+            // Reuse Drop impl of non-owned Permit.
+            drop(Permit { chan: &chan });
         }
 
         // Otherwise, do nothing.

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -788,6 +788,91 @@ async fn drop_permit_iterator_releases_permits() {
     }
 }
 
+#[test]
+fn dropping_last_permit_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permit = tx.try_reserve().unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    drop(permit);
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+}
+
+#[test]
+fn dropping_last_owned_permit_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permit = tx.try_reserve_owned().unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    drop(permit);
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+}
+
+#[test]
+fn dropping_last_permit_iterator_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permits = tx.try_reserve_many(1).unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    drop(permits);
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+}
+
+#[test]
+fn sending_last_permit_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permit = tx.try_reserve().unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    permit.send(());
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+}
+
+#[test]
+fn sending_last_owned_permit_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permit = tx.try_reserve_owned().unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    permit.send(());
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+}
+
+#[test]
+fn releasing_last_owned_permit_closes_channel() {
+    let (tx, mut rx) = mpsc::channel::<()>(100);
+
+    let permit = tx.try_reserve_owned().unwrap();
+    rx.close();
+
+    let mut recv = tokio_test::task::spawn(rx.recv());
+    assert_pending!(recv.poll());
+    let inert_sender = permit.release();
+    assert!(recv.is_woken());
+    assert_ready!(recv.poll());
+    drop(inert_sender);
+}
+
 #[maybe_tokio_test]
 async fn dropping_rx_closes_channel() {
     let (tx, rx) = mpsc::channel(100);

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -789,7 +789,7 @@ async fn drop_permit_iterator_releases_permits() {
 }
 
 #[test]
-fn dropping_last_permit_closes_channel() {
+fn dropping_last_permit_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permit = tx.try_reserve().unwrap();
@@ -803,7 +803,7 @@ fn dropping_last_permit_closes_channel() {
 }
 
 #[test]
-fn dropping_last_owned_permit_closes_channel() {
+fn dropping_last_owned_permit_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permit = tx.try_reserve_owned().unwrap();
@@ -817,7 +817,7 @@ fn dropping_last_owned_permit_closes_channel() {
 }
 
 #[test]
-fn dropping_last_permit_iterator_closes_channel() {
+fn dropping_last_permit_iterator_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permits = tx.try_reserve_many(1).unwrap();
@@ -831,7 +831,7 @@ fn dropping_last_permit_iterator_closes_channel() {
 }
 
 #[test]
-fn sending_last_permit_closes_channel() {
+fn sending_last_permit_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permit = tx.try_reserve().unwrap();
@@ -845,7 +845,7 @@ fn sending_last_permit_closes_channel() {
 }
 
 #[test]
-fn sending_last_owned_permit_closes_channel() {
+fn sending_last_owned_permit_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permit = tx.try_reserve_owned().unwrap();
@@ -859,7 +859,7 @@ fn sending_last_owned_permit_closes_channel() {
 }
 
 #[test]
-fn releasing_last_owned_permit_closes_channel() {
+fn releasing_last_owned_permit_wakes_closed_receiver() {
     let (tx, mut rx) = mpsc::channel::<()>(100);
 
     let permit = tx.try_reserve_owned().unwrap();


### PR DESCRIPTION
The `OwnedPermit::release()` method is missing a check for whether the receiver should be woken up. This results in lost wakeups when combined with `Receiver::close()`.

This bug was discovered by asking Gemini to look for bugs in the `release` method of `tokio/src/sync/mpsc/bounded.rs`.
