### PR TITLE
util: implement cancellation token getter for drop guard

### DIFF
--- a/tokio-util/src/sync/cancellation_token/guard.rs
+++ b/tokio-util/src/sync/cancellation_token/guard.rs
@@ -11,7 +11,7 @@ pub struct DropGuard {
 
 impl DropGuard {
     /// Returns a reference to the cancellation token wrapped by this guard.
-    pub fn cancellation_token(&self) -> &CancellationToken {
+    pub fn token(&self) -> &CancellationToken {
         self.inner
             .as_ref()
             .expect("`inner` can only be None in a destructor")

--- a/tokio-util/src/sync/cancellation_token/guard.rs
+++ b/tokio-util/src/sync/cancellation_token/guard.rs
@@ -10,6 +10,13 @@ pub struct DropGuard {
 }
 
 impl DropGuard {
+    /// Returns a reference to the cancellation token wrapped by this guard.
+    pub fn cancellation_token(&self) -> &CancellationToken {
+        self.inner
+            .as_ref()
+            .expect("`inner` can only be None in a destructor")
+    }
+
     /// Returns stored cancellation token and removes this drop guard instance
     /// (i.e. it will no longer cancel token). Other guards for this token
     /// are not affected.

--- a/tokio-util/src/sync/cancellation_token/guard_ref.rs
+++ b/tokio-util/src/sync/cancellation_token/guard_ref.rs
@@ -13,6 +13,13 @@ pub struct DropGuardRef<'a> {
 }
 
 impl<'a> DropGuardRef<'a> {
+    /// Returns a reference to the cancellation token wrapped by this guard.
+    pub fn token(&self) -> &CancellationToken {
+        self.inner
+            .as_ref()
+            .expect("`inner` can only be None in a destructor")
+    }
+
     /// Returns stored cancellation token and removes this drop guard instance
     /// (i.e. it will no longer cancel token). Other guards for this token
     /// are not affected.


### PR DESCRIPTION
I went ahead and implemented the method `DropGuard::cancellation_token` I had proposed in https://github.com/tokio-rs/tokio/issues/8224. It was a trivial implementation effort, so I thought I could do it myself.

## Motivation

In `tokio-util`, `DropGuard`s are very useful to cancel tasks associated with some object. When the object gets dropped, the tasks get cancelled. The canonical pattern is, e.g., in the object's constructor:

 - Create a `CancellationToken`.
 - Spawn all tasks you need, provide each with a clone of the `CancellationToken`.
 - Wrap the `CancellationToken` into a `DropGuard`, assemble and return the object.

Amazing! Sometimes, however, I'd really like to spawn tasks associated with the object after the object is constructed. To do that, I usually have to keep a clone of the `CancellationToken` around in the object, so I can clone it. That feels a bit redundant? 

## Solution

I implemented a new method `DropGuard::cancellation_token() -> &CancellationToken`? It simply returns a reference to the `CancellationToken` inside the `DropGuard`, which now can be cloned freely:

```
let cancellation = guard.cancellation_token().clone();

let new_task = NewTask::new();
new_task.spawn(cancellation);
```
