### PR TITLE
time: skip fired Timer registration

### DIFF
--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -221,7 +221,7 @@ async fn reset_much_later() {
 
     sleep(ms(20)).await;
 
-    assert!(queue.is_woken());
+    assert_ready!(poll!(queue));
 }
 
 // Reproduces tokio-rs/tokio#849.
@@ -248,7 +248,7 @@ async fn reset_twice() {
 
     sleep(ms(20)).await;
 
-    assert!(queue.is_woken());
+    assert_ready!(poll!(queue));
 }
 
 /// Regression test: Given an entry inserted with a deadline in the past, so
@@ -412,8 +412,6 @@ async fn expire_first_key_when_reset_to_expire_earlier() {
 
     sleep(ms(100)).await;
 
-    assert!(queue.is_woken());
-
     let entry = assert_ready_some!(poll!(queue)).into_inner();
     assert_eq!(entry, "one");
 }
@@ -435,8 +433,6 @@ async fn expire_second_key_when_reset_to_expire_earlier() {
 
     sleep(ms(100)).await;
 
-    assert!(queue.is_woken());
-
     let entry = assert_ready_some!(poll!(queue)).into_inner();
     assert_eq!(entry, "two");
 }
@@ -456,8 +452,6 @@ async fn reset_first_expiring_item_to_expire_later() {
 
     queue.reset_at(&one, now + ms(300));
     sleep(ms(250)).await;
-
-    assert!(queue.is_woken());
 
     let entry = assert_ready_some!(poll!(queue)).into_inner();
     assert_eq!(entry, "two");
@@ -545,7 +539,6 @@ async fn reset_later_after_slot_starts() {
     // that slot, but doesn't know when, it must wake immediately to advance
     // the wheel.
     queue.reset_at(&foo, now + ms(120));
-    assert!(queue.is_woken());
 
     assert_pending!(poll!(queue));
 
@@ -607,7 +600,6 @@ async fn reset_earlier_after_slot_starts() {
     // that slot, but doesn't know when, it must wake immediately to advance
     // the wheel.
     queue.reset_at(&foo, now + ms(120));
-    assert!(queue.is_woken());
 
     assert_pending!(poll!(queue));
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -502,7 +502,7 @@ cfg_time! {
         pub(crate) fn poll_elapsed(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
-        ) -> Poll<Result<(), crate::time::error::Error>> {
+        ) -> Poll<()> {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
@@ -513,7 +513,7 @@ cfg_time! {
                 // Safety: we never move the inner entries.
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 Timer::Alternative(entry) => unsafe {
-                    Pin::new_unchecked(entry).poll_elapsed(cx).map(Ok)
+                    Pin::new_unchecked(entry).poll_elapsed(cx)
                 }
             }
         }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -446,14 +446,17 @@ cfg_time! {
     impl Timer {
         #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
         #[track_caller]
-        pub(crate) fn new(handle: scheduler::Handle, deadline: Instant) -> Self {
+        pub(crate) fn new(
+            handle: scheduler::Handle,
+            deadline: Instant,
+        ) -> Result<Self, scheduler::Handle> {
             match handle.timer_flavor() {
                 TimerFlavor::Traditional => {
-                    Timer::Traditional(time::TimerEntry::new(handle))
+                    Ok(Timer::Traditional(time::TimerEntry::new(handle)))
                 }
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 TimerFlavor::Alternative => {
-                    Timer::Alternative(time_alt::Timer::new(handle, deadline))
+                    time_alt::Timer::new(handle, deadline).map(Timer::Alternative)
                 }
             }
         }
@@ -480,19 +483,20 @@ cfg_time! {
         }
 
         #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
-        pub(crate) fn reset(self: Pin<&mut Self>, handle: scheduler::Handle, deadline: Instant) {
+        pub(crate) fn reset(
+            self: Pin<&mut Self>,
+            handle: scheduler::Handle,
+            deadline: Instant,
+        ) -> Result<(), scheduler::Handle> {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
                 // Safety: we never move the inner entries.
                 Timer::Traditional(entry) => unsafe {
-                    Pin::new_unchecked(entry).reset(deadline)
+                    Ok(Pin::new_unchecked(entry).reset(deadline))
                 }
-                // Safety: we never move the inner entries.
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-                Timer::Alternative(entry) => unsafe {
-                    Pin::new_unchecked(entry).set(time_alt::Timer::new(handle, deadline))
-                },
+                Timer::Alternative(_) => Err(handle),
             }
         }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -461,7 +461,7 @@ cfg_time! {
             }
         }
 
-        pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) {
+        pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) -> Result<(), ()> {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
@@ -470,7 +470,7 @@ cfg_time! {
                     Pin::new_unchecked(entry).init(deadline)
                 }
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
-                Timer::Alternative(_) => {},
+                Timer::Alternative(_) => Ok(()),
             }
         }
 
@@ -482,7 +482,6 @@ cfg_time! {
             }
         }
 
-        #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
         pub(crate) fn reset(
             self: Pin<&mut Self>,
             handle: scheduler::Handle,
@@ -493,7 +492,7 @@ cfg_time! {
             match this {
                 // Safety: we never move the inner entries.
                 Timer::Traditional(entry) => unsafe {
-                    Ok(Pin::new_unchecked(entry).reset(deadline))
+                    Pin::new_unchecked(entry).reset(deadline).map_err(|()| handle)
                 }
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 Timer::Alternative(_) => Err(handle),

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -162,41 +162,20 @@ impl StateCell {
     }
 
     /// Marks this timer as being moved to the pending list, if its scheduled
-    /// time is not after `not_after`.
+    /// time is `registered`.
     ///
-    /// If the timer is scheduled for a time after `not_after`, returns an Err
-    /// containing the current scheduled time.
+    /// If the timer is scheduled for another time, returns an Err containing
+    /// the current scheduled time.
     ///
     /// SAFETY: Must hold the driver lock.
-    unsafe fn mark_pending(&self, not_after: u64) -> Result<(), u64> {
-        // Quick initial debug check to see if the timer is already fired. Since
-        // firing the timer can only happen with the driver lock held, we know
-        // we shouldn't be able to "miss" a transition to a fired state, even
-        // with relaxed ordering.
-        let mut cur_state = self.state.load(Ordering::Relaxed);
-
-        loop {
-            // improve the error message for things like
-            // https://github.com/tokio-rs/tokio/issues/3675
-            assert!(
-                cur_state < STATE_MIN_VALUE,
-                "mark_pending called when the timer entry is in an invalid state"
-            );
-
-            if cur_state > not_after {
-                break Err(cur_state);
-            }
-
-            match self.state.compare_exchange_weak(
-                cur_state,
-                STATE_PENDING_FIRE,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => break Ok(()),
-                Err(actual_state) => cur_state = actual_state,
-            }
-        }
+    unsafe fn mark_pending(&self, registered: u64) -> Result<(), u64> {
+        self.state.compare_exchange(
+            registered,
+            STATE_PENDING_FIRE,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        )?;
+        Ok(())
     }
 
     /// Fires the timer, setting the result to the provided result.
@@ -204,20 +183,10 @@ impl StateCell {
     /// Returns:
     /// * `Some(waker)` - if fired and a waker needs to be invoked once the
     ///   driver lock is released
-    /// * `None` - if fired and a waker does not need to be invoked, or if
-    ///   already fired
+    /// * `None` - if fired and a waker does not need to be invoked
     ///
     /// SAFETY: The driver lock must be held.
     unsafe fn fire(&self, result: TimerResult) -> Option<Waker> {
-        // Quick initial check to see if the timer is already fired. Since
-        // firing the timer can only happen with the driver lock held, we know
-        // we shouldn't be able to "miss" a transition to a fired state, even
-        // with relaxed ordering.
-        let cur_state = self.state.load(Ordering::Relaxed);
-        if cur_state == STATE_DEREGISTERED {
-            return None;
-        }
-
         // SAFETY: We assume the driver lock is held and the timer is not
         // fired, so only the driver is accessing this field.
         //
@@ -480,12 +449,12 @@ impl TimerEntry {
         }
     }
 
-    pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) {
+    pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) -> Result<(), ()> {
         let tick = self.driver().time_source().deadline_to_tick(deadline);
 
         unsafe {
             self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
+                .register(&self.driver.driver().io, tick, self.inner.handle())
         }
     }
 
@@ -521,17 +490,9 @@ impl TimerEntry {
         unsafe { self.driver().clear_entry(NonNull::from(&self.inner)) };
     }
 
-    pub(crate) fn reset(self: Pin<&mut Self>, deadline: Instant) {
+    pub(crate) fn reset(self: Pin<&mut Self>, deadline: Instant) -> Result<(), ()> {
         let tick = self.driver().time_source().deadline_to_tick(deadline);
-
-        if self.inner.extend_expiration(tick).is_ok() {
-            return;
-        }
-
-        unsafe {
-            self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
-        }
+        self.inner.extend_expiration(tick)
     }
 
     pub(crate) fn poll_elapsed(
@@ -575,8 +536,8 @@ impl TimerHandle {
         }
     }
 
-    /// Attempts to mark this entry as pending. If the expiration time is after
-    /// `not_after`, however, returns an Err with the current expiration time.
+    /// Attempts to mark this entry as pending. If the expiration time is not
+    /// `registered`, however, returns an Err with the current expiration time.
     ///
     /// If an `Err` is returned, the `registered_when` value will be updated to this
     /// new expiration time.
@@ -584,8 +545,8 @@ impl TimerHandle {
     /// SAFETY: The caller must ensure that the handle remains valid, the driver
     /// lock is held, and that the timer is not in any wheel linked lists.
     /// After returning Ok, the entry must be added to the pending list.
-    pub(super) unsafe fn mark_pending(&self, not_after: u64) -> Result<(), u64> {
-        match unsafe { self.inner.as_ref().state.mark_pending(not_after) } {
+    pub(super) unsafe fn mark_pending(&self, registered: u64) -> Result<(), u64> {
+        match unsafe { self.inner.as_ref().state.mark_pending(registered) } {
             Ok(()) => {
                 // mark this as being on the pending queue in registered_when
                 unsafe {
@@ -602,8 +563,7 @@ impl TimerHandle {
         }
     }
 
-    /// Attempts to transition to a terminal state. If the state is already a
-    /// terminal state, does nothing.
+    /// Transitions to a terminal state.
     ///
     /// Because the entry might be dropped after the state is moved to a
     /// terminal state, this function consumes the handle to ensure we don't

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -22,8 +22,7 @@
 //! Each timer has a state field associated with it. This field contains either
 //! the current scheduled time, or a special flag value indicating its state.
 //! This state can either indicate that the timer is on the 'pending' queue (and
-//! thus will be fired with an `Ok(())` result soon) or that it has already been
-//! fired/deregistered.
+//! thus will be fired soon) or that it has already been fired/deregistered.
 //!
 //! This single state field allows for code that is firing the timer to
 //! synchronize with any racing `reset` calls reliably.
@@ -54,7 +53,6 @@
 //!
 //! [mark_pending]: TimerHandle::mark_pending
 
-use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicU64;
 use crate::loom::sync::atomic::Ordering;
 
@@ -67,8 +65,6 @@ use pin_project_lite::pin_project;
 use std::task::{Context, Poll, Waker};
 use std::{marker::PhantomPinned, pin::Pin, ptr::NonNull};
 
-type TimerResult = Result<(), crate::time::error::Error>;
-
 pub(in crate::runtime::time) const STATE_DEREGISTERED: u64 = u64::MAX;
 const STATE_PENDING_FIRE: u64 = STATE_DEREGISTERED - 1;
 const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
@@ -78,8 +74,7 @@ const STATE_MIN_VALUE: u64 = STATE_PENDING_FIRE;
 pub(super) const MAX_SAFE_MILLIS_DURATION: u64 = STATE_MIN_VALUE - 1;
 
 /// This structure holds the current shared state of the timer - its scheduled
-/// time (if registered), or otherwise the result of the timer completing, as
-/// well as the registered waker.
+/// time (if registered) as well as the registered waker.
 ///
 /// Generally, the `StateCell` is only permitted to be accessed from two contexts:
 /// Either a thread holding the corresponding `&mut TimerEntry`, or a thread
@@ -92,11 +87,6 @@ pub(super) struct StateCell {
     /// Holds either the scheduled expiration time for this timer, or (if the
     /// timer has been fired and is unregistered), `u64::MAX`.
     state: AtomicU64,
-    /// If the timer is fired (an Acquire order read on state shows
-    /// `u64::MAX`), holds the result that should be returned from
-    /// polling the timer. Otherwise, the contents are unspecified and reading
-    /// without holding the driver lock is undefined behavior.
-    result: UnsafeCell<TimerResult>,
     /// The currently-registered waker
     waker: AtomicWaker,
 }
@@ -117,7 +107,6 @@ impl StateCell {
     fn new() -> Self {
         Self {
             state: AtomicU64::new(STATE_DEREGISTERED),
-            result: UnsafeCell::new(Ok(())),
             waker: AtomicWaker::new(),
         }
     }
@@ -137,9 +126,7 @@ impl StateCell {
         }
     }
 
-    /// If the timer is completed, returns the result of the timer. Otherwise,
-    /// returns None and registers the waker.
-    fn poll(&self, waker: &Waker) -> Poll<TimerResult> {
+    fn poll(&self, waker: &Waker) -> Poll<()> {
         // We must register first. This ensures that either `fire` will
         // observe the new waker, or we will observe a racing fire to have set
         // the state, or both.
@@ -148,14 +135,11 @@ impl StateCell {
         self.read_state()
     }
 
-    fn read_state(&self) -> Poll<TimerResult> {
+    fn read_state(&self) -> Poll<()> {
         let cur_state = self.state.load(Ordering::Acquire);
 
         if cur_state == STATE_DEREGISTERED {
-            // SAFETY: The driver has fired this timer; this involves writing
-            // the result, and then writing (with release ordering) the state
-            // field.
-            Poll::Ready(unsafe { self.result.with(|p| *p) })
+            Poll::Ready(())
         } else {
             Poll::Pending
         }
@@ -178,7 +162,7 @@ impl StateCell {
         Ok(())
     }
 
-    /// Fires the timer, setting the result to the provided result.
+    /// Fires the timer.
     ///
     /// Returns:
     /// * `Some(waker)` - if fired and a waker needs to be invoked once the
@@ -186,14 +170,7 @@ impl StateCell {
     /// * `None` - if fired and a waker does not need to be invoked
     ///
     /// SAFETY: The driver lock must be held.
-    unsafe fn fire(&self, result: TimerResult) -> Option<Waker> {
-        // SAFETY: We assume the driver lock is held and the timer is not
-        // fired, so only the driver is accessing this field.
-        //
-        // We perform a release-ordered store to state below, to ensure this
-        // write is visible before the state update is visible.
-        unsafe { self.result.with_mut(|p| *p = result) };
-
+    unsafe fn fire(&self) -> Option<Waker> {
         self.state.store(STATE_DEREGISTERED, Ordering::Release);
 
         self.waker.take_waker()
@@ -495,10 +472,7 @@ impl TimerEntry {
         self.inner.extend_expiration(tick)
     }
 
-    pub(crate) fn poll_elapsed(
-        self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-    ) -> Poll<Result<(), super::Error>> {
+    pub(crate) fn poll_elapsed(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         assert!(
             !self.driver().is_shutdown(),
             "{}",
@@ -573,7 +547,7 @@ impl TimerHandle {
     ///
     /// SAFETY: The driver lock must be held while invoking this function, and
     /// the entry must not be in any wheel linked lists.
-    pub(super) unsafe fn fire(self, completed_state: TimerResult) -> Option<Waker> {
-        unsafe { self.inner.as_ref().state.fire(completed_state) }
+    pub(super) unsafe fn fire(self) -> Option<Waker> {
+        unsafe { self.inner.as_ref().state.fire() }
     }
 }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -24,7 +24,6 @@ use super::time_alt;
 use crate::loom::sync::atomic::{AtomicBool, Ordering};
 use crate::loom::sync::Mutex;
 use crate::runtime::driver::{self, IoHandle, IoStack};
-use crate::time::error::Error;
 use crate::time::{Clock, Duration};
 use crate::util::WakeList;
 
@@ -312,7 +311,7 @@ impl Handle {
             debug_assert!(unsafe { entry.is_pending() });
 
             // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
-            if let Some(waker) = unsafe { entry.fire(Ok(())) } {
+            if let Some(waker) = unsafe { entry.fire() } {
                 waker_list.push(waker);
 
                 if !waker_list.can_push() {
@@ -417,7 +416,7 @@ impl Handle {
                     Ok(())
                 }
                 Err((entry, crate::time::error::InsertError::Elapsed)) => {
-                    unsafe { entry.fire(Ok(())) };
+                    unsafe { entry.fire() };
                     Err(())
                 }
             }

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -384,69 +384,43 @@ impl Handle {
             if entry.as_ref().might_be_registered() {
                 lock.wheel.remove(entry);
             }
-
-            entry.as_ref().handle().fire(Ok(()));
         }
     }
 
-    /// Removes and re-adds an entry to the driver.
+    /// Adds an entry to the driver.
     ///
-    /// SAFETY: The timer must be either unregistered, or registered with this
-    /// driver. No other threads are allowed to concurrently manipulate the
-    /// timer at all (the current thread should hold an exclusive reference to
-    /// the `TimerEntry`)
-    pub(self) unsafe fn reregister(
+    /// SAFETY: The timer must be unregistered.
+    unsafe fn register(
         &self,
         unpark: &IoHandle,
         new_tick: u64,
-        entry: NonNull<TimerShared>,
-    ) {
-        let waker = unsafe {
-            let mut lock = self.inner.lock();
+        entry: TimerHandle,
+    ) -> Result<(), ()> {
+        let mut lock = self.inner.lock();
 
-            // We may have raced with a firing/deregistration, so check before
-            // deregistering.
-            if unsafe { entry.as_ref().might_be_registered() } {
-                lock.wheel.remove(entry);
-            }
-
-            // Now that we have exclusive control of this entry, mint a handle to reinsert it.
-            let entry = entry.as_ref().handle();
-
-            if self.is_shutdown() {
-                unsafe { entry.fire(Err(crate::time::error::Error::shutdown())) }
-            } else {
-                entry.set_expiration(new_tick);
-
-                // Note: We don't have to worry about racing with some other resetting
-                // thread, because add_entry and reregister require exclusive control of
-                // the timer entry.
-                match unsafe { lock.wheel.insert(entry) } {
-                    Ok(when) => {
-                        if lock
-                            .next_wake
-                            .map(|next_wake| when < next_wake.get())
-                            .unwrap_or(true)
-                        {
-                            unpark.unpark();
-                        }
-
-                        None
+        if self.is_shutdown() {
+            panic!("{}", crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR);
+        } else {
+            unsafe { entry.set_expiration(new_tick) }
+            // Note: We don't have to worry about racing with some other resetting
+            // thread, because add_entry and reregister require exclusive control of
+            // the timer entry.
+            match unsafe { lock.wheel.insert(entry) } {
+                Ok(when) => {
+                    if lock
+                        .next_wake
+                        .map(|next_wake| when < next_wake.get())
+                        .unwrap_or(true)
+                    {
+                        unpark.unpark();
                     }
-                    Err((entry, crate::time::error::InsertError::Elapsed)) => unsafe {
-                        entry.fire(Ok(()))
-                    },
+                    Ok(())
+                }
+                Err((entry, crate::time::error::InsertError::Elapsed)) => {
+                    unsafe { entry.fire(Ok(())) };
+                    Err(())
                 }
             }
-
-            // Must release lock before invoking waker to avoid the risk of deadlock.
-        };
-
-        // The timer was fired synchronously as a result of the reregistration.
-        // Wake the waker; this is needed because we might reset _after_ a poll,
-        // and otherwise the task won't be awoken to poll again.
-        if let Some(waker) = waker {
-            waker.wake();
         }
     }
 

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -52,7 +52,7 @@ fn single_timer() {
             .init(handle.inner.driver().clock().now() + Duration::from_secs(1))
             .unwrap();
         let jh = thread::spawn(move || {
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx)));
         });
 
         thread::yield_now();
@@ -115,7 +115,7 @@ fn change_waker() {
                 .as_mut()
                 .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
 
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx)));
         });
 
         thread::yield_now();
@@ -153,7 +153,7 @@ fn reset_future() {
             .unwrap();
         let jh = thread::spawn(move || {
             // shouldn't complete before 2s
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx)));
 
             finished_early_.store(true, Ordering::Relaxed);
         });

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -46,14 +46,12 @@ fn single_timer() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
+        entry
+            .as_mut()
+            .init(handle.inner.driver().clock().now() + Duration::from_secs(1))
+            .unwrap();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
-            pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
-
             block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
         });
 
@@ -75,14 +73,12 @@ fn drop_timer() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
+        entry
+            .as_mut()
+            .init(handle.inner.driver().clock().now() + Duration::from_secs(1))
+            .unwrap();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
-            pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
-
             let _ = entry
                 .as_mut()
                 .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
@@ -109,14 +105,12 @@ fn change_waker() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
+        entry
+            .as_mut()
+            .init(handle.inner.driver().clock().now() + Duration::from_secs(1))
+            .unwrap();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
-            pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
-
             let _ = entry
                 .as_mut()
                 .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
@@ -144,21 +138,20 @@ fn reset_future() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
         let finished_early_ = finished_early.clone();
         let start = handle.inner.driver().clock().now();
 
+        let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
+        entry.as_mut().init(start + Duration::from_secs(1)).unwrap();
+
+        let _ = entry
+            .as_mut()
+            .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
+        entry
+            .as_mut()
+            .reset(start + Duration::from_secs(2))
+            .unwrap();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
-            pin!(entry);
-            entry.as_mut().init(start + Duration::from_secs(1));
-
-            let _ = entry
-                .as_mut()
-                .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
-
-            entry.as_mut().reset(start + Duration::from_secs(2));
-
             // shouldn't complete before 2s
             block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
 
@@ -206,11 +199,12 @@ fn poll_process_levels() {
 
     let mut entries = vec![];
 
-    for i in 0..normal_or_miri(1024, 64) {
+    for i in 1..normal_or_miri(1024, 64) + 1 {
         let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
         entry
             .as_mut()
-            .init(handle.inner.driver().clock().now() + Duration::from_millis(i));
+            .init(handle.inner.driver().clock().now() + Duration::from_millis(i))
+            .unwrap();
 
         let _ = entry
             .as_mut()
@@ -219,12 +213,12 @@ fn poll_process_levels() {
         entries.push(entry);
     }
 
-    for t in 1..normal_or_miri(1024, 64) {
+    for t in 1..normal_or_miri(1024, 64) + 1 {
         handle.inner.driver().time().process_at_time(t as u64);
 
         for (deadline, future) in entries.iter_mut().enumerate() {
             let mut context = Context::from_waker(noop_waker_ref());
-            if deadline <= t {
+            if deadline < t {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_ready());
             } else {
                 assert!(future.as_mut().poll_elapsed(&mut context).is_pending());
@@ -244,7 +238,8 @@ fn poll_process_levels_targeted() {
     let e1 = TimerEntry::new(handle.inner.clone());
     pin!(e1);
     e1.as_mut()
-        .init(handle.inner.driver().clock().now() + Duration::from_millis(193));
+        .init(handle.inner.driver().clock().now() + Duration::from_millis(193))
+        .unwrap();
 
     let handle = handle.inner.driver().time();
 

--- a/tokio/src/runtime/time_alt/context.rs
+++ b/tokio/src/runtime/time_alt/context.rs
@@ -24,6 +24,7 @@ impl LocalContext {
 pub(crate) enum TempLocalContext<'a> {
     /// The runtime is running, we can access it.
     Running {
+        elapsed: u64,
         registration_queue: &'a mut RegistrationQueue,
     },
     #[cfg(feature = "rt-multi-thread")]
@@ -34,6 +35,7 @@ pub(crate) enum TempLocalContext<'a> {
 impl<'a> TempLocalContext<'a> {
     pub(crate) fn new_running(cx: &'a mut LocalContext) -> Self {
         TempLocalContext::Running {
+            elapsed: cx.wheel.elapsed(),
             registration_queue: &mut cx.registration_queue,
         }
     }

--- a/tokio/src/runtime/time_alt/timer.rs
+++ b/tokio/src/runtime/time_alt/timer.rs
@@ -27,13 +27,23 @@ impl Drop for Timer {
 
 impl Timer {
     #[track_caller]
-    pub(crate) fn new(handle: scheduler::Handle, deadline: Instant) -> Self {
+    pub(crate) fn new(
+        handle: scheduler::Handle,
+        deadline: Instant,
+    ) -> Result<Self, scheduler::Handle> {
         let tick = deadline_to_tick(&handle, deadline);
-        let entry = with_current_temp_local_context(&handle, |ctx| match ctx {
-            Some(TempLocalContext::Running { registration_queue }) => {
+        with_current_temp_local_context(handle, |handle, ctx| match ctx {
+            Some(TempLocalContext::Running {
+                elapsed,
+                registration_queue: _,
+            }) if tick <= elapsed => Err(handle),
+            Some(TempLocalContext::Running {
+                elapsed: _,
+                registration_queue,
+            }) => {
                 let entry = EntryHandle::new(tick);
                 unsafe { registration_queue.push_front(entry.clone()) }
-                entry
+                Ok(Timer { entry })
             }
             #[cfg(feature = "rt-multi-thread")]
             Some(TempLocalContext::Shutdown) => panic!("{RUNTIME_SHUTTING_DOWN_ERROR}"),
@@ -41,11 +51,9 @@ impl Timer {
             _ => {
                 let entry = EntryHandle::new(tick);
                 push_from_remote(&handle, entry.clone());
-                entry
+                Ok(Timer { entry })
             }
-        });
-
-        Timer { entry }
+        })
     }
 
     pub(crate) fn is_elapsed(&self) -> bool {
@@ -57,9 +65,9 @@ impl Timer {
     }
 }
 
-fn with_current_temp_local_context<F, R>(sched_hdl: &scheduler::Handle, f: F) -> R
+fn with_current_temp_local_context<F, R>(sched_hdl: scheduler::Handle, f: F) -> R
 where
-    F: FnOnce(Option<TempLocalContext<'_>>) -> R,
+    F: FnOnce(scheduler::Handle, Option<TempLocalContext<'_>>) -> R,
 {
     #[cfg(not(feature = "rt"))]
     {
@@ -78,7 +86,7 @@ where
         let is_same_rt = context::with_current(|cur_sched_hdl| {
             use crate::runtime::scheduler::Handle;
 
-            match (sched_hdl, cur_sched_hdl) {
+            match (&sched_hdl, cur_sched_hdl) {
                 (Handle::CurrentThread(_), _) => {
                     // this case is impossible as `tokio::runtime::Builder::enable_alt_timer`
                     // is not supported in the current-thread runtime, but we'd better handle it
@@ -97,14 +105,16 @@ where
             // The timer is being registered from a runtime
             // that is different from the runtime that the timer is created in,
             // so we cannot access `TempLocalContext` of the original runtime.
-            return f(None);
+            return f(sched_hdl, None);
         }
 
         // The timer is being registered from the same runtime that the timer is created in,
         // so we can access `TempLocalContext`.
         context::with_scheduler(|maybe_cx| match maybe_cx {
-            Some(cx) => cx.expect_multi_thread().with_time_temp_local_context(f),
-            None => f(None),
+            Some(cx) => cx
+                .expect_multi_thread()
+                .with_time_temp_local_context(|ctx| f(sched_hdl, ctx)),
+            None => f(sched_hdl, None),
         })
     }
 }

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -227,8 +227,15 @@ pin_project! {
         driver: scheduler::Handle,
         inner: Inner,
         #[pin]
-        timer: Option<Timer>,
+        state: SleepState,
     }
+}
+
+#[derive(Debug)]
+enum SleepState {
+    Active { timer: Timer },
+    Elapsed,
+    Inactive,
 }
 
 cfg_trace! {
@@ -292,7 +299,7 @@ impl Sleep {
             deadline,
             driver: handle,
             inner,
-            timer: None,
+            state: SleepState::Inactive,
         }
     }
 
@@ -309,7 +316,11 @@ impl Sleep {
     ///
     /// A `Sleep` instance is elapsed when the requested duration has elapsed.
     pub fn is_elapsed(&self) -> bool {
-        self.timer.as_ref().is_some_and(Timer::is_elapsed)
+        match &self.state {
+            SleepState::Active { timer } => timer.is_elapsed(),
+            SleepState::Elapsed => true,
+            SleepState::Inactive => false,
+        }
     }
 
     /// Resets the `Sleep` instance to a new deadline.
@@ -369,12 +380,12 @@ impl Sleep {
             );
         }
 
-        match this.timer.as_mut().as_pin_mut() {
+        match this.state.as_mut().as_timer() {
             Some(timer) => timer.reset(handle.clone(), deadline),
             None => {
                 let timer = Timer::new(handle.clone(), deadline);
-                this.timer.set(Some(timer));
-                this.timer.as_pin_mut().unwrap().init(deadline);
+                this.state.set(SleepState::Active { timer });
+                this.state.as_timer().unwrap().init(deadline);
             }
         }
     }
@@ -385,7 +396,7 @@ impl Sleep {
     pub(super) fn reset_without_timer(self: Pin<&mut Self>, deadline: Instant) {
         let mut this = self.project();
         *this.deadline = deadline;
-        this.timer.set(None);
+        this.state.set(SleepState::Inactive);
     }
 
     fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
@@ -402,8 +413,8 @@ impl Sleep {
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 
         let mut this = self.project();
-        let timer = match this.timer.as_mut().as_pin_mut() {
-            Some(timer) => timer,
+        let result = match this.state.as_mut().as_timer() {
+            Some(timer) => timer.poll_elapsed(cx),
             None => {
                 let handle = this.driver;
 
@@ -422,17 +433,17 @@ impl Sleep {
                 }
 
                 let timer = Timer::new(handle.clone(), *this.deadline);
-                this.timer.set(Some(timer));
-                let mut timer = this.timer.as_pin_mut().unwrap();
+                this.state.set(SleepState::Active { timer });
+                let mut timer = this.state.as_mut().as_timer().unwrap();
                 timer.as_mut().init(*this.deadline);
-                timer
+                timer.poll_elapsed(cx)
             }
         };
 
-        let result = timer.poll_elapsed(cx).map(move |r| {
+        if result.is_ready() {
             coop.made_progress();
-            r
-        });
+            this.state.set(SleepState::Elapsed);
+        }
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         return trace_poll_op!("poll_elapsed", result);
@@ -455,6 +466,10 @@ impl Future for Sleep {
     // "logic errors", so we just panic in this case. A user couldn't
     // really do much better if we passed the error onwards.
     fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+        if matches!(self.state, SleepState::Elapsed) {
+            return Poll::Ready(());
+        }
+
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let _res_span = self.inner.ctx.resource_span.clone().entered();
         #[cfg(all(tokio_unstable, feature = "tracing"))]
@@ -464,6 +479,15 @@ impl Future for Sleep {
         match ready!(self.as_mut().poll_elapsed(cx)) {
             Ok(()) => Poll::Ready(()),
             Err(e) => panic!("timer error: {e}"),
+        }
+    }
+}
+
+impl SleepState {
+    fn as_timer(self: Pin<&mut Self>) -> Option<Pin<&mut Timer>> {
+        match unsafe { self.get_unchecked_mut() } {
+            Self::Active { timer } => unsafe { Some(Pin::new_unchecked(timer)) },
+            _ => None,
         }
     }
 }

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -1,5 +1,5 @@
 use crate::runtime::{scheduler, Timer};
-use crate::time::{error::Error, Duration, Instant};
+use crate::time::{Duration, Instant};
 use crate::util::trace;
 
 use pin_project_lite::pin_project;
@@ -407,7 +407,7 @@ impl Sleep {
         this.state.set(SleepState::Inactive);
     }
 
-    fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
+    fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<()> {
         ready!(crate::trace::trace_leaf());
 
         // Keep track of task budget
@@ -445,10 +445,10 @@ impl Sleep {
                     let mut timer = this.state.as_mut().as_timer().unwrap();
                     match timer.as_mut().init(*this.deadline) {
                         Ok(()) => timer.poll_elapsed(cx),
-                        Err(()) => Poll::Ready(Ok(())),
+                        Err(()) => Poll::Ready(()),
                     }
                 } else {
-                    Poll::Ready(Ok(()))
+                    Poll::Ready(())
                 }
             }
         };
@@ -469,16 +469,7 @@ impl Sleep {
 impl Future for Sleep {
     type Output = ();
 
-    // `poll_elapsed` can return an error in two cases:
-    //
-    // - AtCapacity: this is a pathological case where far too many
-    //   sleep instances have been scheduled.
-    // - Shutdown: No timer has been setup, which is a misuse error.
-    //
-    // Both cases are extremely rare, and pretty accurately fit into
-    // "logic errors", so we just panic in this case. A user couldn't
-    // really do much better if we passed the error onwards.
-    fn poll(mut self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Self::Output> {
         if matches!(self.state, SleepState::Elapsed) {
             return Poll::Ready(());
         }
@@ -489,10 +480,7 @@ impl Future for Sleep {
         let _ao_span = self.inner.ctx.async_op_span.clone().entered();
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let _ao_poll_span = self.inner.ctx.async_op_poll_span.clone().entered();
-        match ready!(self.as_mut().poll_elapsed(cx)) {
-            Ok(()) => Poll::Ready(()),
-            Err(e) => panic!("timer error: {e}"),
-        }
+        self.poll_elapsed(cx)
     }
 }
 

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -356,7 +356,7 @@ impl Sleep {
         let mut this = self.project();
         *this.deadline = deadline;
 
-        let handle = this.driver;
+        let mut handle = this.driver.clone();
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         {
@@ -380,13 +380,18 @@ impl Sleep {
             );
         }
 
-        match this.state.as_mut().as_timer() {
-            Some(timer) => timer.reset(handle.clone(), deadline),
-            None => {
-                let timer = Timer::new(handle.clone(), deadline);
-                this.state.set(SleepState::Active { timer });
-                this.state.as_timer().unwrap().init(deadline);
+        if let Some(timer) = this.state.as_mut().as_timer() {
+            match timer.reset(handle, deadline) {
+                Ok(()) => return,
+                Err(recovered) => handle = recovered,
             }
+        }
+
+        if let Ok(timer) = Timer::new(handle, deadline) {
+            this.state.set(SleepState::Active { timer });
+            this.state.as_timer().unwrap().init(deadline);
+        } else {
+            this.state.set(SleepState::Elapsed);
         }
     }
 
@@ -432,11 +437,14 @@ impl Sleep {
                     );
                 }
 
-                let timer = Timer::new(handle.clone(), *this.deadline);
-                this.state.set(SleepState::Active { timer });
-                let mut timer = this.state.as_mut().as_timer().unwrap();
-                timer.as_mut().init(*this.deadline);
-                timer.poll_elapsed(cx)
+                if let Ok(timer) = Timer::new(handle.clone(), *this.deadline) {
+                    this.state.set(SleepState::Active { timer });
+                    let mut timer = this.state.as_mut().as_timer().unwrap();
+                    timer.as_mut().init(*this.deadline);
+                    timer.poll_elapsed(cx)
+                } else {
+                    Poll::Ready(Ok(()))
+                }
             }
         };
 

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -389,7 +389,10 @@ impl Sleep {
 
         if let Ok(timer) = Timer::new(handle, deadline) {
             this.state.set(SleepState::Active { timer });
-            this.state.as_timer().unwrap().init(deadline);
+            let timer = this.state.as_mut().as_timer().unwrap();
+            if timer.init(deadline).is_err() {
+                this.state.set(SleepState::Elapsed);
+            }
         } else {
             this.state.set(SleepState::Elapsed);
         }
@@ -440,8 +443,10 @@ impl Sleep {
                 if let Ok(timer) = Timer::new(handle.clone(), *this.deadline) {
                     this.state.set(SleepState::Active { timer });
                     let mut timer = this.state.as_mut().as_timer().unwrap();
-                    timer.as_mut().init(*this.deadline);
-                    timer.poll_elapsed(cx)
+                    match timer.as_mut().init(*this.deadline) {
+                        Ok(()) => timer.poll_elapsed(cx),
+                        Err(()) => Poll::Ready(Ok(())),
+                    }
                 } else {
                     Poll::Ready(Ok(()))
                 }

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -167,9 +167,6 @@ async fn reset_sleep_to_past() {
 
     sleep.as_mut().reset(now + ms(40));
 
-    // TODO: is this required?
-    //assert!(sleep.is_woken());
-
     assert_ready!(sleep.poll());
 }
 


### PR DESCRIPTION
## Motivation

Timer firing and registration is expensive. Adding an elapsed Sleep state enables skipping fired timer registration as well as reduce Timer complexity.

## Solution

Add an elapsed Sleep state. Make Timer creation and extension fallible for past deadlines. Make Timer firing a terminal state (don't reregister fired timers, but create new ones) and clean up dead code.

### Compatibility Notes

- Calling `Sleep::reset` with an elapsed deadline no longer spuriously wakes the previously registered waker.
- Calling `Sleep::poll` for an elapsed deadline no longer spuriously wakes the waker.
- Calling `Sleep::poll` for an elapsed deadline no longer spuriously returns `Poll::Pending` if it previously returned `Poll::Ready` (i.e. it is Fused).