### PR TITLE
macros: reduce noisy return type mismatch diagnostics

### DIFF
--- a/tests-build/tests/fail/macros_type_mismatch.stderr
+++ b/tests-build/tests/fail/macros_type_mismatch.stderr
@@ -1,14 +1,3 @@
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:3:1: 3:15}` to be a future that resolves to `()`, but it resolves to `Result<(), _>`
- --> tests/fail/macros_type_mismatch.rs:3:1
-  |
-3 | #[tokio::main]
-  | ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), _>`
-  = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:3:1: 3:15}` to `&dyn Future<Output = ()>`
-  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0308]: mismatched types
  --> tests/fail/macros_type_mismatch.rs:5:5
   |
@@ -26,17 +15,6 @@ help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panic
 5 |     Ok(()).expect("REASON")
   |           +++++++++++++++++
 
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:8:1: 8:15}` to be a future that resolves to `()`, but it resolves to `Result<(), _>`
- --> tests/fail/macros_type_mismatch.rs:8:1
-  |
-8 | #[tokio::main]
-  | ^^^^^^^^^^^^^^ expected `()`, found `Result<(), _>`
-  |
-  = note: expected unit type `()`
-                  found enum `Result<(), _>`
-  = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:8:1: 8:15}` to `&dyn Future<Output = ()>`
-  = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:10:5
    |
@@ -53,17 +31,6 @@ help: consider using `Result::expect` to unwrap the `Result<(), _>` value, panic
    |
 10 |     return Ok(());.expect("REASON")
    |                   +++++++++++++++++
-
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:13:1: 13:15}` to be a future that resolves to `Result<(), ()>`, but it resolves to `()`
-  --> tests/fail/macros_type_mismatch.rs:13:1
-   |
-13 | #[tokio::main]
-   | ^^^^^^^^^^^^^^ expected `Result<(), ()>`, found `()`
-   |
-   = note:   expected enum `Result<(), ()>`
-           found unit type `()`
-   = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:13:1: 13:15}` to `&dyn Future<Output = Result<(), ()>>`
-   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:23:5
@@ -90,17 +57,6 @@ error[E0277]: the `?` operator can only be used in an async block that returns `
 39 | async fn question_mark_operator_with_invalid_option() -> Option<()> {
 40 |     None?;
    |         ^ cannot use the `?` operator in an async block that returns `()`
-
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:38:1: 38:15}` to be a future that resolves to `Option<()>`, but it resolves to `()`
-  --> tests/fail/macros_type_mismatch.rs:38:1
-   |
-38 | #[tokio::main]
-   | ^^^^^^^^^^^^^^ expected `Option<()>`, found `()`
-   |
-   = note:   expected enum `Option<()>`
-           found unit type `()`
-   = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:38:1: 38:15}` to `&dyn Future<Output = Option<()>>`
-   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:40:5
@@ -130,17 +86,6 @@ error[E0277]: the `?` operator can only be used in an async block that returns `
 57 |     Ok(())?;
    |           ^ cannot use the `?` operator in an async block that returns `()`
 
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:55:1: 55:15}` to be a future that resolves to `Result<(), ()>`, but it resolves to `()`
-  --> tests/fail/macros_type_mismatch.rs:55:1
-   |
-55 | #[tokio::main]
-   | ^^^^^^^^^^^^^^ expected `Result<(), ()>`, found `()`
-   |
-   = note:   expected enum `Result<(), ()>`
-           found unit type `()`
-   = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:55:1: 55:15}` to `&dyn Future<Output = Result<(), ()>>`
-   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
-
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:57:5
    |
@@ -156,15 +101,6 @@ help: try adding an expression at the end of the block
 57 ~     Ok(())?;;
 58 +     Ok(())
    |
-
-error[E0271]: expected `{async block@$DIR/tests/fail/macros_type_mismatch.rs:63:1: 63:15}` to be a future that resolves to `()`, but it resolves to `{integer}`
-  --> tests/fail/macros_type_mismatch.rs:63:1
-   |
-63 | #[tokio::main]
-   | ^^^^^^^^^^^^^^ expected `()`, found integer
-   |
-   = note: required for the cast from `&{async block@$DIR/tests/fail/macros_type_mismatch.rs:63:1: 63:15}` to `&dyn Future<Output = ()>`
-   = note: this error originates in the attribute macro `tokio::main` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0308]: mismatched types
   --> tests/fail/macros_type_mismatch.rs:66:5

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -556,7 +556,7 @@ fn parse_knobs(mut input: ItemFn, is_test: bool, config: FinalConfig) -> TokenSt
             }
             _ => quote! {
                 if false {
-                    let _: &dyn ::core::future::Future<Output = #output_type> = &body;
+                    let _ = &body;
                 }
             },
         };


### PR DESCRIPTION
Avoid forcing a dyn Future cast when checking the generated async body.

This removes extra macro-generated E0271 diagnostics (a type mismatched an associated type of a trait) and leaves rustc's more direct type mismatch errors in place.

## Motivation

The macro currently uses an internal `dyn Future` cast to force early type checking
of the generated async body.

However, this introduces additional E0271 diagnostics (a type mismatched an associated type of a trait) related to async block
coercion, which can obscure the more relevant E0308 (expected type did not match the received type) return type mismatch errors.

In cases like #6306, this results in confusing error messages that point to the
async block rather than the actual issue (e.g. an extra semicolon causing `()`).

## Solution

Replace the `dyn Future` trait-object coercion with a simpler reference check:
    let _ = &body;

This still ensures the async body is type-checked, but avoids forcing a
trait-object cast, allowing rustc to emit clearer and more direct diagnostics
focused on the actual type mismatch.
