### PR TITLE
fs(tests): do not leak FDs with shutdown background

### DIFF
--- a/tokio/tests/fs_uring_cancel_open.rs
+++ b/tokio/tests/fs_uring_cancel_open.rs
@@ -12,6 +12,7 @@ use futures::future::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio_test::assert_pending;
 
@@ -66,6 +67,9 @@ async fn file_descriptors_are_closed_when_cancelling_open_op() {
         let res = handle.await.unwrap_err();
         assert!(res.is_cancelled());
     }
+
+    // Give completions a moment to settle before counting fds.
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
     let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);

--- a/tokio/tests/fs_uring_cancel_open.rs
+++ b/tokio/tests/fs_uring_cancel_open.rs
@@ -12,11 +12,10 @@ use futures::future::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
-use std::time::{Duration, Instant};
 use tempfile::NamedTempFile;
 use tokio_test::assert_pending;
 
-use crate::support::io_uring::io_uring_supported;
+use crate::support::io_uring::{assert_fds_are_not_leaking, io_uring_supported};
 
 mod support {
     pub(crate) mod io_uring;
@@ -31,10 +30,10 @@ async fn file_descriptors_are_closed_when_cancelling_open_op() {
 
     let tmp = NamedTempFile::new().unwrap();
     let path = tmp.path().to_path_buf();
-
+    let file_number = 128;
     let fd_count_before_opens = fs::read_dir("/proc/self/fd").unwrap().count();
 
-    for _ in 0..128 {
+    for _ in 0..file_number {
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
 
         let path = path.clone();
@@ -68,24 +67,5 @@ async fn file_descriptors_are_closed_when_cancelling_open_op() {
         assert!(res.is_cancelled());
     }
 
-    let fd_check_start = Instant::now();
-
-    while fd_check_start.elapsed() < Duration::from_secs(1) {
-        tokio::task::yield_now().await;
-
-        let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
-        let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);
-
-        // Since we are opening 128 files, we expect that the related fds
-        // related to this operation will be closed. Since some other fds
-        // can be opened in the meantime, we expect this number to be higher
-        // than the counter before opening the files. This number could be
-        // lower, but to avoid test flakiness we check that this is at most
-        // half the number of the file we opened to check if there's a leak.
-        if leaked <= 64 {
-            // test success
-            return;
-        }
-    }
-    panic!("Number of FDs is staying above 64. There is probably an FD leak.");
+    assert_fds_are_not_leaking(fd_count_before_opens, file_number, 1).await
 }

--- a/tokio/tests/fs_uring_cancel_open.rs
+++ b/tokio/tests/fs_uring_cancel_open.rs
@@ -12,7 +12,7 @@ use futures::future::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::NamedTempFile;
 use tokio_test::assert_pending;
 
@@ -68,17 +68,24 @@ async fn file_descriptors_are_closed_when_cancelling_open_op() {
         assert!(res.is_cancelled());
     }
 
-    // Give completions a moment to settle before counting fds.
-    tokio::time::sleep(Duration::from_millis(250)).await;
+    let fd_check_start = Instant::now();
 
-    let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
-    let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);
+    while fd_check_start.elapsed() < Duration::from_secs(1) {
+        tokio::task::yield_now().await;
 
-    // Since we are opening 128 files, we expect that the related fds
-    // related to this operation will be closed. Since some other fds
-    // can be opened in the meantime, we expect this number to be higher
-    // than the counter before opening the files. This number could be
-    // lower, but to avoid test flakiness we check that this is at most
-    // half the number of the file we opened to check if there's a leak.
-    assert!(leaked <= 64);
+        let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
+        let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);
+
+        // Since we are opening 128 files, we expect that the related fds
+        // related to this operation will be closed. Since some other fds
+        // can be opened in the meantime, we expect this number to be higher
+        // than the counter before opening the files. This number could be
+        // lower, but to avoid test flakiness we check that this is at most
+        // half the number of the file we opened to check if there's a leak.
+        if leaked <= 64 {
+            // test success
+            return;
+        }
+    }
+    panic!("Number of FDs is staying above 64. There is probably an FD leak.");
 }

--- a/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
+++ b/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -128,18 +128,25 @@ fn uring_completed_then_dropped() {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        // Give completions a moment to settle before counting fds.
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        let fd_check_start = Instant::now();
 
-        let after = fd_count();
-        let leaked = after.saturating_sub(before);
+        while fd_check_start.elapsed() < Duration::from_secs(1) {
+            tokio::task::yield_now().await;
 
-        // Since we are opening 128 files, we expect that the related fds
-        // related to this operation will be closed. Since some other fds
-        // can be opened in the meantime, we expect this number to be higher
-        // than the counter before opening the files. This number could be
-        // lower, but to avoid test flakiness we check that this is at most
-        // half the number of the file we opened to check if there's a leak.
-        assert!(leaked <= 64);
+            let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
+            let leaked = fd_count_after_cancel.saturating_sub(before);
+
+            // Since we are opening 128 files, we expect that the related fds
+            // related to this operation will be closed. Since some other fds
+            // can be opened in the meantime, we expect this number to be higher
+            // than the counter before opening the files. This number could be
+            // lower, but to avoid test flakiness we check that this is at most
+            // half the number of the file we opened to check if there's a leak.
+            if leaked <= 64 {
+                // test success
+                return;
+            }
+        }
+        panic!("Number of FDs is staying above 64. There is probably an FD leak.");
     });
 }

--- a/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
+++ b/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
@@ -23,7 +23,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::time::timeout;
 use tokio_test::assert_pending;
 
-use crate::support::io_uring::{assert_fd_are_not_leaking, io_uring_supported};
+use crate::support::io_uring::{assert_fds_are_not_leaking, io_uring_supported};
 
 /// Count currently-open fds in this process.
 fn fd_count() -> usize {
@@ -129,6 +129,6 @@ fn uring_completed_then_dropped() {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        assert_fd_are_not_leaking(before, file_number, 1).await
+        assert_fds_are_not_leaking(before, file_number, 1).await
     });
 }

--- a/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
+++ b/tokio/tests/fs_uring_completed_then_dropped_before_repoll.rs
@@ -16,14 +16,14 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tempfile::NamedTempFile;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::time::timeout;
 use tokio_test::assert_pending;
 
-use crate::support::io_uring::io_uring_supported;
+use crate::support::io_uring::{assert_fd_are_not_leaking, io_uring_supported};
 
 /// Count currently-open fds in this process.
 fn fd_count() -> usize {
@@ -123,30 +123,12 @@ fn uring_completed_then_dropped() {
         let before = fd_count();
         let tmp = NamedTempFile::new().unwrap();
         let path = tmp.path().to_path_buf();
+        let file_number = 128;
 
-        for _ in 0..128 {
+        for _ in 0..file_number {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        let fd_check_start = Instant::now();
-
-        while fd_check_start.elapsed() < Duration::from_secs(1) {
-            tokio::task::yield_now().await;
-
-            let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
-            let leaked = fd_count_after_cancel.saturating_sub(before);
-
-            // Since we are opening 128 files, we expect that the related fds
-            // related to this operation will be closed. Since some other fds
-            // can be opened in the meantime, we expect this number to be higher
-            // than the counter before opening the files. This number could be
-            // lower, but to avoid test flakiness we check that this is at most
-            // half the number of the file we opened to check if there's a leak.
-            if leaked <= 64 {
-                // test success
-                return;
-            }
-        }
-        panic!("Number of FDs is staying above 64. There is probably an FD leak.");
+        assert_fd_are_not_leaking(before, file_number, 1).await
     });
 }

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -73,8 +73,8 @@ fn shutdown_runtime_while_performing_io_uring_ops() {
         }
     });
 
-    // Shutdown the runtime and give some time before counting the fds
-    rt.shutdown_timeout(Duration::from_millis(250));
+    // Shutdown the runtime and wait for fds to be closed
+    drop(rt);
 
     let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
     let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -12,6 +12,7 @@ use futures::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::runtime::Builder;
 use tokio_test::assert_pending;
@@ -72,7 +73,8 @@ fn shutdown_runtime_while_performing_io_uring_ops() {
         }
     });
 
-    rt.shutdown_background();
+    // Shutdown the runtime and give some time before counting the fds
+    rt.shutdown_timeout(Duration::from_millis(250));
 
     let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
     let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -73,7 +73,6 @@ fn shutdown_runtime_while_performing_io_uring_ops() {
         }
     });
 
-    // Shutdown the runtime and wait for fds to be closed
     rt.shutdown_timeout(Duration::from_millis(250));
 
     let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -12,7 +12,7 @@ use futures::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::NamedTempFile;
 use tokio::runtime::Builder;
 use tokio_test::assert_pending;
@@ -73,16 +73,24 @@ fn shutdown_runtime_while_performing_io_uring_ops() {
         }
     });
 
-    rt.shutdown_timeout(Duration::from_millis(250));
+    rt.shutdown_background();
 
-    let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
-    let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);
+    let fd_check_start = Instant::now();
 
-    // Since we are opening 128 files, we expect that the related fds
-    // related to this operation will be closed. Since some other fds
-    // can be opened in the meantime, we expect this number to be higher
-    // than the counter before opening the files. This number could be
-    // lower, but to avoid test flakiness we check that this is at most
-    // half the number of the file we opened to check if there's a leak.
-    assert!(leaked <= 64);
+    while fd_check_start.elapsed() < Duration::from_secs(1) {
+        let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
+        let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);
+
+        // Since we are opening 128 files, we expect that the related fds
+        // related to this operation will be closed. Since some other fds
+        // can be opened in the meantime, we expect this number to be higher
+        // than the counter before opening the files. This number could be
+        // lower, but to avoid test flakiness we check that this is at most
+        // half the number of the file we opened to check if there's a leak.
+        if leaked <= 64 {
+            // test success
+            return;
+        }
+    }
+    panic!("Number of FDs is staying above 64. There is probably an FD leak.");
 }

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -12,6 +12,7 @@ use futures::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
+use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::runtime::Builder;
 use tokio_test::assert_pending;
@@ -73,7 +74,7 @@ fn shutdown_runtime_while_performing_io_uring_ops() {
     });
 
     // Shutdown the runtime and wait for fds to be closed
-    drop(rt);
+    rt.shutdown_timeout(Duration::from_millis(250));
 
     let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
     let leaked = fd_count_after_cancel.saturating_sub(fd_count_before_opens);

--- a/tokio/tests/fs_uring_runtime_shutdown.rs
+++ b/tokio/tests/fs_uring_runtime_shutdown.rs
@@ -12,7 +12,6 @@ use futures::FutureExt;
 use std::fs;
 use std::future::poll_fn;
 use std::task::Poll;
-use std::time::Duration;
 use tempfile::NamedTempFile;
 use tokio::runtime::Builder;
 use tokio_test::assert_pending;

--- a/tokio/tests/fs_uring_statx_fd_leak_test.rs
+++ b/tokio/tests/fs_uring_statx_fd_leak_test.rs
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::time::timeout;
 use tokio_test::assert_pending;
 
-use crate::support::io_uring::{assert_fd_are_not_leaking, io_uring_supported};
+use crate::support::io_uring::{assert_fds_are_not_leaking, io_uring_supported};
 
 /// Count currently-open fds in this process.
 fn fd_count() -> usize {
@@ -145,6 +145,6 @@ fn uring_completed_then_dropped() {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        assert_fd_are_not_leaking(before, file_number, 1).await
+        assert_fds_are_not_leaking(before, file_number, 1).await
     });
 }

--- a/tokio/tests/fs_uring_statx_fd_leak_test.rs
+++ b/tokio/tests/fs_uring_statx_fd_leak_test.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use tempfile::NamedTempFile;
 use tokio::fs::read;
@@ -24,7 +24,7 @@ use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use tokio::time::timeout;
 use tokio_test::assert_pending;
 
-use crate::support::io_uring::io_uring_supported;
+use crate::support::io_uring::{assert_fd_are_not_leaking, io_uring_supported};
 
 /// Count currently-open fds in this process.
 fn fd_count() -> usize {
@@ -139,30 +139,12 @@ fn uring_completed_then_dropped() {
         let before = fd_count();
         let tmp = NamedTempFile::new().unwrap();
         let path = tmp.path().to_path_buf();
+        let file_number = 128;
 
-        for _ in 0..128 {
+        for _ in 0..file_number {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        let fd_check_start = Instant::now();
-
-        while fd_check_start.elapsed() < Duration::from_secs(1) {
-            tokio::task::yield_now().await;
-
-            let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
-            let leaked = fd_count_after_cancel.saturating_sub(before);
-
-            // Since we are opening 128 files, we expect that the related fds
-            // related to this operation will be closed. Since some other fds
-            // can be opened in the meantime, we expect this number to be higher
-            // than the counter before opening the files. This number could be
-            // lower, but to avoid test flakiness we check that this is at most
-            // half the number of the file we opened to check if there's a leak.
-            if leaked <= 64 {
-                // test success
-                return;
-            }
-        }
-        panic!("Number of FDs is staying above 64. There is probably an FD leak.");
+        assert_fd_are_not_leaking(before, file_number, 1).await
     });
 }

--- a/tokio/tests/fs_uring_statx_fd_leak_test.rs
+++ b/tokio/tests/fs_uring_statx_fd_leak_test.rs
@@ -16,7 +16,7 @@ use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tempfile::NamedTempFile;
 use tokio::fs::read;
@@ -144,18 +144,25 @@ fn uring_completed_then_dropped() {
             completed_then_dropped_before_repoll(path.clone()).await;
         }
 
-        // Give completions a moment to settle before counting fds.
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        let fd_check_start = Instant::now();
 
-        let after = fd_count();
-        let leaked = after.saturating_sub(before);
+        while fd_check_start.elapsed() < Duration::from_secs(1) {
+            tokio::task::yield_now().await;
 
-        // Since we are opening 128 files, we expect that the related fds
-        // related to this operation will be closed. Since some other fds
-        // can be opened in the meantime, we expect this number to be higher
-        // than the counter before opening the files. This number could be
-        // lower, but to avoid test flakiness we check that this is at most
-        // half the number of the file we opened to check if there's a leak.
-        assert!(leaked <= 64);
+            let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
+            let leaked = fd_count_after_cancel.saturating_sub(before);
+
+            // Since we are opening 128 files, we expect that the related fds
+            // related to this operation will be closed. Since some other fds
+            // can be opened in the meantime, we expect this number to be higher
+            // than the counter before opening the files. This number could be
+            // lower, but to avoid test flakiness we check that this is at most
+            // half the number of the file we opened to check if there's a leak.
+            if leaked <= 64 {
+                // test success
+                return;
+            }
+        }
+        panic!("Number of FDs is staying above 64. There is probably an FD leak.");
     });
 }

--- a/tokio/tests/support/io_uring.rs
+++ b/tokio/tests/support/io_uring.rs
@@ -28,6 +28,7 @@ pub fn io_uring_supported() -> bool {
     }
 }
 
+#[allow(dead_code)]
 pub async fn assert_fds_are_not_leaking(count_before: usize, opened_files: usize, timeout: u64) {
     let fd_check_start = Instant::now();
 

--- a/tokio/tests/support/io_uring.rs
+++ b/tokio/tests/support/io_uring.rs
@@ -6,6 +6,11 @@
     target_os = "linux"
 ))]
 
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
+
 use io_uring::IoUring;
 
 // Currently, we are running some of the tests on Kernels where io_uring is not supported
@@ -21,4 +26,29 @@ pub fn io_uring_supported() -> bool {
             "The target should either support io_uring or return ENOSYS if not supported"
         ),
     }
+}
+
+pub async fn assert_fds_are_not_leaking(count_before: usize, opened_files: usize, timeout: u64) {
+    let fd_check_start = Instant::now();
+
+    let max_leaked_fd = opened_files / 2;
+
+    while fd_check_start.elapsed() < Duration::from_secs(timeout) {
+        tokio::task::yield_now().await;
+
+        let fd_count_after_cancel = fs::read_dir("/proc/self/fd").unwrap().count();
+        let leaked = fd_count_after_cancel.saturating_sub(count_before);
+
+        // Since we are opening {opened_files} files, we expect that the related fds
+        // related to this operation will be closed. Since some other fds
+        // can be opened in the meantime, we expect this number to be higher
+        // than the counter before opening the files. This number could be
+        // lower, but to avoid test flakiness we check that this is at most
+        // half the number of the file we opened to check if there's a leak.
+        if leaked <= max_leaked_fd {
+            // test success
+            return;
+        }
+    }
+    panic!("Number of FDs is staying above {max_leaked_fd}. There is probably an FD leak.");
 }


### PR DESCRIPTION
I noticed [this](https://github.com/tokio-rs/tokio/actions/runs/26756684540/job/78858719364) spurious failure in io-uring tests due to the fact that `shutdown_background` does not wait for tasks to finish the work. I was able to reproduce this locally by running the tests multiple times, and the wait fixes the issue.