### PR TITLE
runtime: document interaction with fork()

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -236,6 +236,20 @@
 //! guaranteed to have been terminated. See the
 //! [struct level documentation](Runtime#shutdown) for more details.
 //!
+//! ## Unix `fork`
+//!
+//! User code that calls `fork(2)` without immediately calling `exec` must not
+//! reuse Tokio in the child process. Tokio supports this kind of fork only in
+//! two cases:
+//!
+//! - The fork happens before the parent process has used Tokio in any way.
+//! - The child process does not use Tokio after the fork.
+//!
+//! Creating or using a Tokio runtime in a child process after the parent has
+//! used Tokio is not supported, even if the runtime in the child is newly
+//! created. Some Tokio modules, including process and signal handling, use
+//! process-global state that cannot currently be reset after `fork`.
+//!
 //! [tasks]: crate::task
 //! [`Runtime`]: Runtime
 //! [`tokio::spawn`]: crate::spawn


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Tokio's interaction with `fork()` is currently undocumented, and users have been surprised by runtime behavior when forking after starting the runtime. This has caused confusion in real-world usage, as described in issue #4301.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Document that `fork()` is not supported once the runtime has started, and recommend performing any necessary `fork()` calls before initializing Tokio. The docs also note that this area is not well investigated and invite users to report well-motivated use cases where `fork()` and Tokio need to coexist.

Fixes #4301
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
