### PR TITLE
Avoid illegal state in `FastRand`

### DIFF
--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -39,7 +39,7 @@ impl RngSeed {
 
     fn from_u64(seed: u64) -> Self {
         let one = (seed >> 32) as u32;
-        let mut two = seed as u32;
+        let two = seed as u32;
 
         Self::from_pair(one, two)
     }

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -41,16 +41,15 @@ impl RngSeed {
         let one = (seed >> 32) as u32;
         let mut two = seed as u32;
 
-        if two == 0 {
-            // This value cannot be zero
-            two = 1;
-        }
-
         Self::from_pair(one, two)
     }
 
     fn from_pair(s: u32, r: u32) -> Self {
-        Self { s, r }
+        if s == 0 && r == 0 {
+            Self { s: 0, r: 1 }
+        } else {
+            Self { s, r }
+        }
     }
 }
 

--- a/tokio/src/util/rand.rs
+++ b/tokio/src/util/rand.rs
@@ -92,3 +92,22 @@ impl FastRand {
         s0.wrapping_add(s1)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_zero_seed_from_u64() {
+        let seed = RngSeed::from_u64(0);
+        assert_eq!(seed.s, 0);
+        assert_eq!(seed.r, 1);
+    }
+
+    #[test]
+    fn non_zero_seed_from_pair() {
+        let seed = RngSeed::from_pair(0, 0);
+        assert_eq!(seed.s, 0);
+        assert_eq!(seed.r, 1);
+    }
+}


### PR DESCRIPTION
Since `tokio/src/util/rand/rt.rs` calls `from_pair()` with two random numbers, it is possible that `rt.rs` will create an rng with seed zero. However, the seed zero is not allowed because the Xorshift64+ algorithm produces zeroes indefinitely for this seed. The `from_seed()` method was also adjusted to check both integers for zero instead of just `two`.

This bug was discovered by asking Gemini to look for bugs in the `from_pair` method of `tokio/src/util/rand.rs`.
