### PR TITLE
Relax Lines::get_ref receiver to &self

### DIFF
--- a/tokio/src/io/util/lines.rs
+++ b/tokio/src/io/util/lines.rs
@@ -78,7 +78,7 @@ where
     }
 
     /// Obtains a reference to the underlying reader.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.reader
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Lines::get_ref only returns a shared reference to the underlying reader and does not mutate internal state, so it does not need a mutable receiver. 

Changing the receiver from &mut self to &self also makes it consistent with other Tokio IO wrapper get_ref methods such as BufReader, BufWriter, BufStream, Take, and Chain.



## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
