### PR TITLE
chore: prepare Tokio v1.52.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.1", features = ["full"] }
+tokio = { version = "1.52.2", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.52.2 (May 4th, 2026)
+
+This release reverts the LIFO slot stealing change introduced in 1.51.0
+([#7431]), due to [its performance impact][#8065]. ([#8100])
+
 # 1.52.1 (April 16th, 2026)
 
 ## Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.52.1"
+version = "1.52.2"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.52.1", features = ["full"] }
+tokio = { version = "1.52.2", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.52.2 (May 4th, 2026)

This release reverts the LIFO slot stealing change introduced in 1.51.0 ([#7431]), due to [its performance impact][#8065]. ([#8100])

[#7431]: https://github.com/tokio-rs/tokio/pull/7431
[#8065]: https://github.com/tokio-rs/tokio/pull/8065
[#8100]: https://github.com/tokio-rs/tokio/pull/8100