### PR TITLE
stream: stop polling map_while after the closure returns None

### DIFF
--- a/tokio-stream/src/stream_ext/map_while.rs
+++ b/tokio-stream/src/stream_ext/map_while.rs
@@ -73,10 +73,9 @@ where
     }
 }
 
-impl<St, F, T> FusedStream for MapWhile<St, F>
+impl<St, F> FusedStream for MapWhile<St, F>
 where
-    St: Stream,
-    F: FnMut(St::Item) -> Option<T>,
+    Self: Stream,
 {
     fn is_terminated(&self) -> bool {
         self.done

--- a/tokio-stream/src/stream_ext/map_while.rs
+++ b/tokio-stream/src/stream_ext/map_while.rs
@@ -3,6 +3,7 @@ use crate::Stream;
 use core::fmt;
 use core::pin::Pin;
 use core::task::{Context, Poll};
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 
 pin_project! {
@@ -12,6 +13,7 @@ pin_project! {
         #[pin]
         stream: St,
         f: F,
+        done: bool,
     }
 }
 
@@ -22,13 +24,18 @@ where
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MapWhile")
             .field("stream", &self.stream)
+            .field("done", &self.done)
             .finish()
     }
 }
 
 impl<St, F> MapWhile<St, F> {
     pub(super) fn new(stream: St, f: F) -> Self {
-        MapWhile { stream, f }
+        MapWhile {
+            stream,
+            f,
+            done: false,
+        }
     }
 }
 
@@ -41,12 +48,37 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
         let me = self.project();
+        if *me.done {
+            return Poll::Ready(None);
+        }
+
         let f = me.f;
-        me.stream.poll_next(cx).map(|opt| opt.and_then(f))
+        let done = me.done;
+        me.stream.poll_next(cx).map(|opt| {
+            let mapped = opt.and_then(f);
+            if mapped.is_none() {
+                *done = true;
+            }
+            mapped
+        })
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.done {
+            return (0, Some(0));
+        }
+
         let (_, upper) = self.stream.size_hint();
         (0, upper)
+    }
+}
+
+impl<St, F, T> FusedStream for MapWhile<St, F>
+where
+    St: Stream,
+    F: FnMut(St::Item) -> Option<T>,
+{
+    fn is_terminated(&self) -> bool {
+        self.done
     }
 }

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -144,10 +144,9 @@ async fn map_while_terminated_after_closure_returns_none() {
         tokio_stream::iter(vec![1, 5, 2]).map_while(|x| if x < 3 { Some(x) } else { None });
     assert_eq!(stream.next().await, Some(1));
     assert!(!stream.is_terminated());
-    // closure returns `None` on 5 → done flag set; the trailing 2 must not be yielded
+    // closure returns `None` on 5 → done flag set
     assert_eq!(stream.next().await, None);
     assert!(stream.is_terminated());
-    assert_eq!(stream.next().await, None);
 }
 
 // ── then ─────────────────────────────────────────────────────────────────────

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -129,6 +129,27 @@ async fn take_while_terminated_after_predicate_fails() {
     assert!(stream.is_terminated());
 }
 
+// ── map_while ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn map_while_not_terminated_before_closure_returns_none() {
+    let stream =
+        tokio_stream::iter(vec![1, 2, 3]).map_while(|x| if x < 10 { Some(x) } else { None });
+    assert!(!stream.is_terminated());
+}
+
+#[tokio::test]
+async fn map_while_terminated_after_closure_returns_none() {
+    let mut stream =
+        tokio_stream::iter(vec![1, 5, 2]).map_while(|x| if x < 3 { Some(x) } else { None });
+    assert_eq!(stream.next().await, Some(1));
+    assert!(!stream.is_terminated());
+    // closure returns `None` on 5 → done flag set; the trailing 2 must not be yielded
+    assert_eq!(stream.next().await, None);
+    assert!(stream.is_terminated());
+    assert_eq!(stream.next().await, None);
+}
+
 // ── then ─────────────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/tokio-stream/tests/stream_map_while.rs
+++ b/tokio-stream/tests/stream_map_while.rs
@@ -1,0 +1,22 @@
+use tokio_stream::StreamExt;
+
+#[tokio::test]
+async fn map_while_yields_until_closure_returns_none() {
+    let mut stream =
+        tokio_stream::iter(1..=10).map_while(|x| if x < 4 { Some(x + 3) } else { None });
+    assert_eq!(stream.next().await, Some(4));
+    assert_eq!(stream.next().await, Some(5));
+    assert_eq!(stream.next().await, Some(6));
+    assert_eq!(stream.next().await, None);
+}
+
+#[tokio::test]
+async fn map_while_does_not_poll_after_closure_returns_none() {
+    // Once the closure returns `None`, the underlying stream must not be polled
+    // again, so the trailing `2` is never yielded.
+    let mut stream =
+        tokio_stream::iter(vec![1, 5, 2]).map_while(|x| if x < 3 { Some(x) } else { None });
+    assert_eq!(stream.next().await, Some(1));
+    assert_eq!(stream.next().await, None);
+    assert_eq!(stream.next().await, None);
+}


### PR DESCRIPTION
## Motivation

The docs for `StreamExt::map_while` state that "Once `None` is returned, the
underlying stream will not be polled again." `MapWhile` does not uphold this:
`poll_next` polls the inner stream on every call, so once the mapping closure
returns `None` the inner stream keeps being polled and can yield further items.

```rust
let mut s = tokio_stream::iter(vec![1, 5, 2])
    .map_while(|x| if x < 3 { Some(x) } else { None });
assert_eq!(s.next().await, Some(1));
assert_eq!(s.next().await, None); // closure returns None on 5
assert_eq!(s.next().await, None); // documented behavior; today this yields Some(2)
```

This is a deliberately stronger guarantee than `std`'s `Iterator::map_while`
(which is not fused); it has been documented since `map_while` was added in
#4351 and matches the neighboring `take_while`, which enforces the same
guarantee with a `done` flag and implements `FusedStream`. `map_while` was the
one adapter left out of #8096, which noted that a correct `is_terminated()` was
"not possible without a separate semantic change to the adaptor itself."

## Solution

Track completion in `MapWhile` with a `done` flag, mirroring `take_while`: once
the closure returns `None` (or the inner stream finishes), set `done`, return
`Poll::Ready(None)` without polling the inner stream again, and report
`(0, Some(0))` from `size_hint`. With that in place, implement `FusedStream` for
`MapWhile`, completing the set started in #8096.

Tests added to `tokio-stream/tests/stream_fused.rs` cover the `is_terminated()`
transition and assert that no further items are produced after the closure
returns `None`.

Verified with `cargo test -p tokio-stream`, `cargo clippy` (1.88) and
`cargo check` (1.71, MSRV), and `rustfmt --check`.
