### PR TITLE
sync: add take method to SetOnce

### DIFF
--- a/tokio/src/sync/set_once.rs
+++ b/tokio/src/sync/set_once.rs
@@ -124,11 +124,13 @@ impl<T: Eq> Eq for SetOnce<T> {}
 
 impl<T> Drop for SetOnce<T> {
     fn drop(&mut self) {
-        // TODO: Use get_mut()
-        if self.value_set.load(Ordering::Relaxed) {
+        if *self.value_set.get_mut() {
             // SAFETY: If the value_set is true, then the value is initialized
             // then there is a value to be dropped and this is safe
-            unsafe { self.value.with_mut(|ptr| ptr::drop_in_place(ptr as *mut T)) }
+            unsafe {
+                self.value
+                    .with_mut(|ptr| ptr::drop_in_place((*ptr).as_mut_ptr()));
+            }
         }
     }
 }
@@ -308,24 +310,27 @@ impl<T> SetOnce<T> {
 
     /// Takes the value from the cell, destroying the cell in the process.
     /// Returns `None` if the cell is empty.
-    pub fn into_inner(self) -> Option<T> {
-        // TODO: Use get_mut()
-        let value_set = self.value_set.load(Ordering::Relaxed);
-
-        if value_set {
+    pub fn into_inner(mut self) -> Option<T> {
+        if *self.value_set.get_mut() {
             // Since we have taken ownership of self, its drop implementation
             // will be called by the end of this function, to prevent a double
             // free we will set the value_set to false so that the drop
             // implementation does not try to drop the value again.
-            self.value_set.store(false, Ordering::Relaxed);
+            *self.value_set.get_mut() = false;
 
             // SAFETY: The SetOnce is currently initialized, we can assume the
             // value is initialized and return that, when we return the value
             // we give the drop handler to the return scope.
-            Some(unsafe { self.value.with_mut(|ptr| ptr::read(ptr).assume_init()) })
+            Some(unsafe { self.value.with(|ptr| ptr::read(ptr).assume_init()) })
         } else {
             None
         }
+    }
+
+    /// Takes ownership of the current value, leaving the cell empty. Returns
+    /// `None` if the cell is empty.
+    pub fn take(&mut self) -> Option<T> {
+        std::mem::take(self).into_inner()
     }
 
     /// Waits until the value is set.

--- a/tokio/src/sync/set_once.rs
+++ b/tokio/src/sync/set_once.rs
@@ -124,13 +124,11 @@ impl<T: Eq> Eq for SetOnce<T> {}
 
 impl<T> Drop for SetOnce<T> {
     fn drop(&mut self) {
-        if *self.value_set.get_mut() {
+        // TODO: Use get_mut()
+        if self.value_set.load(Ordering::Relaxed) {
             // SAFETY: If the value_set is true, then the value is initialized
             // then there is a value to be dropped and this is safe
-            unsafe {
-                self.value
-                    .with_mut(|ptr| ptr::drop_in_place((*ptr).as_mut_ptr()));
-            }
+            unsafe { self.value.with_mut(|ptr| ptr::drop_in_place(ptr as *mut T)) }
         }
     }
 }
@@ -310,18 +308,21 @@ impl<T> SetOnce<T> {
 
     /// Takes the value from the cell, destroying the cell in the process.
     /// Returns `None` if the cell is empty.
-    pub fn into_inner(mut self) -> Option<T> {
-        if *self.value_set.get_mut() {
+    pub fn into_inner(self) -> Option<T> {
+        // TODO: Use get_mut()
+        let value_set = self.value_set.load(Ordering::Relaxed);
+
+        if value_set {
             // Since we have taken ownership of self, its drop implementation
             // will be called by the end of this function, to prevent a double
             // free we will set the value_set to false so that the drop
             // implementation does not try to drop the value again.
-            *self.value_set.get_mut() = false;
+            self.value_set.store(false, Ordering::Relaxed);
 
             // SAFETY: The SetOnce is currently initialized, we can assume the
             // value is initialized and return that, when we return the value
             // we give the drop handler to the return scope.
-            Some(unsafe { self.value.with(|ptr| ptr::read(ptr).assume_init()) })
+            Some(unsafe { self.value.with_mut(|ptr| ptr::read(ptr).assume_init()) })
         } else {
             None
         }

--- a/tokio/tests/sync_set_once.rs
+++ b/tokio/tests/sync_set_once.rs
@@ -178,3 +178,30 @@ fn into_inner_int_empty_setonce() {
 
     assert!(val.is_none());
 }
+
+#[test]
+fn take_empty() {
+    let mut once = SetOnce::<u32>::new();
+    assert!(once.take().is_none());
+}
+
+#[test]
+fn take_full() {
+    let mut once = SetOnce::<u32>::new();
+    assert!(once.set(42).is_ok());
+    assert_eq!(once.take(), Some(42));
+    assert!(once.get().is_none());
+    assert!(once.take().is_none());
+}
+
+#[test]
+fn drop_take() {
+    let fooer = DropCounter::new();
+    let mut once = SetOnce::new();
+    assert!(once.set(fooer.clone()).is_ok());
+    let val = once.take();
+    fooer.assert_num_drops(0);
+    drop(val);
+    fooer.assert_num_drops(1);
+    assert!(once.get().is_none());
+}


### PR DESCRIPTION
## Motivation
  
 This Pull Request addresses the following goal:
  
  • API parity: Previously,  SetOnce  did not support taking the value out of the cell without consuming the cell itself. Adding a  take  method provides parity with  OnceCell::take .   
  
  ### Solution
              
  •  take(&mut self)  Method:
      • Implemented  pub fn take(&mut self) -> Option<T>  on  SetOnce , using  std::mem::take(self).into_inner() . Since  SetOnce  implements  Default  (initializing to an empty cell),
      this cleanly resets the cell in-place.                                                                                                                                              
  • Verification:
      • Added unit tests ( take_empty ,  take_full ,  drop_take ) inside  sync_set_once.rs  to verify correct drop tracking and state resetting.
      • Verified formatting with  rustfmt  and ran all standard unit tests and Loom tests ( RUSTFLAGS="--cfg loom" cargo test ) to ensure everything
  
