### PR TITLE
tokio: add LinkedList collection interfaces

### DIFF
--- a/tokio/src/runtime/io/registration_set.rs
+++ b/tokio/src/runtime/io/registration_set.rs
@@ -92,13 +92,7 @@ impl RegistrationSet {
         // this is the shutdown operation. In theory, shutdowns should be
         // "clean" with no outstanding I/O resources. Even if it is slow, we
         // aren't optimizing for shutdown.
-        let mut ret = vec![];
-
-        while let Some(io) = synced.registrations.pop_back() {
-            ret.push(io);
-        }
-
-        ret
+        synced.registrations.drain_back().collect::<Vec<_>>()
     }
 
     pub(super) fn release(&self, synced: &mut Synced) {

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -225,9 +225,7 @@ impl Wheel {
         // they actually need to be dropped down a level. We then reinsert them
         // back into the same position; we must make sure we don't then process
         // those entries again or we'll end up in an infinite loop.
-        let mut entries = self.take_entries(expiration);
-
-        while let Some(item) = entries.pop_back() {
+        for item in self.take_entries(expiration).drain_back() {
             if expiration.level == 0 {
                 debug_assert_eq!(unsafe { item.registered_when() }, expiration.deadline);
             }

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -168,9 +168,7 @@ impl Wheel {
         // they actually need to be dropped down a level. We then reinsert them
         // back into the same position; we must make sure we don't then process
         // those entries again or we'll end up in an infinite loop.
-        let mut entries = self.take_entries(expiration);
-
-        while let Some(hdl) = entries.pop_back() {
+        for hdl in self.take_entries(expiration).drain_back() {
             if expiration.level == 0 {
                 debug_assert_eq!(hdl.deadline(), expiration.deadline);
             }

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -250,7 +250,7 @@ impl Semaphore {
         // permit counter is closed, but the wait list is not.
         self.permits.fetch_or(Self::CLOSED, Release);
         waiters.closed = true;
-        while let Some(mut waiter) = waiters.queue.pop_back() {
+        for mut waiter in waiters.queue.drain_back() {
             let waker = unsafe { waiter.as_mut().waker.with_mut(|waker| (*waker).take()) };
             if let Some(waker) = waker {
                 waker.wake();

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -7,7 +7,7 @@
 //! similar.
 
 use std::marker::PhantomPinned;
-use std::mem::ManuallyDrop;
+use std::mem::{self, ManuallyDrop};
 use std::ptr::NonNull;
 use std::task::{Context, Waker};
 
@@ -230,21 +230,6 @@ impl<T> IdleNotifiedSet<T> {
 
     /// Call a function on every element in this list.
     pub(crate) fn for_each<F: FnMut(&mut T)>(&mut self, mut func: F) {
-        fn get_ptrs<T>(list: &mut LinkedList<ListEntry<T>>, ptrs: &mut Vec<*mut T>) {
-            let mut node = list.last();
-
-            while let Some(entry) = node {
-                ptrs.push(entry.value.with_mut(|ptr| {
-                    let ptr: *mut ManuallyDrop<T> = ptr;
-                    let ptr: *mut T = ptr.cast();
-                    ptr
-                }));
-
-                let prev = entry.pointers.get_prev();
-                node = prev.map(|prev| unsafe { &*prev.as_ptr() });
-            }
-        }
-
         // Atomically get a raw pointer to the value of every entry.
         //
         // Since this only locks the mutex once, it is not possible for a value
@@ -253,10 +238,14 @@ impl<T> IdleNotifiedSet<T> {
         // twice.
         let mut ptrs = Vec::with_capacity(self.len());
         {
-            let mut lock = self.lists.lock();
+            let lock = self.lists.lock();
 
-            get_ptrs(&mut lock.idle, &mut ptrs);
-            get_ptrs(&mut lock.notified, &mut ptrs);
+            ptrs.extend(
+                lock.idle
+                    .iter_back()
+                    .chain(lock.notified.iter_back())
+                    .map(|entry| entry.value.with_mut(|ptr| ptr.cast())),
+            );
         }
         debug_assert_eq!(ptrs.len(), ptrs.capacity());
 
@@ -293,68 +282,45 @@ impl<T> IdleNotifiedSet<T> {
         }
 
         impl<T, F: FnMut(T)> AllEntries<T, F> {
-            fn pop_next(&mut self) -> bool {
-                if let Some(entry) = self.all_entries.pop_back() {
+            fn iter(&mut self) {
+                for entry in self.all_entries.drain_back() {
                     // Safety: We just took this value from the list, so we can
                     // destroy the value in the entry.
                     entry
                         .value
                         .with_mut(|ptr| unsafe { (self.func)(ManuallyDrop::take(&mut *ptr)) });
-                    true
-                } else {
-                    false
                 }
             }
         }
 
         impl<T, F: FnMut(T)> Drop for AllEntries<T, F> {
             fn drop(&mut self) {
-                while self.pop_next() {}
+                self.iter()
             }
         }
 
-        let mut all_entries = AllEntries {
-            all_entries: LinkedList::new(),
-            func,
+        // Atomically take all entries.
+        let all_entries = {
+            let mut lock = self.lists.lock();
+            mem::take(&mut lock.idle)
+                .drain_back()
+                .chain(mem::take(&mut lock.notified).drain_back())
+                .inspect(|entry| {
+                    // Safety: pointer is accessed while holding the mutex.
+                    entry
+                        .my_list
+                        .with_mut(|ptr| unsafe { *ptr = List::Neither });
+                })
+                .collect::<LinkedList<_>>()
         };
 
-        // Atomically move all entries to the new linked list in the AllEntries
-        // object.
-        {
-            let mut lock = self.lists.lock();
-            unsafe {
-                // Safety: We are holding the lock and `all_entries` is a new
-                // LinkedList.
-                move_to_new_list(&mut lock.idle, &mut all_entries.all_entries);
-                move_to_new_list(&mut lock.notified, &mut all_entries.all_entries);
-            }
-        }
-
+        let mut all_entries = AllEntries { all_entries, func };
         // Keep destroying entries in the list until it is empty.
         //
         // If the closure panics, then the destructor of the `AllEntries` bomb
         // ensures that we keep running the destructor on the remaining values.
         // A second panic will abort the program.
-        while all_entries.pop_next() {}
-    }
-}
-
-/// # Safety
-///
-/// The mutex for the entries must be held, and the target list must be such
-/// that setting `my_list` to `Neither` is ok.
-unsafe fn move_to_new_list<T>(
-    from: &mut LinkedList<ListEntry<T>>,
-    to: &mut LinkedList<ListEntry<T>>,
-) {
-    while let Some(entry) = from.pop_back() {
-        entry.my_list.with_mut(|ptr| {
-            // Safety: pointer is accessed while holding the mutex.
-            unsafe {
-                *ptr = List::Neither;
-            }
-        });
-        to.push_front(entry);
+        all_entries.iter();
     }
 }
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -280,7 +280,7 @@ impl<T> IdleNotifiedSet<T> {
         }
 
         impl<T, F: FnMut(T)> AllEntries<T, F> {
-            fn drain(&mut self) {
+            fn consume(&mut self) {
                 for entry in self.all_entries.drain_back() {
                     // Safety: We just took this value from the list, so we can
                     // destroy the value in the entry.
@@ -293,7 +293,7 @@ impl<T> IdleNotifiedSet<T> {
 
         impl<T, F: FnMut(T)> Drop for AllEntries<T, F> {
             fn drop(&mut self) {
-                self.drain()
+                self.consume()
             }
         }
 
@@ -317,7 +317,7 @@ impl<T> IdleNotifiedSet<T> {
         // If the closure panics, then the destructor of the `AllEntries` bomb
         // ensures that we keep running the destructor on the remaining values.
         // A second panic will abort the program.
-        AllEntries { all_entries, func }.drain();
+        AllEntries { all_entries, func }.consume();
     }
 }
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -230,6 +230,13 @@ impl<T> IdleNotifiedSet<T> {
 
     /// Call a function on every element in this list.
     pub(crate) fn for_each<F: FnMut(&mut T)>(&mut self, mut func: F) {
+        fn get_ptrs<T>(list: &mut LinkedList<ListEntry<T>>, ptrs: &mut Vec<*mut T>) {
+            ptrs.extend(
+                list.iter_back()
+                    .map(|entry| entry.value.with_mut(|ptr| ptr.cast())),
+            );
+        }
+
         // Atomically get a raw pointer to the value of every entry.
         //
         // Since this only locks the mutex once, it is not possible for a value
@@ -238,14 +245,10 @@ impl<T> IdleNotifiedSet<T> {
         // twice.
         let mut ptrs = Vec::with_capacity(self.len());
         {
-            let lock = self.lists.lock();
+            let mut lock = self.lists.lock();
 
-            ptrs.extend(
-                lock.idle
-                    .iter_back()
-                    .chain(lock.notified.iter_back())
-                    .map(|entry| entry.value.with_mut(|ptr| ptr.cast())),
-            );
+            get_ptrs(&mut lock.idle, &mut ptrs);
+            get_ptrs(&mut lock.notified, &mut ptrs);
         }
         debug_assert_eq!(ptrs.len(), ptrs.capacity());
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -285,7 +285,7 @@ impl<T> IdleNotifiedSet<T> {
         }
 
         impl<T, F: FnMut(T)> AllEntries<T, F> {
-            fn iter(&mut self) {
+            fn drain(&mut self) {
                 for entry in self.all_entries.drain_back() {
                     // Safety: We just took this value from the list, so we can
                     // destroy the value in the entry.
@@ -298,7 +298,7 @@ impl<T> IdleNotifiedSet<T> {
 
         impl<T, F: FnMut(T)> Drop for AllEntries<T, F> {
             fn drop(&mut self) {
-                self.iter()
+                self.drain()
             }
         }
 
@@ -323,7 +323,7 @@ impl<T> IdleNotifiedSet<T> {
         // If the closure panics, then the destructor of the `AllEntries` bomb
         // ensures that we keep running the destructor on the remaining values.
         // A second panic will abort the program.
-        all_entries.iter();
+        all_entries.drain();
     }
 }
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -7,7 +7,7 @@
 //! similar.
 
 use std::marker::PhantomPinned;
-use std::mem::{self, ManuallyDrop};
+use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
 use std::task::{Context, Waker};
 
@@ -297,28 +297,27 @@ impl<T> IdleNotifiedSet<T> {
             }
         }
 
-        // Atomically take all entries.
-        let all_entries = {
-            let mut lock = self.lists.lock();
-            mem::take(&mut lock.idle)
-                .drain_back()
-                .chain(mem::take(&mut lock.notified).drain_back())
-                .inspect(|entry| {
-                    // Safety: pointer is accessed while holding the mutex.
-                    entry
-                        .my_list
-                        .with_mut(|ptr| unsafe { *ptr = List::Neither });
-                })
-                .collect::<LinkedList<_>>()
-        };
+        let mut all_entries = LinkedList::new();
 
-        let mut all_entries = AllEntries { all_entries, func };
+        // Atomically move all entries to the new linked list.
+        {
+            let f = |entry: &Arc<ListEntry<T>>| {
+                // Safety: pointer is accessed while holding the mutex.
+                entry
+                    .my_list
+                    .with_mut(|ptr| unsafe { *ptr = List::Neither });
+            };
+            let mut lock = self.lists.lock();
+            all_entries.extend(lock.idle.drain_back().inspect(f));
+            all_entries.extend(lock.notified.drain_back().inspect(f));
+        }
+
         // Keep destroying entries in the list until it is empty.
         //
         // If the closure panics, then the destructor of the `AllEntries` bomb
         // ensures that we keep running the destructor on the remaining values.
         // A second panic will abort the program.
-        all_entries.drain();
+        AllEntries { all_entries, func }.drain();
     }
 }
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -230,13 +230,6 @@ impl<T> IdleNotifiedSet<T> {
 
     /// Call a function on every element in this list.
     pub(crate) fn for_each<F: FnMut(&mut T)>(&mut self, mut func: F) {
-        fn get_ptrs<T>(list: &mut LinkedList<ListEntry<T>>, ptrs: &mut Vec<*mut T>) {
-            ptrs.extend(
-                list.iter_back()
-                    .map(|entry| entry.value.with_mut(|ptr| ptr.cast())),
-            );
-        }
-
         // Atomically get a raw pointer to the value of every entry.
         //
         // Since this only locks the mutex once, it is not possible for a value
@@ -245,10 +238,12 @@ impl<T> IdleNotifiedSet<T> {
         // twice.
         let mut ptrs = Vec::with_capacity(self.len());
         {
-            let mut lock = self.lists.lock();
+            let lock = self.lists.lock();
 
-            get_ptrs(&mut lock.idle, &mut ptrs);
-            get_ptrs(&mut lock.notified, &mut ptrs);
+            let f = |entry: &ListEntry<T>| entry.value.with_mut(|ptr| ptr.cast());
+            // Iterator::chain results in worse codegen.
+            ptrs.extend(lock.idle.iter_back().map(f));
+            ptrs.extend(lock.notified.iter_back().map(f));
         }
         debug_assert_eq!(ptrs.len(), ptrs.capacity());
 

--- a/tokio/src/util/idle_notified_set.rs
+++ b/tokio/src/util/idle_notified_set.rs
@@ -301,13 +301,14 @@ impl<T> IdleNotifiedSet<T> {
 
         // Atomically move all entries to the new linked list.
         {
+            let mut lock = self.lists.lock();
+
             let f = |entry: &Arc<ListEntry<T>>| {
                 // Safety: pointer is accessed while holding the mutex.
                 entry
                     .my_list
                     .with_mut(|ptr| unsafe { *ptr = List::Neither });
             };
-            let mut lock = self.lists.lock();
             all_entries.extend(lock.idle.drain_back().inspect(f));
             all_entries.extend(lock.notified.drain_back().inspect(f));
         }

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -276,9 +276,7 @@ impl<L: Link> Default for LinkedList<L> {
 
 impl<L: Link> Extend<L::Handle> for LinkedList<L> {
     fn extend<T: IntoIterator<Item = L::Handle>>(&mut self, iter: T) {
-        for handle in iter.into_iter() {
-            self.push_front(handle);
-        }
+        iter.into_iter().for_each(|handle| self.push_front(handle));
     }
 }
 

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -15,7 +15,7 @@
 
 use core::cell::UnsafeCell;
 use core::fmt;
-use core::marker::PhantomPinned;
+use core::marker::{PhantomData, PhantomPinned};
 use core::mem::ManuallyDrop;
 use core::ptr::{self, NonNull};
 
@@ -232,6 +232,17 @@ impl<L: Link> LinkedList<L> {
 
         Some(L::from_raw(node))
     }
+
+    pub(crate) fn iter_back(&self) -> IterBack<'_, L> {
+        IterBack {
+            list: PhantomData,
+            curr: self.tail,
+        }
+    }
+
+    pub(crate) fn drain_back(&mut self) -> DrainBack<'_, L> {
+        DrainBack { list: self }
+    }
 }
 
 impl<L: Link> fmt::Debug for LinkedList<L> {
@@ -260,6 +271,49 @@ impl<L: Link> LinkedList<L> {
 impl<L: Link> Default for LinkedList<L> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<L: Link> Extend<L::Handle> for LinkedList<L> {
+    fn extend<T: IntoIterator<Item = L::Handle>>(&mut self, iter: T) {
+        for handle in iter.into_iter() {
+            self.push_front(handle);
+        }
+    }
+}
+
+impl<L: Link> FromIterator<L::Handle> for LinkedList<L> {
+    fn from_iter<T: IntoIterator<Item = L::Handle>>(iter: T) -> Self {
+        let mut list = Self::new();
+        list.extend(iter);
+        list
+    }
+}
+
+pub(crate) struct IterBack<'a, L: Link> {
+    list: PhantomData<&'a LinkedList<L>>,
+    curr: Option<NonNull<L::Target>>,
+}
+
+impl<'a, L: Link> Iterator for IterBack<'a, L> {
+    type Item = &'a L::Target;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr = self.curr?;
+        self.curr = unsafe { L::pointers(curr).as_ref() }.get_prev();
+        Some(unsafe { curr.as_ref() })
+    }
+}
+
+pub(crate) struct DrainBack<'a, L: Link> {
+    list: &'a mut LinkedList<L>,
+}
+
+impl<'a, L: Link> Iterator for DrainBack<'a, L> {
+    type Item = L::Handle;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.list.pop_back()
     }
 }
 


### PR DESCRIPTION
The multiple manual `Extend`, `FromIterator`, and `Iterator` linked list implementations can be merged and then used to simplify its operations through iterator adapters.

Split out of #8140