### PR TITLE
net: enable Miri tests for TCP socket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2026-04-27
+  rust_miri_nightly: nightly-2026-05-20
   rust_clippy: '1.88'
   # When updating this, also update:
   # - README.md

--- a/tokio-util/tests/udp.rs
+++ b/tokio-util/tests/udp.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(not(target_os = "wasi"))] // Wasi doesn't support UDP
-#![cfg(not(miri))] // No `socket` in Miri.
+#![cfg(not(miri))] // No UDP sockets in Miri.
 #![cfg(not(loom))] // No udp / UdpFramed in loom
 
 use tokio::net::UdpSocket;

--- a/tokio/src/io/util/mod.rs
+++ b/tokio/src/io/util/mod.rs
@@ -84,7 +84,7 @@ cfg_io_util! {
 
 
     // used by `BufReader` and `BufWriter`
-    // https://github.com/rust-lang/rust/blob/master/library/std/src/sys_common/io.rs#L1
+    // https://github.com/rust-lang/rust/blob/main/library/std/src/sys/io/mod.rs#L72
     const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 
     cfg_coop! {

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -91,7 +91,6 @@ impl TcpListener {
         ///
         /// #[tokio::main]
         /// async fn main() -> io::Result<()> {
-        /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
         ///     let listener = TcpListener::bind("127.0.0.1:2345").await?;
         ///
         ///     // use the listener

--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -945,7 +945,6 @@ impl TcpSocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> std::io::Result<()> {
-    /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
     ///     let socket2_socket = Socket::new(Domain::IPV4, Type::STREAM, None)?;
     ///     socket2_socket.set_nonblocking(true)?;
     ///

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -231,7 +231,6 @@ impl TcpStream {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
-    /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
     ///     let mut data = [0u8; 12];
     /// #   if false {
     ///     let listener = TcpListener::bind("127.0.0.1:34254").await?;

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -140,7 +140,7 @@ impl UdpSocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> io::Result<()> {
-    /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// #   if cfg!(miri) { return Ok(()); } // No UDP sockets in miri.
     ///     let sock = UdpSocket::bind("0.0.0.0:8080").await?;
     ///     // use `sock`
     /// #   let _ = sock;
@@ -308,7 +308,7 @@ impl UdpSocket {
     /// # use std::{io, net::SocketAddr};
     /// # #[tokio::main]
     /// # async fn main() -> io::Result<()> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No UDP sockets in miri.
     /// let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
     /// let peer = "127.0.0.1:11100".parse::<SocketAddr>().unwrap();
     /// let sock = UdpSocket::bind(addr).await?;
@@ -2288,7 +2288,7 @@ impl UdpSocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> io::Result<()> {
-    /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// #   if cfg!(miri) { return Ok(()); } // No UDP sockets in miri.
     ///     // Create a socket
     ///     let socket = UdpSocket::bind("0.0.0.0:8080").await?;
     ///

--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -39,7 +39,7 @@ cfg_net_unix! {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -377,7 +377,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -469,7 +469,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use std::os::unix::net::UnixDatagram as StdUDS;
     /// use tempfile::tempdir;
@@ -536,7 +536,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -576,7 +576,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -903,7 +903,7 @@ impl UnixDatagram {
         /// # use std::error::Error;
         /// # #[tokio::main]
         /// # async fn main() -> Result<(), Box<dyn Error>> {
-        /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+        /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
         /// use tokio::net::UnixDatagram;
         /// use tempfile::tempdir;
         ///
@@ -1071,7 +1071,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -1122,7 +1122,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -1439,7 +1439,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -1462,7 +1462,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     ///
     /// // Create an unbound socket
@@ -1487,7 +1487,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     /// use tempfile::tempdir;
     ///
@@ -1535,7 +1535,7 @@ impl UnixDatagram {
     /// # use std::error::Error;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn Error>> {
-    /// # if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// # if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     /// use tokio::net::UnixDatagram;
     ///
     /// // Create an unbound socket

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -848,7 +848,7 @@ impl UnixStream {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<(), Box<dyn Error>> {
-    /// #   if cfg!(miri) { return Ok(()); } // No `socket` in miri.
+    /// #   if cfg!(miri) { return Ok(()); } // No Unix domain sockets in miri.
     ///     let dir = tempfile::tempdir().unwrap();
     ///     let bind_path = dir.path().join("bind_path");
     ///

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -59,7 +59,6 @@ where
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 async fn test_basic_transfer() {
     symmetric(|_handle, mut a, mut b| async move {
         a.write_all(b"test").await.unwrap();
@@ -71,7 +70,6 @@ async fn test_basic_transfer() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 async fn test_transfer_after_close() {
     symmetric(|handle, mut a, mut b| async move {
         AsyncWriteExt::shutdown(&mut a).await.unwrap();
@@ -91,7 +89,6 @@ async fn test_transfer_after_close() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 async fn blocking_one_side_does_not_block_other() {
     symmetric(|handle, mut a, mut b| async move {
         block_write(&mut a).await;
@@ -103,10 +100,14 @@ async fn blocking_one_side_does_not_block_other() {
 
         AsyncWriteExt::shutdown(&mut a).await.unwrap();
 
+        std::thread::yield_now();
+
         let mut buf = Vec::new();
         b.read_to_end(&mut buf).await.unwrap();
 
         drop(b);
+
+        std::thread::yield_now();
 
         assert_eq!(handle.await.unwrap().unwrap(), (buf.len() as u64, 4));
     })

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -89,6 +89,7 @@ async fn test_transfer_after_close() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
 async fn blocking_one_side_does_not_block_other() {
     symmetric(|handle, mut a, mut b| async move {
         block_write(&mut a).await;
@@ -100,14 +101,10 @@ async fn blocking_one_side_does_not_block_other() {
 
         AsyncWriteExt::shutdown(&mut a).await.unwrap();
 
-        std::thread::yield_now();
-
         let mut buf = Vec::new();
         b.read_to_end(&mut buf).await.unwrap();
 
         drop(b);
-
-        std::thread::yield_now();
 
         assert_eq!(handle.await.unwrap().unwrap(), (buf.len() as u64, 4));
     })

--- a/tokio/tests/io_driver.rs
+++ b/tokio/tests/io_driver.rs
@@ -32,7 +32,6 @@ impl<T> Task<T> {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn test_drop_on_notify() {
     // When the reactor receives a kernel notification, it notifies the
     // task that holds the associated socket. If this notification results in
@@ -91,7 +90,6 @@ fn test_drop_on_notify() {
 #[should_panic(
     expected = "A Tokio 1.x context was found, but IO is disabled. Call `enable_io` on the runtime builder to enable IO."
 )]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn panics_when_io_disabled() {
     let rt = runtime::Builder::new_current_thread().build().unwrap();
 

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -6,7 +6,6 @@ use tokio::runtime;
 use tokio_test::{assert_err, assert_pending, assert_ready, task};
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn tcp_doesnt_block() {
     let rt = rt();
 
@@ -29,7 +28,6 @@ fn tcp_doesnt_block() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn drop_wakes() {
     let rt = rt();
 

--- a/tokio/tests/net_bind_resource.rs
+++ b/tokio/tests/net_bind_resource.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use tokio::net::TcpListener;
@@ -16,7 +14,6 @@ use std::net;
 
 #[test]
 #[should_panic]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn no_runtime_panics_binding_net_tcp_listener() {
     let listener = net::TcpListener::bind("127.0.0.1:0").expect("failed to bind listener");
     let _ = TcpListener::try_from(listener);

--- a/tokio/tests/net_lookup_host.rs
+++ b/tokio/tests/net_lookup_host.rs
@@ -37,7 +37,6 @@ async fn lookup_str_socket_addr() {
     ignore = "net::lookup_host requires multithreading, which WASI does not yet support"
 )]
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `getaddrinfo` in miri.
 async fn resolve_dns() -> io::Result<()> {
     let mut hosts = net::lookup_host("localhost:3000").await?;
     let host = hosts.next().unwrap();

--- a/tokio/tests/net_panic.rs
+++ b/tokio/tests/net_panic.rs
@@ -12,7 +12,7 @@ mod support {
 use support::panic::test_panic;
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No UDP sockets in miri.
 fn udp_socket_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use std::net::SocketAddr;
     use tokio::net::UdpSocket;
@@ -35,7 +35,6 @@ fn udp_socket_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn tcp_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     std_listener.set_nonblocking(true).unwrap();
@@ -54,7 +53,6 @@ fn tcp_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn tcp_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     let std_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
 
@@ -76,7 +74,7 @@ fn tcp_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -98,7 +96,7 @@ fn unix_listener_bind_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixListener;
 
@@ -121,7 +119,7 @@ fn unix_listener_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use tokio::net::UnixStream;
 
@@ -145,7 +143,7 @@ fn unix_stream_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
 
 #[test]
 #[cfg(unix)]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 fn unix_datagram_from_std_panic_caller() -> Result<(), Box<dyn Error>> {
     use std::os::unix::net::UnixDatagram as StdUDS;
     use tokio::net::UnixDatagram;

--- a/tokio/tests/net_quickack.rs
+++ b/tokio/tests/net_quickack.rs
@@ -8,7 +8,7 @@
         target_os = "cygwin",
     )
 ))]
-#![cfg(not(miri))] // No `socket` in miri.
+#![cfg(not(miri))] // Miri doesn't support TCP quickack socket option.
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpListener;

--- a/tokio/tests/net_unix_pipe.rs
+++ b/tokio/tests/net_unix_pipe.rs
@@ -135,7 +135,7 @@ async fn fifo_multiple_writes() -> io::Result<()> {
 /// with writers sequentially opening and closing a FIFO.
 #[tokio::test]
 #[cfg(any(target_os = "linux", target_os = "android"))]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No `mkfifo` in miri.
 async fn fifo_resilient_reader() -> io::Result<()> {
     const DATA: &[u8] = b"this is some data to write to the fifo";
 

--- a/tokio/tests/no_rt.rs
+++ b/tokio/tests/no_rt.rs
@@ -20,7 +20,6 @@ fn timeout_panics_when_no_tokio_context() {
 #[should_panic(
     expected = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"
 )]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn panics_when_no_reactor() {
     let srv = TcpListener::bind("127.0.0.1:0").unwrap();
     let addr = srv.local_addr().unwrap();
@@ -37,7 +36,6 @@ async fn timeout_value() {
 #[should_panic(
     expected = "there is no reactor running, must be called from the context of a Tokio 1.x runtime"
 )]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn io_panics_when_no_tokio_context() {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
 

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1168,6 +1168,7 @@ rt_test! {
     }
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
+    #[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
     async fn client_server_local(tx: mpsc::Sender<()>) {
         let server = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
 
@@ -1184,8 +1185,6 @@ rt_test! {
         });
 
         let mut client = TcpStream::connect(&addr).await.unwrap();
-
-        std::thread::yield_now();
 
         let mut buf = vec![];
         client.read_to_end(&mut buf).await.unwrap();

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1155,6 +1155,7 @@ rt_test! {
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
     fn local_set_client_server_block_on() {
         let rt = rt();
         let (tx, rx) = mpsc::channel();

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::needless_range_loop)]
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
-#![cfg(not(miri))]
 
 // Tests to run on both current-thread & multi-thread runtime variants.
 
@@ -188,6 +187,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
+    #[cfg_attr(miri, ignore)] // Too slow on miri
     fn spawn_many_from_block_on() {
         use tokio::sync::mpsc;
 
@@ -239,6 +239,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
+    #[cfg_attr(miri, ignore)] // Too slow on miri
     fn spawn_many_from_task() {
         use tokio::sync::mpsc;
 
@@ -507,7 +508,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support bind
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[test]
     fn block_on_socket() {
         let rt = rt();
@@ -582,7 +582,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support bind
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[test]
     fn socket_from_blocking() {
         let rt = rt();
@@ -653,7 +652,6 @@ rt_test! {
     // concern. There also isn't a great/obvious solution to take. For now, the
     // test is disabled.
     #[cfg(not(windows))]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[cfg(not(target_os="wasi"))] // Wasi does not support bind or threads
     fn io_driver_called_when_under_load() {
         let rt = rt();
@@ -708,7 +706,6 @@ rt_test! {
     /// spuriously.
     #[test]
     #[cfg(not(target_os="wasi"))]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     fn yield_defers_until_park() {
         for _ in 0..10 {
             if yield_defers_until_park_inner(false) {
@@ -726,7 +723,6 @@ rt_test! {
     /// Same as above, but with cooperative scheduling.
     #[test]
     #[cfg(not(target_os="wasi"))]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     fn coop_yield_defers_until_park() {
         for _ in 0..10 {
             if yield_defers_until_park_inner(true) {
@@ -836,7 +832,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[test]
     fn client_server_block_on() {
         let rt = rt();
@@ -1002,7 +997,7 @@ rt_test! {
     }
 
     #[cfg(not(target_os="wasi"))] // Wasi doesn't support UDP or bind()
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
+    #[cfg_attr(miri, ignore)] // No UDP sockets in miri.
     #[test]
     fn io_notify_while_shutting_down() {
         use tokio::net::UdpSocket;
@@ -1040,6 +1035,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri detects leaked threads (see #7010)
     fn shutdown_timeout() {
         let (tx, rx) = oneshot::channel();
         let runtime = rt();
@@ -1058,6 +1054,7 @@ rt_test! {
 
     #[cfg(not(target_os="wasi"))] // Wasi does not support threads
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri detects leaked threads (see #7010)
     fn shutdown_timeout_0() {
         let runtime = rt();
 
@@ -1073,6 +1070,7 @@ rt_test! {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri detects leaked threads (see #7010)
     fn shutdown_wakeup_time() {
         let runtime = rt();
 
@@ -1134,7 +1132,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[test]
     fn local_set_block_on_socket() {
         let rt = rt();
@@ -1157,7 +1154,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     #[test]
     fn local_set_client_server_block_on() {
         let rt = rt();
@@ -1188,6 +1184,8 @@ rt_test! {
         });
 
         let mut client = TcpStream::connect(&addr).await.unwrap();
+
+        std::thread::yield_now();
 
         let mut buf = vec![];
         client.read_to_end(&mut buf).await.unwrap();
@@ -1278,6 +1276,7 @@ rt_test! {
     // Tests that the "next task" scheduler optimization is not able to starve
     // other tasks.
     #[test]
+    #[cfg_attr(miri, ignore)] // Too slow on miri
     fn ping_pong_saturation() {
         use std::sync::atomic::{Ordering, AtomicBool};
         use tokio::sync::mpsc;
@@ -1341,6 +1340,7 @@ rt_test! {
 
     #[test]
     #[cfg(not(target_os="wasi"))]
+    #[cfg_attr(miri, ignore)] // Too slow on miri
     fn shutdown_concurrent_spawn() {
         const NUM_TASKS: usize = 10_000;
         for _ in 0..5 {

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(miri)))]
+#![cfg(feature = "full")]
 
 // All io tests that deal with shutdown is currently ignored because there are known bugs in with
 // shutting down the io driver while concurrently registering new resources. See
@@ -241,7 +241,6 @@ rt_test! {
     // ==== net ======
 
     #[test]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
     fn tcp_listener_bind() {
         let rt = rt();
         let _enter = rt.enter();
@@ -292,7 +291,7 @@ rt_test! {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
+    #[cfg_attr(miri, ignore)] // No UDP sockets in miri.
     fn udp_socket_bind() {
         let rt = rt();
         let _enter = rt.enter();
@@ -453,7 +452,7 @@ rt_test! {
 #[cfg(not(target_os = "wasi"))]
 multi_threaded_rt_test! {
     #[cfg(unix)]
-    #[cfg_attr(miri, ignore)] // No `socket` in miri.
+    #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
     #[test]
     fn unix_listener_bind() {
         let rt = rt();

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms)]
-// Too slow on miri.
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))]
+#![cfg(all(feature = "full", not(target_os = "wasi")))]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -35,6 +34,7 @@ fn single_thread() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Too slow on miri.
 fn many_oneshot_futures() {
     // used for notifying the main thread
     const NUM: usize = 1_000;
@@ -98,6 +98,7 @@ fn spawn_two() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Too slow on miri
 fn many_multishot_futures() {
     const CHAIN: usize = 200;
     const CYCLES: usize = 5;
@@ -188,7 +189,6 @@ fn lifo_slot_budget() {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
 fn spawn_shutdown() {
     let rt = rt();
     let (tx, rx) = mpsc::channel();
@@ -232,6 +232,7 @@ async fn client_server(tx: mpsc::Sender<()>) {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // Too slow on miri
 fn drop_threadpool_drops_futures() {
     for _ in 0..1_000 {
         let num_inc = Arc::new(AtomicUsize::new(0));
@@ -322,8 +323,7 @@ fn start_stop_callbacks_called() {
 }
 
 #[test]
-// too slow on miri
-#[cfg_attr(miri, ignore)]
+#[cfg_attr(miri, ignore)] // Too slow on miri
 fn blocking() {
     // used for notifying the main thread
     const NUM: usize = 1_000;
@@ -747,6 +747,7 @@ fn wake_deferred_tasks_before_block_in_place() {
 // could add limits, but that would be likely to fail on CI.
 #[test]
 #[cfg(not(tokio_no_tuning_tests))]
+#[cfg_attr(miri, ignore)] // Too slow on miri
 fn test_tuning() {
     use std::sync::atomic::AtomicBool;
     use std::time::Duration;

--- a/tokio/tests/tcp_accept.rs
+++ b/tokio/tests/tcp_accept.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_connect.rs
+++ b/tokio/tests/tcp_connect.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use tokio::net::{TcpListener, TcpStream};

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
@@ -15,27 +13,28 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio_test::assert_ok;
 
+
 #[tokio::test]
 async fn echo_server() {
-    const ITER: usize = 1024;
+    const BYTES: &[u8] = b"foo bar baz";
+    const ITER: usize = 32;
 
     let (tx, rx) = oneshot::channel();
 
     let srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
     let addr = assert_ok!(srv.local_addr());
 
-    let msg = "foo bar baz";
     tokio::spawn(async move {
         let mut stream = assert_ok!(TcpStream::connect(&addr).await);
 
         for _ in 0..ITER {
             // write
-            assert_ok!(stream.write_all(msg.as_bytes()).await);
+            assert_ok!(stream.write_all(BYTES).await);
 
             // read
-            let mut buf = [0; 11];
+            let mut buf = [0; BYTES.len()];
             assert_ok!(stream.read_exact(&mut buf).await);
-            assert_eq!(&buf[..], msg.as_bytes());
+            assert_eq!(&buf[..], BYTES);
         }
 
         assert_ok!(tx.send(()));
@@ -45,7 +44,7 @@ async fn echo_server() {
     let (mut rd, mut wr) = stream.split();
 
     let n = assert_ok!(io::copy(&mut rd, &mut wr).await);
-    assert_eq!(n, (ITER * msg.len()) as u64);
+    assert_eq!(n, (ITER * BYTES.len()) as u64);
 
     assert_ok!(rx.await);
 }

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -13,7 +13,6 @@ use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio_test::assert_ok;
 
-
 #[tokio::test]
 async fn echo_server() {
     const BYTES: &[u8] = b"foo bar baz";

--- a/tokio/tests/tcp_echo.rs
+++ b/tokio/tests/tcp_echo.rs
@@ -16,6 +16,9 @@ use tokio_test::assert_ok;
 #[tokio::test]
 async fn echo_server() {
     const BYTES: &[u8] = b"foo bar baz";
+    #[cfg(not(miri))]
+    const ITER: usize = 1024;
+    #[cfg(miri)] // Use a lower iteration count with Miri because it's too slow otherwise.
     const ITER: usize = 32;
 
     let (tx, rx) = oneshot::channel();

--- a/tokio/tests/tcp_into_split.rs
+++ b/tokio/tests/tcp_into_split.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support multithreading or peeking
-                                                                   // No `socket` on miri.
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support multithreading or peeking
 
 use std::io::{Error, ErrorKind, Result};
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_into_std.rs
+++ b/tokio/tests/tcp_into_std.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use std::io::Read;

--- a/tokio/tests/tcp_peek.rs
+++ b/tokio/tests/tcp_peek.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support peeking
-                                                                   // No `socket` on miri.
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support peeking
 
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support mulithreading
-                                                                   // No `socket` on miri.
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support mulithreading
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -32,6 +31,7 @@ async fn shutdown() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore = "Miri doesn't support `SO_LINGER`")]
 async fn shutdown_after_tcp_reset() {
     let srv = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
     let addr = assert_ok!(srv.local_addr());

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -150,7 +150,7 @@ test!(
 test!(
     #[cfg_attr(
         miri,
-        ignore = "Miri doesn't support setting the reuseaddr socket option"
+        ignore = "Miri doesn't support reading the reuseaddr socket option"
     )]
     reuseaddr,
     set_reuseaddr(true)

--- a/tokio/tests/tcp_socket.rs
+++ b/tokio/tests/tcp_socket.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use std::time::Duration;
@@ -51,6 +49,7 @@ async fn basic_usage_v6() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore = "Miri doesn't support binding before connecting")]
 async fn bind_before_connect() {
     // Create server
     let any_addr = assert_ok!("127.0.0.1:0".parse());
@@ -71,6 +70,7 @@ async fn bind_before_connect() {
 
 #[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support `SO_LINGER`")]
 #[tokio::test]
+#[cfg_attr(miri, ignore = "Miri doesn't support `SO_LINGER`")]
 async fn basic_linger() {
     // Create server
     let addr = assert_ok!("127.0.0.1:0".parse());
@@ -138,9 +138,23 @@ const GET_BUF_SIZE: u32 = SET_BUF_SIZE;
 #[cfg(any(target_os = "android", target_os = "linux"))]
 const GET_BUF_SIZE: u32 = 2 * SET_BUF_SIZE;
 
-test!(keepalive, set_keepalive(true));
+test!(
+    #[cfg_attr(
+        miri,
+        ignore = "Miri doesn't support setting the keepalive socket option"
+    )]
+    keepalive,
+    set_keepalive(true)
+);
 
-test!(reuseaddr, set_reuseaddr(true));
+test!(
+    #[cfg_attr(
+        miri,
+        ignore = "Miri doesn't support setting the reuseaddr socket option"
+    )]
+    reuseaddr,
+    set_reuseaddr(true)
+);
 
 #[cfg(all(
     unix,
@@ -148,15 +162,30 @@ test!(reuseaddr, set_reuseaddr(true));
     not(target_os = "illumos"),
     not(target_os = "cygwin"),
 ))]
-test!(reuseport, set_reuseport(true));
+test!(
+    #[cfg_attr(
+        miri,
+        ignore = "Miri doesn't support setting the reuseport socket option"
+    )]
+    reuseport,
+    set_reuseport(true)
+);
 
 test!(
+    #[cfg_attr(
+        miri,
+        ignore = "Miri doesn't support setting the send buffer size socket option"
+    )]
     send_buffer_size,
     set_send_buffer_size(SET_BUF_SIZE),
     GET_BUF_SIZE
 );
 
 test!(
+    #[cfg_attr(
+        miri,
+        ignore = "Miri doesn't support setting the receive buffer size socket option"
+    )]
     recv_buffer_size,
     set_recv_buffer_size(SET_BUF_SIZE),
     GET_BUF_SIZE
@@ -164,12 +193,17 @@ test!(
 
 test!(
     #[cfg_attr(target_os = "wasi", ignore = "WASI does not yet support `SO_LINGER`")]
+    #[cfg_attr(miri, ignore = "Miri doesn't support `SO_LINGER`")]
     #[expect(deprecated, reason = "set_linger is deprecated")]
     linger,
     set_linger(Some(Duration::from_secs(10)))
 );
 
-test!(nodelay, set_nodelay(true));
+test!(
+    #[cfg_attr(miri, ignore = "Miri only supports `TCP_NODELAY` on connected sockets")]
+    nodelay,
+    set_nodelay(true)
+);
 
 #[cfg(any(
     target_os = "android",
@@ -182,7 +216,11 @@ test!(nodelay, set_nodelay(true));
     target_os = "openbsd",
     target_os = "cygwin",
 ))]
-test!(IPv6 tclass_v6, set_tclass_v6(96));
+#[cfg(not(miri))] // Miri doesn't support TClass.
+test!(
+    IPv6 tclass_v6,
+    set_tclass_v6(96)
+);
 
 #[cfg(not(any(
     target_os = "fuchsia",
@@ -190,6 +228,7 @@ test!(IPv6 tclass_v6, set_tclass_v6(96));
     target_os = "solaris",
     target_os = "illumos",
     target_os = "haiku",
-    target_os = "wasi"
+    target_os = "wasi",
+    miri // Miri doesn't support TOS.
 )))]
 test!(IPv4 tos_v4, set_tos_v4(96));

--- a/tokio/tests/tcp_split.rs
+++ b/tokio/tests/tcp_split.rs
@@ -1,6 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))] // Wasi doesn't support peeking
-                                                                   // No `socket` on miri.
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support peeking
 
 use std::io::Result;
 use std::io::{Read, Write};

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -48,7 +48,6 @@ async fn set_linger() {
 )]
 async fn try_read_write() {
     const DATA: &[u8] = &[2u8; 4000];
-    // const DATA: &[u8] = b"this is some data to write to the socket";
 
     // Create listener
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -114,48 +113,52 @@ async fn try_read_write() {
     written.reserve(10 * 1024 * 1024);
     client.writable().await.unwrap();
 
-    // Fill the write buffer using vectored I/O
-    let data_bufs: Vec<_> = DATA.chunks(10).map(io::IoSlice::new).collect();
-    loop {
-        // Still ready
-        let mut writable = task::spawn(client.writable());
-        assert_ready_ok!(writable.poll());
-
-        match client.try_write_vectored(&data_bufs) {
-            Ok(n) => {
-                written.extend(&DATA[..n]);
-            }
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                break;
-            }
-            Err(e) => panic!("error = {e:?}"),
-        }
-    }
-
+    #[cfg(not(miri))]
+    // Miri currently has a memory leak when `readv` returns an error: See https://github.com/rust-lang/miri/pull/5054
     {
-        // Write buffer full
-        let mut writable = task::spawn(client.writable());
-        assert_pending!(writable.poll());
+        // Fill the write buffer using vectored I/O
+        let data_bufs: Vec<_> = DATA.chunks(10).map(io::IoSlice::new).collect();
+        loop {
+            // Still ready
+            let mut writable = task::spawn(client.writable());
+            assert_ready_ok!(writable.poll());
 
-        // Drain the socket from the server end using vectored I/O
-        let mut read = vec![0; written.len()];
-        let mut i = 0;
-
-        while i < read.len() {
-            server.readable().await.unwrap();
-
-            let mut bufs: Vec<_> = read[i..]
-                .chunks_mut(0x10000)
-                .map(io::IoSliceMut::new)
-                .collect();
-            match server.try_read_vectored(&mut bufs) {
-                Ok(n) => i += n,
-                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+            match client.try_write_vectored(&data_bufs) {
+                Ok(n) => {
+                    written.extend(&DATA[..n]);
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    break;
+                }
                 Err(e) => panic!("error = {e:?}"),
             }
         }
 
-        assert_eq!(read, written);
+        {
+            // Write buffer full
+            let mut writable = task::spawn(client.writable());
+            assert_pending!(writable.poll());
+
+            // Drain the socket from the server end using vectored I/O
+            let mut read = vec![0; written.len()];
+            let mut i = 0;
+
+            while i < read.len() {
+                server.readable().await.unwrap();
+
+                let mut bufs: Vec<_> = read[i..]
+                    .chunks_mut(0x10000)
+                    .map(io::IoSliceMut::new)
+                    .collect();
+                match server.try_read_vectored(&mut bufs) {
+                    Ok(n) => i += n,
+                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
+                    Err(e) => panic!("error = {e:?}"),
+                }
+            }
+
+            assert_eq!(read, written);
+        }
     }
 
     // Now, we listen for shutdown
@@ -315,7 +318,6 @@ fn write_until_pending(stream: &mut TcpStream) -> usize {
 #[tokio::test]
 async fn try_read_buf() {
     const DATA: &[u8] = &[2u8; 4000];
-    // const DATA: &[u8] = b"this is some data to write to the socket";
 
     // Create listener
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -1,13 +1,11 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",
     feature = "rt",
     feature = "io-util",
     not(all(target_os = "wasi", target_env = "p1")),
-    not(miri)
 ))]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt, Interest};
@@ -24,7 +22,7 @@ use std::time::Duration;
 
 #[tokio::test]
 #[cfg(not(target_os = "wasi"))] // WASI does not yet support `SO_LINGER`
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore = "Miri doesn't support `SO_LINGER`")]
 #[expect(deprecated)] // set_linger is deprecated
 async fn set_linger() {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -48,9 +46,9 @@ async fn set_linger() {
     target_os = "wasi",
     ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
 )]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn try_read_write() {
-    const DATA: &[u8] = b"this is some data to write to the socket";
+    const DATA: &[u8] = &[2u8; 4000];
+    // const DATA: &[u8] = b"this is some data to write to the socket";
 
     // Create listener
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -235,7 +233,6 @@ macro_rules! assert_not_writable_by_polling {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn poll_read_ready() {
     let (mut client, mut server) = create_pair().await;
 
@@ -259,7 +256,6 @@ async fn poll_read_ready() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn poll_write_ready() {
     let (mut client, server) = create_pair().await;
 
@@ -317,9 +313,9 @@ fn write_until_pending(stream: &mut TcpStream) -> usize {
 // it once that issue is fixed and the fix is included in a Wasmtime release.
 #[cfg_attr(target_os = "wasi", ignore)]
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn try_read_buf() {
-    const DATA: &[u8] = b"this is some data to write to the socket";
+    const DATA: &[u8] = &[2u8; 4000];
+    // const DATA: &[u8] = b"this is some data to write to the socket";
 
     // Create listener
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -409,7 +405,6 @@ async fn try_read_buf() {
     target_os = "wasi",
     ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
 )]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn read_closed() {
     let (client, mut server) = create_pair().await;
 
@@ -425,7 +420,6 @@ async fn read_closed() {
 
 // write_closed is a best effort event, so test only for no false positives.
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
 async fn write_closed() {
     let (mut client, mut server) = create_pair().await;
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 // WASIp1 doesn't support bind
-// No `socket` on miri.
+// No UDP sockets on miri.
 #![cfg(all(
     feature = "net",
     feature = "macros",

--- a/tokio/tests/uds_cred.rs
+++ b/tokio/tests/uds_cred.rs
@@ -1,6 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
-#![cfg(all(unix, not(target_os = "dragonfly"), not(miri)))] // No `getsockopt` on miri.
+#![cfg(all(unix, not(target_os = "dragonfly"), not(miri)))] // No `getsockopt` for Unix domain sockets on miri.
 
 use tokio::net::UnixStream;
 

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -21,7 +21,7 @@ async fn echo_server(socket: UnixDatagram) -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn echo() -> io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let server_path = dir.path().join("server.sock");
@@ -46,7 +46,7 @@ async fn echo() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn echo_from() -> io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let server_path = dir.path().join("server.sock");
@@ -119,7 +119,7 @@ async fn try_send_recv_never_block() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn split() -> std::io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("split.sock");
@@ -144,7 +144,7 @@ async fn split() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn send_to_recv_from_poll() -> std::io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let sender_path = dir.path().join("sender.sock");
@@ -166,7 +166,7 @@ async fn send_to_recv_from_poll() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn send_recv_poll() -> std::io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let sender_path = dir.path().join("sender.sock");
@@ -190,7 +190,7 @@ async fn send_recv_poll() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn try_send_to_recv_from() -> std::io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let server_path = dir.path().join("server.sock");
@@ -238,7 +238,7 @@ async fn try_send_to_recv_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn try_recv_buf_from() -> std::io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let server_path = dir.path().join("server.sock");
@@ -286,7 +286,7 @@ async fn try_recv_buf_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` on miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets on miri.
 async fn recv_buf_from() -> std::io::Result<()> {
     let tmp = tempfile::tempdir()?;
 

--- a/tokio/tests/uds_socket.rs
+++ b/tokio/tests/uds_socket.rs
@@ -10,7 +10,7 @@ use tokio::{
 };
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 async fn datagram_echo_server() -> io::Result<()> {
     let dir = tempfile::tempdir().unwrap();
     let server_path = dir.path().join("server.sock");
@@ -52,7 +52,7 @@ async fn datagram_echo_server() -> io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 async fn listen_and_stream() -> std::io::Result<()> {
     let dir = tempfile::Builder::new().tempdir().unwrap();
     let sock_path = dir.path().join("connect.sock");
@@ -92,7 +92,7 @@ async fn listen_and_stream() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // No `socket` in miri.
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
 async fn assert_usage() -> std::io::Result<()> {
     let datagram_socket = UnixSocket::new_datagram()?;
     let result = datagram_socket

--- a/tokio/tests/uds_split.rs
+++ b/tokio/tests/uds_split.rs
@@ -1,7 +1,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 #![cfg(unix)]
-#![cfg(not(miri))] // No `socket` in miri.
+#![cfg(not(miri))] // No Unix domain sockets in miri.
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::UnixStream;

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "full")]
 #![warn(rust_2018_idioms)]
 #![cfg(unix)]
-#![cfg(not(miri))] // No socket in miri.
+#![cfg(not(miri))] // No Unix domain sockets on miri.
 
 use std::io;
 #[cfg(target_os = "android")]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Because Miri didn't have TCP socket support, the tokio tests which relied on `TcpStream`s and `TcpListener`s had to be ignored when being run with Miri. However, over the past months TCP socket support was added to Miri, so these tests no longer need to be ignored when being run with Miri. 

Some tests were using very small buffers or many iterations which caused them to be very slow with Miri. For the tests I considered important I've changed the buffer size/iteration count, the other tests I've annotated with `#[cfg_attr(miri, ignore)]`. 

A few tests using TCP sockets currently don't work with Miri, but there are open issues/PRs for those:
- `readv` can leak memory: https://github.com/rust-lang/miri/pull/5054
- Host I/O events are only processed when entering the scheduler: https://github.com/rust-lang/miri/issues/5047

I'll open new PRs here once those issues are fixed in Miri and landed in a nightly rust version. 