### PR TITLE
examples: connect proxy upstream per client

### DIFF
--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -25,7 +25,6 @@
 use tokio::io::copy_bidirectional;
 use tokio::net::{TcpListener, TcpStream};
 
-use futures::FutureExt;
 use std::env;
 use std::error::Error;
 
@@ -44,16 +43,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let listener = TcpListener::bind(listen_addr).await?;
 
     while let Ok((mut inbound, _)) = listener.accept().await {
-        let mut outbound = TcpStream::connect(server_addr.clone()).await?;
+        let server_addr = server_addr.clone();
 
         tokio::spawn(async move {
-            copy_bidirectional(&mut inbound, &mut outbound)
-                .map(|r| {
-                    if let Err(e) = r {
-                        println!("Failed to transfer; error={e}");
-                    }
-                })
-                .await
+            let mut outbound = match TcpStream::connect(server_addr).await {
+                Ok(outbound) => outbound,
+                Err(e) => {
+                    println!("Failed to connect; error={e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = copy_bidirectional(&mut inbound, &mut outbound).await {
+                println!("Failed to transfer; error={e}");
+            }
         });
     }
 


### PR DESCRIPTION
## Summary

- spawn proxy connection handling immediately after accepting a client
- move the upstream `TcpStream::connect` into the spawned task
- handle upstream connect failures as per-connection errors instead of returning from `main`
- remove the now-unused `FutureExt` import

## Context

The proxy example says each TCP connection is processed concurrently. The current code awaits the upstream connect before spawning the per-client task, so a slow upstream connect stalls accepting other clients. A single upstream connect failure also exits the proxy through `?`.

This restores the older concurrency boundary while keeping the newer `copy_bidirectional` implementation.

## History

The async/await proxy version spawned a `transfer(...)` future from the accept loop, and `transfer` performed the upstream connect. The connect moved into the accept loop in `6aca07be` when the example was simplified to use `copy_bidirectional`.

## Validation

- `cargo fmt --check`
- `cargo check --example proxy`
- `cargo test --example proxy`