### PR TITLE
Don't panic when using an interval with max Duration

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -340,10 +340,12 @@ impl MissedTickBehavior {
     /// If a tick is missed, this method is called to determine when the next tick should happen.
     fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
         match self {
-            Self::Burst => timeout + period,
-            Self::Delay => now + period,
+            Self::Burst => timeout
+                .checked_add(period)
+                .unwrap_or_else(Instant::far_future),
+            Self::Delay => now.checked_add(period).unwrap_or_else(Instant::far_future),
             Self::Skip => {
-                now + period
+                now.checked_add(period).unwrap_or_else(Instant::far_future)
                     - Duration::from_nanos(
                         ((now - timeout).as_nanos() % period.as_nanos())
                             .try_into()

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -352,6 +352,37 @@ async fn reset_at_bigger_than_interval() {
     check_interval_poll!(i, start, 1701);
 }
 
+#[tokio::test(start_paused = true)]
+async fn interval_missed_tick_doesnt_panic_with_max_duration() {
+    // all behaviors should be able to handle Duration::MAX
+    for behavior in [
+        MissedTickBehavior::Delay,
+        MissedTickBehavior::Burst,
+        MissedTickBehavior::Skip,
+    ] {
+        for missed_tick_delay_duration in [
+            ms(300),
+            // a long time just less than `far_future` uses
+            Duration::from_secs(86400 * 365 * 29),
+            // a long time just more than `far_future` uses
+            Duration::from_secs(86400 * 365 * 31),
+        ] {
+            let mut long_interval = time::interval(Duration::MAX);
+            long_interval.set_missed_tick_behavior(behavior);
+
+            // cause a missed tick
+            time::advance(missed_tick_delay_duration).await;
+
+            tokio::select! {
+                // when the missed tick overflow bug exists, this will panic in missed tick logic
+                _ = long_interval.tick() => {}
+                // if no bug, the above branch will wait forever, but this will let the test pass
+                _ = time::sleep(Duration::from_millis(10)) => {}
+            }
+        }
+    }
+}
+
 fn poll_next(interval: &mut task::Spawn<time::Interval>) -> Poll<Instant> {
     interval.enter(|cx, mut interval| interval.poll_tick(cx))
 }


### PR DESCRIPTION
Currently, `MissedTickBehavior::next_timeout` panics when `period` is `Duration::MAX`. (Using such a large duration is convenient when you want to conditionally disable an interval.)

## Motivation

Nothing should panic when using `Duration::MAX`.

## Solution

Use `checked_add` with `Instant::far_future` as a fallback instead of `ops::Add`, as this fits with another case that uses `far_future` instead of `std::time::Instant::saturating_add`.

Side note 1: consider adding `saturating_add` to `Instant`, since this idiom is likely to be more common, especially given side note 2.

Side note 2: consider removing `ops::*` impls for `Instant` as there are likely other panics lurking. In my current project we have done this with our own Instant equivalent, and require all time manipulation to handle edge cases explicitly. With some `saturating_*` and perhaps `add_or_panic(duration, "explanation of why it will never panic")`, the same could probably be done here. Given the [history](https://github.com/tokio-rs/tokio/issues/6634) of previous similar issues, I think a more blanket approach to resolving that bug class is warranted.