### PR TITLE
ci: run ci with v1.96.0 beta release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTUP_WINDOWS_PATH_ADD_BIN: 1
   # Change to specific Rust release to pin
-  rust_stable: stable
+  rust_stable: beta
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
   rust_miri_nightly: nightly-2026-05-20


### PR DESCRIPTION
To catch issues with the upcoming release, give beta a try.