### PR TITLE
signal: support creating new runtimes in a forked child process

### DIFF
--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -45,6 +45,10 @@ pub(crate) struct OrphanQueueImpl<T> {
     /// `process::id()` of the process that owns the queued orphans, or zero
     /// before first use. A forked child discards orphans inherited from its
     /// parent, see [`OrphanQueueImpl::discard_stale_orphans_after_fork`].
+    ///
+    /// The `std` atomic is used instead of the loom one because `new` must
+    /// be a `const fn` and loom atomics lack const constructors; this is
+    /// fine since every access happens while holding the `queue` lock.
     pid: AtomicU32,
 }
 
@@ -289,7 +293,9 @@ pub(crate) mod test {
     #[test]
     fn discards_orphans_inherited_across_fork() {
         let orphanage = OrphanQueueImpl::new();
-        orphanage.push_orphan(MockWait::new(2));
+        let stale = MockWait::new(2);
+        let stale_waits = stale.total_waits.clone();
+        orphanage.push_orphan(stale);
         assert_eq!(orphanage.len(), 1);
 
         // Simulate a fork by pretending the queued orphan was pushed by a
@@ -304,9 +310,11 @@ pub(crate) mod test {
         orphanage.push_orphan(orphan);
         assert_eq!(orphanage.len(), 1);
 
-        // The surviving entry is the newly pushed one.
+        // The surviving entry is the newly pushed one, and the discarded
+        // orphan was never waited on: it is not this process's child.
         drain_orphan_queue(orphanage.queue.lock());
         assert_eq!(waits.get(), 1);
+        assert_eq!(stale_waits.get(), 0);
     }
 
     #[test]

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -44,9 +44,9 @@ pub(crate) struct OrphanQueueImpl<T> {
     queue: Mutex<Vec<T>>,
     /// `process::id()` of the process that pushed the queued orphans,
     /// stamped on every push. A forked child inherits its parent's queue
-    /// entries but not its pid, so [`OrphanQueueImpl::lock_queue`] discards
+    /// entries but not its PID, so [`OrphanQueueImpl::lock_queue`] discards
     /// them: waiting on them would fail with `ECHILD` at best, or target an
-    /// unrelated process in case of pid reuse. Dropping them is safe, since
+    /// unrelated process in case of PID reuse. Dropping them is safe, since
     /// dropping a `std::process::Child` neither kills nor waits on the
     /// process.
     ///

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -42,9 +42,13 @@ impl<T, O: OrphanQueue<T>> OrphanQueue<T> for &O {
 pub(crate) struct OrphanQueueImpl<T> {
     sigchild: Mutex<Option<watch::Receiver<()>>>,
     queue: Mutex<Vec<T>>,
-    /// `process::id()` of the process that owns the queued orphans, or zero
-    /// before first use. A forked child discards orphans inherited from its
-    /// parent, see [`OrphanQueueImpl::discard_stale_orphans_after_fork`].
+    /// `process::id()` of the process that pushed the queued orphans,
+    /// stamped on every push. A forked child inherits its parent's queue
+    /// entries but not its pid, so [`OrphanQueueImpl::lock_queue`] discards
+    /// them: waiting on them would fail with `ECHILD` at best, or target an
+    /// unrelated process in case of pid reuse. Dropping them is safe, since
+    /// dropping a `std::process::Child` neither kills nor waits on the
+    /// process.
     ///
     /// The `std` atomic is used instead of the loom one because `new` must
     /// be a `const fn` and loom atomics lack const constructors; this is
@@ -73,24 +77,17 @@ impl<T> OrphanQueueImpl<T> {
         }
     }
 
-    /// Discards orphans queued by a parent process before a `fork`.
+    /// Locks the queue, first discarding any orphans queued by a pre-fork
+    /// parent process.
     ///
-    /// Those children belong to the parent: `wait`ing on them from this
-    /// process would fail with `ECHILD` at best, or target an unrelated
-    /// process in case of pid reuse. Dropping them is safe, since dropping a
-    /// `std::process::Child` neither kills nor waits on the process.
-    ///
-    /// Must be called with the `queue` lock held.
-    fn discard_stale_orphans_after_fork(&self, queue: &mut Vec<T>) {
-        let pid = std::process::id();
-        if self.pid.load(Ordering::Relaxed) == pid {
-            return;
-        }
-
-        let old = self.pid.swap(pid, Ordering::Relaxed);
-        if old != 0 {
+    /// The emptiness check keeps the common reaping path — an empty queue
+    /// checked on every driver park — free of the `getpid` syscall.
+    fn lock_queue(&self) -> MutexGuard<'_, Vec<T>> {
+        let mut queue = self.queue.lock();
+        if !queue.is_empty() && self.pid.load(Ordering::Relaxed) != std::process::id() {
             queue.clear();
         }
+        queue
     }
 
     #[cfg(test)]
@@ -102,8 +99,9 @@ impl<T> OrphanQueueImpl<T> {
     where
         T: Wait,
     {
-        let mut queue = self.queue.lock();
-        self.discard_stale_orphans_after_fork(&mut queue);
+        let mut queue = self.lock_queue();
+        // Stamp ownership: everything in the queue belongs to this process.
+        self.pid.store(std::process::id(), Ordering::Relaxed);
         queue.push(orphan);
     }
 
@@ -119,20 +117,14 @@ impl<T> OrphanQueueImpl<T> {
             match &mut *sigchild_guard {
                 Some(sigchild) => {
                     if sigchild.try_has_changed().and_then(Result::ok).is_some() {
-                        let mut queue = self.queue.lock();
-                        self.discard_stale_orphans_after_fork(&mut queue);
-                        drain_orphan_queue(queue);
+                        drain_orphan_queue(self.lock_queue());
                     }
                 }
                 None => {
-                    let mut queue = self.queue.lock();
+                    let queue = self.lock_queue();
 
                     // Be lazy and only initialize the SIGCHLD listener if there
                     // are any orphaned processes in the queue.
-                    if !queue.is_empty() {
-                        self.discard_stale_orphans_after_fork(&mut queue);
-                    }
-
                     if !queue.is_empty() {
                         // An errors shouldn't really happen here, but if it does it
                         // means that the signal driver isn't running, in

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -4,6 +4,7 @@ use crate::signal::unix::{signal_with_handle, SignalKind};
 use crate::sync::watch;
 use std::io;
 use std::process::ExitStatus;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 /// An interface for waiting on a process to exit.
 pub(crate) trait Wait {
@@ -41,6 +42,10 @@ impl<T, O: OrphanQueue<T>> OrphanQueue<T> for &O {
 pub(crate) struct OrphanQueueImpl<T> {
     sigchild: Mutex<Option<watch::Receiver<()>>>,
     queue: Mutex<Vec<T>>,
+    /// `process::id()` of the process that owns the queued orphans, or zero
+    /// before first use. A forked child discards orphans inherited from its
+    /// parent, see [`OrphanQueueImpl::discard_stale_orphans_after_fork`].
+    pid: AtomicU32,
 }
 
 impl<T> OrphanQueueImpl<T> {
@@ -49,6 +54,7 @@ impl<T> OrphanQueueImpl<T> {
             Self {
                 sigchild: Mutex::new(None),
                 queue: Mutex::new(Vec::new()),
+                pid: AtomicU32::new(0),
             }
         }
     }
@@ -58,7 +64,28 @@ impl<T> OrphanQueueImpl<T> {
             Self {
                 sigchild: Mutex::const_new(None),
                 queue: Mutex::const_new(Vec::new()),
+                pid: AtomicU32::new(0),
             }
+        }
+    }
+
+    /// Discards orphans queued by a parent process before a `fork`.
+    ///
+    /// Those children belong to the parent: `wait`ing on them from this
+    /// process would fail with `ECHILD` at best, or target an unrelated
+    /// process in case of pid reuse. Dropping them is safe, since dropping a
+    /// `std::process::Child` neither kills nor waits on the process.
+    ///
+    /// Must be called with the `queue` lock held.
+    fn discard_stale_orphans_after_fork(&self, queue: &mut Vec<T>) {
+        let pid = std::process::id();
+        if self.pid.load(Ordering::Relaxed) == pid {
+            return;
+        }
+
+        let old = self.pid.swap(pid, Ordering::Relaxed);
+        if old != 0 {
+            queue.clear();
         }
     }
 
@@ -71,7 +98,9 @@ impl<T> OrphanQueueImpl<T> {
     where
         T: Wait,
     {
-        self.queue.lock().push(orphan);
+        let mut queue = self.queue.lock();
+        self.discard_stale_orphans_after_fork(&mut queue);
+        queue.push(orphan);
     }
 
     /// Attempts to reap every process in the queue, ignoring any errors and
@@ -86,14 +115,20 @@ impl<T> OrphanQueueImpl<T> {
             match &mut *sigchild_guard {
                 Some(sigchild) => {
                     if sigchild.try_has_changed().and_then(Result::ok).is_some() {
-                        drain_orphan_queue(self.queue.lock());
+                        let mut queue = self.queue.lock();
+                        self.discard_stale_orphans_after_fork(&mut queue);
+                        drain_orphan_queue(queue);
                     }
                 }
                 None => {
-                    let queue = self.queue.lock();
+                    let mut queue = self.queue.lock();
 
                     // Be lazy and only initialize the SIGCHLD listener if there
                     // are any orphaned processes in the queue.
+                    if !queue.is_empty() {
+                        self.discard_stale_orphans_after_fork(&mut queue);
+                    }
+
                     if !queue.is_empty() {
                         // An errors shouldn't really happen here, but if it does it
                         // means that the signal driver isn't running, in
@@ -249,6 +284,29 @@ pub(crate) mod test {
 
         // Safe to reap when empty
         drain_orphan_queue(orphanage.queue.lock());
+    }
+
+    #[test]
+    fn discards_orphans_inherited_across_fork() {
+        let orphanage = OrphanQueueImpl::new();
+        orphanage.push_orphan(MockWait::new(2));
+        assert_eq!(orphanage.len(), 1);
+
+        // Simulate a fork by pretending the queued orphan was pushed by a
+        // different (parent) process.
+        orphanage
+            .pid
+            .store(std::process::id().wrapping_add(1), Ordering::Relaxed);
+
+        // The next push discards the entry inherited from the "parent".
+        let orphan = MockWait::new(2);
+        let waits = orphan.total_waits.clone();
+        orphanage.push_orphan(orphan);
+        assert_eq!(orphanage.len(), 1);
+
+        // The surviving entry is the newly pushed one.
+        drain_orphan_queue(orphanage.queue.lock());
+        assert_eq!(waits.get(), 1);
     }
 
     #[test]

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -239,16 +239,24 @@
 //! ## Unix `fork`
 //!
 //! User code that calls `fork(2)` without immediately calling `exec` must not
-//! reuse Tokio in the child process. Tokio supports this kind of fork only in
-//! two cases:
+//! reuse in the child process any Tokio state that existed in the parent at
+//! the time of the fork. Tokio supports this kind of fork in the following
+//! cases:
 //!
 //! - The fork happens before the parent process has used Tokio in any way.
 //! - The child process does not use Tokio after the fork.
+//! - The child process creates fresh runtimes after the fork and only
+//!   interacts with those. Runtimes created before the fork, as well as
+//!   anything bound to them (spawned tasks, I/O resources, timers, runtime
+//!   handles), must not be used in the child: their worker threads do not
+//!   exist in the child process, so interacting with them may deadlock. Note
+//!   that this includes implicit uses, such as dropping a value whose
+//!   destructor interacts with a pre-fork runtime.
 //!
-//! Creating or using a Tokio runtime in a child process after the parent has
-//! used Tokio is not supported, even if the runtime in the child is newly
-//! created. Some Tokio modules, including process and signal handling, use
-//! process-global state that cannot currently be reset after `fork`.
+//! Additionally, the usual caveats of forking a multi-threaded process apply:
+//! if another thread holds a lock at the moment of the fork, that lock is
+//! never released in the child process. Forking is safest when no other
+//! thread is interacting with Tokio concurrently.
 //!
 //! [tasks]: crate::task
 //! [`Runtime`]: Runtime

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -253,10 +253,20 @@
 //!   that this includes implicit uses, such as dropping a value whose
 //!   destructor interacts with a pre-fork runtime.
 //!
+//! For the last case, the fork must also not happen on a thread that is
+//! itself running on a Tokio runtime (inside `block_on` or a spawned task):
+//! the forking thread is the only thread that exists in the child, and it
+//! would still be marked as being inside the pre-fork runtime, so entering a
+//! new runtime on it panics. Fork from a thread outside any runtime, or
+//! create the child's runtime on a newly spawned thread.
+//!
 //! Additionally, the usual caveats of forking a multi-threaded process apply:
 //! if another thread holds a lock at the moment of the fork, that lock is
-//! never released in the child process. Forking is safest when no other
-//! thread is interacting with Tokio concurrently.
+//! never released in the child process, and any thread (including Tokio
+//! worker threads) may hold a lock at an unfortunate moment. Forking is
+//! reliable when no runtime exists or no other thread is interacting with
+//! Tokio concurrently; forking while runtimes are running works on common
+//! platforms but is subject to these inherent hazards.
 //!
 //! [tasks]: crate::task
 //! [`Runtime`]: Runtime

--- a/tokio/src/runtime/signal/mod.rs
+++ b/tokio/src/runtime/signal/mod.rs
@@ -63,8 +63,15 @@ impl Driver {
         // safe as each dup is registered with separate reactors **and** we
         // only expect at least one dup to receive the notification.
 
+        let globals = globals();
+
+        // If this process was forked from a process that already used Tokio,
+        // the self-pipe inherited from the parent must be replaced before it
+        // is registered with this runtime's reactor.
+        globals.reinit_after_fork_if_needed()?;
+
         // Manually drop as we don't actually own this instance of UnixStream.
-        let receiver_fd = globals().receiver.as_raw_fd();
+        let receiver_fd = globals.receiver.as_raw_fd();
 
         // safety: there is nothing unsafe about this, but the `from_raw_fd` fn is marked as unsafe.
         let original =

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -2,8 +2,8 @@ use crate::signal::unix::{OsExtraData, OsStorage};
 use crate::sync::watch;
 
 use std::ops;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 pub(crate) type EventId = usize;
 
@@ -83,6 +83,13 @@ impl<S: Storage> Registry<S> {
         }
     }
 
+    /// Discards all recorded events without broadcasting them.
+    fn clear_pending(&self) {
+        self.storage.for_each(|event_info| {
+            event_info.pending.store(false, Ordering::SeqCst);
+        });
+    }
+
     /// Broadcasts all previously recorded events to their respective listeners.
     ///
     /// Returns `true` if an event was delivered to at least one listener.
@@ -107,6 +114,12 @@ impl<S: Storage> Registry<S> {
 pub(crate) struct Globals {
     extra: OsExtraData,
     registry: Registry<OsStorage>,
+    /// `process::id()` of the process whose self-pipe is currently installed
+    /// in `extra`. A forked child inherits its parent's pipe and must replace
+    /// it before use, see [`Globals::reinit_after_fork_if_needed`].
+    pid: AtomicU32,
+    /// Serializes post-fork re-initialization.
+    fork_lock: Mutex<()>,
 }
 
 impl ops::Deref for Globals {
@@ -140,6 +153,41 @@ impl Globals {
     pub(crate) fn storage(&self) -> &OsStorage {
         &self.registry.storage
     }
+
+    /// Re-creates process-wide signal resources if this process was forked
+    /// from the process that initialized them.
+    ///
+    /// The self-pipe inherited across a `fork` shares the underlying pipe
+    /// with the parent process: both processes would race to consume wakeups
+    /// from it, silently losing signal notifications in either process.
+    /// Replacing the pipe gives the forked child one of its own.
+    ///
+    /// The signal handler installed before the fork is inherited and keeps
+    /// working without re-registration, because the replacement preserves the
+    /// file descriptor numbers, see [`OsExtraData::replace_pipe`].
+    pub(crate) fn reinit_after_fork_if_needed(&self) -> std::io::Result<()> {
+        if self.pid.load(Ordering::Acquire) == std::process::id() {
+            return Ok(());
+        }
+
+        self.reinit_after_fork()
+    }
+
+    #[cold]
+    fn reinit_after_fork(&self) -> std::io::Result<()> {
+        let _guard = self.fork_lock.lock().unwrap();
+
+        let pid = std::process::id();
+        if self.pid.load(Ordering::Acquire) == pid {
+            return Ok(());
+        }
+
+        self.extra.replace_pipe()?;
+        // Events recorded before the fork were meant for the parent process.
+        self.registry.clear_pending();
+        self.pid.store(pid, Ordering::Release);
+        Ok(())
+    }
 }
 
 fn globals_init() -> Globals
@@ -150,6 +198,8 @@ where
     Globals {
         extra: OsExtraData::default(),
         registry: Registry::new(OsStorage::default()),
+        pid: AtomicU32::new(std::process::id()),
+        fork_lock: Mutex::new(()),
     }
 }
 

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -120,9 +120,9 @@ pub(crate) struct Globals {
     ///
     /// Known limitation: if the process recorded here dies and a descendant
     /// that never created a runtime forks a child that is assigned the
-    /// recycled pid, the fork goes undetected. This is inherent to pid
-    /// comparison; closing it would require `pthread_atfork`, a process-wide,
-    /// unremovable hook that is deliberately avoided here.
+    /// recycled PID, the fork goes undetected. This is inherent to PID
+    /// comparison; closing it would require `pthread_atfork`, a process-wide
+    /// hook that cannot be removed again and is deliberately avoided here.
     pid: Mutex<u32>,
 }
 
@@ -165,7 +165,7 @@ impl Globals {
     /// inherited signal handler working.
     ///
     /// This runs once per runtime creation (a cold path), so a plain mutex
-    /// around the pid is plenty.
+    /// around the PID is plenty.
     pub(crate) fn reinit_after_fork_if_needed(&self) -> std::io::Result<()> {
         let mut pid = self.pid.lock().unwrap();
         let current = std::process::id();

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -2,7 +2,7 @@ use crate::signal::unix::{OsExtraData, OsStorage};
 use crate::sync::watch;
 
 use std::ops;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Mutex, OnceLock};
 
 pub(crate) type EventId = usize;
@@ -123,9 +123,7 @@ pub(crate) struct Globals {
     /// recycled pid, the fork goes undetected. This is inherent to pid
     /// comparison; closing it would require `pthread_atfork`, a process-wide,
     /// unremovable hook that is deliberately avoided here.
-    pid: AtomicU32,
-    /// Serializes post-fork re-initialization.
-    fork_lock: Mutex<()>,
+    pid: Mutex<u32>,
 }
 
 impl ops::Deref for Globals {
@@ -160,31 +158,18 @@ impl Globals {
         &self.registry.storage
     }
 
-    /// Re-creates process-wide signal resources if this process was forked
-    /// from the process that initialized them.
+    /// Re-creates the process-wide self-pipe if this process was forked from
+    /// the process that initialized it, so that signal wakeups are no longer
+    /// shared with the parent process. See [`OsExtraData::replace_pipe`] for
+    /// why the pipe must be replaced and how the replacement keeps the
+    /// inherited signal handler working.
     ///
-    /// The self-pipe inherited across a `fork` shares the underlying pipe
-    /// with the parent process: both processes would race to consume wakeups
-    /// from it, silently losing signal notifications in either process.
-    /// Replacing the pipe gives the forked child one of its own.
-    ///
-    /// The signal handler installed before the fork is inherited and keeps
-    /// working without re-registration, because the replacement preserves the
-    /// file descriptor numbers, see [`OsExtraData::replace_pipe`].
+    /// This runs once per runtime creation (a cold path), so a plain mutex
+    /// around the pid is plenty.
     pub(crate) fn reinit_after_fork_if_needed(&self) -> std::io::Result<()> {
-        if self.pid.load(Ordering::Acquire) == std::process::id() {
-            return Ok(());
-        }
-
-        self.reinit_after_fork()
-    }
-
-    #[cold]
-    fn reinit_after_fork(&self) -> std::io::Result<()> {
-        let _guard = self.fork_lock.lock().unwrap();
-
-        let pid = std::process::id();
-        if self.pid.load(Ordering::Acquire) == pid {
+        let mut pid = self.pid.lock().unwrap();
+        let current = std::process::id();
+        if *pid == current {
             return Ok(());
         }
 
@@ -197,7 +182,7 @@ impl Globals {
         self.extra.replace_pipe()?;
         // Events recorded before the fork were meant for the parent process.
         self.registry.clear_pending();
-        self.pid.store(pid, Ordering::Release);
+        *pid = current;
         Ok(())
     }
 }
@@ -210,8 +195,7 @@ where
     Globals {
         extra: OsExtraData::default(),
         registry: Registry::new(OsStorage::default()),
-        pid: AtomicU32::new(std::process::id()),
-        fork_lock: Mutex::new(()),
+        pid: Mutex::new(std::process::id()),
     }
 }
 

--- a/tokio/src/signal/registry.rs
+++ b/tokio/src/signal/registry.rs
@@ -117,6 +117,12 @@ pub(crate) struct Globals {
     /// `process::id()` of the process whose self-pipe is currently installed
     /// in `extra`. A forked child inherits its parent's pipe and must replace
     /// it before use, see [`Globals::reinit_after_fork_if_needed`].
+    ///
+    /// Known limitation: if the process recorded here dies and a descendant
+    /// that never created a runtime forks a child that is assigned the
+    /// recycled pid, the fork goes undetected. This is inherent to pid
+    /// comparison; closing it would require `pthread_atfork`, a process-wide,
+    /// unremovable hook that is deliberately avoided here.
     pid: AtomicU32,
     /// Serializes post-fork re-initialization.
     fork_lock: Mutex<()>,
@@ -182,6 +188,12 @@ impl Globals {
             return Ok(());
         }
 
+        // Invariant: no signal listener can exist in this process yet —
+        // registering one requires a signal driver, and the first driver of
+        // this process is the caller, which is still being constructed. So
+        // a signal arriving while this runs is recorded with no one to
+        // observe it, and discarding it below is indistinguishable from the
+        // (unsupported) delivery of a signal before any listener exists.
         self.extra.replace_pipe()?;
         // Events recorded before the fork were meant for the parent process.
         self.registry.clear_pending();

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -74,6 +74,51 @@ impl Default for OsExtraData {
     }
 }
 
+impl OsExtraData {
+    /// Replaces the self-pipe with a freshly created one, redirecting the
+    /// existing file descriptor numbers at it via `dup2`.
+    ///
+    /// This is used by a forked child process, whose inherited descriptors
+    /// share the underlying pipe with the parent process. Keeping the
+    /// descriptor numbers stable means the already-installed signal handler,
+    /// which is also inherited across the fork, needs no re-registration nor
+    /// synchronization: a handler running concurrently with the swap writes
+    /// either to the old pipe (at worst a spurious wakeup for the parent) or
+    /// to the new one.
+    pub(crate) fn replace_pipe(&self) -> io::Result<()> {
+        use std::os::unix::io::AsRawFd;
+
+        let (new_receiver, new_sender) = UnixStream::pair()?;
+        replace_fd(new_sender.as_raw_fd(), self.sender.as_raw_fd())?;
+        replace_fd(new_receiver.as_raw_fd(), self.receiver.as_raw_fd())?;
+
+        // `new_sender`/`new_receiver` are dropped here, closing the temporary
+        // descriptors; the new pipe stays alive behind the original
+        // descriptor numbers.
+        Ok(())
+    }
+}
+
+/// Atomically redirects the `dst` file descriptor at the resource behind
+/// `src`, preserving `dst`'s number.
+fn replace_fd(src: std::os::unix::io::RawFd, dst: std::os::unix::io::RawFd) -> io::Result<()> {
+    // Safety: `dup2` is async-signal-safe and atomic; both descriptors are
+    // owned by `OsExtraData`, which lives for the rest of the process.
+    if unsafe { libc::dup2(src, dst) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // `O_NONBLOCK` is carried over from `src`'s open file description, but
+    // `dup2` does not carry over the close-on-exec flag, which lives on the
+    // descriptor itself; restore it.
+    // Safety: setting a flag on a descriptor we own.
+    if unsafe { libc::fcntl(dst, libc::F_SETFD, libc::FD_CLOEXEC) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    Ok(())
+}
+
 /// Represents the specific kind of signal to listen for.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct SignalKind(libc::c_int);

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -89,8 +89,16 @@ impl OsExtraData {
         use std::os::unix::io::AsRawFd;
 
         let (new_receiver, new_sender) = UnixStream::pair()?;
-        replace_fd(new_sender.as_raw_fd(), self.sender.as_raw_fd())?;
+
+        // Replace the receiver first: if replacing the sender then fails, the
+        // sender still points at the old (shared) pipe, where a concurrent
+        // signal handler write is at worst a spurious wakeup for the parent
+        // process. The reverse order could leave the sender pointing at a
+        // pipe whose read end gets closed below, making later handler writes
+        // raise `SIGPIPE`. Either failure leaves the pid unpublished, so the
+        // whole replacement is retried on the next runtime creation.
         replace_fd(new_receiver.as_raw_fd(), self.receiver.as_raw_fd())?;
+        replace_fd(new_sender.as_raw_fd(), self.sender.as_raw_fd())?;
 
         // `new_sender`/`new_receiver` are dropped here, closing the temporary
         // descriptors; the new pipe stays alive behind the original
@@ -102,16 +110,30 @@ impl OsExtraData {
 /// Atomically redirects the `dst` file descriptor at the resource behind
 /// `src`, preserving `dst`'s number.
 fn replace_fd(src: std::os::unix::io::RawFd, dst: std::os::unix::io::RawFd) -> io::Result<()> {
-    // Safety: `dup2` is async-signal-safe and atomic; both descriptors are
-    // owned by `OsExtraData`, which lives for the rest of the process.
-    if unsafe { libc::dup2(src, dst) } == -1 {
-        return Err(io::Error::last_os_error());
+    loop {
+        // Safety: `dup2` replaces the descriptor slot atomically; both
+        // descriptors are owned by `OsExtraData`, which lives for the rest
+        // of the process.
+        if unsafe { libc::dup2(src, dst) } != -1 {
+            break;
+        }
+        // `dup2` may fail with `EINTR` on some platforms, and signals are
+        // very much expected here; retrying covers the POSIX-unspecified
+        // state of `dst` after such a failure.
+        let err = io::Error::last_os_error();
+        if err.kind() != io::ErrorKind::Interrupted {
+            return Err(err);
+        }
     }
 
     // `O_NONBLOCK` is carried over from `src`'s open file description, but
     // `dup2` does not carry over the close-on-exec flag, which lives on the
-    // descriptor itself; restore it.
-    // Safety: setting a flag on a descriptor we own.
+    // descriptor itself; restore it. The gap until the `fcntl` call below
+    // can leak the descriptor into a concurrently spawned process; this is
+    // accepted (the pair-creating syscalls have the same gap on platforms
+    // without `SOCK_CLOEXEC`) and harmless beyond the descriptor itself.
+    // Safety: setting a flag on a descriptor we own; `FD_CLOEXEC` is the
+    // only file descriptor flag, so overwriting loses nothing.
     if unsafe { libc::fcntl(dst, libc::F_SETFD, libc::FD_CLOEXEC) } == -1 {
         return Err(io::Error::last_os_error());
     }

--- a/tokio/src/signal/unix.rs
+++ b/tokio/src/signal/unix.rs
@@ -14,6 +14,7 @@ use crate::sync::watch;
 
 use mio::net::UnixStream;
 use std::io::{self, Error, ErrorKind, Write};
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::OnceLock;
 use std::task::{Context, Poll};
 
@@ -86,8 +87,6 @@ impl OsExtraData {
     /// either to the old pipe (at worst a spurious wakeup for the parent) or
     /// to the new one.
     pub(crate) fn replace_pipe(&self) -> io::Result<()> {
-        use std::os::unix::io::AsRawFd;
-
         let (new_receiver, new_sender) = UnixStream::pair()?;
 
         // Replace the receiver first: if replacing the sender then fails, the
@@ -109,7 +108,7 @@ impl OsExtraData {
 
 /// Atomically redirects the `dst` file descriptor at the resource behind
 /// `src`, preserving `dst`'s number.
-fn replace_fd(src: std::os::unix::io::RawFd, dst: std::os::unix::io::RawFd) -> io::Result<()> {
+fn replace_fd(src: RawFd, dst: RawFd) -> io::Result<()> {
     loop {
         // Safety: `dup2` replaces the descriptor slot atomically; both
         // descriptors are owned by `OsExtraData`, which lives for the rest

--- a/tokio/tests/signal_fork.rs
+++ b/tokio/tests/signal_fork.rs
@@ -23,27 +23,52 @@ fn new_runtime() -> Runtime {
         .unwrap()
 }
 
-/// Registers a listener for `kind`, raises the signal, and reports whether
-/// the listener observed it.
-fn receives_signal(rt: &Runtime, kind: SignalKind) -> bool {
+/// Registers a listener for `kind`, then raises the signal and awaits it
+/// `rounds` times. Reports whether the listener observed every round.
+///
+/// Multiple rounds matter when the parent process also has a runtime
+/// running: with a self-pipe incorrectly shared across a fork, each round is
+/// an independent race between the two processes' drivers for the wakeup
+/// byte, so N rounds catch a regression with probability ~(1 - p^N).
+fn receives_signal_rounds(rt: &Runtime, kind: SignalKind, rounds: u32) -> bool {
     rt.block_on(async {
         let mut sig = signal(kind).expect("failed to register signal listener");
-        // Safety: raising a signal for which a listener was just registered.
-        unsafe { libc::raise(kind.as_raw_value()) };
-        tokio::time::timeout(Duration::from_secs(15), sig.recv())
-            .await
-            .is_ok()
+        for round in 0..rounds {
+            // Safety: raising a signal for which a listener is registered.
+            unsafe { libc::raise(kind.as_raw_value()) };
+            if tokio::time::timeout(Duration::from_secs(15), sig.recv())
+                .await
+                .is_err()
+            {
+                eprintln!(
+                    "signal_fork: signal {} lost in round {round}",
+                    kind.as_raw_value()
+                );
+                return false;
+            }
+        }
+        true
     })
 }
 
+/// Single-round variant of [`receives_signal_rounds`].
+fn receives_signal(rt: &Runtime, kind: SignalKind) -> bool {
+    receives_signal_rounds(rt, kind, 1)
+}
+
 /// Spawns a short-lived child process and reports whether waiting on it
-/// succeeds. Exercises the process reaping machinery (SIGCHLD or pidfd).
+/// succeeds. Exercises the process reaping machinery. Note that on Linux
+/// this takes the pidfd path; the SIGCHLD reaper path is only covered on
+/// platforms without pidfd support, such as macOS.
 fn spawns_child_process(rt: &Runtime) -> bool {
     rt.block_on(async {
         let status = tokio::process::Command::new("true").status();
         match tokio::time::timeout(Duration::from_secs(15), status).await {
             Ok(Ok(status)) => status.success(),
-            _ => false,
+            other => {
+                eprintln!("signal_fork: waiting on a spawned process failed: {other:?}");
+                false
+            }
         }
     })
 }
@@ -89,7 +114,7 @@ fn fork_and_check(f: impl FnOnce() -> bool) -> bool {
 #[test]
 fn fork_scenarios() {
     // Scenario 1: the parent uses signals, shuts its runtime down, and forks.
-    // A fresh runtime in the child must receive signals.
+    // Fresh runtimes in the child, of both flavors, must receive signals.
     let rt = new_runtime();
     assert!(
         receives_signal(&rt, SignalKind::user_defined1()),
@@ -100,6 +125,15 @@ fn fork_scenarios() {
     assert!(
         fork_and_check(|| {
             let rt = new_runtime();
+            if !receives_signal(&rt, SignalKind::user_defined1()) {
+                return false;
+            }
+            drop(rt);
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
             receives_signal(&rt, SignalKind::user_defined1())
         }),
         "child created after parent runtime shutdown",
@@ -108,17 +142,20 @@ fn fork_scenarios() {
     // Scenario 2: the parent runtime stays alive across the fork. The child
     // must not touch it, but a fresh runtime in the child must receive
     // signals and reap child processes, and the parent's signal handling
-    // must keep working after the fork.
+    // must keep working after the fork. Multiple signal rounds make a
+    // wrongly shared pipe (a per-round wakeup race against the parent's
+    // driver) overwhelmingly likely to be caught.
     let rt = new_runtime();
     assert!(receives_signal(&rt, SignalKind::user_defined2()));
-    // Give the parent's worker a moment to park, reducing the chance of
-    // forking while it holds a lock.
+    // Give the parent's worker a moment to park. This only reduces the
+    // chance of forking while it holds a lock; that risk is inherent to
+    // forking a multi-threaded process.
     std::thread::sleep(Duration::from_millis(100));
 
     assert!(
         fork_and_check(|| {
             let child_rt = new_runtime();
-            receives_signal(&child_rt, SignalKind::user_defined2())
+            receives_signal_rounds(&child_rt, SignalKind::user_defined2(), 20)
                 && spawns_child_process(&child_rt)
         }),
         "child created while the parent runtime is alive",
@@ -128,10 +165,15 @@ fn fork_scenarios() {
         receives_signal(&rt, SignalKind::user_defined2()),
         "parent signal handling must survive the child's pipe replacement",
     );
+    // Shut the parent runtime down before the remaining scenarios: scenario 3
+    // requires that nothing in the parent consumes signal events between its
+    // `raise` and the fork.
+    drop(rt);
 
     // Scenario 3: a signal recorded in the parent but not yet broadcast at
     // the moment of the fork must not be delivered as a ghost signal to a
-    // listener in the child.
+    // listener in the child, while a real signal raised in the child
+    // afterwards must still be delivered.
     let rt = new_runtime();
     assert!(receives_signal(&rt, SignalKind::hangup()));
     // Drop the runtime so nothing consumes signal events anymore, then raise:
@@ -147,15 +189,44 @@ fn fork_scenarios() {
                 let mut sig =
                     signal(SignalKind::hangup()).expect("failed to register signal listener");
                 // No SIGHUP was raised in the child, so nothing must arrive.
-                tokio::time::timeout(Duration::from_millis(500), sig.recv())
+                if tokio::time::timeout(Duration::from_millis(500), sig.recv())
                     .await
-                    .is_err()
+                    .is_ok()
+                {
+                    eprintln!("signal_fork: ghost SIGHUP delivered to the child");
+                    return false;
+                }
+                // A real SIGHUP raised in the child must still arrive,
+                // proving the listener is alive and the silence above was
+                // not a broken listener.
+                // Safety: raising a signal for which a listener is registered.
+                unsafe { libc::raise(libc::SIGHUP) };
+                tokio::time::timeout(Duration::from_secs(15), sig.recv())
+                    .await
+                    .is_ok()
             })
         }),
         "child must not observe signals recorded by the parent before the fork",
     );
 
-    // Scenario 4: forking twice in a row; each generation gets its own pipe.
+    // Scenario 4: two threads in the child create runtimes concurrently,
+    // racing to re-initialize the process-global signal state.
+    assert!(
+        fork_and_check(|| {
+            let threads: Vec<_> = (0..2)
+                .map(|_| {
+                    std::thread::spawn(|| {
+                        let rt = new_runtime();
+                        receives_signal(&rt, SignalKind::user_defined1())
+                    })
+                })
+                .collect();
+            threads.into_iter().all(|t| t.join().unwrap_or_default())
+        }),
+        "concurrent runtime creation in the child",
+    );
+
+    // Scenario 5: forking twice in a row; each generation gets its own pipe.
     assert!(
         fork_and_check(|| {
             let rt = new_runtime();

--- a/tokio/tests/signal_fork.rs
+++ b/tokio/tests/signal_fork.rs
@@ -10,6 +10,11 @@
 //! sibling test threads run risks inheriting locks held by those threads,
 //! which would deadlock the child. Keep this file to exactly one test.
 
+mod support {
+    pub mod signal;
+}
+use support::signal::send_signal;
+
 use std::time::{Duration, Instant};
 
 use tokio::runtime::Runtime;
@@ -34,8 +39,7 @@ fn receives_signal_rounds(rt: &Runtime, kind: SignalKind, rounds: u32) -> bool {
     rt.block_on(async {
         let mut sig = signal(kind).expect("failed to register signal listener");
         for round in 0..rounds {
-            // Safety: raising a signal for which a listener is registered.
-            unsafe { libc::raise(kind.as_raw_value()) };
+            send_signal(kind.as_raw_value());
             if tokio::time::timeout(Duration::from_secs(15), sig.recv())
                 .await
                 .is_err()
@@ -54,6 +58,12 @@ fn receives_signal_rounds(rt: &Runtime, kind: SignalKind, rounds: u32) -> bool {
 /// Single-round variant of [`receives_signal_rounds`].
 fn receives_signal(rt: &Runtime, kind: SignalKind) -> bool {
     receives_signal_rounds(rt, kind, 1)
+}
+
+/// Creates a fresh runtime and reports whether it receives `kind`.
+fn fresh_runtime_receives(kind: SignalKind) -> bool {
+    let rt = new_runtime();
+    receives_signal(&rt, kind)
 }
 
 /// Spawns a short-lived child process and reports whether waiting on it
@@ -124,11 +134,9 @@ fn fork_scenarios() {
 
     assert!(
         fork_and_check(|| {
-            let rt = new_runtime();
-            if !receives_signal(&rt, SignalKind::user_defined1()) {
+            if !fresh_runtime_receives(SignalKind::user_defined1()) {
                 return false;
             }
-            drop(rt);
 
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
@@ -142,9 +150,8 @@ fn fork_scenarios() {
     // Scenario 2: the parent runtime stays alive across the fork. The child
     // must not touch it, but a fresh runtime in the child must receive
     // signals and reap child processes, and the parent's signal handling
-    // must keep working after the fork. Multiple signal rounds make a
-    // wrongly shared pipe (a per-round wakeup race against the parent's
-    // driver) overwhelmingly likely to be caught.
+    // must keep working after the fork. Multiple rounds maximize the chance
+    // of catching a wrongly shared pipe, see `receives_signal_rounds`.
     let rt = new_runtime();
     assert!(receives_signal(&rt, SignalKind::user_defined2()));
     // Give the parent's worker a moment to park. This only reduces the
@@ -180,7 +187,7 @@ fn fork_scenarios() {
     // the process-global signal handler stays installed and records the event
     // as pending, where it remains until the fork.
     drop(rt);
-    unsafe { libc::raise(libc::SIGHUP) };
+    send_signal(libc::SIGHUP);
 
     assert!(
         fork_and_check(|| {
@@ -199,8 +206,7 @@ fn fork_scenarios() {
                 // A real SIGHUP raised in the child must still arrive,
                 // proving the listener is alive and the silence above was
                 // not a broken listener.
-                // Safety: raising a signal for which a listener is registered.
-                unsafe { libc::raise(libc::SIGHUP) };
+                send_signal(libc::SIGHUP);
                 tokio::time::timeout(Duration::from_secs(15), sig.recv())
                     .await
                     .is_ok()
@@ -214,12 +220,7 @@ fn fork_scenarios() {
     assert!(
         fork_and_check(|| {
             let threads: Vec<_> = (0..2)
-                .map(|_| {
-                    std::thread::spawn(|| {
-                        let rt = new_runtime();
-                        receives_signal(&rt, SignalKind::user_defined1())
-                    })
-                })
+                .map(|_| std::thread::spawn(|| fresh_runtime_receives(SignalKind::user_defined1())))
                 .collect();
             threads.into_iter().all(|t| t.join().unwrap_or_default())
         }),
@@ -229,16 +230,8 @@ fn fork_scenarios() {
     // Scenario 5: forking twice in a row; each generation gets its own pipe.
     assert!(
         fork_and_check(|| {
-            let rt = new_runtime();
-            if !receives_signal(&rt, SignalKind::user_defined1()) {
-                return false;
-            }
-            drop(rt);
-
-            fork_and_check(|| {
-                let rt = new_runtime();
-                receives_signal(&rt, SignalKind::user_defined1())
-            })
+            fresh_runtime_receives(SignalKind::user_defined1())
+                && fork_and_check(|| fresh_runtime_receives(SignalKind::user_defined1()))
         }),
         "grandchild runtimes must work as well",
     );

--- a/tokio/tests/signal_fork.rs
+++ b/tokio/tests/signal_fork.rs
@@ -1,0 +1,174 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "full")]
+#![cfg(unix)]
+#![cfg(not(miri))] // No `sigaction` or `fork` on Miri.
+
+//! Verifies that a process that has used Tokio can `fork(2)` and create a
+//! fresh, fully working runtime in the child process.
+//!
+//! All scenarios run sequentially inside a single `#[test]`: forking while
+//! sibling test threads run risks inheriting locks held by those threads,
+//! which would deadlock the child. Keep this file to exactly one test.
+
+use std::time::{Duration, Instant};
+
+use tokio::runtime::Runtime;
+use tokio::signal::unix::{signal, SignalKind};
+
+fn new_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(1)
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Registers a listener for `kind`, raises the signal, and reports whether
+/// the listener observed it.
+fn receives_signal(rt: &Runtime, kind: SignalKind) -> bool {
+    rt.block_on(async {
+        let mut sig = signal(kind).expect("failed to register signal listener");
+        // Safety: raising a signal for which a listener was just registered.
+        unsafe { libc::raise(kind.as_raw_value()) };
+        tokio::time::timeout(Duration::from_secs(15), sig.recv())
+            .await
+            .is_ok()
+    })
+}
+
+/// Spawns a short-lived child process and reports whether waiting on it
+/// succeeds. Exercises the process reaping machinery (SIGCHLD or pidfd).
+fn spawns_child_process(rt: &Runtime) -> bool {
+    rt.block_on(async {
+        let status = tokio::process::Command::new("true").status();
+        match tokio::time::timeout(Duration::from_secs(15), status).await {
+            Ok(Ok(status)) => status.success(),
+            _ => false,
+        }
+    })
+}
+
+/// Runs `f` in a forked child process; returns true iff the child exited
+/// with code 0. The child exits via `_exit`, skipping destructors and atexit
+/// handlers, so it never touches state inherited from the parent on its way
+/// out.
+fn fork_and_check(f: impl FnOnce() -> bool) -> bool {
+    unsafe {
+        match libc::fork() {
+            -1 => panic!("fork failed: {}", std::io::Error::last_os_error()),
+            0 => {
+                let ok = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)).unwrap_or(false);
+                libc::_exit(i32::from(!ok));
+            }
+            child => {
+                // Reap with a timeout so a hung child fails the test instead
+                // of hanging it forever.
+                let deadline = Instant::now() + Duration::from_secs(60);
+                loop {
+                    let mut status = 0;
+                    match libc::waitpid(child, &mut status, libc::WNOHANG) {
+                        0 => {
+                            if Instant::now() > deadline {
+                                libc::kill(child, libc::SIGKILL);
+                                libc::waitpid(child, &mut status, 0);
+                                return false;
+                            }
+                            std::thread::sleep(Duration::from_millis(20));
+                        }
+                        pid if pid == child => {
+                            return libc::WIFEXITED(status) && libc::WEXITSTATUS(status) == 0;
+                        }
+                        _ => panic!("waitpid failed: {}", std::io::Error::last_os_error()),
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn fork_scenarios() {
+    // Scenario 1: the parent uses signals, shuts its runtime down, and forks.
+    // A fresh runtime in the child must receive signals.
+    let rt = new_runtime();
+    assert!(
+        receives_signal(&rt, SignalKind::user_defined1()),
+        "parent must receive signals before the fork",
+    );
+    drop(rt);
+
+    assert!(
+        fork_and_check(|| {
+            let rt = new_runtime();
+            receives_signal(&rt, SignalKind::user_defined1())
+        }),
+        "child created after parent runtime shutdown",
+    );
+
+    // Scenario 2: the parent runtime stays alive across the fork. The child
+    // must not touch it, but a fresh runtime in the child must receive
+    // signals and reap child processes, and the parent's signal handling
+    // must keep working after the fork.
+    let rt = new_runtime();
+    assert!(receives_signal(&rt, SignalKind::user_defined2()));
+    // Give the parent's worker a moment to park, reducing the chance of
+    // forking while it holds a lock.
+    std::thread::sleep(Duration::from_millis(100));
+
+    assert!(
+        fork_and_check(|| {
+            let child_rt = new_runtime();
+            receives_signal(&child_rt, SignalKind::user_defined2())
+                && spawns_child_process(&child_rt)
+        }),
+        "child created while the parent runtime is alive",
+    );
+
+    assert!(
+        receives_signal(&rt, SignalKind::user_defined2()),
+        "parent signal handling must survive the child's pipe replacement",
+    );
+
+    // Scenario 3: a signal recorded in the parent but not yet broadcast at
+    // the moment of the fork must not be delivered as a ghost signal to a
+    // listener in the child.
+    let rt = new_runtime();
+    assert!(receives_signal(&rt, SignalKind::hangup()));
+    // Drop the runtime so nothing consumes signal events anymore, then raise:
+    // the process-global signal handler stays installed and records the event
+    // as pending, where it remains until the fork.
+    drop(rt);
+    unsafe { libc::raise(libc::SIGHUP) };
+
+    assert!(
+        fork_and_check(|| {
+            let child_rt = new_runtime();
+            child_rt.block_on(async {
+                let mut sig =
+                    signal(SignalKind::hangup()).expect("failed to register signal listener");
+                // No SIGHUP was raised in the child, so nothing must arrive.
+                tokio::time::timeout(Duration::from_millis(500), sig.recv())
+                    .await
+                    .is_err()
+            })
+        }),
+        "child must not observe signals recorded by the parent before the fork",
+    );
+
+    // Scenario 4: forking twice in a row; each generation gets its own pipe.
+    assert!(
+        fork_and_check(|| {
+            let rt = new_runtime();
+            if !receives_signal(&rt, SignalKind::user_defined1()) {
+                return false;
+            }
+            drop(rt);
+
+            fork_and_check(|| {
+                let rt = new_runtime();
+                receives_signal(&rt, SignalKind::user_defined1())
+            })
+        }),
+        "grandchild runtimes must work as well",
+    );
+}


### PR DESCRIPTION
## Motivation

Creating a new runtime in a forked child process is currently broken, because three pieces of process-global state are inherited from the parent: the signal self-pipe (parent and child race to consume wakeups from the same pipe, silently losing signal notifications in either process), signal events recorded but not yet broadcast at the moment of the fork (delivered to listeners in the child as ghost signals), and the orphan process queue (its entries belong to the parent).

This breaks libraries embedded in host applications that fork at times the library cannot control, e.g. Rust extensions for Python under `multiprocessing` or prefork servers. In #4301 it was indicated that supporting fork followed by fresh runtimes seems possible, but "there probably needs to be some mechanism to recreate the file descriptor". This PR implements that mechanism.

## Solution

Detect the fork by pid comparison when a signal driver is created, and rebuild the process-global state:

- Replace the self-pipe with a fresh socketpair, redirecting the existing descriptor *numbers* at it with `dup2`. Keeping the numbers stable means the signal handler inherited across the fork keeps working without re-registration and without synchronization with the swap: a concurrently running handler writes either to the old pipe (at worst a spurious wakeup for the parent) or to the new one.
- Clear events recorded before the fork; no listener can exist in the child at that point, so nothing observable is lost.
- The orphan queue stamps the pushing process's pid and discards entries inherited from a pre-fork parent on first contact.

Hot paths are untouched: the signal handler is unchanged (the reason for the stable-fd-number design), the per-park reaping path pays nothing while the orphan queue is empty, and the fork check itself runs once per runtime creation.

One known limitation is recorded in the code: pid comparison cannot detect a fork if the recorded process dies and a later descendant happens to reuse its pid. Closing that would require `pthread_atfork`, which is process-wide and unremovable, so it is deliberately avoided.

The runtime module documentation is updated: forking while runtimes are running is described as subject to the inherent hazards of forking a multi-threaded process, not unconditionally supported. Happy to adjust the wording in either direction.

Refs #4301.

---

**Parts of this PR were drafted with assistance from Claude Code (with `claude-fable-5`) and fully reviewed and edited by me. I take full responsibility for all changes.**