### PR TITLE
net/unix: return Unsupported instead of fake root creds on espidf/vita/hurd

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -323,10 +323,9 @@ pub(crate) mod impl_noproc {
     use std::io;
 
     pub(crate) fn get_peer_cred(_sock: &UnixStream) -> io::Result<super::UCred> {
-        Ok(super::UCred {
-            uid: 0,
-            gid: 0,
-            pid: None,
-        })
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "SO_PEERCRED is not available on this target",
+        ))
     }
 }


### PR DESCRIPTION
While reviewing some unix-socket auth code that uses `peer_cred()` for authorization, I traced the no-proc fallback in `ucred.rs` and noticed it returns `Ok(UCred { uid: 0, gid: 0, pid: None })` on `espidf`, `vita`, and `hurd`:

```rust
#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
pub(crate) mod impl_noproc {
    use crate::net::unix::UnixStream;
    use std::io;

    pub(crate) fn get_peer_cred(_sock: &UnixStream) -> io::Result<super::UCred> {
        Ok(super::UCred {
            uid: 0,
            gid: 0,
            pid: None,
        })
    }
}
```

The signature is `io::Result<UCred>` — i.e. it advertises that it can fail — but the stub never does. Any caller that uses peer creds for an authz decision (which is one of the documented reasons to call this method) will silently treat every connecting peer as `uid=0`/`gid=0` on those targets. That's the opposite of fail-closed.

I think this should just return `Unsupported`. Callers already have to handle `io::Error` because every other implementation path can fail, so it's not adding a new failure mode they weren't already accounting for — it just makes the actual behavior visible.

Proposed change:

```rust
#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
pub(crate) mod impl_noproc {
    use crate::net::unix::UnixStream;
    use std::io;

    pub(crate) fn get_peer_cred(_sock: &UnixStream) -> io::Result<super::UCred> {
        Err(io::Error::new(
            io::ErrorKind::Unsupported,
            "SO_PEERCRED is not available on this target",
        ))
    }
}
```

A couple of things I'm not sure about and want to flag:

- This is technically a behavior change. If anything in the wild was matching on `Ok(UCred { uid: 0, .. })` from this stub, it'll start getting `Err` instead. I couldn't find any obvious reason to do that on purpose, but worth a thought.
- Happy to add a doc note on `UCred::new` / `UnixStream::peer_cred` saying "returns `Unsupported` on espidf/vita/hurd" if you want; just didn't want to scope-creep this.

If a different error kind makes more sense (e.g. `Other` to match what some of the other UCred impls do on weird kernels), happy to switch.

Original observation came out of running a static-analysis pass over `tokio/src/net/` looking for places where fallback semantics deviate from the public contract; this was the only one in that file that flagged.
