### PR TITLE
runtime: don't skip the driver when before_park schedules work

### DIFF
--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -385,12 +385,6 @@ impl Context {
             core = c;
         }
 
-        // If `before_park` spawns a task (or otherwise schedules work for us), then we should not
-        // block the thread. We must still poll the driver once without blocking, though, so that
-        // timer and I/O events keep making progress; otherwise a runtime driven by repeated short
-        // `block_on` calls whose `before_park` always schedules work (e.g. an `on_thread_park` hook
-        // that wakes the `block_on` future) would never advance the driver and its timers would
-        // stall. See <https://github.com/tokio-rs/tokio/issues/8212>.
         if !self.has_pending_work(&core) {
             // Park until the thread is signaled
             core.metrics.about_to_park();
@@ -401,6 +395,11 @@ impl Context {
             core.metrics.unparked();
             core.submit_metrics(handle);
         } else {
+            // `before_park` scheduled work (e.g. an `on_thread_park` hook that woke the
+            // `block_on` future), so we don't block. We must still poll the driver once
+            // without blocking, or timer and I/O events would stall under a runtime driven
+            // by repeated short `block_on` calls. See
+            // <https://github.com/tokio-rs/tokio/issues/8212>.
             core.submit_metrics(handle);
 
             core = self.park_internal(core, handle, &mut driver, Some(Duration::from_millis(0)));

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -386,7 +386,11 @@ impl Context {
         }
 
         // If `before_park` spawns a task (or otherwise schedules work for us), then we should not
-        // park the thread.
+        // block the thread. We must still poll the driver once without blocking, though, so that
+        // timer and I/O events keep making progress; otherwise a runtime driven by repeated short
+        // `block_on` calls whose `before_park` always schedules work (e.g. an `on_thread_park` hook
+        // that wakes the `block_on` future) would never advance the driver and its timers would
+        // stall. See <https://github.com/tokio-rs/tokio/issues/8212>.
         if !self.has_pending_work(&core) {
             // Park until the thread is signaled
             core.metrics.about_to_park();
@@ -396,6 +400,10 @@ impl Context {
 
             core.metrics.unparked();
             core.submit_metrics(handle);
+        } else {
+            core.submit_metrics(handle);
+
+            core = self.park_internal(core, handle, &mut driver, Some(Duration::from_millis(0)));
         }
 
         if let Some(f) = &handle.shared.config.after_unpark {

--- a/tokio/tests/rt_common_before_park.rs
+++ b/tokio/tests/rt_common_before_park.rs
@@ -114,27 +114,25 @@ fn before_park_does_not_stall_spawned_timer() {
     rt.spawn({
         let task_done = task_done.clone();
         async move {
-            tokio::time::sleep(Duration::from_millis(50)).await;
+            tokio::time::sleep(Duration::from_millis(1)).await;
             task_done.store(true, Ordering::SeqCst);
         }
     });
 
-    // Let the spawned task register its timer before we start driving.
-    std::thread::sleep(Duration::from_millis(10));
+    // A current-thread runtime only runs tasks while inside `block_on`, so drive it
+    // once to let the spawned task register its timer.
+    rt.block_on(tokio::task::yield_now());
 
-    // Drive the runtime in short bursts, the way an external event loop would.
-    for _ in 0..60 {
+    // Drive the runtime in short bursts, the way an external event loop would. Each
+    // burst parks via `on_thread_park` (which wakes the `block_on` future); the fix
+    // keeps polling the driver so the spawned timer still fires. A regression stalls
+    // the timer, failing the assert below instead of hanging.
+    for _ in 0..100 {
         if task_done.load(Ordering::SeqCst) {
             break;
         }
-        rt.block_on(async {
-            let notify = notify.clone();
-            tokio::select! {
-                _ = notify.notified() => {}
-                _ = tokio::time::sleep(Duration::from_millis(500)) => {}
-            }
-        });
-        std::thread::sleep(Duration::from_millis(10));
+        rt.block_on(notify.notified());
+        std::thread::sleep(Duration::from_millis(1));
     }
 
     assert!(

--- a/tokio/tests/rt_common_before_park.rs
+++ b/tokio/tests/rt_common_before_park.rs
@@ -4,6 +4,7 @@
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::runtime::Builder;
 use tokio::sync::Notify;
 
@@ -89,4 +90,55 @@ fn wake_from_other_thread_block_on() {
     });
 
     th.join().unwrap();
+}
+
+// Regression test for #8212: a current-thread runtime driven by repeated short
+// `block_on` calls, where `on_thread_park` wakes the `block_on` future, must
+// still drive the time driver so a spawned timer keeps making progress. Before
+// the fix, `before_park` setting the `woken` flag caused `park` to skip the
+// driver entirely, so the timer never fired.
+#[test]
+fn before_park_does_not_stall_spawned_timer() {
+    let notify = Arc::new(Notify::new());
+    let task_done = Arc::new(AtomicBool::new(false));
+
+    let rt = Builder::new_current_thread()
+        .enable_all()
+        .on_thread_park({
+            let notify = notify.clone();
+            move || notify.notify_waiters()
+        })
+        .build()
+        .unwrap();
+
+    rt.spawn({
+        let task_done = task_done.clone();
+        async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            task_done.store(true, Ordering::SeqCst);
+        }
+    });
+
+    // Let the spawned task register its timer before we start driving.
+    std::thread::sleep(Duration::from_millis(10));
+
+    // Drive the runtime in short bursts, the way an external event loop would.
+    for _ in 0..60 {
+        if task_done.load(Ordering::SeqCst) {
+            break;
+        }
+        rt.block_on(async {
+            let notify = notify.clone();
+            tokio::select! {
+                _ = notify.notified() => {}
+                _ = tokio::time::sleep(Duration::from_millis(500)) => {}
+            }
+        });
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    assert!(
+        task_done.load(Ordering::SeqCst),
+        "spawned task's timer never fired (issue #8212)"
+    );
 }


### PR DESCRIPTION
## Motivation

Fixes #8212.

Two 1.50 changes to the current-thread scheduler combine to cause this:
- #7835 made `park` skip parking when `has_pending_work` is true, so work scheduled from `before_park` doesn't block the thread.
- #7834 added the `woken` flag to `has_pending_work` (and dropped the redundant `unpark` for wakeups originating inside the runtime).

So when `on_thread_park` wakes the `block_on` future, `woken` is set, `has_pending_work` returns true, and `park` returns without touching the driver at all — not just skipping the blocking part. A runtime driven by repeated short `block_on` calls then never advances the timer (or I/O) driver, and a spawned `sleep` never fires.

## Solution

On the has-pending-work path, poll the driver once without blocking (zero-timeout `park_internal`), mirroring `park_yield`. We still don't block when there's work, so this doesn't reintroduce what #7835 fixed — it just keeps the driver getting polled.

Regression test added next to the existing `before_park` tests; it fails on master and passes with this change. The `loom_current_thread` models (including `block_on_num_polls`) pass with this change.