### PR TITLE
re-enable LIFO slot stealing

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -143,9 +143,8 @@ pub struct Builder {
 
     timer_flavor: TimerFlavor,
 
-    /// Whether or not to enable eager hand-off for the I/O and time drivers (in
-    /// `tokio_unstable`).
-    enable_eager_driver_handoff: bool,
+    #[cfg(feature = "rt-multi-thread")]
+    worker_thread_unparking_mode: UnparkingMode,
 }
 
 cfg_unstable! {
@@ -230,6 +229,84 @@ cfg_unstable! {
         /// [`JoinHandle`]: struct@crate::task::JoinHandle
         ShutdownRuntime,
     }
+}
+
+/// Configures the multi-threaded runtime's policy for unparking worker
+/// threads.
+///
+/// Instances of `UnparkingMode` are passed to
+/// [`Builder::worker_thread_unparking_mode`] to configure the runtime
+/// behavior for when worker threads are unparked.
+///
+/// See the individual variants of this enum for more details on each
+/// unparking mode's behavior.
+#[cfg(feature = "rt-multi-thread")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+#[derive(Debug, Default, Clone)]
+#[non_exhaustive]
+pub enum UnparkingMode {
+    /// Traditional pre-Tokio 1.51.0 unparking behavior.
+    ///
+    /// This mode attempts to minimize unnecessary cross-thread wakeups. When
+    /// the traditional unparking behavior is selected, a parked worker thread
+    /// will be woken when A task running on a worker thread notifies another
+    /// task, and it is pushed to that worker thread's local queue (see
+    /// [here][rt-behavior] for details). If the [LIFO slot optimization][lifo]
+    /// is enabled, pushing a task to an *empty* LIFO slot will not notify
+    /// another worker thread. If the LIFO slot already contains a task when
+    /// another task is woken, the previous LIFO task is pushed to the worker's
+    /// local queue, which will unpark a parked worker thread.
+    ///
+    /// This unparking mode reduces the overhead of cross-thread notifications,
+    /// which generally results in better throughput for applications under
+    /// heavy load. However, it is more susceptible to latency bubbles when
+    /// tasks may become CPU-bound for long periods of time, and can deadlock
+    /// if a task blocks the thread indefinitely.
+    ///
+    /// [rt-behavior]: crate::runtime#multi-threaded-runtime-behavior-at-the-time-of-writing
+    /// [lifo]: crate::runtime::Builder::disable_lifo_slot
+    #[default]
+    Traditional,
+    /// Experimental unparking behavior that reduces the risk of deadlocks and
+    /// latency bubbles, at the expense of increased cross-thread notification
+    /// overhead.
+    ///
+    /// In contrast to the [`Traditional`](Self::Traditional) unparking mode,
+    /// this mode unparks worker threads more aggressively. This prevents tasks
+    /// which block their worker thread or execute large amounts of CPU-bound
+    /// code without yielding from starving other tasks from running, as
+    /// described in issues like [#4941] and [#6315]. This can increase overhead
+    /// due to waking parked workers in more frequently, and may not be
+    /// necessary in applications which never expect tasks to go CPU-bound for
+    /// long periods of time without yielding.
+    ///
+    /// In the `Cautious` unparking mode, a parked worker thread is unparked
+    /// whenever a task is notified by another task. Unlike the `Traditional`
+    /// unparking mode, this occurs regardless of whether or not the notified
+    /// task is placed in its worker thread's [LIFO slot]. This ensures that
+    /// there will always be another worker thread available to steal the
+    /// notified task, should the currently executing task block the worker for
+    /// a long period of time. This prevents the issue described in [#4941].
+    ///
+    /// In addition, this mode will also unpark a parked worker thread whenever
+    /// a worker thread which had previously parked on the I/O or timer driver
+    /// transitions to begin polling tasks. This ensures that another worker is
+    /// always available to process I/O events immediately, so that a
+    /// long-running task on the worker which was previously holding the I/O or
+    /// time driver does not preventing I/O or timer notifications from being
+    /// processed in a timely manner.
+    ///
+    /// Applications which are not under constant load at all times may benefit
+    /// from this unparking mode, especially if they anticipate that some tasks
+    /// may perform large amounts of CPU-bound work without yielding.
+    ///
+    /// [#4941]: https://github.com/tokio-rs/tokio/issues/4941
+    /// [#6315]: https://github.com/tokio-rs/tokio/issues/6315
+    /// [LIFO slot]: crate::runtime::Builder::disable_lifo_slot
+    #[cfg(tokio_unstable)]
+    #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
+    Cautious,
 }
 
 pub(crate) type ThreadNameFn = std::sync::Arc<dyn Fn() -> String + Send + Sync + 'static>;
@@ -339,8 +416,8 @@ impl Builder {
 
             timer_flavor: TimerFlavor::Traditional,
 
-            // Eager driver handoff is disabled by default.
-            enable_eager_driver_handoff: false,
+            #[cfg(feature = "rt-multi-thread")]
+            worker_thread_unparking_mode: UnparkingMode::default(),
         }
     }
 
@@ -450,8 +527,50 @@ impl Builder {
     /// [unstable]: crate#unstable-features
     #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
     #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt-multi-thread"))))]
+    #[deprecated(
+        since = "1.53.0",
+        note = "use `worker_thread_unparking_mode(UnparkingMode::Cautious)` instead"
+    )]
     pub fn enable_eager_driver_handoff(&mut self) -> &mut Self {
-        self.enable_eager_driver_handoff = true;
+        self.worker_thread_unparking_mode(UnparkingMode::Cautious)
+    }
+
+    /// Selects the [unparking behavior](UnparkingMode) used by the
+    /// multi-threaded runtime. This configuration determines when the runtime
+    /// will attempt to unpark an idle worker thread.
+    ///
+    /// This option only applies to multi-threaded runtimes. Attempting to use
+    /// this option with any other runtime type will have no effect.
+    ///
+    /// By default, the multi-threaded runtime will use the [`Traditional`]
+    /// unparking mode. This mode attempts to avoid the overhead of unnecessary
+    /// cross-thread notifications, which biases the runtime for improved
+    /// throughput in applications under high levels of load.
+    ///
+    /// Alternatively, this method may be used to select the [`Cautious`]
+    /// unparking mode, which unparks worker threads more aggressively. This
+    /// mode prevents potential deadlocks and/or latency bubbles which may occur
+    /// when tasks perform very large amounts of CPU-bound work without
+    /// yielding, or block the worker thread for other reasons. However, this
+    /// behavior also results in increased runtime overhead, and may not be
+    /// necessary in applications which are always under high load and in which
+    /// tasks always yield within a short period of time.
+    ///
+    /// See the documentation for the [`UnparkingMode`] type and its variants
+    /// for more details on the behaviors of these modes.
+    ///
+    /// **Note**: This is an [unstable API][unstable]. Eager driver hand-off is
+    /// an experimental feature whose behavior may be removed or changed in 1.x
+    /// releases. See [the documentation on unstable features][unstable] for
+    /// details.
+    ///
+    /// [unstable]: crate#unstable-features
+    /// [`Traditional`]: UnparkingMode::Traditional
+    /// [`Cautious`]: UnparkingMode::Cautious
+    #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+    #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "rt-multi-thread"))))]
+    pub fn worker_thread_unparking_mode(&mut self, mode: UnparkingMode) -> &mut Self {
+        self.worker_thread_unparking_mode = mode;
         self
     }
 
@@ -1708,6 +1827,9 @@ impl Builder {
                 enable_eager_driver_handoff: false,
                 seed_generator: seed_generator_1,
                 metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
+                // This setting never makes sense for the current thread
+                // runtime, as it has no notion of "waking a parked worker".
+                wake_on_lifo_push: false,
             },
             local_tid,
             self.name.clone(),
@@ -1888,7 +2010,8 @@ cfg_rt_multi_thread! {
                     #[cfg(tokio_unstable)]
                     unhandled_panic: self.unhandled_panic.clone(),
                     disable_lifo_slot: self.disable_lifo_slot,
-                    enable_eager_driver_handoff: self.enable_eager_driver_handoff,
+                    enable_eager_driver_handoff: self.worker_thread_unparking_mode.enable_eager_driver_handoff(),
+                    wake_on_lifo_push: self.worker_thread_unparking_mode.wake_on_lifo_push(),
                     seed_generator: seed_generator_1,
                     metrics_poll_count_histogram: self.metrics_poll_count_histogram_builder(),
                 },
@@ -1926,16 +2049,36 @@ impl fmt::Debug for Builder {
             .field("after_start", &self.after_start.as_ref().map(|_| "..."))
             .field("before_stop", &self.before_stop.as_ref().map(|_| "..."))
             .field("before_park", &self.before_park.as_ref().map(|_| "..."))
-            .field("after_unpark", &self.after_unpark.as_ref().map(|_| "..."))
-            .field(
-                "enable_eager_driver_handoff",
-                &self.enable_eager_driver_handoff,
-            );
+            .field("after_unpark", &self.after_unpark.as_ref().map(|_| "..."));
+        #[cfg(feature = "rt-multi-thread")]
+        debug.field(
+            "worker_thread_unparking_mode",
+            &self.worker_thread_unparking_mode,
+        );
 
         if self.name.is_none() {
             debug.finish_non_exhaustive()
         } else {
             debug.finish()
+        }
+    }
+}
+
+#[cfg(feature = "rt-multi-thread")]
+impl UnparkingMode {
+    fn wake_on_lifo_push(&self) -> bool {
+        match self {
+            Self::Traditional => false,
+            #[cfg(tokio_unstable)]
+            Self::Cautious => true,
+        }
+    }
+
+    fn enable_eager_driver_handoff(&self) -> bool {
+        match self {
+            Self::Traditional => false,
+            #[cfg(tokio_unstable)]
+            Self::Cautious => true,
         }
     }
 }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1298,22 +1298,21 @@ impl Builder {
         /// scheduled task being polled first.
         ///
         /// To implement this heuristic, each worker thread has a slot which
-        /// holds the task that should be polled next. However, this slot cannot
-        /// be stolen by other worker threads, which can result in lower total
-        /// throughput when tasks tend to have longer poll times.
+        /// holds the task that should be polled next. In earlier versions of
+        /// Tokio, this slot could not be stolen by other worker threads, which
+        /// can result in lower total throughput when tasks tend to have longer
+        /// poll times.
         ///
         /// This configuration option will disable this heuristic resulting in
-        /// all scheduled tasks being pushed into the worker-local queue, which
-        /// is stealable.
-        ///
-        /// Consider trying this option when the task "scheduled" time is high
-        /// but the runtime is underutilized. Use [tokio-rs/tokio-metrics] to
-        /// collect this data.
+        /// all scheduled tasks being pushed into the worker-local queue. This
+        /// was intended as a workaround for the LIFO slot not being stealable.
+        /// As of Tokio 1.51, tasks can be stolen from the LIFO slot. In a
+        /// future version, this option may be deprecated.
         ///
         /// # Unstable
         ///
-        /// This configuration option is considered a workaround for the LIFO
-        /// slot not being stealable. When the slot becomes stealable, we will
+        /// This configuration option was considered a workaround for the LIFO
+        /// slot not being stealable. Since this is no longer the case, we will
         /// revisit whether or not this option is necessary. See
         /// issue [tokio-rs/tokio#4941].
         ///

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -34,11 +34,13 @@ pub(crate) struct Config {
 
     /// The multi-threaded scheduler includes a per-worker LIFO slot used to
     /// store the last scheduled task. This can improve certain usage patterns,
-    /// especially message passing between tasks. However, this LIFO slot is not
-    /// currently stealable.
+    /// especially message passing between tasks.
     ///
-    /// Eventually, the LIFO slot **will** become stealable, however as a
-    /// stop-gap, this unstable option lets users disable the LIFO task.
+    /// In Tokio versions before 1.51, tasks in the LIFO slot could not be
+    /// stolen, which could cause issues in applications with long poll times.
+    /// As a stop-gap, this unstable option lets users disable the LIFO task.
+    /// Now that the LIFO slot is stealable, we may remove this option in a
+    /// future version.
     pub(crate) disable_lifo_slot: bool,
 
     /// Random number generator seed to configure runtimes to act in a

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -58,4 +58,10 @@ pub(crate) struct Config {
     /// from polling the I/O driver to polling its own tasks (requires
     /// `tokio_unstable`).
     pub(crate) enable_eager_driver_handoff: bool,
+
+    /// If `true`, a parked worker is woken whenever a task is pushed to a
+    /// worker's LIFO slot, to ensure that the LIFO task is always
+    /// stealable.`Otherwise, pushing a task to the LIFO slot does not wake a
+    /// parked worker.
+    pub(crate) wake_on_lifo_push: bool,
 }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -367,8 +367,8 @@
 //! three times in a row, it is temporarily disabled until the worker thread has
 //! scheduled a task that didn't come from the lifo slot. The lifo slot can be
 //! disabled using the [`disable_lifo_slot`] setting. The lifo slot is separate
-//! from the local queue, so other worker threads cannot steal the task in the
-//! lifo slot.
+//! from the local queue, and is stolen from by other worker threads only when
+//! a worker's local queue has been drained.
 //!
 //! When a task is woken from a thread that is not a worker thread, then the
 //! task is placed in the global queue.

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -575,6 +575,10 @@ cfg_rt! {
         pub use self::builder::UnhandledPanic;
         pub use crate::util::rand::RngSeed;
 
+        #[cfg(feature = "rt-multi-thread")]
+        #[cfg_attr(docsrs, doc(cfg(feature = "rt-multi-thread")))]
+        pub use self::builder::UnparkingMode;
+
         /// Returns the index of the current worker thread, if called from a
         /// runtime worker thread.
         ///

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -437,10 +437,15 @@ impl<T> Steal<T> {
     }
 
     /// Steals half the tasks from self and place them into `dst`.
+    ///
+    /// If `steal_lifo` is set, this method will attempt to steal from the LIFO
+    /// slot if this worker's run queue is empty. Otherwise, it will only steal
+    /// from the main queue.
     pub(crate) fn steal_into(
         &self,
         dst: &mut Local<T>,
         dst_stats: &mut Stats,
+        steal_lifo: bool,
     ) -> Option<task::Notified<T>> {
         // Safety: the caller is the only thread that mutates `dst.tail` and
         // holds a mutable reference.
@@ -462,14 +467,18 @@ impl<T> Steal<T> {
         let mut n = self.steal_into2(dst, dst_tail);
 
         if n == 0 {
-            // If no tasks were stolen, let's see if there's one in the LIFO
-            // slot.
-            let lifo = self.0.lifo.take();
-            if lifo.is_some() {
-                dst_stats.incr_steal_count(1);
-                dst_stats.incr_steal_operations();
+            if steal_lifo {
+                // If no tasks were stolen, let's see if there's one in the
+                // LIFO slot.
+                let lifo = self.0.lifo.take();
+                if lifo.is_some() {
+                    dst_stats.incr_steal_count(1);
+                    dst_stats.incr_steal_operations();
+                }
+                return lifo;
+            } else {
+                return None;
             }
-            return lifo;
         }
 
         dst_stats.incr_steal_count(n as u16);

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -27,6 +27,9 @@ cfg_not_has_atomic_u64! {
 
 /// Producer handle. May only be used from a single thread.
 pub(crate) struct Local<T: 'static> {
+    // If this is `false`, we DEFINITELY don't have a task in the LIFO slot,
+    // allowing us to avoid an atomic swap to try and pop from it.
+    might_have_lifo: bool,
     inner: Arc<Inner<T>>,
 }
 
@@ -100,6 +103,7 @@ pub(crate) fn local<T: 'static>() -> (Steal<T>, Local<T>) {
     });
 
     let local = Local {
+        might_have_lifo: false,
         inner: inner.clone(),
     };
 
@@ -112,7 +116,7 @@ impl<T> Local<T> {
     /// Returns the number of entries in the queue
     pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.inner.head.load(Acquire));
-        let lifo = self.inner.lifo.is_some() as usize;
+        let lifo = (self.might_have_lifo && self.inner.lifo.is_some()) as usize;
         // safety: this is the **only** thread that updates this cell.
         let tail = unsafe { self.inner.tail.unsync_load() };
         len(head, tail) + lifo
@@ -409,13 +413,20 @@ impl<T> Local<T> {
 
     /// Pushes a task to the LIFO slot, returning the task previously in the
     /// LIFO slot (if there was one).
-    pub(crate) fn push_lifo(&self, task: task::Notified<T>) -> Option<task::Notified<T>> {
+    pub(crate) fn push_lifo(&mut self, task: task::Notified<T>) -> Option<task::Notified<T>> {
+        self.might_have_lifo = true;
         self.inner.lifo.swap(Some(task))
     }
 
     /// Pops the task currently held in the LIFO slot, if there is one;
     /// otherwise, returns `None`.
-    pub(crate) fn pop_lifo(&self) -> Option<task::Notified<T>> {
+    pub(crate) fn pop_lifo(&mut self) -> Option<task::Notified<T>> {
+        if !self.might_have_lifo {
+            return None;
+        }
+
+        self.might_have_lifo = false;
+
         // LIFO-suction!
         self.inner.lifo.take()
     }

--- a/tokio/src/runtime/scheduler/multi_thread/queue.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/queue.rs
@@ -52,6 +52,13 @@ pub(crate) struct Inner<T: 'static> {
     /// Only updated by producer thread but read by many threads.
     tail: AtomicUnsignedShort,
 
+    /// When a task is scheduled from a worker, it is stored in this slot. The
+    /// worker will check this slot for a task **before** checking the run
+    /// queue. This effectively results in the **last** scheduled task to be run
+    /// next (LIFO). This is an optimization for improving locality which
+    /// benefits message passing patterns and helps to reduce latency.
+    lifo: task::AtomicNotified<T>,
+
     /// Elements
     buffer: Box<[UnsafeCell<MaybeUninit<task::Notified<T>>>; LOCAL_QUEUE_CAPACITY]>,
 }
@@ -89,6 +96,7 @@ pub(crate) fn local<T: 'static>() -> (Steal<T>, Local<T>) {
         head: AtomicUnsignedLong::new(0),
         tail: AtomicUnsignedShort::new(0),
         buffer: make_fixed_size(buffer.take(LOCAL_QUEUE_CAPACITY).collect()),
+        lifo: task::AtomicNotified::empty(),
     });
 
     let local = Local {
@@ -104,9 +112,10 @@ impl<T> Local<T> {
     /// Returns the number of entries in the queue
     pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.inner.head.load(Acquire));
+        let lifo = self.inner.lifo.is_some() as usize;
         // safety: this is the **only** thread that updates this cell.
         let tail = unsafe { self.inner.tail.unsync_load() };
-        len(head, tail)
+        len(head, tail) + lifo
     }
 
     /// How many tasks can be pushed into the queue
@@ -397,6 +406,19 @@ impl<T> Local<T> {
 
         Some(self.inner.buffer[idx].with(|ptr| unsafe { ptr::read(ptr).assume_init() }))
     }
+
+    /// Pushes a task to the LIFO slot, returning the task previously in the
+    /// LIFO slot (if there was one).
+    pub(crate) fn push_lifo(&self, task: task::Notified<T>) -> Option<task::Notified<T>> {
+        self.inner.lifo.swap(Some(task))
+    }
+
+    /// Pops the task currently held in the LIFO slot, if there is one;
+    /// otherwise, returns `None`.
+    pub(crate) fn pop_lifo(&self) -> Option<task::Notified<T>> {
+        // LIFO-suction!
+        self.inner.lifo.take()
+    }
 }
 
 impl<T> Steal<T> {
@@ -404,7 +426,8 @@ impl<T> Steal<T> {
     pub(crate) fn len(&self) -> usize {
         let (_, head) = unpack(self.0.head.load(Acquire));
         let tail = self.0.tail.load(Acquire);
-        len(head, tail)
+        let lifo = self.0.lifo.is_some() as usize;
+        len(head, tail) + lifo
     }
 
     /// Return true if the queue is empty,
@@ -439,8 +462,14 @@ impl<T> Steal<T> {
         let mut n = self.steal_into2(dst, dst_tail);
 
         if n == 0 {
-            // No tasks were stolen
-            return None;
+            // If no tasks were stolen, let's see if there's one in the LIFO
+            // slot.
+            let lifo = self.0.lifo.take();
+            if lifo.is_some() {
+                dst_stats.incr_steal_count(1);
+                dst_stats.incr_steal_operations();
+            }
+            return lifo;
         }
 
         dst_stats.incr_steal_count(n as u16);
@@ -572,6 +601,7 @@ impl<T> Drop for Local<T> {
     fn drop(&mut self) {
         if !std::thread::panicking() {
             assert!(self.pop().is_none(), "queue not empty");
+            assert!(self.pop_lifo().is_none(), "LIFO slot not empty");
         }
     }
 }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1349,9 +1349,12 @@ impl Handle {
         // task must always be pushed to the back of the queue, enabling other
         // tasks to be executed. If **not** a yield, then there is more
         // flexibility and the task may go to the front of the queue.
-        if is_yield || !core.lifo_enabled {
+        let should_notify = if is_yield || !core.lifo_enabled {
             core.run_queue
                 .push_back_or_overflow(task, self, &mut core.stats);
+            // Always notify a worker, as we have pushed to the end of the
+            // queue.
+            true
         } else {
             // Push to the LIFO slot
             if let Some(prev) = core.run_queue.push_lifo(task) {
@@ -1359,13 +1362,18 @@ impl Handle {
                 // to be pushed to the back of the run queue.
                 core.run_queue
                     .push_back_or_overflow(prev, self, &mut core.stats);
+                // Again, we have pushed the previous LIFO task to the end of
+                // the queue, so we should always notify a parked worker.
+                true
+            } else {
+                self.shared.config.wake_on_lifo_push
             }
         };
 
         // Only notify if not currently parked. If `park` is `None`, then the
         // scheduling is from a resource driver. As notifications often come in
         // batches, the notification is delayed until the park is complete.
-        if core.park.is_some() {
+        if should_notify && core.park.is_some() {
             self.notify_parked_local();
         }
     }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1139,12 +1139,13 @@ impl Core {
         // giving up? On the final pass we shall additionally attempt to steal
         // tasks from each worker's LIFO slot should the run queue be empty.
         //
-        // Two passes was chosen arbitrarily. The Go runtime makes four similar
-        // workstealing passes, but it also attempts to steal both timers and GC
-        // work as well as goroutines (tasks), so that's a bit different than
-        // our behavior. See:
+        // The Go runtime makes four similar work-stealing passes, and only attempts to steal from `runnext` (its name for a LIFO slot) on the final pass. See:
         // https://github.com/golang/go/blob/release-branch.go1.26/src/runtime/proc.go#L3828-L3895
-        const PASSES: usize = 2;
+        //
+        // Empirically, 4 seems to result in better performance on the
+        // `rt_multi_thread` benchmarks than 2 passes, so we'll do the same
+        // thing Go does, I guess.
+        const PASSES: usize = 4;
 
         let num = worker.handle.shared.remotes.len();
         for i in 1..=PASSES {

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1135,27 +1135,45 @@ impl Core {
             return None;
         }
 
+        // How many passes over the set of worker threads shall we make before
+        // giving up? On the final pass we shall additionally attempt to steal
+        // tasks from each worker's LIFO slot should the run queue be empty.
+        //
+        // Two passes was chosen arbitrarily. The Go runtime makes four similar
+        // workstealing passes, but it also attempts to steal both timers and GC
+        // work as well as goroutines (tasks), so that's a bit different than
+        // our behavior. See:
+        // https://github.com/golang/go/blob/release-branch.go1.26/src/runtime/proc.go#L3828-L3895
+        const PASSES: usize = 2;
+
         let num = worker.handle.shared.remotes.len();
-        // Start from a random worker
-        let start = self.rand.fastrand_n(num as u32) as usize;
+        for i in 1..=PASSES {
+            // If we are making our final pass over the other workers, we shall
+            // also attempt to steal a task from the LIFO slot if we were not
+            // able to steal from the main queue.
+            let steal_lifo = i == PASSES;
 
-        for i in 0..num {
-            let i = (start + i) % num;
+            // Start from a random worker
+            let start = self.rand.fastrand_n(num as u32) as usize;
 
-            // Don't steal from ourself! We know we don't have work.
-            if i == worker.index {
-                continue;
-            }
+            for i in 0..num {
+                let i = (start + i) % num;
 
-            let target = &worker.handle.shared.remotes[i];
-            if let Some(task) = target
-                .steal
-                .steal_into(&mut self.run_queue, &mut self.stats)
-            {
-                return Some(task);
+                // Don't steal from ourself! We know we don't have work.
+                if i == worker.index {
+                    continue;
+                }
+
+                let target = &worker.handle.shared.remotes[i];
+                if let Some(task) =
+                    target
+                        .steal
+                        .steal_into(&mut self.run_queue, &mut self.stats, steal_lifo)
+                {
+                    return Some(task);
+                }
             }
         }
-
         // Fallback on checking the global queue
         worker.handle.next_remote_task()
     }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -112,13 +112,6 @@ struct Core {
     /// Used to schedule bookkeeping tasks every so often.
     tick: u32,
 
-    /// When a task is scheduled from a worker, it is stored in this slot. The
-    /// worker will check this slot for a task **before** checking the run
-    /// queue. This effectively results in the **last** scheduled task to be run
-    /// next (LIFO). This is an optimization for improving locality which
-    /// benefits message passing patterns and helps to reduce latency.
-    lifo_slot: Option<Notified>,
-
     /// When `true`, locally scheduled tasks go to the LIFO slot. When `false`,
     /// they go to the back of the `run_queue`.
     lifo_enabled: bool,
@@ -289,7 +282,6 @@ pub(super) fn create(
 
         cores.push(Box::new(Core {
             tick: 0,
-            lifo_slot: None,
             lifo_enabled: !config.disable_lifo_slot,
             run_queue,
             #[cfg(all(tokio_unstable, feature = "time"))]
@@ -451,7 +443,7 @@ where
         // If we heavily call `spawn_blocking`, there might be no available thread to
         // run this core. Except for the task in the lifo_slot, all tasks can be
         // stolen, so we move the task out of the lifo_slot to the run_queue.
-        if let Some(task) = core.lifo_slot.take() {
+        if let Some(task) = core.run_queue.pop_lifo() {
             core.run_queue
                 .push_back_or_overflow(task, &*cx.worker.handle, &mut core.stats);
         }
@@ -704,7 +696,7 @@ impl Context {
                 };
 
                 // Check for a task in the LIFO slot
-                let task = match core.lifo_slot.take() {
+                let task = match core.run_queue.pop_lifo() {
                     Some(task) => task,
                     None => {
                         self.reset_lifo_enabled(&mut core);
@@ -1130,7 +1122,7 @@ impl Core {
     }
 
     fn next_local_task(&mut self) -> Option<Notified> {
-        self.lifo_slot.take().or_else(|| self.run_queue.pop())
+        self.run_queue.pop_lifo().or_else(|| self.run_queue.pop())
     }
 
     /// Function responsible for stealing tasks from another worker
@@ -1186,7 +1178,7 @@ impl Core {
     }
 
     fn has_tasks(&self) -> bool {
-        self.lifo_slot.is_some() || self.run_queue.has_tasks()
+        self.run_queue.has_tasks()
     }
 
     fn should_notify_others(&self) -> bool {
@@ -1195,7 +1187,7 @@ impl Core {
         if self.is_searching {
             return false;
         }
-        self.lifo_slot.is_some() as usize + self.run_queue.len() > 1
+        self.run_queue.len() > 1
     }
 
     /// Prepares the worker state for parking.
@@ -1357,29 +1349,23 @@ impl Handle {
         // task must always be pushed to the back of the queue, enabling other
         // tasks to be executed. If **not** a yield, then there is more
         // flexibility and the task may go to the front of the queue.
-        let should_notify = if is_yield || !core.lifo_enabled {
+        if is_yield || !core.lifo_enabled {
             core.run_queue
                 .push_back_or_overflow(task, self, &mut core.stats);
-            true
         } else {
             // Push to the LIFO slot
-            let prev = core.lifo_slot.take();
-            let ret = prev.is_some();
-
-            if let Some(prev) = prev {
+            if let Some(prev) = core.run_queue.push_lifo(task) {
+                // There was a previous task in the LIFO slot which needs
+                // to be pushed to the back of the run queue.
                 core.run_queue
                     .push_back_or_overflow(prev, self, &mut core.stats);
             }
-
-            core.lifo_slot = Some(task);
-
-            ret
         };
 
         // Only notify if not currently parked. If `park` is `None`, then the
         // scheduling is from a resource driver. As notifications often come in
         // batches, the notification is delayed until the park is complete.
-        if should_notify && core.park.is_some() {
+        if core.park.is_some() {
             self.notify_parked_local();
         }
     }

--- a/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker/taskdump.rs
@@ -68,7 +68,9 @@ impl Shared {
         for remote in self.remotes.iter() {
             let steal = &remote.steal;
             while !steal.is_empty() {
-                if let Some(task) = steal.steal_into(&mut local, &mut stats) {
+                // Always pass the `steal_lifo` flag here to ensure we also
+                // steal from the LIFO slot if we have drained the main queue.
+                if let Some(task) = steal.steal_into(&mut local, &mut stats, true) {
                     local.push_back([task].into_iter());
                 }
             }

--- a/tokio/src/runtime/task/atomic_notified.rs
+++ b/tokio/src/runtime/task/atomic_notified.rs
@@ -1,0 +1,58 @@
+use crate::loom::sync::atomic::AtomicPtr;
+use crate::runtime::task::{Header, Notified, RawTask};
+
+use std::marker::PhantomData;
+use std::ptr;
+use std::ptr::NonNull;
+use std::sync::atomic::Ordering::SeqCst;
+
+/// An atomic cell which can contain a pointer to a [`Notified`] task.
+///
+/// This is similar to the `crate::util::AtomicCell` type, but specialized to
+/// hold a task pointer --- this type "remembers" the task's scheduler generic
+/// when a task is stored in the cell, so that the pointer can be turned back
+/// into a [`Notified`] task with the correct generic type when it is retrieved.
+pub(crate) struct AtomicNotified<S: 'static> {
+    task: AtomicPtr<Header>,
+    _scheduler: PhantomData<S>,
+}
+
+impl<S: 'static> AtomicNotified<S> {
+    pub(crate) fn empty() -> Self {
+        Self {
+            task: AtomicPtr::new(ptr::null_mut()),
+            _scheduler: PhantomData,
+        }
+    }
+
+    pub(crate) fn swap(&self, task: Option<Notified<S>>) -> Option<Notified<S>> {
+        let new = task
+            .map(|t| t.into_raw().header_ptr().as_ptr())
+            .unwrap_or_else(ptr::null_mut);
+        let old = self.task.swap(new, SeqCst);
+        NonNull::new(old).map(|ptr| unsafe {
+            // Safety: since we only allow tasks with the same scheduler type to
+            // be placed in this cell, we know that the pointed task's scheduler
+            // type matches the type parameter S.
+            Notified::from_raw(RawTask::from_raw(ptr))
+        })
+    }
+
+    pub(crate) fn take(&self) -> Option<Notified<S>> {
+        self.swap(None)
+    }
+
+    pub(crate) fn is_some(&self) -> bool {
+        !self.task.load(SeqCst).is_null()
+    }
+}
+
+unsafe impl<S: Send> Send for AtomicNotified<S> {}
+unsafe impl<S: Send> Sync for AtomicNotified<S> {}
+
+impl<S> Drop for AtomicNotified<S> {
+    fn drop(&mut self) {
+        // Ensure the task reference is dropped if this cell is dropped.
+        let _ = self.take();
+    }
+}

--- a/tokio/src/runtime/task/atomic_notified.rs
+++ b/tokio/src/runtime/task/atomic_notified.rs
@@ -4,7 +4,7 @@ use crate::runtime::task::{Header, Notified, RawTask};
 use std::marker::PhantomData;
 use std::ptr;
 use std::ptr::NonNull;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::{AcqRel, Acquire};
 
 /// An atomic cell which can contain a pointer to a [`Notified`] task.
 ///
@@ -29,7 +29,7 @@ impl<S: 'static> AtomicNotified<S> {
         let new = task
             .map(|t| t.into_raw().header_ptr().as_ptr())
             .unwrap_or_else(ptr::null_mut);
-        let old = self.task.swap(new, SeqCst);
+        let old = self.task.swap(new, AcqRel);
         NonNull::new(old).map(|ptr| unsafe {
             // Safety: since we only allow tasks with the same scheduler type to
             // be placed in this cell, we know that the pointed task's scheduler
@@ -43,7 +43,7 @@ impl<S: 'static> AtomicNotified<S> {
     }
 
     pub(crate) fn is_some(&self) -> bool {
-        !self.task.load(SeqCst).is_null()
+        !self.task.load(Acquire).is_null()
     }
 }
 

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -209,6 +209,11 @@ pub(crate) use self::raw::RawTask;
 mod state;
 use self::state::State;
 
+#[cfg(feature = "rt-multi-thread")]
+mod atomic_notified;
+#[cfg(feature = "rt-multi-thread")]
+pub(crate) use self::atomic_notified::AtomicNotified;
+
 mod waker;
 
 pub(crate) use self::spawn_location::SpawnLocation;

--- a/tokio/src/runtime/tests/loom_multi_thread/queue.rs
+++ b/tokio/src/runtime/tests/loom_multi_thread/queue.rs
@@ -21,7 +21,9 @@ fn basic() {
             let mut n = 0;
 
             for _ in 0..3 {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                // steal_lifo = false here is fine since there are no LIFO slot
+                // tasks in this test.
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 
@@ -76,7 +78,7 @@ fn basic_lifo() {
             let mut n = 0;
 
             for _ in 0..3 {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, true).is_some() {
                     n += 1;
                 }
 
@@ -133,7 +135,7 @@ fn steal_overflow() {
             let (_, mut local) = queue::local();
             let mut n = 0;
 
-            if steal.steal_into(&mut local, &mut stats).is_some() {
+            if steal.steal_into(&mut local, &mut stats, false).is_some() {
                 n += 1;
             }
 
@@ -256,7 +258,7 @@ fn steal_tasks(steal: queue::Steal<NoopSchedule>) -> usize {
     let mut stats = new_stats();
     let (_, mut local) = queue::local();
 
-    if steal.steal_into(&mut local, &mut stats).is_none() {
+    if steal.steal_into(&mut local, &mut stats, true).is_none() {
         return 0;
     }
 
@@ -290,7 +292,9 @@ fn chained_steal() {
         let th = thread::spawn(move || {
             let mut stats = new_stats();
             let (_, mut local) = queue::local();
-            s1.steal_into(&mut local, &mut stats);
+            // again, steal_lifo = false here is fine since there are no LIFO slot
+            // tasks in this test.
+            s1.steal_into(&mut local, &mut stats, false);
 
             while local.pop().is_some() {}
         });
@@ -298,7 +302,7 @@ fn chained_steal() {
         // Drain our tasks, then attempt to steal
         while l1.pop().is_some() {}
 
-        s2.steal_into(&mut l1, &mut stats);
+        s2.steal_into(&mut l1, &mut stats, false);
 
         th.join().unwrap();
 

--- a/tokio/src/runtime/tests/queue.rs
+++ b/tokio/src/runtime/tests/queue.rs
@@ -125,7 +125,7 @@ fn steal_batch() {
         local1.push_back_or_overflow(task, &inject, &mut stats);
     }
 
-    assert!(steal1.steal_into(&mut local2, &mut stats).is_some());
+    assert!(steal1.steal_into(&mut local2, &mut stats, false).is_some());
 
     cfg_unstable_metrics! {
         assert_metrics!(stats, steal_count == 2);
@@ -172,7 +172,7 @@ fn stress1() {
             let mut n = 0;
 
             for _ in 0..NUM_STEAL {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 
@@ -233,7 +233,7 @@ fn stress2() {
             let mut n = 0;
 
             for _ in 0..NUM_STEAL {
-                if steal.steal_into(&mut local, &mut stats).is_some() {
+                if steal.steal_into(&mut local, &mut stats, false).is_some() {
                     n += 1;
                 }
 

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -692,6 +692,112 @@ fn mutex_in_block_in_place() {
     })
 }
 
+// Tests that when a task is notified by another task and is placed in the LIFO
+// slot, and then the notifying task blocks the runtime, the notified task will
+// be stolen by another worker thread.
+//
+// Integration test for: https://github.com/tokio-rs/tokio/issues/4941
+#[test]
+fn lifo_stealable() {
+    use std::time::Duration;
+
+    // This test constructs a scenario where a task (the "blocker task")
+    // notifies another task (the "victim task") and then blocks that worker
+    // thread indefinitely. The victim task is placed in the worker's LIFO
+    // slot, and will only run to completion if another worker steals it from
+    // the LIFO slot, as the current worker remains blocked running the blocker
+    // task.
+    //
+    // To make the blocker task block its worker thread without yielding, we use
+    // a `std::sync` blocking channel, so that we can eventually unblock it when
+    // the test completes.
+    let (block_thread_tx, block_thread_rx) = mpsc::channel::<()>();
+    // We use this channel to wait until the victim task has started running. If
+    // we just spawned the victim task and then immediately blocked the worker
+    // thread, it would be in the global inject queue, rather than in the
+    // worker's LIFO slot.
+    let (task_started_tx, task_started_rx) = tokio::sync::oneshot::channel();
+    // Finally, this channel is used by the blocker task to wake up the victim
+    // task, so that it is placed in the worker's LIFO slot.
+    let (notify_tx, notify_rx) = tokio::sync::oneshot::channel();
+    let rt = runtime::Builder::new_multi_thread()
+        // Make sure there are enough workers that one can be parked running the
+        // I/O driver and another can be parked running the timer wheel and
+        // there's still at least one worker free to steal the blocked task.
+        .worker_threads(4)
+        .enable_time()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        // Keep the runtime busy so that the workers that might steal the
+        // blocked task don't all park themselves forever.
+        //
+        // Since this task will always be woken by whichever worker is holding
+        // the time driver, rather than a worker that's executing tasks, it
+        // shouldn't ever kick the victim task out of its worker's LIFO slot.
+        let churn = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(4)).await;
+            }
+        });
+
+        let victim_task_joined = tokio::spawn(async move {
+            println!("[victim] task started");
+            task_started_tx.send(()).unwrap();
+            println!("[victim] task waiting for wakeup...");
+            notify_rx.await.unwrap();
+            println!("[victim] task running after wakeup");
+        });
+
+        // Wait for the victim task to have been polled once and have yielded
+        // before we spawn the task that will notify it. This ensures that it
+        // will be placed in the LIFO slot of the same worker thread as the
+        // blocker task, rather than on the global injector queue.
+        task_started_rx.await.unwrap();
+        println!("[main] victim slot task start acked!");
+
+        // Now, spawn a task that will notify the victim task before going
+        // blocking forever.
+        tokio::spawn(async move {
+            println!("[blocker] sending wakeup");
+            notify_tx.send(()).unwrap();
+
+            println!("[blocker] blocking the worker thread...");
+            // Block the worker thread indefinitely by waiting for a message on
+            // a blocking channel. Since we just notified the victim task, it
+            // went into the current worker thread's LIFO slot, and will only
+            // be able to complete if another worker thread successfully steals
+            // it from the LIFO slot.
+            //
+            // Using a channel rather than e.g. `loop {}` allows us to terminate
+            // the task cleanly when the test finishes.
+            let _ = block_thread_rx.recv();
+            println!("[blocker] done");
+        });
+
+        println!("[main] blocker task spawned");
+
+        // Wait for the victim task to join. If it does, then it has been stolen
+        // by another worker thread successfully.
+        //
+        // The 30-second timeout is chosen arbitrarily: its purpose is to ensure
+        // that the failure mode for this test is a panic, rather than hanging
+        // indefinitely. 30 seconds should be plenty of time for the task to be
+        // stolen, if it's going to work.
+        let result = tokio::time::timeout(Duration::from_secs(30), victim_task_joined).await;
+        println!("[main] result: {result:?}");
+
+        // Before possibly panicking, make sure that we wake up the blocker task
+        // so that it doesn't stop the runtime from shutting down.
+        block_thread_tx.send(()).unwrap();
+        churn.abort();
+        result
+            .expect("task in LIFO slot should complete within 30 seconds")
+            .expect("task in LIFO slot should not panic");
+    })
+}
+
 #[test]
 /// Deferred tasks should be woken before starting the [`tokio::task::block_in_place`]
 // https://github.com/tokio-rs/tokio/issues/7877

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -730,18 +730,6 @@ fn lifo_stealable() {
         .unwrap();
 
     rt.block_on(async {
-        // Keep the runtime busy so that the workers that might steal the
-        // blocked task don't all park themselves forever.
-        //
-        // Since this task will always be woken by whichever worker is holding
-        // the time driver, rather than a worker that's executing tasks, it
-        // shouldn't ever kick the victim task out of its worker's LIFO slot.
-        let churn = tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(Duration::from_millis(4)).await;
-            }
-        });
-
         let victim_task_joined = tokio::spawn(async move {
             println!("[victim] task started");
             task_started_tx.send(()).unwrap();
@@ -791,7 +779,6 @@ fn lifo_stealable() {
         // Before possibly panicking, make sure that we wake up the blocker task
         // so that it doesn't stop the runtime from shutting down.
         block_thread_tx.send(()).unwrap();
-        churn.abort();
         result
             .expect("task in LIFO slot should complete within 30 seconds")
             .expect("task in LIFO slot should not panic");

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -694,10 +694,12 @@ fn mutex_in_block_in_place() {
 
 // Tests that when a task is notified by another task and is placed in the LIFO
 // slot, and then the notifying task blocks the runtime, the notified task will
-// be stolen by another worker thread.
+// be stolen by another worker thread, if the `Cautious` unparking mode is
+// selected.
 //
 // Integration test for: https://github.com/tokio-rs/tokio/issues/4941
 #[test]
+#[cfg(tokio_unstable)]
 fn lifo_stealable() {
     use std::time::Duration;
 
@@ -726,6 +728,7 @@ fn lifo_stealable() {
         // there's still at least one worker free to steal the blocked task.
         .worker_threads(4)
         .enable_time()
+        .worker_thread_unparking_mode(runtime::UnparkingMode::Cautious)
         .build()
         .unwrap();
 

--- a/tokio/tests/rt_unstable_eager_driver_handoff.rs
+++ b/tokio/tests/rt_unstable_eager_driver_handoff.rs
@@ -8,17 +8,17 @@
 use std::sync::mpsc::RecvTimeoutError;
 use std::time::Duration;
 
-/// Test that, without `enable_eager_driver_handoff`, we can reliably reproduce
+/// Test that, without the `Cautious` unparking mode, we can reliably reproduce
 /// a deadlock when a task blocks indefinitely. If this test fails, it means
-/// that the test `eager_driver_handoff_fixes_deadlock` is not actually testing
-/// a condition that can deadlock the runtime.
+/// that the test `cautious_unparking_fixes_deadlock` is not actually testing a
+/// condition that can deadlock the runtime.
 #[test]
 fn deadlocks_consistently() {
     let rt = rt_builder().build().unwrap();
     assert_eq!(
         do_test(rt),
         Err(RecvTimeoutError::Timeout),
-        "runtime did not deadlock! the `eager_driver_handoff_fixes_deadlock` \
+        "runtime did not deadlock! the `cautious_unparking_fixes_deadlock` \
          test may no longer reproduce the bug it is intended to test a fix \
          for!",
     );
@@ -26,12 +26,15 @@ fn deadlocks_consistently() {
 
 /// This is the one that actually tests whether eager driver handoff works as
 /// expected: it runs the same reproducer as `deadlocks_consistently` a single
-/// timebut with `enable_eager_driver_handoff` enabled. If this test fails, it
+/// time, but with the `Cautious` unparking mode selected. If this test fails, it
 /// means that the eager driver handoff fix is not working as expected.
 #[test]
 #[cfg(tokio_unstable)]
-fn eager_driver_handoff_fixes_deadlock() {
-    let rt = rt_builder().enable_eager_driver_handoff().build().unwrap();
+fn cautious_unparking_fixes_deadlock() {
+    let rt = rt_builder()
+        .worker_thread_unparking_mode(tokio::runtime::UnparkingMode::Cautious)
+        .build()
+        .unwrap();
     assert_eq!(
         do_test(rt),
         Ok(()),
@@ -140,7 +143,7 @@ fn do_test(rt: tokio::runtime::Runtime) -> Result<(), RecvTimeoutError> {
 
 /// Base runtime builder for both tests in this module: two worker threads, time
 /// driver enabled. This returns a `Builder`, rather than a `Runtime`, so that
-/// the `eager_driver_handoff_fixes_deadlock` test can configure the runtime to
+/// the `cautious_unparking_fixes_deadlock` test can configure the runtime to
 /// enable eager driver handoff before building it.
 fn rt_builder() -> tokio::runtime::Builder {
     let mut builder = tokio::runtime::Builder::new_multi_thread();

--- a/tokio/tests/rt_unstable_metrics.rs
+++ b/tokio/tests/rt_unstable_metrics.rs
@@ -674,9 +674,13 @@ fn worker_local_queue_depth() {
             });
 
             // Bump the next-run spawn
-            tokio::spawn(async {});
+            let nop = tokio::spawn(async {});
 
+            // Wait until we're sure the other worker is blocked.
             rx1.recv().unwrap();
+            // Make sure the no-op task has terminated so that it doesn't end up
+            // in the LIFO slot and throw off our counts.
+            let _ = nop.await;
 
             // Spawn some tasks
             for _ in 0..100 {


### PR DESCRIPTION
This branch puts back the LIFO slot work-stealing behavior which was added in #7431 and reverted in 9605999c0a70e43ff27dfddd7e9dc5bb1869efbe. It consists of four commits which I would prefer to rebase merge so that all the commits make it to the master branch. Here are the descriptions of those individual commits:

- **rt: reintroduce LIFO slot work stealing**

    This commit puts back the change to allow stealing tasks from the LIFO
    slot, which was originally introduced in #7431. This change was reverted
    in 9605999c0a70e43ff27dfddd7e9dc5bb1869efbe in order to fix the
    performance regression due to increased cross thread wakeups (#8065).
    Previously, pushing a task to an unoccupied LIFO slot would not notify a
    parked worker, but when #7431 made the LIFO slot stealable, we started
    notifying in that case, which increases runtime overhead. Therefore, the
    change was reverted in v1.52.2. This commit reintroduces it.
    Subsequent commits on this branch will allow configuring whether LIFO
    slot pushes wake a parked worker, so that we can allow stealing from
    the LIFO slot while making the increased wakeup overhead opt-in.

    Closes #4941

- **rt: change `AtomicNotified` back to `AcqRel`**

    In #7431, I originally implemented `AtomicNotified` with the `AcqRel`
    atomic ordering, which is all that *should* be necessary here. While
    trying to debug a failing test on ARM, I changed it to `SeqCst`. This
    fixed the test, but was not actually necessary to solve the root cause
    of that test failure, which was ultimately fixed in #8008 instead. Using
    `SeqCst` here and locking the bus probably increases the overhead of
    using the LIFO slot substantially, so I've un-done that.

- **test: remove `churn()` task from `lifo_stealable`**

    This one is just a simple un-revert of #8070.

- **rt: add `worker_thread_unparking_mode` unstable setting**

    In order to re-enable stealing tasks from the LIFO slot, we would like
    to allow the user to configure whether or not pushing tasks to the LIFO
    slot unparks another worker thread. This is in order to avoid
    performance regressions due to the overhead of additional cross-thread
    wakeups (i.e. #8065). In https://github.com/tokio-rs/tokio/pull/8092#pullrequestreview-4212068053, @carllerche
    suggested that we do this by having a single option controlling whether
    we wake parked workers more or less aggressively which would also
    control the eager I/O and time driver handoff behavior from #8010, which
    also causes the runtime to wake parked workers more aggressively in
    order to prevent potential deadlocks and task starvation.

    This PR adds such a knob to the `runtime::Builder` type, which requires
    `tokio_unstable`. This is represented as an `UnparkingMode` enum. We use
    an enum rather than a `bool` primarily because I would like to add a
    third unparking mode in the future. This mode would wake parked workers
    much less frequently, but would instead track whether there are any
    stealable tasks enqueued, and wake a stealer only when _transitioning_
    from 0-1 stealable tasks, and have parking workers park with a timeout
    while we are in the "stealable tasks" state. The idea is that we would
    prevent deadlocks while avoiding spurious IPIs in this case. But, I
    haven't actually implemented this behavior yet, so presently, the enum
    has two variants: `Traditional`, which is the current runtime behavior,
    and `Cautious`, which wakes more aggressively to try to prevent
    deadlocks (and enables waking on LIFO pushes and on I/O driver handoff).
    The existing `enable_eager_driver_handoff` is deprecated in favor of the
    new API.

    I also felt that the enum made it a bit easier to document the different
    behaviors. If anyone has input on how we can better explain the two
    unparking modes to users, I'd welcome suggestions!

    Closes #8118