### PR TITLE
rt: add global queue share per worker config

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -121,6 +121,19 @@ pub struct Builder {
     /// self-tuning strategy based on mean task poll times.
     pub(super) global_queue_interval: Option<u32>,
 
+    /// The share of the global queue a multi-threaded scheduler worker takes
+    /// each time it pulls a batch, as a fraction in `0.0..=1.0`.
+    ///
+    /// When `Some(f)`, a worker takes `floor(len * f) + 1` of the `len` tasks
+    /// currently in the global queue per pull (at least one, and still capped
+    /// by local-queue space). `1.0` lets a worker drain the whole queue in one
+    /// lock acquisition; smaller values take less per lock, spreading work more
+    /// evenly at the cost of contending on the global queue lock more often.
+    ///
+    /// When `None` (the default), the scheduler uses its built-in behavior: a
+    /// `1 / N` share, where `N` is the number of workers.
+    pub(super) global_queue_share_per_worker: Option<f32>,
+
     /// How many ticks before yielding to the driver for timer and I/O events?
     pub(super) event_interval: u32,
 
@@ -324,6 +337,7 @@ impl Builder {
             // Defaults for these values depend on the scheduler kind, so we get them
             // as parameters.
             global_queue_interval: None,
+            global_queue_share_per_worker: None,
             event_interval,
 
             seed_generator: RngSeedGenerator::new(RngSeed::new()),
@@ -1338,6 +1352,59 @@ impl Builder {
             self
         }
 
+        /// Sets the share of the global task queue a multi-threaded scheduler
+        /// worker takes each time it pulls a batch.
+        ///
+        /// When a worker runs out of local work it pulls a batch of tasks from
+        /// the global (injection) queue rather than draining it completely, so
+        /// that other workers can also grab work. By default each worker takes a
+        /// `1 / N` share of the queued tasks, where `N` is the number of worker
+        /// threads. When `N` is large, that share becomes small, so workers must
+        /// lock the global queue more often to make progress, increasing
+        /// contention on the shared mutex.
+        ///
+        /// This option replaces that worker-count-derived share with a fixed
+        /// fraction `share` in `0.0..=1.0`. With `len` tasks in the global
+        /// queue, a worker takes `floor(len * share) + 1` of them per pull (at
+        /// least one, and still capped by available local-queue space):
+        ///
+        /// * `1.0` lets a worker drain the whole queue in one lock acquisition,
+        ///   minimizing global-queue locking at the cost of an uneven
+        ///   distribution.
+        /// * smaller values take less per lock, spreading work more evenly but
+        ///   contending on the global queue lock more often.
+        ///
+        /// If this is never called, the scheduler keeps its default `1 / N`
+        /// behavior. This setting only affects the multi-threaded scheduler.
+        ///
+        /// # Panics
+        ///
+        /// This function panics if `share` is not in the range `0.0..=1.0`,
+        /// is `0.0`, or is `NaN`.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// # #[cfg(not(target_family = "wasm"))]
+        /// # {
+        /// use tokio::runtime;
+        ///
+        /// let rt = runtime::Builder::new_multi_thread()
+        ///     .global_queue_share_per_worker(0.5)
+        ///     .build()
+        ///     .unwrap();
+        /// # }
+        /// ```
+        #[track_caller]
+        pub fn global_queue_share_per_worker(&mut self, share: f32) -> &mut Self {
+            assert!(
+                share > 0.0 && share <= 1.0,
+                "global_queue_share_per_worker must be in the range 0.0..=1.0 and greater than 0.0"
+            );
+            self.global_queue_share_per_worker = Some(share);
+            self
+        }
+
         /// Specifies the random number generation seed to use within all
         /// threads associated with the runtime being built.
         ///
@@ -1699,6 +1766,7 @@ impl Builder {
                 after_poll: self.after_poll.clone(),
                 after_termination: self.after_termination.clone(),
                 global_queue_interval: self.global_queue_interval,
+                global_queue_share_per_worker: self.global_queue_share_per_worker,
                 event_interval: self.event_interval,
                 #[cfg(tokio_unstable)]
                 unhandled_panic: self.unhandled_panic.clone(),
@@ -1885,6 +1953,7 @@ cfg_rt_multi_thread! {
                     after_poll: self.after_poll.clone(),
                     after_termination: self.after_termination.clone(),
                     global_queue_interval: self.global_queue_interval,
+                    global_queue_share_per_worker: self.global_queue_share_per_worker,
                     event_interval: self.event_interval,
                     #[cfg(tokio_unstable)]
                     unhandled_panic: self.unhandled_panic.clone(),

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -9,6 +9,13 @@ pub(crate) struct Config {
     /// How many ticks before pulling a task from the global/remote queue?
     pub(crate) global_queue_interval: Option<u32>,
 
+    /// The share of the global queue a multi-threaded scheduler worker takes
+    /// per pull, as a fraction in `0.0..=1.0`. `Some(f)` means take
+    /// `floor(len * f) + 1` of the `len` queued tasks per lock (at least one,
+    /// capped by local-queue space); `None` keeps the default `1 / N` share,
+    /// where `N` is the number of workers.
+    pub(crate) global_queue_share_per_worker: Option<f32>,
+
     /// How many ticks before yielding to the driver for timer and I/O events?
     pub(crate) event_interval: u32,
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -197,6 +197,12 @@ pub(crate) struct Shared {
     /// Scheduler configuration options
     config: Config,
 
+    /// Fraction of the global queue a worker takes per batch pull, resolved
+    /// once at build time: `config.global_queue_share_per_worker` when set, or
+    /// `1 / N` (the default) otherwise. Pre-computed so the hot path that sizes
+    /// a batch has no per-pull branch on the configuration.
+    global_queue_share: f32,
+
     /// Collects metrics from the runtime.
     pub(super) scheduler_metrics: SchedulerMetrics,
 
@@ -312,6 +318,13 @@ pub(super) fn create(
     let (idle, idle_synced) = Idle::new(size);
     let (inject, inject_synced) = inject::Shared::new();
 
+    // Resolve the per-pull global-queue share once, so the batch-sizing hot
+    // path does not branch on the configuration. Unset keeps the default
+    // `1 / N` share.
+    let global_queue_share = config
+        .global_queue_share_per_worker
+        .unwrap_or(1.0 / size as f32);
+
     let remotes_len = remotes.len();
     let handle = Arc::new(Handle {
         name,
@@ -330,6 +343,7 @@ pub(super) fn create(
             shutdown_cores: Mutex::new(vec![]),
             trace_status: TraceStatus::new(remotes_len),
             config,
+            global_queue_share,
             scheduler_metrics: SchedulerMetrics::new(),
             worker_metrics: worker_metrics.into_boxed_slice(),
             _counters: Counters,
@@ -1104,16 +1118,17 @@ impl Core {
             );
 
             // The worker is currently idle, pull a batch of work from the
-            // injection queue. We don't want to pull *all* the work so other
-            // workers can also get some.
-            let n = usize::min(
-                worker.inject().len() / worker.handle.shared.remotes.len() + 1,
-                cap,
-            );
-
-            // Take at least one task since the first task is returned directly
-            // and not pushed onto the local queue.
-            let n = usize::max(1, n);
+            // injection queue. We don't pull *all* the work so other workers can
+            // also get some. Take a `global_queue_share` fraction of the queued
+            // tasks, plus one. The `+ 1` guarantees we always take at least one
+            // task (the first is returned directly, not pushed to the local
+            // queue) even when the share rounds down to zero; `cap` is at least
+            // `max_capacity() / 2 > 0` here, so the batch stays >= 1 without a
+            // separate clamp. The share is resolved once at build time (the
+            // configured value, or `1 / N` by default), so there is no branch.
+            let len = worker.inject().len();
+            let n = (len as f32 * worker.handle.shared.global_queue_share) as usize + 1;
+            let n = usize::min(n, cap);
 
             let mut synced = worker.handle.shared.synced.lock();
             // safety: passing in the correct `inject::Synced`.

--- a/tokio/tests/rt_threaded.rs
+++ b/tokio/tests/rt_threaded.rs
@@ -951,4 +951,72 @@ mod unstable {
 
         assert_ne!(rt1.handle().id(), rt2.handle().id());
     }
+
+    /// `global_queue_share_per_worker` sets the fraction of the global queue a
+    /// worker takes per pull. Across the valid `(0.0, 1.0]` range and a spread
+    /// of worker counts, every spawned task must still complete (the global
+    /// queue is always fully drained, regardless of the share).
+    #[test]
+    fn global_queue_share_per_worker_drains_all_tasks() {
+        const TASKS: usize = 1_000;
+
+        for worker_threads in [1, 2, 4, 16] {
+            for share in [0.1, 0.25, 0.5, 1.0] {
+                let rt = runtime::Builder::new_multi_thread()
+                    .worker_threads(worker_threads)
+                    .global_queue_share_per_worker(share)
+                    .build()
+                    .unwrap();
+
+                let cnt = Arc::new(AtomicUsize::new(0));
+                rt.block_on(async {
+                    let mut set = tokio::task::JoinSet::new();
+                    for _ in 0..TASKS {
+                        let cnt = cnt.clone();
+                        set.spawn(async move { cnt.fetch_add(1, Ordering::Relaxed) });
+                    }
+                    while let Some(res) = set.join_next().await {
+                        res.unwrap();
+                    }
+                });
+
+                assert_eq!(
+                    cnt.load(Relaxed),
+                    TASKS,
+                    "worker_threads={worker_threads}, share={share}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "global_queue_share_per_worker must be in the range")]
+    fn global_queue_share_per_worker_rejects_out_of_range() {
+        let _ = runtime::Builder::new_multi_thread().global_queue_share_per_worker(1.5);
+    }
+
+    #[test]
+    #[should_panic(expected = "global_queue_share_per_worker must be in the range")]
+    fn global_queue_share_per_worker_rejects_zero() {
+        let _ = runtime::Builder::new_multi_thread().global_queue_share_per_worker(0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "global_queue_share_per_worker must be in the range")]
+    fn global_queue_share_per_worker_rejects_nan() {
+        let _ = runtime::Builder::new_multi_thread().global_queue_share_per_worker(f32::NAN);
+    }
+
+    #[test]
+    #[should_panic(expected = "global_queue_share_per_worker must be in the range")]
+    fn global_queue_share_per_worker_rejects_infinity() {
+        let _ = runtime::Builder::new_multi_thread().global_queue_share_per_worker(f32::INFINITY);
+    }
+
+    #[test]
+    #[should_panic(expected = "global_queue_share_per_worker must be in the range")]
+    fn global_queue_share_per_worker_rejects_neg_infinity() {
+        let _ =
+            runtime::Builder::new_multi_thread().global_queue_share_per_worker(f32::NEG_INFINITY);
+    }
 }


### PR DESCRIPTION
## Motivation

When a multi-threaded scheduler worker runs out of local work, it pulls a batch of tasks from the global (injection) queue rather than draining it completely, so other workers can also grab work. The batch is the worker's `1 / N` share of the queued tasks, where `N` is the number of workers. When `N` is large this share is small, so workers must lock the global queue more frequently to make progress, increasing contention on the shared mutex.

## Solution

Add an unstable `Builder::global_queue_share_per_worker` option that overrides the sharing with a fixed fraction. For an worker share `s` in `0.0..=1.0`, a worker takes a `s * len` of the global queue:

* `0.0` - Forces each worker to take the minimum amount (1)
* `1.0` - Forces each worker to take the maximum amount it can accommodate 
* values in between trade an even work distribution for less frequent global-queue locking.

The fraction `s` is computed once when the runtime is built and stored on the scheduler's shared state, so the hot path stays an integer division.

## Try it

I (and a robot) created a benchmarking tool to verify whether this change makes any difference. The short answer is **yes**. 

https://github.com/johnhurt/tokio-equitability-bench

For the (humble) 128-thread test machine, the improvement is significant _as long as your workload is heavily mutex bound_ meaning if you have a runtime with that sometimes overflows or does significant work on blocking thread pools, you probably have some churn on the mutex containing the global task queue. This benchmark shows that if you have a runtime above a certain size (20 in the case of the 64-core test computer), the improvement in throughput is substantial. Below that and there's a small penalty, so it's not for everyone. But it is for me!

<img width="720" height="437" alt="Screenshot 2026-06-15 at 9 05 58 PM" src="https://github.com/user-attachments/assets/ba426087-1c46-4649-a8e4-ed7a1da0a6c3" />

