### PR TITLE
docs: add interactive and non-interactive stdin examples

### DIFF
--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -93,13 +93,18 @@ cfg_io_std! {
     ///         }
     ///     });
     ///
+    ///     // Create the Ctrl-C future once and poll it across loop iterations,
+    ///     // rather than building a new one each time through `select!`.
+    ///     let ctrl_c = tokio::signal::ctrl_c();
+    ///     tokio::pin!(ctrl_c);
+    ///
     ///     loop {
     ///         tokio::select! {
     ///             maybe_line = rx.recv() => match maybe_line {
     ///                 Some(line) => println!("read line: {}", line),
     ///                 None => break, // input thread reached end-of-file
     ///             },
-    ///             _ = tokio::signal::ctrl_c() => {
+    ///             _ = &mut ctrl_c => {
     ///                 // Stop awaiting input so the runtime can shut down, even
     ///                 // though the reader thread may still be blocked on read.
     ///                 println!("shutting down");

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -40,6 +40,75 @@ cfg_io_std! {
     ///
     /// For interactive uses, it is recommended to spawn a thread dedicated to
     /// user input and use blocking IO directly in that thread.
+    ///
+    /// # Examples
+    ///
+    /// Reading all data piped into the process from standard input. This is the
+    /// recommended, non-interactive use of [`Stdin`]: when input is piped in,
+    /// stdin reaches end-of-file and the read completes, so the runtime can shut
+    /// down cleanly.
+    ///
+    /// ```no_run
+    /// use tokio::io::{self, AsyncReadExt};
+    ///
+    /// #[tokio::main]
+    /// async fn main() -> io::Result<()> {
+    ///     let mut stdin = io::stdin();
+    ///     let mut buf = Vec::new();
+    ///     stdin.read_to_end(&mut buf).await?;
+    ///
+    ///     println!("read {} bytes from stdin", buf.len());
+    ///     Ok(())
+    /// }
+    /// ```
+    ///
+    /// Handling *interactive* input. Reading [`Stdin`] directly from async code
+    /// is not recommended: because the read is performed by an uncancellable
+    /// blocking operation, awaiting it can make runtime shutdown hang until the
+    /// user presses enter. Instead, spawn a dedicated thread that performs the
+    /// blocking reads and forwards each line over a channel. Async code then
+    /// selects over that channel, so it can stop on a shutdown signal without
+    /// waiting for the blocking read to finish:
+    ///
+    /// ```no_run
+    /// use std::io::BufRead;
+    /// use tokio::sync::mpsc;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let (tx, mut rx) = mpsc::channel::<String>(16);
+    ///
+    ///     // Blocking, uncancellable reads live on this dedicated thread, off
+    ///     // the async runtime. Each line is forwarded to async code.
+    ///     std::thread::spawn(move || {
+    ///         for line in std::io::stdin().lock().lines() {
+    ///             let line = match line {
+    ///                 Ok(line) => line,
+    ///                 Err(_) => break,
+    ///             };
+    ///             // The receiver is dropped once the runtime shuts down; stop.
+    ///             if tx.blocking_send(line).is_err() {
+    ///                 break;
+    ///             }
+    ///         }
+    ///     });
+    ///
+    ///     loop {
+    ///         tokio::select! {
+    ///             maybe_line = rx.recv() => match maybe_line {
+    ///                 Some(line) => println!("read line: {}", line),
+    ///                 None => break, // input thread reached end-of-file
+    ///             },
+    ///             _ = tokio::signal::ctrl_c() => {
+    ///                 // Stop awaiting input so the runtime can shut down, even
+    ///                 // though the reader thread may still be blocked on read.
+    ///                 println!("shutting down");
+    ///                 break;
+    ///             }
+    ///         }
+    ///     }
+    /// }
+    /// ```
     pub fn stdin() -> Stdin {
         let std = io::stdin();
         // SAFETY: The `Read` implementation of `std` does not read from the

--- a/tokio/src/io/stdin.rs
+++ b/tokio/src/io/stdin.rs
@@ -63,10 +63,10 @@ cfg_io_std! {
     /// ```
     ///
     /// Handling *interactive* input. Reading [`Stdin`] directly from async code
-    /// is not recommended: because the read is performed by an uncancellable
-    /// blocking operation, awaiting it can make runtime shutdown hang until the
-    /// user presses enter. Instead, spawn a dedicated thread that performs the
-    /// blocking reads and forwards each line over a channel. Async code then
+    /// is not recommended: because the read is performed by a blocking operation
+    /// that cannot be cancelled, awaiting it can make runtime shutdown hang until
+    /// the user presses enter. Instead, spawn a dedicated thread that performs
+    /// the blocking reads and forwards each line over a channel. Async code then
     /// selects over that channel, so it can stop on a shutdown signal without
     /// waiting for the blocking read to finish:
     ///
@@ -78,8 +78,8 @@ cfg_io_std! {
     /// async fn main() {
     ///     let (tx, mut rx) = mpsc::channel::<String>(16);
     ///
-    ///     // Blocking, uncancellable reads live on this dedicated thread, off
-    ///     // the async runtime. Each line is forwarded to async code.
+    ///     // Blocking reads that cannot be cancelled live on this dedicated
+    ///     // thread, off the async runtime. Each line is forwarded to async code.
     ///     std::thread::spawn(move || {
     ///         for line in std::io::stdin().lock().lines() {
     ///             let line = match line {


### PR DESCRIPTION
Closes #4934

The `stdin()` docs recommend spawning a dedicated thread for interactive
input but give no example. This adds a `# Examples` section with two
doctests:

1. **Non-interactive** — reads piped input to EOF with `read_to_end`. This
   is the recommended use of `Stdin`: when input is piped in, the read
   completes on its own and the runtime shuts down cleanly.
2. **Interactive** — runs the blocking, uncancellable reads on a dedicated
   `std::thread` and forwards each line over an `mpsc` channel. Async code
   selects the channel against `ctrl_c()`, so it can shut down promptly
   without waiting on the blocking read — which is the failure mode the
   existing note warns about (and which real projects have hit, e.g.
   chatmail/core#4325, which resorted to `std::process::exit` because the
   read could not be cancelled).

Both examples are marked `no_run`: they perform real stdin reads, so
executing them as doctests could hang. They are still compiled by
`cargo test --doc`. I verified both compile under `--features full`, and
`cargo fmt --check` is clean. Happy to make the non-interactive example
runnable, or to mirror the examples into the `Stdin` struct docs, if
preferred.