### PR TITLE
tokio: standardize WakeList usage

### DIFF
--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -252,37 +252,33 @@ impl ScheduledIo {
             }
         }
 
-        'outer: loop {
+        loop {
             let mut iter = waiters.list.drain_filter(|w| ready.satisfies(w.interest));
 
             while wakers.can_push() {
                 match iter.next() {
-                    Some(waiter) => {
-                        let waiter = unsafe { &mut *waiter.as_ptr() };
+                    Some(mut waiter) => {
+                        let waiter = unsafe { waiter.as_mut() };
 
                         if let Some(waker) = waiter.waker.take() {
                             waiter.is_ready = true;
                             wakers.push(waker);
                         }
                     }
-                    None => {
-                        break 'outer;
-                    }
+                    None => break,
                 }
             }
 
+            let can_push = wakers.can_push();
+            // Prevent deadlock.
             drop(waiters);
 
             wakers.wake_all();
-
-            // Acquire the lock again.
+            if can_push {
+                break;
+            }
             waiters = self.waiters.lock();
         }
-
-        // Release the lock before notifying
-        drop(waiters);
-
-        wakers.wake_all();
     }
 
     pub(super) fn ready_event(&self, interest: Interest) -> ReadyEvent {

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -308,32 +308,39 @@ impl Handle {
             now = lock.wheel.elapsed();
         }
 
-        while let Some(entry) = lock.wheel.poll(now) {
-            debug_assert!(unsafe { entry.is_pending() });
+        loop {
+            while waker_list.can_push() {
+                match lock.wheel.poll(now) {
+                    Some(entry) => {
+                        debug_assert!(unsafe { entry.is_pending() });
 
-            // SAFETY: We hold the driver lock, and just removed the entry from any linked lists.
-            if let Some(waker) = unsafe { entry.fire(Ok(())) } {
-                waker_list.push(waker);
-
-                if !waker_list.can_push() {
-                    // Wake a batch of wakers. To avoid deadlock, we must do this with the lock temporarily dropped.
-                    drop(lock);
-
-                    waker_list.wake_all();
-
-                    lock = self.inner.lock();
+                        // SAFETY: We hold the driver lock, and just removed the entry from any
+                        // linked lists.
+                        if let Some(waker) = unsafe { entry.fire(Ok(())) } {
+                            waker_list.push(waker);
+                        }
+                    }
+                    None => break,
                 }
             }
+
+            if waker_list.can_push() {
+                lock.next_wake = lock
+                    .wheel
+                    .poll_at()
+                    .map(|t| NonZeroU64::new(t).unwrap_or_else(|| NonZeroU64::new(1).unwrap()));
+            }
+
+            let can_push = waker_list.can_push();
+            // Prevent deadlock.
+            drop(lock);
+
+            waker_list.wake_all();
+            if can_push {
+                break;
+            }
+            lock = self.inner.lock();
         }
-
-        lock.next_wake = lock
-            .wheel
-            .poll_at()
-            .map(|t| NonZeroU64::new(t).unwrap_or_else(|| NonZeroU64::new(1).unwrap()));
-
-        drop(lock);
-
-        waker_list.wake_all();
     }
 
     #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -156,12 +156,10 @@ impl Wheel {
                     // the current list of timers.  advance to the poll's
                     // current time and do nothing else.
                     self.set_elapsed(now);
-                    break;
+                    return None;
                 }
             }
         }
-
-        self.pending.pop_back()
     }
 
     /// Returns the instant at which the next timeout expires.

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -303,36 +303,22 @@ impl Semaphore {
     ///
     /// If `rem` exceeds the number of permits needed by the wait list, the
     /// remainder are assigned back to the semaphore.
-    fn add_permits_locked(&self, mut rem: usize, waiters: MutexGuard<'_, Waitlist>) {
+    fn add_permits_locked<'a>(&'a self, mut rem: usize, mut waiters: MutexGuard<'a, Waitlist>) {
         let mut wakers = WakeList::new();
-        let mut lock = Some(waiters);
-        let mut is_empty = false;
-        while rem > 0 {
-            let mut waiters = lock.take().unwrap_or_else(|| self.waiters.lock());
-            'inner: while wakers.can_push() {
-                // Was the waiter assigned enough permits to wake it?
-                match waiters.queue.last() {
-                    Some(waiter) => {
-                        if !waiter.assign_permits(&mut rem) {
-                            break 'inner;
-                        }
-                    }
-                    None => {
-                        is_empty = true;
-                        // If we assigned permits to all the waiters in the queue, and there are
-                        // still permits left over, assign them back to the semaphore.
-                        break 'inner;
-                    }
-                };
-                let mut waiter = waiters.queue.pop_back().unwrap();
-                if let Some(waker) =
-                    unsafe { waiter.as_mut().waker.with_mut(|waker| (*waker).take()) }
-                {
+        loop {
+            while wakers.can_push()
+                && waiters
+                    .queue
+                    .last()
+                    .is_some_and(|waiter| waiter.assign_permits(&mut rem))
+            {
+                let waiter = unsafe { waiters.queue.pop_back().unwrap().as_mut() };
+                if let Some(waker) = waiter.waker.with_mut(|waker| unsafe { &mut *waker }.take()) {
                     wakers.push(waker);
                 }
             }
 
-            if rem > 0 && is_empty {
+            if rem > 0 && waiters.queue.is_empty() {
                 let permits = rem;
                 assert!(
                     permits <= Self::MAX_PERMITS,
@@ -361,12 +347,15 @@ impl Semaphore {
                 rem = 0;
             }
 
-            drop(waiters); // release the lock
+            // Prevent deadlock.
+            drop(waiters);
 
             wakers.wake_all();
+            if rem == 0 {
+                break;
+            }
+            waiters = self.waiters.lock();
         }
-
-        assert_eq!(rem, 0);
     }
 
     /// Decrease a semaphore's permits by a maximum of `n`.

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -126,6 +126,8 @@ use crate::util::WakeList;
 use std::fmt;
 use std::future::Future;
 use std::marker::PhantomPinned;
+use std::mem;
+use std::ops::Deref;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
@@ -939,117 +941,64 @@ fn new_receiver<T>(shared: Arc<Shared<T>>) -> Receiver<T> {
     Receiver { shared, next }
 }
 
-/// List used in `Shared::notify_rx`. It wraps a guarded linked list
-/// and gates the access to it on the `Shared.tail` mutex. It also empties
-/// the list on drop.
-struct WaitersList<'a, T> {
-    list: GuardedLinkedList<Waiter>,
-    is_empty: bool,
-    shared: &'a Shared<T>,
-}
-
-impl<'a, T> Drop for WaitersList<'a, T> {
-    fn drop(&mut self) {
-        // If the list is not empty, we unlink all waiters from it.
-        // We do not wake the waiters to avoid double panics.
-        if !self.is_empty {
-            let _lock_guard = self.shared.tail.lock();
-            while self.list.pop_back().is_some() {}
-        }
-    }
-}
-
-impl<'a, T> WaitersList<'a, T> {
-    fn new(
-        unguarded_list: LinkedList<Waiter>,
-        guard: Pin<&'a Waiter>,
-        shared: &'a Shared<T>,
-    ) -> Self {
-        let guard_ptr = NonNull::from(guard.get_ref());
-        let list = unguarded_list.into_guarded(guard_ptr);
-        WaitersList {
-            list,
-            is_empty: false,
-            shared,
-        }
-    }
-
-    /// Removes the last element from the guarded list. Modifying this list
-    /// requires an exclusive access to the main list in `Notify`.
-    fn pop_back_locked(&mut self, _tail: &mut Tail) -> Option<NonNull<Waiter>> {
-        let result = self.list.pop_back();
-        if result.is_none() {
-            // Save information about emptiness to avoid waiting for lock
-            // in the destructor.
-            self.is_empty = true;
-        }
-        result
-    }
-}
-
 impl<T> Shared<T> {
     fn notify_rx<'a, 'b: 'a>(&'b self, mut tail: MutexGuard<'a, Tail>) {
+        struct DropGuard<'a, T> {
+            list: Option<GuardedLinkedList<Waiter>>,
+            shared: &'a Shared<T>,
+        }
+
+        impl<T> Drop for DropGuard<'_, T> {
+            fn drop(&mut self) {
+                // If the list is not empty, we unlink all waiters from it.
+                let Some(mut list) = self.list.take().filter(|list| !list.is_empty()) else {
+                    return;
+                };
+
+                let _tail = self.shared.tail.lock();
+                // We do not wake the waiters to avoid double panics.
+                while list.pop_back().is_some() {}
+            }
+        }
+
         // It is critical for `GuardedLinkedList` safety that the guard node is
         // pinned in memory and is not dropped until the guarded list is dropped.
         let guard = Waiter::new();
         pin!(guard);
 
-        // We move all waiters to a secondary list. It uses a `GuardedLinkedList`
-        // underneath to allow every waiter to safely remove itself from it.
-        //
-        // * This list will be still guarded by the `waiters` lock.
-        //   `NotifyWaitersList` wrapper makes sure we hold the lock to modify it.
-        // * This wrapper will empty the list on drop. It is critical for safety
-        //   that we will not leave any list entry with a pointer to the local
-        //   guard node after this function returns / panics.
-        let mut list = WaitersList::new(std::mem::take(&mut tail.waiters), guard.as_ref(), self);
+        let mut list = mem::take(&mut tail.waiters).into_guarded(guard.deref().into());
 
         let mut wakers = WakeList::new();
-        'outer: loop {
-            while wakers.can_push() {
-                match list.pop_back_locked(&mut tail) {
-                    Some(waiter) => {
-                        unsafe {
-                            // Safety: accessing `waker` is safe because
-                            // the tail lock is held.
-                            if let Some(waker) = (*waiter.as_ptr()).waker.take() {
-                                wakers.push(waker);
-                            }
-
-                            // Safety: `queued` is atomic.
-                            let queued = &(*waiter.as_ptr()).queued;
-                            // `Relaxed` suffices because the tail lock is held.
-                            assert!(queued.load(Relaxed));
-                            // `Release` is needed to synchronize with `Recv::drop`.
-                            // It is critical to set this variable **after** waker
-                            // is extracted, otherwise we may data race with `Recv::drop`.
-                            queued.store(false, Release);
-                        }
-                    }
-                    None => {
-                        break 'outer;
-                    }
+        loop {
+            while wakers.can_push() && !list.is_empty() {
+                // SAFETY: accessing `waker` is safe because the tail lock is held.
+                let waiter = unsafe { list.pop_back().unwrap().as_mut() };
+                if let Some(waker) = waiter.waker.take() {
+                    wakers.push(waker);
                 }
+                // `Relaxed` suffices because the tail lock is held.
+                assert!(waiter.queued.load(Relaxed));
+                // `Release` is needed to synchronize with `Recv::drop`. It is critical to set this
+                // variable **after** waker is extracted, otherwise we may data race with
+                // `Recv::drop`.
+                waiter.queued.store(false, Release);
             }
 
-            // Release the lock before waking.
+            let can_push = wakers.can_push();
+            // Prevent deadlock.
             drop(tail);
 
-            // Before we acquire the lock again all sorts of things can happen:
-            // some waiters may remove themselves from the list and new waiters
-            // may be added. This is fine since at worst we will unnecessarily
-            // wake up waiters which will then queue themselves again.
-
+            let mut guard = DropGuard {
+                list: Some(list),
+                shared: self,
+            };
             wakers.wake_all();
-
-            // Acquire the lock again.
+            if can_push {
+                break;
+            }
+            list = guard.list.take().unwrap();
             tail = self.tail.lock();
         }
-
-        // Release the lock before waking.
-        drop(tail);
-
-        wakers.wake_all();
     }
 }
 

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -127,7 +127,6 @@ use std::fmt;
 use std::future::Future;
 use std::marker::PhantomPinned;
 use std::mem;
-use std::ops::Deref;
 use std::pin::Pin;
 use std::ptr::NonNull;
 use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
@@ -966,7 +965,7 @@ impl<T> Shared<T> {
         let guard = Waiter::new();
         pin!(guard);
 
-        let mut list = mem::take(&mut tail.waiters).into_guarded(guard.deref().into());
+        let mut list = mem::take(&mut tail.waiters).into_guarded((&*guard).into());
 
         let mut wakers = WakeList::new();
         loop {

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -13,6 +13,8 @@ use crate::util::WakeList;
 
 use std::future::Future;
 use std::marker::PhantomPinned;
+use std::mem;
+use std::ops::Deref;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::ptr::NonNull;
@@ -318,58 +320,6 @@ enum NotifyOneStrategy {
 enum Notification {
     One(NotifyOneStrategy),
     All,
-}
-
-/// List used in `Notify::notify_waiters`. It wraps a guarded linked list
-/// and gates the access to it on `notify.waiters` mutex. It also empties
-/// the list on drop.
-struct NotifyWaitersList<'a> {
-    list: GuardedLinkedList<Waiter>,
-    is_empty: bool,
-    notify: &'a Notify,
-}
-
-impl<'a> NotifyWaitersList<'a> {
-    fn new(
-        unguarded_list: LinkedList<Waiter>,
-        guard: Pin<&'a Waiter>,
-        notify: &'a Notify,
-    ) -> NotifyWaitersList<'a> {
-        let guard_ptr = NonNull::from(guard.get_ref());
-        let list = unguarded_list.into_guarded(guard_ptr);
-        NotifyWaitersList {
-            list,
-            is_empty: false,
-            notify,
-        }
-    }
-
-    /// Removes the last element from the guarded list. Modifying this list
-    /// requires an exclusive access to the main list in `Notify`.
-    fn pop_back_locked(&mut self, _waiters: &mut LinkedList<Waiter>) -> Option<NonNull<Waiter>> {
-        let result = self.list.pop_back();
-        if result.is_none() {
-            // Save information about emptiness to avoid waiting for lock
-            // in the destructor.
-            self.is_empty = true;
-        }
-        result
-    }
-}
-
-impl Drop for NotifyWaitersList<'_> {
-    fn drop(&mut self) {
-        // If the list is not empty, we unlink all waiters from it.
-        // We do not wake the waiters to avoid double panics.
-        if !self.is_empty {
-            let _lock_guard = self.notify.waiters.lock();
-            while let Some(waiter) = self.list.pop_back() {
-                // Safety: we never make mutable references to waiters.
-                let waiter = unsafe { waiter.as_ref() };
-                waiter.notification.store_release(Notification::All);
-            }
-        }
-    }
 }
 
 /// Future returned from [`Notify::notified()`].
@@ -746,6 +696,28 @@ impl Notify {
         curr: usize,
         mut waiters: crate::loom::sync::MutexGuard<'a, LinkedList<Waiter>>,
     ) {
+        struct DropGuard<'a> {
+            list: Option<GuardedLinkedList<Waiter>>,
+            notify: &'a Notify,
+        }
+
+        impl Drop for DropGuard<'_> {
+            fn drop(&mut self) {
+                // If the list is not empty, we unlink all waiters from it.
+                let Some(mut list) = self.list.take().filter(|list| !list.is_empty()) else {
+                    return;
+                };
+
+                let _waiters = self.notify.waiters.lock();
+                // Do not wake the waiters to avoid double panics.
+                while let Some(waiter) = list.pop_back() {
+                    // Safety: we never make mutable references to waiters.
+                    let waiter = unsafe { waiter.as_ref() };
+                    waiter.notification.store_release(Notification::All);
+                }
+            }
+        }
+
         if matches!(get_state(curr), EMPTY | NOTIFIED) {
             // There are no waiting tasks. All we need to do is increment the
             // number of times this method was called.
@@ -763,55 +735,38 @@ impl Notify {
         let guard = Waiter::new();
         pin!(guard);
 
-        // We move all waiters to a secondary list. It uses a `GuardedLinkedList`
-        // underneath to allow every waiter to safely remove itself from it.
-        //
-        // * This list will be still guarded by the `waiters` lock.
-        //   `NotifyWaitersList` wrapper makes sure we hold the lock to modify it.
-        // * This wrapper will empty the list on drop. It is critical for safety
-        //   that we will not leave any list entry with a pointer to the local
-        //   guard node after this function returns / panics.
-        let mut list = NotifyWaitersList::new(std::mem::take(&mut *waiters), guard.as_ref(), self);
+        let mut list = mem::take(&mut *waiters).into_guarded(guard.deref().into());
 
         let mut wakers = WakeList::new();
-        'outer: loop {
-            while wakers.can_push() {
-                match list.pop_back_locked(&mut waiters) {
-                    Some(waiter) => {
-                        // Safety: we never make mutable references to waiters.
-                        let waiter = unsafe { waiter.as_ref() };
+        loop {
+            while wakers.can_push() && !list.is_empty() {
+                // Safety: we never make mutable references to waiters.
+                let waiter = unsafe { list.pop_back().unwrap().as_ref() };
 
-                        // Safety: we hold the lock, so we can access the waker.
-                        if let Some(waker) =
-                            unsafe { waiter.waker.with_mut(|waker| (*waker).take()) }
-                        {
-                            wakers.push(waker);
-                        }
-
-                        // This waiter is unlinked and will not be shared ever again, release it.
-                        waiter.notification.store_release(Notification::All);
-                    }
-                    None => {
-                        break 'outer;
-                    }
+                // Safety: we hold the lock, so we can access the waker.
+                if let Some(waker) = waiter.waker.with_mut(|waker| unsafe { &mut *waker }.take()) {
+                    wakers.push(waker);
                 }
+
+                // This waiter is unlinked and will not be shared ever again, release it.
+                waiter.notification.store_release(Notification::All);
             }
 
-            // Release the lock before notifying.
+            let can_push = wakers.can_push();
+            // Prevent deadlock.
             drop(waiters);
 
-            // One of the wakers may panic, but the remaining waiters will still
-            // be unlinked from the list in `NotifyWaitersList` destructor.
+            let mut guard = DropGuard {
+                list: Some(list),
+                notify: self,
+            };
             wakers.wake_all();
-
-            // Acquire the lock again.
+            if can_push {
+                break;
+            }
+            list = guard.list.take().unwrap();
             waiters = self.waiters.lock();
         }
-
-        // Release the lock before notifying
-        drop(waiters);
-
-        wakers.wake_all();
     }
 
     pub(crate) fn lock_waiter_list(&self) -> NotifyGuard<'_> {

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -14,7 +14,6 @@ use crate::util::WakeList;
 use std::future::Future;
 use std::marker::PhantomPinned;
 use std::mem;
-use std::ops::Deref;
 use std::panic::{RefUnwindSafe, UnwindSafe};
 use std::pin::Pin;
 use std::ptr::NonNull;
@@ -735,7 +734,7 @@ impl Notify {
         let guard = Waiter::new();
         pin!(guard);
 
-        let mut list = mem::take(&mut *waiters).into_guarded(guard.deref().into());
+        let mut list = mem::take(&mut *waiters).into_guarded((&*guard).into());
 
         let mut wakers = WakeList::new();
         loop {

--- a/tokio/src/util/linked_list.rs
+++ b/tokio/src/util/linked_list.rs
@@ -380,6 +380,10 @@ feature! {
     }
 
     impl<L: Link> GuardedLinkedList<L> {
+        pub(crate) fn is_empty(&self) -> bool {
+            self.tail().is_none()
+        }
+
         fn tail(&self) -> Option<NonNull<L::Target>> {
             let tail_ptr = unsafe {
                 L::pointers(self.guard).as_ref().get_prev().unwrap()


### PR DESCRIPTION
Retry of #8140

## Motivation

The wake list's usage is complex (featuring labeled loops and post-conditions) and differs across tokio. I would ultimately like to refactor this code into iterator adapters, but that requires some additional transformation. This PR does that transformation such that an iterator translation becomes trivial.

## Solution

Instead of conditionally breaking the outer loop, we can break after the wake (à la do-while). I also rewrote broadcast and notify to use a normal drop-guard.