### PR TITLE
stream: honor StreamMap next_many limit

### DIFF
--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -632,6 +632,10 @@ where
                         should_loop = true;
 
                         idx = idx.wrapping_add(1) % self.entries.len();
+
+                        if added == limit {
+                            break;
+                        }
                     }
                     Poll::Ready(None) => {
                         // Remove the entry

--- a/tokio-stream/tests/stream_stream_map.rs
+++ b/tokio-stream/tests/stream_stream_map.rs
@@ -430,6 +430,27 @@ async fn poll_next_many_enough() {
 }
 
 #[tokio::test]
+async fn poll_next_many_does_not_exceed_limit() {
+    let mut stream_map: StreamMap<usize, UsizeStream> = StreamMap::new();
+
+    stream_map.insert(0, Box::pin(iter([0usize].into_iter())) as UsizeStream);
+    stream_map.insert(1, Box::pin(iter([1usize].into_iter())) as UsizeStream);
+
+    let mut buffer = vec![];
+    let n = poll_fn(|cx| stream_map.poll_next_many(cx, &mut buffer, 1)).await;
+
+    assert_eq!(n, 1);
+    assert_eq!(buffer.len(), 1);
+
+    let n = poll_fn(|cx| stream_map.poll_next_many(cx, &mut buffer, 1)).await;
+
+    assert_eq!(n, 1);
+    assert_eq!(buffer.len(), 2);
+    assert!(buffer.contains(&(0, 0)));
+    assert!(buffer.contains(&(1, 1)));
+}
+
+#[tokio::test]
 async fn poll_next_many_correctly_loops_around() {
     for _ in 0..10 {
         let mut stream_map: StreamMap<usize, UsizeStream> = StreamMap::new();
@@ -538,6 +559,27 @@ async fn next_many_enough() {
     let n = poll_fn(|cx| pin!(stream_map.next_many(&mut buffer, 2)).poll(cx)).await;
 
     assert_eq!(n, 2);
+    assert_eq!(buffer.len(), 2);
+    assert!(buffer.contains(&(0, 0)));
+    assert!(buffer.contains(&(1, 1)));
+}
+
+#[tokio::test]
+async fn next_many_does_not_exceed_limit() {
+    let mut stream_map: StreamMap<usize, UsizeStream> = StreamMap::new();
+
+    stream_map.insert(0, Box::pin(iter([0usize].into_iter())) as UsizeStream);
+    stream_map.insert(1, Box::pin(iter([1usize].into_iter())) as UsizeStream);
+
+    let mut buffer = vec![];
+    let n = poll_fn(|cx| pin!(stream_map.next_many(&mut buffer, 1)).poll(cx)).await;
+
+    assert_eq!(n, 1);
+    assert_eq!(buffer.len(), 1);
+
+    let n = poll_fn(|cx| pin!(stream_map.next_many(&mut buffer, 1)).poll(cx)).await;
+
+    assert_eq!(n, 1);
     assert_eq!(buffer.len(), 2);
     assert!(buffer.contains(&(0, 0)));
     assert!(buffer.contains(&(1, 1)));


### PR DESCRIPTION
## Summary

- stop `StreamMap::poll_next_many` as soon as it reaches the requested limit
- add regressions for both `poll_next_many` and `next_many` with multiple ready streams and `limit = 1`

## Context

`poll_next_many` checked `added < limit` only at the outer loop. When more than one stream was ready during the same scan, it could append past the documented limit before the next outer-loop check.

The new tests also make sure the second ready item is still returned by the next call, so the fix does not drop anything.

## Validation

- `cargo fmt --check`
- `cargo test -p tokio-stream --test stream_stream_map does_not_exceed_limit` (fails before the fix, passes after)
- `cargo test -p tokio-stream --test stream_stream_map`
- `cargo test -p tokio-stream`