### PR TITLE
io: fix write_all_vectored dropping data after partial writes

### DIFF
--- a/tokio-util/src/io/write_all_vectored.rs
+++ b/tokio-util/src/io/write_all_vectored.rs
@@ -147,7 +147,7 @@ fn advance_slices<'a>(bufs: &mut &mut [IoSlice<'a>], n: usize) {
 
     *bufs = &mut std::mem::take(bufs)[remove..];
     if let Some(first) = bufs.first_mut() {
-        let buf = &first[..left];
+        let buf = &first[left..];
         // necessary due to limitating in the borrow checker,
         // when tokio MSRV reaches 1.81.0 this entire function
         // can be replaced with `IoSlice::advance_slices`

--- a/tokio-util/tests/io_write_all_vectored.rs
+++ b/tokio-util/tests/io_write_all_vectored.rs
@@ -140,3 +140,85 @@ async fn write_all_vectored_with_empty_slice() {
     write_all_vectored(&mut wr, buf).await.unwrap();
     assert_eq!(&wr.buf[..], b"hello");
 }
+
+#[tokio::test]
+async fn write_all_vectored_partial_writes() {
+    // Writer that reports writing only `limit` bytes per call, exercising the
+    // partial write path inside `write_all_vectored`. This is the path that
+    // previously dropped or duplicated bytes when `advance_slices` advanced the
+    // first remaining buffer incorrectly.
+    struct LimitedWr {
+        buf: BytesMut,
+        limit: usize,
+    }
+    impl AsyncWrite for LimitedWr {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            panic!("shouldn't be called")
+        }
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+        fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Ok(()).into()
+        }
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            bufs: &[io::IoSlice<'_>],
+        ) -> Poll<Result<usize, io::Error>> {
+            let mut written = 0;
+            for buf in bufs {
+                let take = std::cmp::min(self.limit - written, buf.len());
+                self.buf.extend_from_slice(&buf[..take]);
+                written += take;
+                if written == self.limit {
+                    break;
+                }
+            }
+            Ok(written).into()
+        }
+        fn is_write_vectored(&self) -> bool {
+            true
+        }
+    }
+
+    // case 1: write count lands exactly on a buffer boundary.
+    // Previously, `advance_slices` would replace the next buffer with an
+    // empty subslice, causing the data to be silently dropped.
+    let mut wr = LimitedWr {
+        buf: BytesMut::with_capacity(64),
+        limit: 2,
+    };
+    let buf = &mut [IoSlice::new(b"ab"), IoSlice::new(b"cd")];
+    write_all_vectored(&mut wr, buf).await.unwrap();
+    assert_eq!(&wr.buf[..], b"abcd");
+
+    // case 2: partial write inside a buffer.
+    // Previously, `advance_slices` would resume from the already-written
+    // prefix (e.g. "hel" instead of "lo"), duplicating bytes and skipping
+    // the unwritten suffix.
+    let mut wr = LimitedWr {
+        buf: BytesMut::with_capacity(64),
+        limit: 3,
+    };
+    let buf = &mut [IoSlice::new(b"hello"), IoSlice::new(b"world")];
+    write_all_vectored(&mut wr, buf).await.unwrap();
+    assert_eq!(&wr.buf[..], b"helloworld");
+
+    // case 3: partial write that spans into the second buffer.
+    let mut wr = LimitedWr {
+        buf: BytesMut::with_capacity(64),
+        limit: 4,
+    };
+    let buf = &mut [
+        IoSlice::new(b"ab"),
+        IoSlice::new(b"cdef"),
+        IoSlice::new(b"gh"),
+    ];
+    write_all_vectored(&mut wr, buf).await.unwrap();
+    assert_eq!(&wr.buf[..], b"abcdefgh");
+}


### PR DESCRIPTION
## Motivation

`tokio_util::io::write_all_vectored` can silently drop or duplicate bytes after a partial `poll_write_vectored` result, because the local `advance_slices` helper re-slices the first remaining buffer with `&first[..left]` instead of `&first[left..]`. At that point, `left` is the number of bytes already consumed from that buffer, so the helper keeps the written prefix rather than the unwritten suffix.

For `[b"ab", b"cd"]` with a write count of 2, the helper removes the first buffer and then replaces `b"cd"` with `b"cd"[..0]`. The future sees no non-empty buffers and returns `Ok(())`, silently dropping `b"cd"`. For `[b"hello", b"world"]` with a write count of 3, the helper resumes from `b"hel"` instead of `b"lo"`, duplicating already-written bytes and skipping unwritten bytes.

## Solution

Change the helper to slice the first remaining buffer as `&first[left..]`, matching the behavior of `std::io::IoSlice::advance_slices` (which will replace this helper once the MSRV reaches 1.81.0).

The new `write_all_vectored_partial_writes` test exercises three scenarios that all fail on the current code: an exact buffer-boundary write that drops the next buffer, a partial write inside a buffer that duplicates bytes, and a partial write that spans into the second buffer.

Closes #8158.