### PR TITLE
docs(select!): warn about chained merge unfairness, recommend StreamMap

### DIFF
--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -454,17 +454,18 @@ macro_rules! doc {
         /// # }
         /// ```
         ///
-        /// ### Moving to `merge`
+        /// ### Moving to a stream
         ///
-        /// By using merge, you can unify multiple asynchronous tasks into a single stream,
-        /// eliminating the need to manage tasks manually and reducing the risk of
-        /// unintended behavior like data loss.
+        /// By combining the tasks into a single stream, you avoid managing them manually
+        /// and reduce the risk of unintended behavior like data loss. [`StreamMap`] polls
+        /// its entries fairly, which suits three or more sources (chaining
+        /// [`StreamExt::merge`] works for two streams but grows unfair beyond that):
         ///
         /// ```
-        /// use std::pin::pin;
+        /// use std::pin::Pin;
         ///
         /// use futures::stream::unfold;
-        /// use tokio_stream::StreamExt;
+        /// use tokio_stream::{Stream, StreamExt, StreamMap};
         ///
         /// struct File;
         /// struct Channel;
@@ -503,8 +504,13 @@ macro_rules! doc {
         /// });
         /// let c = tokio_stream::iter([Message::Stop]);
         ///
-        /// let mut s = pin!(a.merge(b).merge(c));
-        /// while let Some(msg) = s.next().await {
+        /// let mut s: StreamMap<&str, Pin<Box<dyn Stream<Item = Message>>>> =
+        ///     StreamMap::from_iter([
+        ///         ("file_channel", Box::pin(a) as _),
+        ///         ("socket", Box::pin(b) as _),
+        ///         ("control", Box::pin(c) as _),
+        ///     ]);
+        /// while let Some((_key, msg)) = s.next().await {
         ///     match msg {
         ///         Message::Data(_data) => { /* ... */ }
         ///         Message::Sent => continue,
@@ -513,6 +519,9 @@ macro_rules! doc {
         /// }
         /// # }
         /// ```
+        ///
+        /// [`StreamExt::merge`]: https://docs.rs/tokio-stream/latest/tokio_stream/trait.StreamExt.html#method.merge
+        /// [`StreamMap`]: https://docs.rs/tokio-stream/latest/tokio_stream/struct.StreamMap.html
         ///
         /// ## Racing Futures
         ///


### PR DESCRIPTION
## Motivation

Closes #7277.

The `select!` macro docs have a "Moving to merge" section whose example uses `a.merge(b).merge(c)` to combine three streams. However `tokio_stream::StreamExt::merge` only guarantees fairness between its two operands and warns against chaining `merge` calls.

Chained merges are left-biased: `a.merge(b).merge(c)` alternates between the inner `a.merge(b)` and `c`, so `c` is polled roughly as often as `a` and `b` combined, and each additional `.merge(..)` halves the share of every previously chained stream. For three or more streams, `tokio_stream::StreamMap` polls all of its entries with equal priority and is the better fit.

## Change

Adds a "Fairness when merging more than two streams" subsection right after the existing merge example in `tokio/src/macros/select.rs`. It explains the bias, sketches the equivalent `StreamMap` rewrite (reusing the `a`, `b`, and `c` from the preceding example), and links the `StreamExt::merge` fairness note and the `StreamMap` docs.

The rewrite snippet is `ignore`-gated because it continues the preceding compiled example's `a`, `b`, and `c` bindings. It carries an explicit `StreamMap<&str, Pin<Box<dyn Stream<Item = Message>>>>` type so the boxed streams unify to a single trait object. Without the annotation the array element type cannot be inferred (`E0282`).

## Verification

- `cargo doc --no-deps -p tokio` succeeds with no new warnings.
- `cargo test --doc -p tokio --features full` passes all doctests, including the `select!` doctests.
