### PR TITLE
net: disable some Miri tests for TCP socket

### DIFF
--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -89,6 +89,7 @@ async fn test_transfer_after_close() {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)] // Miri sometimes fails to establish the tcp connection
 async fn blocking_one_side_does_not_block_other() {
     symmetric(|handle, mut a, mut b| async move {
         block_write(&mut a).await;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1155,6 +1155,7 @@ rt_test! {
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
     #[test]
+    #[cfg_attr(miri, ignore)] // Miri is too slow on this test
     fn local_set_client_server_block_on() {
         let rt = rt();
         let (tx, rx) = mpsc::channel();

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1155,7 +1155,7 @@ rt_test! {
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri is too slow on this test
+    #[cfg_attr(miri, ignore)] // Miri sometimes fails to establish the tcp connection
     fn local_set_client_server_block_on() {
         let rt = rt();
         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
This test is too slow and causes CI failures multiple times.

- https://github.com/tokio-rs/tokio/actions/runs/27274974896/job/80554174300
- https://github.com/tokio-rs/tokio/actions/runs/27205813489/job/80321590056