### PR TITLE
docs(time): clarify Sleep behavior when polled after completion

### DIFF
--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -217,12 +217,8 @@ pin_project! {
     ///
     /// # Polling after completion
     ///
-    /// `Sleep` is safe to poll after completion. Polling a completed
-    /// `Sleep` does not panic, and the timer remains elapsed until you
-    /// [`reset`](Sleep::reset) it, so a completed `Sleep` may remain as
-    /// a branch of a [`select!`] loop. A given `poll` may still return
-    /// `Poll::Pending` for runtime reasons such as cooperative
-    /// scheduling, but this does not change the timer's state.
+    /// `Sleep` is safe to poll after completion. Polling a completed `Sleep` does
+    /// not panic and is idempotent, but may spuriously return `Poll::Pending`.
     ///
     /// [`select!`]: ../macro.select.html
     /// [`tokio::pin!`]: ../macro.pin.html

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -136,6 +136,9 @@ pin_project! {
     /// use it with [`select!`] or by calling `poll`, you have to pin it first.
     /// If you use it with `.await`, this does not apply.
     ///
+    /// `Sleep` is safe to poll after completion. Polling a completed `Sleep` does
+    /// not panic and is idempotent, but may spuriously return `Poll::Pending`.
+    ///
     /// # Examples
     ///
     /// Wait 100ms and print "100 ms have elapsed".
@@ -214,11 +217,6 @@ pin_project! {
     ///     }
     /// }
     /// ```
-    ///
-    /// # Polling after completion
-    ///
-    /// `Sleep` is safe to poll after completion. Polling a completed `Sleep` does
-    /// not panic and is idempotent, but may spuriously return `Poll::Pending`.
     ///
     /// [`select!`]: ../macro.select.html
     /// [`tokio::pin!`]: ../macro.pin.html

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -215,6 +215,15 @@ pin_project! {
     /// }
     /// ```
     ///
+    /// # Polling after completion
+    ///
+    /// `Sleep` is safe to poll after completion. Polling a completed
+    /// `Sleep` does not panic, and the timer remains elapsed until you
+    /// [`reset`](Sleep::reset) it, so a completed `Sleep` may remain as
+    /// a branch of a [`select!`] loop. A given `poll` may still return
+    /// `Poll::Pending` for runtime reasons such as cooperative
+    /// scheduling, but this does not change the timer's state.
+    ///
     /// [`select!`]: ../macro.select.html
     /// [`tokio::pin!`]: ../macro.pin.html
     #[project(!Unpin)]

--- a/tokio/tests/time_alt.rs
+++ b/tokio/tests/time_alt.rs
@@ -1,8 +1,14 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(tokio_unstable, feature = "time", feature = "rt-multi-thread"))]
 
+use std::future::Future;
+use std::task::Context;
+
+use futures::task::noop_waker_ref;
+
 use tokio::runtime::Runtime;
 use tokio::time::*;
+use tokio_test::assert_ready;
 
 fn rt_combinations() -> Vec<Runtime> {
     let mut rts = vec![];
@@ -102,6 +108,26 @@ fn timeout() {
 
             for jh in jhs {
                 jh.await.unwrap();
+            }
+        });
+    }
+}
+
+#[test]
+fn poll_after_completion_is_ready() {
+    // `unconstrained` removes coop so the assertion only depends on `Sleep`.
+    for rt in rt_combinations() {
+        rt.block_on(async {
+            let timer =
+                tokio::task::coop::unconstrained(tokio::time::sleep(Duration::from_millis(1)));
+            tokio::pin!(timer);
+
+            timer.as_mut().await;
+
+            for _ in 0..1024 {
+                assert_ready!(timer
+                    .as_mut()
+                    .poll(&mut Context::from_waker(noop_waker_ref())));
             }
         });
     }

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -260,6 +260,21 @@ async fn reset_after_firing() {
 }
 
 #[tokio::test]
+async fn poll_after_completion_is_ready() {
+    // `unconstrained` removes coop so the assertion only depends on `Sleep`.
+    let timer = tokio::task::coop::unconstrained(tokio::time::sleep(Duration::from_millis(1)));
+    tokio::pin!(timer);
+
+    timer.as_mut().await;
+
+    for _ in 0..1024 {
+        assert_ready!(timer
+            .as_mut()
+            .poll(&mut Context::from_waker(noop_waker_ref())));
+    }
+}
+
+#[tokio::test]
 async fn exactly_max() {
     time::pause();
     time::sleep(Duration::MAX).await;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Closes #8073. The behavior of polling a `Sleep` after it has resolved is not currently documented, leaving users uncertain whether reusing the same `Sleep` in a `select!` loop is safe.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add a "Polling after completion" section to the `Sleep` docs stating that polling a completed `Sleep` does not panic and that the timer remains elapsed until `reset` is called. Add a regression test in `tokio/tests/time_sleep.rs`, and mirror it in `tokio/tests/time_alt.rs` so both the default and alternative timer implementations are covered.