### PR TITLE
signal: merge windows statics

### DIFF
--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -11,28 +11,29 @@ use windows_sys::Win32::System::Console as console;
 type EventInfo = watch::Sender<()>;
 
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {
-    new(console::CTRL_BREAK_EVENT)
+    unsafe { new(console::CTRL_BREAK_EVENT) }
 }
 
 pub(super) fn ctrl_close() -> io::Result<RxFuture> {
-    new(console::CTRL_CLOSE_EVENT)
+    unsafe { new(console::CTRL_CLOSE_EVENT) }
 }
 
 pub(super) fn ctrl_c() -> io::Result<RxFuture> {
-    new(console::CTRL_C_EVENT)
+    unsafe { new(console::CTRL_C_EVENT) }
 }
 
 pub(super) fn ctrl_logoff() -> io::Result<RxFuture> {
-    new(console::CTRL_LOGOFF_EVENT)
+    unsafe { new(console::CTRL_LOGOFF_EVENT) }
 }
 
 pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
-    new(console::CTRL_SHUTDOWN_EVENT)
+    unsafe { new(console::CTRL_SHUTDOWN_EVENT) }
 }
 
-fn new(signum: u32) -> io::Result<RxFuture> {
+unsafe fn new(signum: u32) -> io::Result<RxFuture> {
     let rx = match REGISTRY.get_or_init(init).as_ref() {
-        Ok(registry) => registry.event_info(signum).expect("valid").subscribe(),
+        // SAFETY: signum is valid (the compiler is unable to determine this)
+        Ok(registry) => unsafe { registry.event_info(signum).unwrap_unchecked() }.subscribe(),
         Err(&code) => return Err(Error::from_raw_os_error(code)),
     };
     Ok(RxFuture::new(rx))

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -107,10 +107,13 @@ unsafe extern "system" fn handler(ty: u32) -> BOOL {
         _ => return 0,
     };
 
-    // Note that `OnceLock::get` does not handle the small window between invoking
+    // Note that `OnceLock::get` does not handle the small window between calling
     // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
-    // SAFETY: `handler` is only invoked if `SetConsoleCtrlHandler` succeded.
-    let registry = unsafe { REGISTRY.wait().as_ref().unwrap_unchecked() };
+    let Ok(registry) = REGISTRY.wait().as_ref() else {
+        // Technically unreachable since `handler` is only called if
+        // `SetConsoleCtrlHandler` succeded.
+        return 0;
+    };
 
     // According to https://learn.microsoft.com/en-us/windows/console/handlerroutine
     // the handler routine is always invoked in a new thread, thus we don't

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -13,7 +13,7 @@ type EventInfo = watch::Sender<()>;
 
 #[derive(Clone, Copy)]
 #[repr(u32)]
-enum SignalType {
+enum SignalKind {
     CtrlC = console::CTRL_C_EVENT,
     CtrlBreak = console::CTRL_BREAK_EVENT,
     CtrlClose = console::CTRL_CLOSE_EVENT,
@@ -21,7 +21,7 @@ enum SignalType {
     CtrlShutdown = console::CTRL_SHUTDOWN_EVENT,
 }
 
-impl SignalType {
+impl SignalKind {
     const fn terminates(&self) -> bool {
         // Returning from the handler function of those events immediately terminates the process.
         // So for async systems, the easiest solution is to simply never return from
@@ -37,26 +37,26 @@ impl SignalType {
 }
 
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {
-    new(SignalType::CtrlBreak)
+    new(SignalKind::CtrlBreak)
 }
 
 pub(super) fn ctrl_close() -> io::Result<RxFuture> {
-    new(SignalType::CtrlClose)
+    new(SignalKind::CtrlClose)
 }
 
 pub(super) fn ctrl_c() -> io::Result<RxFuture> {
-    new(SignalType::CtrlC)
+    new(SignalKind::CtrlC)
 }
 
 pub(super) fn ctrl_logoff() -> io::Result<RxFuture> {
-    new(SignalType::CtrlLogoff)
+    new(SignalKind::CtrlLogoff)
 }
 
 pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
-    new(SignalType::CtrlShutdown)
+    new(SignalKind::CtrlShutdown)
 }
 
-fn new(signal: SignalType) -> io::Result<RxFuture> {
+fn new(signal: SignalKind) -> io::Result<RxFuture> {
     let registry = REGISTRY
         .get_or_init(
             || match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
@@ -80,16 +80,16 @@ struct Registry {
     ctrl_shutdown: EventInfo,
 }
 
-impl Index<SignalType> for Registry {
+impl Index<SignalKind> for Registry {
     type Output = EventInfo;
 
-    fn index(&self, index: SignalType) -> &Self::Output {
-        match index {
-            SignalType::CtrlC => &self.ctrl_c,
-            SignalType::CtrlBreak => &self.ctrl_break,
-            SignalType::CtrlClose => &self.ctrl_close,
-            SignalType::CtrlLogoff => &self.ctrl_logoff,
-            SignalType::CtrlShutdown => &self.ctrl_shutdown,
+    fn index(&self, signal: SignalKind) -> &Self::Output {
+        match signal {
+            SignalKind::CtrlC => &self.ctrl_c,
+            SignalKind::CtrlBreak => &self.ctrl_break,
+            SignalKind::CtrlClose => &self.ctrl_close,
+            SignalKind::CtrlLogoff => &self.ctrl_logoff,
+            SignalKind::CtrlShutdown => &self.ctrl_shutdown,
         }
     }
 }
@@ -98,11 +98,11 @@ static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
     let signal = match ty {
-        console::CTRL_C_EVENT => SignalType::CtrlC,
-        console::CTRL_BREAK_EVENT => SignalType::CtrlBreak,
-        console::CTRL_CLOSE_EVENT => SignalType::CtrlClose,
-        console::CTRL_LOGOFF_EVENT => SignalType::CtrlLogoff,
-        console::CTRL_SHUTDOWN_EVENT => SignalType::CtrlShutdown,
+        console::CTRL_C_EVENT => SignalKind::CtrlC,
+        console::CTRL_BREAK_EVENT => SignalKind::CtrlBreak,
+        console::CTRL_CLOSE_EVENT => SignalKind::CtrlClose,
+        console::CTRL_LOGOFF_EVENT => SignalKind::CtrlLogoff,
+        console::CTRL_SHUTDOWN_EVENT => SignalKind::CtrlShutdown,
         // Ignore unknown signals.
         _ => return 0,
     };
@@ -134,7 +134,7 @@ mod tests {
 
     use tokio_test::{assert_ok, assert_pending, assert_ready_ok, task};
 
-    unsafe fn raise_event(signal: SignalType) {
+    unsafe fn raise_event(signal: SignalKind) {
         if signal.terminates() {
             // Those events will enter an infinite loop in `handler`, so
             // we need to run them on a separate thread
@@ -157,7 +157,7 @@ mod tests {
         // like sending signals on Unix, so we'll stub out the actual OS
         // integration and test that our handling works.
         unsafe {
-            raise_event(SignalType::CtrlC);
+            raise_event(SignalKind::CtrlC);
         }
 
         assert_ready_ok!(ctrl_c.poll());
@@ -174,7 +174,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(SignalType::CtrlBreak);
+                raise_event(SignalKind::CtrlBreak);
             }
 
             ctrl_break.recv().await.unwrap();
@@ -192,7 +192,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(SignalType::CtrlClose);
+                raise_event(SignalKind::CtrlClose);
             }
 
             ctrl_close.recv().await.unwrap();
@@ -210,7 +210,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(SignalType::CtrlShutdown);
+                raise_event(SignalKind::CtrlShutdown);
             }
 
             ctrl_shutdown.recv().await.unwrap();
@@ -228,7 +228,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(SignalType::CtrlLogoff);
+                raise_event(SignalKind::CtrlLogoff);
             }
 
             ctrl_logoff.recv().await.unwrap();

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -30,6 +30,9 @@ pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
     unsafe { new(console::CTRL_SHUTDOWN_EVENT) }
 }
 
+/// # Safety
+///
+/// `signum` must be valid.
 unsafe fn new(signum: u32) -> io::Result<RxFuture> {
     let registry = REGISTRY
         .get_or_init(
@@ -41,7 +44,7 @@ unsafe fn new(signum: u32) -> io::Result<RxFuture> {
         .as_ref()
         .map_err(|&code| Error::from_raw_os_error(code))?;
 
-    // SAFETY: signum is valid (the compiler is unable to infer this).
+    // SAFETY: signum is valid.
     let event_info = unsafe { registry.event_info(signum).unwrap_unchecked() };
     Ok(RxFuture::new(event_info.subscribe()))
 }

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -1,4 +1,5 @@
 use std::io;
+use std::io::Error;
 use std::sync::OnceLock;
 
 use crate::signal::RxFuture;
@@ -10,28 +11,30 @@ use windows_sys::Win32::System::Console as console;
 type EventInfo = watch::Sender<()>;
 
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {
-    new(&registry().ctrl_break)
+    new(console::CTRL_BREAK_EVENT)
 }
 
 pub(super) fn ctrl_close() -> io::Result<RxFuture> {
-    new(&registry().ctrl_close)
+    new(console::CTRL_CLOSE_EVENT)
 }
 
 pub(super) fn ctrl_c() -> io::Result<RxFuture> {
-    new(&registry().ctrl_c)
+    new(console::CTRL_C_EVENT)
 }
 
 pub(super) fn ctrl_logoff() -> io::Result<RxFuture> {
-    new(&registry().ctrl_logoff)
+    new(console::CTRL_LOGOFF_EVENT)
 }
 
 pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
-    new(&registry().ctrl_shutdown)
+    new(console::CTRL_SHUTDOWN_EVENT)
 }
 
-fn new(event_info: &EventInfo) -> io::Result<RxFuture> {
-    global_init()?;
-    let rx = event_info.subscribe();
+fn new(signum: u32) -> io::Result<RxFuture> {
+    let rx = match REGISTRY.get_or_init(init).as_ref() {
+        Ok(registry) => registry.event_info(signum).expect("valid").subscribe(),
+        Err(&code) => return Err(Error::from_raw_os_error(code)),
+    };
     Ok(RxFuture::new(rx))
 }
 
@@ -70,34 +73,21 @@ impl Registry {
     }
 }
 
-fn registry() -> &'static Registry {
-    static REGISTRY: OnceLock<Registry> = OnceLock::new();
+static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
 
-    REGISTRY.get_or_init(Default::default)
-}
-
-fn global_init() -> io::Result<()> {
-    static INIT: OnceLock<Result<(), Option<i32>>> = OnceLock::new();
-
-    INIT.get_or_init(|| {
-        let rc = unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) };
-        if rc == 0 {
-            Err(io::Error::last_os_error().raw_os_error())
-        } else {
-            Ok(())
-        }
-    })
-    .map_err(|e| {
-        e.map_or_else(
-            || io::Error::new(io::ErrorKind::Other, "registering signal handler failed"),
-            io::Error::from_raw_os_error,
-        )
-    })
+fn init() -> Result<Registry, i32> {
+    match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
+        0 => Err(Error::last_os_error().raw_os_error().expect("unreachable")),
+        _ => Ok(Registry::default()),
+    }
 }
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
+    // SAFETY: this function is only invoked if `REGISTRY` was successfully initialized.
+    let registry = unsafe { REGISTRY.get().unwrap_unchecked().unwrap_unchecked() };
+
     // Ignore unknown control signal types.
-    let Some(event_info) = registry().event_info(ty) else {
+    let Some(event_info) = registry.event_info(ty) else {
         return 0;
     };
 

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -11,6 +11,7 @@ use windows_sys::Win32::System::Console as console;
 
 type EventInfo = watch::Sender<()>;
 
+#[derive(Clone, Copy)]
 #[repr(u32)]
 enum SignalType {
     CtrlC = console::CTRL_C_EVENT,
@@ -18,6 +19,21 @@ enum SignalType {
     CtrlClose = console::CTRL_CLOSE_EVENT,
     CtrlLogoff = console::CTRL_LOGOFF_EVENT,
     CtrlShutdown = console::CTRL_SHUTDOWN_EVENT,
+}
+
+impl SignalType {
+    const fn terminates(&self) -> bool {
+        // Returning from the handler function of those events immediately terminates the process.
+        // So for async systems, the easiest solution is to simply never return from
+        // the handler function.
+        //
+        // For more information, see:
+        // https://learn.microsoft.com/en-us/windows/console/handlerroutine#remarks
+        matches!(
+            self,
+            Self::CtrlClose | Self::CtrlLogoff | Self::CtrlShutdown
+        )
+    }
 }
 
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {
@@ -53,19 +69,6 @@ fn new(signal: SignalType) -> io::Result<RxFuture> {
 
     let rx = registry[signal].subscribe();
     Ok(RxFuture::new(rx))
-}
-
-fn event_requires_infinite_sleep_in_handler(signum: u32) -> bool {
-    // Returning from the handler function of those events immediately terminates the process.
-    // So for async systems, the easiest solution is to simply never return from
-    // the handler function.
-    //
-    // For more information, see:
-    // https://learn.microsoft.com/en-us/windows/console/handlerroutine#remarks
-    matches!(
-        signum,
-        console::CTRL_CLOSE_EVENT | console::CTRL_LOGOFF_EVENT | console::CTRL_SHUTDOWN_EVENT
-    )
 }
 
 #[derive(Debug, Default)]
@@ -114,7 +117,7 @@ unsafe extern "system" fn handler(ty: u32) -> BOOL {
     // have the same restrictions as in Unix signal handlers, meaning we can
     // go ahead and perform the broadcast here.
     match registry[signal].send(()) {
-        Ok(_) if event_requires_infinite_sleep_in_handler(ty) => loop {
+        Ok(_) if signal.terminates() => loop {
             std::thread::park();
         },
         Ok(_) => 1,
@@ -131,13 +134,13 @@ mod tests {
 
     use tokio_test::{assert_ok, assert_pending, assert_ready_ok, task};
 
-    unsafe fn raise_event(signum: u32) {
-        if event_requires_infinite_sleep_in_handler(signum) {
+    unsafe fn raise_event(signal: SignalType) {
+        if signal.terminates() {
             // Those events will enter an infinite loop in `handler`, so
             // we need to run them on a separate thread
-            std::thread::spawn(move || unsafe { super::handler(signum) });
+            std::thread::spawn(move || unsafe { super::handler(signal as u32) });
         } else {
-            unsafe { super::handler(signum) };
+            unsafe { super::handler(signal as u32) };
         }
     }
 
@@ -154,7 +157,7 @@ mod tests {
         // like sending signals on Unix, so we'll stub out the actual OS
         // integration and test that our handling works.
         unsafe {
-            raise_event(console::CTRL_C_EVENT);
+            raise_event(SignalType::CtrlC);
         }
 
         assert_ready_ok!(ctrl_c.poll());
@@ -171,7 +174,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(console::CTRL_BREAK_EVENT);
+                raise_event(SignalType::CtrlBreak);
             }
 
             ctrl_break.recv().await.unwrap();
@@ -189,7 +192,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(console::CTRL_CLOSE_EVENT);
+                raise_event(SignalType::CtrlClose);
             }
 
             ctrl_close.recv().await.unwrap();
@@ -207,7 +210,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(console::CTRL_SHUTDOWN_EVENT);
+                raise_event(SignalType::CtrlShutdown);
             }
 
             ctrl_shutdown.recv().await.unwrap();
@@ -225,7 +228,7 @@ mod tests {
             // like sending signals on Unix, so we'll stub out the actual OS
             // integration and test that our handling works.
             unsafe {
-                raise_event(console::CTRL_LOGOFF_EVENT);
+                raise_event(SignalType::CtrlLogoff);
             }
 
             ctrl_logoff.recv().await.unwrap();

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -87,14 +87,10 @@ impl Registry {
 static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
-    // SAFETY: `handler` is only invoked if `REGISTRY` was successfully initialized.
-    let registry = unsafe {
-        REGISTRY
-            .get()
-            .unwrap_unchecked()
-            .as_ref()
-            .unwrap_unchecked()
-    };
+    // Note that `OnceLock::get` does not handle the small window between invoking
+    // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
+    // SAFETY: `handler` is only invoked if `SetConsoleCtrlHandler` succeded.
+    let registry = unsafe { REGISTRY.wait().as_ref().unwrap_unchecked() };
 
     // Ignore unknown control signal types.
     let Some(event_info) = registry.event_info(ty) else {

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -32,7 +32,12 @@ pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
 
 unsafe fn new(signum: u32) -> io::Result<RxFuture> {
     let registry = REGISTRY
-        .get_or_init(init)
+        .get_or_init(
+            || match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
+                0 => Err(Error::last_os_error().raw_os_error().expect("unreachable")),
+                _ => Ok(Registry::default()),
+            },
+        )
         .as_ref()
         .map_err(|&code| Error::from_raw_os_error(code))?;
 
@@ -77,13 +82,6 @@ impl Registry {
 }
 
 static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
-
-fn init() -> Result<Registry, i32> {
-    match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
-        0 => Err(Error::last_os_error().raw_os_error().expect("unreachable")),
-        _ => Ok(Registry::default()),
-    }
-}
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
     // SAFETY: `handler` is only invoked if `REGISTRY` was successfully initialized.

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -84,7 +84,13 @@ fn init() -> Result<Registry, i32> {
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
     // SAFETY: this function is only invoked if `REGISTRY` was successfully initialized.
-    let registry = unsafe { REGISTRY.get().unwrap_unchecked().unwrap_unchecked() };
+    let registry = unsafe {
+        REGISTRY
+            .get()
+            .unwrap_unchecked()
+            .as_ref()
+            .unwrap_unchecked()
+    };
 
     // Ignore unknown control signal types.
     let Some(event_info) = registry.event_info(ty) else {

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -31,12 +31,14 @@ pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
 }
 
 unsafe fn new(signum: u32) -> io::Result<RxFuture> {
-    let rx = match REGISTRY.get_or_init(init).as_ref() {
-        // SAFETY: signum is valid (the compiler is unable to determine this)
-        Ok(registry) => unsafe { registry.event_info(signum).unwrap_unchecked() }.subscribe(),
-        Err(&code) => return Err(Error::from_raw_os_error(code)),
-    };
-    Ok(RxFuture::new(rx))
+    let registry = REGISTRY
+        .get_or_init(init)
+        .as_ref()
+        .map_err(|&code| Error::from_raw_os_error(code))?;
+
+    // SAFETY: signum is valid (the compiler is unable to infer this).
+    let event_info = unsafe { registry.event_info(signum).unwrap_unchecked() };
+    Ok(RxFuture::new(event_info.subscribe()))
 }
 
 fn event_requires_infinite_sleep_in_handler(signum: u32) -> bool {
@@ -84,7 +86,7 @@ fn init() -> Result<Registry, i32> {
 }
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
-    // SAFETY: this function is only invoked if `REGISTRY` was successfully initialized.
+    // SAFETY: `handler` is only invoked if `REGISTRY` was successfully initialized.
     let registry = unsafe {
         REGISTRY
             .get()

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -1,5 +1,6 @@
 use std::io;
 use std::io::Error;
+use std::ops::Index;
 use std::sync::OnceLock;
 
 use crate::signal::RxFuture;
@@ -10,30 +11,36 @@ use windows_sys::Win32::System::Console as console;
 
 type EventInfo = watch::Sender<()>;
 
+#[repr(u32)]
+enum SignalType {
+    CtrlC = console::CTRL_C_EVENT,
+    CtrlBreak = console::CTRL_BREAK_EVENT,
+    CtrlClose = console::CTRL_CLOSE_EVENT,
+    CtrlLogoff = console::CTRL_LOGOFF_EVENT,
+    CtrlShutdown = console::CTRL_SHUTDOWN_EVENT,
+}
+
 pub(super) fn ctrl_break() -> io::Result<RxFuture> {
-    unsafe { new(console::CTRL_BREAK_EVENT) }
+    new(SignalType::CtrlBreak)
 }
 
 pub(super) fn ctrl_close() -> io::Result<RxFuture> {
-    unsafe { new(console::CTRL_CLOSE_EVENT) }
+    new(SignalType::CtrlClose)
 }
 
 pub(super) fn ctrl_c() -> io::Result<RxFuture> {
-    unsafe { new(console::CTRL_C_EVENT) }
+    new(SignalType::CtrlC)
 }
 
 pub(super) fn ctrl_logoff() -> io::Result<RxFuture> {
-    unsafe { new(console::CTRL_LOGOFF_EVENT) }
+    new(SignalType::CtrlLogoff)
 }
 
 pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
-    unsafe { new(console::CTRL_SHUTDOWN_EVENT) }
+    new(SignalType::CtrlShutdown)
 }
 
-/// # Safety
-///
-/// `signum` must be valid.
-unsafe fn new(signum: u32) -> io::Result<RxFuture> {
+fn new(signal: SignalType) -> io::Result<RxFuture> {
     let registry = REGISTRY
         .get_or_init(
             || match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
@@ -44,9 +51,8 @@ unsafe fn new(signum: u32) -> io::Result<RxFuture> {
         .as_ref()
         .map_err(|&code| Error::from_raw_os_error(code))?;
 
-    // SAFETY: signum is valid.
-    let event_info = unsafe { registry.event_info(signum).unwrap_unchecked() };
-    Ok(RxFuture::new(event_info.subscribe()))
+    let rx = registry[signal].subscribe();
+    Ok(RxFuture::new(rx))
 }
 
 fn event_requires_infinite_sleep_in_handler(signum: u32) -> bool {
@@ -71,15 +77,16 @@ struct Registry {
     ctrl_shutdown: EventInfo,
 }
 
-impl Registry {
-    fn event_info(&self, signum: u32) -> Option<&EventInfo> {
-        match signum {
-            console::CTRL_BREAK_EVENT => Some(&self.ctrl_break),
-            console::CTRL_CLOSE_EVENT => Some(&self.ctrl_close),
-            console::CTRL_C_EVENT => Some(&self.ctrl_c),
-            console::CTRL_LOGOFF_EVENT => Some(&self.ctrl_logoff),
-            console::CTRL_SHUTDOWN_EVENT => Some(&self.ctrl_shutdown),
-            _ => None,
+impl Index<SignalType> for Registry {
+    type Output = EventInfo;
+
+    fn index(&self, index: SignalType) -> &Self::Output {
+        match index {
+            SignalType::CtrlC => &self.ctrl_c,
+            SignalType::CtrlBreak => &self.ctrl_break,
+            SignalType::CtrlClose => &self.ctrl_close,
+            SignalType::CtrlLogoff => &self.ctrl_logoff,
+            SignalType::CtrlShutdown => &self.ctrl_shutdown,
         }
     }
 }
@@ -87,21 +94,26 @@ impl Registry {
 static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
+    let signal = match ty {
+        console::CTRL_C_EVENT => SignalType::CtrlC,
+        console::CTRL_BREAK_EVENT => SignalType::CtrlBreak,
+        console::CTRL_CLOSE_EVENT => SignalType::CtrlClose,
+        console::CTRL_LOGOFF_EVENT => SignalType::CtrlLogoff,
+        console::CTRL_SHUTDOWN_EVENT => SignalType::CtrlShutdown,
+        // Ignore unknown signals.
+        _ => return 0,
+    };
+
     // Note that `OnceLock::get` does not handle the small window between invoking
     // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
     // SAFETY: `handler` is only invoked if `SetConsoleCtrlHandler` succeded.
     let registry = unsafe { REGISTRY.wait().as_ref().unwrap_unchecked() };
 
-    // Ignore unknown control signal types.
-    let Some(event_info) = registry.event_info(ty) else {
-        return 0;
-    };
-
     // According to https://learn.microsoft.com/en-us/windows/console/handlerroutine
     // the handler routine is always invoked in a new thread, thus we don't
     // have the same restrictions as in Unix signal handlers, meaning we can
     // go ahead and perform the broadcast here.
-    match event_info.send(()) {
+    match registry[signal].send(()) {
         Ok(_) if event_requires_infinite_sleep_in_handler(ty) => loop {
             std::thread::park();
         },


### PR DESCRIPTION
## Motivation

There is a dependency between setting the handler routine and initializing `Registry` (the first must succeed for the second one to be used). It is therefore possible to merge `OnceLock<Registry>` and `OnceLock<Result<(), Option<i32>>` into a single `OnceLock<Result<Registry, i32>>` (note the dropped `Option`).

## Solution

Add a `SignalKind` enum and use it as the argument of `new` and match the raw value of `handler` into it. `Registry` may then implement `Index<SignalKind>` in a type-safe manner. Note that the panic branch of `raw_os_error` is elided.

[asm/llvm diffs](https://github.com/user-attachments/files/29375392/diffs.zip) (stale)