### PR TITLE
feat: add SQPOLL support for io_uring (rebased)

### DIFF
--- a/spellcheck.dic
+++ b/spellcheck.dic
@@ -245,6 +245,7 @@ SmallCrush
 Solaris
 spawner
 Splitter
+SQPOLL
 spmc
 spsc
 SQE

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -63,6 +63,16 @@ pub struct Builder {
     enable_io: bool,
     nevents: usize,
 
+    /// Idle timeout (in milliseconds) for the io_uring SQPOLL kernel thread.
+    #[cfg(all(
+        tokio_unstable,
+        feature = "io-uring",
+        feature = "rt",
+        feature = "fs",
+        target_os = "linux"
+    ))]
+    uring_setup_sqpoll: Option<u32>,
+
     /// Whether or not to enable the time driver
     enable_time: bool,
 
@@ -286,6 +296,15 @@ impl Builder {
             // I/O defaults to "off"
             enable_io: false,
             nevents: 1024,
+
+            #[cfg(all(
+                tokio_unstable,
+                feature = "io-uring",
+                feature = "rt",
+                feature = "fs",
+                target_os = "linux"
+            ))]
+            uring_setup_sqpoll: None,
 
             // Time defaults to "off"
             enable_time: false,
@@ -1672,6 +1691,13 @@ impl Builder {
         cfg.timer_flavor = TimerFlavor::Traditional;
         let (driver, driver_handle) = driver::Driver::new(cfg)?;
 
+        #[cfg(all(tokio_unstable, feature = "io-uring", feature = "rt", feature = "fs", target_os = "linux"))]
+        if let Some(idle_timeout) = self.uring_setup_sqpoll {
+            if let Some(io) = driver_handle.io.as_ref() {
+                io.setup_uring_sqpoll(idle_timeout);
+            }
+        }
+
         // Blocking pool
         let blocking_pool = blocking::create_blocking_pool(self, self.max_blocking_threads);
         let blocking_spawner = blocking_pool.spawner().clone();
@@ -1821,6 +1847,35 @@ cfg_io_uring! {
             self.enable_io = true;
             self
         }
+
+        /// Configures the io_uring driver to use SQPOLL mode.
+        ///
+        /// When set, the io_uring driver will use a kernel-side thread to poll
+        /// the submission queue, which can reduce latency for I/O operations at
+        /// the cost of increased CPU usage.
+        ///
+        /// The `idle_timeout` parameter specifies how long (in milliseconds) the
+        /// kernel thread should wait before going to sleep when there are no
+        /// submissions to process. A value of 0 means the thread never sleeps.
+        ///
+        /// This option requires `enable_io_uring()` or `enable_all()` to also be called.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime;
+        ///
+        /// let rt = runtime::Builder::new_multi_thread()
+        ///     .enable_io_uring()
+        ///     .uring_setup_sqpoll(2000)
+        ///     .build()
+        ///     .unwrap();
+        /// ```
+        #[cfg_attr(docsrs, doc(cfg(all(feature = "io-uring", feature = "rt", feature = "fs"))))]
+        pub fn uring_setup_sqpoll(&mut self, idle_timeout: u32) -> &mut Self {
+            self.uring_setup_sqpoll = Some(idle_timeout);
+            self
+        }
     }
 }
 
@@ -1859,6 +1914,13 @@ cfg_rt_multi_thread! {
             let worker_threads = self.worker_threads.unwrap_or_else(num_cpus);
 
             let (driver, driver_handle) = driver::Driver::new(self.get_cfg())?;
+
+            #[cfg(all(tokio_unstable, feature = "io-uring", feature = "rt", feature = "fs", target_os = "linux"))]
+            if let Some(idle_timeout) = self.uring_setup_sqpoll {
+                if let Some(io) = driver_handle.io.as_ref() {
+                    io.setup_uring_sqpoll(idle_timeout);
+                }
+            }
 
             // Create the blocking pool
             let blocking_pool =

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1871,7 +1871,7 @@ cfg_io_uring! {
         ///     .build()
         ///     .unwrap();
         /// ```
-        #[cfg_attr(docsrs, doc(cfg(all(feature = "io-uring", feature = "rt", feature = "fs"))))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "io-uring")))]
         pub fn uring_setup_sqpoll(&mut self, idle_timeout: u32) -> &mut Self {
             self.uring_setup_sqpoll = Some(idle_timeout);
             self

--- a/tokio/src/runtime/io/driver/uring.rs
+++ b/tokio/src/runtime/io/driver/uring.rs
@@ -17,6 +17,7 @@ const DEFAULT_RING_SIZE: u32 = 256;
 pub(crate) struct UringContext {
     pub(crate) uring: Option<io_uring::IoUring>,
     pub(crate) ops: slab::Slab<Lifecycle>,
+    pub(crate) sqpoll_idle: Option<u32>,
 }
 
 impl UringContext {
@@ -24,6 +25,7 @@ impl UringContext {
         Self {
             ops: Slab::new(),
             uring: None,
+            sqpoll_idle: None,
         }
     }
 
@@ -46,7 +48,13 @@ impl UringContext {
             return Ok(false);
         }
 
-        let uring = IoUring::new(DEFAULT_RING_SIZE)?;
+        let uring = if let Some(idle_timeout) = self.sqpoll_idle {
+            IoUring::builder()
+                .setup_sqpoll(idle_timeout)
+                .build(DEFAULT_RING_SIZE)?
+        } else {
+            IoUring::new(DEFAULT_RING_SIZE)?
+        };
 
         match uring.submitter().register_probe(probe) {
             Ok(_) => {}
@@ -106,6 +114,14 @@ impl UringContext {
     }
 
     pub(crate) fn submit(&mut self) -> io::Result<()> {
+        if self.sqpoll_idle.is_some() {
+            let mut sq = self.ring_mut().submission();
+            sq.sync();
+            if !sq.need_wakeup() {
+                return Ok(());
+            }
+        }
+
         loop {
             // Errors from io_uring_enter: https://man7.org/linux/man-pages/man2/io_uring_enter.2.html#ERRORS
             match self.ring().submit() {
@@ -181,6 +197,11 @@ impl Handle {
 
     pub(crate) fn get_uring(&self) -> &Mutex<UringContext> {
         &self.uring_context
+    }
+
+    pub(crate) fn setup_uring_sqpoll(&self, idle_timeout: u32) {
+        let mut guard = self.get_uring().lock();
+        guard.sqpoll_idle = Some(idle_timeout);
     }
 
     /// Returns `true` if io_uring has already been initialized and the given

--- a/tokio/tests/fs_uring_sqpoll.rs
+++ b/tokio/tests/fs_uring_sqpoll.rs
@@ -1,0 +1,83 @@
+#![cfg(all(
+    tokio_unstable,
+    feature = "io-uring",
+    feature = "rt",
+    feature = "fs",
+    target_os = "linux"
+))]
+
+use std::io::{Read, Seek, SeekFrom};
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
+use tokio::runtime::Builder;
+
+#[test]
+fn test_sqpoll_current_thread() {
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .uring_setup_sqpoll(1000)
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .await
+            .unwrap();
+
+        file.write_all(b"hello").await.unwrap();
+        file.flush().await.unwrap();
+
+        // Check if data was actually written to the underlying file
+        let mut buf = vec![0; 5];
+        temp.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+        temp.as_file_mut().read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"hello");
+
+        file.seek(std::io::SeekFrom::Start(0)).await.unwrap();
+        let mut buf = vec![0; 5];
+        file.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"hello");
+    });
+}
+
+#[test]
+fn test_sqpoll_multi_thread() {
+    let rt = Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .uring_setup_sqpoll(1000)
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut temp = NamedTempFile::new().unwrap();
+        let path = temp.path().to_path_buf();
+
+        let mut file = tokio::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .await
+            .unwrap();
+
+        file.write_all(b"world").await.unwrap();
+        file.flush().await.unwrap();
+
+        // Check if data was actually written to the underlying file
+        let mut buf = vec![0; 5];
+        temp.as_file_mut().seek(SeekFrom::Start(0)).unwrap();
+        temp.as_file_mut().read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"world");
+
+        file.seek(std::io::SeekFrom::Start(0)).await.unwrap();
+        let mut buf = vec![0; 5];
+        file.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"world");
+    });
+}

--- a/tokio/tests/fs_uring_sqpoll.rs
+++ b/tokio/tests/fs_uring_sqpoll.rs
@@ -1,3 +1,5 @@
+//! SQPOLL mode tests for io_uring file operations.
+
 #![cfg(all(
     tokio_unstable,
     feature = "io-uring",
@@ -11,8 +13,18 @@ use tempfile::NamedTempFile;
 use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt};
 use tokio::runtime::Builder;
 
+use crate::support::io_uring::io_uring_supported;
+
+mod support {
+    pub(crate) mod io_uring;
+}
+
 #[test]
 fn test_sqpoll_current_thread() {
+    if !io_uring_supported() {
+        return;
+    }
+
     let rt = Builder::new_current_thread()
         .enable_all()
         .uring_setup_sqpoll(1000)
@@ -48,6 +60,10 @@ fn test_sqpoll_current_thread() {
 
 #[test]
 fn test_sqpoll_multi_thread() {
+    if !io_uring_supported() {
+        return;
+    }
+
     let rt = Builder::new_multi_thread()
         .worker_threads(2)
         .enable_all()


### PR DESCRIPTION
Rebase of #7960 onto current master. Original PR by @SidongYang, approved by @martin-g.

This adds `uring_setup_sqpoll` to the Runtime Builder, allowing the io_uring driver to use SQPOLL mode which offloads submission queue polling to a kernel thread.

Rebased to resolve divergence and CI failures from the original PR.