### PR TITLE
time: fix reversed poll order in timeout doc

### DIFF
--- a/tokio/src/time/timeout.rs
+++ b/tokio/src/time/timeout.rs
@@ -21,7 +21,7 @@ use std::task::{self, Poll};
 /// value is returned. Otherwise, an error is returned and the future is
 /// canceled.
 ///
-/// Note that the timeout is checked before polling the future, so if the future
+/// Note that the future is polled before the timeout is checked, so if the future
 /// does not yield during execution then it is possible for the future to complete
 /// and exceed the timeout _without_ returning an error.
 ///


### PR DESCRIPTION
## Motivation

The docs for `timeout()` describe the poll order backwards. The current text says:

> Note that the timeout is checked before polling the future, so if the future does not yield during execution then it is possible for the future to complete and exceed the timeout _without_ returning an error.

But the implementation does the opposite. The `Future` impl for `Timeout` polls the inner future first (`me.value.poll(cx)`, under the comment "First, try polling the future") and only checks the delay afterward via `poll_delay`. So the timeout is checked *after* polling the future, not before.

The reversed order also undercuts the sentence's own point: the future can complete and exceed the timeout without an error precisely *because* it is polled before the timeout is checked.

## Solution

Reverse the clause so it matches the implementation:

> Note that the future is polled before the timeout is checked, ...

Only that clause changed; the rest of the sentence is unchanged. Docs only, no behavior change.