### PR TITLE
sync: remove useless conversion in oneshot Receiver::poll

### DIFF
--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -1279,10 +1279,10 @@ impl<T> Future for Receiver<T> {
 
         let ret = if let Some(inner) = self.as_ref().get_ref().inner.as_ref() {
             #[cfg(all(tokio_unstable, feature = "tracing"))]
-            let res = ready!(trace_poll_op!("poll_recv", inner.poll_recv(cx))).map_err(Into::into);
+            let res = ready!(trace_poll_op!("poll_recv", inner.poll_recv(cx)));
 
             #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
-            let res = ready!(inner.poll_recv(cx)).map_err(Into::into);
+            let res = ready!(inner.poll_recv(cx));
 
             res
         } else {


### PR DESCRIPTION
## Summary

`Inner::poll_recv` returns `Poll<Result<T, RecvError>>` and `Receiver`'s `Future::Output` is `Result<T, RecvError>`, so the `.map_err(Into::into)` in `Receiver::poll` is an identity conversion. Newer `clippy` flags it as `clippy::useless_conversion`. This removes it from both `#[cfg]` arms — no behavior change.

Verified `cargo clippy -p tokio --features full --lib` is clean afterwards (and `RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p tokio --features full,tracing --lib` for the other arm), and `cargo test -p tokio --test sync_oneshot` passes.
