### PR TITLE
feat: add AsyncReadExt::read_interruptible()

### DIFF
--- a/tokio/src/io/mod.rs
+++ b/tokio/src/io/mod.rs
@@ -284,7 +284,7 @@ cfg_io_util! {
     pub(crate) mod util;
     pub use util::{
         copy, copy_bidirectional, copy_bidirectional_with_sizes, copy_buf, duplex, empty, repeat, sink, simplex, AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt,
-        BufReader, BufStream, BufWriter, Chain, DuplexStream, Empty, Lines, Repeat, Sink, Split, Take, SimplexStream,
+        BufReader, BufStream, BufWriter, Chain, DuplexStream, Empty, Lines, ReadInterruptible, Repeat, Sink, Split, Take, SimplexStream,
     };
 }
 

--- a/tokio/src/io/util/async_read_ext.rs
+++ b/tokio/src/io/util/async_read_ext.rs
@@ -1,3 +1,5 @@
+use std::future::Future;
+
 use crate::io::util::chain::{chain, Chain};
 use crate::io::util::read::{read, Read};
 use crate::io::util::read_buf::{read_buf, ReadBuf};
@@ -9,10 +11,11 @@ use crate::io::util::read_int::{
 use crate::io::util::read_int::{
     ReadU128, ReadU128Le, ReadU16, ReadU16Le, ReadU32, ReadU32Le, ReadU64, ReadU64Le, ReadU8,
 };
+use crate::io::util::read_interruptible::read_interruptible;
 use crate::io::util::read_to_end::{read_to_end, ReadToEnd};
 use crate::io::util::read_to_string::{read_to_string, ReadToString};
 use crate::io::util::take::{take, Take};
-use crate::io::AsyncRead;
+use crate::io::{AsyncRead, ReadInterruptible};
 
 use bytes::BufMut;
 
@@ -1447,6 +1450,62 @@ cfg_io_util! {
             Self: Sized,
         {
             take(self, limit)
+        }
+
+        /// Creates an adaptor which will stop reading once a signal future resolves.
+        ///
+        /// This function returns an implementation of `AsyncRead` wrapping `Self`
+        /// which will read from the underlying reader until the provided `signal`
+        /// future resolves, after which it will always return EOF (`Ok(0)`).
+        ///
+        /// When the signal resolves, reading stops immediately:
+        /// even data that is already buffered in the underlying
+        /// reader is not returned.
+        /// Any subsequent calls to [`read()`] will return EOF.
+        ///
+        /// The returned `AsyncRead` implementation also implements `AsyncWrite` and `AsyncSeek`;
+        /// it performs writing and seeking regardless of the `signal` future;
+        /// only reading is interrupted by the `signal`.
+        /// The returned type can therefore be used for bi-directional I/O.
+        ///
+        /// [`read()`]: fn@crate::io::AsyncReadExt::read
+        ///
+        /// # Examples
+        ///
+        /// Using a `oneshot` channel as the signal:
+        ///
+        /// ```
+        /// use tokio::io::{self, AsyncReadExt};
+        /// use tokio::sync::oneshot;
+        ///
+        /// #[tokio::main]
+        /// async fn main() -> io::Result<()> {
+        ///     let reader = io::repeat(0xff);
+        ///     let (tx, rx) = oneshot::channel::<()>();
+        ///
+        ///     // Signal that reading should stop.
+        ///     tx.send(()).unwrap();
+        ///
+        ///     let mut buffer = vec![0u8; 10];
+        ///     let mut interruptible = reader.read_interruptible(async move {
+        ///         let _ = rx.await;
+        ///     });
+        ///
+        ///     // Even though `repeat` has data available, no bytes are read
+        ///     // because the signal has already resolved.
+        ///     let n = interruptible.read(&mut buffer).await?;
+        ///     assert_eq!(n, 0);
+        ///
+        ///     assert!(interruptible.is_stopped());
+        ///
+        ///     Ok(())
+        /// }
+        /// ```
+        fn read_interruptible<F: Future>(self, signal: F) -> ReadInterruptible<Self, F>
+        where
+            Self: Sized,
+        {
+            read_interruptible(self, signal)
         }
     }
 }

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -49,6 +49,8 @@ cfg_io_util! {
     mod read_buf;
     mod read_exact;
     mod read_int;
+    mod read_interruptible;
+    pub use read_interruptible::ReadInterruptible;
     mod read_line;
     mod fill_buf;
 

--- a/tokio/src/io/util/read_interruptible.rs
+++ b/tokio/src/io/util/read_interruptible.rs
@@ -1,0 +1,183 @@
+use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+
+use pin_project_lite::pin_project;
+use std::future::Future;
+use std::io::{self, IoSlice, SeekFrom};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+pin_project! {
+    /// `AsyncRead` implementation for the [`read_interruptible`](super::AsyncReadExt::read_interruptible) method.
+    #[derive(Debug)]
+    #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
+    #[project = ReadInterruptibleProject]
+    pub struct ReadInterruptible<R, F> {
+        #[pin]
+        inner: R,
+        #[pin]
+        signal: Option<F>,
+    }
+}
+
+pub(super) fn read_interruptible<R, F>(inner: R, signal: F) -> ReadInterruptible<R, F>
+where
+    R: AsyncRead,
+{
+    ReadInterruptible {
+        inner,
+        signal: Some(signal),
+    }
+}
+
+impl<R, F> ReadInterruptible<R, F>
+where
+    R: AsyncRead,
+{
+    /// Gets a reference to the underlying I/O.
+    pub fn get_ref(&self) -> &R {
+        &self.inner
+    }
+
+    /// Gets a mutable reference to the underlying I/O.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.inner
+    }
+
+    /// Gets a pinned mutable reference to the underlying I/O.
+    pub fn get_pin_mut(self: Pin<&mut Self>) -> Pin<&mut R> {
+        self.project().inner
+    }
+
+    /// Consumes the `ReadInterruptible`, returning the wrapped I/O.
+    ///
+    /// This drops the signaling future regardless of whether it has resolved yet.
+    pub fn into_inner(self) -> R {
+        self.inner
+    }
+
+    /// Indicates whether the reader has already been stopped by the signaling future.
+    ///
+    /// Note that writing or seeking – if supported by the inner I/O – will still work
+    /// even after reading is stopped.
+    pub fn is_stopped(&self) -> bool {
+        self.signal.is_none()
+    }
+}
+
+impl<'pin, R, F> ReadInterruptibleProject<'pin, R, F>
+where
+    F: Future,
+{
+    /// Polls the `signal` future (if any) and returns whether EOF has been signaled.
+    fn poll_eof(&mut self, cx: &mut Context<'_>) -> bool {
+        let eof = if let Some(ft) = self.signal.as_mut().as_pin_mut() {
+            ft.poll(cx).is_ready()
+        } else {
+            true
+        };
+
+        if eof {
+            self.signal.set(None);
+        }
+
+        eof
+    }
+}
+
+impl<R, F> AsyncRead for ReadInterruptible<R, F>
+where
+    R: AsyncRead,
+    F: Future,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let mut this = self.project();
+
+        if this.poll_eof(cx) {
+            Poll::Ready(Ok(()))
+        } else {
+            this.inner.poll_read(cx, buf)
+        }
+    }
+}
+
+impl<R, F> AsyncBufRead for ReadInterruptible<R, F>
+where
+    R: AsyncBufRead,
+    F: Future,
+{
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
+        let mut this = self.project();
+
+        if this.poll_eof(cx) {
+            Poll::Ready(Ok(&[]))
+        } else {
+            this.inner.poll_fill_buf(cx)
+        }
+    }
+
+    fn consume(self: Pin<&mut Self>, amt: usize) {
+        self.project().inner.consume(amt);
+    }
+}
+
+impl<R, F> AsyncWrite for ReadInterruptible<R, F>
+where
+    R: AsyncWrite,
+    F: Future,
+{
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.project().inner.poll_shutdown(cx)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        self.project().inner.poll_write_vectored(cx, bufs)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+}
+
+impl<R, F> AsyncSeek for ReadInterruptible<R, F>
+where
+    R: AsyncSeek,
+    F: Future,
+{
+    fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> io::Result<()> {
+        self.project().inner.start_seek(position)
+    }
+
+    fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
+        self.project().inner.poll_complete(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assert_unpin() {
+        crate::is_unpin::<ReadInterruptible<(), ()>>();
+    }
+}

--- a/tokio/tests/io_read_interruptible.rs
+++ b/tokio/tests/io_read_interruptible.rs
@@ -1,0 +1,108 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+
+use std::future;
+use std::io::SeekFrom;
+use tokio::io::{self, AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+
+#[tokio::test]
+async fn read_not_interrupted() {
+    let mut buf = [0u8; 8];
+    let mut interruptible = io::repeat(0xAB).read_interruptible(future::pending::<()>());
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert!(n > 0);
+    assert!(buf[..n].iter().all(|&b| b == 0xAB));
+    assert!(!interruptible.is_stopped());
+}
+
+#[tokio::test]
+async fn read_interrupted() {
+    let mut buf = [0u8; 8];
+    let mut interruptible = io::repeat(0xAB).read_interruptible(future::ready(()));
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    assert!(interruptible.is_stopped());
+}
+
+#[tokio::test]
+async fn interrupted_read_stays_interrupted() {
+    let mut buf = [0u8; 8];
+    let mut interruptible = io::repeat(0xAB).read_interruptible(future::ready(()));
+
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    assert!(interruptible.is_stopped());
+
+    // Second and third reads must also return EOF, not data from the inner reader.
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+async fn buf_read_not_interrupted() {
+    let data: &[u8] = b"hello world";
+    let mut interruptible = data.read_interruptible(future::pending::<()>());
+    let filled = interruptible.fill_buf().await.unwrap();
+    assert_eq!(filled, b"hello world");
+    assert!(!interruptible.is_stopped());
+}
+
+#[tokio::test]
+async fn buf_read_interrupted() {
+    let data: &[u8] = b"hello world";
+    let mut interruptible = data.read_interruptible(future::ready(()));
+    let filled = interruptible.fill_buf().await.unwrap();
+    assert!(filled.is_empty());
+    assert!(interruptible.is_stopped());
+}
+
+#[tokio::test]
+async fn interrupted_buf_read_stays_interrupted() {
+    let data: &[u8] = b"hello world";
+    let mut interruptible = data.read_interruptible(future::ready(()));
+
+    let filled = interruptible.fill_buf().await.unwrap();
+    assert!(filled.is_empty());
+    assert!(interruptible.is_stopped());
+
+    // Subsequent fill_buf calls must also return empty, not data from the inner reader.
+    let filled = interruptible.fill_buf().await.unwrap();
+    assert!(filled.is_empty());
+    let filled = interruptible.fill_buf().await.unwrap();
+    assert!(filled.is_empty());
+}
+
+#[tokio::test]
+async fn write_never_interrupted() {
+    let cursor = std::io::Cursor::new(Vec::<u8>::new());
+    let mut interruptible = cursor.read_interruptible(future::ready(()));
+
+    // Reading is interrupted.
+    let mut buf = [0u8; 1];
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    assert!(interruptible.is_stopped());
+
+    // Writing still works.
+    let written = interruptible.write(b"hello").await.unwrap();
+    assert_eq!(written, 5);
+    assert_eq!(interruptible.get_ref().get_ref(), b"hello");
+}
+
+#[tokio::test]
+async fn seek_never_interrupted() {
+    let cursor = std::io::Cursor::new(b"hello world".to_vec());
+    let mut interruptible = cursor.read_interruptible(future::ready(()));
+
+    // Reading is interrupted.
+    let mut buf = [0u8; 1];
+    let n = interruptible.read(&mut buf).await.unwrap();
+    assert_eq!(n, 0);
+    assert!(interruptible.is_stopped());
+
+    // Seeking still works.
+    let pos = interruptible.seek(SeekFrom::Start(6)).await.unwrap();
+    assert_eq!(pos, 6);
+}


### PR DESCRIPTION
Adds `AsyncReadExt::read_interruptible()`

## Motivation

I find myself sometimes in a need of stopping async reader(s) based on a future for graceful shutdown.

I'm already using this code in a project so I thought might as well offer that for upstreaming, in case others find it useful. (If not that's ok too.)

## Solution

The usual, a method on the `AsyncReadExt` trait returning a wrapper.
