### PR TITLE
Make LIFO slot stealing opt-in

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -130,7 +130,7 @@ pub struct Builder {
     pub(super) disable_lifo_slot: bool,
 
     /// When true, the LIFO slot can be work stolen.
-    enable_lifo_stealing: bool,
+    enable_lifo_slot_stealing: bool,
 
     /// Whether or not to enable eager hand-off for tasks in the LIFO slot.
     enable_eager_lifo_handoff: bool,
@@ -342,7 +342,7 @@ impl Builder {
             metrics_poll_count_histogram: HistogramBuilder::default(),
 
             disable_lifo_slot: false,
-            enable_lifo_stealing: false,
+            enable_lifo_slot_stealing: false,
             enable_eager_lifo_handoff: false,
 
             timer_flavor: TimerFlavor::Traditional,
@@ -1362,6 +1362,12 @@ impl Builder {
         /// See the docs for [`disable_lifo_slot`] for more details on what the
         /// LIFO slot is.
         ///
+        /// # Panics
+        ///
+        /// This option requires the LIFO slot to be enabled. If this option is
+        /// set together with [`disable_lifo_slot`], then building the runtime
+        /// will fail with a panic.
+        ///
         /// # Unstable
         ///
         /// This configuration option is unstable because we are considering
@@ -1371,7 +1377,7 @@ impl Builder {
         /// [`disable_lifo_slot`]: Self::disable_lifo_slot()
         /// [`enable_eager_lifo_handoff`]: Self::enable_eager_lifo_handoff()
         pub fn enable_lifo_slot_stealing(&mut self) -> &mut Self {
-            self.enable_lifo_stealing = true;
+            self.enable_lifo_slot_stealing = true;
             self
         }
 
@@ -1387,6 +1393,12 @@ impl Builder {
         /// blocks and the LIFO slot needs to be stolen. This can hurt the
         /// performance of some workloads. See [tokio-rs/tokio#8065] for
         /// details.
+        ///
+        /// # Panics
+        ///
+        /// This option requires that LIFO slot stealing is enabled. If this
+        /// option is enabled without [`enable_lifo_slot_stealing`], then this
+        /// results in a panic when building the runtime.
         ///
         /// # Unstable
         ///
@@ -1765,7 +1777,7 @@ impl Builder {
                 #[cfg(tokio_unstable)]
                 unhandled_panic: self.unhandled_panic.clone(),
                 disable_lifo_slot: self.disable_lifo_slot,
-                enable_lifo_stealing: self.enable_lifo_stealing,
+                enable_lifo_slot_stealing: self.enable_lifo_slot_stealing,
                 enable_eager_lifo_handoff: self.enable_eager_lifo_handoff,
                 // This setting never makes sense for a current thread runtime,
                 // as it only configures how the I/O driver is stolen across
@@ -1933,6 +1945,15 @@ cfg_rt_multi_thread! {
             let seed_generator_1 = self.seed_generator.next_generator();
             let seed_generator_2 = self.seed_generator.next_generator();
 
+            if self.disable_lifo_slot {
+                assert!(!self.enable_lifo_slot_stealing, "Enabling LIFO slot stealing does not make sense when LIFO slot is disabled");
+                assert!(!self.enable_eager_lifo_handoff, "Enabling eager LIFO handoff does not make sense when LIFO slot is disabled");
+            }
+
+            if self.enable_eager_lifo_handoff {
+                assert!(self.enable_lifo_slot_stealing, "Enabling eager LIFO handoff requires LIFO slot stealing to be enabled");
+            }
+
             let (scheduler, handle, launch) = MultiThread::new(
                 worker_threads,
                 driver,
@@ -1953,7 +1974,7 @@ cfg_rt_multi_thread! {
                     #[cfg(tokio_unstable)]
                     unhandled_panic: self.unhandled_panic.clone(),
                     disable_lifo_slot: self.disable_lifo_slot,
-                    enable_lifo_stealing: self.enable_lifo_stealing,
+                    enable_lifo_slot_stealing: self.enable_lifo_slot_stealing,
                     enable_eager_lifo_handoff: self.enable_eager_lifo_handoff,
                     enable_eager_driver_handoff: self.enable_eager_driver_handoff,
                     seed_generator: seed_generator_1,

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -129,6 +129,12 @@ pub struct Builder {
     /// This option should only be exposed as unstable.
     pub(super) disable_lifo_slot: bool,
 
+    /// When true, the LIFO slot can be work stolen.
+    enable_lifo_stealing: bool,
+
+    /// Whether or not to enable eager hand-off for tasks in the LIFO slot.
+    enable_eager_lifo_handoff: bool,
+
     /// Specify a random number generator seed to provide deterministic results
     pub(super) seed_generator: RngSeedGenerator,
 
@@ -336,6 +342,8 @@ impl Builder {
             metrics_poll_count_histogram: HistogramBuilder::default(),
 
             disable_lifo_slot: false,
+            enable_lifo_stealing: false,
+            enable_eager_lifo_handoff: false,
 
             timer_flavor: TimerFlavor::Traditional,
 
@@ -1306,15 +1314,16 @@ impl Builder {
         /// This configuration option will disable this heuristic resulting in
         /// all scheduled tasks being pushed into the worker-local queue. This
         /// was intended as a workaround for the LIFO slot not being stealable.
-        /// As of Tokio 1.51, tasks can be stolen from the LIFO slot. In a
-        /// future version, this option may be deprecated.
+        /// As of Tokio 1.51, tasks can be stolen from the LIFO slot when
+        /// [`enable_lifo_slot_stealing`] is enabled. In a future version, this
+        /// option may be deprecated.
         ///
         /// # Unstable
         ///
         /// This configuration option was considered a workaround for the LIFO
-        /// slot not being stealable. Since this is no longer the case, we will
-        /// revisit whether or not this option is necessary. See
-        /// issue [tokio-rs/tokio#4941].
+        /// slot not being stealable. Since LIFO slot stealing can now be
+        /// enabled, we will revisit whether or not this option is necessary.
+        /// See issue [tokio-rs/tokio#4941].
         ///
         /// # Examples
         ///
@@ -1332,8 +1341,62 @@ impl Builder {
         ///
         /// [tokio-rs/tokio-metrics]: https://github.com/tokio-rs/tokio-metrics
         /// [tokio-rs/tokio#4941]: https://github.com/tokio-rs/tokio/issues/4941
+        /// [`enable_lifo_slot_stealing`]: Self::enable_lifo_slot_stealing()
         pub fn disable_lifo_slot(&mut self) -> &mut Self {
             self.disable_lifo_slot = true;
+            self
+        }
+
+        /// Makes it possible to steal the task in the LIFO slot.
+        ///
+        /// When a worker thread tries to steal work from other workers, it will
+        /// normally never steal the work stored in the LIFO slot. When enabling
+        /// this option, workers will steal the LIFO slot task when the queue is
+        /// otherwise empty.
+        ///
+        /// Note that the LIFO slot is only stolen if another worker thread
+        /// attempts work stealing while the LIFO slot is non-empty, but the
+        /// runtime will not wake up other workers to steal the task unless the
+        /// [`enable_eager_lifo_handoff`] option is also enabled.
+        ///
+        /// See the docs for [`disable_lifo_slot`] for more details on what the
+        /// LIFO slot is.
+        ///
+        /// # Unstable
+        ///
+        /// This configuration option is unstable because we are considering
+        /// enabling it by default. See issue [tokio-rs/tokio#4941].
+        ///
+        /// [tokio-rs/tokio#4941]: https://github.com/tokio-rs/tokio/issues/4941
+        /// [`disable_lifo_slot`]: Self::disable_lifo_slot()
+        /// [`enable_eager_lifo_handoff`]: Self::enable_eager_lifo_handoff()
+        pub fn enable_lifo_slot_stealing(&mut self) -> &mut Self {
+            self.enable_lifo_stealing = true;
+            self
+        }
+
+        /// Enable eager hand-off of the LIFO slot on multi-threaded runtimes.
+        ///
+        /// Normally when a task is pushed to the LIFO slot, no worker thread is
+        /// woken up, which means that if the task that pushed it to the LIFO
+        /// slot does not yield and all other workers are idle, then even if
+        /// [`enable_lifo_slot_stealing`] is enabled the task may not be stolen.
+        ///
+        /// This option may significantly increase [the number of noop
+        /// wakes][noop-wake], where a worker is woken just in case the task
+        /// blocks and the LIFO slot needs to be stolen. This can hurt the
+        /// performance of some workloads. See [tokio-rs/tokio#8065] for
+        /// details.
+        ///
+        /// # Unstable
+        ///
+        /// This configuration option is unstable.
+        ///
+        /// [noop-wake]: crate::runtime::RuntimeMetrics::worker_noop_count
+        /// [tokio-rs/tokio#8065]: https://github.com/tokio-rs/tokio/issues/8065
+        /// [`enable_lifo_slot_stealing`]: Self::enable_lifo_slot_stealing()
+        pub fn enable_eager_lifo_handoff(&mut self) -> &mut Self {
+            self.enable_eager_lifo_handoff = true;
             self
         }
 
@@ -1702,6 +1765,8 @@ impl Builder {
                 #[cfg(tokio_unstable)]
                 unhandled_panic: self.unhandled_panic.clone(),
                 disable_lifo_slot: self.disable_lifo_slot,
+                enable_lifo_stealing: self.enable_lifo_stealing,
+                enable_eager_lifo_handoff: self.enable_eager_lifo_handoff,
                 // This setting never makes sense for a current thread runtime,
                 // as it only configures how the I/O driver is stolen across
                 // workers.
@@ -1888,6 +1953,8 @@ cfg_rt_multi_thread! {
                     #[cfg(tokio_unstable)]
                     unhandled_panic: self.unhandled_panic.clone(),
                     disable_lifo_slot: self.disable_lifo_slot,
+                    enable_lifo_stealing: self.enable_lifo_stealing,
+                    enable_eager_lifo_handoff: self.enable_eager_lifo_handoff,
                     enable_eager_driver_handoff: self.enable_eager_driver_handoff,
                     seed_generator: seed_generator_1,
                     metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -39,8 +39,8 @@ pub(crate) struct Config {
     /// In Tokio versions before 1.51, tasks in the LIFO slot could not be
     /// stolen, which could cause issues in applications with long poll times.
     /// As a stop-gap, this unstable option lets users disable the LIFO task.
-    /// Now that the LIFO slot is stealable, we may remove this option in a
-    /// future version.
+    /// Now that the LIFO slot is stealable, we may remove this option when the
+    /// LIFO slot stealing will be enabled by default.
     pub(crate) disable_lifo_slot: bool,
 
     /// Can work stealing occur for tasks in the per-worker LIFO slot?

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -44,7 +44,7 @@ pub(crate) struct Config {
     pub(crate) disable_lifo_slot: bool,
 
     /// Can work stealing occur for tasks in the per-worker LIFO slot?
-    pub(crate) enable_lifo_stealing: bool,
+    pub(crate) enable_lifo_slot_stealing: bool,
 
     /// Should a worker be woken up when a task is pushed to the per-worker LIFO slot?
     pub(crate) enable_eager_lifo_handoff: bool,

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -43,6 +43,12 @@ pub(crate) struct Config {
     /// future version.
     pub(crate) disable_lifo_slot: bool,
 
+    /// Can work stealing occur for tasks in the per-worker LIFO slot?
+    pub(crate) enable_lifo_stealing: bool,
+
+    /// Should a worker be woken up when a task is pushed to the per-worker LIFO slot?
+    pub(crate) enable_eager_lifo_handoff: bool,
+
     /// Random number generator seed to configure runtimes to act in a
     /// deterministic way.
     pub(crate) seed_generator: RngSeedGenerator,

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -443,7 +443,10 @@ impl<T> Steal<T> {
         (len(head, tail) > 0) || (steal_lifo && self.0.lifo.is_some())
     }
 
-    /// Steals half the tasks from self and place them into `dst`.
+    /// Steals half the tasks from the run queue and places them into `dst`.
+    ///
+    /// When `steal_lifo` is set, this will also attempt to steal from the LIFO
+    /// slot if the queue is otherwise empty.
     pub(crate) fn steal_into(
         &self,
         dst: &mut Local<T>,

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -435,8 +435,10 @@ impl<T> Steal<T> {
         len(head, tail) + lifo
     }
 
-    /// Return true if the queue is empty,
-    /// false if there are any entries in the queue
+    /// Returns true if `steal_into` might be able to steal tasks.
+    ///
+    /// The `steal_lifo` parameter indicates whether the LIFO slot should be counted in this
+    /// analysis. Use the same value as what is passed to `steal_into`.
     pub(crate) fn can_steal(&self, steal_lifo: bool) -> bool {
         let (_, head) = unpack(self.0.head.load(Acquire));
         let tail = self.0.tail.load(Acquire);

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -427,6 +427,7 @@ impl<T> Local<T> {
 
 impl<T> Steal<T> {
     /// Returns the number of entries in the queue
+    #[cfg(tokio_unstable)]
     pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.0.head.load(Acquire));
         let tail = self.0.tail.load(Acquire);
@@ -436,8 +437,10 @@ impl<T> Steal<T> {
 
     /// Return true if the queue is empty,
     /// false if there are any entries in the queue
-    pub(crate) fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub(crate) fn can_steal(&self, steal_lifo: bool) -> bool {
+        let (_, head) = unpack(self.0.head.load(Acquire));
+        let tail = self.0.tail.load(Acquire);
+        (len(head, tail) > 0) || (steal_lifo && self.0.lifo.is_some())
     }
 
     /// Steals half the tasks from self and place them into `dst`.
@@ -445,6 +448,7 @@ impl<T> Steal<T> {
         &self,
         dst: &mut Local<T>,
         dst_stats: &mut Stats,
+        steal_lifo: bool,
     ) -> Option<task::Notified<T>> {
         // Safety: the caller is the only thread that mutates `dst.tail` and
         // holds a mutable reference.
@@ -466,14 +470,17 @@ impl<T> Steal<T> {
         let mut n = self.steal_into2(dst, dst_tail);
 
         if n == 0 {
-            // If no tasks were stolen, let's see if there's one in the LIFO
-            // slot.
-            let lifo = self.0.lifo.take();
-            if lifo.is_some() {
-                dst_stats.incr_steal_count(1);
-                dst_stats.incr_steal_operations();
+            if steal_lifo {
+                // If no tasks were stolen, let's see if there's one in the LIFO
+                // slot.
+                let lifo = self.0.lifo.take();
+                if lifo.is_some() {
+                    dst_stats.incr_steal_count(1);
+                    dst_stats.incr_steal_operations();
+                }
+                return lifo;
             }
-            return lifo;
+            return None;
         }
 
         dst_stats.incr_steal_count(n as u16);

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1135,7 +1135,8 @@ impl Core {
             return None;
         }
 
-        let num = worker.handle.shared.remotes.len();
+        let shared = &worker.handle.shared;
+        let num = shared.remotes.len();
         // Start from a random worker
         let start = self.rand.fastrand_n(num as u32) as usize;
 
@@ -1147,10 +1148,12 @@ impl Core {
                 continue;
             }
 
-            let target = &worker.handle.shared.remotes[i];
-            if let Some(task) = target
-                .steal
-                .steal_into(&mut self.run_queue, &mut self.stats)
+            let target = &shared.remotes[i];
+            let steal_lifo = shared.config.enable_lifo_stealing;
+            if let Some(task) =
+                target
+                    .steal
+                    .steal_into(&mut self.run_queue, &mut self.stats, steal_lifo)
             {
                 return Some(task);
             }
@@ -1349,9 +1352,10 @@ impl Handle {
         // task must always be pushed to the back of the queue, enabling other
         // tasks to be executed. If **not** a yield, then there is more
         // flexibility and the task may go to the front of the queue.
-        if is_yield || !core.lifo_enabled {
+        let should_notify = if is_yield || !core.lifo_enabled {
             core.run_queue
                 .push_back_or_overflow(task, self, &mut core.stats);
+            true
         } else {
             // Push to the LIFO slot
             if let Some(prev) = core.run_queue.push_lifo(task) {
@@ -1359,13 +1363,18 @@ impl Handle {
                 // to be pushed to the back of the run queue.
                 core.run_queue
                     .push_back_or_overflow(prev, self, &mut core.stats);
+                true
+            } else {
+                // We pushed to the LIFO slot, and it was empty, so only notify if eager lifo
+                // handoff is enabled.
+                self.shared.config.enable_eager_lifo_handoff
             }
         };
 
         // Only notify if not currently parked. If `park` is `None`, then the
         // scheduling is from a resource driver. As notifications often come in
         // batches, the notification is delayed until the park is complete.
-        if core.park.is_some() {
+        if should_notify && core.park.is_some() {
             self.notify_parked_local();
         }
     }
@@ -1449,8 +1458,9 @@ impl Handle {
     }
 
     fn notify_if_work_pending(&self) {
+        let steal_lifo = self.shared.config.enable_lifo_stealing;
         for remote in &self.shared.remotes[..] {
-            if !remote.steal.is_empty() {
+            if remote.steal.can_steal(steal_lifo) {
                 self.notify_parked_local();
                 return;
             }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1149,7 +1149,7 @@ impl Core {
             }
 
             let target = &shared.remotes[i];
-            let steal_lifo = shared.config.enable_lifo_stealing;
+            let steal_lifo = shared.config.enable_lifo_slot_stealing;
             if let Some(task) =
                 target
                     .steal
@@ -1458,7 +1458,7 @@ impl Handle {
     }
 
     fn notify_if_work_pending(&self) {
-        let steal_lifo = self.shared.config.enable_lifo_stealing;
+        let steal_lifo = self.shared.config.enable_lifo_slot_stealing;
         for remote in &self.shared.remotes[..] {
             if remote.steal.can_steal(steal_lifo) {
                 self.notify_parked_local();

--- a/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
@@ -67,8 +67,8 @@ impl Shared {
 
         for remote in self.remotes.iter() {
             let steal = &remote.steal;
-            while !steal.is_empty() {
-                if let Some(task) = steal.steal_into(&mut local, &mut stats) {
+            while steal.can_steal(true) {
+                if let Some(task) = steal.steal_into(&mut local, &mut stats, true) {
                     local.push_back([task].into_iter());
                 }
             }

--- a/tokio/src/runtime/tests/loom_multi_thread/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/queue.rs
@@ -306,3 +306,66 @@ fn chained_steal() {
         while l2.pop().is_some() {}
     });
 }
+
+#[test]
+fn concurrent_steal_and_pop_lifo() {
+    loom::model(|| {
+        let (steal, local) = queue::local();
+
+        // Push a task to the LIFO slot
+        let (task, _) = unowned(async {});
+        local.push_lifo(task);
+
+        let th = thread::spawn({
+            let steal = steal.clone();
+            move || {
+                let mut stats = new_stats();
+                let (_, mut local) = queue::local();
+
+                // Attempt to steal, with steal_lifo = true
+                steal.steal_into(&mut local, &mut stats, true).is_some()
+            }
+        });
+
+        // Concurrently attempt to pop LIFO locally
+        let popped = local.pop_lifo().is_some();
+
+        let stolen = th.join().unwrap();
+
+        // Exactly one of them should have succeeded in getting the task.
+        assert!(stolen ^ popped, "exactly one should get the task");
+
+        // Verify that the LIFO slot is now empty.
+        assert!(local.pop_lifo().is_none());
+    });
+}
+
+#[test]
+fn concurrent_push_and_steal_lifo() {
+    loom::model(|| {
+        let (steal, local) = queue::local();
+
+        let th = thread::spawn({
+            let steal = steal.clone();
+            move || {
+                let mut stats = new_stats();
+                let (_, mut local) = queue::local();
+
+                // Attempt to steal, with steal_lifo = true
+                steal.steal_into(&mut local, &mut stats, true).is_some()
+            }
+        });
+
+        // Concurrently push a task to LIFO
+        let (task, _) = unowned(async {});
+        local.push_lifo(task);
+
+        let stolen = th.join().unwrap();
+
+        // Check if the task is still in the local LIFO slot
+        let in_local = local.pop_lifo().is_some();
+
+        // The task must be in exactly one place: either stolen or still local.
+        assert!(stolen ^ in_local, "task must be in exactly one place");
+    });
+}

--- a/tokio/src/runtime/tests/loom_multi_thread/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/queue.rs
@@ -21,7 +21,7 @@ fn basic() {
             let mut n = 0;
 
             for _ in 0..3 {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 
@@ -76,7 +76,7 @@ fn basic_lifo() {
             let mut n = 0;
 
             for _ in 0..3 {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 
@@ -133,7 +133,7 @@ fn steal_overflow() {
             let (_, mut local) = queue::local();
             let mut n = 0;
 
-            if steal.steal_into(&mut local, &mut stats).is_some() {
+            if steal.steal_into(&mut local, &mut stats, false).is_some() {
                 n += 1;
             }
 
@@ -256,7 +256,7 @@ fn steal_tasks(steal: queue::Steal<NoopSchedule>) -> usize {
     let mut stats = new_stats();
     let (_, mut local) = queue::local();
 
-    if steal.steal_into(&mut local, &mut stats).is_none() {
+    if steal.steal_into(&mut local, &mut stats, false).is_none() {
         return 0;
     }
 
@@ -290,7 +290,7 @@ fn chained_steal() {
         let th = thread::spawn(move || {
             let mut stats = new_stats();
             let (_, mut local) = queue::local();
-            s1.steal_into(&mut local, &mut stats);
+            s1.steal_into(&mut local, &mut stats, false);
 
             while local.pop().is_some() {}
         });
@@ -298,7 +298,7 @@ fn chained_steal() {
         // Drain our tasks, then attempt to steal
         while l1.pop().is_some() {}
 
-        s2.steal_into(&mut l1, &mut stats);
+        s2.steal_into(&mut l1, &mut stats, false);
 
         th.join().unwrap();
 

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -125,7 +125,7 @@ fn steal_batch() {
         local1.push_back_or_overflow(task, &inject, &mut stats);
     }
 
-    assert!(steal1.steal_into(&mut local2, &mut stats).is_some());
+    assert!(steal1.steal_into(&mut local2, &mut stats, false).is_some());
 
     cfg_unstable_metrics! {
         assert_metrics!(stats, steal_count == 2);
@@ -172,7 +172,7 @@ fn stress1() {
             let mut n = 0;
 
             for _ in 0..NUM_STEAL {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 
@@ -233,7 +233,7 @@ fn stress2() {
             let mut n = 0;
 
             for _ in 0..NUM_STEAL {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -698,7 +698,8 @@ fn mutex_in_block_in_place() {
 //
 // Integration test for: https://github.com/tokio-rs/tokio/issues/4941
 #[test]
-fn lifo_stealable() {
+#[cfg(tokio_unstable)]
+fn lifo_stealable_inner() {
     use std::time::Duration;
 
     // This test constructs a scenario where a task (the "blocker task")
@@ -726,6 +727,8 @@ fn lifo_stealable() {
         // there's still at least one worker free to steal the blocked task.
         .worker_threads(4)
         .enable_time()
+        .enable_lifo_slot_stealing()
+        .enable_eager_lifo_handoff()
         .build()
         .unwrap();
 


### PR DESCRIPTION
We made it possible to steal the LIFO slot in #7431, but this causes a performance regression #8065. Thus, make it opt-in.

The feature is split into two options:

* Can stealing happen at all?
* Are workers woken up eagerly to check whether stealing should be carried out?

Both options are needed to make the runtime fully tolerate slow tasks, but I split them up as the first option can probably be enabled by default without adverse performance impact. But for now, both are off by default.

Fixes: #8065