### PR TITLE
tokio-stream: fix duplicated word in changelog

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Documented
 
-- stream: improve the the docs of `TcpListenerStream` ([#7578])
+- stream: improve the docs of `TcpListenerStream` ([#7578])
 
 [#7024]: https://github.com/tokio-rs/tokio/pull/7024
 [#7492]: https://github.com/tokio-rs/tokio/pull/7492


### PR DESCRIPTION
Fix a duplicated word in the `tokio-stream` CHANGELOG entry.

Line in question: `- stream: improve the the docs of `TcpListenerStream``

The word "the" appears twice. This removes the duplicate.