### PR TITLE
stream: avoid overflow in StreamMap size_hint

### DIFF
--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -685,15 +685,15 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut ret = (0, Some(0));
+        let mut ret: (usize, Option<usize>) = (0, Some(0));
 
         for (_, stream) in &self.entries {
             let hint = stream.size_hint();
 
-            ret.0 += hint.0;
+            ret.0 = ret.0.saturating_add(hint.0);
 
             match (ret.1, hint.1) {
-                (Some(a), Some(b)) => ret.1 = Some(a + b),
+                (Some(a), Some(b)) => ret.1 = a.checked_add(b),
                 (Some(_), None) => ret.1 = None,
                 _ => {}
             }

--- a/tokio-stream/tests/stream_stream_map.rs
+++ b/tokio-stream/tests/stream_stream_map.rs
@@ -226,6 +226,30 @@ fn size_hint_without_upper() {
 }
 
 #[test]
+fn size_hint_overflow() {
+    struct Monster;
+
+    impl Stream for Monster {
+        type Item = ();
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> Poll<Option<()>> {
+            panic!()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, Some(usize::MAX))
+        }
+    }
+
+    let mut map = StreamMap::new();
+
+    map.insert("a", Monster);
+    map.insert("b", Monster);
+
+    assert_eq!(map.size_hint(), (usize::MAX, None));
+}
+
+#[test]
 fn new_capacity_zero() {
     let map = StreamMap::<&str, stream::Pending<()>>::new();
     assert_eq!(0, map.capacity());


### PR DESCRIPTION
## Summary

- use saturating addition for `StreamMap` lower-bound size hints
- use checked addition for exact upper bounds, returning `None` if the sum overflows
- add a regression test with streams that report `usize::MAX` size hints

## Context

`StreamMap::size_hint` previously added lower and upper bounds with unchecked arithmetic. In debug builds this could panic for very large hints, and in release builds it could wrap to an incorrect result.

This matches the existing behavior used by `chain` and `merge`: saturate the lower bound and drop the upper bound when it can no longer be represented exactly.

## History

The unchecked summation goes back to the original `StreamMap` implementation and was later moved into `tokio-stream`; it does not appear to have been materially changed since.

## Validation

- `cargo test -p tokio-stream --test stream_stream_map size_hint_overflow` (fails before the fix, passes after)
- `cargo fmt --check`
- `cargo test -p tokio-stream --test stream_stream_map`
- `cargo test -p tokio-stream`