### PR TITLE
Require that an `RwLock` has `max_readers != 0`

### DIFF
--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -266,13 +266,13 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// # Panics
     ///
-    /// Panics if `max_reads` is more than `u32::MAX >> 3`.
+    /// Panics if `max_reads` is `0` or is bigger than `u32::MAX >> 3`.
     #[track_caller]
     pub fn with_max_readers(value: T, max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {
-        assert_ne!(max_reads, 0);
+        assert_ne!(max_reads, 0, "a RwLock may not be created with 0 readers");
         assert!(
             max_reads <= MAX_READS,
             "a RwLock may not be created with more than {MAX_READS} readers"
@@ -368,12 +368,16 @@ impl<T: ?Sized> RwLock<T> {
     ///
     /// static LOCK: RwLock<i32> = RwLock::const_with_max_readers(5, 1024);
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `max_reads` is `0` or is bigger than `u32::MAX >> 3`.
     #[cfg(not(all(loom, test)))]
     pub const fn const_with_max_readers(value: T, max_reads: u32) -> RwLock<T>
     where
         T: Sized,
     {
-        assert!(max_reads != 0);
+        assert!(max_reads != 0, "a RwLock may not be created with 0 readers");
         assert!(max_reads <= MAX_READS);
 
         RwLock {

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -272,6 +272,7 @@ impl<T: ?Sized> RwLock<T> {
     where
         T: Sized,
     {
+        assert_ne!(max_reads, 0);
         assert!(
             max_reads <= MAX_READS,
             "a RwLock may not be created with more than {MAX_READS} readers"
@@ -372,6 +373,7 @@ impl<T: ?Sized> RwLock<T> {
     where
         T: Sized,
     {
+        assert!(max_reads != 0);
         assert!(max_reads <= MAX_READS);
 
         RwLock {
@@ -771,6 +773,7 @@ impl<T: ?Sized> RwLock<T> {
     /// ```
     pub async fn write(&self) -> RwLockWriteGuard<'_, T> {
         let acquire_fut = async {
+            debug_assert_ne!(self.mr, 0);
             self.s.acquire(self.mr as usize).await.unwrap_or_else(|_| {
                 // The semaphore was closed. but, we never explicitly close it, and we have a
                 // handle to it through the Arc, which means that this can never happen.
@@ -906,6 +909,7 @@ impl<T: ?Sized> RwLock<T> {
         let resource_span = self.resource_span.clone();
 
         let acquire_fut = async {
+            debug_assert_ne!(self.mr, 0);
             self.s.acquire(self.mr as usize).await.unwrap_or_else(|_| {
                 // The semaphore was closed. but, we never explicitly close it, and we have a
                 // handle to it through the Arc, which means that this can never happen.
@@ -970,6 +974,7 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     pub fn try_write(&self) -> Result<RwLockWriteGuard<'_, T>, TryLockError> {
+        debug_assert_ne!(self.mr, 0);
         match self.s.try_acquire(self.mr as usize) {
             Ok(permit) => permit,
             Err(TryAcquireError::NoPermits) => return Err(TryLockError(())),
@@ -1028,6 +1033,7 @@ impl<T: ?Sized> RwLock<T> {
     /// }
     /// ```
     pub fn try_write_owned(self: Arc<Self>) -> Result<OwnedRwLockWriteGuard<T>, TryLockError> {
+        debug_assert_ne!(self.mr, 0);
         match self.s.try_acquire(self.mr as usize) {
             Ok(permit) => permit,
             Err(TryAcquireError::NoPermits) => return Err(TryLockError(())),

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -79,13 +79,13 @@ fn exhaust_reading() {
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "a RwLock may not be created with 0 readers")]
 fn zero_max_readers() {
     RwLock::with_max_readers(100, 0);
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "a RwLock may not be created with 0 readers")]
 fn zero_max_readers_const() {
     RwLock::const_with_max_readers(100, 0);
 }

--- a/tokio/tests/sync_rwlock.rs
+++ b/tokio/tests/sync_rwlock.rs
@@ -78,6 +78,18 @@ fn exhaust_reading() {
     let _g1 = assert_ready!(t1.poll());
 }
 
+#[test]
+#[should_panic]
+fn zero_max_readers() {
+    RwLock::with_max_readers(100, 0);
+}
+
+#[test]
+#[should_panic]
+fn zero_max_readers_const() {
+    RwLock::const_with_max_readers(100, 0);
+}
+
 // When there is an active exclusive owner, subsequent exclusive access should not be possible
 #[test]
 fn write_exclusive_pending() {


### PR DESCRIPTION
If an `RwLock` is created with max readers equal to zero, then write locks do not ensure mutual exclusion because they acquire 0 permits. This can be abused to trigger UB.
```rs
let v = RwLock::with_max_readers(vec![1], 0);
let mut w1 = v.write().await;
let w2 = v.write().await;
let one = &w2[0];
*w1 = Vec::new();
println!("{one}"); // UAF
```
This bug was discovered by asking Gemini to look for bugs in the `with_max_readers` method of `tokio/src/sync/rwlock.rs`.
