### PR TITLE
test(fs): rename Windows symlink dir test

### DIFF
--- a/tokio/tests/fs_symlink_dir_windows.rs
+++ b/tokio/tests/fs_symlink_dir_windows.rs
@@ -6,7 +6,7 @@ use tempfile::tempdir;
 use tokio::fs;
 
 #[tokio::test]
-async fn symlink_file_windows() {
+async fn symlink_dir_windows() {
     const FILE_NAME: &str = "abc.txt";
 
     let temp_dir = tempdir().unwrap();


### PR DESCRIPTION
## Motivation

The Windows directory symlink test is defined in `fs_symlink_dir_windows.rs`, but the test function was named `symlink_file_windows`.

This made the test output look like it was exercising file symlink behavior even though the test uses `tokio::fs::symlink_dir`.

## Solution

Rename the test function to `symlink_dir_windows` so the test name matches the file and the behavior being verified.

Tests run:

- `cargo test -p tokio --test fs_symlink_dir_windows --features full`
- `cargo test -p tokio --test fs_symlink_file_windows --features full`