### PR TITLE
hooks: overhaul task hooks

### DIFF
--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -5,7 +5,7 @@
 
 mod pool;
 #[cfg(feature = "rt-multi-thread")]
-pub(crate) use pool::spawn_blocking_internal;
+pub(crate) use pool::spawn_blocking_skip_hooks;
 pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
 
 cfg_fs! {

--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -5,6 +5,8 @@
 
 mod pool;
 pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
+#[cfg(feature = "rt-multi-thread")]
+pub(crate) use pool::spawn_blocking_internal;
 
 cfg_fs! {
     pub(crate) use pool::spawn_mandatory_blocking;

--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -4,9 +4,9 @@
 //! compilation.
 
 mod pool;
-pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
 #[cfg(feature = "rt-multi-thread")]
 pub(crate) use pool::spawn_blocking_internal;
+pub(crate) use pool::{spawn_blocking, BlockingPool, Spawner};
 
 cfg_fs! {
     pub(crate) use pool::spawn_mandatory_blocking;

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -307,6 +307,8 @@ impl Spawner {
                 Mandatory::NonMandatory,
                 SpawnMeta::new_unnamed(fn_size),
                 rt,
+                #[cfg(tokio_unstable)]
+                None,
             )
         } else {
             self.spawn_blocking_inner(
@@ -314,6 +316,8 @@ impl Spawner {
                 Mandatory::NonMandatory,
                 SpawnMeta::new_unnamed(fn_size),
                 rt,
+                #[cfg(tokio_unstable)]
+                None,
             )
         };
 
@@ -345,6 +349,8 @@ impl Spawner {
                     Mandatory::Mandatory,
                     SpawnMeta::new_unnamed(fn_size),
                     rt,
+                    #[cfg(tokio_unstable)]
+                    None,
                 )
             } else {
                 self.spawn_blocking_inner(
@@ -352,6 +358,8 @@ impl Spawner {
                     Mandatory::Mandatory,
                     SpawnMeta::new_unnamed(fn_size),
                     rt,
+                    #[cfg(tokio_unstable)]
+                    None,
                 )
             };
 
@@ -370,6 +378,7 @@ impl Spawner {
         is_mandatory: Mandatory,
         spawn_meta: SpawnMeta<'_>,
         rt: &Handle,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (JoinHandle<R>, Result<(), SpawnError>)
     where
         F: FnOnce() -> R + Send + 'static,
@@ -384,6 +393,8 @@ impl Spawner {
             BlockingSchedule::new(rt),
             id,
             task::SpawnLocation::capture(),
+            #[cfg(tokio_unstable)]
+            user_data,
         );
 
         let spawned = self.spawn_task(Task::new(task, is_mandatory), rt);

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -185,6 +185,20 @@ where
     rt.spawn_blocking(func)
 }
 
+/// Runs an internal runtime worker on the blocking pool without invoking task
+/// lifecycle hooks.
+#[track_caller]
+#[cfg(feature = "rt-multi-thread")]
+#[cfg_attr(target_os = "wasi", allow(dead_code))]
+pub(crate) fn spawn_blocking_internal<F, R>(func: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let rt = Handle::current();
+    rt.inner.blocking_spawner().spawn_blocking_internal(&rt, func)
+}
+
 cfg_fs! {
     #[cfg_attr(any(
         all(loom, not(test)), // the function is covered by loom tests
@@ -300,6 +314,40 @@ impl Spawner {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
+        self.spawn_blocking_impl(
+            rt,
+            func,
+            #[cfg(tokio_unstable)]
+            true,
+        )
+    }
+
+    #[track_caller]
+    #[cfg(feature = "rt-multi-thread")]
+    pub(crate) fn spawn_blocking_internal<F, R>(&self, rt: &Handle, func: F) -> JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
+        self.spawn_blocking_impl(
+            rt,
+            func,
+            #[cfg(tokio_unstable)]
+            false,
+        )
+    }
+
+    #[track_caller]
+    fn spawn_blocking_impl<F, R>(
+        &self,
+        rt: &Handle,
+        func: F,
+        #[cfg(tokio_unstable)] run_task_hooks: bool,
+    ) -> JoinHandle<R>
+    where
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
+    {
         let fn_size = std::mem::size_of::<F>();
         let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
             self.spawn_blocking_inner(
@@ -309,6 +357,8 @@ impl Spawner {
                 rt,
                 #[cfg(tokio_unstable)]
                 None,
+                #[cfg(tokio_unstable)]
+                run_task_hooks,
             )
         } else {
             self.spawn_blocking_inner(
@@ -318,6 +368,8 @@ impl Spawner {
                 rt,
                 #[cfg(tokio_unstable)]
                 None,
+                #[cfg(tokio_unstable)]
+                run_task_hooks,
             )
         };
 
@@ -351,6 +403,8 @@ impl Spawner {
                     rt,
                     #[cfg(tokio_unstable)]
                     None,
+                    #[cfg(tokio_unstable)]
+                    true,
                 )
             } else {
                 self.spawn_blocking_inner(
@@ -360,6 +414,8 @@ impl Spawner {
                     rt,
                     #[cfg(tokio_unstable)]
                     None,
+                    #[cfg(tokio_unstable)]
+                    true,
                 )
             };
 
@@ -379,6 +435,7 @@ impl Spawner {
         spawn_meta: SpawnMeta<'_>,
         rt: &Handle,
         #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+        #[cfg(tokio_unstable)] run_task_hooks: bool,
     ) -> (JoinHandle<R>, Result<(), SpawnError>)
     where
         F: FnOnce() -> R + Send + 'static,
@@ -390,12 +447,26 @@ impl Spawner {
 
         let (task, handle) = task::unowned(
             fut,
-            BlockingSchedule::new(rt),
+            BlockingSchedule::new(
+                rt,
+                #[cfg(tokio_unstable)]
+                run_task_hooks,
+            ),
             id,
             task::SpawnLocation::capture(),
             #[cfg(tokio_unstable)]
             user_data,
         );
+
+        #[cfg(tokio_unstable)]
+        if run_task_hooks {
+            task::with_current_task_meta(|parent| {
+                // Safety: the task is freshly allocated and has not been published
+                // to the blocking queue yet.
+                let mut meta = unsafe { task.task_meta() };
+                rt.inner.hooks().spawn(&mut meta, parent);
+            });
+        }
 
         let spawned = self.spawn_task(Task::new(task, is_mandatory), rt);
         (handle, spawned)
@@ -408,6 +479,10 @@ impl Spawner {
             // Shutdown the task: it's fine to shutdown this task (even if
             // mandatory) because it was scheduled after the shutdown of the
             // runtime began.
+            //
+            // Dropping the task can run lifecycle hooks, and those hooks are
+            // allowed to re-enter the blocking pool.
+            drop(shared);
             task.task.shutdown();
 
             // no need to even push this task; it would never get picked up

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -196,7 +196,9 @@ where
     R: Send + 'static,
 {
     let rt = Handle::current();
-    rt.inner.blocking_spawner().spawn_blocking_internal(&rt, func)
+    rt.inner
+        .blocking_spawner()
+        .spawn_blocking_internal(&rt, func)
 }
 
 cfg_fs! {

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -190,7 +190,7 @@ where
 #[track_caller]
 #[cfg(feature = "rt-multi-thread")]
 #[cfg_attr(target_os = "wasi", allow(dead_code))]
-pub(crate) fn spawn_blocking_internal<F, R>(func: F) -> JoinHandle<R>
+pub(crate) fn spawn_blocking_skip_hooks<F, R>(func: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,
     R: Send + 'static,
@@ -198,7 +198,7 @@ where
     let rt = Handle::current();
     rt.inner
         .blocking_spawner()
-        .spawn_blocking_internal(&rt, func)
+        .spawn_blocking_skip_hooks(&rt, func)
 }
 
 cfg_fs! {
@@ -326,7 +326,7 @@ impl Spawner {
 
     #[track_caller]
     #[cfg(feature = "rt-multi-thread")]
-    pub(crate) fn spawn_blocking_internal<F, R>(&self, rt: &Handle, func: F) -> JoinHandle<R>
+    pub(crate) fn spawn_blocking_skip_hooks<F, R>(&self, rt: &Handle, func: F) -> JoinHandle<R>
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,

--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -20,7 +20,10 @@ pub(crate) struct BlockingSchedule {
 
 impl BlockingSchedule {
     #[cfg_attr(not(feature = "test-util"), allow(unused_variables))]
-    pub(crate) fn new(handle: &Handle) -> Self {
+    pub(crate) fn new(
+        handle: &Handle,
+        #[cfg(tokio_unstable)] run_task_hooks: bool,
+    ) -> Self {
         #[cfg(feature = "test-util")]
         {
             match &handle.inner {
@@ -35,7 +38,11 @@ impl BlockingSchedule {
             #[cfg(feature = "test-util")]
             handle: handle.clone(),
             #[cfg(tokio_unstable)]
-            task_terminate_callback: handle.inner.hooks().task_terminate_callback.clone(),
+            task_terminate_callback: if run_task_hooks {
+                handle.inner.hooks().task_terminate_callback.clone()
+            } else {
+                None
+            },
         }
     }
 }

--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -20,10 +20,7 @@ pub(crate) struct BlockingSchedule {
 
 impl BlockingSchedule {
     #[cfg_attr(not(feature = "test-util"), allow(unused_variables))]
-    pub(crate) fn new(
-        handle: &Handle,
-        #[cfg(tokio_unstable)] run_task_hooks: bool,
-    ) -> Self {
+    pub(crate) fn new(handle: &Handle, #[cfg(tokio_unstable)] run_task_hooks: bool) -> Self {
         #[cfg(feature = "test-util")]
         {
             match &handle.inner {

--- a/tokio/src/runtime/blocking/schedule.rs
+++ b/tokio/src/runtime/blocking/schedule.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "test-util")]
 use crate::runtime::scheduler;
-use crate::runtime::task::{self, Task, TaskHarnessScheduleHooks};
+use crate::runtime::task::{self, Task};
 use crate::runtime::Handle;
+#[cfg(tokio_unstable)]
+use crate::runtime::{TaskCallback, TaskMeta};
 
 /// `task::Schedule` implementation that does nothing (except some bookkeeping
 /// in test-util builds). This is unique to the blocking scheduler as tasks
@@ -12,7 +14,8 @@ use crate::runtime::Handle;
 pub(crate) struct BlockingSchedule {
     #[cfg(feature = "test-util")]
     handle: Handle,
-    hooks: TaskHarnessScheduleHooks,
+    #[cfg(tokio_unstable)]
+    task_terminate_callback: Option<TaskCallback>,
 }
 
 impl BlockingSchedule {
@@ -31,9 +34,8 @@ impl BlockingSchedule {
         BlockingSchedule {
             #[cfg(feature = "test-util")]
             handle: handle.clone(),
-            hooks: TaskHarnessScheduleHooks {
-                task_terminate_callback: handle.inner.hooks().task_terminate_callback.clone(),
-            },
+            #[cfg(tokio_unstable)]
+            task_terminate_callback: handle.inner.hooks().task_terminate_callback.clone(),
         }
     }
 }
@@ -58,9 +60,10 @@ impl task::Schedule for BlockingSchedule {
         unreachable!();
     }
 
-    fn hooks(&self) -> TaskHarnessScheduleHooks {
-        TaskHarnessScheduleHooks {
-            task_terminate_callback: self.hooks.task_terminate_callback.clone(),
+    #[cfg(tokio_unstable)]
+    fn task_terminate_callback(&self, meta: &mut TaskMeta<'_>) {
+        if let Some(task_terminate_callback) = &self.task_terminate_callback {
+            task_terminate_callback(meta);
         }
     }
 }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -2,7 +2,8 @@
 
 use crate::runtime::handle::Handle;
 use crate::runtime::{
-    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TimerFlavor,
+    blocking, driver, Callback, HistogramBuilder, Runtime, TaskCallback, TaskSpawnCallback,
+    TimerFlavor,
 };
 #[cfg(tokio_unstable)]
 use crate::runtime::{metrics::HistogramConfiguration, TaskMeta};
@@ -96,7 +97,7 @@ pub struct Builder {
     pub(super) after_unpark: Option<Callback>,
 
     /// To run before each task is spawned.
-    pub(super) before_spawn: Option<TaskCallback>,
+    pub(super) before_spawn: Option<TaskSpawnCallback>,
 
     /// To run before each poll
     #[cfg(tokio_unstable)]
@@ -873,7 +874,7 @@ impl Builder {
     /// # use tokio::runtime;
     /// # pub fn main() {
     /// let runtime = runtime::Builder::new_current_thread()
-    ///     .on_task_spawn(|_| {
+    ///     .on_task_spawn(|_, _| {
     ///         println!("spawning task");
     ///     })
     ///     .build()
@@ -892,7 +893,7 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_task_spawn<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+        F: Fn(&mut TaskMeta<'_>, Option<crate::runtime::TaskMetaRef<'_>>) + Send + Sync + 'static,
     {
         self.before_spawn = Some(std::sync::Arc::new(f));
         self
@@ -939,7 +940,7 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_before_task_poll<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+        F: Fn(&mut TaskMeta<'_>) + Send + Sync + 'static,
     {
         self.before_poll = Some(std::sync::Arc::new(f));
         self
@@ -986,7 +987,7 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_after_task_poll<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+        F: Fn(&mut TaskMeta<'_>) + Send + Sync + 'static,
     {
         self.after_poll = Some(std::sync::Arc::new(f));
         self
@@ -1035,7 +1036,7 @@ impl Builder {
     #[cfg_attr(docsrs, doc(cfg(tokio_unstable)))]
     pub fn on_task_terminate<F>(&mut self, f: F) -> &mut Self
     where
-        F: Fn(&TaskMeta<'_>) + Send + Sync + 'static,
+        F: Fn(&mut TaskMeta<'_>) + Send + Sync + 'static,
     {
         self.after_termination = Some(std::sync::Arc::new(f));
         self

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -2,7 +2,7 @@
     any(not(all(tokio_unstable, feature = "full")), target_family = "wasm"),
     allow(dead_code)
 )]
-use crate::runtime::{Callback, TaskCallback};
+use crate::runtime::{Callback, TaskCallback, TaskSpawnCallback};
 use crate::util::RngSeedGenerator;
 
 pub(crate) struct Config {
@@ -19,7 +19,7 @@ pub(crate) struct Config {
     pub(crate) after_unpark: Option<Callback>,
 
     /// To run before each task is spawned.
-    pub(crate) before_spawn: Option<TaskCallback>,
+    pub(crate) before_spawn: Option<TaskSpawnCallback>,
 
     /// To run after each task is terminated.
     pub(crate) after_termination: Option<TaskCallback>,

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -21,6 +21,8 @@ cfg_rt! {
 
     use crate::runtime::{scheduler, task::Id};
 
+    #[cfg(tokio_unstable)]
+    use std::ptr::NonNull;
     use std::task::Waker;
 
     cfg_taskdump! {
@@ -48,6 +50,9 @@ struct Context {
 
     #[cfg(feature = "rt")]
     current_task_id: Cell<Option<Id>>,
+
+    #[cfg(all(feature = "rt", tokio_unstable))]
+    current_task: Cell<Option<NonNull<()>>>,
 
     /// Tracks if the current thread is currently driving a runtime.
     /// Note, that if this is set to "entered", the current scheduler
@@ -91,6 +96,9 @@ tokio_thread_local! {
 
             #[cfg(feature = "rt")]
             current_task_id: Cell::new(None),
+
+            #[cfg(all(feature = "rt", tokio_unstable))]
+            current_task: Cell::new(None),
 
             // Tracks if the current thread is currently driving a runtime.
             // Note, that if this is set to "entered", the current scheduler
@@ -157,6 +165,20 @@ cfg_rt! {
 
     pub(crate) fn current_task_id() -> Option<Id> {
         CONTEXT.try_with(|ctx| ctx.current_task_id.get()).unwrap_or(None)
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn set_current_task(task: Option<NonNull<()>>) -> Option<NonNull<()>> {
+        CONTEXT
+            .try_with(|ctx| ctx.current_task.replace(task))
+            .unwrap_or(None)
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn current_task() -> Option<NonNull<()>> {
+        CONTEXT
+            .try_with(|ctx| ctx.current_task.get())
+            .unwrap_or(None)
     }
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -20,6 +20,8 @@ cfg_rt! {
     use scoped::Scoped;
 
     use crate::runtime::{scheduler, task::Id};
+    #[cfg(tokio_unstable)]
+    use crate::runtime::task::Header;
 
     #[cfg(tokio_unstable)]
     use std::ptr::NonNull;
@@ -52,7 +54,7 @@ struct Context {
     current_task_id: Cell<Option<Id>>,
 
     #[cfg(all(feature = "rt", tokio_unstable))]
-    current_task: Cell<Option<NonNull<()>>>,
+    current_task: Cell<Option<NonNull<Header>>>,
 
     /// Tracks if the current thread is currently driving a runtime.
     /// Note, that if this is set to "entered", the current scheduler
@@ -168,14 +170,28 @@ cfg_rt! {
     }
 
     #[cfg(tokio_unstable)]
-    pub(crate) fn set_current_task(task: Option<NonNull<()>>) -> Option<NonNull<()>> {
+    pub(crate) fn set_current_task(task: Option<NonNull<Header>>) -> Option<NonNull<Header>> {
         CONTEXT
             .try_with(|ctx| ctx.current_task.replace(task))
             .unwrap_or(None)
     }
 
     #[cfg(tokio_unstable)]
-    pub(crate) fn current_task() -> Option<NonNull<()>> {
+    pub(crate) fn set_current_task_id_and_task(
+        id: Option<Id>,
+        task: Option<NonNull<Header>>,
+    ) -> (Option<Id>, Option<NonNull<Header>>) {
+        CONTEXT
+            .try_with(|ctx| {
+                let parent_task_id = ctx.current_task_id.replace(id);
+                let parent_task = ctx.current_task.replace(task);
+                (parent_task_id, parent_task)
+            })
+            .unwrap_or((None, None))
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn current_task() -> Option<NonNull<Header>> {
         CONTEXT
             .try_with(|ctx| ctx.current_task.get())
             .unwrap_or(None)

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -376,6 +376,40 @@ impl Handle {
         F: Future + Send + 'static,
         F::Output: Send + 'static,
     {
+        self.spawn_named_inner(
+            future,
+            meta,
+            #[cfg(tokio_unstable)]
+            None,
+        )
+    }
+
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[track_caller]
+    pub(crate) fn spawn_named_with_data<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        self.spawn_named_inner(future, meta, user_data)
+    }
+
+    #[track_caller]
+    fn spawn_named_inner<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
         let id = crate::runtime::task::Id::next();
         #[cfg(all(
             tokio_unstable,
@@ -387,7 +421,13 @@ impl Handle {
         let future = super::task::trace::Trace::root(future);
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(future, "task", meta, id.as_u64());
-        self.inner.spawn(future, id, meta.spawned_at)
+        self.inner.spawn(
+            future,
+            id,
+            meta.spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        )
     }
 
     #[track_caller]
@@ -405,6 +445,47 @@ impl Handle {
         F: Future + 'static,
         F::Output: 'static,
     {
+        unsafe {
+            self.spawn_local_named_inner(
+                future,
+                meta,
+                #[cfg(tokio_unstable)]
+                None,
+            )
+        }
+    }
+
+    /// # Safety
+    ///
+    /// This must only be called in `LocalRuntime` if the runtime has been verified to be owned
+    /// by the current thread.
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[track_caller]
+    #[allow(dead_code)]
+    pub(crate) unsafe fn spawn_local_named_with_data<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+    {
+        unsafe { self.spawn_local_named_inner(future, meta, user_data) }
+    }
+
+    #[track_caller]
+    unsafe fn spawn_local_named_inner<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+    {
         let id = crate::runtime::task::Id::next();
         #[cfg(all(
             tokio_unstable,
@@ -416,7 +497,15 @@ impl Handle {
         let future = super::task::trace::Trace::root(future);
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let future = crate::util::trace::task(future, "task", meta, id.as_u64());
-        unsafe { self.inner.spawn_local(future, id, meta.spawned_at) }
+        unsafe {
+            self.inner.spawn_local(
+                future,
+                id,
+                meta.spawned_at,
+                #[cfg(tokio_unstable)]
+                user_data,
+            )
+        }
     }
 
     /// Returns the flavor of the current `Runtime`.

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -475,6 +475,10 @@ impl Handle {
         unsafe { self.spawn_local_named_inner(future, meta, user_data) }
     }
 
+    /// # Safety
+    ///
+    /// This must only be called in `LocalRuntime` if the runtime has been verified to be owned
+    /// by the current thread.
     #[track_caller]
     unsafe fn spawn_local_named_inner<F>(
         &self,

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -589,9 +589,11 @@ cfg_rt! {
     }
 
     mod task_hooks;
-    pub(crate) use task_hooks::{TaskHooks, TaskCallback};
+    pub(crate) use task_hooks::{TaskCallback, TaskHooks, TaskSpawnCallback};
+    #[cfg(tokio_unstable)]
+    pub(crate) use task_hooks::TaskData;
     cfg_unstable! {
-        pub use task_hooks::TaskMeta;
+        pub use task_hooks::{TaskMeta, TaskMetaRef};
     }
     #[cfg(not(tokio_unstable))]
     pub(crate) use task_hooks::TaskMeta;

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -530,6 +530,8 @@ cfg_rt! {
     mod blocking;
     #[cfg_attr(target_os = "wasi", allow(unused_imports))]
     pub(crate) use blocking::spawn_blocking;
+    #[cfg(feature = "rt-multi-thread")]
+    pub(crate) use blocking::spawn_blocking_internal;
 
     cfg_trace! {
         pub(crate) use blocking::Mandatory;

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -531,7 +531,7 @@ cfg_rt! {
     #[cfg_attr(target_os = "wasi", allow(unused_imports))]
     pub(crate) use blocking::spawn_blocking;
     #[cfg(feature = "rt-multi-thread")]
-    pub(crate) use blocking::spawn_blocking_internal;
+    pub(crate) use blocking::spawn_blocking_skip_hooks;
 
     cfg_trace! {
         pub(crate) use blocking::Mandatory;

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -3,7 +3,7 @@ use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{
-    self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task, TaskHarnessScheduleHooks,
+    self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task,
 };
 use crate::runtime::{
     blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, TaskMeta, WorkerMetrics,
@@ -470,18 +470,35 @@ impl Handle {
         future: F,
         id: crate::runtime::task::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> JoinHandle<F::Output>
     where
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
-
-        me.task_hooks.spawn(&TaskMeta {
+        #[cfg(tokio_unstable)]
+        let parent = task::current_task_meta();
+        #[cfg(tokio_unstable)]
+        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
+            future,
+            me.clone(),
             id,
             spawned_at,
-            _phantom: Default::default(),
-        });
+            user_data,
+            |task| {
+                // Safety: the task is freshly allocated and not published yet.
+                let mut meta = unsafe { task.task_meta() };
+                me.task_hooks.spawn(&mut meta, parent);
+            },
+        );
+        #[cfg(not(tokio_unstable))]
+        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
+
+        #[cfg(not(tokio_unstable))]
+        {
+            let mut meta = TaskMeta::new(id, spawned_at);
+            me.task_hooks.spawn(&mut meta, None);
+        }
 
         if let Some(notified) = notified {
             me.schedule(notified);
@@ -503,23 +520,44 @@ impl Handle {
         future: F,
         id: crate::runtime::task::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> JoinHandle<F::Output>
     where
         F: crate::future::Future + 'static,
         F::Output: 'static,
     {
         // Safety: the caller guarantees that this is only called on a `LocalRuntime`.
+        #[cfg(tokio_unstable)]
+        let parent = task::current_task_meta();
+        #[cfg(tokio_unstable)]
+        let before_bind = |task: &Task<Arc<Handle>>| {
+            // Safety: the task is freshly allocated and not published yet.
+            let mut meta = unsafe { task.task_meta() };
+            me.task_hooks.spawn(&mut meta, parent);
+        };
+        #[cfg(tokio_unstable)]
+        let (handle, notified) = unsafe {
+            me.shared.owned.bind_local_with_spawn_hook(
+                future,
+                me.clone(),
+                id,
+                spawned_at,
+                user_data,
+                before_bind,
+            )
+        };
+        #[cfg(not(tokio_unstable))]
         let (handle, notified) = unsafe {
             me.shared
                 .owned
                 .bind_local(future, me.clone(), id, spawned_at)
         };
 
-        me.task_hooks.spawn(&TaskMeta {
-            id,
-            spawned_at,
-            _phantom: Default::default(),
-        });
+        #[cfg(not(tokio_unstable))]
+        {
+            let mut meta = TaskMeta::new(id, spawned_at);
+            me.task_hooks.spawn(&mut meta, None);
+        }
 
         if let Some(notified) = notified {
             me.schedule(notified);
@@ -687,13 +725,19 @@ impl Schedule for Arc<Handle> {
         });
     }
 
-    fn hooks(&self) -> TaskHarnessScheduleHooks {
-        TaskHarnessScheduleHooks {
-            task_terminate_callback: self.task_hooks.task_terminate_callback.clone(),
-        }
-    }
-
     cfg_unstable! {
+        fn task_terminate_callback(&self, meta: &mut TaskMeta<'_>) {
+            self.task_hooks.task_terminate_callback(meta);
+        }
+
+        fn task_poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
+            self.task_hooks.poll_start_callback(meta);
+        }
+
+        fn task_poll_stop_callback(&self, meta: &mut TaskMeta<'_>) {
+            self.task_hooks.poll_stop_callback(meta);
+        }
+
         fn unhandled_panic(&self) {
             use crate::runtime::UnhandledPanic;
 
@@ -815,17 +859,8 @@ impl CoreGuard<'_> {
 
                     let task = context.handle.shared.owned.assert_owner(task);
 
-                    #[cfg(tokio_unstable)]
-                    let task_meta = task.task_meta();
-
                     let (c, ()) = context.run_task(core, || {
-                        #[cfg(tokio_unstable)]
-                        context.handle.task_hooks.poll_start_callback(&task_meta);
-
                         task.run();
-
-                        #[cfg(tokio_unstable)]
-                        context.handle.task_hooks.poll_stop_callback(&task_meta);
                     });
 
                     core = c;

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -475,20 +475,20 @@ impl Handle {
         F::Output: Send + 'static,
     {
         #[cfg(tokio_unstable)]
-        let parent = task::current_task_meta();
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
-            future,
-            me.clone(),
-            id,
-            spawned_at,
-            user_data,
-            |task| {
-                // Safety: the task is freshly allocated and not published yet.
-                let mut meta = unsafe { task.task_meta() };
-                me.task_hooks.spawn(&mut meta, parent);
-            },
-        );
+        let (handle, notified) = task::with_current_task_meta(|parent| {
+            me.shared.owned.bind_with_spawn_hook(
+                future,
+                me.clone(),
+                id,
+                spawned_at,
+                user_data,
+                |task| {
+                    // Safety: the task is freshly allocated and not published yet.
+                    let mut meta = unsafe { task.task_meta() };
+                    me.task_hooks.spawn(&mut meta, parent);
+                },
+            )
+        });
         #[cfg(not(tokio_unstable))]
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
 
@@ -524,26 +524,25 @@ impl Handle {
         F: crate::future::Future + 'static,
         F::Output: 'static,
     {
-        // Safety: the caller guarantees that this is only called on a `LocalRuntime`.
         #[cfg(tokio_unstable)]
-        let parent = task::current_task_meta();
-        #[cfg(tokio_unstable)]
-        let before_bind = |task: &Task<Arc<Handle>>| {
-            // Safety: the task is freshly allocated and not published yet.
-            let mut meta = unsafe { task.task_meta() };
-            me.task_hooks.spawn(&mut meta, parent);
-        };
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = unsafe {
-            me.shared.owned.bind_local_with_spawn_hook(
-                future,
-                me.clone(),
-                id,
-                spawned_at,
-                user_data,
-                before_bind,
-            )
-        };
+        let (handle, notified) = task::with_current_task_meta(|parent| {
+            let before_bind = |task: &Task<Arc<Handle>>| {
+                // Safety: the task is freshly allocated and not published yet.
+                let mut meta = unsafe { task.task_meta() };
+                me.task_hooks.spawn(&mut meta, parent);
+            };
+            // Safety: the caller guarantees that this is only called on a `LocalRuntime`.
+            unsafe {
+                me.shared.owned.bind_local_with_spawn_hook(
+                    future,
+                    me.clone(),
+                    id,
+                    spawned_at,
+                    user_data,
+                    before_bind,
+                )
+            }
+        });
         #[cfg(not(tokio_unstable))]
         let (handle, notified) = unsafe {
             me.shared

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -3,11 +3,11 @@ use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task};
+#[cfg(tokio_unstable)]
+use crate::runtime::TaskMeta;
 use crate::runtime::{
     blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, WorkerMetrics,
 };
-#[cfg(tokio_unstable)]
-use crate::runtime::TaskMeta;
 use crate::sync::notify::Notify;
 use crate::util::atomic_cell::AtomicCell;
 use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -474,29 +474,15 @@ impl Handle {
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = task::with_current_task_meta(|parent| {
-            me.shared.owned.bind_with_spawn_hook(
-                future,
-                me.clone(),
-                id,
-                spawned_at,
-                user_data,
-                |task| {
-                    // Safety: the task is freshly allocated and not published yet.
-                    let mut meta = unsafe { task.task_meta() };
-                    me.task_hooks.spawn(&mut meta, parent);
-                },
-            )
-        });
-        #[cfg(not(tokio_unstable))]
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
-
-        #[cfg(not(tokio_unstable))]
-        {
-            let mut meta = TaskMeta::new(id, spawned_at);
-            me.task_hooks.spawn(&mut meta, None);
-        }
+        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
+            future,
+            me.clone(),
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+            &me.task_hooks,
+        );
 
         if let Some(notified) = notified {
             me.schedule(notified);
@@ -524,37 +510,18 @@ impl Handle {
         F: crate::future::Future + 'static,
         F::Output: 'static,
     {
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = task::with_current_task_meta(|parent| {
-            let before_bind = |task: &Task<Arc<Handle>>| {
-                // Safety: the task is freshly allocated and not published yet.
-                let mut meta = unsafe { task.task_meta() };
-                me.task_hooks.spawn(&mut meta, parent);
-            };
-            // Safety: the caller guarantees that this is only called on a `LocalRuntime`.
-            unsafe {
-                me.shared.owned.bind_local_with_spawn_hook(
-                    future,
-                    me.clone(),
-                    id,
-                    spawned_at,
-                    user_data,
-                    before_bind,
-                )
-            }
-        });
-        #[cfg(not(tokio_unstable))]
+        // Safety: the caller guarantees that this is only called on a `LocalRuntime`.
         let (handle, notified) = unsafe {
-            me.shared
-                .owned
-                .bind_local(future, me.clone(), id, spawned_at)
+            me.shared.owned.bind_local_with_spawn_hook(
+                future,
+                me.clone(),
+                id,
+                spawned_at,
+                #[cfg(tokio_unstable)]
+                user_data,
+                &me.task_hooks,
+            )
         };
-
-        #[cfg(not(tokio_unstable))]
-        {
-            let mut meta = TaskMeta::new(id, spawned_at);
-            me.task_hooks.spawn(&mut meta, None);
-        }
 
         if let Some(notified) = notified {
             me.schedule(notified);
@@ -727,8 +694,16 @@ impl Schedule for Arc<Handle> {
             self.task_hooks.task_terminate_callback(meta);
         }
 
+        fn has_task_poll_start_callback(&self) -> bool {
+            self.task_hooks.has_poll_start_callback()
+        }
+
         fn task_poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
             self.task_hooks.poll_start_callback(meta);
+        }
+
+        fn has_task_poll_stop_callback(&self) -> bool {
+            self.task_hooks.has_poll_stop_callback()
         }
 
         fn task_poll_stop_callback(&self, meta: &mut TaskMeta<'_>) {

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -2,9 +2,7 @@ use crate::loom::sync::atomic::AtomicBool;
 use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
-use crate::runtime::task::{
-    self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task,
-};
+use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task};
 use crate::runtime::{
     blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, TaskMeta, WorkerMetrics,
 };

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -4,8 +4,10 @@ use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task};
 use crate::runtime::{
-    blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, TaskMeta, WorkerMetrics,
+    blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, WorkerMetrics,
 };
+#[cfg(tokio_unstable)]
+use crate::runtime::TaskMeta;
 use crate::sync::notify::Notify;
 use crate::util::atomic_cell::AtomicCell;
 use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -8,8 +8,8 @@ cfg_rt! {
     pub(crate) mod inject;
     pub(crate) use inject::Inject;
 
+    #[cfg(tokio_unstable)]
     use crate::runtime::TaskHooks;
-
     use crate::runtime::WorkerMetrics;
 }
 
@@ -149,16 +149,36 @@ cfg_rt! {
             }
         }
 
-        pub(crate) fn spawn<F>(&self, future: F, id: Id, spawned_at: SpawnLocation) -> JoinHandle<F::Output>
+        pub(crate) fn spawn<F>(
+            &self,
+            future: F,
+            id: Id,
+            spawned_at: SpawnLocation,
+            #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+        ) -> JoinHandle<F::Output>
         where
             F: Future + Send + 'static,
             F::Output: Send + 'static,
         {
             match self {
-                Handle::CurrentThread(h) => current_thread::Handle::spawn(h, future, id, spawned_at),
+                Handle::CurrentThread(h) => current_thread::Handle::spawn(
+                    h,
+                    future,
+                    id,
+                    spawned_at,
+                    #[cfg(tokio_unstable)]
+                    user_data,
+                ),
 
                 #[cfg(feature = "rt-multi-thread")]
-                Handle::MultiThread(h) => multi_thread::Handle::spawn(h, future, id, spawned_at),
+                Handle::MultiThread(h) => multi_thread::Handle::spawn(
+                    h,
+                    future,
+                    id,
+                    spawned_at,
+                    #[cfg(tokio_unstable)]
+                    user_data,
+                ),
             }
         }
 
@@ -170,14 +190,29 @@ cfg_rt! {
         /// by the current thread.
         #[allow(irrefutable_let_patterns)]
         #[track_caller]
-        pub(crate) unsafe fn spawn_local<F>(&self, future: F, id: Id, spawned_at: SpawnLocation) -> JoinHandle<F::Output>
+        pub(crate) unsafe fn spawn_local<F>(
+            &self,
+            future: F,
+            id: Id,
+            spawned_at: SpawnLocation,
+            #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+        ) -> JoinHandle<F::Output>
         where
             F: Future + 'static,
             F::Output: 'static,
         {
             if let Handle::CurrentThread(h) = self {
                 // Safety: caller guarantees that this is a `LocalRuntime`.
-                unsafe { current_thread::Handle::spawn_local(h, future, id, spawned_at) }
+                unsafe {
+                    current_thread::Handle::spawn_local(
+                        h,
+                        future,
+                        id,
+                        spawned_at,
+                        #[cfg(tokio_unstable)]
+                        user_data,
+                    )
+                }
             } else {
                 panic!("Only current_thread and LocalSet have spawn_local internals implemented")
             }
@@ -204,6 +239,7 @@ cfg_rt! {
             }
         }
 
+        #[cfg(tokio_unstable)]
         pub(crate) fn hooks(&self) -> &TaskHooks {
             match self {
                 Handle::CurrentThread(h) => &h.task_hooks,

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -2,13 +2,13 @@ use crate::future::Future;
 use crate::loom::sync::Arc;
 use crate::runtime::scheduler::multi_thread::worker;
 use crate::runtime::task::{Notified, Task};
+#[cfg(tokio_unstable)]
+use crate::runtime::TaskMeta;
 use crate::runtime::{
     blocking, driver,
     task::{self, JoinHandle, SpawnLocation},
     TaskHooks, TimerFlavor,
 };
-#[cfg(tokio_unstable)]
-use crate::runtime::TaskMeta;
 use crate::util::RngSeedGenerator;
 
 use std::fmt;

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -97,29 +97,15 @@ impl Handle {
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = task::with_current_task_meta(|parent| {
-            me.shared.owned.bind_with_spawn_hook(
-                future,
-                me.clone(),
-                id,
-                spawned_at,
-                user_data,
-                |task| {
-                    // Safety: the task is freshly allocated and not published yet.
-                    let mut meta = unsafe { task.task_meta() };
-                    me.task_hooks.spawn(&mut meta, parent);
-                },
-            )
-        });
-        #[cfg(not(tokio_unstable))]
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
-
-        #[cfg(not(tokio_unstable))]
-        {
-            let mut meta = TaskMeta::new(id, spawned_at);
-            me.task_hooks.spawn(&mut meta, None);
-        }
+        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
+            future,
+            me.clone(),
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+            &me.task_hooks,
+        );
 
         me.schedule_option_task_without_yield(notified);
 
@@ -146,8 +132,18 @@ impl task::Schedule for Arc<Handle> {
     }
 
     #[cfg(tokio_unstable)]
+    fn has_task_poll_start_callback(&self) -> bool {
+        self.task_hooks.has_poll_start_callback()
+    }
+
+    #[cfg(tokio_unstable)]
     fn task_poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
         self.task_hooks.poll_start_callback(meta);
+    }
+
+    #[cfg(tokio_unstable)]
+    fn has_task_poll_stop_callback(&self) -> bool {
+        self.task_hooks.has_poll_stop_callback()
     }
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -5,8 +5,10 @@ use crate::runtime::task::{Notified, Task};
 use crate::runtime::{
     blocking, driver,
     task::{self, JoinHandle, SpawnLocation},
-    TaskHooks, TaskMeta, TimerFlavor,
+    TaskHooks, TimerFlavor,
 };
+#[cfg(tokio_unstable)]
+use crate::runtime::TaskMeta;
 use crate::util::RngSeedGenerator;
 
 use std::fmt;

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -1,7 +1,7 @@
 use crate::future::Future;
 use crate::loom::sync::Arc;
 use crate::runtime::scheduler::multi_thread::worker;
-use crate::runtime::task::{Notified, Task, TaskHarnessScheduleHooks};
+use crate::runtime::task::{Notified, Task};
 use crate::runtime::{
     blocking, driver,
     task::{self, JoinHandle, SpawnLocation},
@@ -57,12 +57,20 @@ impl Handle {
         future: F,
         id: task::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> JoinHandle<F::Output>
     where
         F: crate::future::Future + Send + 'static,
         F::Output: Send + 'static,
     {
-        Self::bind_new_task(me, future, id, spawned_at)
+        Self::bind_new_task(
+            me,
+            future,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        )
     }
 
     #[cfg(all(tokio_unstable, feature = "time"))]
@@ -83,18 +91,35 @@ impl Handle {
         future: T,
         id: task::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
-
-        me.task_hooks.spawn(&TaskMeta {
+        #[cfg(tokio_unstable)]
+        let parent = task::current_task_meta();
+        #[cfg(tokio_unstable)]
+        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
+            future,
+            me.clone(),
             id,
             spawned_at,
-            _phantom: Default::default(),
-        });
+            user_data,
+            |task| {
+                // Safety: the task is freshly allocated and not published yet.
+                let mut meta = unsafe { task.task_meta() };
+                me.task_hooks.spawn(&mut meta, parent);
+            },
+        );
+        #[cfg(not(tokio_unstable))]
+        let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
+
+        #[cfg(not(tokio_unstable))]
+        {
+            let mut meta = TaskMeta::new(id, spawned_at);
+            me.task_hooks.spawn(&mut meta, None);
+        }
 
         me.schedule_option_task_without_yield(notified);
 
@@ -111,14 +136,23 @@ impl task::Schedule for Arc<Handle> {
         self.schedule_task(task, false);
     }
 
-    fn hooks(&self) -> TaskHarnessScheduleHooks {
-        TaskHarnessScheduleHooks {
-            task_terminate_callback: self.task_hooks.task_terminate_callback.clone(),
-        }
-    }
-
     fn yield_now(&self, task: Notified<Self>) {
         self.schedule_task(task, true);
+    }
+
+    #[cfg(tokio_unstable)]
+    fn task_terminate_callback(&self, meta: &mut TaskMeta<'_>) {
+        self.task_hooks.task_terminate_callback(meta);
+    }
+
+    #[cfg(tokio_unstable)]
+    fn task_poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
+        self.task_hooks.poll_start_callback(meta);
+    }
+
+    #[cfg(tokio_unstable)]
+    fn task_poll_stop_callback(&self, meta: &mut TaskMeta<'_>) {
+        self.task_hooks.poll_stop_callback(meta);
     }
 }
 

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -98,20 +98,20 @@ impl Handle {
         T::Output: Send + 'static,
     {
         #[cfg(tokio_unstable)]
-        let parent = task::current_task_meta();
-        #[cfg(tokio_unstable)]
-        let (handle, notified) = me.shared.owned.bind_with_spawn_hook(
-            future,
-            me.clone(),
-            id,
-            spawned_at,
-            user_data,
-            |task| {
-                // Safety: the task is freshly allocated and not published yet.
-                let mut meta = unsafe { task.task_meta() };
-                me.task_hooks.spawn(&mut meta, parent);
-            },
-        );
+        let (handle, notified) = task::with_current_task_meta(|parent| {
+            me.shared.owned.bind_with_spawn_hook(
+                future,
+                me.clone(),
+                id,
+                spawned_at,
+                user_data,
+                |task| {
+                    // Safety: the task is freshly allocated and not published yet.
+                    let mut meta = unsafe { task.task_meta() };
+                    me.task_hooks.spawn(&mut meta, parent);
+                },
+            )
+        });
         #[cfg(not(tokio_unstable))]
         let (handle, notified) = me.shared.owned.bind(future, me.clone(), id, spawned_at);
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -475,7 +475,7 @@ where
         // Once the blocking task is done executing, we will attempt to
         // steal the core back.
         let worker = cx.worker.clone();
-        runtime::spawn_blocking_internal(move || run(worker));
+        runtime::spawn_blocking_skip_hooks(move || run(worker));
         Ok(())
     });
 
@@ -500,7 +500,7 @@ where
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
-            runtime::spawn_blocking_internal(move || run(worker));
+            runtime::spawn_blocking_skip_hooks(move || run(worker));
         }
     }
 }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -475,7 +475,7 @@ where
         // Once the blocking task is done executing, we will attempt to
         // steal the core back.
         let worker = cx.worker.clone();
-        runtime::spawn_blocking(move || run(worker));
+        runtime::spawn_blocking_internal(move || run(worker));
         Ok(())
     });
 
@@ -500,7 +500,7 @@ where
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
-            runtime::spawn_blocking(move || run(worker));
+            runtime::spawn_blocking_internal(move || run(worker));
         }
     }
 }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -628,9 +628,6 @@ impl Context {
     }
 
     fn run_task(&self, task: Notified, mut core: Box<Core>) -> RunResult {
-        #[cfg(tokio_unstable)]
-        let task_meta = task.task_meta();
-
         let task = self.worker.handle.shared.owned.assert_owner(task);
 
         // Make sure the worker is not in the **searching** state. This enables
@@ -673,18 +670,7 @@ impl Context {
 
         // Run the task
         coop::budget(|| {
-            // Unlike the poll time above, poll start callback is attached to the task id,
-            // so it is tightly associated with the actual poll invocation.
-            #[cfg(tokio_unstable)]
-            self.worker
-                .handle
-                .task_hooks
-                .poll_start_callback(&task_meta);
-
             task.run();
-
-            #[cfg(tokio_unstable)]
-            self.worker.handle.task_hooks.poll_stop_callback(&task_meta);
 
             let mut lifo_polls = 0;
 
@@ -749,19 +735,7 @@ impl Context {
                 *self.core.borrow_mut() = Some(core);
                 let task = self.worker.handle.shared.owned.assert_owner(task);
 
-                #[cfg(tokio_unstable)]
-                let task_meta = task.task_meta();
-
-                #[cfg(tokio_unstable)]
-                self.worker
-                    .handle
-                    .task_hooks
-                    .poll_start_callback(&task_meta);
-
                 task.run();
-
-                #[cfg(tokio_unstable)]
-                self.worker.handle.task_hooks.poll_stop_callback(&task_meta);
             }
         })
     }

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -350,6 +350,32 @@ impl Drop for TaskIdGuard {
     }
 }
 
+#[cfg(tokio_unstable)]
+struct TaskContextGuard {
+    parent_task_id: Option<Id>,
+    parent_task: Option<NonNull<Header>>,
+}
+
+#[cfg(tokio_unstable)]
+impl TaskContextGuard {
+    fn enter(id: Id, header: NonNull<Header>) -> Self {
+        let (parent_task_id, parent_task) =
+            context::set_current_task_id_and_task(Some(id), Some(header));
+
+        TaskContextGuard {
+            parent_task_id,
+            parent_task,
+        }
+    }
+}
+
+#[cfg(tokio_unstable)]
+impl Drop for TaskContextGuard {
+    fn drop(&mut self) {
+        context::set_current_task_id_and_task(self.parent_task_id, self.parent_task);
+    }
+}
+
 impl<T: Future, S: Schedule> Core<T, S> {
     /// Polls the future.
     ///
@@ -365,12 +391,11 @@ impl<T: Future, S: Schedule> Core<T, S> {
     /// `self` must also be pinned. This is handled by storing the task on the
     /// heap.
     ///
-    /// When `tokio_unstable` is enabled, `header` must point to the header for
-    /// this exact task allocation, and the allocation must remain live until
-    /// this function returns.
+    /// `header` must point to the header for this exact task allocation, and
+    /// the allocation must remain live until this function returns.
     pub(super) unsafe fn poll(
         &self,
-        #[cfg(tokio_unstable)] header: NonNull<Header>,
+        header: NonNull<Header>,
         mut cx: Context<'_>,
     ) -> Poll<T::Output> {
         let res = {
@@ -384,18 +409,16 @@ impl<T: Future, S: Schedule> Core<T, S> {
                 // Safety: The caller ensures the future is pinned.
                 let future = unsafe { Pin::new_unchecked(future) };
 
-                let _guard = TaskIdGuard::enter(self.task_id);
                 #[cfg(tokio_unstable)]
-                let _current_task = CurrentTaskGuard::enter(header);
+                let _guard = TaskContextGuard::enter(self.task_id, header);
+                #[cfg(not(tokio_unstable))]
+                let _guard = TaskIdGuard::enter(self.task_id);
                 future.poll(&mut cx)
             })
         };
 
         if res.is_ready() {
-            self.drop_future_or_output(
-                #[cfg(tokio_unstable)]
-                header,
-            );
+            self.drop_future_or_output(header);
         }
 
         res
@@ -406,7 +429,10 @@ impl<T: Future, S: Schedule> Core<T, S> {
     /// # Safety
     ///
     /// The caller must ensure it is safe to mutate the `stage` field.
-    pub(super) fn drop_future_or_output(&self, #[cfg(tokio_unstable)] header: NonNull<Header>) {
+    pub(super) fn drop_future_or_output(&self, header: NonNull<Header>) {
+        #[cfg(not(tokio_unstable))]
+        let _ = header;
+
         #[cfg(tokio_unstable)]
         let _current_task = {
             let dropping_future = self.stage.stage.with(|ptr| {
@@ -464,14 +490,14 @@ impl<T: Future, S: Schedule> Core<T, S> {
 
 #[cfg(tokio_unstable)]
 pub(crate) struct CurrentTaskGuard {
-    parent_task: Option<NonNull<()>>,
+    parent_task: Option<NonNull<Header>>,
 }
 
 #[cfg(tokio_unstable)]
 impl CurrentTaskGuard {
     fn enter(header: NonNull<Header>) -> Self {
         CurrentTaskGuard {
-            parent_task: context::set_current_task(Some(header.cast())),
+            parent_task: context::set_current_task(Some(header)),
         }
     }
 }

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -23,7 +23,9 @@ use crate::loom::cell::UnsafeCell;
 use crate::runtime::context;
 use crate::runtime::task::raw::{self, Vtable};
 use crate::runtime::task::state::State;
-use crate::runtime::task::{Id, Schedule, TaskHarnessScheduleHooks};
+use crate::runtime::task::{Id, Schedule};
+#[cfg(tokio_unstable)]
+use crate::runtime::TaskData;
 use crate::util::linked_list;
 
 use std::num::NonZeroU64;
@@ -203,9 +205,8 @@ pub(super) struct Trailer {
     pub(super) owned: linked_list::Pointers<Header>,
     /// Consumer task waiting on completion of this task.
     pub(super) waker: UnsafeCell<Option<Waker>>,
-    /// Optional hooks needed in the harness.
-    #[cfg_attr(not(tokio_unstable), allow(dead_code))] //TODO: remove when hooks are stabilized
-    pub(super) hooks: TaskHarnessScheduleHooks,
+    #[cfg(tokio_unstable)]
+    pub(super) user_data: UnsafeCell<Option<TaskData>>,
 }
 
 generate_addr_of_methods! {
@@ -233,6 +234,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         state: State,
         task_id: Id,
         #[cfg(tokio_unstable)] spawned_at: &'static Location<'static>,
+        #[cfg(tokio_unstable)] user_data: Option<TaskData>,
     ) -> Box<Cell<T, S>> {
         // Separated into a non-generic function to reduce LLVM codegen
         fn new_header(
@@ -254,7 +256,10 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         let tracing_id = future.id();
         let vtable = raw::vtable::<T, S>();
         let result = Box::new(Cell {
-            trailer: Trailer::new(scheduler.hooks()),
+            trailer: Trailer::new(
+                #[cfg(tokio_unstable)]
+                user_data,
+            ),
             header: new_header(
                 state,
                 vtable,
@@ -359,7 +364,11 @@ impl<T: Future, S: Schedule> Core<T, S> {
     ///
     /// `self` must also be pinned. This is handled by storing the task on the
     /// heap.
-    pub(super) fn poll(&self, mut cx: Context<'_>) -> Poll<T::Output> {
+    pub(super) fn poll(
+        &self,
+        #[cfg(tokio_unstable)] header: NonNull<Header>,
+        mut cx: Context<'_>,
+    ) -> Poll<T::Output> {
         let res = {
             self.stage.stage.with_mut(|ptr| {
                 // Safety: The caller ensures mutual exclusion to the field.
@@ -372,6 +381,8 @@ impl<T: Future, S: Schedule> Core<T, S> {
                 let future = unsafe { Pin::new_unchecked(future) };
 
                 let _guard = TaskIdGuard::enter(self.task_id);
+                #[cfg(tokio_unstable)]
+                let _current_task = CurrentTaskGuard::enter(header);
                 future.poll(&mut cx)
             })
         };
@@ -427,6 +438,27 @@ impl<T: Future, S: Schedule> Core<T, S> {
     unsafe fn set_stage(&self, stage: Stage<T>) {
         let _guard = TaskIdGuard::enter(self.task_id);
         self.stage.stage.with_mut(|ptr| *ptr = stage);
+    }
+}
+
+#[cfg(tokio_unstable)]
+pub(crate) struct CurrentTaskGuard {
+    parent_task: Option<NonNull<()>>,
+}
+
+#[cfg(tokio_unstable)]
+impl CurrentTaskGuard {
+    fn enter(header: NonNull<Header>) -> Self {
+        CurrentTaskGuard {
+            parent_task: context::set_current_task(Some(header.cast())),
+        }
+    }
+}
+
+#[cfg(tokio_unstable)]
+impl Drop for CurrentTaskGuard {
+    fn drop(&mut self) {
+        context::set_current_task(self.parent_task);
     }
 }
 
@@ -537,12 +569,19 @@ impl Header {
 }
 
 impl Trailer {
-    fn new(hooks: TaskHarnessScheduleHooks) -> Self {
+    fn new(#[cfg(tokio_unstable)] user_data: Option<TaskData>) -> Self {
         Trailer {
             waker: UnsafeCell::new(None),
             owned: linked_list::Pointers::new(),
-            hooks,
+            #[cfg(tokio_unstable)]
+            user_data: UnsafeCell::new(user_data),
         }
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(super) fn user_data_ptr(&self) -> NonNull<Option<TaskData>> {
+        self.user_data
+            .with_mut(|ptr| unsafe { NonNull::new_unchecked(ptr) })
     }
 
     pub(super) unsafe fn set_waker(&self, waker: Option<Waker>) {

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -392,7 +392,10 @@ impl<T: Future, S: Schedule> Core<T, S> {
         };
 
         if res.is_ready() {
-            self.drop_future_or_output();
+            self.drop_future_or_output(
+                #[cfg(tokio_unstable)]
+                header,
+            );
         }
 
         res
@@ -403,7 +406,24 @@ impl<T: Future, S: Schedule> Core<T, S> {
     /// # Safety
     ///
     /// The caller must ensure it is safe to mutate the `stage` field.
-    pub(super) fn drop_future_or_output(&self) {
+    pub(super) fn drop_future_or_output(
+        &self,
+        #[cfg(tokio_unstable)] header: NonNull<Header>,
+    ) {
+        #[cfg(tokio_unstable)]
+        let _current_task = {
+            let dropping_future = self.stage.stage.with(|ptr| {
+                // Safety: the caller ensures mutual exclusion to the field.
+                matches!(unsafe { &*ptr }, Stage::Running(_))
+            });
+
+            if dropping_future {
+                Some(CurrentTaskGuard::enter(header))
+            } else {
+                None
+            }
+        };
+
         // Safety: the caller ensures mutual exclusion to the field.
         unsafe {
             self.set_stage(Stage::Consumed);

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -350,29 +350,67 @@ impl Drop for TaskIdGuard {
     }
 }
 
-#[cfg(tokio_unstable)]
 struct TaskContextGuard {
     parent_task_id: Option<Id>,
+    #[cfg(tokio_unstable)]
     parent_task: Option<NonNull<Header>>,
 }
 
-#[cfg(tokio_unstable)]
 impl TaskContextGuard {
     fn enter(id: Id, header: NonNull<Header>) -> Self {
-        let (parent_task_id, parent_task) =
-            context::set_current_task_id_and_task(Some(id), Some(header));
+        #[cfg(tokio_unstable)]
+        {
+            let (parent_task_id, parent_task) =
+                context::set_current_task_id_and_task(Some(id), Some(header));
 
-        TaskContextGuard {
-            parent_task_id,
-            parent_task,
+            TaskContextGuard {
+                parent_task_id,
+                parent_task,
+            }
+        }
+
+        #[cfg(not(tokio_unstable))]
+        {
+            let _ = header;
+            TaskContextGuard {
+                parent_task_id: context::set_current_task_id(Some(id)),
+            }
+        }
+    }
+}
+
+impl Drop for TaskContextGuard {
+    fn drop(&mut self) {
+        #[cfg(tokio_unstable)]
+        {
+            context::set_current_task_id_and_task(self.parent_task_id, self.parent_task);
+        }
+
+        #[cfg(not(tokio_unstable))]
+        {
+            context::set_current_task_id(self.parent_task_id);
         }
     }
 }
 
 #[cfg(tokio_unstable)]
-impl Drop for TaskContextGuard {
+struct CurrentTaskGuard {
+    parent_task: Option<NonNull<Header>>,
+}
+
+#[cfg(tokio_unstable)]
+impl CurrentTaskGuard {
+    fn enter(header: NonNull<Header>) -> Self {
+        CurrentTaskGuard {
+            parent_task: context::set_current_task(Some(header)),
+        }
+    }
+}
+
+#[cfg(tokio_unstable)]
+impl Drop for CurrentTaskGuard {
     fn drop(&mut self) {
-        context::set_current_task_id_and_task(self.parent_task_id, self.parent_task);
+        context::set_current_task(self.parent_task);
     }
 }
 
@@ -409,10 +447,7 @@ impl<T: Future, S: Schedule> Core<T, S> {
                 // Safety: The caller ensures the future is pinned.
                 let future = unsafe { Pin::new_unchecked(future) };
 
-                #[cfg(tokio_unstable)]
                 let _guard = TaskContextGuard::enter(self.task_id, header);
-                #[cfg(not(tokio_unstable))]
-                let _guard = TaskIdGuard::enter(self.task_id);
                 future.poll(&mut cx)
             })
         };
@@ -485,27 +520,6 @@ impl<T: Future, S: Schedule> Core<T, S> {
     unsafe fn set_stage(&self, stage: Stage<T>) {
         let _guard = TaskIdGuard::enter(self.task_id);
         self.stage.stage.with_mut(|ptr| *ptr = stage);
-    }
-}
-
-#[cfg(tokio_unstable)]
-pub(crate) struct CurrentTaskGuard {
-    parent_task: Option<NonNull<Header>>,
-}
-
-#[cfg(tokio_unstable)]
-impl CurrentTaskGuard {
-    fn enter(header: NonNull<Header>) -> Self {
-        CurrentTaskGuard {
-            parent_task: context::set_current_task(Some(header)),
-        }
-    }
-}
-
-#[cfg(tokio_unstable)]
-impl Drop for CurrentTaskGuard {
-    fn drop(&mut self) {
-        context::set_current_task(self.parent_task);
     }
 }
 

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -364,7 +364,11 @@ impl<T: Future, S: Schedule> Core<T, S> {
     ///
     /// `self` must also be pinned. This is handled by storing the task on the
     /// heap.
-    pub(super) fn poll(
+    ///
+    /// When `tokio_unstable` is enabled, `header` must point to the header for
+    /// this exact task allocation, and the allocation must remain live until
+    /// this function returns.
+    pub(super) unsafe fn poll(
         &self,
         #[cfg(tokio_unstable)] header: NonNull<Header>,
         mut cx: Context<'_>,

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -406,10 +406,7 @@ impl<T: Future, S: Schedule> Core<T, S> {
     /// # Safety
     ///
     /// The caller must ensure it is safe to mutate the `stage` field.
-    pub(super) fn drop_future_or_output(
-        &self,
-        #[cfg(tokio_unstable)] header: NonNull<Header>,
-    ) {
+    pub(super) fn drop_future_or_output(&self, #[cfg(tokio_unstable)] header: NonNull<Header>) {
         #[cfg(tokio_unstable)]
         let _current_task = {
             let dropping_future = self.stage.stage.with(|ptr| {

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -222,8 +222,9 @@ where
 
                 #[cfg(tokio_unstable)]
                 {
-                    // Safety: the task is in the RUNNING state, which excludes
-                    // concurrent shutdown and termination metadata access.
+                    // Safety: the task is in the RUNNING state, so shutdown
+                    // cannot take ownership of the task contents and termination
+                    // cannot access hook data concurrently.
                     let mut task_meta = unsafe { self.task_meta() };
                     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                         self.core()
@@ -232,7 +233,9 @@ where
                     }));
 
                     if let Err(panic) = res {
-                        poll_hook_panic(self.core(), panic);
+                        // Safety: the task is still in the RUNNING state, so we
+                        // have exclusive access to the future/output storage.
+                        unsafe { poll_hook_panic(self.core(), panic) };
                         return PollFuture::Complete;
                     }
 
@@ -245,18 +248,23 @@ where
                 let header_ptr = self.header_ptr();
                 let waker_ref = waker_ref::<S>(&header_ptr);
                 let cx = Context::from_waker(&waker_ref);
-                let res = poll_future(
-                    self.core(),
-                    #[cfg(tokio_unstable)]
-                    header_ptr,
-                    cx,
-                );
+                // Safety: `transition_to_running` succeeded, so this thread has
+                // exclusive access to the future/output storage. The header pointer
+                // comes from this harness and remains live while the task is running.
+                let res = unsafe {
+                    poll_future(
+                        self.core(),
+                        #[cfg(tokio_unstable)]
+                        header_ptr,
+                        cx,
+                    )
+                };
 
                 #[cfg(tokio_unstable)]
                 {
-                    // Safety: the task is still in the RUNNING state, which
-                    // excludes concurrent shutdown and termination metadata
-                    // access.
+                    // Safety: the task is still in the RUNNING state, so
+                    // shutdown cannot take ownership of the task contents and
+                    // termination cannot access hook data concurrently.
                     let mut task_meta = unsafe { self.task_meta() };
                     let hook_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
                         self.core()
@@ -265,7 +273,9 @@ where
                     }));
 
                     if let Err(panic) = hook_res {
-                        poll_hook_panic(self.core(), panic);
+                        // Safety: the task is still in the RUNNING state, so we
+                        // have exclusive access to the future/output storage.
+                        unsafe { poll_hook_panic(self.core(), panic) };
                         return PollFuture::Complete;
                     }
                 }
@@ -578,8 +588,14 @@ fn panic_result_to_join_error(
     }
 }
 
+/// Convert a poll hook panic into the task output.
+///
+/// # Safety
+///
+/// The caller must have exclusive access to the task's future/output storage,
+/// such as by holding the task in the RUNNING state.
 #[cfg(tokio_unstable)]
-fn poll_hook_panic<T: Future, S: Schedule>(
+unsafe fn poll_hook_panic<T: Future, S: Schedule>(
     core: &Core<T, S>,
     hook_panic: Box<dyn Any + Send + 'static>,
 ) {
@@ -602,7 +618,15 @@ fn poll_hook_panic<T: Future, S: Schedule>(
 
 /// Polls the future. If the future completes, the output is written to the
 /// stage field.
-fn poll_future<T: Future, S: Schedule>(
+///
+/// # Safety
+///
+/// The caller must satisfy the mutual-exclusion requirements of `Core::poll`.
+///
+/// When `tokio_unstable` is enabled, `header` must point to the header for this
+/// exact task allocation, and the allocation must remain live until this
+/// function returns.
+unsafe fn poll_future<T: Future, S: Schedule>(
     core: &Core<T, S>,
     #[cfg(tokio_unstable)] header: NonNull<Header>,
     cx: Context<'_>,
@@ -620,11 +644,15 @@ fn poll_future<T: Future, S: Schedule>(
             }
         }
         let guard = Guard { core };
-        let res = guard.core.poll(
-            #[cfg(tokio_unstable)]
-            header,
-            cx,
-        );
+        // Safety: the caller guarantees the mutual-exclusion requirements of
+        // `Core::poll` and that `header` identifies this live task allocation.
+        let res = unsafe {
+            guard.core.poll(
+                #[cfg(tokio_unstable)]
+                header,
+                cx,
+            )
+        };
         mem::forget(guard);
         res
     }));

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -48,6 +48,21 @@ where
     fn core(&self) -> &Core<T, S> {
         unsafe { &self.cell.as_ref().core }
     }
+
+    /// # Safety
+    ///
+    /// The returned metadata must only be used while the caller has exclusive
+    /// access to task hook data.
+    #[cfg(tokio_unstable)]
+    unsafe fn task_meta<'meta>(&self) -> TaskMeta<'meta> {
+        unsafe {
+            TaskMeta::new(
+                self.core().task_id,
+                self.core().spawned_at.into(),
+                Some(self.trailer().user_data_ptr()),
+            )
+        }
+    }
 }
 
 /// Task operations that can be implemented without being generic over the
@@ -204,10 +219,56 @@ where
                         TransitionToIdle::Cancelled => PollFuture::Complete,
                     }
                 }
+
+                #[cfg(tokio_unstable)]
+                {
+                    // Safety: the task is in the RUNNING state, which excludes
+                    // concurrent shutdown and termination metadata access.
+                    let mut task_meta = unsafe { self.task_meta() };
+                    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        self.core()
+                            .scheduler
+                            .task_poll_start_callback(&mut task_meta);
+                    }));
+
+                    if let Err(panic) = res {
+                        poll_hook_panic(self.core(), panic);
+                        return PollFuture::Complete;
+                    }
+
+                    if self.state().load().is_cancelled() {
+                        cancel_task(self.core());
+                        return PollFuture::Complete;
+                    }
+                }
+
                 let header_ptr = self.header_ptr();
                 let waker_ref = waker_ref::<S>(&header_ptr);
                 let cx = Context::from_waker(&waker_ref);
-                let res = poll_future(self.core(), cx);
+                let res = poll_future(
+                    self.core(),
+                    #[cfg(tokio_unstable)]
+                    header_ptr,
+                    cx,
+                );
+
+                #[cfg(tokio_unstable)]
+                {
+                    // Safety: the task is still in the RUNNING state, which
+                    // excludes concurrent shutdown and termination metadata
+                    // access.
+                    let mut task_meta = unsafe { self.task_meta() };
+                    let hook_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                        self.core()
+                            .scheduler
+                            .task_poll_stop_callback(&mut task_meta);
+                    }));
+
+                    if let Err(panic) = hook_res {
+                        poll_hook_panic(self.core(), panic);
+                        return PollFuture::Complete;
+                    }
+                }
 
                 if res == Poll::Ready(()) {
                     // The future completed. Move on to complete the task.
@@ -255,6 +316,8 @@ where
         // because we are going to drop them. This only matters when running
         // under loom.
         self.trailer().waker.with_mut(|_| ());
+        #[cfg(tokio_unstable)]
+        self.trailer().user_data.with_mut(|_| ());
         self.core().stage.with_mut(|_| ());
 
         // Safety: The caller of this method just transitioned our ref-count to
@@ -369,13 +432,12 @@ where
         // We call this in a separate block so that it runs after the task appears to have
         // completed and will still run if the destructor panics.
         #[cfg(tokio_unstable)]
-        if let Some(f) = self.trailer().hooks.task_terminate_callback.as_ref() {
+        {
+            // Safety: completion owns the task lifecycle transition, and the
+            // terminate hook is invoked synchronously with exclusive metadata access.
+            let mut meta = unsafe { self.task_meta() };
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                f(&TaskMeta {
-                    id: self.core().task_id,
-                    spawned_at: self.core().spawned_at.into(),
-                    _phantom: Default::default(),
-                })
+                self.core().scheduler.task_terminate_callback(&mut meta)
             }));
         }
 
@@ -516,9 +578,35 @@ fn panic_result_to_join_error(
     }
 }
 
+#[cfg(tokio_unstable)]
+fn poll_hook_panic<T: Future, S: Schedule>(
+    core: &Core<T, S>,
+    hook_panic: Box<dyn Any + Send + 'static>,
+) {
+    let drop_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        core.drop_future_or_output();
+    }));
+    let join_error = match drop_res {
+        Ok(()) => panic_to_error(&core.scheduler, core.task_id, hook_panic),
+        Err(drop_panic) => panic_to_error(&core.scheduler, core.task_id, drop_panic),
+    };
+
+    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        core.store_output(Err(join_error));
+    }));
+
+    if res.is_err() {
+        core.scheduler.unhandled_panic();
+    }
+}
+
 /// Polls the future. If the future completes, the output is written to the
 /// stage field.
-fn poll_future<T: Future, S: Schedule>(core: &Core<T, S>, cx: Context<'_>) -> Poll<()> {
+fn poll_future<T: Future, S: Schedule>(
+    core: &Core<T, S>,
+    #[cfg(tokio_unstable)] header: NonNull<Header>,
+    cx: Context<'_>,
+) -> Poll<()> {
     // Poll the future.
     let output = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         struct Guard<'a, T: Future, S: Schedule> {
@@ -532,7 +620,11 @@ fn poll_future<T: Future, S: Schedule>(core: &Core<T, S>, cx: Context<'_>) -> Po
             }
         }
         let guard = Guard { core };
-        let res = guard.core.poll(cx);
+        let res = guard.core.poll(
+            #[cfg(tokio_unstable)]
+            header,
+            cx,
+        );
         mem::forget(guard);
         res
     }));

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -222,57 +222,12 @@ where
 
                 let header_ptr = self.header_ptr();
 
-                #[cfg(tokio_unstable)]
-                {
-                    // Safety: the task is in the RUNNING state, so shutdown
-                    // cannot take ownership of the task contents and termination
-                    // cannot access hook data concurrently.
-                    let mut task_meta = unsafe { self.task_meta() };
-                    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                        self.core()
-                            .scheduler
-                            .task_poll_start_callback(&mut task_meta);
-                    }));
-
-                    if let Err(panic) = res {
-                        // Safety: the task is still in the RUNNING state, so we
-                        // have exclusive access to the future/output storage.
-                        unsafe { poll_hook_panic(self.core(), header_ptr, panic) };
-                        return PollFuture::Complete;
-                    }
-
-                    if self.state().load().is_cancelled() {
-                        cancel_task(self.core(), header_ptr);
-                        return PollFuture::Complete;
-                    }
-                }
-
                 let waker_ref = waker_ref::<S>(&header_ptr);
                 let cx = Context::from_waker(&waker_ref);
                 // Safety: `transition_to_running` succeeded, so this thread has
                 // exclusive access to the future/output storage. The header pointer
                 // comes from this harness and remains live while the task is running.
                 let res = unsafe { poll_future(self.core(), header_ptr, cx) };
-
-                #[cfg(tokio_unstable)]
-                {
-                    // Safety: the task is still in the RUNNING state, so
-                    // shutdown cannot take ownership of the task contents and
-                    // termination cannot access hook data concurrently.
-                    let mut task_meta = unsafe { self.task_meta() };
-                    let hook_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                        self.core()
-                            .scheduler
-                            .task_poll_stop_callback(&mut task_meta);
-                    }));
-
-                    if let Err(panic) = hook_res {
-                        // Safety: the task is still in the RUNNING state, so we
-                        // have exclusive access to the future/output storage.
-                        unsafe { poll_hook_panic(self.core(), header_ptr, panic) };
-                        return PollFuture::Complete;
-                    }
-                }
 
                 if res == Poll::Ready(()) {
                     // The future completed. Move on to complete the task.
@@ -582,32 +537,42 @@ fn panic_result_to_join_error(
     }
 }
 
-/// Convert a poll hook panic into the task output.
-///
-/// # Safety
-///
-/// The caller must have exclusive access to the task's future/output storage,
-/// such as by holding the task in the RUNNING state.
 #[cfg(tokio_unstable)]
-unsafe fn poll_hook_panic<T: Future, S: Schedule>(
+unsafe fn task_meta<'meta, T: Future, S: Schedule>(
     core: &Core<T, S>,
     header: NonNull<Header>,
-    hook_panic: Box<dyn Any + Send + 'static>,
-) {
-    let drop_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        core.drop_future_or_output(header);
-    }));
-    let join_error = match drop_res {
-        Ok(()) => panic_to_error(&core.scheduler, core.task_id, hook_panic),
-        Err(drop_panic) => panic_to_error(&core.scheduler, core.task_id, drop_panic),
-    };
+) -> TaskMeta<'meta> {
+    // Safety: `header` points to this live task allocation.
+    let trailer = unsafe { Header::get_trailer(header).as_ref() };
+    // Safety: the task is in the RUNNING state, so shutdown cannot take
+    // ownership of the task contents and termination cannot access hook data
+    // concurrently.
+    unsafe {
+        TaskMeta::new(
+            core.task_id,
+            core.spawned_at.into(),
+            Some(trailer.user_data_ptr()),
+        )
+    }
+}
 
-    let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        core.store_output(Err(join_error));
-    }));
+#[cfg(tokio_unstable)]
+unsafe fn poll_start_hook<T: Future, S: Schedule>(core: &Core<T, S>, header: NonNull<Header>) {
+    if core.scheduler.has_task_poll_start_callback() {
+        let mut task_meta = unsafe { task_meta(core, header) };
+        let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            core.scheduler.task_poll_start_callback(&mut task_meta);
+        }));
+    }
+}
 
-    if res.is_err() {
-        core.scheduler.unhandled_panic();
+#[cfg(tokio_unstable)]
+unsafe fn poll_stop_hook<T: Future, S: Schedule>(core: &Core<T, S>, header: NonNull<Header>) {
+    if core.scheduler.has_task_poll_stop_callback() {
+        let mut task_meta = unsafe { task_meta(core, header) };
+        let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            core.scheduler.task_poll_stop_callback(&mut task_meta);
+        }));
     }
 }
 
@@ -625,6 +590,16 @@ unsafe fn poll_future<T: Future, S: Schedule>(
     header: NonNull<Header>,
     cx: Context<'_>,
 ) -> Poll<()> {
+    #[cfg(tokio_unstable)]
+    {
+        unsafe { poll_start_hook(core, header) };
+
+        if unsafe { header.as_ref() }.state.load().is_cancelled() {
+            cancel_task(core, header);
+            return Poll::Ready(());
+        }
+    }
+
     // Poll the future.
     let output = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         struct Guard<'a, T: Future, S: Schedule> {
@@ -645,6 +620,11 @@ unsafe fn poll_future<T: Future, S: Schedule>(
         mem::forget(guard);
         res
     }));
+
+    #[cfg(tokio_unstable)]
+    unsafe {
+        poll_stop_hook(core, header);
+    }
 
     // Prepare output for being placed in the core stage.
     let output = match output {

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -638,10 +638,7 @@ unsafe fn poll_future<T: Future, S: Schedule>(
                 self.core.drop_future_or_output(self.header);
             }
         }
-        let guard = Guard {
-            core,
-            header,
-        };
+        let guard = Guard { core, header };
         // Safety: the caller guarantees the mutual-exclusion requirements of
         // `Core::poll` and that `header` identifies this live task allocation.
         let res = unsafe { guard.core.poll(header, cx) };

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -242,11 +242,7 @@ where
                     }
 
                     if self.state().load().is_cancelled() {
-                        cancel_task(
-                            self.core(),
-                            #[cfg(tokio_unstable)]
-                            header_ptr,
-                        );
+                        cancel_task(self.core(), header_ptr);
                         return PollFuture::Complete;
                     }
                 }
@@ -256,14 +252,7 @@ where
                 // Safety: `transition_to_running` succeeded, so this thread has
                 // exclusive access to the future/output storage. The header pointer
                 // comes from this harness and remains live while the task is running.
-                let res = unsafe {
-                    poll_future(
-                        self.core(),
-                        #[cfg(tokio_unstable)]
-                        header_ptr,
-                        cx,
-                    )
-                };
+                let res = unsafe { poll_future(self.core(), header_ptr, cx) };
 
                 #[cfg(tokio_unstable)]
                 {
@@ -294,20 +283,12 @@ where
                 if let TransitionToIdle::Cancelled = transition_res {
                     // The transition to idle failed because the task was
                     // cancelled during the poll.
-                    cancel_task(
-                        self.core(),
-                        #[cfg(tokio_unstable)]
-                        header_ptr,
-                    );
+                    cancel_task(self.core(), header_ptr);
                 }
                 transition_result_to_poll_future(transition_res)
             }
             TransitionToRunning::Cancelled => {
-                cancel_task(
-                    self.core(),
-                    #[cfg(tokio_unstable)]
-                    self.header_ptr(),
-                );
+                cancel_task(self.core(), self.header_ptr());
                 PollFuture::Complete
             }
             TransitionToRunning::Failed => PollFuture::Done,
@@ -330,11 +311,7 @@ where
 
         // By transitioning the lifecycle to `Running`, we have permission to
         // drop the future.
-        cancel_task(
-            self.core(),
-            #[cfg(tokio_unstable)]
-            self.header_ptr(),
-        );
+        cancel_task(self.core(), self.header_ptr());
         self.complete();
     }
 
@@ -390,10 +367,7 @@ where
             // they are dropping the `JoinHandle`, we assume they are not
             // interested in the panic and swallow it.
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                self.core().drop_future_or_output(
-                    #[cfg(tokio_unstable)]
-                    self.header_ptr(),
-                );
+                self.core().drop_future_or_output(self.header_ptr());
             }));
         }
 
@@ -434,10 +408,7 @@ where
                 // this task. It is our responsibility to drop the
                 // output. The join waker was already dropped by the
                 // `JoinHandle` before.
-                self.core().drop_future_or_output(
-                    #[cfg(tokio_unstable)]
-                    self.header_ptr(),
-                );
+                self.core().drop_future_or_output(self.header_ptr());
             } else if snapshot.is_join_waker_set() {
                 // Notify the waker. Reading the waker field is safe per rule 4
                 // in task/mod.rs, since the JOIN_WAKER bit is set and the call
@@ -592,16 +563,10 @@ enum PollFuture {
 }
 
 /// Cancels the task and store the appropriate error in the stage field.
-fn cancel_task<T: Future, S: Schedule>(
-    core: &Core<T, S>,
-    #[cfg(tokio_unstable)] header: NonNull<Header>,
-) {
+fn cancel_task<T: Future, S: Schedule>(core: &Core<T, S>, header: NonNull<Header>) {
     // Drop the future from a panic guard.
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        core.drop_future_or_output(
-            #[cfg(tokio_unstable)]
-            header,
-        );
+        core.drop_future_or_output(header);
     }));
 
     core.store_output(Err(panic_result_to_join_error(core.task_id, res)));
@@ -653,45 +618,33 @@ unsafe fn poll_hook_panic<T: Future, S: Schedule>(
 ///
 /// The caller must satisfy the mutual-exclusion requirements of `Core::poll`.
 ///
-/// When `tokio_unstable` is enabled, `header` must point to the header for this
-/// exact task allocation, and the allocation must remain live until this
-/// function returns.
+/// `header` must point to the header for this exact task allocation, and the
+/// allocation must remain live until this function returns.
 unsafe fn poll_future<T: Future, S: Schedule>(
     core: &Core<T, S>,
-    #[cfg(tokio_unstable)] header: NonNull<Header>,
+    header: NonNull<Header>,
     cx: Context<'_>,
 ) -> Poll<()> {
     // Poll the future.
     let output = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         struct Guard<'a, T: Future, S: Schedule> {
             core: &'a Core<T, S>,
-            #[cfg(tokio_unstable)]
             header: NonNull<Header>,
         }
         impl<'a, T: Future, S: Schedule> Drop for Guard<'a, T, S> {
             fn drop(&mut self) {
                 // If the future panics on poll, we drop it inside the panic
                 // guard.
-                self.core.drop_future_or_output(
-                    #[cfg(tokio_unstable)]
-                    self.header,
-                );
+                self.core.drop_future_or_output(self.header);
             }
         }
         let guard = Guard {
             core,
-            #[cfg(tokio_unstable)]
             header,
         };
         // Safety: the caller guarantees the mutual-exclusion requirements of
         // `Core::poll` and that `header` identifies this live task allocation.
-        let res = unsafe {
-            guard.core.poll(
-                #[cfg(tokio_unstable)]
-                header,
-                cx,
-            )
-        };
+        let res = unsafe { guard.core.poll(header, cx) };
         mem::forget(guard);
         res
     }));

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -220,6 +220,8 @@ where
                     }
                 }
 
+                let header_ptr = self.header_ptr();
+
                 #[cfg(tokio_unstable)]
                 {
                     // Safety: the task is in the RUNNING state, so shutdown
@@ -235,17 +237,20 @@ where
                     if let Err(panic) = res {
                         // Safety: the task is still in the RUNNING state, so we
                         // have exclusive access to the future/output storage.
-                        unsafe { poll_hook_panic(self.core(), panic) };
+                        unsafe { poll_hook_panic(self.core(), header_ptr, panic) };
                         return PollFuture::Complete;
                     }
 
                     if self.state().load().is_cancelled() {
-                        cancel_task(self.core());
+                        cancel_task(
+                            self.core(),
+                            #[cfg(tokio_unstable)]
+                            header_ptr,
+                        );
                         return PollFuture::Complete;
                     }
                 }
 
-                let header_ptr = self.header_ptr();
                 let waker_ref = waker_ref::<S>(&header_ptr);
                 let cx = Context::from_waker(&waker_ref);
                 // Safety: `transition_to_running` succeeded, so this thread has
@@ -275,7 +280,7 @@ where
                     if let Err(panic) = hook_res {
                         // Safety: the task is still in the RUNNING state, so we
                         // have exclusive access to the future/output storage.
-                        unsafe { poll_hook_panic(self.core(), panic) };
+                        unsafe { poll_hook_panic(self.core(), header_ptr, panic) };
                         return PollFuture::Complete;
                     }
                 }
@@ -289,12 +294,20 @@ where
                 if let TransitionToIdle::Cancelled = transition_res {
                     // The transition to idle failed because the task was
                     // cancelled during the poll.
-                    cancel_task(self.core());
+                    cancel_task(
+                        self.core(),
+                        #[cfg(tokio_unstable)]
+                        header_ptr,
+                    );
                 }
                 transition_result_to_poll_future(transition_res)
             }
             TransitionToRunning::Cancelled => {
-                cancel_task(self.core());
+                cancel_task(
+                    self.core(),
+                    #[cfg(tokio_unstable)]
+                    self.header_ptr(),
+                );
                 PollFuture::Complete
             }
             TransitionToRunning::Failed => PollFuture::Done,
@@ -317,7 +330,11 @@ where
 
         // By transitioning the lifecycle to `Running`, we have permission to
         // drop the future.
-        cancel_task(self.core());
+        cancel_task(
+            self.core(),
+            #[cfg(tokio_unstable)]
+            self.header_ptr(),
+        );
         self.complete();
     }
 
@@ -373,7 +390,10 @@ where
             // they are dropping the `JoinHandle`, we assume they are not
             // interested in the panic and swallow it.
             let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                self.core().drop_future_or_output();
+                self.core().drop_future_or_output(
+                    #[cfg(tokio_unstable)]
+                    self.header_ptr(),
+                );
             }));
         }
 
@@ -414,7 +434,10 @@ where
                 // this task. It is our responsibility to drop the
                 // output. The join waker was already dropped by the
                 // `JoinHandle` before.
-                self.core().drop_future_or_output();
+                self.core().drop_future_or_output(
+                    #[cfg(tokio_unstable)]
+                    self.header_ptr(),
+                );
             } else if snapshot.is_join_waker_set() {
                 // Notify the waker. Reading the waker field is safe per rule 4
                 // in task/mod.rs, since the JOIN_WAKER bit is set and the call
@@ -569,10 +592,16 @@ enum PollFuture {
 }
 
 /// Cancels the task and store the appropriate error in the stage field.
-fn cancel_task<T: Future, S: Schedule>(core: &Core<T, S>) {
+fn cancel_task<T: Future, S: Schedule>(
+    core: &Core<T, S>,
+    #[cfg(tokio_unstable)] header: NonNull<Header>,
+) {
     // Drop the future from a panic guard.
     let res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        core.drop_future_or_output();
+        core.drop_future_or_output(
+            #[cfg(tokio_unstable)]
+            header,
+        );
     }));
 
     core.store_output(Err(panic_result_to_join_error(core.task_id, res)));
@@ -597,10 +626,11 @@ fn panic_result_to_join_error(
 #[cfg(tokio_unstable)]
 unsafe fn poll_hook_panic<T: Future, S: Schedule>(
     core: &Core<T, S>,
+    header: NonNull<Header>,
     hook_panic: Box<dyn Any + Send + 'static>,
 ) {
     let drop_res = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        core.drop_future_or_output();
+        core.drop_future_or_output(header);
     }));
     let join_error = match drop_res {
         Ok(()) => panic_to_error(&core.scheduler, core.task_id, hook_panic),
@@ -635,15 +665,24 @@ unsafe fn poll_future<T: Future, S: Schedule>(
     let output = panic::catch_unwind(panic::AssertUnwindSafe(|| {
         struct Guard<'a, T: Future, S: Schedule> {
             core: &'a Core<T, S>,
+            #[cfg(tokio_unstable)]
+            header: NonNull<Header>,
         }
         impl<'a, T: Future, S: Schedule> Drop for Guard<'a, T, S> {
             fn drop(&mut self) {
                 // If the future panics on poll, we drop it inside the panic
                 // guard.
-                self.core.drop_future_or_output();
+                self.core.drop_future_or_output(
+                    #[cfg(tokio_unstable)]
+                    self.header,
+                );
             }
         }
-        let guard = Guard { core };
+        let guard = Guard {
+            core,
+            #[cfg(tokio_unstable)]
+            header,
+        };
         // Safety: the caller guarantees the mutual-exclusion requirements of
         // `Core::poll` and that `header` identifies this live task allocation.
         let res = unsafe {

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -86,19 +86,50 @@ impl<S: 'static> OwnedTasks<S> {
 
     /// Binds the provided task to this `OwnedTasks` instance. This fails if the
     /// `OwnedTasks` has been closed.
+    #[cfg_attr(tokio_unstable, allow(dead_code))]
     pub(crate) fn bind<T>(
         &self,
         task: T,
         scheduler: S,
         id: super::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
     where
         S: Schedule,
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at);
+        let (task, notified, join) = super::new_task(
+            task,
+            scheduler,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
+        let notified = unsafe { self.bind_inner(task, notified) };
+        (join, notified)
+    }
+
+    #[cfg(tokio_unstable)]
+    pub(crate) fn bind_with_spawn_hook<T>(
+        &self,
+        task: T,
+        scheduler: S,
+        id: super::Id,
+        spawned_at: SpawnLocation,
+        user_data: Option<crate::runtime::TaskData>,
+        before_bind: impl FnOnce(&Task<S>),
+    ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
+    where
+        S: Schedule,
+        T: Future + Send + 'static,
+        T::Output: Send + 'static,
+    {
+        let (task, notified, join) =
+            super::new_task(task, scheduler, id, spawned_at, user_data);
+        before_bind(&task);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }
@@ -108,19 +139,53 @@ impl<S: 'static> OwnedTasks<S> {
     /// # Safety
     ///
     /// Only use this in `LocalRuntime` where the task cannot move
+    #[cfg_attr(tokio_unstable, allow(dead_code))]
     pub(crate) unsafe fn bind_local<T>(
         &self,
         task: T,
         scheduler: S,
         id: super::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
     where
         S: Schedule,
         T: Future + 'static,
         T::Output: 'static,
     {
-        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at);
+        let (task, notified, join) = super::new_task(
+            task,
+            scheduler,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
+        let notified = unsafe { self.bind_inner(task, notified) };
+        (join, notified)
+    }
+
+    /// # Safety
+    ///
+    /// Only use this in `LocalRuntime` where the task cannot move.
+    #[cfg(tokio_unstable)]
+    pub(crate) unsafe fn bind_local_with_spawn_hook<T>(
+        &self,
+        task: T,
+        scheduler: S,
+        id: super::Id,
+        spawned_at: SpawnLocation,
+        user_data: Option<crate::runtime::TaskData>,
+        before_bind: impl FnOnce(&Task<S>),
+    ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
+    where
+        S: Schedule,
+        T: Future + 'static,
+        T::Output: 'static,
+    {
+        let (task, notified, join) =
+            super::new_task(task, scheduler, id, spawned_at, user_data);
+        before_bind(&task);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }
@@ -264,13 +329,21 @@ impl<S: 'static> LocalOwnedTasks<S> {
         scheduler: S,
         id: super::Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
     where
         S: Schedule,
         T: Future + 'static,
         T::Output: 'static,
     {
-        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at);
+        let (task, notified, join) = super::new_task(
+            task,
+            scheduler,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
 
         unsafe {
             // safety: We just created the task, so we have exclusive access

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -112,23 +112,29 @@ impl<S: 'static> OwnedTasks<S> {
         (join, notified)
     }
 
-    #[cfg(tokio_unstable)]
     pub(crate) fn bind_with_spawn_hook<T>(
         &self,
         task: T,
         scheduler: S,
         id: super::Id,
         spawned_at: SpawnLocation,
-        user_data: Option<crate::runtime::TaskData>,
-        before_bind: impl FnOnce(&Task<S>),
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+        task_hooks: &crate::runtime::TaskHooks,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
     where
         S: Schedule,
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at, user_data);
-        before_bind(&task);
+        let (task, notified, join) = super::new_task(
+            task,
+            scheduler,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
+        run_spawn_hook(&task, id, spawned_at, task_hooks);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }
@@ -167,23 +173,29 @@ impl<S: 'static> OwnedTasks<S> {
     /// # Safety
     ///
     /// Only use this in `LocalRuntime` where the task cannot move.
-    #[cfg(tokio_unstable)]
     pub(crate) unsafe fn bind_local_with_spawn_hook<T>(
         &self,
         task: T,
         scheduler: S,
         id: super::Id,
         spawned_at: SpawnLocation,
-        user_data: Option<crate::runtime::TaskData>,
-        before_bind: impl FnOnce(&Task<S>),
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+        task_hooks: &crate::runtime::TaskHooks,
     ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
     where
         S: Schedule,
         T: Future + 'static,
         T::Output: 'static,
     {
-        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at, user_data);
-        before_bind(&task);
+        let (task, notified, join) = super::new_task(
+            task,
+            scheduler,
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
+        run_spawn_hook(&task, id, spawned_at, task_hooks);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }
@@ -295,6 +307,31 @@ impl<S: 'static> OwnedTasks<S> {
         const MAX_SHARED_LIST_SIZE: usize = 1 << 16;
         usize::min(MAX_SHARED_LIST_SIZE, num_cores.next_power_of_two() * 4)
     }
+}
+
+#[cfg(tokio_unstable)]
+fn run_spawn_hook<S: 'static>(
+    task: &Task<S>,
+    _id: super::Id,
+    _spawned_at: SpawnLocation,
+    task_hooks: &crate::runtime::TaskHooks,
+) {
+    super::with_current_task_meta(|parent| {
+        // Safety: the task is freshly allocated and not published yet.
+        let mut meta = unsafe { task.task_meta() };
+        task_hooks.spawn(&mut meta, parent);
+    });
+}
+
+#[cfg(not(tokio_unstable))]
+fn run_spawn_hook<S: 'static>(
+    _task: &Task<S>,
+    id: super::Id,
+    spawned_at: SpawnLocation,
+    task_hooks: &crate::runtime::TaskHooks,
+) {
+    let mut meta = crate::runtime::TaskMeta::new(id, spawned_at);
+    task_hooks.spawn(&mut meta, None);
 }
 
 cfg_taskdump! {

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -127,8 +127,7 @@ impl<S: 'static> OwnedTasks<S> {
         T: Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, notified, join) =
-            super::new_task(task, scheduler, id, spawned_at, user_data);
+        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at, user_data);
         before_bind(&task);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
@@ -183,8 +182,7 @@ impl<S: 'static> OwnedTasks<S> {
         T: Future + 'static,
         T::Output: 'static,
     {
-        let (task, notified, join) =
-            super::new_task(task, scheduler, id, spawned_at, user_data);
+        let (task, notified, join) = super::new_task(task, scheduler, id, spawned_at, user_data);
         before_bind(&task);
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)

--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -84,34 +84,6 @@ impl<S: 'static> OwnedTasks<S> {
         }
     }
 
-    /// Binds the provided task to this `OwnedTasks` instance. This fails if the
-    /// `OwnedTasks` has been closed.
-    #[cfg_attr(tokio_unstable, allow(dead_code))]
-    pub(crate) fn bind<T>(
-        &self,
-        task: T,
-        scheduler: S,
-        id: super::Id,
-        spawned_at: SpawnLocation,
-        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
-    ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
-    where
-        S: Schedule,
-        T: Future + Send + 'static,
-        T::Output: Send + 'static,
-    {
-        let (task, notified, join) = super::new_task(
-            task,
-            scheduler,
-            id,
-            spawned_at,
-            #[cfg(tokio_unstable)]
-            user_data,
-        );
-        let notified = unsafe { self.bind_inner(task, notified) };
-        (join, notified)
-    }
-
     pub(crate) fn bind_with_spawn_hook<T>(
         &self,
         task: T,
@@ -135,37 +107,6 @@ impl<S: 'static> OwnedTasks<S> {
             user_data,
         );
         run_spawn_hook(&task, id, spawned_at, task_hooks);
-        let notified = unsafe { self.bind_inner(task, notified) };
-        (join, notified)
-    }
-
-    /// Bind a task that isn't safe to transfer across thread boundaries.
-    ///
-    /// # Safety
-    ///
-    /// Only use this in `LocalRuntime` where the task cannot move
-    #[cfg_attr(tokio_unstable, allow(dead_code))]
-    pub(crate) unsafe fn bind_local<T>(
-        &self,
-        task: T,
-        scheduler: S,
-        id: super::Id,
-        spawned_at: SpawnLocation,
-        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
-    ) -> (JoinHandle<T::Output>, Option<Notified<S>>)
-    where
-        S: Schedule,
-        T: Future + 'static,
-        T::Output: 'static,
-    {
-        let (task, notified, join) = super::new_task(
-            task,
-            scheduler,
-            id,
-            spawned_at,
-            #[cfg(tokio_unstable)]
-            user_data,
-        );
         let notified = unsafe { self.bind_inner(task, notified) };
         (join, notified)
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -119,6 +119,12 @@
 //!    the `JoinHandle` exclusive access again so that it is able to drop the waker
 //!    at a later point.
 //!
+//!  * The `user_data` field is accessed only through scoped task hook metadata.
+//!    The spawn hook runs before the task is scheduled, poll hooks run while
+//!    the task holds the RUNNING lock but outside the actual future poll, and
+//!    the terminate hook runs after completion. Parent task metadata exposed to
+//!    spawn hooks is read-only.
+//!
 //! All other fields are immutable and can be accessed immutably without
 //! synchronization by anyone.
 //!
@@ -221,7 +227,6 @@ use crate::future::Future;
 use crate::util::linked_list;
 use crate::util::sharded_list;
 
-use crate::runtime::TaskCallback;
 use std::marker::PhantomData;
 use std::panic::Location;
 use std::ptr::NonNull;
@@ -241,14 +246,6 @@ unsafe impl<S> Sync for Task<S> {}
 #[repr(transparent)]
 pub(crate) struct Notified<S: 'static>(Task<S>);
 
-impl<S> Notified<S> {
-    #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-    #[inline]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        self.0.task_meta()
-    }
-}
-
 // safety: This type cannot be used to touch the task without first verifying
 // that the value is on a thread where it is safe to poll the task.
 unsafe impl<S: Schedule> Send for Notified<S> {}
@@ -260,14 +257,6 @@ unsafe impl<S: Schedule> Sync for Notified<S> {}
 pub(crate) struct LocalNotified<S: 'static> {
     task: Task<S>,
     _not_send: PhantomData<*const ()>,
-}
-
-impl<S> LocalNotified<S> {
-    #[cfg(tokio_unstable)]
-    #[inline]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        self.task.task_meta()
-    }
 }
 
 /// A task that is not owned by any `OwnedTasks`. Used for blocking tasks.
@@ -284,12 +273,6 @@ unsafe impl<S> Sync for UnownedTask<S> {}
 /// Task result sent back.
 pub(crate) type Result<T> = std::result::Result<T, JoinError>;
 
-/// Hooks for scheduling tasks which are needed in the task harness.
-#[derive(Clone)]
-pub(crate) struct TaskHarnessScheduleHooks {
-    pub(crate) task_terminate_callback: Option<TaskCallback>,
-}
-
 pub(crate) trait Schedule: Sync + Sized + 'static {
     /// The task has completed work and is ready to be released. The scheduler
     /// should release it immediately and return it. The task module will batch
@@ -301,8 +284,6 @@ pub(crate) trait Schedule: Sync + Sized + 'static {
     /// Schedule the task
     fn schedule(&self, task: Notified<Self>);
 
-    fn hooks(&self) -> TaskHarnessScheduleHooks;
-
     /// Schedule the task to run in the near future, yielding the thread to
     /// other tasks.
     fn yield_now(&self, task: Notified<Self>) {
@@ -313,6 +294,15 @@ pub(crate) trait Schedule: Sync + Sized + 'static {
     fn unhandled_panic(&self) {
         // By default, do nothing. This maintains the 1.0 behavior.
     }
+
+    #[cfg(tokio_unstable)]
+    fn task_terminate_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}
+
+    #[cfg(tokio_unstable)]
+    fn task_poll_start_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}
+
+    #[cfg(tokio_unstable)]
+    fn task_poll_stop_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}
 }
 
 cfg_rt! {
@@ -325,6 +315,7 @@ cfg_rt! {
         scheduler: S,
         id: Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (Task<S>, Notified<S>, JoinHandle<T::Output>)
     where
         S: Schedule,
@@ -336,6 +327,8 @@ cfg_rt! {
             scheduler,
             id,
             spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
         );
         let task = Task {
             raw,
@@ -359,6 +352,7 @@ cfg_rt! {
         scheduler: S,
         id: Id,
         spawned_at: SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
     ) -> (UnownedTask<S>, JoinHandle<T::Output>)
     where
         S: Schedule,
@@ -370,6 +364,8 @@ cfg_rt! {
             scheduler,
             id,
             spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
         );
 
         // This transfers the ref-count of task and notified into an UnownedTask.
@@ -429,22 +425,16 @@ impl<S: 'static> Task<S> {
         unsafe { Header::get_id(self.raw.header_ptr()) }
     }
 
-    #[cfg(tokio_unstable)]
-    pub(crate) fn spawned_at(&self) -> &'static Location<'static> {
-        // Safety: The header pointer is valid.
-        unsafe { Header::get_spawn_location(self.raw.header_ptr()) }
-    }
-
     // Explicit `'task` and `'meta` lifetimes are necessary here, as otherwise,
     // the compiler infers the lifetimes to be the same, and considers the task
     // to be borrowed for the lifetime of the returned `TaskMeta`.
     #[cfg(tokio_unstable)]
-    pub(crate) fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        crate::runtime::TaskMeta {
-            id: self.id(),
-            spawned_at: self.spawned_at().into(),
-            _phantom: PhantomData,
-        }
+    /// # Safety
+    ///
+    /// The returned metadata must have exclusive access to hook data for as long
+    /// as it can expose mutable references.
+    pub(crate) unsafe fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
+        unsafe { self.raw.task_meta() }
     }
 
     cfg_taskdump! {
@@ -676,4 +666,16 @@ impl SpawnLocation {
     pub(crate) fn capture() -> Self {
         Self::from(Location::caller())
     }
+}
+
+#[cfg(tokio_unstable)]
+pub(crate) fn current_task_meta<'meta>() -> Option<crate::runtime::TaskMetaRef<'meta>> {
+    let ptr = crate::runtime::context::current_task()?;
+
+    // Safety: the context stores this pointer only while the referenced task is
+    // being polled, so the allocation is alive for the duration of this call.
+    let raw = unsafe { RawTask::from_raw(ptr.cast()) };
+    // Safety: parent metadata is exposed read-only during synchronous spawn
+    // hook invocation while no mutable parent hook metadata is live.
+    Some(unsafe { raw.task_meta_ref() })
 }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -669,13 +669,18 @@ impl SpawnLocation {
 }
 
 #[cfg(tokio_unstable)]
-pub(crate) fn current_task_meta<'meta>() -> Option<crate::runtime::TaskMetaRef<'meta>> {
-    let ptr = crate::runtime::context::current_task()?;
+pub(crate) fn with_current_task_meta<R>(
+    f: impl for<'meta> FnOnce(Option<crate::runtime::TaskMetaRef<'meta>>) -> R,
+) -> R {
+    let Some(ptr) = crate::runtime::context::current_task() else {
+        return f(None);
+    };
 
     // Safety: the context stores this pointer only while the referenced task is
-    // being polled, so the allocation is alive for the duration of this call.
+    // being polled, so the allocation is alive for this synchronous call.
     let raw = unsafe { RawTask::from_raw(ptr.cast()) };
-    // Safety: parent metadata is exposed read-only during synchronous spawn
-    // hook invocation while no mutable parent hook metadata is live.
-    Some(unsafe { raw.task_meta_ref() })
+    // Safety: parent metadata is exposed read-only during this synchronous call
+    // while no mutable parent hook metadata is live. The closure-bound lifetime
+    // prevents references exposed through the metadata from escaping.
+    f(Some(unsafe { raw.task_meta_ref() }))
 }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -186,7 +186,7 @@
 
 mod core;
 use self::core::Cell;
-use self::core::Header;
+pub(crate) use self::core::Header;
 
 mod error;
 pub use self::error::JoinError;
@@ -687,7 +687,7 @@ pub(crate) fn with_current_task_meta<R>(
 
     // Safety: the context stores this pointer only while the referenced task is
     // being polled, so the allocation is alive for this synchronous call.
-    let raw = unsafe { RawTask::from_raw(ptr.cast()) };
+    let raw = unsafe { RawTask::from_raw(ptr) };
     // Safety: parent metadata is exposed read-only during this synchronous call
     // while no mutable parent hook metadata is live. The closure-bound lifetime
     // prevents references exposed through the metadata from escaping.

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -537,6 +537,15 @@ impl<S: Schedule> UnownedTask<S> {
         task
     }
 
+    /// # Safety
+    ///
+    /// The returned metadata must have exclusive access to hook data for as long
+    /// as it can expose mutable references.
+    #[cfg(tokio_unstable)]
+    pub(crate) unsafe fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
+        unsafe { self.raw.task_meta() }
+    }
+
     pub(crate) fn run(self) {
         let raw = self.raw;
         mem::forget(self);

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -123,7 +123,9 @@
 //!    The spawn hook runs before the task is scheduled, poll hooks run while
 //!    the task holds the RUNNING lock but outside the actual future poll, and
 //!    the terminate hook runs after completion. Parent task metadata exposed to
-//!    spawn hooks is read-only.
+//!    spawn hooks is read-only. If the data is not taken or cleared by a hook,
+//!    it is dropped when the task allocation is deallocated, after the terminate
+//!    hook has run and all task references are gone.
 //!
 //! All other fields are immutable and can be accessed immutably without
 //! synchronization by anyone.
@@ -299,7 +301,17 @@ pub(crate) trait Schedule: Sync + Sized + 'static {
     fn task_terminate_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}
 
     #[cfg(tokio_unstable)]
+    fn has_task_poll_start_callback(&self) -> bool {
+        false
+    }
+
+    #[cfg(tokio_unstable)]
     fn task_poll_start_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}
+
+    #[cfg(tokio_unstable)]
+    fn has_task_poll_stop_callback(&self) -> bool {
+        false
+    }
 
     #[cfg(tokio_unstable)]
     fn task_poll_stop_callback(&self, _meta: &mut crate::runtime::TaskMeta<'_>) {}

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -272,11 +272,11 @@ impl RawTask {
         unsafe { &*self.trailer_ptr().as_ptr() }
     }
 
-    #[cfg(tokio_unstable)]
     /// # Safety
     ///
     /// The task allocation must be live, and the returned metadata must have
     /// exclusive access to hook data for as long as it can expose mutable references.
+    #[cfg(tokio_unstable)]
     pub(crate) unsafe fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
         // Safety: the caller guarantees that the task allocation is live and that
         // the returned metadata has exclusive access to hook data.
@@ -289,11 +289,11 @@ impl RawTask {
         }
     }
 
-    #[cfg(tokio_unstable)]
     /// # Safety
     ///
     /// The task allocation must be live, and hook data must not be mutated while
     /// references exposed through the returned metadata are live.
+    #[cfg(tokio_unstable)]
     pub(crate) unsafe fn task_meta_ref<'meta>(&self) -> crate::runtime::TaskMetaRef<'meta> {
         // Safety: the caller guarantees that the task allocation is live and that
         // hook data is not mutated while exposed references are live.

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -11,6 +11,8 @@ use crate::future::Future;
 use crate::runtime::task::core::{Core, Trailer};
 use crate::runtime::task::{Cell, Harness, Header, Id, Schedule, State};
 #[cfg(tokio_unstable)]
+use crate::runtime::TaskData;
+#[cfg(tokio_unstable)]
 use std::panic::Location;
 use std::ptr::NonNull;
 use std::task::{Poll, Waker};
@@ -213,6 +215,7 @@ impl RawTask {
         scheduler: S,
         id: Id,
         _spawned_at: super::SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<TaskData>,
     ) -> RawTask
     where
         T: Future,
@@ -225,6 +228,8 @@ impl RawTask {
             id,
             #[cfg(tokio_unstable)]
             _spawned_at.0,
+            #[cfg(tokio_unstable)]
+            user_data,
         ));
         let ptr = unsafe { NonNull::new_unchecked(ptr.cast()) };
 
@@ -265,6 +270,40 @@ impl RawTask {
     /// Returns a reference to the task's trailer.
     pub(super) fn trailer(&self) -> &Trailer {
         unsafe { &*self.trailer_ptr().as_ptr() }
+    }
+
+    #[cfg(tokio_unstable)]
+    /// # Safety
+    ///
+    /// The task allocation must be live, and the returned metadata must have
+    /// exclusive access to hook data for as long as it can expose mutable references.
+    pub(crate) unsafe fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
+        // Safety: `self` holds a live task reference, and callers use the
+        // metadata only for the current hook invocation.
+        unsafe {
+            crate::runtime::TaskMeta::new(
+                Header::get_id(self.ptr),
+                Header::get_spawn_location(self.ptr).into(),
+                Some(self.trailer().user_data_ptr()),
+            )
+        }
+    }
+
+    #[cfg(tokio_unstable)]
+    /// # Safety
+    ///
+    /// The task allocation must be live, and hook data must not be mutated while
+    /// references exposed through the returned metadata are live.
+    pub(crate) unsafe fn task_meta_ref<'meta>(&self) -> crate::runtime::TaskMetaRef<'meta> {
+        // Safety: `self` holds a live task reference, and this only exposes
+        // shared access to task data.
+        unsafe {
+            crate::runtime::TaskMetaRef::new(
+                Header::get_id(self.ptr),
+                Header::get_spawn_location(self.ptr).into(),
+                Some(self.trailer().user_data_ptr()),
+            )
+        }
     }
 
     /// Returns a reference to the task's state.

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -278,8 +278,8 @@ impl RawTask {
     /// The task allocation must be live, and the returned metadata must have
     /// exclusive access to hook data for as long as it can expose mutable references.
     pub(crate) unsafe fn task_meta<'meta>(&self) -> crate::runtime::TaskMeta<'meta> {
-        // Safety: `self` holds a live task reference, and callers use the
-        // metadata only for the current hook invocation.
+        // Safety: the caller guarantees that the task allocation is live and that
+        // the returned metadata has exclusive access to hook data.
         unsafe {
             crate::runtime::TaskMeta::new(
                 Header::get_id(self.ptr),
@@ -295,8 +295,8 @@ impl RawTask {
     /// The task allocation must be live, and hook data must not be mutated while
     /// references exposed through the returned metadata are live.
     pub(crate) unsafe fn task_meta_ref<'meta>(&self) -> crate::runtime::TaskMetaRef<'meta> {
-        // Safety: `self` holds a live task reference, and this only exposes
-        // shared access to task data.
+        // Safety: the caller guarantees that the task allocation is live and that
+        // hook data is not mutated while exposed references are live.
         unsafe {
             crate::runtime::TaskMetaRef::new(
                 Header::get_id(self.ptr),

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -30,10 +30,22 @@ impl TaskHooks {
 
     #[cfg(tokio_unstable)]
     #[inline]
+    pub(crate) fn has_poll_start_callback(&self) -> bool {
+        self.before_poll_callback.is_some()
+    }
+
+    #[cfg(tokio_unstable)]
+    #[inline]
     pub(crate) fn poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
         if let Some(poll_start) = &self.before_poll_callback {
             (poll_start)(meta);
         }
+    }
+
+    #[cfg(tokio_unstable)]
+    #[inline]
+    pub(crate) fn has_poll_stop_callback(&self) -> bool {
+        self.after_poll_callback.is_some()
     }
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -215,8 +215,11 @@ pub struct TaskMetaRef<'a> {
 impl<'a> TaskMetaRef<'a> {
     /// # Safety
     ///
-    /// If `user_data` is present, it must point to live task storage for the
-    /// duration of any references exposed through this metadata value.
+    /// If `user_data` is present, it must point to live task storage for the duration
+    /// of any references exposed through this metadata value.
+    ///
+    /// While any references exposed through this metadata value are live, the task
+    /// data must not be mutably accessed, replaced, cleared, or dropped.
     #[cfg(tokio_unstable)]
     pub(crate) unsafe fn new(
         id: super::task::Id,
@@ -251,7 +254,8 @@ impl<'a> TaskMetaRef<'a> {
         let user_data = self.user_data?;
 
         // Safety: `TaskMetaRef` is only constructed while the task allocation is
-        // known to be alive, and it does not expose mutation.
+        // known to be alive. Its constructor requires that the data is not mutated
+        // while exposed references are live.
         unsafe { user_data.as_ref().as_ref()?.downcast_ref::<T>() }
     }
 }

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,10 +1,18 @@
 use super::Config;
+#[cfg(tokio_unstable)]
+use std::any::Any;
 use std::marker::PhantomData;
+#[cfg(tokio_unstable)]
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+#[cfg(tokio_unstable)]
+pub(crate) type TaskData = Box<dyn Any + Send + Sync + 'static>;
 
 impl TaskHooks {
-    pub(crate) fn spawn(&self, meta: &TaskMeta<'_>) {
+    pub(crate) fn spawn(&self, meta: &mut TaskMeta<'_>, parent: Option<TaskMetaRef<'_>>) {
         if let Some(f) = self.task_spawn_callback.as_ref() {
-            f(meta)
+            f(meta, parent)
         }
     }
 
@@ -22,7 +30,7 @@ impl TaskHooks {
 
     #[cfg(tokio_unstable)]
     #[inline]
-    pub(crate) fn poll_start_callback(&self, meta: &TaskMeta<'_>) {
+    pub(crate) fn poll_start_callback(&self, meta: &mut TaskMeta<'_>) {
         if let Some(poll_start) = &self.before_poll_callback {
             (poll_start)(meta);
         }
@@ -30,16 +38,25 @@ impl TaskHooks {
 
     #[cfg(tokio_unstable)]
     #[inline]
-    pub(crate) fn poll_stop_callback(&self, meta: &TaskMeta<'_>) {
+    pub(crate) fn poll_stop_callback(&self, meta: &mut TaskMeta<'_>) {
         if let Some(poll_stop) = &self.after_poll_callback {
             (poll_stop)(meta);
+        }
+    }
+
+    #[cfg(tokio_unstable)]
+    #[inline]
+    pub(crate) fn task_terminate_callback(&self, meta: &mut TaskMeta<'_>) {
+        if let Some(task_terminate) = &self.task_terminate_callback {
+            (task_terminate)(meta);
         }
     }
 }
 
 #[derive(Clone)]
 pub(crate) struct TaskHooks {
-    pub(crate) task_spawn_callback: Option<TaskCallback>,
+    pub(crate) task_spawn_callback: Option<TaskSpawnCallback>,
+    #[cfg_attr(not(tokio_unstable), allow(dead_code))]
     pub(crate) task_terminate_callback: Option<TaskCallback>,
     #[cfg(tokio_unstable)]
     pub(crate) before_poll_callback: Option<TaskCallback>,
@@ -62,10 +79,44 @@ pub struct TaskMeta<'a> {
     /// The location where the task was spawned.
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
     pub(crate) spawned_at: crate::runtime::task::SpawnLocation,
+    #[cfg(tokio_unstable)]
+    pub(crate) user_data: Option<NonNull<Option<TaskData>>>,
     pub(crate) _phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> TaskMeta<'a> {
+    #[cfg(not(tokio_unstable))]
+    pub(crate) fn new(
+        id: super::task::Id,
+        spawned_at: crate::runtime::task::SpawnLocation,
+    ) -> Self {
+        Self {
+            id,
+            spawned_at,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// # Safety
+    ///
+    /// If `user_data` is present, it must point to live task storage, and this
+    /// metadata value must have exclusive access to that storage while it can
+    /// expose mutable references to it.
+    #[cfg(tokio_unstable)]
+    pub(crate) unsafe fn new(
+        id: super::task::Id,
+        spawned_at: crate::runtime::task::SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<NonNull<Option<TaskData>>>,
+    ) -> Self {
+        Self {
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Return the opaque ID of the task.
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
     pub fn id(&self) -> super::task::Id {
@@ -77,7 +128,136 @@ impl<'a> TaskMeta<'a> {
     pub fn spawned_at(&self) -> &'static std::panic::Location<'static> {
         self.spawned_at.0
     }
+
+    /// Returns a shared reference to this task's user data when the stored type
+    /// is `T`.
+    #[cfg(tokio_unstable)]
+    pub fn data<T: Any>(&self) -> Option<&T> {
+        let user_data = self.user_data?;
+
+        // Safety: `TaskMeta` is only constructed while the task allocation is
+        // known to be alive. Shared access is allowed for the duration of hook
+        // invocation.
+        unsafe { user_data.as_ref().as_ref()?.downcast_ref::<T>() }
+    }
+
+    /// Returns a mutable reference to this task's user data when the stored type
+    /// is `T`.
+    #[cfg(tokio_unstable)]
+    pub fn data_mut<T: Any>(&mut self) -> Option<&mut T> {
+        let mut user_data = self.user_data?;
+
+        // Safety: mutable `TaskMeta` is only handed to hooks for the exact task
+        // currently being initialized, polled under the RUNNING task state, or
+        // terminated. Tokio does not hold this borrow across polling the future.
+        unsafe { user_data.as_mut().as_mut()?.downcast_mut::<T>() }
+    }
+
+    /// Replaces this task's user data.
+    #[cfg(tokio_unstable)]
+    pub fn set_data<T: Any + Send + Sync + 'static>(&mut self, data: T) {
+        if let Some(mut user_data) = self.user_data {
+            // Safety: see `data_mut`.
+            unsafe {
+                *user_data.as_mut() = Some(Box::new(data));
+            }
+        }
+    }
+
+    /// Takes this task's user data when the stored type is `T`.
+    #[cfg(tokio_unstable)]
+    pub fn take_data<T: Any>(&mut self) -> Option<Box<T>> {
+        let mut user_data = self.user_data?;
+
+        // Safety: see `data_mut`.
+        unsafe {
+            let user_data = user_data.as_mut();
+            if !user_data.as_ref()?.is::<T>() {
+                return None;
+            }
+
+            user_data.take()?.downcast::<T>().ok()
+        }
+    }
+
+    /// Clears this task's user data, returning whether any data was present.
+    #[cfg(tokio_unstable)]
+    pub fn clear_data(&mut self) -> bool {
+        let Some(mut user_data) = self.user_data else {
+            return false;
+        };
+
+        // Safety: see `data_mut`.
+        unsafe { user_data.as_mut().take().is_some() }
+    }
+}
+
+/// Read-only task metadata supplied to task spawn hooks for parent tasks.
+///
+/// **Note**: This is an [unstable API][unstable]. The public API of this type
+/// may break in 1.x releases. See [the documentation on unstable
+/// features][unstable] for details.
+///
+/// [unstable]: crate#unstable-features
+#[allow(missing_debug_implementations)]
+#[cfg_attr(not(tokio_unstable), allow(unreachable_pub))]
+pub struct TaskMetaRef<'a> {
+    /// The opaque ID of the task.
+    pub(crate) id: super::task::Id,
+    /// The location where the task was spawned.
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
+    pub(crate) spawned_at: crate::runtime::task::SpawnLocation,
+    #[cfg(tokio_unstable)]
+    pub(crate) user_data: Option<NonNull<Option<TaskData>>>,
+    pub(crate) _phantom: PhantomData<&'a ()>,
+}
+
+impl<'a> TaskMetaRef<'a> {
+    /// # Safety
+    ///
+    /// If `user_data` is present, it must point to live task storage for the
+    /// duration of any references exposed through this metadata value.
+    #[cfg(tokio_unstable)]
+    pub(crate) unsafe fn new(
+        id: super::task::Id,
+        spawned_at: crate::runtime::task::SpawnLocation,
+        #[cfg(tokio_unstable)] user_data: Option<NonNull<Option<TaskData>>>,
+    ) -> Self {
+        Self {
+            id,
+            spawned_at,
+            #[cfg(tokio_unstable)]
+            user_data,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Return the opaque ID of the task.
+    #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
+    pub fn id(&self) -> super::task::Id {
+        self.id
+    }
+
+    /// Return the source code location where the task was spawned.
+    #[cfg(tokio_unstable)]
+    pub fn spawned_at(&self) -> &'static std::panic::Location<'static> {
+        self.spawned_at.0
+    }
+
+    /// Returns a shared reference to this task's user data when the stored type
+    /// is `T`.
+    #[cfg(tokio_unstable)]
+    pub fn data<T: Any>(&self) -> Option<&T> {
+        let user_data = self.user_data?;
+
+        // Safety: `TaskMetaRef` is only constructed while the task allocation is
+        // known to be alive, and it does not expose mutation.
+        unsafe { user_data.as_ref().as_ref()?.downcast_ref::<T>() }
+    }
 }
 
 /// Runs on specific task-related events
-pub(crate) type TaskCallback = std::sync::Arc<dyn Fn(&TaskMeta<'_>) + Send + Sync>;
+pub(crate) type TaskCallback = Arc<dyn Fn(&mut TaskMeta<'_>) + Send + Sync>;
+
+pub(crate) type TaskSpawnCallback =
+    Arc<dyn Fn(&mut TaskMeta<'_>, Option<TaskMetaRef<'_>>) + Send + Sync>;

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -6,7 +6,7 @@ use self::noop_scheduler::NoopSchedule;
 use self::unowned_wrapper::unowned;
 
 mod noop_scheduler {
-    use crate::runtime::task::{self, Task, TaskHarnessScheduleHooks};
+    use crate::runtime::task::{self, Task};
 
     /// `task::Schedule` implementation that does nothing, for testing.
     pub(crate) struct NoopSchedule;
@@ -20,11 +20,6 @@ mod noop_scheduler {
             unreachable!();
         }
 
-        fn hooks(&self) -> TaskHarnessScheduleHooks {
-            TaskHarnessScheduleHooks {
-                task_terminate_callback: None,
-            }
-        }
     }
 }
 
@@ -43,7 +38,14 @@ mod unowned_wrapper {
         let span = tracing::trace_span!("test_span");
         let task = task.instrument(span);
         let (task, handle) =
-            crate::runtime::task::unowned(task, NoopSchedule, Id::next(), SpawnLocation::capture());
+            crate::runtime::task::unowned(
+                task,
+                NoopSchedule,
+                Id::next(),
+                SpawnLocation::capture(),
+                #[cfg(tokio_unstable)]
+                None,
+            );
         (task.into_notified(), handle)
     }
 
@@ -55,7 +57,14 @@ mod unowned_wrapper {
         T::Output: Send + 'static,
     {
         let (task, handle) =
-            crate::runtime::task::unowned(task, NoopSchedule, Id::next(), SpawnLocation::capture());
+            crate::runtime::task::unowned(
+                task,
+                NoopSchedule,
+                Id::next(),
+                SpawnLocation::capture(),
+                #[cfg(tokio_unstable)]
+                None,
+            );
         (task.into_notified(), handle)
     }
 }

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -19,7 +19,6 @@ mod noop_scheduler {
         fn schedule(&self, _task: task::Notified<Self>) {
             unreachable!();
         }
-
     }
 }
 
@@ -37,15 +36,14 @@ mod unowned_wrapper {
         use tracing::Instrument;
         let span = tracing::trace_span!("test_span");
         let task = task.instrument(span);
-        let (task, handle) =
-            crate::runtime::task::unowned(
-                task,
-                NoopSchedule,
-                Id::next(),
-                SpawnLocation::capture(),
-                #[cfg(tokio_unstable)]
-                None,
-            );
+        let (task, handle) = crate::runtime::task::unowned(
+            task,
+            NoopSchedule,
+            Id::next(),
+            SpawnLocation::capture(),
+            #[cfg(tokio_unstable)]
+            None,
+        );
         (task.into_notified(), handle)
     }
 
@@ -56,15 +54,14 @@ mod unowned_wrapper {
         T: std::future::Future + Send + 'static,
         T::Output: Send + 'static,
     {
-        let (task, handle) =
-            crate::runtime::task::unowned(
-                task,
-                NoopSchedule,
-                Id::next(),
-                SpawnLocation::capture(),
-                #[cfg(tokio_unstable)]
-                None,
-            );
+        let (task, handle) = crate::runtime::task::unowned(
+            task,
+            NoopSchedule,
+            Id::next(),
+            SpawnLocation::capture(),
+            #[cfg(tokio_unstable)]
+            None,
+        );
         (task.into_notified(), handle)
     }
 }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -1,6 +1,5 @@
 use crate::runtime::task::{
     self, unowned, Id, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task,
-    TaskHarnessScheduleHooks,
 };
 use crate::runtime::tests::NoopSchedule;
 
@@ -61,6 +60,8 @@ fn create_drop1() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     drop(notified);
     handle.assert_not_dropped();
@@ -79,6 +80,8 @@ fn create_drop2() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     drop(join);
     handle.assert_not_dropped();
@@ -97,6 +100,8 @@ fn drop_abort_handle1() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     let abort = join.abort_handle();
     drop(join);
@@ -118,6 +123,8 @@ fn drop_abort_handle2() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     let abort = join.abort_handle();
     drop(notified);
@@ -139,6 +146,8 @@ fn drop_abort_handle_clone() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     let abort = join.abort_handle();
     let abort_clone = abort.clone();
@@ -164,6 +173,8 @@ fn create_shutdown1() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     drop(join);
     handle.assert_not_dropped();
@@ -182,6 +193,8 @@ fn create_shutdown2() {
         NoopSchedule,
         Id::next(),
         SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
     );
     handle.assert_not_dropped();
     notified.shutdown();
@@ -191,7 +204,14 @@ fn create_shutdown2() {
 
 #[test]
 fn unowned_poll() {
-    let (task, _) = unowned(async {}, NoopSchedule, Id::next(), SpawnLocation::capture());
+    let (task, _) = unowned(
+        async {},
+        NoopSchedule,
+        Id::next(),
+        SpawnLocation::capture(),
+        #[cfg(tokio_unstable)]
+        None,
+    );
     task.run();
 }
 
@@ -402,9 +422,14 @@ impl Runtime {
         T::Output: 'static + Send,
     {
         let (handle, notified) =
-            self.0
-                .owned
-                .bind(future, self.clone(), Id::next(), SpawnLocation::capture());
+            self.0.owned.bind(
+                future,
+                self.clone(),
+                Id::next(),
+                SpawnLocation::capture(),
+                #[cfg(tokio_unstable)]
+                None,
+            );
 
         if let Some(notified) = notified {
             self.schedule(notified);
@@ -459,11 +484,5 @@ impl Schedule for Runtime {
 
     fn schedule(&self, task: task::Notified<Self>) {
         self.0.core.try_lock().unwrap().queue.push_back(task);
-    }
-
-    fn hooks(&self) -> TaskHarnessScheduleHooks {
-        TaskHarnessScheduleHooks {
-            task_terminate_callback: None,
-        }
     }
 }

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -421,15 +421,14 @@ impl Runtime {
         T: 'static + Send + Future,
         T::Output: 'static + Send,
     {
-        let (handle, notified) =
-            self.0.owned.bind(
-                future,
-                self.clone(),
-                Id::next(),
-                SpawnLocation::capture(),
-                #[cfg(tokio_unstable)]
-                None,
-            );
+        let (handle, notified) = self.0.owned.bind(
+            future,
+            self.clone(),
+            Id::next(),
+            SpawnLocation::capture(),
+            #[cfg(tokio_unstable)]
+            None,
+        );
 
         if let Some(notified) = notified {
             self.schedule(notified);

--- a/tokio/src/runtime/tests/task.rs
+++ b/tokio/src/runtime/tests/task.rs
@@ -2,6 +2,7 @@ use crate::runtime::task::{
     self, unowned, Id, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task,
 };
 use crate::runtime::tests::NoopSchedule;
+use crate::runtime::TaskHooks;
 
 use std::collections::VecDeque;
 use std::future::Future;
@@ -421,13 +422,22 @@ impl Runtime {
         T: 'static + Send + Future,
         T::Output: 'static + Send,
     {
-        let (handle, notified) = self.0.owned.bind(
+        let task_hooks = TaskHooks {
+            task_spawn_callback: None,
+            task_terminate_callback: None,
+            #[cfg(tokio_unstable)]
+            before_poll_callback: None,
+            #[cfg(tokio_unstable)]
+            after_poll_callback: None,
+        };
+        let (handle, notified) = self.0.owned.bind_with_spawn_hook(
             future,
             self.clone(),
             Id::next(),
             SpawnLocation::capture(),
             #[cfg(tokio_unstable)]
             None,
+            &task_hooks,
         );
 
         if let Some(notified) = notified {

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     task::{JoinHandle, LocalSet},
     util::trace::SpawnMeta,
 };
-use std::{future::Future, io, mem};
+use std::{any::Any, fmt, future::Future, io, mem};
 
 /// Factory which is used to configure the properties of a new task.
 ///
@@ -14,10 +14,11 @@ use std::{future::Future, io, mem};
 ///
 /// Methods can be chained in order to configure it.
 ///
-/// Currently, there is only one configuration option:
+/// Configuration options include:
 ///
 /// - [`name`], which specifies an associated name for
 ///   the task
+/// - [`data`], which stores user data for runtime task hooks
 ///
 /// There are three types of task that can be spawned from a Builder:
 /// - [`spawn_local`] for executing not [`Send`] futures
@@ -55,13 +56,15 @@ use std::{future::Future, io, mem};
 /// ```
 /// [unstable]: crate#unstable-features
 /// [`name`]: Builder::name
+/// [`data`]: Builder::data
 /// [`spawn_local`]: Builder::spawn_local
 /// [`spawn`]: Builder::spawn
 /// [`spawn_blocking`]: Builder::spawn_blocking
-#[derive(Default, Debug)]
+#[derive(Default)]
 #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
 pub struct Builder<'a> {
     name: Option<&'a str>,
+    data: Option<crate::runtime::TaskData>,
 }
 
 impl<'a> Builder<'a> {
@@ -71,8 +74,22 @@ impl<'a> Builder<'a> {
     }
 
     /// Assigns a name to the task which will be spawned.
-    pub fn name(&self, name: &'a str) -> Self {
-        Self { name: Some(name) }
+    pub fn name(self, name: &'a str) -> Self {
+        Self {
+            name: Some(name),
+            ..self
+        }
+    }
+
+    /// Sets task data visible to runtime task hooks.
+    pub fn data<T>(self, data: T) -> Self
+    where
+        T: Any + Send + Sync + 'static,
+    {
+        Self {
+            data: Some(Box::new(data)),
+            ..self
+        }
     }
 
     /// Spawns a task with this builder's settings on the current runtime.
@@ -89,11 +106,12 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
+        let Builder { name, data } = self;
         let fut_size = mem::size_of::<Fut>();
         Ok(if fut_size > BOX_FUTURE_THRESHOLD {
-            super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(name, fut_size), data)
         } else {
-            super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
+            super::spawn::spawn_inner(future, SpawnMeta::new(name, fut_size), data)
         })
     }
 
@@ -110,11 +128,12 @@ impl<'a> Builder<'a> {
         Fut: Future + Send + 'static,
         Fut::Output: Send + 'static,
     {
+        let Builder { name, data } = self;
         let fut_size = mem::size_of::<Fut>();
         Ok(if fut_size > BOX_FUTURE_THRESHOLD {
-            handle.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            handle.spawn_named_with_data(Box::pin(future), SpawnMeta::new(name, fut_size), data)
         } else {
-            handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
+            handle.spawn_named_with_data(future, SpawnMeta::new(name, fut_size), data)
         })
     }
 
@@ -141,11 +160,12 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
+        let Builder { name, data } = self;
         let fut_size = mem::size_of::<Fut>();
         Ok(if fut_size > BOX_FUTURE_THRESHOLD {
-            super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(name, fut_size), data)
         } else {
-            super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
+            super::local::spawn_local_inner(future, SpawnMeta::new(name, fut_size), data)
         })
     }
 
@@ -166,11 +186,12 @@ impl<'a> Builder<'a> {
         Fut: Future + 'static,
         Fut::Output: 'static,
     {
+        let Builder { name, data } = self;
         let fut_size = mem::size_of::<Fut>();
         Ok(if fut_size > BOX_FUTURE_THRESHOLD {
-            local_set.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            local_set.spawn_named_with_data(Box::pin(future), SpawnMeta::new(name, fut_size), data)
         } else {
-            local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
+            local_set.spawn_named_with_data(future, SpawnMeta::new(name, fut_size), data)
         })
     }
 
@@ -212,24 +233,36 @@ impl<'a> Builder<'a> {
         Output: Send + 'static,
     {
         use crate::runtime::Mandatory;
+        let Builder { name, data } = self;
         let fn_size = mem::size_of::<Function>();
         let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 Box::new(function),
                 Mandatory::NonMandatory,
-                SpawnMeta::new(self.name, fn_size),
+                SpawnMeta::new(name, fn_size),
                 handle,
+                data,
             )
         } else {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 function,
                 Mandatory::NonMandatory,
-                SpawnMeta::new(self.name, fn_size),
+                SpawnMeta::new(name, fn_size),
                 handle,
+                data,
             )
         };
 
         spawn_result?;
         Ok(join_handle)
+    }
+}
+
+impl fmt::Debug for Builder<'_> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("Builder")
+            .field("name", &self.name)
+            .field("data", &self.data.as_ref().map(|_| "<task data>"))
+            .finish()
     }
 }

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -242,6 +242,8 @@ impl<'a> Builder<'a> {
                 SpawnMeta::new(name, fn_size),
                 handle,
                 data,
+                #[cfg(tokio_unstable)]
+                true,
             )
         } else {
             handle.inner.blocking_spawner().spawn_blocking_inner(
@@ -250,6 +252,8 @@ impl<'a> Builder<'a> {
                 SpawnMeta::new(name, fn_size),
                 handle,
                 data,
+                #[cfg(tokio_unstable)]
+                true,
             )
         };
 

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -705,6 +705,15 @@ impl<'a, T: 'static> Builder<'a, T> {
         Self { builder, ..self }
     }
 
+    /// Sets task data visible to runtime task hooks.
+    pub fn data<D>(self, data: D) -> Self
+    where
+        D: std::any::Any + Send + Sync + 'static,
+    {
+        let builder = self.builder.data(data);
+        Self { builder, ..self }
+    }
+
     /// Spawn the provided task with this builder's settings and store it in the
     /// [`JoinSet`], returning an [`AbortHandle`] that can be used to remotely
     /// cancel the task.

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -2,9 +2,7 @@
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::{Arc, Mutex};
 use crate::runtime;
-use crate::runtime::task::{
-    self, JoinHandle, LocalOwnedTasks, SpawnLocation, Task, TaskHarnessScheduleHooks,
-};
+use crate::runtime::task::{self, JoinHandle, LocalOwnedTasks, SpawnLocation, Task};
 use crate::runtime::{context, ThreadId, BOX_FUTURE_THRESHOLD};
 use crate::sync::AtomicWaker;
 use crate::util::trace::SpawnMeta;
@@ -399,21 +397,37 @@ cfg_rt! {
     {
         let fut_size = std::mem::size_of::<F>();
         if fut_size > BOX_FUTURE_THRESHOLD {
-            spawn_local_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            spawn_local_inner(
+                Box::pin(future),
+                SpawnMeta::new_unnamed(fut_size),
+                #[cfg(tokio_unstable)]
+                None,
+            )
         } else {
-            spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
+            spawn_local_inner(
+                future,
+                SpawnMeta::new_unnamed(fut_size),
+                #[cfg(tokio_unstable)]
+                None,
+            )
         }
     }
 
 
     #[track_caller]
-    pub(super) fn spawn_local_inner<F>(future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
+    pub(super) fn spawn_local_inner<F>(
+        future: F,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
     where F: Future + 'static,
           F::Output: 'static
     {
         use crate::runtime::{context, task};
 
         let mut future = Some(future);
+        #[cfg(tokio_unstable)]
+        let mut user_data = Some(user_data);
 
         let res = context::with_current(|handle| {
             Some(if handle.is_local() {
@@ -439,11 +453,24 @@ cfg_rt! {
                 let task = crate::util::trace::task(future, "task", meta, id.as_u64());
 
                 // safety: we have verified that this is a `LocalRuntime` owned by the current thread
-                unsafe { handle.spawn_local(task, id, meta.spawned_at) }
+                unsafe {
+                    handle.spawn_local(
+                        task,
+                        id,
+                        meta.spawned_at,
+                        #[cfg(tokio_unstable)]
+                        user_data.take().unwrap(),
+                    )
+                }
             } else {
                 match CURRENT.with(|LocalData { ctx, .. }| ctx.get()) {
                     None => panic!("`spawn_local` called from outside of a `task::LocalSet` or `runtime::LocalRuntime`"),
-                    Some(cx) => cx.spawn(future.take().unwrap(), meta)
+                    Some(cx) => cx.spawn(
+                        future.take().unwrap(),
+                        meta,
+                        #[cfg(tokio_unstable)]
+                        user_data.take().unwrap(),
+                    )
                 }
             })
         });
@@ -453,7 +480,12 @@ cfg_rt! {
             Ok(Some(join_handle)) => join_handle,
             Err(_) => match CURRENT.with(|LocalData { ctx, .. }| ctx.get()) {
                 None => panic!("`spawn_local` called from outside of a `task::LocalSet` or `runtime::LocalRuntime`"),
-                Some(cx) => cx.spawn(future.unwrap(), meta)
+                Some(cx) => cx.spawn(
+                    future.unwrap(),
+                    meta,
+                    #[cfg(tokio_unstable)]
+                    user_data.unwrap(),
+                )
             }
         }
     }
@@ -729,16 +761,46 @@ impl LocalSet {
         F: Future + 'static,
         F::Output: 'static,
     {
-        self.spawn_named_inner(future, meta)
+        self.spawn_named_inner(
+            future,
+            meta,
+            #[cfg(tokio_unstable)]
+            None,
+        )
     }
 
+    #[cfg(all(tokio_unstable, feature = "tracing"))]
     #[track_caller]
-    fn spawn_named_inner<F>(&self, future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
+    pub(in crate::task) fn spawn_named_with_data<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
         F::Output: 'static,
     {
-        let handle = self.context.spawn(future, meta);
+        self.spawn_named_inner(future, meta, user_data)
+    }
+
+    #[track_caller]
+    fn spawn_named_inner<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
+    where
+        F: Future + 'static,
+        F::Output: 'static,
+    {
+        let handle = self.context.spawn(
+            future,
+            meta,
+            #[cfg(tokio_unstable)]
+            user_data,
+        );
 
         // Because a task was spawned from *outside* the `LocalSet`, wake the
         // `LocalSet` future to execute the new task, if it hasn't been woken.
@@ -1024,7 +1086,12 @@ impl Drop for LocalSet {
 
 impl Context {
     #[track_caller]
-    fn spawn<F>(&self, future: F, meta: SpawnMeta<'_>) -> JoinHandle<F::Output>
+    fn spawn<F>(
+        &self,
+        future: F,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<F::Output>
     where
         F: Future + 'static,
         F::Output: 'static,
@@ -1040,6 +1107,8 @@ impl Context {
                 self.shared.clone(),
                 id,
                 SpawnLocation::capture(),
+                #[cfg(tokio_unstable)]
+                user_data,
             )
         };
 
@@ -1146,13 +1215,6 @@ impl task::Schedule for Arc<Shared> {
 
     fn schedule(&self, task: task::Notified<Self>) {
         Shared::schedule(self, task);
-    }
-
-    // localset does not currently support task hooks
-    fn hooks(&self) -> TaskHarnessScheduleHooks {
-        TaskHarnessScheduleHooks {
-            task_terminate_callback: None,
-        }
     }
 
     cfg_unstable! {

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -178,14 +178,28 @@ cfg_rt! {
     {
         let fut_size = std::mem::size_of::<F>();
         if fut_size > BOX_FUTURE_THRESHOLD {
-            spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            spawn_inner(
+                Box::pin(future),
+                SpawnMeta::new_unnamed(fut_size),
+                #[cfg(tokio_unstable)]
+                None,
+            )
         } else {
-            spawn_inner(future, SpawnMeta::new_unnamed(fut_size))
+            spawn_inner(
+                future,
+                SpawnMeta::new_unnamed(fut_size),
+                #[cfg(tokio_unstable)]
+                None,
+            )
         }
     }
 
     #[track_caller]
-    pub(super) fn spawn_inner<T>(future: T, meta: SpawnMeta<'_>) -> JoinHandle<T::Output>
+    pub(super) fn spawn_inner<T>(
+        future: T,
+        meta: SpawnMeta<'_>,
+        #[cfg(tokio_unstable)] user_data: Option<crate::runtime::TaskData>,
+    ) -> JoinHandle<T::Output>
     where
         T: Future + Send + 'static,
         T::Output: Send + 'static,
@@ -207,7 +221,15 @@ cfg_rt! {
         let id = task::Id::next();
         let task = crate::util::trace::task(future, "task", meta, id.as_u64());
 
-        match context::with_current(|handle| handle.spawn(task, id, meta.spawned_at)) {
+        match context::with_current(|handle| {
+            handle.spawn(
+                task,
+                id,
+                meta.spawned_at,
+                #[cfg(tokio_unstable)]
+                user_data,
+            )
+        }) {
             Ok(join_handle) => join_handle,
             Err(e) => panic!("{}", e),
         }

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -77,6 +77,128 @@ fn terminate_task_hook_fires() {
     assert_eq!(TASKS, count.load(Ordering::SeqCst));
 }
 
+#[test]
+fn spawn_blocking_task_hooks_are_balanced() {
+    let (spawned_tx, spawned_rx) = std::sync::mpsc::channel();
+    let (terminated_tx, terminated_rx) = std::sync::mpsc::channel();
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(move |meta, parent| {
+            assert!(parent.is_none());
+            spawned_tx.send(meta.id()).unwrap();
+        })
+        .on_task_terminate(move |meta| {
+            terminated_tx.send(meta.id()).unwrap();
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::task::spawn_blocking(|| {}).await.unwrap();
+    });
+
+    let spawned = spawned_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("spawn_blocking task did not fire spawn hook");
+    let terminated = terminated_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("spawn_blocking task did not fire terminate hook");
+
+    assert_eq!(spawned, terminated);
+    assert!(matches!(
+        spawned_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+    assert!(matches!(
+        terminated_rx.try_recv(),
+        Err(std::sync::mpsc::TryRecvError::Empty)
+    ));
+}
+
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn internal_runtime_blocking_tasks_do_not_fire_task_hooks() {
+    let spawned = Arc::new(Mutex::new(Vec::new()));
+    let spawned2 = Arc::clone(&spawned);
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(1)
+        .on_task_spawn(move |meta, _parent| {
+            spawned2.lock().unwrap().push(meta.spawned_at().file());
+        })
+        .on_task_terminate(move |meta| {
+            terminated2.lock().unwrap().push(meta.spawned_at().file());
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            tokio::task::block_in_place(|| {});
+        })
+        .await
+        .unwrap();
+    });
+
+    runtime.shutdown_timeout(Duration::from_secs(5));
+
+    let spawned = spawned.lock().unwrap();
+    assert!(
+        !spawned.iter().any(is_multi_thread_worker_file),
+        "internal worker task fired spawn hook: {spawned:?}"
+    );
+
+    let terminated = terminated.lock().unwrap();
+    assert!(
+        !terminated.iter().any(is_multi_thread_worker_file),
+        "internal worker task fired terminate hook: {terminated:?}"
+    );
+}
+
+fn is_multi_thread_worker_file(file: &&'static str) -> bool {
+    file.ends_with("runtime/scheduler/multi_thread/worker.rs")
+        || file.ends_with(r"runtime\scheduler\multi_thread\worker.rs")
+}
+
+#[test]
+fn spawn_blocking_after_shutdown_terminate_hook_can_reenter_pool() {
+    let handle: Arc<Mutex<Option<tokio::runtime::Handle>>> = Arc::new(Mutex::new(None));
+    let hook_handle = Arc::clone(&handle);
+    let terminated = Arc::new(AtomicUsize::new(0));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_terminate(move |_meta| {
+            if terminated2.fetch_add(1, Ordering::SeqCst) == 0 {
+                let handle = hook_handle.lock().unwrap().clone().unwrap();
+                drop(handle.spawn_blocking(|| {}));
+            }
+        })
+        .build()
+        .unwrap();
+
+    let runtime_handle = runtime.handle().clone();
+    *handle.lock().unwrap() = Some(runtime_handle.clone());
+    runtime.shutdown_timeout(Duration::from_secs(5));
+
+    let (done_tx, done_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        drop(runtime_handle.spawn_blocking(|| {}));
+        done_tx.send(()).unwrap();
+    });
+
+    done_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("terminate hook deadlocked while re-entering the blocking pool");
+
+    assert_eq!(terminated.load(Ordering::SeqCst), 2);
+}
+
 /// Test that the correct spawn location is provided to the task hooks on a
 /// current thread runtime.
 #[test]

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -534,6 +534,34 @@ fn abort_during_before_poll_hook_does_not_poll_future() {
     assert_eq!(polls.load(Ordering::SeqCst), 0);
 }
 
+#[test]
+fn poll_hook_panics_do_not_kill_task() {
+    let before = Arc::new(AtomicUsize::new(0));
+    let before2 = Arc::clone(&before);
+    let after = Arc::new(AtomicUsize::new(0));
+    let after2 = Arc::clone(&after);
+
+    let runtime = Builder::new_current_thread()
+        .on_before_task_poll(move |_meta| {
+            if before2.fetch_add(1, Ordering::SeqCst) == 0 {
+                panic!("before poll hook panic");
+            }
+        })
+        .on_after_task_poll(move |_meta| {
+            if after2.fetch_add(1, Ordering::SeqCst) == 0 {
+                panic!("after poll hook panic");
+            }
+        })
+        .build()
+        .unwrap();
+
+    let output = runtime.block_on(async { tokio::spawn(async { 17usize }).await.unwrap() });
+
+    assert_eq!(output, 17);
+    assert_eq!(before.load(Ordering::SeqCst), 1);
+    assert_eq!(after.load(Ordering::SeqCst), 1);
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct Lineage {
     depth: usize,

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -2,8 +2,12 @@
 #![cfg(all(feature = "full", tokio_unstable, target_has_atomic = "64"))]
 
 use std::collections::HashSet;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
 
 use tokio::runtime::Builder;
 
@@ -19,7 +23,8 @@ fn spawn_task_hook_fires() {
     let ids2 = Arc::clone(&ids);
 
     let runtime = Builder::new_current_thread()
-        .on_task_spawn(move |data| {
+        .on_task_spawn(move |data, _parent| {
+            assert!(data.data::<usize>().is_none());
             ids2.lock().unwrap().insert(data.id());
 
             count2.fetch_add(1, Ordering::SeqCst);
@@ -85,11 +90,11 @@ fn task_hook_spawn_location_current_thread() {
             "(current_thread) on_task_spawn",
             &spawns,
         ))
-        .on_before_task_poll(mk_spawn_location_hook(
+        .on_before_task_poll(mk_poll_location_hook(
             "(current_thread) on_before_task_poll",
             &poll_starts,
         ))
-        .on_after_task_poll(mk_spawn_location_hook(
+        .on_after_task_poll(mk_poll_location_hook(
             "(current_thread) on_after_task_poll",
             &poll_ends,
         ))
@@ -136,11 +141,11 @@ fn task_hook_spawn_location_multi_thread() {
             "(multi_thread) on_task_spawn",
             &spawns,
         ))
-        .on_before_task_poll(mk_spawn_location_hook(
+        .on_before_task_poll(mk_poll_location_hook(
             "(multi_thread) on_before_task_poll",
             &poll_starts,
         ))
-        .on_after_task_poll(mk_spawn_location_hook(
+        .on_after_task_poll(mk_poll_location_hook(
             "(multi_thread) on_after_task_poll",
             &poll_ends,
         ))
@@ -174,21 +179,430 @@ fn task_hook_spawn_location_multi_thread() {
     assert_eq!(poll_starts, poll_ends.fetch_add(0, Ordering::SeqCst));
 }
 
+#[derive(Debug)]
+struct PollState {
+    before: usize,
+    after: usize,
+}
+
+#[test]
+fn task_data_mutates_across_current_thread_hooks() {
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(|meta, parent| {
+            assert!(parent.is_none());
+            assert!(!meta.clear_data());
+            meta.set_data(PollState {
+                before: 0,
+                after: 0,
+            });
+        })
+        .on_before_task_poll(|meta| {
+            meta.data_mut::<PollState>().unwrap().before += 1;
+        })
+        .on_after_task_poll(|meta| {
+            if let Some(data) = meta.data_mut::<PollState>() {
+                data.after += 1;
+            }
+        })
+        .on_task_terminate(move |meta| {
+            let data = meta.take_data::<PollState>().unwrap();
+            assert!(meta.data::<PollState>().is_none());
+            terminated2.lock().unwrap().push((data.before, data.after));
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            for _ in 0..3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    });
+
+    let terminated = terminated.lock().unwrap();
+    assert_eq!(terminated.len(), 1);
+    let (before, after) = terminated[0];
+    assert!(before > 1);
+    assert_eq!(before, after);
+}
+
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn task_data_mutates_across_multi_thread_hooks() {
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(2)
+        .on_task_spawn(|meta, _parent| {
+            meta.set_data(PollState {
+                before: 0,
+                after: 0,
+            });
+        })
+        .on_before_task_poll(|meta| {
+            meta.data_mut::<PollState>().unwrap().before += 1;
+        })
+        .on_after_task_poll(|meta| {
+            if let Some(data) = meta.data_mut::<PollState>() {
+                data.after += 1;
+            }
+        })
+        .on_task_terminate(move |meta| {
+            let data = meta.take_data::<PollState>().unwrap();
+            terminated2.lock().unwrap().push((data.before, data.after));
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            for _ in 0..3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+    });
+
+    runtime.shutdown_timeout(std::time::Duration::from_secs(60));
+
+    let terminated = terminated.lock().unwrap();
+    assert_eq!(terminated.len(), 1);
+    let (before, after) = terminated[0];
+    assert!(before > 1);
+    assert_eq!(before, after);
+}
+
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn poll_hook_data_is_not_terminated_during_multi_thread_shutdown() {
+    let entered = Arc::new((Mutex::new(false), Condvar::new()));
+    let entered2 = Arc::clone(&entered);
+    let release = Arc::new((Mutex::new(false), Condvar::new()));
+    let release2 = Arc::clone(&release);
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(2)
+        .on_task_spawn(|meta, _parent| {
+            meta.set_data(Vec::<&'static str>::new());
+        })
+        .on_before_task_poll(move |meta| {
+            let (lock, cvar) = &*entered2;
+            *lock.lock().unwrap() = true;
+            cvar.notify_one();
+
+            let (lock, cvar) = &*release2;
+            let mut released = lock.lock().unwrap();
+            while !*released {
+                released = cvar.wait(released).unwrap();
+            }
+
+            meta.data_mut::<Vec<&'static str>>()
+                .unwrap()
+                .push("before_done");
+        })
+        .on_task_terminate(move |meta| {
+            let data = meta.take_data::<Vec<&'static str>>().unwrap();
+            terminated2.lock().unwrap().push(*data);
+        })
+        .build()
+        .unwrap();
+
+    drop(runtime.spawn(std::future::pending::<()>()));
+
+    let (lock, cvar) = &*entered;
+    let entered_guard = lock.lock().unwrap();
+    let (entered_guard, wait_result) = cvar
+        .wait_timeout_while(entered_guard, Duration::from_secs(5), |entered| !*entered)
+        .unwrap();
+    assert!(*entered_guard);
+    assert!(!wait_result.timed_out());
+
+    let shutdown = std::thread::spawn(move || {
+        runtime.shutdown_timeout(Duration::from_secs(5));
+    });
+
+    std::thread::sleep(Duration::from_millis(50));
+
+    let (lock, cvar) = &*release;
+    *lock.lock().unwrap() = true;
+    cvar.notify_one();
+
+    shutdown.join().unwrap();
+
+    assert_eq!(*terminated.lock().unwrap(), vec![vec!["before_done"]]);
+}
+
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn abort_during_before_poll_hook_does_not_poll_future() {
+    struct CountPolls {
+        polls: Arc<AtomicUsize>,
+    }
+
+    impl Future for CountPolls {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            self.polls.fetch_add(1, Ordering::SeqCst);
+            Poll::Pending
+        }
+    }
+
+    let entered = Arc::new((Mutex::new(false), Condvar::new()));
+    let entered2 = Arc::clone(&entered);
+    let release = Arc::new((Mutex::new(false), Condvar::new()));
+    let release2 = Arc::clone(&release);
+    let polls = Arc::new(AtomicUsize::new(0));
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(2)
+        .on_before_task_poll(move |_meta| {
+            let (lock, cvar) = &*entered2;
+            *lock.lock().unwrap() = true;
+            cvar.notify_one();
+
+            let (lock, cvar) = &*release2;
+            let mut released = lock.lock().unwrap();
+            while !*released {
+                released = cvar.wait(released).unwrap();
+            }
+        })
+        .build()
+        .unwrap();
+
+    let task = runtime.spawn(CountPolls {
+        polls: Arc::clone(&polls),
+    });
+
+    let (lock, cvar) = &*entered;
+    let entered_guard = lock.lock().unwrap();
+    let (entered_guard, wait_result) = cvar
+        .wait_timeout_while(entered_guard, Duration::from_secs(5), |entered| !*entered)
+        .unwrap();
+    assert!(*entered_guard);
+    assert!(!wait_result.timed_out());
+
+    task.abort();
+
+    let (lock, cvar) = &*release;
+    *lock.lock().unwrap() = true;
+    cvar.notify_one();
+
+    let err = runtime.block_on(task).unwrap_err();
+    assert!(err.is_cancelled());
+    assert_eq!(polls.load(Ordering::SeqCst), 0);
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Lineage {
+    depth: usize,
+}
+
+#[test]
+fn spawn_hook_can_inherit_parent_task_data() {
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(|meta, parent| {
+            let depth = match parent {
+                Some(parent) => parent
+                    .data::<Lineage>()
+                    .map_or(0, |parent| parent.depth + 1),
+                None => 0,
+            };
+
+            meta.set_data(Lineage { depth });
+        })
+        .on_task_terminate(move |meta| {
+            let data = meta.take_data::<Lineage>().unwrap();
+            terminated2.lock().unwrap().push(data.depth);
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::spawn(async {
+            tokio::spawn(async {}).await.unwrap();
+        })
+        .await
+        .unwrap();
+    });
+
+    let mut terminated = terminated.lock().unwrap().clone();
+    terminated.sort_unstable();
+    assert_eq!(terminated, vec![0, 1]);
+}
+
+#[test]
+fn spawn_hook_runs_before_terminate_when_current_thread_runtime_is_closed() {
+    struct ClosedSpawnData;
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let events2 = Arc::clone(&events);
+    let events3 = Arc::clone(&events);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(move |meta, _parent| {
+            meta.set_data(ClosedSpawnData);
+            events2.lock().unwrap().push("spawn");
+        })
+        .on_task_terminate(move |meta| {
+            if meta.take_data::<ClosedSpawnData>().is_some() {
+                events3.lock().unwrap().push("terminate_with_data");
+            }
+        })
+        .build()
+        .unwrap();
+
+    let handle = runtime.handle().clone();
+    drop(runtime);
+
+    drop(handle.spawn(async {}));
+
+    assert_eq!(*events.lock().unwrap(), ["spawn", "terminate_with_data"]);
+}
+
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "WASI does not support multi-threaded runtime"
+)]
+#[test]
+fn spawn_hook_runs_before_terminate_when_multi_thread_runtime_is_closed() {
+    struct ClosedSpawnData;
+
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let events2 = Arc::clone(&events);
+    let events3 = Arc::clone(&events);
+
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(1)
+        .on_task_spawn(move |meta, _parent| {
+            meta.set_data(ClosedSpawnData);
+            events2.lock().unwrap().push("spawn");
+        })
+        .on_task_terminate(move |meta| {
+            if meta.take_data::<ClosedSpawnData>().is_some() {
+                events3.lock().unwrap().push("terminate_with_data");
+            }
+        })
+        .build()
+        .unwrap();
+
+    let handle = runtime.handle().clone();
+    drop(runtime);
+
+    drop(handle.spawn(async {}));
+
+    assert_eq!(*events.lock().unwrap(), ["spawn", "terminate_with_data"]);
+}
+
+#[cfg(feature = "tracing")]
+#[test]
+fn task_builder_data_is_visible_to_hooks() {
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(|meta, _parent| {
+            let value = meta.data_mut::<usize>().unwrap();
+            *value += 1;
+        })
+        .on_task_terminate(move |meta| {
+            let value = meta.take_data::<usize>().unwrap();
+            terminated2.lock().unwrap().push(*value);
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::task::Builder::new()
+            .data(41usize)
+            .spawn(async {})
+            .unwrap()
+            .await
+            .unwrap();
+    });
+
+    assert_eq!(*terminated.lock().unwrap(), vec![42]);
+}
+
+#[cfg(feature = "tracing")]
+#[test]
+fn task_builder_data_is_not_dropped_for_spawn_blocking() {
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_terminate(move |meta| {
+            if let Some(value) = meta.take_data::<usize>() {
+                terminated2.lock().unwrap().push(*value);
+            }
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        tokio::task::Builder::new()
+            .data(7usize)
+            .spawn_blocking(|| {})
+            .unwrap()
+            .await
+            .unwrap();
+    });
+
+    assert_eq!(*terminated.lock().unwrap(), vec![7]);
+}
+
 fn mk_spawn_location_hook(
     event: &'static str,
     count: &Arc<AtomicUsize>,
-) -> impl Fn(&tokio::runtime::TaskMeta<'_>) {
+) -> impl Fn(&mut tokio::runtime::TaskMeta<'_>, Option<tokio::runtime::TaskMetaRef<'_>>) {
+    let count = Arc::clone(count);
+    move |data, _parent| {
+        assert_spawn_location(event, count.as_ref(), data);
+    }
+}
+
+fn mk_poll_location_hook(
+    event: &'static str,
+    count: &Arc<AtomicUsize>,
+) -> impl Fn(&mut tokio::runtime::TaskMeta<'_>) {
     let count = Arc::clone(count);
     move |data| {
-        eprintln!("{event} ({:?}): {:?}", data.id(), data.spawned_at());
-        // Assert that the spawn location is in this file.
-        // Don't make assertions about line number/column here, as these
-        // may change as new code is added to the test file...
-        assert_eq!(
-            data.spawned_at().file(),
-            file!(),
-            "incorrect spawn location in {event} hook",
-        );
-        count.fetch_add(1, Ordering::SeqCst);
+        assert_spawn_location(event, count.as_ref(), data);
     }
+}
+
+fn assert_spawn_location(
+    event: &'static str,
+    count: &AtomicUsize,
+    data: &tokio::runtime::TaskMeta<'_>,
+) {
+    eprintln!("{event} ({:?}): {:?}", data.id(), data.spawned_at());
+    assert_eq!(
+        data.spawned_at().file(),
+        file!(),
+        "incorrect spawn location in {event} hook",
+    );
+    count.fetch_add(1, Ordering::SeqCst);
 }

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -454,6 +454,62 @@ fn spawn_hook_can_inherit_parent_task_data() {
 }
 
 #[test]
+fn spawn_hook_can_inherit_parent_task_data_from_future_drop() {
+    struct SpawnOnDrop;
+
+    impl Future for SpawnOnDrop {
+        type Output = ();
+
+        fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for SpawnOnDrop {
+        fn drop(&mut self) {
+            tokio::spawn(async {});
+        }
+    }
+
+    let terminated = Arc::new(Mutex::new(Vec::new()));
+    let terminated2 = Arc::clone(&terminated);
+
+    let runtime = Builder::new_current_thread()
+        .on_task_spawn(|meta, parent| {
+            let depth = match parent {
+                Some(parent) => parent
+                    .data::<Lineage>()
+                    .map_or(0, |parent| parent.depth + 1),
+                None => 0,
+            };
+
+            meta.set_data(Lineage { depth });
+        })
+        .on_task_terminate(move |meta| {
+            let data = meta.take_data::<Lineage>().unwrap();
+            terminated2.lock().unwrap().push(data.depth);
+        })
+        .build()
+        .unwrap();
+
+    runtime.block_on(async {
+        let task = tokio::spawn(SpawnOnDrop);
+        tokio::task::yield_now().await;
+
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+    });
+
+    let mut terminated = terminated.lock().unwrap().clone();
+    terminated.sort_unstable();
+    assert_eq!(terminated, vec![0, 1]);
+}
+
+#[test]
 fn spawn_hook_runs_before_terminate_when_current_thread_runtime_is_closed() {
     struct ClosedSpawnData;
 

--- a/tokio/tests/task_hooks.rs
+++ b/tokio/tests/task_hooks.rs
@@ -549,13 +549,12 @@ fn task_builder_data_is_visible_to_hooks() {
 #[cfg(feature = "tracing")]
 #[test]
 fn task_builder_data_is_not_dropped_for_spawn_blocking() {
-    let terminated = Arc::new(Mutex::new(Vec::new()));
-    let terminated2 = Arc::clone(&terminated);
+    let (terminated_tx, terminated_rx) = std::sync::mpsc::channel();
 
     let runtime = Builder::new_current_thread()
         .on_task_terminate(move |meta| {
             if let Some(value) = meta.take_data::<usize>() {
-                terminated2.lock().unwrap().push(*value);
+                terminated_tx.send(*value).unwrap();
             }
         })
         .build()
@@ -570,7 +569,10 @@ fn task_builder_data_is_not_dropped_for_spawn_blocking() {
             .unwrap();
     });
 
-    assert_eq!(*terminated.lock().unwrap(), vec![7]);
+    let terminated = terminated_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("spawn_blocking task terminate hook did not receive task data");
+    assert_eq!(terminated, 7);
 }
 
 fn mk_spawn_location_hook(


### PR DESCRIPTION
This change overhauls our task hooks system, allowing users to attach user data to individual tasks, which are passed into hooks. Spawn hooks can see both parent and child metadata.