### PR TITLE
fs: avoid panic after failed file write spawn

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -744,15 +744,22 @@ impl AsyncWrite for File {
                     let mut buf = buf_cell.take().unwrap();
 
                     let seek = if !buf.is_empty() {
-                        Some(SeekFrom::Current(buf.discard_read()))
+                        Some(SeekFrom::Current(-(buf.bytes().len() as i64)))
                     } else {
                         None
                     };
 
-                    let n = buf.copy_from(src, me.max_buf_size);
+                    let mut write_buf = Buf::with_capacity(0);
+                    if seek.is_none() {
+                        std::mem::swap(&mut buf, &mut write_buf);
+                    }
+
+                    let n = write_buf.copy_from(src, me.max_buf_size);
                     let std = me.std.clone();
 
-                    let blocking_task_join_handle = spawn_mandatory_blocking(move || {
+                    let blocking_task_join_handle = match spawn_mandatory_blocking(move || {
+                        let mut buf = write_buf;
+
                         let res = if let Some(seek) = seek {
                             (&*std).seek(seek).and_then(|_| buf.write_to(&mut &*std))
                         } else {
@@ -760,10 +767,16 @@ impl AsyncWrite for File {
                         };
 
                         (Operation::Write(res), buf)
-                    })
-                    .ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::Other, "background task failed")
-                    })?;
+                    }) {
+                        Some(join_handle) => join_handle,
+                        None => {
+                            inner.state = State::Idle(Some(buf));
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                "background task failed",
+                            )));
+                        }
+                    };
 
                     inner.state = State::Busy(blocking_task_join_handle);
 
@@ -815,15 +828,22 @@ impl AsyncWrite for File {
                     let mut buf = buf_cell.take().unwrap();
 
                     let seek = if !buf.is_empty() {
-                        Some(SeekFrom::Current(buf.discard_read()))
+                        Some(SeekFrom::Current(-(buf.bytes().len() as i64)))
                     } else {
                         None
                     };
 
-                    let n = buf.copy_from_bufs(bufs, me.max_buf_size);
+                    let mut write_buf = Buf::with_capacity(0);
+                    if seek.is_none() {
+                        std::mem::swap(&mut buf, &mut write_buf);
+                    }
+
+                    let n = write_buf.copy_from_bufs(bufs, me.max_buf_size);
                     let std = me.std.clone();
 
-                    let blocking_task_join_handle = spawn_mandatory_blocking(move || {
+                    let blocking_task_join_handle = match spawn_mandatory_blocking(move || {
+                        let mut buf = write_buf;
+
                         let res = if let Some(seek) = seek {
                             (&*std).seek(seek).and_then(|_| buf.write_to(&mut &*std))
                         } else {
@@ -831,10 +851,16 @@ impl AsyncWrite for File {
                         };
 
                         (Operation::Write(res), buf)
-                    })
-                    .ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::Other, "background task failed")
-                    })?;
+                    }) {
+                        Some(join_handle) => join_handle,
+                        None => {
+                            inner.state = State::Idle(Some(buf));
+                            return Poll::Ready(Err(io::Error::new(
+                                io::ErrorKind::Other,
+                                "background task failed",
+                            )));
+                        }
+                    };
 
                     inner.state = State::Busy(blocking_task_join_handle);
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -4,9 +4,11 @@
 use futures::future::FutureExt;
 use std::io::prelude::*;
 use std::io::IoSlice;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 use tempfile::NamedTempFile;
 use tokio::fs::File;
-use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, SeekFrom};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWrite, AsyncWriteExt, SeekFrom};
 use tokio_test::task;
 
 const HELLO: &[u8] = b"hello world...";
@@ -83,6 +85,60 @@ async fn write_vectored_and_shutdown() {
 
     let file = std::fs::read(tempfile.path()).unwrap();
     assert_eq!(file, [HELLO, HELLO].concat());
+}
+
+#[test]
+fn poll_write_after_runtime_shutdown_returns_errors() {
+    let tempfile = tempfile();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    let handle = rt.handle().clone();
+    let mut file = rt.block_on(async { File::create(tempfile.path()).await.unwrap() });
+
+    rt.shutdown_background();
+    let _guard = handle.enter();
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert!(matches!(
+        Pin::new(&mut file).poll_write(&mut cx, b"first write"),
+        Poll::Ready(Err(_))
+    ));
+    assert!(matches!(
+        Pin::new(&mut file).poll_write(&mut cx, b"second write"),
+        Poll::Ready(Err(_))
+    ));
+}
+
+#[test]
+fn poll_write_vectored_after_runtime_shutdown_returns_errors() {
+    let tempfile = tempfile();
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    let handle = rt.handle().clone();
+    let mut file = rt.block_on(async { File::create(tempfile.path()).await.unwrap() });
+
+    rt.shutdown_background();
+    let _guard = handle.enter();
+    let waker = futures::task::noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let first = [IoSlice::new(b"first write")];
+    let second = [IoSlice::new(b"second write")];
+
+    assert!(matches!(
+        Pin::new(&mut file).poll_write_vectored(&mut cx, &first),
+        Poll::Ready(Err(_))
+    ));
+    assert!(matches!(
+        Pin::new(&mut file).poll_write_vectored(&mut cx, &second),
+        Poll::Ready(Err(_))
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Fixes #8182.

`tokio::fs::File::poll_write` and `poll_write_vectored` can return an error when mandatory blocking spawn fails. Today that path moves the buffer out of the idle state before returning, leaving the file as `State::Idle(None)`. A later write poll can then panic while unwrapping the missing buffer.

## Solution

Restore a valid idle buffer before returning the spawn failure error. When there is buffered unread data, use a separate write buffer so the original idle buffer can be restored if spawn fails; on successful spawn, the write task returns the write buffer as before.

Added regression coverage for repeated `poll_write` and `poll_write_vectored` calls after the runtime blocking pool has shut down.
