### PR TITLE
time: clean up Instant overflow prevention

### DIFF
--- a/tokio/src/time/instant.rs
+++ b/tokio/src/time/instant.rs
@@ -54,14 +54,6 @@ impl Instant {
         Instant { std }
     }
 
-    pub(crate) fn far_future() -> Instant {
-        // Roughly 30 years from now.
-        // API does not provide a way to obtain max `Instant`
-        // or convert specific date in the future to instant.
-        // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
-        Self::now() + Duration::from_secs(86400 * 365 * 30)
-    }
-
     /// Convert the value into a `std::time::Instant`.
     pub fn into_std(self) -> std::time::Instant {
         self.std

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -1,4 +1,4 @@
-use crate::time::{sleep_until, Duration, Instant, Sleep};
+use crate::time::{safe_delay, sleep_until, Duration, Instant, Sleep};
 use crate::util::trace;
 
 use std::future::{poll_fn, Future};
@@ -139,7 +139,7 @@ fn internal_interval_at(
 
     Interval {
         delay,
-        period,
+        period: safe_delay(period),
         missed_tick_behavior: MissedTickBehavior::default(),
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         resource_span,
@@ -479,9 +479,7 @@ impl Interval {
             self.missed_tick_behavior
                 .next_timeout(timeout, now, self.period)
         } else {
-            timeout
-                .checked_add(self.period)
-                .unwrap_or_else(Instant::far_future)
+            timeout + self.period
         };
 
         // When we arrive here, the internal delay returned `Poll::Ready`.

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -351,7 +351,7 @@ impl MissedTickBehavior {
                             "too much time has elapsed since the interval was supposed to tick",
                         ),
                 );
-                now + period - offset
+                now + (period - offset)
             }
         }
     }
@@ -633,25 +633,5 @@ impl Interval {
     /// Returns the period of the interval.
     pub fn period(&self) -> Duration {
         self.period
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn missed_tick_behavior_doesnt_panic_on_overflow() {
-        let now = Instant::now();
-        let timeout = now - Duration::from_millis(10);
-
-        for behavior in [
-            MissedTickBehavior::Burst,
-            MissedTickBehavior::Delay,
-            MissedTickBehavior::Skip,
-        ] {
-            let next = behavior.next_timeout(timeout, now, safe_delay(Duration::MAX));
-            assert!(next > now);
-        }
     }
 }

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -650,7 +650,7 @@ mod tests {
             MissedTickBehavior::Delay,
             MissedTickBehavior::Skip,
         ] {
-            let next = behavior.next_timeout(timeout, now, Duration::MAX);
+            let next = behavior.next_timeout(timeout, now, safe_delay(Duration::MAX));
             assert!(next > now);
         }
     }

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -1,4 +1,4 @@
-use crate::time::{sleep_until, Duration, Instant, Sleep};
+use crate::time::{safe_delay, sleep_until, Duration, Instant, Sleep};
 use crate::util::trace;
 
 use std::future::{poll_fn, Future};
@@ -133,7 +133,7 @@ fn internal_interval_at(
 
     Interval {
         delay: Box::pin(sleep_until(start)),
-        period,
+        period: safe_delay(period),
         missed_tick_behavior: MissedTickBehavior::default(),
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         resource_span,
@@ -330,18 +330,12 @@ pub enum MissedTickBehavior {
     Skip,
 }
 
-fn saturating_add(instant: Instant, duration: Duration) -> Instant {
-    instant
-        .checked_add(duration)
-        .unwrap_or_else(Instant::far_future)
-}
-
 impl MissedTickBehavior {
     /// If a tick is missed, this method is called to determine when the next tick should happen.
     fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
         match self {
-            Self::Burst => saturating_add(timeout, period),
-            Self::Delay => saturating_add(now, period),
+            Self::Burst => timeout + period,
+            Self::Delay => now + period,
             Self::Skip => {
                 let offset = Duration::from_nanos(
                     ((now - timeout).as_nanos() % period.as_nanos())
@@ -357,7 +351,7 @@ impl MissedTickBehavior {
                             "too much time has elapsed since the interval was supposed to tick",
                         ),
                 );
-                saturating_add(now, period - offset)
+                now + period - offset
             }
         }
     }
@@ -480,9 +474,7 @@ impl Interval {
             self.missed_tick_behavior
                 .next_timeout(timeout, now, self.period)
         } else {
-            timeout
-                .checked_add(self.period)
-                .unwrap_or_else(Instant::far_future)
+            timeout + self.period
         };
 
         // When we arrive here, the internal delay returned `Poll::Ready`.
@@ -523,9 +515,7 @@ impl Interval {
     /// # }
     /// ```
     pub fn reset(&mut self) {
-        self.delay
-            .as_mut()
-            .reset(saturating_add(Instant::now(), self.period));
+        self.delay.as_mut().reset(Instant::now() + self.period);
     }
 
     /// Resets the interval immediately.
@@ -590,9 +580,8 @@ impl Interval {
     /// # }
     /// ```
     pub fn reset_after(&mut self, after: Duration) {
-        self.delay
-            .as_mut()
-            .reset(saturating_add(Instant::now(), after));
+        let deadline = Instant::now() + safe_delay(after);
+        self.delay.as_mut().reset(deadline);
     }
 
     /// Resets the interval to a [`crate::time::Instant`] deadline.

--- a/tokio/src/time/mod.rs
+++ b/tokio/src/time/mod.rs
@@ -84,6 +84,12 @@
 //! [`interval`]: crate::time::interval()
 //! [`sleep`]: sleep()
 
+fn safe_delay(duration: Duration) -> Duration {
+    // Roughly 30 years from now.
+    // 1000 years overflows on macOS, 100 years overflows on FreeBSD.
+    duration.min(Duration::from_secs(86400 * 365 * 30))
+}
+
 mod clock;
 pub(crate) use self::clock::Clock;
 cfg_test_util! {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{scheduler, Timer};
-use crate::time::{error::Error, Duration, Instant};
+use crate::time::{error::Error, safe_delay, Duration, Instant};
 use crate::util::trace;
 
 use pin_project_lite::pin_project;
@@ -121,12 +121,8 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 #[cfg_attr(docsrs, doc(alias = "wait"))]
 #[track_caller]
 pub fn sleep(duration: Duration) -> Sleep {
-    let location = trace::caller_location();
-
-    match Instant::now().checked_add(duration) {
-        Some(deadline) => Sleep::new_timeout(deadline, location),
-        None => Sleep::new_timeout(Instant::far_future(), location),
-    }
+    let deadline = Instant::now() + safe_delay(duration);
+    Sleep::new_timeout(deadline, trace::caller_location())
 }
 
 pin_project! {
@@ -294,10 +290,6 @@ impl Sleep {
             inner,
             timer: None,
         }
-    }
-
-    pub(crate) fn far_future(location: Option<&'static Location<'static>>) -> Sleep {
-        Self::new_timeout(Instant::far_future(), location)
     }
 
     /// Returns the instant at which the future will complete.

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -1,5 +1,5 @@
 use crate::runtime::Timer;
-use crate::time::{error::Error, Duration, Instant};
+use crate::time::{error::Error, safe_delay, Duration, Instant};
 use crate::util::trace;
 
 use pin_project_lite::pin_project;
@@ -121,12 +121,8 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 #[cfg_attr(docsrs, doc(alias = "wait"))]
 #[track_caller]
 pub fn sleep(duration: Duration) -> Sleep {
-    let location = trace::caller_location();
-
-    match Instant::now().checked_add(duration) {
-        Some(deadline) => Sleep::new_timeout(deadline, location),
-        None => Sleep::new_timeout(Instant::far_future(), location),
-    }
+    let deadline = Instant::now() + safe_delay(duration);
+    Sleep::new_timeout(deadline, trace::caller_location())
 }
 
 pin_project! {
@@ -301,10 +297,6 @@ impl Sleep {
         let inner = Inner {};
 
         Sleep { inner, entry }
-    }
-
-    pub(crate) fn far_future(location: Option<&'static Location<'static>>) -> Sleep {
-        Self::new_timeout(Instant::far_future(), location)
     }
 
     /// Returns the instant at which the future will complete.

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     task::coop,
-    time::{error::Elapsed, sleep_until, Duration, Instant, Sleep},
+    time::{error::Elapsed, safe_delay, Duration, Instant, Sleep},
     util::trace,
 };
 
@@ -87,13 +87,8 @@ pub fn timeout<F>(duration: Duration, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
-    let location = trace::caller_location();
-
-    let deadline = Instant::now().checked_add(duration);
-    let delay = match deadline {
-        Some(deadline) => Sleep::new_timeout(deadline, location),
-        None => Sleep::far_future(location),
-    };
+    let deadline = Instant::now() + safe_delay(duration);
+    let delay = Sleep::new_timeout(deadline, trace::caller_location());
     Timeout::new_with_delay(future.into_future(), delay)
 }
 
@@ -165,7 +160,7 @@ pub fn timeout_at<F>(deadline: Instant, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
-    let delay = sleep_until(deadline);
+    let delay = Sleep::new_timeout(deadline, trace::caller_location());
     Timeout::new_with_delay(future.into_future(), delay)
 }
 

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -87,7 +87,8 @@ pub fn timeout<F>(duration: Duration, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
-    #[allow(clippy::manual_map, reason = "preserve #[track_caller]")]
+    // Closures don't preserve `#[track_caller]`.
+    #[allow(clippy::manual_map)]
     Timeout {
         value: future.into_future(),
         delay: match Instant::now().checked_add(duration) {

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -87,11 +87,13 @@ pub fn timeout<F>(duration: Duration, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
+    #[allow(clippy::manual_map, reason = "preserve #[track_caller]")]
     Timeout {
         value: future.into_future(),
-        delay: Instant::now()
-            .checked_add(duration)
-            .map(|deadline| Sleep::new_timeout(deadline, trace::caller_location())),
+        delay: match Instant::now().checked_add(duration) {
+            Some(deadline) => Some(Sleep::new_timeout(deadline, trace::caller_location())),
+            None => None,
+        },
     }
 }
 

--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -6,7 +6,7 @@
 
 use crate::{
     task::coop,
-    time::{error::Elapsed, safe_delay, Duration, Instant, Sleep},
+    time::{error::Elapsed, Duration, Instant, Sleep},
     util::trace,
 };
 
@@ -87,9 +87,12 @@ pub fn timeout<F>(duration: Duration, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
-    let deadline = Instant::now() + safe_delay(duration);
-    let delay = Sleep::new_timeout(deadline, trace::caller_location());
-    Timeout::new_with_delay(future.into_future(), delay)
+    Timeout {
+        value: future.into_future(),
+        delay: Instant::now()
+            .checked_add(duration)
+            .map(|deadline| Sleep::new_timeout(deadline, trace::caller_location())),
+    }
 }
 
 /// Requires a `Future` to complete before the specified instant in time.
@@ -160,8 +163,10 @@ pub fn timeout_at<F>(deadline: Instant, future: F) -> Timeout<F::IntoFuture>
 where
     F: IntoFuture,
 {
-    let delay = Sleep::new_timeout(deadline, trace::caller_location());
-    Timeout::new_with_delay(future.into_future(), delay)
+    Timeout {
+        value: future.into_future(),
+        delay: Some(Sleep::new_timeout(deadline, trace::caller_location())),
+    }
 }
 
 pin_project! {
@@ -172,15 +177,11 @@ pin_project! {
         #[pin]
         value: T,
         #[pin]
-        delay: Sleep,
+        delay: Option<Sleep>,
     }
 }
 
 impl<T> Timeout<T> {
-    pub(crate) fn new_with_delay(value: T, delay: Sleep) -> Timeout<T> {
-        Timeout { value, delay }
-    }
-
     /// Gets a reference to the underlying value in this timeout.
     pub fn get_ref(&self) -> &T {
         &self.value
@@ -213,7 +214,10 @@ where
             return Poll::Ready(Ok(v));
         }
 
-        poll_delay(had_budget_before, me.delay, cx).map(Err)
+        match me.delay.as_pin_mut() {
+            Some(delay) => poll_delay(had_budget_before, delay, cx).map(Err),
+            None => Poll::Pending,
+        }
     }
 }
 


### PR DESCRIPTION
The `Instant::far_future` ctor unnecessarily called `Instant::now` (again). Shrinking `Duration` before calling `Instant::add` achieves the same result more succinctly.

Also fixed `timeout_at` using the wrong `Location` for its delay.
