### PR TITLE
tracing: remove unnecessary span clone

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1268,16 +1268,18 @@ impl<T> Drop for Receiver<T> {
 impl<T> Future for Receiver<T> {
     type Output = Result<T, RecvError>;
 
-    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // If `inner` is `None`, then `poll()` has already completed.
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _res_span = self.resource_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _ao_span = self.async_op_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _ao_poll_span = self.async_op_poll_span.clone().entered();
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
 
-        let ret = if let Some(inner) = self.as_ref().get_ref().inner.as_ref() {
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _res_span = this.resource_span.enter();
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _ao_span = this.async_op_span.enter();
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _ao_poll_span = this.async_op_poll_span.enter();
+
+        // If `inner` is `None`, then `poll()` has already completed.
+        let ret = if let Some(inner) = this.inner.as_ref() {
             #[cfg(all(tokio_unstable, feature = "tracing"))]
             let res = ready!(trace_poll_op!("poll_recv", inner.poll_recv(cx)));
 
@@ -1289,7 +1291,7 @@ impl<T> Future for Receiver<T> {
             panic!("called after complete");
         };
 
-        self.inner = None;
+        this.inner = None;
         Ready(ret)
     }
 }

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -390,6 +390,14 @@ impl Sleep {
 
     fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
         ready!(crate::trace::trace_leaf());
+        let mut this = self.project();
+
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _res_span = this.inner.ctx.resource_span.enter();
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _ao_span = this.inner.ctx.async_op_span.enter();
+        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        let _ao_poll_span = this.inner.ctx.async_op_poll_span.enter();
 
         // Keep track of task budget
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -401,7 +409,6 @@ impl Sleep {
         #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 
-        let mut this = self.project();
         let timer = match this.timer.as_mut().as_pin_mut() {
             Some(timer) => timer,
             None => {
@@ -454,14 +461,8 @@ impl Future for Sleep {
     // Both cases are extremely rare, and pretty accurately fit into
     // "logic errors", so we just panic in this case. A user couldn't
     // really do much better if we passed the error onwards.
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _res_span = self.inner.ctx.resource_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _ao_span = self.inner.ctx.async_op_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let _ao_poll_span = self.inner.ctx.async_op_poll_span.clone().entered();
-        match ready!(self.as_mut().poll_elapsed(cx)) {
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        match ready!(self.poll_elapsed(cx)) {
             Ok(()) => Poll::Ready(()),
             Err(e) => panic!("timer error: {e}"),
         }

--- a/tokio/tests/tracing_time.rs
+++ b/tokio/tests/tracing_time.rs
@@ -7,6 +7,7 @@
 
 use std::time::Duration;
 
+use tokio_test::task;
 use tracing_mock::{expect, subscriber};
 
 #[tokio::test]
@@ -64,17 +65,17 @@ async fn test_sleep_creates_span() {
         .event(state_update)
         .event(poll_op())
         .exit(async_op_poll_span.clone())
-        .drop_span(async_op_poll_span)
         .exit(async_op_span.clone())
-        .drop_span(async_op_span)
         .exit(sleep_span.clone())
+        .drop_span(async_op_span)
+        .drop_span(async_op_poll_span)
         .drop_span(sleep_span)
         .run_with_handle();
 
     {
         let _guard = tracing::subscriber::set_default(subscriber);
 
-        tokio::time::sleep(Duration::from_millis(7)).await;
+        _ = task::spawn(tokio::time::sleep(Duration::from_millis(7))).poll();
     }
 
     handle.assert_finished();


### PR DESCRIPTION
Span cloning is left as is in `BatchSemaphore` due to its `unsafe` usage (though it should be possible to change this too).