### PR TITLE
docs(fs): clarify create_dir_all succeeds if path exists

### DIFF
--- a/tokio/src/fs/create_dir_all.rs
+++ b/tokio/src/fs/create_dir_all.rs
@@ -26,6 +26,9 @@ use std::path::Path;
 ///   when a directory is being created (after it is determined to not exist) are
 ///   outlined by [`fs::create_dir`].
 ///
+/// If the final component at `path` already exists and is a directory, this
+/// function will also return successfully without error.
+///
 /// Notable exception is made for situations where any of the directories
 /// specified in the `path` could not be created as it was being created concurrently.
 /// Such cases are considered to be successful. That is, calling `create_dir_all`


### PR DESCRIPTION
Fixes #7424