### PR TITLE
tokio-stream: implement FusedStream for stream adaptors

### DIFF
--- a/tokio-stream/src/stream_ext/chain.rs
+++ b/tokio-stream/src/stream_ext/chain.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 
 use core::pin::Pin;
 use core::task::{ready, Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -46,5 +47,15 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         super::merge_size_hints(self.a.size_hint(), self.b.size_hint())
+    }
+}
+
+impl<T, U> FusedStream for Chain<T, U>
+where
+    T: Stream,
+    U: FusedStream<Item = T::Item>,
+{
+    fn is_terminated(&self) -> bool {
+        self.a.is_terminated() && self.b.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/filter.rs
+++ b/tokio-stream/src/stream_ext/filter.rs
@@ -60,8 +60,8 @@ where
 
 impl<St, F> FusedStream for Filter<St, F>
 where
-    Self: Stream,
     St: FusedStream,
+    F: FnMut(&St::Item) -> bool,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/filter.rs
+++ b/tokio-stream/src/stream_ext/filter.rs
@@ -60,8 +60,8 @@ where
 
 impl<St, F> FusedStream for Filter<St, F>
 where
+    Self: Stream,
     St: FusedStream,
-    F: FnMut(&St::Item) -> bool,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/filter.rs
+++ b/tokio-stream/src/stream_ext/filter.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{ready, Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -54,5 +55,15 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.stream.size_hint().1) // can't know a lower bound, due to the predicate
+    }
+}
+
+impl<St, F> FusedStream for Filter<St, F>
+where
+    St: FusedStream,
+    F: FnMut(&St::Item) -> bool,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/filter_map.rs
+++ b/tokio-stream/src/stream_ext/filter_map.rs
@@ -58,10 +58,10 @@ where
     }
 }
 
-impl<St, F, T> FusedStream for FilterMap<St, F>
+impl<St, F> FusedStream for FilterMap<St, F>
 where
+    Self: Stream,
     St: FusedStream,
-    F: FnMut(St::Item) -> Option<T>,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/filter_map.rs
+++ b/tokio-stream/src/stream_ext/filter_map.rs
@@ -58,10 +58,10 @@ where
     }
 }
 
-impl<St, F> FusedStream for FilterMap<St, F>
+impl<St, F, T> FusedStream for FilterMap<St, F>
 where
-    Self: Stream,
     St: FusedStream,
+    F: FnMut(St::Item) -> Option<T>,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/filter_map.rs
+++ b/tokio-stream/src/stream_ext/filter_map.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{ready, Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -54,5 +55,15 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         (0, self.stream.size_hint().1) // can't know a lower bound, due to the predicate
+    }
+}
+
+impl<St, F, T> FusedStream for FilterMap<St, F>
+where
+    St: FusedStream,
+    F: FnMut(St::Item) -> Option<T>,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/map.rs
+++ b/tokio-stream/src/stream_ext/map.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -47,5 +48,15 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         self.stream.size_hint()
+    }
+}
+
+impl<St, F, T> FusedStream for Map<St, F>
+where
+    St: FusedStream,
+    F: FnMut(St::Item) -> T,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/map.rs
+++ b/tokio-stream/src/stream_ext/map.rs
@@ -51,10 +51,10 @@ where
     }
 }
 
-impl<St, F, T> FusedStream for Map<St, F>
+impl<St, F> FusedStream for Map<St, F>
 where
+    Self: Stream,
     St: FusedStream,
-    F: FnMut(St::Item) -> T,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/map.rs
+++ b/tokio-stream/src/stream_ext/map.rs
@@ -51,10 +51,10 @@ where
     }
 }
 
-impl<St, F> FusedStream for Map<St, F>
+impl<St, F, T> FusedStream for Map<St, F>
 where
-    Self: Stream,
     St: FusedStream,
+    F: FnMut(St::Item) -> T,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/merge.rs
+++ b/tokio-stream/src/stream_ext/merge.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -54,6 +55,16 @@ where
 
     fn size_hint(&self) -> (usize, Option<usize>) {
         super::merge_size_hints(self.a.size_hint(), self.b.size_hint())
+    }
+}
+
+impl<T, U> FusedStream for Merge<T, U>
+where
+    T: Stream,
+    U: Stream<Item = T::Item>,
+{
+    fn is_terminated(&self) -> bool {
+        self.a.is_terminated() && self.b.is_terminated()
     }
 }
 

--- a/tokio-stream/src/stream_ext/skip.rs
+++ b/tokio-stream/src/stream_ext/skip.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{ready, Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -59,5 +60,14 @@ where
         let upper = upper.map(|x| x.saturating_sub(self.remaining));
 
         (lower, upper)
+    }
+}
+
+impl<St> FusedStream for Skip<St>
+where
+    St: FusedStream,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/skip_while.rs
+++ b/tokio-stream/src/stream_ext/skip_while.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{ready, Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -69,5 +70,15 @@ where
         }
 
         (lower, upper)
+    }
+}
+
+impl<St, F> FusedStream for SkipWhile<St, F>
+where
+    St: FusedStream,
+    F: FnMut(&St::Item) -> bool,
+{
+    fn is_terminated(&self) -> bool {
+        self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/skip_while.rs
+++ b/tokio-stream/src/stream_ext/skip_while.rs
@@ -75,8 +75,8 @@ where
 
 impl<St, F> FusedStream for SkipWhile<St, F>
 where
+    Self: Stream,
     St: FusedStream,
-    F: FnMut(&St::Item) -> bool,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/skip_while.rs
+++ b/tokio-stream/src/stream_ext/skip_while.rs
@@ -75,8 +75,8 @@ where
 
 impl<St, F> FusedStream for SkipWhile<St, F>
 where
-    Self: Stream,
     St: FusedStream,
+    F: FnMut(&St::Item) -> bool,
 {
     fn is_terminated(&self) -> bool {
         self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/take.rs
+++ b/tokio-stream/src/stream_ext/take.rs
@@ -4,6 +4,7 @@ use core::cmp;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -72,5 +73,14 @@ where
         };
 
         (lower, upper)
+    }
+}
+
+impl<St> FusedStream for Take<St>
+where
+    St: Stream,
+{
+    fn is_terminated(&self) -> bool {
+        self.remaining == 0
     }
 }

--- a/tokio-stream/src/stream_ext/take_while.rs
+++ b/tokio-stream/src/stream_ext/take_while.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -75,5 +76,15 @@ where
         let (_, upper) = self.stream.size_hint();
 
         (0, upper)
+    }
+}
+
+impl<St, F> FusedStream for TakeWhile<St, F>
+where
+    St: Stream,
+    F: FnMut(&St::Item) -> bool,
+{
+    fn is_terminated(&self) -> bool {
+        self.done
     }
 }

--- a/tokio-stream/src/stream_ext/then.rs
+++ b/tokio-stream/src/stream_ext/then.rs
@@ -85,9 +85,8 @@ where
 
 impl<St, F, Fut> FusedStream for Then<St, Fut, F>
 where
+    Self: Stream,
     St: FusedStream,
-    Fut: Future,
-    F: FnMut(St::Item) -> Fut,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()

--- a/tokio-stream/src/stream_ext/then.rs
+++ b/tokio-stream/src/stream_ext/then.rs
@@ -4,6 +4,7 @@ use core::fmt;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -79,5 +80,16 @@ where
         let upper = upper.and_then(|upper| upper.checked_add(future_len));
 
         (lower, upper)
+    }
+}
+
+impl<St, F, Fut> FusedStream for Then<St, Fut, F>
+where
+    St: FusedStream,
+    Fut: Future,
+    F: FnMut(St::Item) -> Fut,
+{
+    fn is_terminated(&self) -> bool {
+        self.future.is_none() && self.stream.is_terminated()
     }
 }

--- a/tokio-stream/src/stream_ext/then.rs
+++ b/tokio-stream/src/stream_ext/then.rs
@@ -85,8 +85,9 @@ where
 
 impl<St, F, Fut> FusedStream for Then<St, Fut, F>
 where
-    Self: Stream,
     St: FusedStream,
+    Fut: Future,
+    F: FnMut(St::Item) -> Fut,
 {
     fn is_terminated(&self) -> bool {
         self.future.is_none() && self.stream.is_terminated()

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -42,7 +42,7 @@ async fn filter_terminated_after_inner_done() {
 
 #[tokio::test]
 async fn filter_map_not_terminated_before_done() {
-    let stream = fused_iter(vec![1, 2]).filter_map(|x| Some(x));
+    let stream = fused_iter(vec![1, 2]).filter_map(Some);
     assert!(!stream.is_terminated());
 }
 

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -101,8 +101,8 @@ async fn take_terminated_when_remaining_zero() {
     assert!(!stream.is_terminated());
     assert_eq!(stream.next().await, Some(2));
     // remaining hits 0 after getting the second item
-    assert_eq!(stream.next().await, None);
     assert!(stream.is_terminated());
+    assert_eq!(stream.next().await, None);
 }
 
 #[tokio::test]

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -1,0 +1,188 @@
+use futures_core::FusedStream;
+use tokio_stream::StreamExt;
+
+// Helper: a fused base stream built from a vec
+fn fused_iter<T>(items: Vec<T>) -> impl FusedStream<Item = T> {
+    tokio_stream::iter(items).fuse()
+}
+
+// ── map ──────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn map_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2]).map(|x| x * 2);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn map_terminated_after_inner_done() {
+    let mut stream = fused_iter(vec![1]).map(|x| x * 2);
+    assert_eq!(stream.next().await, Some(2));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── filter ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn filter_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2]).filter(|x| *x > 0);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn filter_terminated_after_inner_done() {
+    let mut stream = fused_iter(vec![1]).filter(|x| *x > 0);
+    assert_eq!(stream.next().await, Some(1));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── filter_map ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn filter_map_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2]).filter_map(|x| Some(x));
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn filter_map_terminated_after_inner_done() {
+    let mut stream = fused_iter(vec![1]).filter_map(|x| Some(x * 10));
+    assert_eq!(stream.next().await, Some(10));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── skip ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn skip_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2, 3]).skip(1);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn skip_terminated_after_inner_done() {
+    let mut stream = fused_iter(vec![1, 2]).skip(1);
+    assert_eq!(stream.next().await, Some(2));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── skip_while ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn skip_while_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2, 3]).skip_while(|x| *x < 2);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn skip_while_terminated_after_inner_done() {
+    let mut stream = fused_iter(vec![1, 2]).skip_while(|x| *x < 2);
+    assert_eq!(stream.next().await, Some(2));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── take ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn take_not_terminated_before_limit() {
+    let stream = tokio_stream::iter(vec![1, 2, 3]).take(2);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn take_terminated_when_remaining_zero() {
+    let mut stream = tokio_stream::iter(vec![1, 2]).take(2);
+    assert_eq!(stream.next().await, Some(1));
+    assert!(!stream.is_terminated());
+    assert_eq!(stream.next().await, Some(2));
+    // remaining hits 0 after getting the second item
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+#[tokio::test]
+async fn take_zero_is_immediately_terminated() {
+    let stream = tokio_stream::iter(vec![1, 2]).take(0);
+    assert!(stream.is_terminated());
+}
+
+// ── take_while ───────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn take_while_not_terminated_before_predicate_fails() {
+    let stream = tokio_stream::iter(vec![1, 2, 3]).take_while(|x| *x < 10);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn take_while_terminated_after_predicate_fails() {
+    let mut stream = tokio_stream::iter(vec![1, 5, 2]).take_while(|x| *x < 3);
+    assert_eq!(stream.next().await, Some(1));
+    assert!(!stream.is_terminated());
+    // predicate fails on 5 → done flag set
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+}
+
+// ── then ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn then_not_terminated_before_done() {
+    let stream = fused_iter(vec![1, 2]).then(|x| async move { x * 2 });
+    tokio::pin!(stream);
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn then_terminated_after_inner_done_and_no_pending_future() {
+    let stream = fused_iter(vec![1]).then(|x| async move { x * 2 });
+    tokio::pin!(stream);
+    assert_eq!(stream.next().await, Some(2));
+    assert_eq!(stream.next().await, None);
+    // inner stream done AND no in-flight future
+    assert!(stream.is_terminated());
+}
+
+// ── chain ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn chain_not_terminated_while_either_has_items() {
+    let stream = fused_iter(vec![1]).chain(fused_iter(vec![2]));
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn chain_terminated_only_after_both_done() {
+    let mut stream = fused_iter(vec![1]).chain(fused_iter(vec![2]));
+    assert_eq!(stream.next().await, Some(1));
+    assert!(!stream.is_terminated()); // b still has items
+    assert_eq!(stream.next().await, Some(2));
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated()); // both done now
+}
+
+// ── merge ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn merge_not_terminated_while_either_has_items() {
+    let stream = fused_iter(vec![1]).merge(fused_iter(vec![2]));
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn merge_terminated_only_after_both_done() {
+    let mut stream = fused_iter(vec![1]).merge(fused_iter(vec![2]));
+    // drain both
+    let mut collected = vec![];
+    while let Some(x) = stream.next().await {
+        collected.push(x);
+    }
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+    assert_eq!(collected.len(), 2);
+}


### PR DESCRIPTION
Implements `futures_core::FusedStream` for 10 stream adaptor types in
tokio-stream, improving interoperability with code that depends on this
trait bound.

Follows the precedent set by #8090 (Fuse) and #7854 (IntervalStream).

## Adaptors covered

- `Map`, `Filter`, `FilterMap`, `Skip`, `SkipWhile` — delegate `is_terminated()` to inner stream
- `Take` — terminated when `remaining == 0`
- `TakeWhile` — terminated when internal `done` flag is set
- `Then` — terminated when inner stream is done and no future is in-flight
- `Chain`, `Merge` — terminated when both inner streams are terminated

## Intentionally excluded

`MapWhile` — its current `poll_next` does not track when the closure
returns `None` early (before the inner stream is exhausted), so a
correct `is_terminated()` is not possible without a separate semantic
change to the adaptor itself.

## Tests

Added 21 targeted tests in `tokio-stream/tests/stream_fused.rs`
covering `is_terminated()` transitions for each adaptor.