### PR TITLE
net: accept ConnectionReset in shutdown_after_tcp_reset test

### DIFF
--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -44,7 +44,16 @@ async fn shutdown_after_tcp_reset() {
         connected_tx.send(()).unwrap();
 
         dropped_rx.await.unwrap();
-        assert_ok!(AsyncWriteExt::shutdown(&mut stream).await);
+
+        // After the peer's RST (linger = 0), `shutdown` returns `Ok(())` on most
+        // platforms, but FreeBSD can surface the reset as `ConnectionReset` when
+        // the kernel processed it before `shutdown` ran. Both are valid for an
+        // already-reset connection.
+        match AsyncWriteExt::shutdown(&mut stream).await {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::ConnectionReset => {}
+            Err(e) => panic!("unexpected error after reset: {e:?}"),
+        }
     });
 
     let (stream, _) = assert_ok!(srv.accept().await);


### PR DESCRIPTION
The `shutdown_after_tcp_reset` test asserts `shutdown()` returns `Ok(())` after the peer resets the connection (`linger = 0`). This holds on Linux and macOS, but on FreeBSD the kernel can finish processing the RST before `shutdown()` runs, so it returns `ConnectionReset` and the test fails intermittently — the oneshot only synchronizes the application-level `drop`, not the kernel's RST processing.

Accept `Ok(())` or `ConnectionReset` for the post-reset shutdown, since both are valid for a connection the peer has already reset.

Thanks to @RaghavenderSingh for diagnosing the FreeBSD kernel race.

Closes #8104.