### PR TITLE
ci: install valgrind via apt-get instead of install-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
             toolchain: 1.82
 
       - name: Install Valgrind
-        uses: taiki-e/install-action@valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
 
       - uses: Swatinem/rust-cache@v2
       # Compile tests

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -33,7 +33,7 @@ jobs:
         with:
             toolchain: ${{ env.rust_stable }}
       - name: Install Valgrind
-        uses: taiki-e/install-action@valgrind
+        run: sudo apt-get update && sudo apt-get install -y valgrind
 
       - uses: Swatinem/rust-cache@v2
       # Compiles each of the stress test examples.


### PR DESCRIPTION
Avoids 'unable to contact snap store' errors on GitHub Actions runners.