### PR TITLE
rt: replace current-thread scheduler VecDeque with LinkedList

### DIFF
--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -3,7 +3,8 @@ use crate::loom::sync::Arc;
 use crate::runtime::driver::{self, Driver};
 use crate::runtime::scheduler::{self, Defer, Inject};
 use crate::runtime::task::{
-    self, JoinHandle, OwnedTasks, Schedule, SpawnLocation, Task, TaskHarnessScheduleHooks,
+    self, JoinHandle, LocalQueue, OwnedTasks, Schedule, SpawnLocation, Task,
+    TaskHarnessScheduleHooks,
 };
 use crate::runtime::{
     blocking, context, Config, MetricsBatch, SchedulerMetrics, TaskHooks, TaskMeta, WorkerMetrics,
@@ -13,7 +14,6 @@ use crate::util::atomic_cell::AtomicCell;
 use crate::util::{waker_ref, RngSeedGenerator, Wake, WakerRef};
 
 use std::cell::RefCell;
-use std::collections::VecDeque;
 use std::future::{poll_fn, Future};
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Release};
 use std::task::Poll::{Pending, Ready};
@@ -60,7 +60,7 @@ pub(crate) struct Handle {
 /// a function that will perform the scheduling work and acts as a capability token.
 struct Core {
     /// Scheduler run queue
-    tasks: VecDeque<Notified>,
+    tasks: LocalQueue<Arc<Handle>>,
 
     /// Current tick
     tick: u32,
@@ -119,9 +119,6 @@ pub(crate) struct Context {
 
 type Notified = task::Notified<Arc<Handle>>;
 
-/// Initial queue capacity.
-const INITIAL_CAPACITY: usize = 64;
-
 /// Used if none is specified. This is a temporary constant and will be removed
 /// as we unify tuning logic between the multi-thread and current-thread
 /// schedulers.
@@ -170,7 +167,7 @@ impl CurrentThread {
         });
 
         let core = AtomicCell::new(Some(Box::new(Core {
-            tasks: VecDeque::with_capacity(INITIAL_CAPACITY),
+            tasks: LocalQueue::new(),
             tick: 0,
             driver: Some(driver),
             metrics: MetricsBatch::new(&handle.shared.worker_metrics),

--- a/tokio/src/runtime/task/local_queue.rs
+++ b/tokio/src/runtime/task/local_queue.rs
@@ -1,0 +1,66 @@
+use super::{Notified, RawTask, Schedule};
+
+use std::marker::PhantomData;
+
+/// A singly-linked FIFO queue that reuses `Header::queue_next` for linking.
+///
+/// A task must not be in any other queue that uses `queue_next` (e.g., the
+/// inject queue) while it is in this queue.
+pub(crate) struct LocalQueue<S: 'static> {
+    head: Option<RawTask>,
+    tail: Option<RawTask>,
+    len: usize,
+    _schedule: PhantomData<S>,
+}
+
+// Safety: RawTask is !Send only because it wraps NonNull<Header>. The values
+// stored here originate from Notified<S> which is Send when S: Schedule.
+unsafe impl<S: Schedule> Send for LocalQueue<S> {}
+
+impl<S: 'static> LocalQueue<S> {
+    pub(crate) fn new() -> Self {
+        Self {
+            head: None,
+            tail: None,
+            len: 0,
+            _schedule: PhantomData,
+        }
+    }
+
+    pub(crate) fn push_back(&mut self, task: Notified<S>) {
+        let raw = task.into_raw();
+        unsafe { raw.set_queue_next(None) };
+        if let Some(tail) = self.tail {
+            unsafe { tail.set_queue_next(Some(raw)) };
+        } else {
+            self.head = Some(raw);
+        }
+        self.tail = Some(raw);
+        self.len += 1;
+    }
+
+    pub(crate) fn pop_front(&mut self) -> Option<Notified<S>> {
+        let head = self.head?;
+        self.head = unsafe { head.get_queue_next() };
+        if self.head.is_none() {
+            self.tail = None;
+        }
+        unsafe { head.set_queue_next(None) };
+        self.len -= 1;
+        Some(unsafe { Notified::from_raw(head) })
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<S: 'static> Drop for LocalQueue<S> {
+    fn drop(&mut self) {
+        while self.pop_front().is_some() {}
+    }
+}

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -203,6 +203,9 @@ pub use self::join::JoinHandle;
 mod list;
 pub(crate) use self::list::{LocalOwnedTasks, OwnedTasks};
 
+mod local_queue;
+pub(crate) use self::local_queue::LocalQueue;
+
 mod raw;
 pub(crate) use self::raw::RawTask;
 

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -5,7 +5,6 @@ use crate::task::Id;
 
 use backtrace::BacktraceFrame;
 use std::cell::Cell;
-use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::fmt;
 use std::future::Future;
@@ -20,7 +19,7 @@ mod tree;
 use symbol::Symbol;
 use tree::Tree;
 
-use super::{Notified, OwnedTasks, Schedule};
+use super::{LocalQueue, Notified, OwnedTasks, Schedule};
 
 type Backtrace = Vec<BacktraceFrame>;
 type SymbolTrace = Vec<Symbol>;
@@ -364,14 +363,14 @@ impl<T: Future> Future for Root<T> {
 /// Trace and poll all tasks of the `current_thread` runtime.
 pub(in crate::runtime) fn trace_current_thread(
     owned: &OwnedTasks<Arc<current_thread::Handle>>,
-    local: &mut VecDeque<Notified<Arc<current_thread::Handle>>>,
+    local: &mut LocalQueue<Arc<current_thread::Handle>>,
     injection: &Inject<Arc<current_thread::Handle>>,
 ) -> Vec<(Id, Trace)> {
     // clear the local and injection queues
 
     let mut dequeued = Vec::new();
 
-    while let Some(task) = local.pop_back() {
+    while let Some(task) = local.pop_front() {
         dequeued.push(task);
     }
 


### PR DESCRIPTION
This PR changes `current_thread` runtime `Core.tasks` from a `VecDeque` to an intrusive linked list, `LocalQueue<Arc<Handle>>`. This avoids dynamic allocations in `Core.task`.

I ran `benches/rt_current_thread.rs` on an AMD Ryzen 9 5950X:
* spawn_many_local: 2-3% faster, noise?
* spawn_many_remote_idle: no change
* spawn_many_remote_busy: over 20% faster

Worth noting, if you blow up the number of spawns from 1k to 10k, `spawn_many_remote_busy` ends up being  15% slower with this change. I would guess at this point, the VecDeque ends up being more cache friendly but this also feels a bit like a degenerate situation at this point and it's probably better to take the win at <1k tasks?