### PR TITLE
util: add DropGuard::cancellation_token() / DropGuardRef::cancellation_token()

### DIFF
--- a/tokio-util/src/sync/cancellation_token/guard.rs
+++ b/tokio-util/src/sync/cancellation_token/guard.rs
@@ -18,6 +18,14 @@ impl DropGuard {
             .take()
             .expect("`inner` can be only None in a destructor")
     }
+
+    /// Returns a reference to the wrapped cancellation token, without
+    /// disarming this guard.
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        self.inner
+            .as_ref()
+            .expect("`inner` can be only None in a destructor")
+    }
 }
 
 impl Drop for DropGuard {

--- a/tokio-util/src/sync/cancellation_token/guard_ref.rs
+++ b/tokio-util/src/sync/cancellation_token/guard_ref.rs
@@ -21,6 +21,13 @@ impl<'a> DropGuardRef<'a> {
             .take()
             .expect("`inner` can be only None in a destructor")
     }
+
+    /// Returns a reference to the wrapped cancellation token, without
+    /// disarming this guard.
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        self.inner
+            .expect("`inner` can be only None in a destructor")
+    }
 }
 
 impl Drop for DropGuardRef<'_> {

--- a/tokio-util/tests/sync_cancellation_token.rs
+++ b/tokio-util/tests/sync_cancellation_token.rs
@@ -613,3 +613,27 @@ fn different_cancellation_tokens_have_different_hash() {
     token2.hash(&mut state2);
     assert_ne!(state1.finish(), state2.finish());
 }
+
+#[test]
+fn drop_guard_cancellation_token_can_be_cloned_without_disarming() {
+    let token = CancellationToken::new();
+    let guard = token.clone().drop_guard();
+
+    let cloned = guard.cancellation_token().clone();
+    assert!(!cloned.is_cancelled());
+
+    drop(guard);
+    assert!(cloned.is_cancelled());
+}
+
+#[test]
+fn drop_guard_ref_cancellation_token_can_be_cloned_without_disarming() {
+    let token = CancellationToken::new();
+    let guard = token.drop_guard_ref();
+
+    let cloned = guard.cancellation_token().clone();
+    assert!(!cloned.is_cancelled());
+
+    drop(guard);
+    assert!(cloned.is_cancelled());
+}


### PR DESCRIPTION
## Summary
Fixes #8224. `DropGuard` and `DropGuardRef` already hold a `CancellationToken` internally, but the only way to get it out was `disarm()`, which consumes the guard and stops it from cancelling on drop. If you just want a clone of the token to spawn more tasks later (while still keeping the drop-cancellation behavior), you currently have to keep a separate `CancellationToken` clone around for that purpose.

## Change
Add a borrowing accessor to both guard types:

```rust
impl DropGuard {
    pub fn cancellation_token(&self) -> &CancellationToken { ... }
}

impl<'a> DropGuardRef<'a> {
    pub fn cancellation_token(&self) -> &CancellationToken { ... }
}
```

Callers can now do `guard.cancellation_token().clone()` without disarming the guard.

## Tests
Added two tests in `tokio-util/tests/sync_cancellation_token.rs` asserting that cloning the token via the new accessor doesn't prevent the guard from cancelling it on drop.