### PR TITLE
rt: use a load instead of fetch_add(0) in notify_should_wakeup

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/idle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/idle.rs
@@ -151,7 +151,14 @@ impl Idle {
     }
 
     fn notify_should_wakeup(&self) -> bool {
-        let state = State(self.state.fetch_add(0, SeqCst));
+        // This must be a `SeqCst` load (not Acquire): it has to participate in
+        // the single total order of `SeqCst` operations so that it pairs with
+        // the `fetch_sub(1)` in `dec_num_searching`. A `SeqCst` load is
+        // sufficient — the previous `fetch_add(0)` performed a needless
+        // read-modify-write (exclusive cache-line acquisition) where a load
+        // gives the same ordering. See `worker_to_notify` for the full
+        // happens-before argument.
+        let state = State(self.state.load(SeqCst));
         state.num_searching() == 0 && state.num_unparked() < self.num_workers
     }
 }


### PR DESCRIPTION
## Motivation

`Idle::notify_should_wakeup` reads the idle state with `fetch_add(0, SeqCst)`. That's a read-modify-write used purely as a read: it acquires the cache line exclusively and invalidates every other worker core's copy, even though the stored value never changes. This runs on the worker-notify path — roughly every schedule that may need to wake a parked worker — so on many-core runtimes it adds avoidable coherence traffic to a hot, contended atomic.

## Solution

Replace it with a `SeqCst` load. The load still participates in the single total order of `SeqCst` operations, so it pairs with the `fetch_sub(1)` in `dec_num_searching` exactly as before; the happens-before argument documented in `worker_to_notify` is unaffected. The RMW's write was never observed by any other thread, so dropping it changes nothing about correctness and avoids the exclusive cache-line acquisition.

A comment is added at the call site explaining why `SeqCst` (not `Acquire`) is still required.

## Notes

- Not benchmarked; the change is a strict reduction in coherence traffic (RMW → load) with no behavioural change, expected to matter only on high-core-count, schedule-heavy workloads.
- I did not run the loom multi-thread suite locally. CI exercises it on this PR.