### PR TITLE
tokio-stream: Implement FusedStream for Fuse

### DIFF
--- a/tokio-stream/src/stream_ext/fuse.rs
+++ b/tokio-stream/src/stream_ext/fuse.rs
@@ -1,5 +1,6 @@
 use crate::Stream;
 
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
@@ -49,5 +50,14 @@ where
             Some(ref stream) => stream.size_hint(),
             None => (0, Some(0)),
         }
+    }
+}
+
+impl<T> FusedStream for Fuse<T>
+where
+    T: Stream,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_none()
     }
 }

--- a/tokio-stream/tests/stream_fuse.rs
+++ b/tokio-stream/tests/stream_fuse.rs
@@ -1,3 +1,4 @@
+use futures_core::FusedStream;
 use tokio_stream::{Stream, StreamExt};
 
 use std::pin::Pin;
@@ -37,16 +38,22 @@ async fn basic_usage() {
     // however, once it is fused
     let mut stream = stream.fuse();
 
+    assert!(!stream.is_terminated());
     assert_eq!(stream.size_hint(), (0, None));
     assert_eq!(stream.next().await, Some(4));
 
+    assert!(!stream.is_terminated());
     assert_eq!(stream.size_hint(), (0, None));
     assert_eq!(stream.next().await, None);
+
+    assert!(stream.is_terminated());
 
     // it will always return `None` after the first time.
     assert_eq!(stream.size_hint(), (0, Some(0)));
     assert_eq!(stream.next().await, None);
     assert_eq!(stream.size_hint(), (0, Some(0)));
+
+    assert!(stream.is_terminated());
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fix https://github.com/tokio-rs/tokio/issues/8089

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Implement `futures_core::FusedStream` for `Fuse`, making it interoperable with code that expects this bound to be satisfied.