### PR TITLE
tokio-stream: update coop handling for empty and once

### DIFF
--- a/tokio-stream/src/empty.rs
+++ b/tokio-stream/src/empty.rs
@@ -40,7 +40,17 @@ pub const fn empty<T>() -> Empty<T> {
 impl<T> Stream for Empty<T> {
     type Item = T;
 
-    fn poll_next(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<T>> {
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        #[cfg(feature = "rt")]
+        {
+            use tokio::task::coop;
+
+            let coop = std::task::ready!(coop::poll_proceed(cx));
+            coop.made_progress();
+        }
+        #[cfg(not(feature = "rt"))]
+        let _ = cx;
+
         Poll::Ready(None)
     }
 

--- a/tokio-stream/src/empty.rs
+++ b/tokio-stream/src/empty.rs
@@ -40,16 +40,14 @@ pub const fn empty<T>() -> Empty<T> {
 impl<T> Stream for Empty<T> {
     type Item = T;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+    fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<T>> {
         #[cfg(feature = "rt")]
         {
             use tokio::task::coop;
 
-            let coop = std::task::ready!(coop::poll_proceed(cx));
+            let coop = std::task::ready!(coop::poll_proceed(_cx));
             coop.made_progress();
         }
-        #[cfg(not(feature = "rt"))]
-        let _ = cx;
 
         Poll::Ready(None)
     }

--- a/tokio-stream/src/once.rs
+++ b/tokio-stream/src/once.rs
@@ -1,6 +1,5 @@
-use crate::{Iter, Stream};
+use crate::Stream;
 
-use core::option;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 
@@ -8,7 +7,7 @@ use core::task::{Context, Poll};
 #[derive(Debug)]
 #[must_use = "streams do nothing unless polled"]
 pub struct Once<T> {
-    iter: Iter<option::IntoIter<T>>,
+    value: Option<T>,
 }
 
 impl<I> Unpin for Once<I> {}
@@ -34,19 +33,30 @@ impl<I> Unpin for Once<I> {}
 /// # }
 /// ```
 pub fn once<T>(value: T) -> Once<T> {
-    Once {
-        iter: crate::iter(Some(value)),
-    }
+    Once { value: Some(value) }
 }
 
 impl<T> Stream for Once<T> {
     type Item = T;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        Pin::new(&mut self.iter).poll_next(cx)
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<T>> {
+        #[cfg(feature = "rt")]
+        {
+            use tokio::task::coop;
+
+            let coop = std::task::ready!(coop::poll_proceed(_cx));
+
+            coop.made_progress();
+        }
+
+        Poll::Ready(self.value.take())
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.iter.size_hint()
+        if self.value.is_some() {
+            (1, Some(1))
+        } else {
+            (0, Some(0))
+        }
     }
 }


### PR DESCRIPTION
Refs #8207.

## Motivation

`tokio_stream::empty` returns `None` immediately, but `iter` now treats `None` as cooperative progress when the `rt` feature is enabled. This follows up on the discussion in #8207 and applies the same cooperative budgeting behavior to `empty`.

`tokio_stream::once` was implemented in terms of `iter`, which means it carried `Iter`'s fallback `yield_amt` field even though `once` can yield at most one item.

## Solution

Update `empty` to call `tokio::task::coop::poll_proceed` and `made_progress` before returning `None` when the `rt` feature is enabled.

Refactor `once` to store its value directly as `Option<T>` instead of delegating through `iter`, while preserving its stream behavior and size hints. The direct implementation uses cooperative budgeting under `rt` and a simple immediate return without `rt`.

Tests:
- `cargo test -p tokio-stream --test stream_empty --test stream_once --features rt`
- `cargo test -p tokio-stream --test stream_empty --test stream_once --no-default-features`
- `cargo test -p tokio-stream --test stream_iter --features rt`