### PR TITLE
fs: fall back when io_uring has no IO driver

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -969,20 +969,20 @@ impl Inner {
         ))]
         {
             if let Ok(handle) = crate::runtime::Handle::try_current() {
-                let driver_handle = handle.inner.driver().io();
+                if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                    if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
+                        // Fast path: uring already initialized and Read supported.
+                        let fd: crate::io::uring::utils::ArcFd = std;
+                        return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    }
 
-                if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
-                    // Fast path: uring already initialized and Read supported.
-                    let fd: crate::io::uring::utils::ArcFd = std;
-                    return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    if !driver_handle.is_uring_probed() {
+                        // Not yet probed: lazy init inside an async task so
+                        // `File::from_std()` can still benefit from io-uring.
+                        return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
+                    }
                 }
-
-                if !driver_handle.is_uring_probed() {
-                    // Not yet probed: lazy init inside an async task so
-                    // `File::from_std()` can still benefit from io-uring.
-                    return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
-                }
-                // Probed but unsupported: fall through to spawn_blocking.
+                // No IO driver or probed but unsupported: fall through to spawn_blocking.
             }
         }
 
@@ -1035,23 +1035,25 @@ impl Inner {
         target_os = "linux",
     ))]
     async fn lazy_init_read(std: Arc<StdFile>, buf: Buf, max_buf_size: usize) -> (Operation, Buf) {
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Read::CODE)
-            .await
-            .unwrap_or(false)
-        {
-            let fd: crate::io::uring::utils::ArcFd = std;
-            Self::uring_read(fd, buf, max_buf_size).await
-        } else {
-            match Self::spawn_blocking_read(buf, std, max_buf_size).await {
-                Ok(result) => result,
-                Err(e) => (
-                    Operation::Read(Err(io::Error::new(io::ErrorKind::Other, e))),
-                    Buf::with_capacity(0),
-                ),
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::Read::CODE)
+                    .await
+                    .unwrap_or(false)
+                {
+                    let fd: crate::io::uring::utils::ArcFd = std;
+                    return Self::uring_read(fd, buf, max_buf_size).await;
+                }
             }
+        }
+
+        match Self::spawn_blocking_read(buf, std, max_buf_size).await {
+            Ok(result) => result,
+            Err(e) => (
+                Operation::Read(Err(io::Error::new(io::ErrorKind::Other, e))),
+                Buf::with_capacity(0),
+            ),
         }
     }
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -1017,20 +1017,20 @@ impl Inner {
         ))]
         {
             if let Ok(handle) = crate::runtime::Handle::try_current() {
-                let driver_handle = handle.inner.driver().io();
+                if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                    if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
+                        // Fast path: uring already initialized and Read supported.
+                        let fd: crate::io::uring::utils::ArcFd = std;
+                        return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    }
 
-                if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
-                    // Fast path: uring already initialized and Read supported.
-                    let fd: crate::io::uring::utils::ArcFd = std;
-                    return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    if !driver_handle.is_uring_probed() {
+                        // Not yet probed: lazy init inside an async task so
+                        // `File::from_std()` can still benefit from io-uring.
+                        return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
+                    }
                 }
-
-                if !driver_handle.is_uring_probed() {
-                    // Not yet probed: lazy init inside an async task so
-                    // `File::from_std()` can still benefit from io-uring.
-                    return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
-                }
-                // Probed but unsupported: fall through to spawn_blocking.
+                // No IO driver or probed but unsupported: fall through to spawn_blocking.
             }
         }
 
@@ -1083,23 +1083,25 @@ impl Inner {
         target_os = "linux",
     ))]
     async fn lazy_init_read(std: Arc<StdFile>, buf: Buf, max_buf_size: usize) -> (Operation, Buf) {
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Read::CODE)
-            .await
-            .unwrap_or_default()
-        {
-            let fd: crate::io::uring::utils::ArcFd = std;
-            Self::uring_read(fd, buf, max_buf_size).await
-        } else {
-            match Self::spawn_blocking_read(buf, std, max_buf_size).await {
-                Ok(result) => result,
-                Err(e) => (
-                    Operation::Read(Err(io::Error::new(io::ErrorKind::Other, e))),
-                    Buf::with_capacity(0),
-                ),
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::Read::CODE)
+                    .await
+                    .unwrap_or_default()
+                {
+                    let fd: crate::io::uring::utils::ArcFd = std;
+                    return Self::uring_read(fd, buf, max_buf_size).await;
+                }
             }
+        }
+
+        match Self::spawn_blocking_read(buf, std, max_buf_size).await {
+            Ok(result) => result,
+            Err(e) => (
+                Operation::Read(Err(io::Error::new(io::ErrorKind::Other, e))),
+                Buf::with_capacity(0),
+            ),
         }
     }
 

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -532,18 +532,19 @@ impl OpenOptions {
                 target_os = "linux"
             ))]
             Kind::Uring(opts) => {
-                let handle = crate::runtime::Handle::current();
-                let driver_handle = handle.inner.driver().io();
-
-                if driver_handle
-                    .check_and_init(io_uring::opcode::OpenAt::CODE)
-                    .await?
-                {
-                    Op::open(path, opts)?.await
-                } else {
-                    let opts = opts.clone().into();
-                    Self::std_open(&opts, path).await
+                if let Ok(handle) = crate::runtime::Handle::try_current() {
+                    if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                        if driver_handle
+                            .check_and_init(io_uring::opcode::OpenAt::CODE)
+                            .await?
+                        {
+                            return Op::open(path, opts)?.await;
+                        }
+                    }
                 }
+
+                let opts = opts.clone().into();
+                Self::std_open(&opts, path).await
             }
         }
     }

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -75,13 +75,15 @@ pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
     {
         use crate::fs::read_uring;
 
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Read::CODE)
-            .await?
-        {
-            return read_uring(path).await;
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::Read::CODE)
+                    .await?
+                {
+                    return read_uring(path).await;
+                }
+            }
         }
     }
 

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -24,16 +24,17 @@ pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<
         use crate::io::uring::rename::Rename;
         use crate::runtime::driver::op::Op;
 
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-
         type RenameOp = Op<Rename>;
 
-        if driver_handle
-            .check_and_init(io_uring::opcode::RenameAt::CODE)
-            .await?
-        {
-            return RenameOp::rename(from, to)?.await;
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::RenameAt::CODE)
+                    .await?
+                {
+                    return RenameOp::rename(from, to)?.await;
+                }
+            }
         }
     }
 

--- a/tokio/src/fs/try_exists.rs
+++ b/tokio/src/fs/try_exists.rs
@@ -42,13 +42,15 @@ pub async fn try_exists(path: impl AsRef<Path>) -> io::Result<bool> {
         any(target_env = "gnu", target_os = "android")
     ))]
     {
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Statx::CODE)
-            .await?
-        {
-            return try_exists_uring(path).await;
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::Statx::CODE)
+                    .await?
+                {
+                    return try_exists_uring(path).await;
+                }
+            }
         }
     }
 

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -35,13 +35,15 @@ pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Re
         target_os = "linux"
     ))]
     {
-        let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Write::CODE)
-            .await?
-        {
-            return write_uring(path, contents).await;
+        if let Ok(handle) = crate::runtime::Handle::try_current() {
+            if let Some(driver_handle) = handle.inner.driver().io.as_ref() {
+                if driver_handle
+                    .check_and_init(io_uring::opcode::Write::CODE)
+                    .await?
+                {
+                    return write_uring(path, contents).await;
+                }
+            }
         }
     }
 

--- a/tokio/tests/fs_uring_no_io.rs
+++ b/tokio/tests/fs_uring_no_io.rs
@@ -1,0 +1,79 @@
+//! Tests for io-uring filesystem fallback without a runtime IO driver.
+
+#![cfg(all(
+    tokio_unstable,
+    feature = "io-uring",
+    feature = "rt",
+    feature = "fs",
+    target_os = "linux"
+))]
+
+use std::future::poll_fn;
+use std::io::Write;
+use std::pin::Pin;
+
+use tempfile::NamedTempFile;
+use tokio::io::{AsyncRead, ReadBuf};
+use tokio::runtime::{Builder, Runtime};
+
+fn runtime_without_io() -> Runtime {
+    Builder::new_current_thread().build().unwrap()
+}
+
+#[test]
+fn fs_read_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let mut tempfile = NamedTempFile::new().unwrap();
+    tempfile.write_all(b"hello").unwrap();
+
+    let contents = runtime_without_io()
+        .block_on(tokio::fs::read(tempfile.path()))
+        .unwrap();
+
+    assert_eq!(contents, b"hello");
+}
+
+#[test]
+fn fs_write_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let tempfile = NamedTempFile::new().unwrap();
+
+    runtime_without_io()
+        .block_on(tokio::fs::write(tempfile.path(), b"hello"))
+        .unwrap();
+
+    let contents = std::fs::read(tempfile.path()).unwrap();
+    assert_eq!(contents, b"hello");
+}
+
+#[test]
+fn open_options_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let mut tempfile = NamedTempFile::new().unwrap();
+    tempfile.write_all(b"hello").unwrap();
+
+    let file = runtime_without_io()
+        .block_on(
+            tokio::fs::OpenOptions::new()
+                .read(true)
+                .open(tempfile.path()),
+        )
+        .unwrap();
+
+    drop(file);
+}
+
+#[test]
+fn file_read_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let mut tempfile = NamedTempFile::new().unwrap();
+    tempfile.write_all(b"hello").unwrap();
+
+    let std_file = std::fs::File::open(tempfile.path()).unwrap();
+    let mut file = tokio::fs::File::from_std(std_file);
+    let mut contents = [0; 5];
+
+    let n = runtime_without_io().block_on(async {
+        let mut buf = ReadBuf::new(&mut contents);
+        poll_fn(|cx| Pin::new(&mut file).poll_read(cx, &mut buf)).await?;
+        std::io::Result::Ok(buf.filled().len())
+    });
+
+    assert_eq!(&contents[..n.unwrap()], b"hello");
+}

--- a/tokio/tests/fs_uring_no_io.rs
+++ b/tokio/tests/fs_uring_no_io.rs
@@ -12,7 +12,7 @@ use std::future::poll_fn;
 use std::io::Write;
 use std::pin::Pin;
 
-use tempfile::NamedTempFile;
+use tempfile::{tempdir, NamedTempFile};
 use tokio::io::{AsyncRead, ReadBuf};
 use tokio::runtime::{Builder, Runtime};
 
@@ -76,4 +76,35 @@ fn file_read_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
     });
 
     assert_eq!(&contents[..n.unwrap()], b"hello");
+}
+
+#[test]
+fn try_exists_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let tempfile = NamedTempFile::new().unwrap();
+    let missing_path = tempfile.path().with_extension("missing");
+
+    let exists = runtime_without_io()
+        .block_on(tokio::fs::try_exists(tempfile.path()))
+        .unwrap();
+    let missing = runtime_without_io()
+        .block_on(tokio::fs::try_exists(missing_path))
+        .unwrap();
+
+    assert!(exists);
+    assert!(!missing);
+}
+
+#[test]
+fn rename_should_fall_back_to_blocking_if_runtime_has_no_io_driver() {
+    let temp_dir = tempdir().unwrap();
+    let source_path = temp_dir.path().join("source");
+    let renamed_path = temp_dir.path().join("renamed");
+    std::fs::write(&source_path, b"hello").unwrap();
+
+    runtime_without_io()
+        .block_on(tokio::fs::rename(&source_path, &renamed_path))
+        .unwrap();
+
+    assert!(!source_path.exists());
+    assert_eq!(std::fs::read(renamed_path).unwrap(), b"hello");
 }


### PR DESCRIPTION
Closes #8164.

## Summary

- Skip optional io_uring filesystem paths when the current runtime has no IO driver.
- Keep the existing blocking filesystem fallback for `read`, `write`, `OpenOptions::open`, and `File` reads.
- Add Linux io_uring regression coverage for fs operations on a runtime built without IO enabled.

## Root cause

The io_uring fs probes used `driver().io()`, which panics when a runtime exists but IO is disabled. That prevented the existing blocking fallback from running.

## Tests

- `cargo fmt --check`
- `cargo test -p tokio --test fs --features full`
- `cargo test -p tokio --test fs_file --features full`
- `cargo test -p tokio --test fs_write --features full`
- `cargo test -p tokio --test fs_open_options --features full`
- `RUSTFLAGS='--cfg tokio_unstable' cargo check -p tokio --target x86_64-unknown-linux-gnu --no-default-features --features rt,fs,io-uring --test fs_uring_no_io`
- `RUSTFLAGS='--cfg tokio_unstable' cargo check -p tokio --target x86_64-unknown-linux-gnu --features full,io-uring --tests`
- `RUSTFLAGS='--cfg tokio_unstable' cargo clippy -p tokio --target x86_64-unknown-linux-gnu --no-default-features --features rt,fs,io-uring --test fs_uring_no_io -- -D warnings`
- Docker Linux: `RUSTFLAGS='--cfg tokio_unstable' cargo test -p tokio --features full,io-uring --test fs_uring_no_io -- --nocapture`