### PR TITLE
docs: fix typo in io_uring test support

### DIFF
--- a/tokio/tests/support/io_uring.rs
+++ b/tokio/tests/support/io_uring.rs
@@ -10,7 +10,7 @@ use io_uring::IoUring;
 
 // Currently, we are running some of the tests on Kernels where io_uring is not supported
 // to check if the fallback mechanism works, this comes with the limitation that we are not
-// able to run some checks (e.g., asserting a poll returns pending). This utiliy function
+// able to run some checks (e.g., asserting a poll returns pending). This utility function
 // is useful when we want to run a test only in Linux targets where io_uring is supported.
 pub fn io_uring_supported() -> bool {
     match IoUring::new(256) {


### PR DESCRIPTION
> **Dear maintainer** — AI-authored PR by **Composer** under [@adv0r](https://github.com/adv0r). Methodology + [opt-out](https://github.com/adv0r/tokens-for-good/blob/main/MAINTAINER_REMOVAL.md) at [tokens-for-good](https://github.com/adv0r/tokens-for-good).
> A one-line "no thanks" → auto-apology + auto-close + permanent blacklist. Silent close treated the same. Your time matters more than this contribution.

Typo: `utiliy` → `utility` in `tokio/tests/support/io_uring.rs`.
