### PR TITLE
Prepare Tokio v1.47.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1050,9 +1050,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1405,7 +1405,7 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.47.4"
+version = "1.47.5"
 dependencies = [
  "async-stream",
  "backtrace",

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.47.4", features = ["full"] }
+tokio = { version = "1.47.5", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.47.5 (May 7th, 2026)
 
+### Fixed
+
 * sync: fix underflow in mpsc channel `len()` ([#8062])
 * sync: notify receivers in mpsc `OwnedPermit::release()` method ([#8075])
 * sync: require that an `RwLock` has `max_readers != 0` ([#8076])

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 1.47.5 (May 7th, 2026)
+
+* sync: fix underflow in mpsc channel `len()` ([#8062])
+* sync: notify receivers in mpsc `OwnedPermit::release()` method ([#8075])
+* sync: require that an `RwLock` has `max_readers != 0` ([#8076])
+* sync: return `Empty` from `try_recv()` when mpsc is closed with outstanding permits ([#8074])
+
+[#8062]: https://github.com/tokio-rs/tokio/pull/8062
+[#8074]: https://github.com/tokio-rs/tokio/pull/8074
+[#8075]: https://github.com/tokio-rs/tokio/pull/8075
+[#8076]: https://github.com/tokio-rs/tokio/pull/8076
+
 # 1.47.4 (April 2nd, 2026)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.47.4"
+version = "1.47.5"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -56,7 +56,7 @@ Make sure you activated the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.47.4", features = ["full"] }
+tokio = { version = "1.47.5", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.47.5 (May 7th, 2026)

### Fixed

* sync: fix underflow in mpsc channel `len()` ([#8062])
* sync: notify receivers in mpsc `OwnedPermit::release()` method ([#8075])
* sync: require that an `RwLock` has `max_readers != 0` ([#8076])
* sync: return `Empty` from `try_recv()` when mpsc is closed with outstanding permits ([#8074])

[#8062]: https://github.com/tokio-rs/tokio/pull/8062
[#8074]: https://github.com/tokio-rs/tokio/pull/8074
[#8075]: https://github.com/tokio-rs/tokio/pull/8075
[#8076]: https://github.com/tokio-rs/tokio/pull/8076