### PR TITLE
net: enable more TCP socket tests on Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2026-05-20
+  rust_miri_nightly: nightly-2026-05-30
   rust_clippy: '1.88'
   # When updating this, also update:
   # - README.md

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -89,7 +89,6 @@ async fn test_transfer_after_close() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
 async fn blocking_one_side_does_not_block_other() {
     symmetric(|handle, mut a, mut b| async move {
         block_write(&mut a).await;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1155,7 +1155,6 @@ rt_test! {
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
     fn local_set_client_server_block_on() {
         let rt = rt();
         let (tx, rx) = mpsc::channel();
@@ -1169,7 +1168,6 @@ rt_test! {
     }
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
-    #[cfg_attr(miri, ignore)] // Miri currently only processes host I/O events when switching into the scheduler: See https://github.com/rust-lang/miri/issues/5047
     async fn client_server_local(tx: mpsc::Sender<()>) {
         let server = assert_ok!(TcpListener::bind("127.0.0.1:0").await);
 

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -113,52 +113,48 @@ async fn try_read_write() {
     written.reserve(10 * 1024 * 1024);
     client.writable().await.unwrap();
 
-    #[cfg(not(miri))]
-    // Miri currently has a memory leak when `readv` returns an error: See https://github.com/rust-lang/miri/pull/5054
-    {
-        // Fill the write buffer using vectored I/O
-        let data_bufs: Vec<_> = DATA.chunks(10).map(io::IoSlice::new).collect();
-        loop {
-            // Still ready
-            let mut writable = task::spawn(client.writable());
-            assert_ready_ok!(writable.poll());
+    // Fill the write buffer using vectored I/O
+    let data_bufs: Vec<_> = DATA.chunks(10).map(io::IoSlice::new).collect();
+    loop {
+        // Still ready
+        let mut writable = task::spawn(client.writable());
+        assert_ready_ok!(writable.poll());
 
-            match client.try_write_vectored(&data_bufs) {
-                Ok(n) => {
-                    written.extend(&DATA[..n]);
-                }
-                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-                    break;
-                }
+        match client.try_write_vectored(&data_bufs) {
+            Ok(n) => {
+                written.extend(&DATA[..n]);
+            }
+            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                break;
+            }
+            Err(e) => panic!("error = {e:?}"),
+        }
+    }
+
+    {
+        // Write buffer full
+        let mut writable = task::spawn(client.writable());
+        assert_pending!(writable.poll());
+
+        // Drain the socket from the server end using vectored I/O
+        let mut read = vec![0; written.len()];
+        let mut i = 0;
+
+        while i < read.len() {
+            server.readable().await.unwrap();
+
+            let mut bufs: Vec<_> = read[i..]
+                .chunks_mut(0x10000)
+                .map(io::IoSliceMut::new)
+                .collect();
+            match server.try_read_vectored(&mut bufs) {
+                Ok(n) => i += n,
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
                 Err(e) => panic!("error = {e:?}"),
             }
         }
 
-        {
-            // Write buffer full
-            let mut writable = task::spawn(client.writable());
-            assert_pending!(writable.poll());
-
-            // Drain the socket from the server end using vectored I/O
-            let mut read = vec![0; written.len()];
-            let mut i = 0;
-
-            while i < read.len() {
-                server.readable().await.unwrap();
-
-                let mut bufs: Vec<_> = read[i..]
-                    .chunks_mut(0x10000)
-                    .map(io::IoSliceMut::new)
-                    .collect();
-                match server.try_read_vectored(&mut bufs) {
-                    Ok(n) => i += n,
-                    Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => continue,
-                    Err(e) => panic!("error = {e:?}"),
-                }
-            }
-
-            assert_eq!(read, written);
-        }
+        assert_eq!(read, written);
     }
 
     // Now, we listen for shutdown


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

As mentioned in #8156, there were some open issues/PRs on Miri which would enable some more TCP tests from the tokio test suite. Those PRs have now been merged, this PR enables the tests which now also work on Miri.

Now, basically the only TCP tests which can't be run on Miri are some socket options. However, we'll likely move to `socket2` instead of `mio` sockets in Miri and then those should also work in the future. I'll open a new PR once this is implemented -- however this might take some time :)