### PR TITLE
test: add `Spawn::poll_until_idle`

### DIFF
--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,11 +1,3 @@
-# Unreleased
-
-### Added
-
-- task: add `Spawn::poll_to_block` ([#8213])
-
-[#8213]: https://github.com/tokio-rs/tokio/pulls/8213
-
 # 0.4.5 (January 4th, 2026)
 
 ### Added

--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+### Added
+
+- task: add `Spawn::poll_to_block` ([#8209])
+
+[#8209]: https://github.com/tokio-rs/tokio/issues/8209
+
 # 0.4.5 (January 4th, 2026)
 
 ### Added

--- a/tokio-test/CHANGELOG.md
+++ b/tokio-test/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Added
 
-- task: add `Spawn::poll_to_block` ([#8209])
+- task: add `Spawn::poll_to_block` ([#8213])
 
-[#8209]: https://github.com/tokio-rs/tokio/issues/8209
+[#8213]: https://github.com/tokio-rs/tokio/pulls/8213
 
 # 0.4.5 (January 4th, 2026)
 

--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -70,8 +70,8 @@ const IDLE: usize = 0;
 const WAKE: usize = 1;
 const SLEEP: usize = 2;
 
-/// Default maximum number of poll iterations in [`Spawn::poll_to_block`].
-const POLL_TO_BLOCK_MAX_ITERATIONS: usize = 150;
+/// Default maximum number of poll iterations in [`Spawn::poll_until_idle`].
+const POLL_UNTIL_IDLE_MAX_ITERATIONS: usize = 150;
 
 impl<T> Spawn<T> {
     /// Consumes `self` returning the inner value
@@ -127,7 +127,10 @@ impl<T: Future> Spawn<T> {
         self.task.enter(|cx| fut.poll(cx))
     }
 
-    /// Polls the future until it either completes or is no longer woken.
+    /// Polls the future until it is idle.
+    ///
+    /// A future is considered idle when it either completes, or returns
+    /// [`Poll::Pending`] without a pending wake notification.
     ///
     /// Unlike [`poll`](Self::poll), this method keeps polling while the future
     /// returns [`Poll::Pending`] but has received a wake notification, advancing
@@ -147,17 +150,17 @@ impl<T: Future> Spawn<T> {
     ///
     /// let mut task = task::spawn(async { 42 });
     ///
-    /// assert!(task.poll_to_block().is_ready());
+    /// assert!(task.poll_until_idle().is_ready());
     /// ```
-    pub fn poll_to_block(&mut self) -> Poll<T::Output> {
-        for _ in 0..POLL_TO_BLOCK_MAX_ITERATIONS {
+    pub fn poll_until_idle(&mut self) -> Poll<T::Output> {
+        for _ in 0..POLL_UNTIL_IDLE_MAX_ITERATIONS {
             let result = self.poll();
             if result.is_ready() || !self.is_woken() {
                 return result;
             }
         }
         panic!(
-            "poll_to_block exceeded {POLL_TO_BLOCK_MAX_ITERATIONS} iterations; future may be waking without making progress"
+            "poll_until_idle exceeded {POLL_UNTIL_IDLE_MAX_ITERATIONS} iterations; future may be waking without making progress"
         );
     }
 }

--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -70,6 +70,9 @@ const IDLE: usize = 0;
 const WAKE: usize = 1;
 const SLEEP: usize = 2;
 
+/// Default maximum number of poll iterations in [`Spawn::poll_to_block`].
+const POLL_TO_BLOCK_MAX_ITERATIONS: usize = 128;
+
 impl<T> Spawn<T> {
     /// Consumes `self` returning the inner value
     pub fn into_inner(self) -> T
@@ -130,6 +133,13 @@ impl<T: Future> Spawn<T> {
     /// returns [`Poll::Pending`] but has received a wake notification, advancing
     /// the future as far as possible without waiting for external events.
     ///
+    /// Polling is bounded to avoid infinite loops when a future wakes without
+    /// making progress.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the iteration limit is exceeded.
+    ///
     /// # Example
     ///
     /// ```
@@ -140,12 +150,15 @@ impl<T: Future> Spawn<T> {
     /// assert!(task.poll_to_block().is_ready());
     /// ```
     pub fn poll_to_block(&mut self) -> Poll<T::Output> {
-        loop {
+        for _ in 0..POLL_TO_BLOCK_MAX_ITERATIONS {
             let result = self.poll();
             if result.is_ready() || !self.is_woken() {
                 return result;
             }
         }
+        panic!(
+            "poll_to_block exceeded {POLL_TO_BLOCK_MAX_ITERATIONS} iterations; future may be waking without making progress"
+        );
     }
 }
 

--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -123,6 +123,30 @@ impl<T: Future> Spawn<T> {
         let fut = self.future.as_mut();
         self.task.enter(|cx| fut.poll(cx))
     }
+
+    /// Polls the future until it either completes or is no longer woken.
+    ///
+    /// Unlike [`poll`](Self::poll), this method keeps polling while the future
+    /// returns [`Poll::Pending`] but has received a wake notification, advancing
+    /// the future as far as possible without waiting for external events.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio_test::task;
+    ///
+    /// let mut task = task::spawn(async { 42 });
+    ///
+    /// assert!(task.poll_to_block().is_ready());
+    /// ```
+    pub fn poll_to_block(&mut self) -> Poll<T::Output> {
+        loop {
+            let result = self.poll();
+            if result.is_ready() || !self.is_woken() {
+                return result;
+            }
+        }
+    }
 }
 
 impl<T: Stream> Spawn<T> {

--- a/tokio-test/src/task.rs
+++ b/tokio-test/src/task.rs
@@ -71,7 +71,7 @@ const WAKE: usize = 1;
 const SLEEP: usize = 2;
 
 /// Default maximum number of poll iterations in [`Spawn::poll_to_block`].
-const POLL_TO_BLOCK_MAX_ITERATIONS: usize = 128;
+const POLL_TO_BLOCK_MAX_ITERATIONS: usize = 150;
 
 impl<T> Spawn<T> {
     /// Consumes `self` returning the inner value

--- a/tokio-test/tests/task.rs
+++ b/tokio-test/tests/task.rs
@@ -97,7 +97,7 @@ impl Future for WakeForever {
 }
 
 #[test]
-#[should_panic(expected = "poll_to_block exceeded 128 iterations")]
+#[should_panic(expected = "poll_to_block exceeded 150 iterations")]
 fn poll_to_block_panics_on_infinite_wake() {
     let mut task = task::spawn(WakeForever);
     let _ = task.poll_to_block();

--- a/tokio-test/tests/task.rs
+++ b/tokio-test/tests/task.rs
@@ -26,15 +26,15 @@ fn test_spawn_stream_size_hint() {
 }
 
 #[test]
-fn poll_to_block_ready() {
+fn poll_until_idle_ready() {
     let mut task = task::spawn(async { 42 });
-    assert_eq!(task.poll_to_block(), Poll::Ready(42));
+    assert_eq!(task.poll_until_idle(), Poll::Ready(42));
 }
 
 #[test]
-fn poll_to_block_pending_not_woken() {
+fn poll_until_idle_pending_not_woken() {
     let mut task = task::spawn(pending::<()>());
-    assert!(task.poll_to_block().is_pending());
+    assert!(task.poll_until_idle().is_pending());
 }
 
 struct WakeThenReady {
@@ -57,9 +57,9 @@ impl Future for WakeThenReady {
 }
 
 #[test]
-fn poll_to_block_advances_on_wake() {
+fn poll_until_idle_advances_on_wake() {
     let mut task = task::spawn(WakeThenReady { step: 0 });
-    assert!(task.poll_to_block().is_ready());
+    assert!(task.poll_until_idle().is_ready());
 }
 
 struct WakeNTimes {
@@ -80,9 +80,9 @@ impl Future for WakeNTimes {
 }
 
 #[test]
-fn poll_to_block_multiple_wakes() {
+fn poll_until_idle_multiple_wakes() {
     let mut task = task::spawn(WakeNTimes { remaining: 3 });
-    assert_eq!(task.poll_to_block(), Poll::Ready(0));
+    assert_eq!(task.poll_until_idle(), Poll::Ready(0));
 }
 
 struct WakeForever;
@@ -97,8 +97,8 @@ impl Future for WakeForever {
 }
 
 #[test]
-#[should_panic(expected = "poll_to_block exceeded 150 iterations")]
-fn poll_to_block_panics_on_infinite_wake() {
+#[should_panic(expected = "poll_until_idle exceeded 150 iterations")]
+fn poll_until_idle_panics_on_infinite_wake() {
     let mut task = task::spawn(WakeForever);
-    let _ = task.poll_to_block();
+    let _ = task.poll_until_idle();
 }

--- a/tokio-test/tests/task.rs
+++ b/tokio-test/tests/task.rs
@@ -84,3 +84,21 @@ fn poll_to_block_multiple_wakes() {
     let mut task = task::spawn(WakeNTimes { remaining: 3 });
     assert_eq!(task.poll_to_block(), Poll::Ready(0));
 }
+
+struct WakeForever;
+
+impl Future for WakeForever {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+#[test]
+#[should_panic(expected = "poll_to_block exceeded 128 iterations")]
+fn poll_to_block_panics_on_infinite_wake() {
+    let mut task = task::spawn(WakeForever);
+    let _ = task.poll_to_block();
+}

--- a/tokio-test/tests/task.rs
+++ b/tokio-test/tests/task.rs
@@ -1,3 +1,4 @@
+use std::future::{pending, Future};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio_stream::Stream;
@@ -22,4 +23,64 @@ impl Stream for SizedStream {
 fn test_spawn_stream_size_hint() {
     let spawn = task::spawn(SizedStream);
     assert_eq!(spawn.size_hint(), (100, Some(200)));
+}
+
+#[test]
+fn poll_to_block_ready() {
+    let mut task = task::spawn(async { 42 });
+    assert_eq!(task.poll_to_block(), Poll::Ready(42));
+}
+
+#[test]
+fn poll_to_block_pending_not_woken() {
+    let mut task = task::spawn(pending::<()>());
+    assert!(task.poll_to_block().is_pending());
+}
+
+struct WakeThenReady {
+    step: u8,
+}
+
+impl Future for WakeThenReady {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        match self.step {
+            0 => {
+                self.step = 1;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+            _ => Poll::Ready(()),
+        }
+    }
+}
+
+#[test]
+fn poll_to_block_advances_on_wake() {
+    let mut task = task::spawn(WakeThenReady { step: 0 });
+    assert!(task.poll_to_block().is_ready());
+}
+
+struct WakeNTimes {
+    remaining: u8,
+}
+
+impl Future for WakeNTimes {
+    type Output = u8;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<u8> {
+        if self.remaining == 0 {
+            return Poll::Ready(0);
+        }
+        self.remaining -= 1;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    }
+}
+
+#[test]
+fn poll_to_block_multiple_wakes() {
+    let mut task = task::spawn(WakeNTimes { remaining: 3 });
+    assert_eq!(task.poll_to_block(), Poll::Ready(0));
 }


### PR DESCRIPTION
Add a helper that polls a future until it completes or is no longer woken, simplifying synchronous test driving of composed futures.

Closes #8209

## Motivation

N/A — see #8209.

## Solution

Add `Spawn::poll_to_block`, which polls a future until it completes or is no longer woken. This encapsulates the common test pattern of repeatedly polling while `is_woken()` is true.

## Test plan

- [x] `cargo test -p tokio-test poll_to_block`
- [x] `cargo test -p tokio-test --doc`