### PR TITLE
io: add BufWriter::into_parts

### DIFF
--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -109,6 +109,20 @@ impl<W: AsyncWrite> BufWriter<W> {
         self.inner
     }
 
+    /// Consumes this `BufWriter`, returning the underlying writer and any
+    /// buffered but unwritten data.
+    ///
+    /// The returned data does not include any bytes that were already written to
+    /// the underlying writer before a previous flush returned `Poll::Pending`.
+    /// This method does not attempt to flush data before returning.
+    pub fn into_parts(mut self) -> (W, Vec<u8>) {
+        if self.written > 0 {
+            self.buf.drain(..self.written);
+        }
+
+        (self.inner, self.buf)
+    }
+
     /// Returns a reference to the internally buffered data.
     pub fn buffer(&self) -> &[u8] {
         &self.buf

--- a/tokio/tests/io_buf_writer.rs
+++ b/tokio/tests/io_buf_writer.rs
@@ -58,6 +58,49 @@ impl AsyncWrite for MaybePending {
     }
 }
 
+struct PartialThenPending {
+    inner: Vec<u8>,
+    pending: bool,
+}
+
+impl PartialThenPending {
+    fn new() -> Self {
+        Self {
+            inner: Vec::new(),
+            pending: false,
+        }
+    }
+}
+
+impl AsyncWrite for PartialThenPending {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if self.pending {
+            cx.waker().wake_by_ref();
+            return Poll::Pending;
+        }
+
+        self.pending = true;
+        if let Some(byte) = buf.first() {
+            self.inner.push(*byte);
+            Poll::Ready(Ok(1))
+        } else {
+            Poll::Ready(Ok(0))
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
 async fn write_vectored<W>(writer: &mut W, bufs: &[IoSlice<'_>]) -> io::Result<usize>
 where
     W: AsyncWrite + Unpin,
@@ -116,6 +159,33 @@ async fn buf_writer_inner_flushes() {
     w.flush().await.unwrap();
     let w = w.into_inner();
     assert_eq!(w, [0, 1]);
+}
+
+#[tokio::test]
+async fn buf_writer_into_parts() {
+    let mut w = BufWriter::with_capacity(3, Vec::new());
+    assert_eq!(w.write(&[0, 1]).await.unwrap(), 2);
+
+    let (inner, buf) = w.into_parts();
+    assert_eq!(inner, []);
+    assert_eq!(buf, [0, 1]);
+}
+
+#[tokio::test]
+async fn buf_writer_into_parts_after_partial_flush() {
+    let mut w = BufWriter::with_capacity(4, PartialThenPending::new());
+    w.write_all(&[0, 1, 2]).await.unwrap();
+
+    future::poll_fn(|cx| match Pin::new(&mut w).poll_flush(cx) {
+        Poll::Pending => Poll::Ready(()),
+        Poll::Ready(res) => panic!("flush unexpectedly completed: {res:?}"),
+    })
+    .await;
+
+    assert_eq!(w.buffer(), [0, 1, 2]);
+    let (inner, buf) = w.into_parts();
+    assert_eq!(inner.inner, [0]);
+    assert_eq!(buf, [1, 2]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

`BufWriter::into_inner()` discards buffered data, which makes it hard to recover unwritten bytes when taking the writer back. This addresses #7865 by adding an API that returns the underlying writer together with the buffered data that has not yet been written.

## Solution

Add `BufWriter::into_parts()`, returning `(W, Vec<u8>)` without flushing. If a previous flush partially wrote data before returning `Poll::Pending`, the method drops the already-written prefix and returns only the remaining buffered bytes.

The tests cover both the ordinary buffered case and the partial-flush case where `written` is non-zero.

## Tests

- `cargo test -p tokio --test io_buf_writer --features full buf_writer_into_parts -- --nocapture`
- `cargo test -p tokio --test io_buf_writer --features full`
- `cargo check -p tokio --features full --tests`
- `rustfmt --check --edition 2021 $(git ls-files '*.rs')`\n- `git diff --check`\n\nI also tried `cargo test -p tokio --all-features --test io_buf_writer`, but this macOS environment cannot compile the `io-uring` and `taskdump` feature set: `io-uring` requires `--cfg tokio_unstable`, and `taskdump` is Linux-only.