### PR TITLE
ci: fix macos runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       # Run `tokio` with stable features. This excludes testing utilities which
       # can alter the runtime behavior of Tokio.
@@ -112,7 +112,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       - name: test --features ${{ env.TOKIO_STABLE_FEATURES }}
         run: |
@@ -154,7 +154,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       - name: test --features ${{ env.TOKIO_STABLE_FEATURES }} panic=abort
         run: |
@@ -190,7 +190,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       # Run integration tests for each feature
       - name: test tests-integration --each-feature
@@ -301,7 +301,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
       # Run `tokio` with "unstable" cfg flag.
       - name: test tokio full --cfg unstable
         run: |
@@ -953,7 +953,7 @@ jobs:
           # default: ". -> target"
           workspaces: "./hyper"
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       - name: Test hyper
         run: cargo test --features full
@@ -1003,7 +1003,7 @@ jobs:
           # default: ". -> target"
           workspaces: "./quinn"
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
-          cache-bin: "false"
+          cache-bin: ${{ matrix.os != 'macos-latest' }}
 
       - name: Test Quinn
         working-directory: quinn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
           tool: cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       # Run `tokio` with stable features. This excludes testing utilities which
       # can alter the runtime behavior of Tokio.
@@ -146,6 +149,9 @@ jobs:
           tool: cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       - name: test --features ${{ env.TOKIO_STABLE_FEATURES }} panic=abort
         run: |
@@ -937,7 +943,8 @@ jobs:
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
           workspaces: "./hyper"
-          cache-bin: false # tmp fix for the macos-runner issues: https://github.com/actions/runner-images/issues/14097
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       - name: Test hyper
         run: cargo test --features full
@@ -986,6 +993,9 @@ jobs:
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
           workspaces: "./quinn"
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
+          
 
       - name: Test Quinn
         working-directory: quinn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,6 +937,7 @@ jobs:
           # relative to the `$workspace` and defaults to "target" if not explicitly given.
           # default: ". -> target"
           workspaces: "./hyper"
+          cache-bin: false # tmp fix for the macos-runner issues: https://github.com/actions/runner-images/issues/14097
 
       - name: Test hyper
         run: cargo test --features full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
           tool: cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       - name: test --features ${{ env.TOKIO_STABLE_FEATURES }}
         run: |
@@ -185,6 +188,9 @@ jobs:
           tool: cargo-hack
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
 
       # Run integration tests for each feature
       - name: test tests-integration --each-feature
@@ -293,6 +299,9 @@ jobs:
           tool: cargo-nextest
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
+          cache-bin: "false"
       # Run `tokio` with "unstable" cfg flag.
       - name: test tokio full --cfg unstable
         run: |
@@ -995,7 +1004,6 @@ jobs:
           workspaces: "./quinn"
           # FIXME: temporary workaround, see: https://github.com/Swatinem/rust-cache/issues/341
           cache-bin: "false"
-          
 
       - name: Test Quinn
         working-directory: quinn


### PR DESCRIPTION
We started to observe failures in macOS runners, it seems that disabling the cache-bin option for rust-cache fixes the issue (this is a temporary fix that will be reverted once the upstream fixes the issue). see: https://github.com/Swatinem/rust-cache/issues/341