### PR TITLE
Async scoped tasks proposal

### DIFF
--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -41,6 +41,7 @@ full = [
   "time",
 ]
 
+async-scope = ["rt"]
 fs = []
 io-util = ["bytes"]
 # stdin, stdout, stderr

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -746,3 +746,16 @@ macro_rules! cfg_io_uring {
         )*
     };
 }
+
+macro_rules! cfg_async_scope {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(
+                tokio_unstable,
+                feature = "async-scope",
+                feature = "rt",
+            ))]
+            $item
+        )*
+    };
+}

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -29,6 +29,8 @@ pub(crate) struct Handle {
     /// Time driver handle
     pub(crate) time: TimeHandle,
 
+    pub(crate) scope: ScopeDriver,
+
     /// Source of `Instant::now()`
     #[cfg_attr(not(all(feature = "time", feature = "test-util")), allow(dead_code))]
     pub(crate) clock: Clock,
@@ -52,6 +54,8 @@ impl Driver {
         let (time_driver, time_handle) =
             create_time_driver(cfg.enable_time, cfg.timer_flavor, io_stack, &clock);
 
+        let scope = ScopeDriver::new();
+
         Ok((
             Self { inner: time_driver },
             Handle {
@@ -59,6 +63,7 @@ impl Driver {
                 signal: signal_handle,
                 time: time_handle,
                 clock,
+                scope,
             },
         ))
     }
@@ -374,3 +379,54 @@ cfg_not_time! {
 cfg_io_uring! {
     pub(crate) mod op;
 }
+
+// cfg_async_scope! {
+use crate::task::Id;
+use std::any::Any;
+use std::collections::HashMap;
+use std::mem::transmute;
+use std::pin::Pin;
+use std::sync::Mutex;
+
+pub(crate) struct ScopeDriver {
+    resources: Mutex<HashMap<Id, Pin<Box<dyn Any + Send + Unpin + 'static>>>>,
+}
+
+impl std::fmt::Debug for ScopeDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopeDriver").finish()
+    }
+}
+
+impl ScopeDriver {
+    pub(crate) fn new() -> Self {
+        Self {
+            resources: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn store_resources<R: Send + Any + Unpin + 'static>(
+        &self,
+        task_id: Id,
+        resources: R,
+    ) -> Pin<&'static mut R> {
+        let mut guard = self.resources.lock().unwrap();
+        let mut boxed = Box::pin(resources);
+
+        // SAFETY: R is owned by this driver, and dropped on shutdown. Resources are valid within the lifetime of the async scope, we create a 'static lifetime and manage it in the spawned scoped task.
+        let ret = unsafe { transmute::<Pin<&mut R>, Pin<&'static mut R>>(boxed.as_mut()) };
+
+        guard.insert(task_id, boxed);
+
+        ret
+    }
+
+    pub(crate) fn pop_resources<R: Send + Any + Unpin + 'static>(&self, id: Id) -> R {
+        let mut guard = self.resources.lock().unwrap();
+        let r = guard.remove(&id).unwrap();
+        let b = Pin::into_inner(r);
+        let b2 = b as Box<dyn Any + Send + 'static>;
+        *b2.downcast::<R>().unwrap()
+    }
+}
+// }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -412,6 +412,10 @@ cfg_io_driver_impl! {
     pub(crate) mod io;
 }
 
+cfg_async_scope! {
+    pub(crate) mod scope;
+}
+
 cfg_process_driver! {
     mod process;
 }

--- a/tokio/src/runtime/scope.rs
+++ b/tokio/src/runtime/scope.rs
@@ -1,0 +1,60 @@
+
+use std::{future::Future, marker::PhantomData, mem, pin::Pin};
+
+use crate::{sync::RwLock, task::JoinHandle};
+
+/// A handle that lets tasks be spawned with a non-`'static` lifetime `'s`.
+#[derive(Debug)]
+pub struct Scope<'s> {
+    // Invariant in `'s` so callers can't widen or shrink the lifetime.
+    _p: PhantomData<&'s mut &'s ()>,
+    // Read-locked by every running scoped task. `close` takes the write lock
+    // and therefore blocks until all scoped tasks have released their guards.
+    task_guard: RwLock<()>,
+}
+
+impl<'s> Scope<'s> {
+    pub(crate) fn new() -> Self {
+        Self {
+            _p: PhantomData,
+            task_guard: RwLock::new(()),
+        }
+    }
+
+    /// Spawn a task whose future may borrow data with lifetime `'s`.
+    pub async fn spawn<F>(&'s self, future: F) -> JoinHandle<F::Output>
+    where
+        F: Future + Send + 's,
+        F::Output: Send + 'static,
+    {
+        // Borrow the guard with the scope's lifetime so the spawned future
+        // holds the read guard for as long as it runs.
+        let guard: &'s RwLock<()> = &self.task_guard;
+
+        // we need to acquire the guard before we attempt to spawn the task, to prevent a race condition. Ideally it wouldn't be async.
+        let _g = guard.read().await;
+
+        let wrap = async move {
+            let res = future.await;
+            drop(_g);
+            res
+        };
+
+        // The runtime requires `'static` futures, so we erase `'s` here.
+        //
+        // SAFETY: Before `Scope` is dropped, `close` is awaited, ensuring that no scoped task is still running. Therefore the spawned scoped task is guaranteed to be finished before the rwlock guard/resources are dropped.
+        let boxed: Pin<Box<dyn Future<Output = F::Output> + Send + 's>> = Box::pin(wrap);
+        let boxed: Pin<Box<dyn Future<Output = F::Output> + Send + 'static>> =
+            unsafe { mem::transmute(boxed) };
+
+        crate::task::spawn(boxed)
+    }
+
+    /// Wait for every task spawned on this scope to finish.
+    ///
+    /// Must be awaited before the `Scope` is dropped to uphold the soundness
+    /// invariant on [`Scope::spawn`].
+    pub(crate) async fn close(&self) {
+        let _g = self.task_guard.write().await;
+    }
+}

--- a/tokio/src/task/mod.rs
+++ b/tokio/src/task/mod.rs
@@ -330,6 +330,11 @@ cfg_rt! {
     }
 }
 
+cfg_async_scope! {
+    pub use spawn::spawn_scoped;
+    pub use crate::runtime::scope::Scope;
+}
+
 cfg_not_rt! {
     pub(crate) mod coop;
 }

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -213,3 +213,75 @@ cfg_rt! {
         }
     }
 }
+
+cfg_async_scope! {
+    use crate::runtime::scope::Scope;
+    use std::pin::Pin;
+
+    /// Spawns a new scoped task, returning a [`JoinHandle`] for it.
+    /// this allows for spawning tasks that borrow non-`'static` data.
+    #[track_caller]
+    pub fn spawn_scoped<C, Resources, T>(input: Resources, callback: C) -> JoinHandle<(T, Resources)>
+    where
+        Resources: std::any::Any + Send + Unpin + 'static,
+        // TODO: this should NOT be a Pin<Box<>>, but I couldn't figure out the proper lifetimes/generics without it
+        C: for<'s> FnOnce(
+                &'s Scope<'s>,
+                Pin<&'s mut Resources>,
+            ) -> Pin<Box<dyn Future<Output = T> + Send + 's>>
+            + Send
+            + 'static,
+        T: Send + 'static,
+    {
+        use crate::runtime::{context, task};
+        match context::with_current(|handle| {
+            let id = task::Id::next();
+
+            // needs to be 'static here so that it can be moved into the future
+            let resources: Pin<&'static mut Resources> =
+                handle.driver().scope.store_resources(id, input);
+
+            // it would be unsafe to mem::forget this future. However, we immediately spawn it into a task, so this is fine
+            let future = async move {
+                let scope: Scope<'_> = Scope::new();
+
+                // Reduce the life time of resources and scope to this block
+                let result = {
+                    let resources: Pin<&mut Resources> = resources;
+                    let inner_future = callback(&scope, resources);
+                    inner_future.await
+                };
+
+                // This ensures none of the scope-spawned tasks are running, so it will be safe to regain ownership of resources and drop scope
+                scope.close().await;
+
+                match context::with_current(|handle| {
+                    let resources = handle.driver().scope.pop_resources(id);
+                    (result, resources)
+                }) {
+                    Ok(res) => res,
+                    Err(e) => panic!("{}", e),
+                }
+            };
+
+            let fut_size = std::mem::size_of_val(&future);
+
+            #[cfg(all(
+                tokio_unstable,
+                feature = "taskdump",
+                feature = "rt",
+                target_os = "linux",
+                any(target_arch = "aarch64", target_arch = "x86", target_arch = "x86_64")
+            ))]
+            let future = task::trace::Trace::root(future);
+
+            let meta = SpawnMeta::new_unnamed(fut_size);
+
+            let task = crate::util::trace::task(future, "task", meta, id.as_u64());
+            handle.spawn(task, id, meta.spawned_at)
+        }) {
+            Ok(join_handle) => join_handle,
+            Err(e) => panic!("{}", e),
+        }
+    }
+}

--- a/tokio/tests/task_scope.rs
+++ b/tokio/tests/task_scope.rs
@@ -1,0 +1,120 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(tokio_unstable, feature = "async-scope", not(target_family = "wasm")))]
+
+use tokio::task::spawn_scoped;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_basic_scope() {
+    let data = 8;
+
+    let scope_handle = spawn_scoped(data, |_scope, data_inner| Box::pin(async move {
+       *data_inner + 1
+    }));
+
+    let (sum, _) = scope_handle.await.unwrap();
+
+    assert_eq!(sum, 9);
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scoped_tasks() {
+    let data = vec!["1", "2", "3", "4"];
+
+    let scope_handle = spawn_scoped(data, |scope, data_inner| Box::pin(async move {
+        let mut tasks = vec![];
+        for i in data_inner.iter() {
+            let task = scope.spawn(async {
+                i.parse::<i32>().unwrap()
+            }).await;
+            tasks.push(task);
+        }
+
+        let mut sum = 0;
+        
+        for task in tasks {
+            sum += task.await.unwrap();
+        }
+
+        sum
+    }));
+
+    let (sum, _) = scope_handle.await.unwrap();
+
+    assert_eq!(sum, 10);
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_nested_scoped_tasks() {
+    let data = "scopes are ".to_string();
+
+    let scope_handle = spawn_scoped(data, |scope, data_inner| Box::pin(async move {
+        scope.spawn(async move {
+            scope.spawn(async move {
+                scope.spawn(async move {
+                    5
+                }).await.await.unwrap()
+            }).await.await.unwrap()
+        }).await.await.unwrap()
+    }));
+
+    let (num, _) = scope_handle.await.unwrap();
+
+    assert_eq!(num, 5);
+}
+
+
+// test UAF prevention, make a box, spawn scoped task that sleeps and then reads the box
+#[tokio::test(flavor = "multi_thread")]
+async fn test_scoped_tasks_uaf() {
+    let data = Box::new(8);
+
+    let scope_handle = spawn_scoped(data, |scope, data_inner| Box::pin(async move {
+        scope.spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            **data_inner
+        }).await;
+    }));
+
+    scope_handle.await.unwrap();
+}
+
+// same as above test, but spawns a runtime manually, then shuts down and ensures proper cleanup of scoped resources
+#[test]
+fn test_scoped_tasks_uaf_manual_runtime() {
+    use tokio::runtime::Builder;
+
+    struct DropGuarded {
+        sender: Option<tokio::sync::oneshot::Sender<()>>,
+    }
+
+    impl Drop for DropGuarded {
+        fn drop(&mut self) {
+            if let Some(sender) = self.sender.take() {
+                sender.send(()).unwrap();
+            }
+        }
+    }
+
+    let (tx, mut rx) = tokio::sync::oneshot::channel();
+
+    let rt = Builder::new_current_thread().enable_time().build().unwrap();
+
+    rt.block_on(async {
+        let data = DropGuarded { sender: Some(tx) };
+        let _ = spawn_scoped(data, |scope, data_inner| Box::pin(async move {
+            let task = scope.spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                // this wont run because runtime will be dropped before sleep finishes
+                unreachable!();
+            }).await;
+
+            task.await.unwrap()
+        }));
+    });
+
+    drop(rt);
+
+    rx.try_recv().expect("Expected DropGuarded to be dropped and send on the channel");
+}


### PR DESCRIPTION
## Motivation

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

Have an equivalent of `std::thread::scope` in tokio. This PR is a followup on https://github.com/tokio-rs/tokio/issues/3162 and provides a potential solution for an ergonomic API. From [this blog](https://without.boats/blog/the-scoped-task-trilemma/) this PR would fall into the `Concurrency + Parallelizability` category, disallowing direct borrowing. It is additionally different both from `async_scoped` because it provides a safe API, and also from `tokio_scoped` which blocks the worker thread.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

The main thing this PR does is take ownership of shared resources and store them inside the tokio runtime. The scoped task then receives two parameters, `Pin<&mut R>` of the user provided resource, and `Scope` which enables spawning scoped tasks. Then, once the scope closes (and enforces all scoped tasks are finished), the resource ownership is sent back to the user through the JoinHandle. This ownership passing is done due to the fact that runtime might be dropped in the middle of scoped operation, in which case the tasks holding the references will be dropped first, and the actual data will be dropped later, to prevent use-after-frees.

Example use:
```rs
    let data = vec!["1", "2", "3", "4"];

    let scope_handle = spawn_scoped(data, |scope, data_inner| Box::pin(async move {
        let mut tasks = vec![];
        for i in data_inner.iter() {
            let task = scope.spawn(async {
                i.parse::<i32>().unwrap()
            }).await;

            tasks.push(task);
        }

        let mut sum = 0;
        
        for task in tasks {
            sum += task.await.unwrap();
        }

        sum
    }));
```

Known issues:
- `scope.spawn` is async, because it needs to immediately do `rwlock.read().await`. Not sure if this is resolvable, maybe a while loop of `try_read`s is good enough.
- `tokio::spawn_scoped` takes a `FnOnce -> Pin<Box<dyn Future>>` - there has got to be a way to not need this and use generics instead, but I couldn't figure it out.
- possibly inappropriate use of Pin - I am not 100% sure if the Pin is required to be used at all when giving user access to the resource
- more tests - there are some tests (passing) but given this touches a bunch of unsafe and lifetimes it would be very beneficial to include more tests, probably also with loom
- missing documentation, add example use

I am aware this topic has been quite controversial and every solution has drawbacks, this PR is a potential solution for a good enough safe API to do safe scopes, and there might be more issues that I am not aware of. I did consider making this an external crate, but given it changes tokio runtime structs, it was not possible to do in a very nice way.