### PR TITLE
tokio-stream: add `Stream` wrapper for `JoinSet`

### DIFF
--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -24,6 +24,7 @@ full = [
     "net",
     "io-util",
     "fs",
+    "rt",
     "sync",
     "signal"
 ]
@@ -32,6 +33,7 @@ time = ["tokio/time"]
 net = ["tokio/net"]
 io-util = ["tokio/io-util"]
 fs = ["tokio/fs"]
+rt = ["tokio/rt"]
 sync = ["tokio/sync", "tokio-util"]
 signal = ["tokio/signal"]
 

--- a/tokio-stream/src/macros.rs
+++ b/tokio-stream/src/macros.rs
@@ -57,3 +57,13 @@ macro_rules! cfg_signal {
         )*
     }
 }
+
+macro_rules! cfg_rt {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "rt")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "rt")))]
+            $item
+        )*
+    }
+}

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -13,6 +13,11 @@ pub use mpsc_bounded::ReceiverStream;
 mod mpsc_unbounded;
 pub use mpsc_unbounded::UnboundedReceiverStream;
 
+#[cfg(feature = "rt")]
+mod task;
+#[cfg(feature = "rt")]
+pub use task::JoinSetStream;
+
 cfg_sync! {
     mod broadcast;
     pub use broadcast::BroadcastStream;

--- a/tokio-stream/src/wrappers.rs
+++ b/tokio-stream/src/wrappers.rs
@@ -13,10 +13,10 @@ pub use mpsc_bounded::ReceiverStream;
 mod mpsc_unbounded;
 pub use mpsc_unbounded::UnboundedReceiverStream;
 
-#[cfg(feature = "rt")]
-mod task;
-#[cfg(feature = "rt")]
-pub use task::JoinSetStream;
+cfg_rt! {
+    mod task;
+    pub use task::JoinSetStream;
+}
 
 cfg_sync! {
     mod broadcast;

--- a/tokio-stream/src/wrappers/task.rs
+++ b/tokio-stream/src/wrappers/task.rs
@@ -30,6 +30,7 @@ use tokio::task::{JoinError, JoinSet};
 pub struct JoinSetStream<T> {
     inner: JoinSet<T>,
 }
+
 impl<T> JoinSetStream<T> {
     /// Create a new `JoinSetStream`.
     pub fn new(join_set: JoinSet<T>) -> Self {

--- a/tokio-stream/src/wrappers/task.rs
+++ b/tokio-stream/src/wrappers/task.rs
@@ -1,0 +1,80 @@
+use crate::Stream;
+use core::future::Future;
+use core::pin::pin;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::task::{JoinError, JoinSet};
+
+/// A wrapper around [`tokio::task::JoinSet`] that implements [`Stream`].
+///
+/// # Example
+///
+/// ```
+/// use tokio::task::JoinSet;
+/// use tokio_stream::wrappers::JoinSetStream;
+/// use tokio_stream::StreamExt;
+///
+/// # #[tokio::main(flavor = "current_thread")]
+/// # async fn main() -> Result<(), tokio::task::JoinError> {
+/// let set: JoinSet<_> = (0..2).map(|i| async move { i }).collect();
+///
+/// let mut stream = JoinSetStream::new(set);
+/// assert_eq!(stream.next().await.transpose()?, Some(0));
+/// assert_eq!(stream.next().await.transpose()?, Some(1));
+/// assert_eq!(stream.next().await.transpose()?, None);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// [`tokio::sync::mpsc::Receiver`]: struct@tokio::sync::mpsc::Receiver
+/// [`Stream`]: trait@crate::Stream
+#[derive(Debug)]
+pub struct JoinSetStream<T> {
+    inner: JoinSet<T>,
+}
+impl<T> JoinSetStream<T> {
+    /// Create a new `JoinSetStream`.
+    pub fn new(recv: JoinSet<T>) -> Self {
+        Self { inner: recv }
+    }
+
+    /// Get back the inner `JoinSet`.
+    pub fn into_inner(self) -> JoinSet<T> {
+        self.inner
+    }
+}
+
+impl<T: 'static> Stream for JoinSetStream<T> {
+    type Item = Result<T, JoinError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut pinned = pin!(self.inner.join_next());
+        pinned.as_mut().poll(cx)
+    }
+
+    /// Returns the bounds of the stream based on the underlying `JoinSet`.
+    ///
+    /// It returns `(set.len(), Some(set.len()))`.
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.inner.len();
+        (size, Some(size))
+    }
+}
+
+impl<T> AsRef<JoinSet<T>> for JoinSetStream<T> {
+    fn as_ref(&self) -> &JoinSet<T> {
+        &self.inner
+    }
+}
+
+impl<T> AsMut<JoinSet<T>> for JoinSetStream<T> {
+    fn as_mut(&mut self) -> &mut JoinSet<T> {
+        &mut self.inner
+    }
+}
+
+impl<T> From<JoinSet<T>> for JoinSetStream<T> {
+    fn from(recv: JoinSet<T>) -> Self {
+        Self::new(recv)
+    }
+}

--- a/tokio-stream/src/wrappers/task.rs
+++ b/tokio-stream/src/wrappers/task.rs
@@ -1,6 +1,4 @@
 use crate::Stream;
-use core::future::Future;
-use core::pin::pin;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::task::{JoinError, JoinSet};
@@ -48,8 +46,7 @@ impl<T: 'static> Stream for JoinSetStream<T> {
     type Item = Result<T, JoinError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut pinned = pin!(self.inner.join_next());
-        pinned.as_mut().poll(cx)
+        self.inner.poll_join_next(cx)
     }
 
     /// Returns the bounds of the stream based on the underlying `JoinSet`.

--- a/tokio-stream/src/wrappers/task.rs
+++ b/tokio-stream/src/wrappers/task.rs
@@ -32,8 +32,8 @@ pub struct JoinSetStream<T> {
 }
 impl<T> JoinSetStream<T> {
     /// Create a new `JoinSetStream`.
-    pub fn new(recv: JoinSet<T>) -> Self {
-        Self { inner: recv }
+    pub fn new(join_set: JoinSet<T>) -> Self {
+        Self { inner: join_set }
     }
 
     /// Get back the inner `JoinSet`.
@@ -71,7 +71,7 @@ impl<T> AsMut<JoinSet<T>> for JoinSetStream<T> {
 }
 
 impl<T> From<JoinSet<T>> for JoinSetStream<T> {
-    fn from(recv: JoinSet<T>) -> Self {
-        Self::new(recv)
+    fn from(join_set: JoinSet<T>) -> Self {
+        Self::new(join_set)
     }
 }

--- a/tokio-stream/src/wrappers/task.rs
+++ b/tokio-stream/src/wrappers/task.rs
@@ -24,7 +24,7 @@ use tokio::task::{JoinError, JoinSet};
 /// # }
 /// ```
 ///
-/// [`tokio::sync::mpsc::Receiver`]: struct@tokio::sync::mpsc::Receiver
+/// [`tokio::task::JoinSet`]: struct@tokio::task::JoinSet
 /// [`Stream`]: trait@crate::Stream
 #[derive(Debug)]
 pub struct JoinSetStream<T> {

--- a/tokio-stream/tests/join_set_stream.rs
+++ b/tokio-stream/tests/join_set_stream.rs
@@ -1,0 +1,34 @@
+use futures::{Stream, StreamExt};
+use std::collections::HashSet;
+use tokio::task::JoinSet;
+use tokio_stream::wrappers::JoinSetStream;
+
+#[tokio::test]
+async fn size_hint_stream() {
+    let set: JoinSet<_> = (0..2).map(|i| async move { i }).collect();
+    let mut stream = JoinSetStream::new(set);
+
+    assert_eq!(stream.size_hint(), (2, Some(2)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (1, Some(1)));
+    stream.next().await;
+    assert_eq!(stream.size_hint(), (0, Some(0)));
+}
+
+#[tokio::test]
+async fn join_set_as_stream() {
+    let set: JoinSet<_> = (0..2).map(|i| async move { i }).collect();
+    let stream = JoinSetStream::new(set);
+
+    let values: HashSet<_> = stream.map(|result| result.unwrap()).collect().await;
+    assert_eq!(values, HashSet::from([0, 1]));
+}
+
+#[tokio::test]
+async fn join_set_as_stream_panics_with_error() {
+    let set: JoinSet<_> = std::iter::once(async move { panic!("boom!") }).collect();
+    let mut stream = JoinSetStream::new(set);
+
+    let result = stream.next().await.transpose();
+    assert!(matches!(result, Err(e) if e.is_panic()));
+}

--- a/tokio-stream/tests/join_set_stream.rs
+++ b/tokio-stream/tests/join_set_stream.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "rt")]
+
 use futures::{Stream, StreamExt};
 use std::collections::HashSet;
 use tokio::task::JoinSet;

--- a/tokio-stream/tests/join_set_stream.rs
+++ b/tokio-stream/tests/join_set_stream.rs
@@ -24,6 +24,9 @@ async fn join_set_as_stream() {
     assert_eq!(values, HashSet::from([0, 1]));
 }
 
+// Cannot run this test when “unwind” is disabled
+// since `JoinSet` use it to catch futures that panics.
+#[cfg(panic = "unwind")]
 #[tokio::test]
 async fn join_set_as_stream_panics_with_error() {
     let set: JoinSet<_> = std::iter::once(async move { panic!("boom!") }).collect();


### PR DESCRIPTION
Fixes #8187 (contains the description and a motivation)

## Solution

Mostly a copy of `ReceiverStream`. The main difference is the implementation of `Stream` itself. First, we do not return `T` but `Result<T, JoinError>` since each call to `join_next` can fail. And the implementation of `size_hint` is trivial (`JoinSet` has a known size).

I hid `JoinSetStream` behind the `rt` feature since `JoinSet` is itself behind the `rt` feature in `tokio`.

I’m no expert in `pin` shenanigans. I mostly let the compiler guide me towards the solution. The `pin!()`, from what I can understand seems legit. But I also had to impose a `'static` bound of the `T` and I’m not entirely sure if that is a necessary constraint.